### PR TITLE
Replace entire dep sets, so peer loops don't lock

### DIFF
--- a/lib/arborist/build-ideal-tree.js
+++ b/lib/arborist/build-ideal-tree.js
@@ -1085,14 +1085,22 @@ This is a one-time fix-up, please be patient...
 
     let target
     let canPlace = null
+    let isSource = false
+    const source = this[_peerSetSource].get(dep)
     for (let check = start; check; check = check.resolveParent) {
+      // we always give the FIRST place we possibly *can* put this a little
+      // extra prioritization with peer dep overrides and deduping
+      if (check === source)
+        isSource = true
+
       // if the current location has a peerDep on it, then we can't place here
       // this is pretty rare to hit, since we always prefer deduping peers.
       const checkEdge = check.edgesOut.get(edge.name)
       if (!check.isTop && checkEdge && checkEdge.peer)
         continue
 
-      const cp = this[_canPlaceDep](dep, check, edge, peerEntryEdge, peerPath)
+      const cp = this[_canPlaceDep](dep, check, edge, peerEntryEdge, peerPath, isSource)
+      isSource = false
 
       // anything other than a conflict is fine to proceed with
       if (cp !== CONFLICT) {
@@ -1164,7 +1172,7 @@ This is a one-time fix-up, please be patient...
       const oldDeps = []
       for (const [name, edge] of oldChild.edgesOut.entries()) {
         if (!newDep.edgesOut.has(name) && edge.to)
-          oldDeps.push(edge.to)
+          oldDeps.push(...gatherDepSet([edge.to], e => e.to !== edge.to))
       }
       newDep.replace(oldChild)
       this[_pruneForReplacement](newDep, oldDeps)
@@ -1265,14 +1273,17 @@ This is a one-time fix-up, please be patient...
     // deps that the new node doesn't depend on but the old one did.
     const invalidDeps = new Set([...node.edgesOut.values()]
       .filter(e => e.to && !e.valid).map(e => e.to))
-    for (const dep of oldDeps)
-      invalidDeps.add(dep)
+    for (const dep of oldDeps) {
+      const set = gatherDepSet([dep], e => e.to !== dep && e.valid)
+      for (const dep of set)
+        invalidDeps.add(dep)
+    }
 
     // ignore dependency edges from the node being replaced, but
     // otherwise filter the set down to just the set with no
     // dependencies from outside the set, except the node in question.
     const deps = gatherDepSet(invalidDeps, edge =>
-      edge.from !== node && edge.to !== node)
+      edge.from !== node && edge.to !== node && edge.valid)
 
     // now just delete whatever's left, because it's junk
     for (const dep of deps)
@@ -1299,7 +1310,7 @@ This is a one-time fix-up, please be patient...
   // checking, because either we're leaving it alone, or it won't work anyway.
   // When we check peers, we pass along the peerEntryEdge to track the
   // original edge that caused us to load the family of peer dependencies.
-  [_canPlaceDep] (dep, target, edge, peerEntryEdge = null, peerPath = []) {
+  [_canPlaceDep] (dep, target, edge, peerEntryEdge = null, peerPath = [], isSource = false) {
     /* istanbul ignore next */
     debug(() => {
       if (!dep)
@@ -1307,8 +1318,16 @@ This is a one-time fix-up, please be patient...
     })
     const entryEdge = peerEntryEdge || edge
     const source = this[_peerSetSource].get(dep)
-    const isSource = target === source
-    const { isRoot, isWorkspace } = source || {}
+    isSource = isSource || target === source
+    // if we're overriding the source, then we care if the *target* is
+    // ours, even if it wasn't actually the original source, since we
+    // are depending on something that has a dep that can't go in its own
+    // folder.  for example, a -> b, b -> PEER(a).  Even though a is the
+    // source, b has to be installed up a level, and if the root package
+    // depends on a, and it has a conflict, it's our problem.  So, the root
+    // (or whatever is bringing in a) becomes the "effective source" for
+    // the purposes of this calculation.
+    const { isRoot, isWorkspace } = isSource ? target : source || {}
     const isMine = isRoot || isWorkspace
 
     // Useful testing thingie right here.
@@ -1333,7 +1352,7 @@ This is a one-time fix-up, please be patient...
       const { version: newVer } = dep
       const tryReplace = curVer && newVer && semver.gte(newVer, curVer)
       if (tryReplace && dep.canReplace(current)) {
-        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath)
+        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath, isSource)
         /* istanbul ignore else - It's extremely rare that a replaceable
          * node would be a conflict, if the current one wasn't a conflict,
          * but it is theoretically possible if peer deps are pinned.  In
@@ -1353,7 +1372,7 @@ This is a one-time fix-up, please be patient...
       // a bit harder to be singletons.
       const preferDedupe = this[_preferDedupe] || edge.peer
       if (preferDedupe && !tryReplace && dep.canReplace(current)) {
-        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath)
+        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath, isSource)
         /* istanbul ignore else - It's extremely rare that a replaceable
          * node would be a conflict, if the current one wasn't a conflict,
          * but it is theoretically possible if peer deps are pinned.  In
@@ -1421,7 +1440,7 @@ This is a one-time fix-up, please be patient...
           }
         }
         if (canReplace) {
-          const ret = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath)
+          const ret = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge, peerPath, isSource)
           /* istanbul ignore else - extremely rare that the peer set would
            * conflict if we can replace the node in question, but theoretically
            * possible, if peer deps are pinned aggressively. */
@@ -1482,14 +1501,14 @@ This is a one-time fix-up, please be patient...
     }
 
     // no objections!  ok to place here
-    return this[_canPlacePeers](dep, target, edge, OK, peerEntryEdge, peerPath)
+    return this[_canPlacePeers](dep, target, edge, OK, peerEntryEdge, peerPath, isSource)
   }
 
   // make sure the family of peer deps can live here alongside it.
   // this doesn't guarantee that THIS solution will be the one we take,
   // but it does establish that SOME solution exists at this level in
   // the tree.
-  [_canPlacePeers] (dep, target, edge, ret, peerEntryEdge, peerPath) {
+  [_canPlacePeers] (dep, target, edge, ret, peerEntryEdge, peerPath, isSource) {
     // do not go in cycles when we're resolving a peer group
     if (!dep.parent || peerEntryEdge && peerPath.includes(dep))
       return ret
@@ -1501,7 +1520,7 @@ This is a one-time fix-up, please be patient...
       if (!peerEdge.peer || !peerEdge.to)
         continue
       const peer = peerEdge.to
-      const canPlacePeer = this[_canPlaceDep](peer, target, peerEdge, entryEdge, peerPath)
+      const canPlacePeer = this[_canPlaceDep](peer, target, peerEdge, entryEdge, peerPath, isSource)
       if (canPlacePeer !== CONFLICT)
         continue
 

--- a/scripts/reify.js
+++ b/scripts/reify.js
@@ -15,6 +15,10 @@ process.on('timeEnd', name => {
   }
   const res = process.hrtime(timers[name])
   delete timers[name]
+
+  if (options.quiet)
+    return
+
   console.error(name, res[0] * 1e3 + res[1] / 1e6)
 })
 process.on('exit', () => {
@@ -104,6 +108,8 @@ process.on('log', (level, ...args) => {
   if (level === 'warn' && args[0] === 'ERESOLVE') {
     args[2] = require('util').inspect(args[2], { depth: Infinity })
   }
+  if (options.quiet)
+    return
   return console.error(level, ...args)
 })
 

--- a/test/arborist/build-ideal-tree.js
+++ b/test/arborist/build-ideal-tree.js
@@ -2275,3 +2275,34 @@ t.test('update global', async t => {
   t.matchSnapshot(await printIdeal(path, { global: true, update: true }),
     'update all the deps')
 })
+
+t.test('peer dep that needs to be replaced', async t => {
+  // this verifies that the webpack 5 that gets placed by default for
+  // the initial dep will be successfully replaced by webpack 4 that
+  // webpack-dev-server needs, even though webpack 5 has a dep that
+  // peer-depends back on it.
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      dependencies: {
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
+        "webpack-dev-server": "^3.11.0"
+      },
+    }),
+  })
+  t.matchSnapshot(await printIdeal(path))
+})
+
+t.test('peer dep override with dep sets being replaced', async t => {
+  // in this case, because our root depends on webpack 5, and on something
+  // that has a peer dependency on webpack 4, it overrides but otherwise fails.
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      "devDependencies": {
+        "webpack": "^5.0.0",
+        "webpack-dev-server": "^3.11.0"
+      }
+    })
+  })
+  await t.rejects(printIdeal(path), { code: 'ERESOLVE' })
+  t.matchSnapshot(await printIdeal(path, { force: true }))
+})

--- a/test/fixtures/registry-mocks/content/accepts.json
+++ b/test/fixtures/registry-mocks/content/accepts.json
@@ -1,0 +1,3123 @@
+{
+  "_id": "accepts",
+  "_rev": "91-f04bf255c335d2519aca2e1d537f78f8",
+  "name": "accepts",
+  "description": "Higher-level content negotiation",
+  "dist-tags": {
+    "latest": "1.3.7"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/accepts.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/accepts/issues"
+      },
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "~0.3.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "homepage": "https://github.com/expressjs/accepts",
+      "_id": "accepts@1.0.0",
+      "dist": {
+        "shasum": "3604c765586c3b9cf7877b6937cdbd4587f947dc",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/accepts.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/accepts/issues"
+      },
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "~0.4.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "homepage": "https://github.com/expressjs/accepts",
+      "_id": "accepts@1.0.1",
+      "dist": {
+        "shasum": "c1e06d613e6246ba874678d6d9b92389b7ce310c",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.23",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.0.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/accepts.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/accepts/issues"
+      },
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "0.4.5"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot",
+        "test-travis": "mocha --require should --reporter spec"
+      },
+      "homepage": "https://github.com/expressjs/accepts",
+      "_id": "accepts@1.0.2",
+      "dist": {
+        "shasum": "96266ace1b4c03f9637428f3acafe891959f3883",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.0.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/accepts"
+      },
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "0.4.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require should --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require should --reporter spec test/"
+      },
+      "gitHead": "b17538c271b31cdad481c29d1623d76561a69d81",
+      "bugs": {
+        "url": "https://github.com/expressjs/accepts/issues"
+      },
+      "homepage": "https://github.com/expressjs/accepts",
+      "_id": "accepts@1.0.3",
+      "_shasum": "92b1db0d4f3db47b0530df6e15ae97db514dc2f8",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "92b1db0d4f3db47b0530df6e15ae97db514dc2f8",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.0.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~1.0.0",
+        "negotiator": "0.4.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require should --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require should --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/accepts/issues"
+      },
+      "homepage": "https://github.com/expressjs/accepts",
+      "_id": "accepts@1.0.4",
+      "_shasum": "a01739f55fbd67b26056ac5bc26537166a0707ca",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a01739f55fbd67b26056ac5bc26537166a0707ca",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.0.5",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~1.0.0",
+        "negotiator": "0.4.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require should --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require should --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/accepts/issues"
+      },
+      "homepage": "https://github.com/expressjs/accepts",
+      "_id": "accepts@1.0.5",
+      "dist": {
+        "shasum": "3a484f1870a8264cfa4266cf6fb0197d6bc86bff",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.0.6",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~1.0.0",
+        "negotiator": "0.4.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require should --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require should --reporter spec test/"
+      },
+      "gitHead": "77b5766d9233a208870b7cd4e92347c2b9cafc4c",
+      "bugs": {
+        "url": "https://github.com/expressjs/accepts/issues"
+      },
+      "homepage": "https://github.com/expressjs/accepts",
+      "_id": "accepts@1.0.6",
+      "_shasum": "8cbbf84772d70211110d9b00b1208aae01f15724",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8cbbf84772d70211110d9b00b1208aae01f15724",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.7": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.0.7",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~1.0.0",
+        "negotiator": "0.4.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require should --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require should --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/accepts/issues"
+      },
+      "homepage": "https://github.com/expressjs/accepts",
+      "_id": "accepts@1.0.7",
+      "dist": {
+        "shasum": "5b501fb4f0704309964ccdb048172541208dab1a",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.0",
+        "negotiator": "0.4.7"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1",
+        "should": "4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require should --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require should --reporter spec test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "564a01f1d1b4864365029a55773b765fb9e7756a",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.1.0",
+      "_shasum": "43ba6d946374c80f91823eaec6bb43dc4955500b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43ba6d946374c80f91823eaec6bb43dc4955500b",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.2",
+        "negotiator": "0.4.8"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "57e2960cfc6e8863c258613aa7e5947169e1d824",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.1.1",
+      "_shasum": "3b40bf6abc3fe3bc004534f4672ae1efd0063a96",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3b40bf6abc3fe3bc004534f4672ae1efd0063a96",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.1.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.2",
+        "negotiator": "0.4.9"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "026a08f23ee1aaa1bb0fb874fab49fbc00b6d898",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.1.2",
+      "_shasum": "8469a0a0a215b50cb0d156d351662f8978b00876",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8469a0a0a215b50cb0d156d351662f8978b00876",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.1.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.3",
+        "negotiator": "0.4.9"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~2.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "8c3267ffe54e657b00dcd019ce6fdf8b342377b6",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.1.3",
+      "_shasum": "14d99f8ee3ea69f8709d4bd17ffe153bef0f6c6d",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "14d99f8ee3ea69f8709d4bd17ffe153bef0f6c6d",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.1.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.4",
+        "negotiator": "0.4.9"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.4",
+        "mocha": "~2.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "df66414d80f096627b28f137127fce0a851d7900",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.1.4",
+      "_shasum": "d71c96f7d41d0feda2c38cd14e8a27c04158df4a",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d71c96f7d41d0feda2c38cd14e8a27c04158df4a",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.4",
+        "negotiator": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.4",
+        "mocha": "~2.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "2e889c93fc7f7907fb89468bafe23d352f9cdc9a",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.0",
+      "_shasum": "6dabb991bfa82ad0011f6e970b99151d6e109966",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6dabb991bfa82ad0011f6e970b99151d6e109966",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.5",
+        "negotiator": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "b517171bbd972803dbbe6c80050a9c795288265f",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.1",
+      "_shasum": "07f17ad3e9d8f0cc6097931c310079d6c1eac704",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "07f17ad3e9d8f0cc6097931c310079d6c1eac704",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.7",
+        "negotiator": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "08c807538789b4908ddb5f6ad58550b2d0c3c261",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.2",
+      "_shasum": "9bc29b9b39f33a351e76a76058184ebc8ed7783f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9bc29b9b39f33a351e76a76058184ebc8ed7783f",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.8",
+        "negotiator": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "b4f616ff54790683759280244384cbead0742095",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.3",
+      "_shasum": "2cb8b306cce2aa70e73ab39cc750061526c0778f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2cb8b306cce2aa70e73ab39cc750061526c0778f",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.4": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.9",
+        "negotiator": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "dfa143a31879bf5fb4934bbefc5741504a1cc15f",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.4",
+      "_shasum": "f4e6c66f4faf69c76bd7a63a1ffc5bd2dacfb2ac",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f4e6c66f4faf69c76bd7a63a1ffc5bd2dacfb2ac",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.5": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.5",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.10",
+        "negotiator": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "e74f846e885aa70fceba1af6ce96e3952e6782c1",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.5",
+      "_shasum": "bb07dc52c141ae562611a836ff433bcec8871ce9",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bb07dc52c141ae562611a836ff433bcec8871ce9",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.6": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.6",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.11",
+        "negotiator": "0.5.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "bebfc8d4f557d68662184751af0f9c64bea6da01",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.6",
+      "_shasum": "8f6c694267f0dc2f722d8b1752f56434e58be469",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8f6c694267f0dc2f722d8b1752f56434e58be469",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.7": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.7",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.0.11",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "067cd4c96d517cf3299f0d9c67733e752d0257e1",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.7",
+      "_shasum": "efea24e36e0b5b93d001a7598ac441c32ef56003",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "efea24e36e0b5b93d001a7598ac441c32ef56003",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.8": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.8",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.0",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "0d60f3a79aec8f682ebf86dd871c8e69c72b5170",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.8",
+      "_shasum": "6ae87f81ceb551258163531988b435142cf927e2",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6ae87f81ceb551258163531988b435142cf927e2",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.9": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.9",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.1",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "66496bc5b99bfc99aa0fa96d160f8b5eec7f9b5d",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.9",
+      "_shasum": "76e9631d05e3ff192a34afb9389f7b3953ded001",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "76e9631d05e3ff192a34afb9389f7b3953ded001",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.9.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.10": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.10",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.2",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "9afac08d5ab40aff6af007121672adc83d85ebf1",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.10",
+      "_shasum": "f825f151c0960914881625be845d04940691ef69",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f825f151c0960914881625be845d04940691ef69",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.10.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.11": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.11",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.3",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "c9c8adea7bb8395089ead858fc059a38e99ac3bc",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.11",
+      "_shasum": "d341c6e3b420489632f0f4f8d2ad4fd9ddf374e0",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d341c6e3b420489632f0f4f8d2ad4fd9ddf374e0",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.11.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.12": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.12",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.4",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "f01900aa33b1089575bd29caea851a8a241df07c",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.12",
+      "_shasum": "7e6d880f473b5c48d46e3e35f71ea7c3b68514c3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e6d880f473b5c48d46e3e35f71ea7c3b68514c3",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.12.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.13": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.2.13",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.6",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.19",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "b7e15ecb25dacc0b2133ed0553d64f8a79537e01",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.2.13",
+      "_shasum": "e5f1f3928c6d95fd96558c36ec3d9d0de4a6ecea",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e5f1f3928c6d95fd96558c36ec3d9d0de4a6ecea",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.3.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.7",
+        "negotiator": "0.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "f4a54dfbc147808b2ed89428a52db858be0838d5",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.3.0",
+      "_shasum": "2341420f16d0b2d538a5898416ab0faa28912622",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2341420f16d0b2d538a5898416ab0faa28912622",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.3.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.9",
+        "negotiator": "0.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "6551051596cfcbd7aaaf9f02af8f487ce83cbf00",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.3.1",
+      "_shasum": "dc295faf85024e05b04f5a6faf5eec1d1fd077e5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dc295faf85024e05b04f5a6faf5eec1d1fd077e5",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.3.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/accepts"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.10",
+        "negotiator": "0.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "abc38f70222e9c3b73d2f74f2259fbcc3fdd09ca",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts",
+      "_id": "accepts@1.3.2",
+      "_shasum": "9bfd7ddc497fdc1dad73a97b3f7cdc133929fac1",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9bfd7ddc497fdc1dad73a97b3f7cdc133929fac1",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/accepts-1.3.2.tgz_1457497267109_0.11459392495453358"
+      },
+      "directories": {}
+    },
+    "1.3.3": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.3.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/accepts.git"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.11",
+        "negotiator": "0.6.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "3e925b1e65ed7da2798849683d49814680dfa426",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts#readme",
+      "_id": "accepts@1.3.3",
+      "_shasum": "c3ca7434938648c3e0d9c1e328dd68b622c284ca",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "c3ca7434938648c3e0d9c1e328dd68b622c284ca",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/accepts-1.3.3.tgz_1462251932032_0.7092335098423064"
+      },
+      "directories": {}
+    },
+    "1.3.4": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.3.4",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/accepts.git"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.16",
+        "negotiator": "0.6.1"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "71ea430741d6eb5484b6c67c95924540a98186a5",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts#readme",
+      "_id": "accepts@1.3.4",
+      "_shasum": "86246758c7dd6d21a6474ff084a4740ec05eb21f",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "86246758c7dd6d21a6474ff084a4740ec05eb21f",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/accepts-1.3.4.tgz_1503455053008_0.43370609171688557"
+      },
+      "directories": {}
+    },
+    "1.3.5": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.3.5",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/accepts.git"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      },
+      "devDependencies": {
+        "eslint": "4.18.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.9.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "c38d0e968cdc1526f7cc7a718977ee76655c84f5",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts#readme",
+      "_id": "accepts@1.3.5",
+      "_shasum": "eb777df6011723a3b14e8a72c0805c8e86746bd2",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "eb777df6011723a3b14e8a72c0805c8e86746bd2",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16555
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/accepts_1.3.5_1519869527663_0.6663620712347182"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.3.6": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.3.6",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/accepts.git"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.1"
+      },
+      "devDependencies": {
+        "deep-equal": "1.0.1",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "9073b101e04d52711ba05918b19f9aaa8ee93f64",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts#readme",
+      "_id": "accepts@1.3.6",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-QsaoUD2dpVpjENy8JFpQnXP9vyzoZPmAoKrE3S6HtSB7qzSebkJNnmdY4p004FQUSSiHXPueENpoeuUW/7a8Ig==",
+        "shasum": "27de8682f0833e966dde5c5d7a63ec8523106e4b",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.6.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16622,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcxdY4CRA9TVsSAnZWagAAwVsQAKRxXFaYDKxfJF2Uo/Qc\ns5SyR5DD5cZNA+jAvBvbbHPMCN1Unqkyqvy7wqzyvK/4NbISi3zgkUqKBRfy\nt1twSdfeVorBx7RuL+RuzL9xB4xu7puksd7GzV/43gaclLN1/XHYgKfJnQTj\nUsqqhXLDWYo8GDJtKPh+i5wjOBNyLEa1Ygyhl7D/7+SlgK8fqRthR4UqRYg5\nOTsrRmYJTzMKKE+rmsPFHkYMK2VM0nITBzCBAqAr5dIQjOG0fkUPOqQKAJ4M\nSR1+mcrWZfU7qEUKcGtVpRaZufRYpdS9DfB4I+8nDIjuSoDLjkLD5NsZddZt\nvHjDzQMttHTlnKBhTCLq1FtbXgZ+IrEbRwzCYhbCmQIJXX39w1eDWUydUHuQ\nElPS2kYBFtrSWMrrtuVjXC2eXf3vbGX+i+iQyoN8+ZJgqFydLjXT8e5oFCki\nSQNK5x9MyVJfiXBM2tv363GEPfd3r7eW5Uo6KjMTS/OrzLFCZImlaoUsUy1P\nj/4gDyUWlYrOO7500hVj+4+a0aqvK/IarS4ozBYiWMQLENlLvJilcPNTINv2\nE2ljP0xi0P/c8ryFghSB3cpvMbAe+goCo8WGq3CXXcmlIbHnc1+cZnQUv2Jp\nMdVdCmhEfCZE9iTiRmJOGJrmWHU1IOLJVlEsKJT4twNY1K9bz31KeIuCnxG9\nmvTH\r\n=JCfs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/accepts_1.3.6_1556469304437_0.6314449329354344"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.3.7": {
+      "name": "accepts",
+      "description": "Higher-level content negotiation",
+      "version": "1.3.7",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/accepts.git"
+      },
+      "dependencies": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      },
+      "devDependencies": {
+        "deep-equal": "1.0.1",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "keywords": [
+        "content",
+        "negotiation",
+        "accept",
+        "accepts"
+      ],
+      "gitHead": "2a6e060aebb52813fdb074e9e7f66da1cfa61902",
+      "bugs": {
+        "url": "https://github.com/jshttp/accepts/issues"
+      },
+      "homepage": "https://github.com/jshttp/accepts#readme",
+      "_id": "accepts@1.3.7",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+        "shasum": "531bc726517a3b2b41f850021c6cc15eaab507cd",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16646,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcx8PPCRA9TVsSAnZWagAAM+kP/jPydIHPrA4TftraRNde\nnxojlC9prOP0Sn9FxBvevf3S9zBFEa2sa5fVUP4LUkNmG57fcmroDAaXnllW\nof8elLx8Al27QtOUi5lZ36AZAJ/aYHtGcTPnLjZejZOido1Mi2h8em/4Rk7M\nK/1RhYxG48u6B1Q/ZPXyJ23r95/PqfBhzAmaAKUfYBrcCMU/WT1SPS6DLCKv\nQZ6Oj9DFFlK7R+L15vRG7U1qmyMjkOVgK+oaNev7fpR0qVtc92xhfomgfrSK\ngqTrj05bKu4KIpJwH/T5GieWE2w7s42Q5TlmgWh/OMJNUFs9rltoe9tyetJE\nJcpTPFysR2lX5DS3YYwjgyguy515sseGMOIts0+92oE53OCKIC0FzE3IbPQw\nmXQCsUXK2IR+p3JwpIUz0oMswN4JDZ4I+BLNIy6LLibTiWw12NKdg1BWK/Yw\nJqZ5cyUW+45S3i82slyGttRABPS6WXq3CU5SqVp8+EUnwKqMceglw/b9dLfk\n0OiaPGGqUU48012PNNkqu1ERWqbb0JaGAlSrmaQRofGnceuAXvv2lCvAdhyc\n1hD32bl54Xox1ejJMCihiFJQCEOpTXrIEfXUEbyJFzSIZwaCW2uIP1OkYs9W\nPLWCaBiMcE12foiMMqv0cO1QrLYRyW1OPPttUhQoxbk//uKTMlrKPUjZM5PE\nR3Kk\r\n=HEy7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/accepts_1.3.7_1556595662948_0.6750107293886682"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# accepts\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nHigher level content negotiation based on [negotiator](https://www.npmjs.com/package/negotiator).\nExtracted from [koa](https://www.npmjs.com/package/koa) for general use.\n\nIn addition to negotiator, it allows:\n\n- Allows types as an array or arguments list, ie `(['text/html', 'application/json'])`\n  as well as `('text/html', 'application/json')`.\n- Allows type shorthands such as `json`.\n- Returns `false` when no types match\n- Treats non-existent headers as `*`\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install accepts\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar accepts = require('accepts')\n```\n\n### accepts(req)\n\nCreate a new `Accepts` object for the given `req`.\n\n#### .charset(charsets)\n\nReturn the first accepted charset. If nothing in `charsets` is accepted,\nthen `false` is returned.\n\n#### .charsets()\n\nReturn the charsets that the request accepts, in the order of the client's\npreference (most preferred first).\n\n#### .encoding(encodings)\n\nReturn the first accepted encoding. If nothing in `encodings` is accepted,\nthen `false` is returned.\n\n#### .encodings()\n\nReturn the encodings that the request accepts, in the order of the client's\npreference (most preferred first).\n\n#### .language(languages)\n\nReturn the first accepted language. If nothing in `languages` is accepted,\nthen `false` is returned.\n\n#### .languages()\n\nReturn the languages that the request accepts, in the order of the client's\npreference (most preferred first).\n\n#### .type(types)\n\nReturn the first accepted type (and it is returned as the same text as what\nappears in the `types` array). If nothing in `types` is accepted, then `false`\nis returned.\n\nThe `types` array can contain full MIME types or file extensions. Any value\nthat is not a full MIME types is passed to `require('mime-types').lookup`.\n\n#### .types()\n\nReturn the types that the request accepts, in the order of the client's\npreference (most preferred first).\n\n## Examples\n\n### Simple type negotiation\n\nThis simple example shows how to use `accepts` to return a different typed\nrespond body based on what the client wants to accept. The server lists it's\npreferences in order and will get back the best match between the client and\nserver.\n\n```js\nvar accepts = require('accepts')\nvar http = require('http')\n\nfunction app (req, res) {\n  var accept = accepts(req)\n\n  // the order of this list is significant; should be server preferred order\n  switch (accept.type(['json', 'html'])) {\n    case 'json':\n      res.setHeader('Content-Type', 'application/json')\n      res.write('{\"hello\":\"world!\"}')\n      break\n    case 'html':\n      res.setHeader('Content-Type', 'text/html')\n      res.write('<b>hello, world!</b>')\n      break\n    default:\n      // the fallback is text/plain, so no need to specify it above\n      res.setHeader('Content-Type', 'text/plain')\n      res.write('hello, world!')\n      break\n  }\n\n  res.end()\n}\n\nhttp.createServer(app).listen(3000)\n```\n\nYou can test this out with the cURL program:\n```sh\ncurl -I -H'Accept: text/html' http://localhost:3000/\n```\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/accepts/master\n[coveralls-url]: https://coveralls.io/r/jshttp/accepts?branch=master\n[node-version-image]: https://badgen.net/npm/node/accepts\n[node-version-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/accepts\n[npm-url]: https://npmjs.org/package/accepts\n[npm-version-image]: https://badgen.net/npm/v/accepts\n[travis-image]: https://badgen.net/travis/jshttp/accepts/master\n[travis-url]: https://travis-ci.org/jshttp/accepts\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-30T03:41:05.722Z",
+    "created": "2013-12-27T21:42:44.260Z",
+    "1.0.0": "2013-12-27T21:42:44.260Z",
+    "1.0.1": "2014-01-18T10:45:26.867Z",
+    "1.0.2": "2014-05-29T17:39:16.522Z",
+    "1.0.3": "2014-06-12T02:20:47.089Z",
+    "1.0.4": "2014-06-20T09:14:35.360Z",
+    "1.0.5": "2014-06-20T18:09:25.636Z",
+    "1.0.6": "2014-06-25T00:41:01.419Z",
+    "1.0.7": "2014-07-04T16:44:27.323Z",
+    "1.1.0": "2014-09-02T08:42:07.312Z",
+    "1.1.1": "2014-09-29T02:33:19.048Z",
+    "1.1.2": "2014-10-15T05:46:17.738Z",
+    "1.1.3": "2014-11-09T22:54:13.630Z",
+    "1.1.4": "2014-12-10T20:46:16.678Z",
+    "1.2.0": "2014-12-19T18:39:58.872Z",
+    "1.2.1": "2014-12-30T16:53:59.673Z",
+    "1.2.2": "2014-12-30T23:03:52.908Z",
+    "1.2.3": "2015-02-01T06:44:08.286Z",
+    "1.2.4": "2015-02-15T02:26:32.170Z",
+    "1.2.5": "2015-03-14T02:00:21.101Z",
+    "1.2.6": "2015-05-07T13:19:34.052Z",
+    "1.2.7": "2015-05-11T02:38:21.186Z",
+    "1.2.8": "2015-06-08T04:36:45.130Z",
+    "1.2.9": "2015-06-08T15:33:29.234Z",
+    "1.2.10": "2015-07-01T20:17:54.682Z",
+    "1.2.11": "2015-07-17T03:21:56.994Z",
+    "1.2.12": "2015-07-31T02:33:20.250Z",
+    "1.2.13": "2015-09-07T02:59:01.117Z",
+    "1.3.0": "2015-09-30T01:30:22.953Z",
+    "1.3.1": "2016-01-20T04:49:25.286Z",
+    "1.3.2": "2016-03-09T04:21:11.635Z",
+    "1.3.3": "2016-05-03T05:05:33.253Z",
+    "1.3.4": "2017-08-23T02:24:13.961Z",
+    "1.3.5": "2018-03-01T01:58:47.742Z",
+    "1.3.6": "2019-04-28T16:35:04.574Z",
+    "1.3.7": "2019-04-30T03:41:03.144Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jshttp/accepts#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/accepts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/accepts/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "goodseller": true,
+    "simplyianm": true,
+    "program247365": true,
+    "flyslow": true,
+    "santihbc": true,
+    "jessaustin": true,
+    "qqqppp9998": true,
+    "kungkk": true,
+    "wangnan0610": true,
+    "snowdream": true,
+    "mobeicaoyuan": true,
+    "magicadiii": true,
+    "kkuehl": true,
+    "quafoo": true,
+    "rocket0191": true,
+    "nisimjoseph": true,
+    "akiva": true,
+    "eyson": true,
+    "tedyhy": true,
+    "leelee.echo": true,
+    "zuojiang": true
+  },
+  "keywords": [
+    "content",
+    "negotiation",
+    "accept",
+    "accepts"
+  ],
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/accepts.min.json
+++ b/test/fixtures/registry-mocks/content/accepts.min.json
@@ -1,0 +1,714 @@
+{
+  "name": "accepts",
+  "dist-tags": {
+    "latest": "1.3.7"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "accepts",
+      "version": "1.0.0",
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "~0.3.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "3604c765586c3b9cf7877b6937cdbd4587f947dc",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "accepts",
+      "version": "1.0.1",
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "~0.4.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "c1e06d613e6246ba874678d6d9b92389b7ce310c",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "accepts",
+      "version": "1.0.2",
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "0.4.5"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "96266ace1b4c03f9637428f3acafe891959f3883",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.3": {
+      "name": "accepts",
+      "version": "1.0.3",
+      "dependencies": {
+        "mime": "~1.2.11",
+        "negotiator": "0.4.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "92b1db0d4f3db47b0530df6e15ae97db514dc2f8",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.4": {
+      "name": "accepts",
+      "version": "1.0.4",
+      "dependencies": {
+        "mime-types": "~1.0.0",
+        "negotiator": "0.4.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "a01739f55fbd67b26056ac5bc26537166a0707ca",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.5": {
+      "name": "accepts",
+      "version": "1.0.5",
+      "dependencies": {
+        "mime-types": "~1.0.0",
+        "negotiator": "0.4.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "3a484f1870a8264cfa4266cf6fb0197d6bc86bff",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.6": {
+      "name": "accepts",
+      "version": "1.0.6",
+      "dependencies": {
+        "mime-types": "~1.0.0",
+        "negotiator": "0.4.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "8cbbf84772d70211110d9b00b1208aae01f15724",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.7": {
+      "name": "accepts",
+      "version": "1.0.7",
+      "dependencies": {
+        "mime-types": "~1.0.0",
+        "negotiator": "0.4.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "5b501fb4f0704309964ccdb048172541208dab1a",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.0.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.0": {
+      "name": "accepts",
+      "version": "1.1.0",
+      "dependencies": {
+        "mime-types": "~2.0.0",
+        "negotiator": "0.4.7"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1",
+        "should": "4"
+      },
+      "dist": {
+        "shasum": "43ba6d946374c80f91823eaec6bb43dc4955500b",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.1": {
+      "name": "accepts",
+      "version": "1.1.1",
+      "dependencies": {
+        "mime-types": "~2.0.2",
+        "negotiator": "0.4.8"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "3b40bf6abc3fe3bc004534f4672ae1efd0063a96",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.2": {
+      "name": "accepts",
+      "version": "1.1.2",
+      "dependencies": {
+        "mime-types": "~2.0.2",
+        "negotiator": "0.4.9"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "8469a0a0a215b50cb0d156d351662f8978b00876",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.3": {
+      "name": "accepts",
+      "version": "1.1.3",
+      "dependencies": {
+        "mime-types": "~2.0.3",
+        "negotiator": "0.4.9"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~2.0.1"
+      },
+      "dist": {
+        "shasum": "14d99f8ee3ea69f8709d4bd17ffe153bef0f6c6d",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.4": {
+      "name": "accepts",
+      "version": "1.1.4",
+      "dependencies": {
+        "mime-types": "~2.0.4",
+        "negotiator": "0.4.9"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.4",
+        "mocha": "~2.0.1"
+      },
+      "dist": {
+        "shasum": "d71c96f7d41d0feda2c38cd14e8a27c04158df4a",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.0": {
+      "name": "accepts",
+      "version": "1.2.0",
+      "dependencies": {
+        "mime-types": "~2.0.4",
+        "negotiator": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.4",
+        "mocha": "~2.0.1"
+      },
+      "dist": {
+        "shasum": "6dabb991bfa82ad0011f6e970b99151d6e109966",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.1": {
+      "name": "accepts",
+      "version": "1.2.1",
+      "dependencies": {
+        "mime-types": "~2.0.5",
+        "negotiator": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0"
+      },
+      "dist": {
+        "shasum": "07f17ad3e9d8f0cc6097931c310079d6c1eac704",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.2": {
+      "name": "accepts",
+      "version": "1.2.2",
+      "dependencies": {
+        "mime-types": "~2.0.7",
+        "negotiator": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0"
+      },
+      "dist": {
+        "shasum": "9bc29b9b39f33a351e76a76058184ebc8ed7783f",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.3": {
+      "name": "accepts",
+      "version": "1.2.3",
+      "dependencies": {
+        "mime-types": "~2.0.8",
+        "negotiator": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0"
+      },
+      "dist": {
+        "shasum": "2cb8b306cce2aa70e73ab39cc750061526c0778f",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.4": {
+      "name": "accepts",
+      "version": "1.2.4",
+      "dependencies": {
+        "mime-types": "~2.0.9",
+        "negotiator": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "f4e6c66f4faf69c76bd7a63a1ffc5bd2dacfb2ac",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.5": {
+      "name": "accepts",
+      "version": "1.2.5",
+      "dependencies": {
+        "mime-types": "~2.0.10",
+        "negotiator": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "bb07dc52c141ae562611a836ff433bcec8871ce9",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.6": {
+      "name": "accepts",
+      "version": "1.2.6",
+      "dependencies": {
+        "mime-types": "~2.0.11",
+        "negotiator": "0.5.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "8f6c694267f0dc2f722d8b1752f56434e58be469",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.7": {
+      "name": "accepts",
+      "version": "1.2.7",
+      "dependencies": {
+        "mime-types": "~2.0.11",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "efea24e36e0b5b93d001a7598ac441c32ef56003",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.8": {
+      "name": "accepts",
+      "version": "1.2.8",
+      "dependencies": {
+        "mime-types": "~2.1.0",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "6ae87f81ceb551258163531988b435142cf927e2",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.9": {
+      "name": "accepts",
+      "version": "1.2.9",
+      "dependencies": {
+        "mime-types": "~2.1.1",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "76e9631d05e3ff192a34afb9389f7b3953ded001",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.10": {
+      "name": "accepts",
+      "version": "1.2.10",
+      "dependencies": {
+        "mime-types": "~2.1.2",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "f825f151c0960914881625be845d04940691ef69",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.11": {
+      "name": "accepts",
+      "version": "1.2.11",
+      "dependencies": {
+        "mime-types": "~2.1.3",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "d341c6e3b420489632f0f4f8d2ad4fd9ddf374e0",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.11.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.12": {
+      "name": "accepts",
+      "version": "1.2.12",
+      "dependencies": {
+        "mime-types": "~2.1.4",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "7e6d880f473b5c48d46e3e35f71ea7c3b68514c3",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.12.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.13": {
+      "name": "accepts",
+      "version": "1.2.13",
+      "dependencies": {
+        "mime-types": "~2.1.6",
+        "negotiator": "0.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.19",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "e5f1f3928c6d95fd96558c36ec3d9d0de4a6ecea",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.0": {
+      "name": "accepts",
+      "version": "1.3.0",
+      "dependencies": {
+        "mime-types": "~2.1.7",
+        "negotiator": "0.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "2341420f16d0b2d538a5898416ab0faa28912622",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.1": {
+      "name": "accepts",
+      "version": "1.3.1",
+      "dependencies": {
+        "mime-types": "~2.1.9",
+        "negotiator": "0.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "dc295faf85024e05b04f5a6faf5eec1d1fd077e5",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.2": {
+      "name": "accepts",
+      "version": "1.3.2",
+      "dependencies": {
+        "mime-types": "~2.1.10",
+        "negotiator": "0.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "9bfd7ddc497fdc1dad73a97b3f7cdc133929fac1",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.3": {
+      "name": "accepts",
+      "version": "1.3.3",
+      "dependencies": {
+        "mime-types": "~2.1.11",
+        "negotiator": "0.6.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "c3ca7434938648c3e0d9c1e328dd68b622c284ca",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.4": {
+      "name": "accepts",
+      "version": "1.3.4",
+      "dependencies": {
+        "mime-types": "~2.1.16",
+        "negotiator": "0.6.1"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "86246758c7dd6d21a6474ff084a4740ec05eb21f",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.5": {
+      "name": "accepts",
+      "version": "1.3.5",
+      "dependencies": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      },
+      "devDependencies": {
+        "eslint": "4.18.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.9.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "eb777df6011723a3b14e8a72c0805c8e86746bd2",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16555
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.6": {
+      "name": "accepts",
+      "version": "1.3.6",
+      "dependencies": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.1"
+      },
+      "devDependencies": {
+        "deep-equal": "1.0.1",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4"
+      },
+      "dist": {
+        "integrity": "sha512-QsaoUD2dpVpjENy8JFpQnXP9vyzoZPmAoKrE3S6HtSB7qzSebkJNnmdY4p004FQUSSiHXPueENpoeuUW/7a8Ig==",
+        "shasum": "27de8682f0833e966dde5c5d7a63ec8523106e4b",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.6.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16622,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcxdY4CRA9TVsSAnZWagAAwVsQAKRxXFaYDKxfJF2Uo/Qc\ns5SyR5DD5cZNA+jAvBvbbHPMCN1Unqkyqvy7wqzyvK/4NbISi3zgkUqKBRfy\nt1twSdfeVorBx7RuL+RuzL9xB4xu7puksd7GzV/43gaclLN1/XHYgKfJnQTj\nUsqqhXLDWYo8GDJtKPh+i5wjOBNyLEa1Ygyhl7D/7+SlgK8fqRthR4UqRYg5\nOTsrRmYJTzMKKE+rmsPFHkYMK2VM0nITBzCBAqAr5dIQjOG0fkUPOqQKAJ4M\nSR1+mcrWZfU7qEUKcGtVpRaZufRYpdS9DfB4I+8nDIjuSoDLjkLD5NsZddZt\nvHjDzQMttHTlnKBhTCLq1FtbXgZ+IrEbRwzCYhbCmQIJXX39w1eDWUydUHuQ\nElPS2kYBFtrSWMrrtuVjXC2eXf3vbGX+i+iQyoN8+ZJgqFydLjXT8e5oFCki\nSQNK5x9MyVJfiXBM2tv363GEPfd3r7eW5Uo6KjMTS/OrzLFCZImlaoUsUy1P\nj/4gDyUWlYrOO7500hVj+4+a0aqvK/IarS4ozBYiWMQLENlLvJilcPNTINv2\nE2ljP0xi0P/c8ryFghSB3cpvMbAe+goCo8WGq3CXXcmlIbHnc1+cZnQUv2Jp\nMdVdCmhEfCZE9iTiRmJOGJrmWHU1IOLJVlEsKJT4twNY1K9bz31KeIuCnxG9\nmvTH\r\n=JCfs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.7": {
+      "name": "accepts",
+      "version": "1.3.7",
+      "dependencies": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      },
+      "devDependencies": {
+        "deep-equal": "1.0.1",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+        "shasum": "531bc726517a3b2b41f850021c6cc15eaab507cd",
+        "tarball": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16646,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcx8PPCRA9TVsSAnZWagAAM+kP/jPydIHPrA4TftraRNde\nnxojlC9prOP0Sn9FxBvevf3S9zBFEa2sa5fVUP4LUkNmG57fcmroDAaXnllW\nof8elLx8Al27QtOUi5lZ36AZAJ/aYHtGcTPnLjZejZOido1Mi2h8em/4Rk7M\nK/1RhYxG48u6B1Q/ZPXyJ23r95/PqfBhzAmaAKUfYBrcCMU/WT1SPS6DLCKv\nQZ6Oj9DFFlK7R+L15vRG7U1qmyMjkOVgK+oaNev7fpR0qVtc92xhfomgfrSK\ngqTrj05bKu4KIpJwH/T5GieWE2w7s42Q5TlmgWh/OMJNUFs9rltoe9tyetJE\nJcpTPFysR2lX5DS3YYwjgyguy515sseGMOIts0+92oE53OCKIC0FzE3IbPQw\nmXQCsUXK2IR+p3JwpIUz0oMswN4JDZ4I+BLNIy6LLibTiWw12NKdg1BWK/Yw\nJqZ5cyUW+45S3i82slyGttRABPS6WXq3CU5SqVp8+EUnwKqMceglw/b9dLfk\n0OiaPGGqUU48012PNNkqu1ERWqbb0JaGAlSrmaQRofGnceuAXvv2lCvAdhyc\n1hD32bl54Xox1ejJMCihiFJQCEOpTXrIEfXUEbyJFzSIZwaCW2uIP1OkYs9W\nPLWCaBiMcE12foiMMqv0cO1QrLYRyW1OPPttUhQoxbk//uKTMlrKPUjZM5PE\nR3Kk\r\n=HEy7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2019-04-30T03:41:05.722Z"
+}

--- a/test/fixtures/registry-mocks/content/ajv-errors.json
+++ b/test/fixtures/registry-mocks/content/ajv-errors.json
@@ -1,0 +1,843 @@
+{
+  "_id": "ajv-errors",
+  "_rev": "11-0f37f5dfbd6af59ec5117afb4dfd125c",
+  "name": "ajv-errors",
+  "description": "Custom error messages in JSON-Schema for Ajv validator",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "ajv-errors",
+      "version": "0.0.1",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "gitHead": "c30cfd8987e0cf23cc39ff8dd6dc1feede17ad9e",
+      "_id": "ajv-errors@0.0.1",
+      "_shasum": "9d25c7a77ec8e9ec88017059d32cd699251f2e5b",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9d25c7a77ec8e9ec88017059d32cd699251f2e5b",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/ajv-errors-0.0.1.tgz_1488714041336_0.44593694899231195"
+      },
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "ajv-errors",
+      "version": "0.1.0",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "24eb684608f778a592905e8ecc7b1e124683e98d",
+      "_id": "ajv-errors@0.1.0",
+      "_shasum": "575fe73af89ca815664c97534f6cb21e0fd3143f",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "575fe73af89ca815664c97534f6cb21e0fd3143f",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ajv-errors-0.1.0.tgz_1493578076194_0.40459733200259507"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "ajv-errors",
+      "version": "0.1.1",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "5f5941837a99e14593d254dee53476cd64ea4959",
+      "_id": "ajv-errors@0.1.1",
+      "_shasum": "0e3efa3f1c043b8ba9cbd7c792a1c4d159b7541c",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0e3efa3f1c043b8ba9cbd7c792a1c4d159b7541c",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/ajv-errors-0.1.1.tgz_1493581004672_0.3394001806154847"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "ajv-errors",
+      "version": "0.1.2",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov",
+        "prepublish": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "ef36fa1ad34937b6baab7f5fccc9b1cbed88b7b7",
+      "_id": "ajv-errors@0.1.2",
+      "_shasum": "561877abb7f15c44032687e37fd9b7638ada7909",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "561877abb7f15c44032687e37fd9b7638ada7909",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.1.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ajv-errors-0.1.2.tgz_1493583855068_0.06978772417642176"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "ajv-errors",
+      "version": "0.2.0",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov",
+        "prepublish": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "cd9af6681bfdcf3d6f4bb1c143790b1470762999",
+      "_id": "ajv-errors@0.2.0",
+      "_shasum": "008204c64a57c9be5ced529a80b05c094f7cd3c0",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "008204c64a57c9be5ced529a80b05c094f7cd3c0",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ajv-errors-0.2.0.tgz_1493656328770_0.18939133686944842"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "ajv-errors",
+      "version": "0.3.0",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov",
+        "prepublish": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "2198d2e98180658c3f11aa27a5b1be6105dd64c3",
+      "_id": "ajv-errors@0.3.0",
+      "_shasum": "539c41568e1bfd9cf0f50a33a3bf02c11a38f917",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "539c41568e1bfd9cf0f50a33a3bf02c11a38f917",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.3.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ajv-errors-0.3.0.tgz_1494357272151_0.45966680673882365"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "ajv-errors",
+      "version": "0.4.0",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov",
+        "prepublish": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "463b2a6dd8b806b0b22bf1a19b55b7bd5141fb48",
+      "_id": "ajv-errors@0.4.0",
+      "_shasum": "22f351b6faafdb65c99a04e48d9c0ef608649138",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "22f351b6faafdb65c99a04e48d9c0ef608649138",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.4.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ajv-errors-0.4.0.tgz_1494366397805_0.6618154644966125"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "ajv-errors",
+      "version": "0.5.0",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov",
+        "prepublish": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "6896050438a254710a674e52802087de0a7d0eb6",
+      "_id": "ajv-errors@0.5.0",
+      "_shasum": "e0df4940776e36fa7084c7944c636ac5ea9b747a",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e0df4940776e36fa7084c7944c636ac5ea9b747a",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.5.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ajv-errors-0.5.0.tgz_1495899292681_0.15062517416663468"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "ajv-errors",
+      "version": "1.0.0",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov",
+        "prepublish": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "99e3352b1b3544efc8ec9c7d40e8e0e4fb76545d",
+      "_id": "ajv-errors@1.0.0",
+      "_shasum": "ecf021fa108fd17dfb5e6b383f2dd233e31ffc59",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ecf021fa108fd17dfb5e6b383f2dd233e31ffc59",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ajv-errors-1.0.0.tgz_1495907979993_0.6698060610797256"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "ajv-errors",
+      "version": "1.0.1",
+      "description": "Custom error messages in JSON-Schema for Ajv validator",
+      "main": "index.js",
+      "scripts": {
+        "build": "node node_modules/ajv/scripts/compile-dots.js node_modules/ajv/lib lib",
+        "eslint": "eslint *.js spec",
+        "test-spec": "mocha spec/*.spec.js -R spec",
+        "test-cov": "nyc npm run test-spec",
+        "test": "npm run eslint && npm run build && npm run test-cov",
+        "prepublish": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+      },
+      "keywords": [
+        "ajv",
+        "json-schema",
+        "validator",
+        "error",
+        "messages"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/epoberezkin/ajv-errors/issues"
+      },
+      "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "nyc": {
+        "exclude": [
+          "**/spec/**",
+          "node_modules"
+        ],
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "gitHead": "5d134394acb6429840438cc262c36c76d91e356c",
+      "_id": "ajv-errors@1.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "esp",
+        "email": "e.poberezkin@me.com"
+      },
+      "dist": {
+        "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+        "shasum": "f35986aceb91afadec4102fbd85014950cefa64d",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 41660,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcDX6nCRA9TVsSAnZWagAAu1sP/R1PmaZCddDScGEKSaDw\npqT+zr5jNjcjyX24Pi8uDye/QwvTdAnqO8kqzg6ZHWJk78kmOw3WsqBGk8S9\nzMDXPJweSTWAZvrNYRiGfchCt9lLuuTdGjvgYxGrTEFiUdEXl9U6SScTxs7X\npy9Vd8hfdTa8TKPxWt8Aj7ELTM13Er71B8V82J63k42YomtsMssxER5d2mqx\nOt92KJvlu+w/cvVzjAS1QquBybVzUwlWWTGzxP/SdN6Z0EzPAT9XoKyr0aeg\n2q+6C0+j88ObOP2tMBS5VOl0E5HTB/1lb0VPVZkMEEDedmnT/bj5r+kSnVKU\nTYQRsLb1VsbYqtHWyCIS996DxtfiAh8hUchHJYSdCSz4eiOkteYRvGYKQlYa\n4t/T9EmDpe6HH7GYKujMIFKSSTZRSAIWwenAlARWSEscZlXyD5ql2CiSLdRh\n2UOWf/DK8QzjbaBX4Iki9W+8ResOA/2nA15o2YT9RSfeX10qymAckwkgU/U4\nRB1QSKFpkdpYvrhcdxSnPIGXB5nhmRik/NP+VbdRz8Fqm4Rjz4LmUg4wqkq4\nbs9JsnrqSsknsNrMxB83nBR0L/iHHWfyJZAIow/KWYHF3cIU5CvmBQQIRDc+\nJ6zgHs6x80YIb0qWey/Wz98rJb2L1uYSI3j8TgBzePf/B+g2ozqKS9+pou0K\n6Z7v\r\n=0kuF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "esp",
+          "email": "e.poberezkin@me.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ajv-errors_1.0.1_1544388262825_0.438145911563087"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# ajv-errors\nCustom error messages in JSON-Schema for Ajv validator\n\n[![Build Status](https://travis-ci.org/epoberezkin/ajv-errors.svg?branch=master)](https://travis-ci.org/epoberezkin/ajv-errors)\n[![npm version](https://badge.fury.io/js/ajv-errors.svg)](http://badge.fury.io/js/ajv-errors)\n[![Coverage Status](https://coveralls.io/repos/github/epoberezkin/ajv-errors/badge.svg?branch=master)](https://coveralls.io/github/epoberezkin/ajv-errors?branch=master)\n[![Gitter](https://img.shields.io/gitter/room/ajv-validator/ajv.svg)](https://gitter.im/ajv-validator/ajv)\n\n\n## Contents\n\n- [Install](#install)\n- [Usage](#usage)\n  - [Single message](#single-message)\n  - [Messages for keywords](#messages-for-keywords)\n  - [Messages for properties and items](#messages-for-properties-and-items)\n  - [Default message](#default-message)\n- [Templates](#templates)\n- [Options](#options)\n- [License](#license)\n\n\n## Install\n\n```\nnpm install ajv-errors\n```\n\n\n## Usage\n\nAdd the keyword `errorMessages` to Ajv instance:\n\n```javascript\nvar Ajv = require('ajv');\nvar ajv = new Ajv({allErrors: true, jsonPointers: true});\n// Ajv options allErrors and jsonPointers are required\nrequire('ajv-errors')(ajv /*, {singleError: true} */);\n```\n\nSee [Options](#options) below.\n\n\n### Single message\n\nReplace all errors in the current schema and subschemas with a single message:\n\n```javascript\nvar schema = {\n  type: 'object',\n  required: ['foo'],\n  properties: {\n    foo: { type: 'integer' }\n  },\n  additionalProperties: false,\n  errorMessage: 'should be an object with an integer property foo only'\n};\n\nvar validate = ajv.compile(schema);\nconsole.log(validate({foo: 'a', bar: 2})); // false\nconsole.log(validate.errors); // processed errors\n```\n\nProcessed errors:\n\n```javascript\n[\n  {\n    keyword: 'errorMessage',\n    message: 'should be an object with an integer property foo only',\n    // ...\n    params: {\n      errors: [\n        { keyword: 'additionalProperties', dataPath: '' /* , ... */ },\n        { keyword: 'type', dataPath: '.foo' /* , ... */ }\n      ]\n    }\n  }\n]\n```\n\n\n### Messages for keywords\n\nReplace errors for certain keywords in the current schema only:\n\n```javascript\nvar schema = {\n  type: 'object',\n  required: ['foo'],\n  properties: {\n    foo: { type: 'integer' }\n  },\n  additionalProperties: false,\n  errorMessage: {\n    type: 'should be an object', // will not replace internal \"type\" error for the property \"foo\"\n    required: 'should have property foo',\n    additionalProperties: 'should not have properties other than foo'\n  }\n};\n\nvar validate = ajv.compile(schema);\nconsole.log(validate({foo: 'a', bar: 2})); // false\nconsole.log(validate.errors); // processed errors\n```\n\nProcessed errors:\n\n```javascript\n[\n  {\n    // original error\n    keyword: type,\n    dataPath: '/foo',\n    // ...\n    message: 'should be integer'\n  },\n  {\n    // generated error\n    keyword: 'errorMessage',\n    message: 'should not have properties other than foo',\n    // ...\n    params: {\n      errors: [\n        { keyword: 'additionalProperties' /* , ... */ }\n      ]\n    },\n  }\n]\n```\n\nFor keywords \"required\" and \"dependencies\" it is possible to specify different messages for different properties:\n\n```javascript\nvar schema = {\n  type: 'object',\n  required: ['foo', 'bar'],\n  properties: {\n    foo: { type: 'integer' },\n    bar: { type: 'string' }\n  },\n  errorMessage: {\n    type: 'should be an object', // will not replace internal \"type\" error for the property \"foo\"\n    required: {\n      foo: 'should have an integer property \"foo\"',\n      bar: 'should have a string property \"bar\"'\n    }\n  }\n};\n```\n\n\n### Messages for properties and items\n\nReplace errors for properties / items (and deeper), regardless where in schema they were created:\n\n```javascript\nvar schema = {\n  type: 'object',\n  required: ['foo', 'bar'],\n  allOf: [{\n    properties: {\n      foo: { type: 'integer', minimum: 2 },\n      bar: { type: 'string', minLength: 2 }\n    },\n    additionalProperties: false\n  }],\n  errorMessage: {\n    properties: {\n      foo: 'data.foo should be integer >= 2',\n      bar: 'data.bar should be string with length >= 2'\n    }\n  }\n};\n\nvar validate = ajv.compile(schema);\nconsole.log(validate({foo: 1, bar: 'a'})); // false\nconsole.log(validate.errors); // processed errors\n```\n\nProcessed errors:\n\n```javascript\n[\n  {\n    keyword: 'errorMessage',\n    message: 'data.foo should be integer >= 2',\n    dataPath: '/foo',\n    // ...\n    params: {\n      errors: [\n        { keyword: 'minimum' /* , ... */ }\n      ]\n    },\n  },\n  {\n    keyword: 'errorMessage',\n    message: 'data.bar should be string with length >= 2',\n    dataPath: '/bar',\n    // ...\n    params: {\n      errors: [\n        { keyword: 'minLength' /* , ... */ }\n      ]\n    },\n  }\n]\n```\n\n\n### Default message\n\nWhen the value of keyword `errorMessage` is an object you can specify a message that will be used if any error appears that is not specified by keywords/properties/items:\n\n```javascript\nvar schema = {\n  type: 'object',\n  required: ['foo', 'bar'],\n  allOf: [{\n    properties: {\n      foo: { type: 'integer', minimum: 2 },\n      bar: { type: 'string', minLength: 2 }\n    },\n    additionalProperties: false\n  }],\n  errorMessage: {\n    type: 'data should be an object',\n    properties: {\n      foo: 'data.foo should be integer >= 2',\n      bar: 'data.bar should be string with length >= 2'\n    },\n    _: 'data should have properties \"foo\" and \"bar\" only'\n  }\n};\n\nvar validate = ajv.compile(schema);\nconsole.log(validate({})); // false\nconsole.log(validate.errors); // processed errors\n```\n\nProcessed errors:\n\n```javascript\n[\n  {\n    keyword: 'errorMessage',\n    message: 'data should be an object with properties \"foo\" and \"bar\" only',\n    dataPath: '',\n    // ...\n    params: {\n      errors: [\n        { keyword: 'required' /* , ... */ },\n        { keyword: 'required' /* , ... */ }\n      ]\n    },\n  }\n]\n```\n\nThe message in property `_` of `errorMessage` replaces the same errors that would have been replaced if `errorMessage` were a string.\n\n\n## Templates\n\nCustom error messages used in `errorMessage` keyword can be templates using [JSON-pointers](https://tools.ietf.org/html/rfc6901) or [relative JSON-pointers](http://tools.ietf.org/html/draft-luff-relative-json-pointer-00) to data being validated, in which case the value will be interpolated. Also see [examples](https://gist.github.com/geraintluff/5911303) of relative JSON-pointers.\n\nThe syntax to interpolate a value is `${<pointer>}`.\n\nThe values used in messages will be JSON-stringified:\n- to differentiate between `false` and `\"false\"`, etc.\n- to support structured values.\n\nExample:\n\n```json\n{\n  \"type\": \"object\",\n  \"properties\": {\n    \"size\": {\n      \"type\": \"number\",\n      \"minimum\": 4\n    }\n  },\n  \"errorMessage\": {\n    \"properties\": {\n      \"size\": \"size should be a number bigger or equal to 4, current value is ${/size}\"\n    }\n  }\n}\n```\n\n\n## Options\n\nDefaults:\n\n```javascript\n{\n  keepErrors: false,\n  singleError: false\n}\n```\n\n- _keepErrors_: keep original errors. Default is to remove matched errors (they will still be available in `params.errors` property of generated error). If an error was matched and included in the error generated by `errorMessage` keyword it will have property `emUsed: true`.\n- _singleError_: create one error for all keywords used in `errorMessage` keyword (error messages defined for properties and items are not merged because they have different dataPaths). Multiple error messages are concatenated. Option values:\n  - `false` (default): create multiple errors, one for each message\n  - `true`: create single error, messages are concatenated using `\"; \"`\n  - non-empty string: this string is used as a separator to concatenate messages\n\n\n## Supporters\n\n[<img src=\"https://media.licdn.com/mpr/mpr/shrinknp_400_400/AAEAAQAAAAAAAAwEAAAAJDg1YzBlYzFjLTA3YWYtNGEzOS1iMTdjLTQ0MTU1NWZjOGM0ZQ.jpg\" width=\"48\" height=\"48\">](https://www.linkedin.com/in/rogerkepler/) [Roger Kepler](https://www.linkedin.com/in/rogerkepler/)\n\n\n## License\n\n[MIT](https://github.com/epoberezkin/ajv-errors/blob/master/LICENSE)\n",
+  "maintainers": [
+    {
+      "name": "esp",
+      "email": "e.poberezkin@me.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-12-09T20:44:25.855Z",
+    "created": "2017-03-05T11:40:42.016Z",
+    "0.0.1": "2017-03-05T11:40:42.016Z",
+    "0.1.0": "2017-04-30T18:47:58.032Z",
+    "0.1.1": "2017-04-30T19:36:45.272Z",
+    "0.1.2": "2017-04-30T20:24:16.937Z",
+    "0.2.0": "2017-05-01T16:32:10.431Z",
+    "0.3.0": "2017-05-09T19:14:33.951Z",
+    "0.4.0": "2017-05-09T21:46:40.263Z",
+    "0.5.0": "2017-05-27T15:34:53.768Z",
+    "1.0.0": "2017-05-27T17:59:41.038Z",
+    "1.0.1": "2018-12-09T20:44:23.016Z"
+  },
+  "homepage": "https://github.com/epoberezkin/ajv-errors#readme",
+  "keywords": [
+    "ajv",
+    "json-schema",
+    "validator",
+    "error",
+    "messages"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/epoberezkin/ajv-errors.git"
+  },
+  "bugs": {
+    "url": "https://github.com/epoberezkin/ajv-errors/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "esilva2902": true,
+    "sopov": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/ajv-errors.min.json
+++ b/test/fixtures/registry-mocks/content/ajv-errors.min.json
@@ -1,0 +1,219 @@
+{
+  "name": "ajv-errors",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "ajv-errors",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "9d25c7a77ec8e9ec88017059d32cd699251f2e5b",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.0.1.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "ajv-errors",
+      "version": "0.1.0",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "shasum": "575fe73af89ca815664c97534f6cb21e0fd3143f",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "ajv-errors",
+      "version": "0.1.1",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "shasum": "0e3efa3f1c043b8ba9cbd7c792a1c4d159b7541c",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "ajv-errors",
+      "version": "0.1.2",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "shasum": "561877abb7f15c44032687e37fd9b7638ada7909",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.1.2.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "ajv-errors",
+      "version": "0.2.0",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "shasum": "008204c64a57c9be5ced529a80b05c094f7cd3c0",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "ajv-errors",
+      "version": "0.3.0",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "shasum": "539c41568e1bfd9cf0f50a33a3bf02c11a38f917",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.3.0.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "ajv-errors",
+      "version": "0.4.0",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "shasum": "22f351b6faafdb65c99a04e48d9c0ef608649138",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.4.0.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "ajv-errors",
+      "version": "0.5.0",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "shasum": "e0df4940776e36fa7084c7944c636ac5ea9b747a",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-0.5.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "ajv-errors",
+      "version": "1.0.0",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "shasum": "ecf021fa108fd17dfb5e6b383f2dd233e31ffc59",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "ajv-errors",
+      "version": "1.0.1",
+      "devDependencies": {
+        "ajv": "^5.0.0",
+        "coveralls": "^2.11.16",
+        "dot": "^1.1.1",
+        "eslint": "^3.17.0",
+        "glob": "^7.1.1",
+        "js-beautify": "^1.6.12",
+        "mocha": "^3.2.0",
+        "nyc": "^10.1.2",
+        "pre-commit": "^1.2.2"
+      },
+      "peerDependencies": {
+        "ajv": ">=5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+        "shasum": "f35986aceb91afadec4102fbd85014950cefa64d",
+        "tarball": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 41660,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcDX6nCRA9TVsSAnZWagAAu1sP/R1PmaZCddDScGEKSaDw\npqT+zr5jNjcjyX24Pi8uDye/QwvTdAnqO8kqzg6ZHWJk78kmOw3WsqBGk8S9\nzMDXPJweSTWAZvrNYRiGfchCt9lLuuTdGjvgYxGrTEFiUdEXl9U6SScTxs7X\npy9Vd8hfdTa8TKPxWt8Aj7ELTM13Er71B8V82J63k42YomtsMssxER5d2mqx\nOt92KJvlu+w/cvVzjAS1QquBybVzUwlWWTGzxP/SdN6Z0EzPAT9XoKyr0aeg\n2q+6C0+j88ObOP2tMBS5VOl0E5HTB/1lb0VPVZkMEEDedmnT/bj5r+kSnVKU\nTYQRsLb1VsbYqtHWyCIS996DxtfiAh8hUchHJYSdCSz4eiOkteYRvGYKQlYa\n4t/T9EmDpe6HH7GYKujMIFKSSTZRSAIWwenAlARWSEscZlXyD5ql2CiSLdRh\n2UOWf/DK8QzjbaBX4Iki9W+8ResOA/2nA15o2YT9RSfeX10qymAckwkgU/U4\nRB1QSKFpkdpYvrhcdxSnPIGXB5nhmRik/NP+VbdRz8Fqm4Rjz4LmUg4wqkq4\nbs9JsnrqSsknsNrMxB83nBR0L/iHHWfyJZAIow/KWYHF3cIU5CvmBQQIRDc+\nJ6zgHs6x80YIb0qWey/Wz98rJb2L1uYSI3j8TgBzePf/B+g2ozqKS9+pou0K\n6Z7v\r\n=0kuF\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2018-12-09T20:44:25.855Z"
+}

--- a/test/fixtures/registry-mocks/content/aproba.json
+++ b/test/fixtures/registry-mocks/content/aproba.json
@@ -1,0 +1,653 @@
+{
+  "_id": "aproba",
+  "_rev": "37-e733fc1dd57e9f122eb3720243a5a609",
+  "name": "aproba",
+  "description": "A ridiculously light-weight argument validator (now browser friendly)",
+  "dist-tags": {
+    "latest": "2.0.0",
+    "😄": "1.1.1",
+    "abc": "1.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "aproba",
+      "version": "1.0.0",
+      "description": "A rediculously light-weight argument validator",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tap": "^0.7.0"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/iarna/aproba"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "7b629c6936c66ca96a92f28868ea4a7437ce0423",
+      "_id": "aproba@1.0.0",
+      "_shasum": "f39befddc04b8838d838fedf410c4ac957c6061e",
+      "_from": ".",
+      "_npmVersion": "2.6.0",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "dist": {
+        "shasum": "f39befddc04b8838d838fedf410c4ac957c6061e",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "aproba",
+      "version": "1.0.1",
+      "description": "A rediculously light-weight argument validator",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tap": "^0.7.0"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/iarna/aproba"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "a2ea029793a14cddb9457afd0a83dc421889c7ad",
+      "_id": "aproba@1.0.1",
+      "_shasum": "c4ac2cc5becfb8b099de7ef9f02790e7d32d99ef",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "dist": {
+        "shasum": "c4ac2cc5becfb8b099de7ef9f02790e7d32d99ef",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "aproba",
+      "version": "1.0.2",
+      "description": "A rediculously light-weight argument validator",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^7.1.0",
+        "tap": "^5.7.1"
+      },
+      "scripts": {
+        "test": "standard && tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/aproba.git"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "a876671b59fb16f69bd09005373e1c855867a45b",
+      "_id": "aproba@1.0.2",
+      "_shasum": "81f5191afa95e3afb7a54d7843206d80eaf556bc",
+      "_from": ".",
+      "_npmVersion": "3.9.2",
+      "_nodeVersion": "4.4.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "81f5191afa95e3afb7a54d7843206d80eaf556bc",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/aproba-1.0.2.tgz_1463783935433_0.4466458926908672"
+      }
+    },
+    "1.0.3": {
+      "name": "aproba",
+      "version": "1.0.3",
+      "description": "A rediculously light-weight argument validator",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^7.1.0",
+        "tap": "^5.7.1"
+      },
+      "scripts": {
+        "test": "standard && tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/aproba.git"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "20cc4fc6589bbf870c3ca7bb8b9cb203af9d96a5",
+      "_id": "aproba@1.0.3",
+      "_shasum": "7fb6da3a72c70249db63fd9b5c64b31af718a94f",
+      "_from": ".",
+      "_npmVersion": "3.9.2",
+      "_nodeVersion": "4.4.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "7fb6da3a72c70249db63fd9b5c64b31af718a94f",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/aproba-1.0.3.tgz_1463784729571_0.7574592484161258"
+      }
+    },
+    "1.0.4": {
+      "name": "aproba",
+      "version": "1.0.4",
+      "description": "A rediculously light-weight argument validator",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tap": "^5.7.3"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "test": "standard && tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/aproba.git"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "c6c8f82d519b9ec3816f20f23a9101083c022200",
+      "_id": "aproba@1.0.4",
+      "_shasum": "2713680775e7614c8ba186c065d4e2e52d1072c0",
+      "_from": ".",
+      "_npmVersion": "3.10.2",
+      "_nodeVersion": "4.4.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "2713680775e7614c8ba186c065d4e2e52d1072c0",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/aproba-1.0.4.tgz_1466718885402_0.5348939662799239"
+      }
+    },
+    "1.1.0": {
+      "name": "aproba",
+      "version": "1.1.0",
+      "description": "A rediculously light-weight argument validator",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "test": "standard && tap -j3 test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/aproba.git"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "e943d94d7a46edb42a04e649ab04009675059132",
+      "_id": "aproba@1.1.0",
+      "_shasum": "4d8f047a318604e18e3c06a0e52230d3d19f147b",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "4d8f047a318604e18e3c06a0e52230d3d19f147b",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/aproba-1.1.0.tgz_1486503816365_0.2735283097717911"
+      }
+    },
+    "1.1.1": {
+      "name": "aproba",
+      "version": "1.1.1",
+      "description": "A rediculously light-weight argument validator",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "test": "standard && tap -j3 test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/aproba.git"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "e7c76b4b42356092db3cd9e2d9388a0134845eb2",
+      "_id": "aproba@1.1.1",
+      "_shasum": "95d3600f07710aa0e9298c726ad5ecf2eacbabab",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "95d3600f07710aa0e9298c726ad5ecf2eacbabab",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/aproba-1.1.1.tgz_1486593129508_0.5718816472217441"
+      }
+    },
+    "1.1.2": {
+      "name": "aproba",
+      "version": "1.1.2",
+      "description": "A rediculously light-weight argument validator",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "test": "standard && tap -j3 test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/aproba.git"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "52c6ebad8d130158e90cc849625a590739c6ce1f",
+      "_id": "aproba@1.1.2",
+      "_npmVersion": "5.0.1",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+        "shasum": "45c6629094de4e96f693ef7eab74ae079c240fc1",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/aproba-1.1.2.tgz_1496445352224_0.2260909820906818"
+      }
+    },
+    "1.2.0": {
+      "name": "aproba",
+      "version": "1.2.0",
+      "description": "A ridiculously light-weight argument validator (now browser friendly)",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tap": "^10.0.2"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "test": "standard && tap -j3 test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/aproba.git"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "ee43ce68c9992e8f9d0d925dc2b1f2e1e5c976de",
+      "_id": "aproba@1.2.0",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+        "shasum": "6802e6264efd18c790a1b0d517f0f2627bf2c94a",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/aproba-1.2.0.tgz_1505861292502_0.3447994305752218"
+      }
+    },
+    "2.0.0": {
+      "name": "aproba",
+      "version": "2.0.0",
+      "description": "A ridiculously light-weight argument validator (now browser friendly)",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "tap": "^12.0.1"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "pretest": "standard",
+        "test": "tap --100 -J test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/aproba.git"
+      },
+      "keywords": [
+        "argument",
+        "validate"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/aproba/issues"
+      },
+      "homepage": "https://github.com/iarna/aproba",
+      "gitHead": "f87074e0c9b1afbd6ba1b2eab4736433d29d85f8",
+      "_id": "aproba@2.0.0",
+      "_npmVersion": "6.1.0-next.0",
+      "_nodeVersion": "9.11.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+        "shasum": "52520b8ae5b569215b354efc0caa3fe1e45a8adc",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8047,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbBIvMCRA9TVsSAnZWagAAAIcP/1qup9qwIgKp+SCSf0rR\nsHJO1GAdECnBCghAqMfUM7biv6tZOP3RbZkQKhVA8YU+Fl80BgFQ4ZiKa1SU\nazt54yur3sb3Tm80lyR4EZ3v3pBq0Gbzp/gVnJgQuvAoTU4bAba/CDXmj8Df\npmRUZNSPqjJK4zD5tGTfWd3sfY6lgQC/T401z0WafF/T82pE6wpJPMLyds/H\nnw8p5rbHwLNbdYihX/Gv8G4AdHuFtRRFOi1vDky1NUrs8k32N21EmlOaNC4y\nJ7x9VsWNZTqcmb8zwp3fQv+/IGdY36hZTFlF2Ig2u2UaapzL9u2vFEZAOmZ9\n6eGjz8ZYepa11/QuOr1sZJM9xQzJNqT89VsB7gZMci4kJ3pk8e8Za1vJC2Ub\nx7bJSKTsCMUclDjZBLpPv0QczW61os6kIWoZLzEs+MIESCBU8GVX4pNjEaoB\nGFDyMTYmu93c6+23FxTVPjofFI7Bt3tJ55l4v5rX5uNiQhlkVHw71kztYQ9r\nv2Uq5tdeaohrzfRUhNVWxwBup6+zDBJP4fS6G+2l7KPtx1Ylkm9xsT8P6LOm\nW+6426jArfwiygOZgNewZDQHhsvbx2PmpWwZt/+WJpW+hPtdAAxBJCD96NFJ\nJqIwaDaJ7K6gSkr56hhwu2BMOptk8WtcD3w0NTsMUhJqy4tJPzeqtznToSD1\n7dh9\r\n=/XJn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/aproba_2.0.0_1527024586301_0.30200366760036923"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "aproba\n======\n\nA ridiculously light-weight function argument validator\n\n```\nvar validate = require(\"aproba\")\n\nfunction myfunc(a, b, c) {\n  // `a` must be a string, `b` a number, `c` a function\n  validate('SNF', arguments) // [a,b,c] is also valid\n}\n\nmyfunc('test', 23, function () {}) // ok\nmyfunc(123, 23, function () {}) // type error\nmyfunc('test', 23) // missing arg error\nmyfunc('test', 23, function () {}, true) // too many args error\n\n```\n\nValid types are:\n\n| type | description\n| :--: | :----------\n| *    | matches any type\n| A    | `Array.isArray` OR an `arguments` object\n| S    | typeof == string\n| N    | typeof == number\n| F    | typeof == function\n| O    | typeof == object and not type A and not type E\n| B    | typeof == boolean\n| E    | `instanceof Error` OR `null` **(special: see below)**\n| Z    | == `null`\n\nValidation failures throw one of three exception types, distinguished by a\n`code` property of `EMISSINGARG`, `EINVALIDTYPE` or `ETOOMANYARGS`.\n\nIf you pass in an invalid type then it will throw with a code of\n`EUNKNOWNTYPE`.\n\nIf an **error** argument is found and is not null then the remaining\narguments are optional.  That is, if you say `ESO` then that's like using a\nnon-magical `E` in: `E|ESO|ZSO`.\n\n### But I have optional arguments?!\n\nYou can provide more than one signature by separating them with pipes `|`.\nIf any signature matches the arguments then they'll be considered valid.\n\nSo for example, say you wanted to write a signature for\n`fs.createWriteStream`.  The docs for it describe it thusly:\n\n```\nfs.createWriteStream(path[, options])\n```\n\nThis would be a signature of `SO|S`.  That is, a string and and object, or\njust a string.\n\nNow, if you read the full `fs` docs, you'll see that actually path can ALSO\nbe a buffer.  And options can be a string, that is:\n```\npath <String> | <Buffer>\noptions <String> | <Object>\n```\n\nTo reproduce this you have to fully enumerate all of the possible\ncombinations and that implies a signature of `SO|SS|OO|OS|S|O`.  The\nawkwardness is a feature: It reminds you of the complexity you're adding to\nyour API when you do this sort of thing.\n\n\n### Browser support\n\nThis has no dependencies and should work in browsers, though you'll have\nnoisier stack traces.\n\n### Why this exists\n\nI wanted a very simple argument validator. It needed to do two things:\n\n1. Be more concise and easier to use than assertions\n\n2. Not encourage an infinite bikeshed of DSLs\n\nThis is why types are specified by a single character and there's no such\nthing as an optional argument. \n\nThis is not intended to validate user data. This is specifically about\nasserting the interface of your functions.\n\nIf you need greater validation, I encourage you to write them by hand or\nlook elsewhere.\n\n",
+  "maintainers": [
+    {
+      "name": "iarna",
+      "email": "me@re-becca.org"
+    }
+  ],
+  "time": {
+    "modified": "2020-01-04T09:18:59.213Z",
+    "created": "2015-02-27T18:11:19.818Z",
+    "1.0.0": "2015-02-27T18:11:19.818Z",
+    "1.0.1": "2015-04-09T19:24:02.127Z",
+    "1.0.2": "2016-05-20T22:38:57.683Z",
+    "1.0.3": "2016-05-20T22:52:09.980Z",
+    "1.0.4": "2016-06-23T21:54:45.947Z",
+    "1.1.0": "2017-02-07T21:43:38.939Z",
+    "1.1.1": "2017-02-08T22:32:11.372Z",
+    "1.1.2": "2017-06-02T23:15:52.316Z",
+    "1.2.0": "2017-09-19T22:48:12.592Z",
+    "2.0.0": "2018-05-22T21:29:46.504Z"
+  },
+  "homepage": "https://github.com/iarna/aproba",
+  "keywords": [
+    "argument",
+    "validate"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iarna/aproba.git"
+  },
+  "author": {
+    "name": "Rebecca Turner",
+    "email": "me@re-becca.org"
+  },
+  "bugs": {
+    "url": "https://github.com/iarna/aproba/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "hal9zillion": true,
+    "nguru": true,
+    "lgomez": true,
+    "iarna": true,
+    "buzuli": true,
+    "oleg_tsyba": true,
+    "wangnan0610": true,
+    "detj": true,
+    "xu3927": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/aproba.min.json
+++ b/test/fixtures/registry-mocks/content/aproba.min.json
@@ -1,0 +1,165 @@
+{
+  "name": "aproba",
+  "dist-tags": {
+    "latest": "2.0.0",
+    "😄": "1.1.1",
+    "abc": "1.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "aproba",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tap": "^0.7.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "f39befddc04b8838d838fedf410c4ac957c6061e",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "aproba",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tap": "^0.7.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "c4ac2cc5becfb8b099de7ef9f02790e7d32d99ef",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "aproba",
+      "version": "1.0.2",
+      "devDependencies": {
+        "standard": "^7.1.0",
+        "tap": "^5.7.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "81f5191afa95e3afb7a54d7843206d80eaf556bc",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "aproba",
+      "version": "1.0.3",
+      "devDependencies": {
+        "standard": "^7.1.0",
+        "tap": "^5.7.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "7fb6da3a72c70249db63fd9b5c64b31af718a94f",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "aproba",
+      "version": "1.0.4",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tap": "^5.7.3"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "2713680775e7614c8ba186c065d4e2e52d1072c0",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "aproba",
+      "version": "1.1.0",
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "4d8f047a318604e18e3c06a0e52230d3d19f147b",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "aproba",
+      "version": "1.1.1",
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "95d3600f07710aa0e9298c726ad5ecf2eacbabab",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "aproba",
+      "version": "1.1.2",
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
+        "shasum": "45c6629094de4e96f693ef7eab74ae079c240fc1",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "aproba",
+      "version": "1.2.0",
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tap": "^10.0.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+        "shasum": "6802e6264efd18c790a1b0d517f0f2627bf2c94a",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "aproba",
+      "version": "2.0.0",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "tap": "^12.0.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
+        "shasum": "52520b8ae5b569215b354efc0caa3fe1e45a8adc",
+        "tarball": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8047,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbBIvMCRA9TVsSAnZWagAAAIcP/1qup9qwIgKp+SCSf0rR\nsHJO1GAdECnBCghAqMfUM7biv6tZOP3RbZkQKhVA8YU+Fl80BgFQ4ZiKa1SU\nazt54yur3sb3Tm80lyR4EZ3v3pBq0Gbzp/gVnJgQuvAoTU4bAba/CDXmj8Df\npmRUZNSPqjJK4zD5tGTfWd3sfY6lgQC/T401z0WafF/T82pE6wpJPMLyds/H\nnw8p5rbHwLNbdYihX/Gv8G4AdHuFtRRFOi1vDky1NUrs8k32N21EmlOaNC4y\nJ7x9VsWNZTqcmb8zwp3fQv+/IGdY36hZTFlF2Ig2u2UaapzL9u2vFEZAOmZ9\n6eGjz8ZYepa11/QuOr1sZJM9xQzJNqT89VsB7gZMci4kJ3pk8e8Za1vJC2Ub\nx7bJSKTsCMUclDjZBLpPv0QczW61os6kIWoZLzEs+MIESCBU8GVX4pNjEaoB\nGFDyMTYmu93c6+23FxTVPjofFI7Bt3tJ55l4v5rX5uNiQhlkVHw71kztYQ9r\nv2Uq5tdeaohrzfRUhNVWxwBup6+zDBJP4fS6G+2l7KPtx1Ylkm9xsT8P6LOm\nW+6426jArfwiygOZgNewZDQHhsvbx2PmpWwZt/+WJpW+hPtdAAxBJCD96NFJ\nJqIwaDaJ7K6gSkr56hhwu2BMOptk8WtcD3w0NTsMUhJqy4tJPzeqtznToSD1\n7dh9\r\n=/XJn\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-01-04T09:18:59.213Z"
+}

--- a/test/fixtures/registry-mocks/content/arr-union.json
+++ b/test/fixtures/registry-mocks/content/arr-union.json
@@ -1,0 +1,523 @@
+{
+  "_id": "arr-union",
+  "_rev": "10-0fd8e6d54b84107189ff607bee51e652",
+  "name": "arr-union",
+  "description": "Combines a list of arrays, returning a single array with unique values, using strict equality for comparisons.",
+  "dist-tags": {
+    "latest": "3.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "arr-union",
+      "description": "Returns an array of unique values using strict equality for comparisons, maintaining the same order as the provided arrays .",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/arr-union",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/arr-union.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/arr-union/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/arr-union/blob/master/LICENSE-MIT"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.3.1"
+      },
+      "dependencies": {
+        "array-unique": "^0.1.1"
+      },
+      "keywords": [
+        "array",
+        "concat",
+        "union",
+        "unique",
+        "javascript",
+        "js",
+        "util",
+        "utility",
+        "utils"
+      ],
+      "_id": "arr-union@1.0.0",
+      "_shasum": "72add1e923d9c3dd9488cd1843c178f4f102108a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "72add1e923d9c3dd9488cd1843c178f4f102108a",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "arr-union",
+      "description": "Returns an array of unique values using strict equality for comparisons.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/arr-union",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/arr-union.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/arr-union/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/arr-union/blob/master/LICENSE-MIT"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "array-union": "^1.0.1",
+        "array-unique": "^0.1.1",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.3.1"
+      },
+      "keywords": [
+        "array",
+        "concat",
+        "javascript",
+        "js",
+        "union",
+        "uniq",
+        "unique",
+        "util",
+        "utility",
+        "utils"
+      ],
+      "gitHead": "475b44f5059072116528bc2a8aac97ec466f0ac0",
+      "_id": "arr-union@2.0.0",
+      "_shasum": "55fb6461d9c1da0164ae706c747365f6fd15ca2d",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "55fb6461d9c1da0164ae706c747365f6fd15ca2d",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "arr-union",
+      "description": "Combines a list of arrays, returning a single array with unique values, using strict equality for comparisons.",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/arr-union",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/arr-union.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/arr-union/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/arr-union/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "array-union": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "benchmarked": "^0.1.3",
+        "chalk": "^1.0.0",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.1",
+        "should": "^5.2.0"
+      },
+      "keywords": [
+        "array",
+        "concat",
+        "javascript",
+        "js",
+        "union",
+        "uniq",
+        "unique",
+        "util",
+        "utility",
+        "utils"
+      ],
+      "gitHead": "475b44f5059072116528bc2a8aac97ec466f0ac0",
+      "_id": "arr-union@2.0.1",
+      "_shasum": "3a08cb18a14a4b54d0765fbc0fd9769ba7a5fa3b",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3a08cb18a14a4b54d0765fbc0fd9769ba7a5fa3b",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "arr-union",
+      "description": "Combines a list of arrays, returning a single array with unique values, using strict equality for comparisons.",
+      "version": "2.1.0",
+      "homepage": "https://github.com/jonschlinkert/arr-union",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/arr-union.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/arr-union/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "array-union": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "benchmarked": "^0.1.3",
+        "chalk": "^1.0.0",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.1",
+        "should": "^5.2.0",
+        "verb": "^0.8.6"
+      },
+      "keywords": [
+        "add",
+        "append",
+        "array",
+        "arrays",
+        "combine",
+        "concat",
+        "extend",
+        "union",
+        "uniq",
+        "unique",
+        "util",
+        "utility",
+        "utils"
+      ],
+      "gitHead": "2eb911d44a165f0e2009c61cc10f65454a1049e3",
+      "_id": "arr-union@2.1.0",
+      "_shasum": "20f9eab5ec70f5c7d215b1077b1c39161d292c7d",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "20f9eab5ec70f5c7d215b1077b1c39161d292c7d",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "arr-union",
+      "description": "Combines a list of arrays, returning a single array with unique values, using strict equality for comparisons.",
+      "version": "3.0.0",
+      "homepage": "https://github.com/jonschlinkert/arr-union",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/arr-union.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/arr-union/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "array-union": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "benchmarked": "^0.1.4",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.5",
+        "should": "^7.0.1"
+      },
+      "keywords": [
+        "add",
+        "append",
+        "array",
+        "arrays",
+        "combine",
+        "concat",
+        "extend",
+        "union",
+        "uniq",
+        "unique",
+        "util",
+        "utility",
+        "utils"
+      ],
+      "gitHead": "f348950a55a09f4ae503137179a41410efd793a7",
+      "_id": "arr-union@3.0.0",
+      "_shasum": "8abd14617847f32479a4c76fd286d91a23238030",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8abd14617847f32479a4c76fd286d91a23238030",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "arr-union",
+      "description": "Combines a list of arrays, returning a single array with unique values, using strict equality for comparisons.",
+      "version": "3.1.0",
+      "homepage": "https://github.com/jonschlinkert/arr-union",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/arr-union.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/arr-union/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "array-union": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "benchmarked": "^0.1.4",
+        "gulp-format-md": "^0.1.7",
+        "minimist": "^1.1.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "add",
+        "append",
+        "array",
+        "arrays",
+        "combine",
+        "concat",
+        "extend",
+        "union",
+        "uniq",
+        "unique",
+        "util",
+        "utility",
+        "utils"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "arr-diff",
+            "arr-flatten",
+            "arr-filter",
+            "arr-map",
+            "arr-pluck",
+            "arr-reduce",
+            "array-unique"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "array-union"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "ede857f5d5082467534e372fd3da45ce5e782e93",
+      "_id": "arr-union@3.1.0",
+      "_shasum": "e39b09aea9def866a8f206e288af63919bae39c4",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e39b09aea9def866a8f206e288af63919bae39c4",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/arr-union-3.1.0.tgz_1456232075611_0.8481670441105962"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# arr-union [![NPM version](https://img.shields.io/npm/v/arr-union.svg)](https://www.npmjs.com/package/arr-union) [![Build Status](https://img.shields.io/travis/jonschlinkert/arr-union.svg)](https://travis-ci.org/jonschlinkert/arr-union)\n\n> Combines a list of arrays, returning a single array with unique values, using strict equality for comparisons.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm i arr-union --save\n```\n\n## Benchmarks\n\nThis library is **10-20 times faster** and more performant than [array-union](https://github.com/sindresorhus/array-union).\n\nSee the [benchmarks](./benchmark).\n\n```sh\n#1: five-arrays\n  array-union x 511,121 ops/sec ±0.80% (96 runs sampled)\n  arr-union x 5,716,039 ops/sec ±0.86% (93 runs sampled)\n\n#2: ten-arrays\n  array-union x 245,196 ops/sec ±0.69% (94 runs sampled)\n  arr-union x 1,850,786 ops/sec ±0.84% (97 runs sampled)\n\n#3: two-arrays\n  array-union x 563,869 ops/sec ±0.97% (94 runs sampled)\n  arr-union x 9,602,852 ops/sec ±0.87% (92 runs sampled)\n```\n\n## Usage\n\n```js\nvar union = require('arr-union');\n\nunion(['a'], ['b', 'c'], ['d', 'e', 'f']);\n//=> ['a', 'b', 'c', 'd', 'e', 'f']\n```\n\nReturns only unique elements:\n\n```js\nunion(['a', 'a'], ['b', 'c']);\n//=> ['a', 'b', 'c']\n```\n\n## Related projects\n\n* [arr-diff](https://www.npmjs.com/package/arr-diff): Returns an array with only the unique values from the first array, by excluding all… [more](https://www.npmjs.com/package/arr-diff) | [homepage](https://github.com/jonschlinkert/arr-diff)\n* [arr-filter](https://www.npmjs.com/package/arr-filter): Faster alternative to javascript's native filter method. | [homepage](https://github.com/jonschlinkert/arr-filter)\n* [arr-flatten](https://www.npmjs.com/package/arr-flatten): Recursively flatten an array or arrays. This is the fastest implementation of array flatten. | [homepage](https://github.com/jonschlinkert/arr-flatten)\n* [arr-map](https://www.npmjs.com/package/arr-map): Faster, node.js focused alternative to JavaScript's native array map. | [homepage](https://github.com/jonschlinkert/arr-map)\n* [arr-pluck](https://www.npmjs.com/package/arr-pluck): Retrieves the value of a specified property from all elements in the collection. | [homepage](https://github.com/jonschlinkert/arr-pluck)\n* [arr-reduce](https://www.npmjs.com/package/arr-reduce): Fast array reduce that also loops over sparse elements. | [homepage](https://github.com/jonschlinkert/arr-reduce)\n* [array-unique](https://www.npmjs.com/package/array-unique): Return an array free of duplicate values. Fastest ES5 implementation. | [homepage](https://github.com/jonschlinkert/array-unique)\n\n## Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](https://github.com/jonschlinkert/arr-union/issues/new).\n\n## Building docs\n\nGenerate readme and API documentation with [verb](https://github.com/verbose/verb):\n\n```sh\n$ npm i verb && npm run docs\n```\n\nOr, if [verb](https://github.com/verbose/verb) is installed globally:\n\n```sh\n$ verb\n```\n\n## Running tests\n\nInstall dev dependencies:\n\n```sh\n$ npm i -d && npm test\n```\n\n## Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](http://twitter.com/jonschlinkert)\n\n## License\n\nCopyright © 2016 [Jon Schlinkert](https://github.com/jonschlinkert)\nReleased under the [MIT license](https://github.com/jonschlinkert/arr-union/blob/master/LICENSE).\n\n***\n\n_This file was generated by [verb](https://github.com/verbose/verb), v0.9.0, on February 23, 2016._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-10-08T11:14:08.952Z",
+    "created": "2014-12-12T11:05:28.499Z",
+    "1.0.0": "2014-12-12T11:05:28.499Z",
+    "2.0.0": "2015-01-04T15:17:19.961Z",
+    "2.0.1": "2015-03-25T06:40:44.401Z",
+    "2.1.0": "2015-06-15T07:47:52.634Z",
+    "3.0.0": "2015-07-04T05:38:29.731Z",
+    "3.1.0": "2016-02-23T12:54:40.819Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/arr-union",
+  "keywords": [
+    "add",
+    "append",
+    "array",
+    "arrays",
+    "combine",
+    "concat",
+    "extend",
+    "union",
+    "uniq",
+    "unique",
+    "util",
+    "utility",
+    "utils"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/arr-union.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/arr-union/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "rocket0191": true,
+    "leix3041": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/arr-union.min.json
+++ b/test/fixtures/registry-mocks/content/arr-union.min.json
@@ -1,0 +1,129 @@
+{
+  "name": "arr-union",
+  "dist-tags": {
+    "latest": "3.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "arr-union",
+      "version": "1.0.0",
+      "dependencies": {
+        "array-unique": "^0.1.1"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.3.1"
+      },
+      "dist": {
+        "shasum": "72add1e923d9c3dd9488cd1843c178f4f102108a",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "arr-union",
+      "version": "2.0.0",
+      "devDependencies": {
+        "array-union": "^1.0.1",
+        "array-unique": "^0.1.1",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.3.1"
+      },
+      "dist": {
+        "shasum": "55fb6461d9c1da0164ae706c747365f6fd15ca2d",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.1": {
+      "name": "arr-union",
+      "version": "2.0.1",
+      "devDependencies": {
+        "array-union": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "benchmarked": "^0.1.3",
+        "chalk": "^1.0.0",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.1",
+        "should": "^5.2.0"
+      },
+      "dist": {
+        "shasum": "3a08cb18a14a4b54d0765fbc0fd9769ba7a5fa3b",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.1.0": {
+      "name": "arr-union",
+      "version": "2.1.0",
+      "devDependencies": {
+        "array-union": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "benchmarked": "^0.1.3",
+        "chalk": "^1.0.0",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.1",
+        "should": "^5.2.0",
+        "verb": "^0.8.6"
+      },
+      "dist": {
+        "shasum": "20f9eab5ec70f5c7d215b1077b1c39161d292c7d",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "arr-union",
+      "version": "3.0.0",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "array-union": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "benchmarked": "^0.1.4",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.5",
+        "should": "^7.0.1"
+      },
+      "dist": {
+        "shasum": "8abd14617847f32479a4c76fd286d91a23238030",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.1.0": {
+      "name": "arr-union",
+      "version": "3.1.0",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "array-union": "^1.0.1",
+        "array-unique": "^0.2.1",
+        "benchmarked": "^0.1.4",
+        "gulp-format-md": "^0.1.7",
+        "minimist": "^1.1.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "e39b09aea9def866a8f206e288af63919bae39c4",
+        "tarball": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-10-08T11:14:08.952Z"
+}

--- a/test/fixtures/registry-mocks/content/array-flatten.json
+++ b/test/fixtures/registry-mocks/content/array-flatten.json
@@ -1,0 +1,859 @@
+{
+  "_id": "array-flatten",
+  "_rev": "38-ff1320bbb141cf4897d277a86db3c973",
+  "name": "array-flatten",
+  "time": {
+    "modified": "2019-11-21T05:14:42.269Z",
+    "created": "2014-03-16T01:38:15.278Z",
+    "0.0.1": "2014-03-16T01:38:15.278Z",
+    "0.0.2": "2014-03-16T04:13:40.954Z",
+    "0.0.3": "2014-08-17T17:49:57.857Z",
+    "1.0.0": "2014-08-17T18:11:00.008Z",
+    "1.0.1": "2015-01-12T09:00:11.413Z",
+    "1.0.2": "2015-01-13T05:58:48.541Z",
+    "1.1.0": "2015-05-09T21:48:40.747Z",
+    "1.1.1": "2015-07-09T21:42:55.619Z",
+    "2.0.0": "2015-11-16T03:14:26.425Z",
+    "2.1.0": "2016-04-29T00:43:12.819Z",
+    "2.1.1": "2017-01-14T01:09:38.922Z",
+    "2.1.2": "2018-12-03T00:21:55.036Z",
+    "3.0.0": "2019-11-21T05:14:39.925Z"
+  },
+  "description": "Flatten nested arrays",
+  "readme": "# Array Flatten\n\n[![NPM version][npm-image]][npm-url]\n[![NPM downloads][downloads-image]][downloads-url]\n[![Build status][travis-image]][travis-url]\n[![Test coverage][coveralls-image]][coveralls-url]\n[![Bundle size][bundlephobia-image]][bundlephobia-url]\n\n> Flatten nested arrays.\n\n## Installation\n\n```\nnpm install array-flatten --save\n```\n\n## Usage\n\n```js\nimport { flatten } from \"array-flatten\";\n\nflatten([1, [2, [3, [4, [5], 6], 7], 8], 9]);\n//=> [1, 2, 3, 4, 5, 6, 7, 8, 9]\n\n(function() {\n  flatten(arguments); //=> [1, 2, 3]\n})(1, [2, 3]);\n```\n\n## License\n\nMIT\n\n[npm-image]: https://img.shields.io/npm/v/array-flatten.svg?style=flat\n[npm-url]: https://npmjs.org/package/array-flatten\n[downloads-image]: https://img.shields.io/npm/dm/array-flatten.svg?style=flat\n[downloads-url]: https://npmjs.org/package/array-flatten\n[travis-image]: https://img.shields.io/travis/blakeembrey/array-flatten.svg?style=flat\n[travis-url]: https://travis-ci.org/blakeembrey/array-flatten\n[coveralls-image]: https://img.shields.io/coveralls/blakeembrey/array-flatten.svg?style=flat\n[coveralls-url]: https://coveralls.io/r/blakeembrey/array-flatten?branch=master\n[bundlephobia-image]: https://img.shields.io/bundlephobia/minzip/array-flatten.svg\n[bundlephobia-url]: https://bundlephobia.com/result?p=array-flatten\n",
+  "maintainers": [
+    {
+      "name": "blakeembrey",
+      "email": "hello@blakeembrey.com"
+    }
+  ],
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "0.0.2": {
+      "name": "array-flatten",
+      "version": "0.0.2",
+      "description": "Flatten a multi-dimensional array.",
+      "main": "array-flatten.js",
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten"
+      ],
+      "author": {
+        "name": "Blake Embrey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "mocha": "^1.18.0",
+        "istanbul": "^0.2.6"
+      },
+      "_id": "array-flatten@0.0.2",
+      "dist": {
+        "shasum": "51b2f144f36fd656f627740a1fd0ad57979ad6c2",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "array-flatten",
+      "version": "0.0.3",
+      "description": "Flatten a multi-dimensional array.",
+      "main": "array-flatten.js",
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten"
+      ],
+      "author": {
+        "name": "Blake Embrey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "mocha": "^1.18.0",
+        "istanbul": "^0.2.6"
+      },
+      "gitHead": "9bcb9b907884f25e343f30488ac7473e65e0bba5",
+      "_id": "array-flatten@0.0.3",
+      "_shasum": "0546c3c23ad49c5fec896930680a154b3014eae8",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0546c3c23ad49c5fec896930680a154b3014eae8",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-0.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "array-flatten",
+      "version": "1.0.0",
+      "description": "Flatten a multi-dimensional array.",
+      "main": "array-flatten.js",
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten"
+      ],
+      "author": {
+        "name": "Blake Embrey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "mocha": "^1.18.0",
+        "istanbul": "^0.2.6"
+      },
+      "gitHead": "b5a19b457cf6b892d45ce22a8b04c749e2146e19",
+      "_id": "array-flatten@1.0.0",
+      "_shasum": "2b672d3b56fad41b050eee8cbf36f7a83ec3b040",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2b672d3b56fad41b050eee8cbf36f7a83ec3b040",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "array-flatten",
+      "version": "1.0.1",
+      "description": "Flatten a multi-dimensional array.",
+      "main": "array-flatten.js",
+      "files": [
+        "array-flatten.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "istanbul": "^0.2.6",
+        "mocha": "^1.18.0",
+        "pre-commit": "0.0.9"
+      },
+      "gitHead": "223b1a9f12df1d98b7c9f517c90e873db959e6b6",
+      "_id": "array-flatten@1.0.1",
+      "_shasum": "cacb24fbeed6c0014fa751a39a01a90e212a38b8",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cacb24fbeed6c0014fa751a39a01a90e212a38b8",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "array-flatten",
+      "version": "1.0.2",
+      "description": "Flatten a multi-dimensional array.",
+      "main": "array-flatten.js",
+      "files": [
+        "array-flatten.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "istanbul": "^0.2.6",
+        "mocha": "^1.18.0",
+        "pre-commit": "0.0.9"
+      },
+      "gitHead": "31e383659b87ad53121565580eb5d354fea42627",
+      "_id": "array-flatten@1.0.2",
+      "_shasum": "c94703edbf0677694f9b61c67b99615b85bd6dd0",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c94703edbf0677694f9b61c67b99615b85bd6dd0",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "array-flatten",
+      "version": "1.1.0",
+      "description": "Flatten an array of nested arrays into a single flat array",
+      "main": "array-flatten.js",
+      "files": [
+        "array-flatten.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments",
+        "depth"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "istanbul": "^0.3.13",
+        "mocha": "^2.2.4",
+        "pre-commit": "^1.0.7",
+        "standard": "^3.7.3"
+      },
+      "gitHead": "73c57136fb4210569e585555988cc8c39c3468df",
+      "_id": "array-flatten@1.1.0",
+      "_shasum": "ac3efac717b0e7bbdc778ce0bde7381ac6604393",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "1.8.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ac3efac717b0e7bbdc778ce0bde7381ac6604393",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "array-flatten",
+      "version": "1.1.1",
+      "description": "Flatten an array of nested arrays into a single flat array",
+      "main": "array-flatten.js",
+      "files": [
+        "array-flatten.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments",
+        "depth"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "istanbul": "^0.3.13",
+        "mocha": "^2.2.4",
+        "pre-commit": "^1.0.7",
+        "standard": "^3.7.3"
+      },
+      "gitHead": "1963a9189229d408e1e8f585a00c8be9edbd1803",
+      "_id": "array-flatten@1.1.1",
+      "_shasum": "9a5f699051b1e7073328f2a008968b64ea2955d2",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "2.3.3",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9a5f699051b1e7073328f2a008968b64ea2955d2",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "array-flatten",
+      "version": "2.0.0",
+      "description": "Flatten nested arrays",
+      "main": "array-flatten.js",
+      "files": [
+        "array-flatten.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha -R spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec --bail",
+        "test": "npm run lint && npm run test-cov",
+        "benchmark": "node benchmark"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments",
+        "depth",
+        "fast",
+        "for"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "benchmarked": "^0.1.4",
+        "istanbul": "^0.4.0",
+        "mocha": "^2.2.4",
+        "pre-commit": "^1.0.7",
+        "standard": "^5.3.1"
+      },
+      "gitHead": "d947b86ed11cd952f1bf84dbfa584099845385a2",
+      "_id": "array-flatten@2.0.0",
+      "_shasum": "24dd98b38b9194b59b2087ba40c21384d6b8a8dc",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "24dd98b38b9194b59b2087ba40c21384d6b8a8dc",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "array-flatten",
+      "version": "2.1.0",
+      "description": "Flatten nested arrays",
+      "main": "array-flatten.js",
+      "typings": "array-flatten.d.ts",
+      "files": [
+        "array-flatten.js",
+        "array-flatten.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha -R spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec --bail",
+        "test": "npm run lint && npm run test-cov",
+        "benchmark": "node benchmark"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments",
+        "depth",
+        "fast",
+        "for"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "benchmarked": "^0.1.4",
+        "istanbul": "^0.4.0",
+        "mocha": "^2.2.4",
+        "standard": "^5.3.1"
+      },
+      "gitHead": "d5446b9a5e373c3dfa73b9275c53fc9c32ef0979",
+      "_id": "array-flatten@2.1.0",
+      "_shasum": "26a692c83881fc68dac3ec5d1f0c1b49bf2304d9",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "26a692c83881fc68dac3ec5d1f0c1b49bf2304d9",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/array-flatten-2.1.0.tgz_1461890592426_0.306347094476223"
+      },
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "array-flatten",
+      "version": "2.1.1",
+      "description": "Flatten nested arrays",
+      "main": "array-flatten.js",
+      "typings": "array-flatten.d.ts",
+      "files": [
+        "array-flatten.js",
+        "array-flatten.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha -R spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec --bail",
+        "test": "npm run lint && npm run test-cov",
+        "benchmark": "node benchmark"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments",
+        "depth",
+        "fast",
+        "for"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "benchmarked": "^0.2.5",
+        "istanbul": "^0.4.0",
+        "mocha": "^3.1.2",
+        "standard": "^8.5.0"
+      },
+      "gitHead": "b5619025bfb5d624fc2106ec81f9fdecf5419e04",
+      "_id": "array-flatten@2.1.1",
+      "_shasum": "426bb9da84090c1838d812c8150af20a8331e296",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "7.3.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "426bb9da84090c1838d812c8150af20a8331e296",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/array-flatten-2.1.1.tgz_1484356178679_0.14589731954038143"
+      },
+      "directories": {}
+    },
+    "2.1.2": {
+      "name": "array-flatten",
+      "version": "2.1.2",
+      "description": "Flatten nested arrays",
+      "main": "array-flatten.js",
+      "typings": "array-flatten.d.ts",
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha -R spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec --bail",
+        "test": "npm run lint && npm run test-cov",
+        "benchmark": "node benchmark"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments",
+        "depth",
+        "fast",
+        "for"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "devDependencies": {
+        "benchmarked": "^2.0.0",
+        "istanbul": "^0.4.0",
+        "mocha": "^3.1.2",
+        "standard": "^10.0.0"
+      },
+      "gitHead": "04b45e7a5a9fb7e7946a1321287a09e84f1d352d",
+      "_id": "array-flatten@2.1.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "11.3.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+        "shasum": "24ef80a28c1a893617e2149b0c6d0d788293b099",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6242,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcBHcjCRA9TVsSAnZWagAA6C4P/1ZV77yfnxvhR9WUixth\nVTQCT4TxIWY/qRmFV8IldijazpVvtKAEkJjdsetwDCoq0Qtt0fJciJQl8+Hi\nPgS19C5sI0bBLuxeCSwbIUKYQon7vCMB6xoR40J8LbM+L7CLczENo2CmilCD\nwMXe6m8dxRPcNaIRY0GhnDDyMx6D7ZANaEu/8D0CKB8zO64I+w6nIUmO287N\nPZQA5hRQz1W1mI+w+J+j2MRYTouqhkPa/FWcdC5o/PF5QoOXpcOXfHYLazCw\nuNEiRIDjrQo4bZ0xYk0YN6iL7PSczJeAXtUB0gHJvIBX4or/Sp4d+RZRAeQA\neCfgnVJ6ayxbgg3nAHDKAqqyOkgC+WZ9BPxbG7x+kL4O8A/bdLetBnP7K8HS\nxetv8WEn5T5t/a7q/crzp81HZPM0MxNeCiRF49Zi41swmoHghN1SH5jWoWKJ\nKfM7TqBgbgsHtY5zlig+y079AfOal73wlVHwDyyNVdMXgv3wv5x1slBSvvx/\nQ4mDOf/7Fi/4Tys/4slYslqpWyFdwKwa4wZrLtw6H6ZoBLj9NonwdrttYIjE\ndWLMi+AiQC0/xAP1FAOrKf9PPasVdnqNZFoRYIqF6OtWX/4DaepSpPY4SL+v\ns+L/hhLP7PLgeDlv0qr/lH4Fa9fglPitQcdIedgP8UZAx/zfCULbkwPvv+XG\n/wqD\r\n=I6rO\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/array-flatten_2.1.2_1543796514917_0.6725103941555342"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "array-flatten",
+      "version": "3.0.0",
+      "description": "Flatten nested arrays",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "jsnext:main": "dist.es2015/index.js",
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**,benchmark/**}/*.{js,ts}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "benchmark": "node benchmark",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/blakeembrey/array-flatten.git"
+      },
+      "keywords": [
+        "array",
+        "flatten",
+        "arguments",
+        "depth",
+        "fast",
+        "for"
+      ],
+      "author": {
+        "name": "Blake Embrey",
+        "email": "hello@blakeembrey.com",
+        "url": "http://blakeembrey.me"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/blakeembrey/array-flatten/issues"
+      },
+      "homepage": "https://github.com/blakeembrey/array-flatten",
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "100 B"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,json,css,md}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.2.1",
+        "@types/jest": "^24.0.23",
+        "@types/node": "^12.12.11",
+        "benchmarked": "^2.0.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.3",
+        "prettier": "^1.19.1",
+        "ts-expect": "^1.1.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "66299a02d2ce6a9b6998be333581a87affbb8631",
+      "_id": "array-flatten@3.0.0",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+        "shasum": "6428ca2ee52c7b823192ec600fa3ed2f157cd541",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 20089,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd1h1ACRA9TVsSAnZWagAAtFIP/3LXzCEqOKxLY0xhdbFj\nwDbeDzN1kTTOlPWlFI1Ef4yPXDZPlooXIgyIG4OEz3Z8FhQGPxxYSnOECvy+\nkOJ7iEK/ItDkKAjQ5QJw8FZGeRBMlimJb7ZV6IA30hRaDN9d5JyWKeVEUUxR\nAAQQTjrVGfFYK3Xu9qKJZWaMHPWm4+5xgcE7hAe1zCNc5Gb5fI2cDzTuGNvk\nPOoFcSgteGrPbFq8e/cgKRgueUkdBuOOjA68p2Y7RtqHTmwqev/z3ZdilOYE\nQnZkPtJMgGHLRrT1NvGzPXjMhgwSKJ4CLGlWeARqXN9jHvcqZ51BKnm49TpA\neluSo5nlwjCACZKrtWstgEbI6xnTAxnG1XaOmuMktGydifo3zseRjIqBmsxB\nZynP5mVmri2sTCnclvDdZ+fjqu8gtw8id8qVrAkZ6WobTD33g83MocQpzAZR\ns1+mocxWroLLRaqEmEv7WSomSExqhnJ7kD+Eq4Hoy0fnHZiqALx2jWdxpaOe\nZ1qqZlOrjM4X/QwQKV+qMyE8ZrMa7ngthBrvSpgNsIL0VqGdpYQpyIwwB0fJ\nOZT2aiugfuRQToVoIO0TK88Yv/z9SHxxMF9ui7Pg8FWz83WagHdopmGDRKvf\nqjiyLipixY/plP+wa8i4GM0SLnfcoUOlyNdWVWYgm+N6S+tQ4IxFRK3Sd74w\nqbCN\r\n=Ps03\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/array-flatten_3.0.0_1574313279784_0.5985838460284738"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "homepage": "https://github.com/blakeembrey/array-flatten",
+  "keywords": [
+    "array",
+    "flatten",
+    "arguments",
+    "depth",
+    "fast",
+    "for"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/blakeembrey/array-flatten.git"
+  },
+  "author": {
+    "name": "Blake Embrey",
+    "email": "hello@blakeembrey.com",
+    "url": "http://blakeembrey.me"
+  },
+  "bugs": {
+    "url": "https://github.com/blakeembrey/array-flatten/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "tunnckocore": true,
+    "jamescostian": true,
+    "acollins-ts": true,
+    "nickeltobias": true,
+    "tobiasnickel": true,
+    "wangnan0610": true,
+    "bluelovers": true,
+    "sunkeyhub": true,
+    "elidoran": true,
+    "d0ughtyj": true,
+    "ninozhang": true,
+    "shoresh319": true,
+    "zuojiang": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/array-flatten.min.json
+++ b/test/fixtures/registry-mocks/content/array-flatten.min.json
@@ -1,0 +1,188 @@
+{
+  "name": "array-flatten",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "0.0.2": {
+      "name": "array-flatten",
+      "version": "0.0.2",
+      "devDependencies": {
+        "mocha": "^1.18.0",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "51b2f144f36fd656f627740a1fd0ad57979ad6c2",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "array-flatten",
+      "version": "0.0.3",
+      "devDependencies": {
+        "mocha": "^1.18.0",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "0546c3c23ad49c5fec896930680a154b3014eae8",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-0.0.3.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "array-flatten",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "^1.18.0",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "2b672d3b56fad41b050eee8cbf36f7a83ec3b040",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "array-flatten",
+      "version": "1.0.1",
+      "devDependencies": {
+        "istanbul": "^0.2.6",
+        "mocha": "^1.18.0",
+        "pre-commit": "0.0.9"
+      },
+      "dist": {
+        "shasum": "cacb24fbeed6c0014fa751a39a01a90e212a38b8",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "array-flatten",
+      "version": "1.0.2",
+      "devDependencies": {
+        "istanbul": "^0.2.6",
+        "mocha": "^1.18.0",
+        "pre-commit": "0.0.9"
+      },
+      "dist": {
+        "shasum": "c94703edbf0677694f9b61c67b99615b85bd6dd0",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "array-flatten",
+      "version": "1.1.0",
+      "devDependencies": {
+        "istanbul": "^0.3.13",
+        "mocha": "^2.2.4",
+        "pre-commit": "^1.0.7",
+        "standard": "^3.7.3"
+      },
+      "dist": {
+        "shasum": "ac3efac717b0e7bbdc778ce0bde7381ac6604393",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "array-flatten",
+      "version": "1.1.1",
+      "devDependencies": {
+        "istanbul": "^0.3.13",
+        "mocha": "^2.2.4",
+        "pre-commit": "^1.0.7",
+        "standard": "^3.7.3"
+      },
+      "dist": {
+        "shasum": "9a5f699051b1e7073328f2a008968b64ea2955d2",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "array-flatten",
+      "version": "2.0.0",
+      "devDependencies": {
+        "benchmarked": "^0.1.4",
+        "istanbul": "^0.4.0",
+        "mocha": "^2.2.4",
+        "pre-commit": "^1.0.7",
+        "standard": "^5.3.1"
+      },
+      "dist": {
+        "shasum": "24dd98b38b9194b59b2087ba40c21384d6b8a8dc",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.0.0.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "array-flatten",
+      "version": "2.1.0",
+      "devDependencies": {
+        "benchmarked": "^0.1.4",
+        "istanbul": "^0.4.0",
+        "mocha": "^2.2.4",
+        "standard": "^5.3.1"
+      },
+      "dist": {
+        "shasum": "26a692c83881fc68dac3ec5d1f0c1b49bf2304d9",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.0.tgz"
+      }
+    },
+    "2.1.1": {
+      "name": "array-flatten",
+      "version": "2.1.1",
+      "devDependencies": {
+        "benchmarked": "^0.2.5",
+        "istanbul": "^0.4.0",
+        "mocha": "^3.1.2",
+        "standard": "^8.5.0"
+      },
+      "dist": {
+        "shasum": "426bb9da84090c1838d812c8150af20a8331e296",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz"
+      }
+    },
+    "2.1.2": {
+      "name": "array-flatten",
+      "version": "2.1.2",
+      "devDependencies": {
+        "benchmarked": "^2.0.0",
+        "istanbul": "^0.4.0",
+        "mocha": "^3.1.2",
+        "standard": "^10.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+        "shasum": "24ef80a28c1a893617e2149b0c6d0d788293b099",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6242,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcBHcjCRA9TVsSAnZWagAA6C4P/1ZV77yfnxvhR9WUixth\nVTQCT4TxIWY/qRmFV8IldijazpVvtKAEkJjdsetwDCoq0Qtt0fJciJQl8+Hi\nPgS19C5sI0bBLuxeCSwbIUKYQon7vCMB6xoR40J8LbM+L7CLczENo2CmilCD\nwMXe6m8dxRPcNaIRY0GhnDDyMx6D7ZANaEu/8D0CKB8zO64I+w6nIUmO287N\nPZQA5hRQz1W1mI+w+J+j2MRYTouqhkPa/FWcdC5o/PF5QoOXpcOXfHYLazCw\nuNEiRIDjrQo4bZ0xYk0YN6iL7PSczJeAXtUB0gHJvIBX4or/Sp4d+RZRAeQA\neCfgnVJ6ayxbgg3nAHDKAqqyOkgC+WZ9BPxbG7x+kL4O8A/bdLetBnP7K8HS\nxetv8WEn5T5t/a7q/crzp81HZPM0MxNeCiRF49Zi41swmoHghN1SH5jWoWKJ\nKfM7TqBgbgsHtY5zlig+y079AfOal73wlVHwDyyNVdMXgv3wv5x1slBSvvx/\nQ4mDOf/7Fi/4Tys/4slYslqpWyFdwKwa4wZrLtw6H6ZoBLj9NonwdrttYIjE\ndWLMi+AiQC0/xAP1FAOrKf9PPasVdnqNZFoRYIqF6OtWX/4DaepSpPY4SL+v\ns+L/hhLP7PLgeDlv0qr/lH4Fa9fglPitQcdIedgP8UZAx/zfCULbkwPvv+XG\n/wqD\r\n=I6rO\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.0.0": {
+      "name": "array-flatten",
+      "version": "3.0.0",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.2.1",
+        "@types/jest": "^24.0.23",
+        "@types/node": "^12.12.11",
+        "benchmarked": "^2.0.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.3",
+        "prettier": "^1.19.1",
+        "ts-expect": "^1.1.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+        "shasum": "6428ca2ee52c7b823192ec600fa3ed2f157cd541",
+        "tarball": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 20089,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd1h1ACRA9TVsSAnZWagAAtFIP/3LXzCEqOKxLY0xhdbFj\nwDbeDzN1kTTOlPWlFI1Ef4yPXDZPlooXIgyIG4OEz3Z8FhQGPxxYSnOECvy+\nkOJ7iEK/ItDkKAjQ5QJw8FZGeRBMlimJb7ZV6IA30hRaDN9d5JyWKeVEUUxR\nAAQQTjrVGfFYK3Xu9qKJZWaMHPWm4+5xgcE7hAe1zCNc5Gb5fI2cDzTuGNvk\nPOoFcSgteGrPbFq8e/cgKRgueUkdBuOOjA68p2Y7RtqHTmwqev/z3ZdilOYE\nQnZkPtJMgGHLRrT1NvGzPXjMhgwSKJ4CLGlWeARqXN9jHvcqZ51BKnm49TpA\neluSo5nlwjCACZKrtWstgEbI6xnTAxnG1XaOmuMktGydifo3zseRjIqBmsxB\nZynP5mVmri2sTCnclvDdZ+fjqu8gtw8id8qVrAkZ6WobTD33g83MocQpzAZR\ns1+mocxWroLLRaqEmEv7WSomSExqhnJ7kD+Eq4Hoy0fnHZiqALx2jWdxpaOe\nZ1qqZlOrjM4X/QwQKV+qMyE8ZrMa7ngthBrvSpgNsIL0VqGdpYQpyIwwB0fJ\nOZT2aiugfuRQToVoIO0TK88Yv/z9SHxxMF9ui7Pg8FWz83WagHdopmGDRKvf\nqjiyLipixY/plP+wa8i4GM0SLnfcoUOlyNdWVWYgm+N6S+tQ4IxFRK3Sd74w\nqbCN\r\n=Ps03\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-11-21T05:14:42.269Z"
+}

--- a/test/fixtures/registry-mocks/content/asn1.js.json
+++ b/test/fixtures/registry-mocks/content/asn1.js.json
@@ -1,0 +1,4321 @@
+{
+  "_id": "asn1.js",
+  "_rev": "108-d677f3d51f210ec93e9a9b161cc58a2f",
+  "name": "asn1.js",
+  "description": "ASN.1 encoder and decoder",
+  "dist-tags": {
+    "latest": "5.4.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "asn1.js",
+      "version": "0.1.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "_id": "asn1.js@0.1.0",
+      "dist": {
+        "shasum": "c7513d88370ae96c35f994258cea9ae5dae8d9ce",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "asn1.js",
+      "version": "0.1.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "_id": "asn1.js@0.1.1",
+      "dist": {
+        "shasum": "c8361b8a66784ff769e75f4867b5ef7ac23dfb28",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "asn1.js",
+      "version": "0.1.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "_id": "asn1.js@0.1.2",
+      "dist": {
+        "shasum": "c686ba92c00fe621e3295f9525efb0cc904c6db9",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "asn1.js",
+      "version": "0.1.3",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "_id": "asn1.js@0.1.3",
+      "dist": {
+        "shasum": "12a9ef54ee28ce6aae942a22ffb1aabbb4c8c624",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "asn1.js",
+      "version": "0.1.4",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "_id": "asn1.js@0.1.4",
+      "dist": {
+        "shasum": "0a1d04de347d1e4e0a18f3699332d0ec4f0d0e97",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "asn1.js",
+      "version": "0.1.5",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "_id": "asn1.js@0.1.5",
+      "dist": {
+        "shasum": "b899a455c84c1efe92042f4dd51da1dd024e5ba2",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "asn1.js",
+      "version": "0.2.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "_id": "asn1.js@0.2.0",
+      "dist": {
+        "shasum": "aeda878632eeca81a591b515b211c63e94db3466",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "asn1.js",
+      "version": "0.2.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "_id": "asn1.js@0.2.1",
+      "dist": {
+        "shasum": "245abfa4c2e9f7e711c3db63952124654f732990",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "asn1.js",
+      "version": "0.3.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bignum": "~0.6.2"
+      },
+      "dependencies": {
+        "bignum": "~0.6.2"
+      },
+      "_id": "asn1.js@0.3.0",
+      "dist": {
+        "shasum": "d97908770e74708d68c551114fe652e6a2706cf8",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "asn1.js",
+      "version": "0.3.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bignum": "~0.6.2"
+      },
+      "dependencies": {
+        "bignum": "~0.6.2"
+      },
+      "_id": "asn1.js@0.3.1",
+      "_shasum": "d193bc68d4575c6167ae7cee2df197a29db77d6d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d193bc68d4575c6167ae7cee2df197a29db77d6d",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "asn1.js",
+      "version": "0.3.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bignum": "~0.6.2"
+      },
+      "dependencies": {
+        "bignum": "~0.6.2"
+      },
+      "_id": "asn1.js@0.3.2",
+      "_shasum": "bff70d8a1c6981377161ab2986232134ebcd06ea",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bff70d8a1c6981377161ab2986232134ebcd06ea",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.3": {
+      "name": "asn1.js",
+      "version": "0.3.3",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bignum": "~0.6.2"
+      },
+      "dependencies": {
+        "bignum": "~0.6.2"
+      },
+      "_id": "asn1.js@0.3.3",
+      "_shasum": "c61886867f1a3576e78a6af36bca4b6a16066752",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c61886867f1a3576e78a6af36bca4b6a16066752",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.3.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "asn1.js",
+      "version": "0.4.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "_id": "asn1.js@0.4.0",
+      "_shasum": "ae0770c94c162d96111bc339cdb78f34a0d05a1d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ae0770c94c162d96111bc339cdb78f34a0d05a1d",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "asn1.js",
+      "version": "0.4.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "_id": "asn1.js@0.4.1",
+      "_shasum": "005533905d223c3faf3ab6ea3b2457e262aea72f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "005533905d223c3faf3ab6ea3b2457e262aea72f",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "asn1.js",
+      "version": "0.5.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "_id": "asn1.js@0.5.0",
+      "_shasum": "8af312d6ba9dcab592d9f9c679d98b2a97846ed7",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8af312d6ba9dcab592d9f9c679d98b2a97846ed7",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "asn1.js",
+      "version": "0.5.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "gitHead": "8cf60e9cf383b399452f3ab197f4b8123b07715b",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "_id": "asn1.js@0.5.1",
+      "_shasum": "4357530cd1959f4433f1209aaacd2bbf3aa1d6e3",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4357530cd1959f4433f1209aaacd2bbf3aa1d6e3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "asn1.js",
+      "version": "0.6.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "gitHead": "29dab51d85b4900dd216ea861a86bd23322b9f50",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "_id": "asn1.js@0.6.0",
+      "_shasum": "29bd86fb437fd5438cb73b73bb2f291c84e09c91",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "29bd86fb437fd5438cb73b73bb2f291c84e09c91",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "asn1.js",
+      "version": "0.6.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "gitHead": "756b4f20f144c979029da483e264616899915403",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "_id": "asn1.js@0.6.1",
+      "_shasum": "8e0de80781190d4677fd3266ea0d3a9e1cad47c6",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8e0de80781190d4677fd3266ea0d3a9e1cad47c6",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.2": {
+      "name": "asn1.js",
+      "version": "0.6.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "gitHead": "5f85a24142ed8a5f4144790217d10d0bdaa569bc",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "_id": "asn1.js@0.6.2",
+      "_shasum": "43b3e082a5f3da4b298831a3e260f1e21007d5a0",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43b3e082a5f3da4b298831a3e260f1e21007d5a0",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.3": {
+      "name": "asn1.js",
+      "version": "0.6.3",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "gitHead": "0325b4f95c5978584d0c152585b7d244e094d173",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "_id": "asn1.js@0.6.3",
+      "_shasum": "0d05f96a42900d4ac7b9e49e9749b8e478ca6d22",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0d05f96a42900d4ac7b9e49e9749b8e478ca6d22",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.4": {
+      "name": "asn1.js",
+      "version": "0.6.4",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "gitHead": "2f38995d89d7cbd8be008d16f7c9dd32720b9f63",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "_id": "asn1.js@0.6.4",
+      "_shasum": "8c64bdab7e3c22c87cb9abc9351aafc89fdc9df3",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8c64bdab7e3c22c87cb9abc9351aafc89fdc9df3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.5": {
+      "name": "asn1.js",
+      "version": "0.6.5",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "gitHead": "8fd924f718703951e5b161564d3d7130b4d52370",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "_id": "asn1.js@0.6.5",
+      "_shasum": "92219d0eeaffa92bd9c26da38f66a990b63c4579",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "92219d0eeaffa92bd9c26da38f66a990b63c4579",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.6": {
+      "name": "asn1.js",
+      "version": "0.6.6",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "gitHead": "aa9b7e009dfaed375da53d11330480f2a67265c9",
+      "dependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "_id": "asn1.js@0.6.6",
+      "_shasum": "0afd54a656498a526fdfd83d8f8d4d48b79d9ece",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0afd54a656498a526fdfd83d8f8d4d48b79d9ece",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.7": {
+      "name": "asn1.js",
+      "version": "0.6.7",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "gitHead": "f3d1a34e8409953b82c2f1744181b6f10e68bc36",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "_id": "asn1.js@0.6.7",
+      "_shasum": "6dbabf3f2acbd21396e6bbcce0be0467bca2490b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6dbabf3f2acbd21396e6bbcce0be0467bca2490b",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "asn1.js",
+      "version": "0.7.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "gitHead": "0cb93629a2d91a012b3b455c423990899077e31b",
+      "dependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "_id": "asn1.js@0.7.0",
+      "_shasum": "c9364bb78f9ee6ed4bea6492a0b13a527113863c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c9364bb78f9ee6ed4bea6492a0b13a527113863c",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "asn1.js",
+      "version": "1.0.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "gitHead": "6f04b478ced0fab07ce21790c669f023014c4a8d",
+      "dependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "_id": "asn1.js@1.0.0",
+      "_shasum": "62aa7c36d18c32ec17883e40b5e2d719562ed01d",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "62aa7c36d18c32ec17883e40b5e2d719562ed01d",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "asn1.js",
+      "version": "1.0.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "gitHead": "28bea825a108076554b6f95942479cf8e1b13a6b",
+      "_id": "asn1.js@1.0.1",
+      "_shasum": "f47221cd355d4de734b1c101453c29c8aed179f4",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f47221cd355d4de734b1c101453c29c8aed179f4",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "asn1.js",
+      "version": "1.0.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "gitHead": "33b88ecbe9fbcd150a6d191b8e95b3f83c8b8015",
+      "_id": "asn1.js@1.0.2",
+      "_shasum": "967f8108b236b2bb056aaf8022316e88d3efe895",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "967f8108b236b2bb056aaf8022316e88d3efe895",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "asn1.js",
+      "version": "1.0.3",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "gitHead": "447fced964c0532bd23dee93d8d11b418fceed76",
+      "_id": "asn1.js@1.0.3",
+      "_shasum": "281ba3ec1f2448fe765f92a4eecf883fe1364b54",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "1.0.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "281ba3ec1f2448fe765f92a4eecf883fe1364b54",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "asn1.js",
+      "version": "1.0.4",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/asn1.js"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "gitHead": "e93bdc43f5b529d3d4e2c0bc8df240e5a31fc304",
+      "_id": "asn1.js@1.0.4",
+      "_shasum": "adc547dc24775be40db2ae921d6c990c387b32a8",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "1.6.5",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "adc547dc24775be40db2ae921d6c990c387b32a8",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "asn1.js",
+      "version": "1.0.5",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "gitHead": "c86479601ba7cbfe390727131f6068fa657bb713",
+      "_id": "asn1.js@1.0.5",
+      "_shasum": "3ab3d08301d3c22a639d8834dcbd821322e9bd93",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3ab3d08301d3c22a639d8834dcbd821322e9bd93",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "asn1.js",
+      "version": "1.0.6",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "gitHead": "fa15f2c44605ad7e18b9999429e2deddf2cb23c4",
+      "_id": "asn1.js@1.0.6",
+      "_shasum": "f43ae7308495e17bd395f8c03fa400fef724da24",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f43ae7308495e17bd395f8c03fa400fef724da24",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "asn1.js",
+      "version": "2.0.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "gitHead": "746937575a6a9f7df99c91fb98fdf912416cc88f",
+      "_id": "asn1.js@2.0.0",
+      "_shasum": "61ed4bf805297c4ac18e438601c2da816ff4a096",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "61ed4bf805297c4ac18e438601c2da816ff4a096",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "asn1.js",
+      "version": "2.0.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "gitHead": "b8eb6cdd69a9d556d8324b79c261287a3963da88",
+      "_id": "asn1.js@2.0.1",
+      "_shasum": "e3a616c6a561be263147d7b169de44878e6558e7",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e3a616c6a561be263147d7b169de44878e6558e7",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "asn1.js",
+      "version": "2.0.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "gitHead": "8be74b961a2758fa41d1d4e11d0f7547cc2da8fe",
+      "_id": "asn1.js@2.0.2",
+      "_shasum": "747978a85a0616db94677db7fcd65fcf5443a649",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "747978a85a0616db94677db7fcd65fcf5443a649",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "asn1.js",
+      "version": "2.0.3",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "gitHead": "a4075f6d1c75405df688c1c4d3399589e516aecf",
+      "_id": "asn1.js@2.0.3",
+      "_shasum": "bc6104b08208770cd200fccc2ad71f921e821b57",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bc6104b08208770cd200fccc2ad71f921e821b57",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "asn1.js",
+      "version": "2.0.4",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "gitHead": "fa16e14ed7fa8dd84604491b00a4e4fe147c09dd",
+      "_id": "asn1.js@2.0.4",
+      "_shasum": "26840262220c1bf725a4707177ca4e09ab25a7c9",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "26840262220c1bf725a4707177ca4e09ab25a7c9",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "asn1.js",
+      "version": "2.1.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "gitHead": "23b02743dd7399916d1da436d39946f1b26c5255",
+      "_id": "asn1.js@2.1.0",
+      "_shasum": "cc136b756902ec511657cf6b2c0a87e9ea70a2c5",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cc136b756902ec511657cf6b2c0a87e9ea70a2c5",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "asn1.js",
+      "version": "2.1.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "211d525f171a06713af1bc7b3a1636f992603976",
+      "_id": "asn1.js@2.1.1",
+      "_shasum": "6d12e413f38a0cd56ecdc4bfe95d20fdc54489a0",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6d12e413f38a0cd56ecdc4bfe95d20fdc54489a0",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.2": {
+      "name": "asn1.js",
+      "version": "2.1.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "cd76dbdcc3b0f88da09aec966c1c9dd532bc5216",
+      "_id": "asn1.js@2.1.2",
+      "_shasum": "733aacc4251eae95834df066b1e5168f25c1c4f3",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "733aacc4251eae95834df066b1e5168f25c1c4f3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.3": {
+      "name": "asn1.js",
+      "version": "2.1.3",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "418cbb3088f6cb1037e0907bf2a792fa5e0e1372",
+      "_id": "asn1.js@2.1.3",
+      "_shasum": "a67e7d1d09a55152fa52a7bee5be962917bdfef5",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a67e7d1d09a55152fa52a7bee5be962917bdfef5",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "asn1.js",
+      "version": "2.2.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "339af5423130c82c04a75ae1af320f82a927ebbd",
+      "_id": "asn1.js@2.2.0",
+      "_shasum": "e4adb1126ba7be9f2ed816139193a163fd182d34",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e4adb1126ba7be9f2ed816139193a163fd182d34",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.1": {
+      "name": "asn1.js",
+      "version": "2.2.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "93ca61d053fd2da6d32419c200d7347368167533",
+      "_id": "asn1.js@2.2.1",
+      "_shasum": "c8ba4dd68e84431288126230cb2045bdfa9fbfe1",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c8ba4dd68e84431288126230cb2045bdfa9fbfe1",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "asn1.js",
+      "version": "3.0.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dependencies": {
+        "bn.js": "^3.2.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "ed50f758afb04ee979b0c98e67d05f955e577a0e",
+      "_id": "asn1.js@3.0.0",
+      "_shasum": "0724e4bb8f8fd533b1dbec8a07e77ea592f3f6f3",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "0724e4bb8f8fd533b1dbec8a07e77ea592f3f6f3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "asn1.js",
+      "version": "4.0.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "75383bad77c869bde876db6a799badfcee9b2a1f",
+      "_id": "asn1.js@4.0.0",
+      "_shasum": "4fe967ace3ca32d88822c277ddbfa190c06b4a27",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "4fe967ace3ca32d88822c277ddbfa190c06b4a27",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.1.0": {
+      "name": "asn1.js",
+      "version": "4.1.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "0958802a7eb6a8290bdc2f33b9e1477bd049b0d5",
+      "_id": "asn1.js@4.1.0",
+      "_shasum": "c9d0dc81d4650ca8730156755f36a4e9d69806d3",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "c9d0dc81d4650ca8730156755f36a4e9d69806d3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.2.0": {
+      "name": "asn1.js",
+      "version": "4.2.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "214c437ec4ddf264bb39d2d5538f2bdfb4faf4c9",
+      "_id": "asn1.js@4.2.0",
+      "_shasum": "d6f07de6d2b7f81afba1788f896af498b94d8d22",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "d6f07de6d2b7f81afba1788f896af498b94d8d22",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.2.1": {
+      "name": "asn1.js",
+      "version": "4.2.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "9f1797a18a1169fced4358528f8afbee66b773c7",
+      "_id": "asn1.js@4.2.1",
+      "_shasum": "75efd3770c00924ddb2c9530c049d98a4520c77b",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "75efd3770c00924ddb2c9530c049d98a4520c77b",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.3.0": {
+      "name": "asn1.js",
+      "version": "4.3.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "255ab1ae505db53a533dab04c35343dd09b14e11",
+      "_id": "asn1.js@4.3.0",
+      "_shasum": "323ffbe1b7ca4e973e7b2ad9036972f972ade2a6",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "323ffbe1b7ca4e973e7b2ad9036972f972ade2a6",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.3.1": {
+      "name": "asn1.js",
+      "version": "4.3.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "983e0802a847cfe197d914c2e2cd2041595cb0ed",
+      "_id": "asn1.js@4.3.1",
+      "_shasum": "f99ae59be6ca0c62cb2460f046debe695f5a23f3",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "f99ae59be6ca0c62cb2460f046debe695f5a23f3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.3.1.tgz_1454385942015_0.7633855394087732"
+      },
+      "directories": {}
+    },
+    "4.4.0": {
+      "name": "asn1.js",
+      "version": "4.4.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "7d5a011cc732dbbcd2e20431929c0a4ce15335c0",
+      "_id": "asn1.js@4.4.0",
+      "_shasum": "62f7b7556228a6ab9b9402072929591d1f5bfefb",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "62f7b7556228a6ab9b9402072929591d1f5bfefb",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.4.0.tgz_1454625787542_0.22236784594133496"
+      },
+      "directories": {}
+    },
+    "4.5.0": {
+      "name": "asn1.js",
+      "version": "4.5.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/3280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "0fa965c47b02040386be76396fa0963d8e0e88f3",
+      "_id": "asn1.js@4.5.0",
+      "_shasum": "04cb9c021fd70fec7d6e8ffdb754a60d9f000681",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "04cb9c021fd70fec7d6e8ffdb754a60d9f000681",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.5.0.tgz_1455946584504_0.6124084168113768"
+      },
+      "directories": {}
+    },
+    "4.5.1": {
+      "name": "asn1.js",
+      "version": "4.5.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "e99b1e922caa9605423bbe738c01cef8cf2c775a",
+      "_id": "asn1.js@4.5.1",
+      "_shasum": "2e4aa5c5827e6f0ca28c61aa9d2bf5159e225861",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "2e4aa5c5827e6f0ca28c61aa9d2bf5159e225861",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.5.1.tgz_1456811888947_0.4974370743148029"
+      },
+      "directories": {}
+    },
+    "4.5.2": {
+      "name": "asn1.js",
+      "version": "4.5.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "803f3df988186cd8be2884beb48e7efe30fb557d",
+      "_id": "asn1.js@4.5.2",
+      "_shasum": "17492bdfd4bb5f1d7e56ab6b085297fee9e640e9",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "17492bdfd4bb5f1d7e56ab6b085297fee9e640e9",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.5.2.tgz_1457551830029_0.461592328036204"
+      },
+      "directories": {}
+    },
+    "4.6.0": {
+      "name": "asn1.js",
+      "version": "4.6.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "69dd64d8ebbc8a9a593fcaf1f3bbd4d70352fed2",
+      "_id": "asn1.js@4.6.0",
+      "_shasum": "dcf612443e28a4432ed950dab1ff99aafb332bbf",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "dcf612443e28a4432ed950dab1ff99aafb332bbf",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.6.0.tgz_1461882306280_0.9410504137631506"
+      },
+      "directories": {}
+    },
+    "4.6.2": {
+      "name": "asn1.js",
+      "version": "4.6.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "832cf33ea7aece8e943619aec60b83386c30b0c4",
+      "_id": "asn1.js@4.6.2",
+      "_shasum": "c7c5a3444a45d40e7c56416400d00b33fd78247f",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "c7c5a3444a45d40e7c56416400d00b33fd78247f",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.6.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.6.2.tgz_1464746797732_0.43585985829122365"
+      },
+      "directories": {}
+    },
+    "4.7.0": {
+      "name": "asn1.js",
+      "version": "4.7.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "3f99adcf94806f9134ec8bd000aca920573a6ed7",
+      "_id": "asn1.js@4.7.0",
+      "_shasum": "7f8da532fe7faf632c1bef0a93acc4f157a55b70",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "7f8da532fe7faf632c1bef0a93acc4f157a55b70",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.7.0.tgz_1468207516740_0.3653897005133331"
+      },
+      "directories": {}
+    },
+    "4.8.0": {
+      "name": "asn1.js",
+      "version": "4.8.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "be1c261eb07e4b5d51abca15f0e7de54046a3de3",
+      "_id": "asn1.js@4.8.0",
+      "_shasum": "e0e04e9923319163be46aed9e5378973b161ef13",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "e0e04e9923319163be46aed9e5378973b161ef13",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.8.0.tgz_1468211184244_0.1349153215996921"
+      },
+      "directories": {}
+    },
+    "4.8.1": {
+      "name": "asn1.js",
+      "version": "4.8.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "c59d73d6fb0f7d6ea981b5639b63b825bbe21dff",
+      "_id": "asn1.js@4.8.1",
+      "_shasum": "3949b7f5fd1e8bedc13be3abebf477f93490c810",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "3949b7f5fd1e8bedc13be3abebf477f93490c810",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.8.1.tgz_1474319297339_0.3031570555176586"
+      },
+      "directories": {}
+    },
+    "4.9.0": {
+      "name": "asn1.js",
+      "version": "4.9.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "b1d3dc3da04ced529ade06ff3e057ac030085cdf",
+      "_id": "asn1.js@4.9.0",
+      "_shasum": "f71a1243f3e79d46d7b07d7fbf4824ee73af054a",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "f71a1243f3e79d46d7b07d7fbf4824ee73af054a",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.9.0.tgz_1478490137660_0.5372811399865896"
+      },
+      "directories": {}
+    },
+    "4.9.1": {
+      "name": "asn1.js",
+      "version": "4.9.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js rfc/2560/test/*-test.js rfc/5280/test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "33e8f17800306ed28150ef8b6db71efa812552e5",
+      "_id": "asn1.js@4.9.1",
+      "_shasum": "48ba240b45a9280e94748990ba597d216617fd40",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "48ba240b45a9280e94748990ba597d216617fd40",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/asn1.js-4.9.1.tgz_1482877947207_0.6697999401949346"
+      },
+      "directories": {}
+    },
+    "4.9.2": {
+      "name": "asn1.js",
+      "version": "4.9.2",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "a67b5b5c827bf3856b3045f331a9f04267d96b9b",
+      "_id": "asn1.js@4.9.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+        "shasum": "8117ef4f7ed87cd8f89044b5bff97ac243a16c9a",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js-4.9.2.tgz_1509459889789_0.450335755944252"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "asn1.js",
+      "version": "5.0.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "lint-2560": "eslint --fix rfc/2560/*.js rfc/2560/test/*.js",
+        "lint-5280": "eslint --fix rfc/5280/*.js rfc/5280/test/*.js",
+        "lint": "eslint --fix lib/*.js lib/**/*.js lib/**/**/*.js && npm run lint-2560 && npm run lint-5280",
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test && cd ../../ && npm run lint"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "83d1a2ff93353f1e742d6429e3aba2e403fb4d92",
+      "_id": "asn1.js@5.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
+        "shasum": "2b0abbc7fa66dc0aadd06a4683c73608c32b0696",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js-5.0.0.tgz_1509538146379_0.9171012288425118"
+      },
+      "directories": {}
+    },
+    "4.10.1": {
+      "name": "asn1.js",
+      "version": "4.10.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "91e2bd0c36ba3cb5b50a4f97e5760757cd80e0dc",
+      "_id": "asn1.js@4.10.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+        "shasum": "b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+        "fileCount": 16,
+        "unpackedSize": 46647
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js_4.10.1_1518564493443_0.34169381174169433"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.1": {
+      "name": "asn1.js",
+      "version": "5.0.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "lint-2560": "eslint --fix rfc/2560/*.js rfc/2560/test/*.js",
+        "lint-5280": "eslint --fix rfc/5280/*.js rfc/5280/test/*.js",
+        "lint": "eslint --fix lib/*.js lib/**/*.js lib/**/**/*.js && npm run lint-2560 && npm run lint-5280",
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test && cd ../../ && npm run lint"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "b99ce086320e0123331e6272f6de75548c6855fa",
+      "_id": "asn1.js@5.0.1",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+        "shasum": "7668b56416953f0ce3421adbb3893ace59c96f59",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 48602,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbDvc6CRA9TVsSAnZWagAAMEgP/iJNToTMaop0HSwEvm64\nc/YisOWZbg5uxT72IT8l3WNdjypy9qevnk6gZtmzAyzz/dTmw10K9qAq67eX\na522dWHloDhQ9U0Q3zC6UsYubRB9tgNzYJcxzbLDMtDH4vUSupUDHIpkNJdd\nFG5zGgCzBbGMnjjvCzk+JYl3P/pgLpgDMCUEuvgEEudQfaSCcJDZ0zU6grVb\njGv1DPjsqu3IMPFncyCFGP92cgm+4OlmB1iw68yVkG31S6H0I6EBIkM3aGoW\nZiZA/AaVTgxVcKGZIAuqjZcK4JyeHCwWCR8Kg7CZqUuCifroLN1W0Mrf7YBZ\nCPiJlQAQ1+5NTyHTlXS9SlImB76CbsUi+CHrWgRP6agy1GVAdSC117pko6yp\nb+/lBdAAKdbI7Zt1G7dpStYT/zT3o29XBWmngXWBrnCtum0zXxLDuBNxXrDK\nDWCSv0c297iZupFdcoalhjRqpgW/T9cP4vuif5cqq/WySnH9Q3+av0NNxNXf\nxOpAJji32b2xTinp9gPeOEg28KjWnN0mVqezNcJligVFW4IMZa5nI3usi9xK\nkpZzPwFU8vACIo4cXoNUPXps6jV4tY+dUryUGmfTM+H+M6+Hv4czKCoXirnx\nol9vQfns0isr+nScNWDfRJPrtJ7L8akP5WT7YWg2FGvu5xHfrBajtfN3yzP1\nccC6\r\n=kiGw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js_5.0.1_1527707448193_0.4388457945683455"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.0": {
+      "name": "asn1.js",
+      "version": "5.1.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "lint-2560": "eslint --fix rfc/2560/*.js rfc/2560/test/*.js",
+        "lint-5280": "eslint --fix rfc/5280/*.js rfc/5280/test/*.js",
+        "lint": "eslint --fix lib/*.js lib/**/*.js lib/**/**/*.js && npm run lint-2560 && npm run lint-5280",
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test && cd ../../ && npm run lint"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "36053af56c7f36226ce57fa896fa8da8f830cebc",
+      "_id": "asn1.js@5.1.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-kaJYnE3x2F0UG03mF97T2pPNPLznuXMn5wGKaCWFl95FCGYukliQNtgK6gEP1ojnpEDWuYS8fHbfD0MnYgBtlA==",
+        "shasum": "b14a2a76bc6c7d0fcd9a42cac4114fc0d8ad9bbd",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.1.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 48489,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdBWggCRA9TVsSAnZWagAAibwP/1UVTv3TKlWqFpSFrfoe\nbDbVbNV7v1KKb3RnpPrHnSSklkaFE4hQh59iJa/neQb0wtfCyx3dgF/RYd+D\n71Smc1QNx5/uOMmhYLuEUtzPh4IPjOfzkv4jq6c37F76tJiNdaQmhYV+HR3J\nsMIM3Wf9Pmg0ktVCthc3ghIXBZWHWG8PR46ccImnTN9714A69fkWX9Ivhd8Z\npKBlzmi4ExXY+jDtrhZJfX7ZjuMsHDGUHMdCmhe0gZcNyoJHYYfDitNRvdwX\nspDnRiG37+J7a7qTimmGLBTejs78YmgAW600uO9X6HZD1/zDvpM9244+WYj8\n9mls+97ekA2+NOc/37yKuHLHDN2BDqLG3xcCnEb/C7Ze6ZRItHJAoArZBSHI\nym+7WmT6qOo5o+9SIRe0ANUHPoYbivmU67bcsH9aGXO1+la7w3vYjPcbwTe1\nI//tQhVSfj3L497UCwR5WzgAVHMRAAd8gIfSo4bqzY0tBhMLJdilL8Qf2uqY\nFiaN4YY1DgJ/OqOgzreW5xvVJA56A4BjChqibMNrRF9X71xXWcK6KZjdyNd5\nOnPuUzsLjhMn/Yly+Fznakcm9BtONA5+6xBzfTcO2MXlmzxLHp6xp1pcIzGj\nphKillwv2H2XzmXo0LTC0nPk4I813aU10VPJrE7N8r5yWWh70ZPa9VMJakl1\n5F3U\r\n=KH5k\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js_5.1.0_1560635423548_0.0335646271188228"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.1": {
+      "name": "asn1.js",
+      "version": "5.1.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "lint-2560": "eslint --fix rfc/2560/*.js rfc/2560/test/*.js",
+        "lint-5280": "eslint --fix rfc/5280/*.js rfc/5280/test/*.js",
+        "lint": "eslint --fix lib/*.js lib/**/*.js lib/**/**/*.js && npm run lint-2560 && npm run lint-5280",
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test && cd ../../ && npm run lint"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "60d397c51f1d164a0b41375e154419d88b2e23a9",
+      "_id": "asn1.js@5.1.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-kkj0MRSG9Yo3B2BpnLwEk/Sc7oiLu3jmEPaxiwOb219+1j8q6zZocqQYncLlSjMGhAw+OCVks5iIwnFAHudczw==",
+        "shasum": "48e98850a6991f8e35b4d35afc51b1b898598a5e",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.1.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49501,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdCplfCRA9TVsSAnZWagAAn/MP/3QcRhHMiFITQ9hfXDNQ\nclvxXoVdjyjarO/Ra6BJnpjmW6kJ16EmN1BnFEDGrj8HE2NA6/+AtmTc0Zfe\ni4MrZTTFYofCT+ScK417Whba8ksbqUajGl4kNiK1/59FxT2dPmZ/zw94rco0\nxv6NKk6ivdu4Ka1RR0xIR1DrsVoSs0E800dgdk/L9d5MY+DPKIkpQDkKRGYx\ncaLxTSXVsfZQ7r9Z7JgO/8SuNjFks9jqCuHhxdWLrSoWKZ0wJIU2v6gWK5CO\n1ziEMf5wxTTu7pY2MBUR7iyarMZdUe/EScHwJciOJIj9v3ZGuWjnR9eh6sWf\nXHrOUcBFgEVOR8RJGxuFB6zdK+6kKGjcazBY4ptFo0gfFLMPsbTRM2X8PMFo\nJ5MQIvMjZy2QhTFTqmGiFaXZh9EOre9ecm9fspJxvcYd5nAm/yCuOngTeGv9\nP96c/6LvhZzEad6FySWMLgJXS90wnhf+dKrfKF8uuGZjgSHVrsq/Bo0LO5OJ\ncGNVP9kdauv8SBZweJjadmf5vimhbD/kX/1yAoO9rcaZKoEl6cHq21QUkI/s\np6aapji2xqD8E4TJ8PZe+YkdMAIfM7tzVUSbb7ydQQy0UUSKE37g7sJLn8rK\nSdhIBghuS24JElIw9RgjdFbxkNSlG6Ttt0nvQS/NHXYwP2ZGZ7EEtmQtT3At\n962V\r\n=HgcG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js_5.1.1_1560975710901_0.20083183329346688"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.0": {
+      "name": "asn1.js",
+      "version": "5.2.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "lint-2560": "eslint --fix rfc/2560/*.js rfc/2560/test/*.js",
+        "lint-5280": "eslint --fix rfc/5280/*.js rfc/5280/test/*.js",
+        "lint": "eslint --fix lib/*.js lib/**/*.js lib/**/**/*.js && npm run lint-2560 && npm run lint-5280",
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test && cd ../../ && npm run lint"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "94d62626f34fb3184ef86e9410895b195658ee9d",
+      "_id": "asn1.js@5.2.0",
+      "_nodeVersion": "12.2.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
+        "shasum": "292c0357f26a47802ac9727e8772c09c7fc9bd85",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49784,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdEu1oCRA9TVsSAnZWagAAklEP/R2LopPs8LRc5e89B2V5\n6nC/WgsF7JMRTDgGZkI+BMUiLQtk2w/Aleve8AQtmMTmgrG1mIGNtac4bUqB\na5uRQ2eFSQMeCqS9kx+yKGqE7IpM10FCBfQBQ+kJO4c+LUo791hEcZvkWsc4\nO7WaGkqj+0bMEjzJYMoufGfzvL9V+yCUMUtJuKRkZnYnBZqOiWqDlYH9cwvX\nbu/bYN9jHkCNRghztRoQgJ7vE2g8FFbBRZ6tmL3ONRRhkt8YXP48OXp9Aiqi\n26MaoNHIsQttHzPE8Qj7+L4JkyIB6ZP7D81Sr/FpNEnZC6ws5sBUadwkgv8K\nlVTE8Nu+aEgTgZpWdWTLuYuCIDXniDy2EHWm95gQWA/JlaGCVb7xv91t57z9\n/eY3xVs9CtqcMHbv+L9crX+5eMidakgbLgIU3HwkPe+K1KmhBfyxDWN791tT\nytKsVUN8mNAZI1skfRX/a19aTBM+fmVsp5U4AfVyhl7DhUfyAfPNS192ptGL\nqkzpmeiiqrL96Z1R+3E6qhTMCfJ0VdgGYIDXilso/V2407vrVXSSWFThm4Om\nScjN+K56M4C4xVIEichpwew7VKv7PJRNhvfBzWIm5usZdCmaTntG4L2fipkQ\nF66nfakuXqIVD/eJNiCarWIc0aCAoLGaWmkoxK3sJhYzXcgmkWuPaaOClvtN\nF6sw\r\n=tXFy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js_5.2.0_1561521511449_0.8873398640146006"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.3.0": {
+      "name": "asn1.js",
+      "version": "5.3.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "lint-2560": "eslint --fix rfc/2560/*.js rfc/2560/test/*.js",
+        "lint-5280": "eslint --fix rfc/5280/*.js rfc/5280/test/*.js",
+        "lint": "eslint --fix lib/*.js lib/**/*.js lib/**/**/*.js && npm run lint-2560 && npm run lint-5280",
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test && cd ../../ && npm run lint"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^7.0.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "gitHead": "d423f49128b25661fe076772d6339b9230941792",
+      "_id": "asn1.js@5.3.0",
+      "_nodeVersion": "12.11.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+        "shasum": "439099fe9174e09cff5a54a9dda70260517e8689",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49847,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeE5iHCRA9TVsSAnZWagAAB3QQAKHvnK/b/oo32kNDb4gs\nNGUu+LTMOEeGCGtab1AfbL9PyeeymYm+rpWY1bS1zXo9hNzum6qKdswH/G3Z\nwQBUuSt3C8tkQ0GjCnyG04UmsW0fTUAewg+gMWKmOl3jPgOFNR5zeN9tr50s\nfu/ELYOVRu+VghWwONWPGvilSezczEp16XHIzsBLS0blYrYdNwK4ht5RfIdJ\nYj+tIM6NMrv0QGuXUdQsoxEkLf/RXfBQRDBdQS0eoJ68VgwfT91XAcawmT0n\nrrvkpvZ8JntumGj7lcwGa3DX1XYokxZwTVhQEjDozyeL8pHfRJWHvBonXbUh\n3diDiR/UlL1V26wO+Qxl2M4PA3qHXCIRnSL/OgsCKmWZL0NrCicQP0mDHmA/\nQwbHghxKQwSBp8372tJog9vcvm1Ws7ICtdqOpjF2mI+QMuTqf9Shks7UTV5n\nSyBJ7wAcEH86E0ksp/Lr7o5KKHGuGt/CNiA9HnAoIKIOJ+P3TI/IWMOY4x0a\nmc8f4PW+lKfgtu2RKnUm8PVTnB2BhnIH7ZoXp1w7gM57oXqh5yvKJfCS7Uuo\n0YmW7nQ1Cfv3qd1idCmrfGTUQ/AFBqNr5kcvFINpgCnwjw+bLRvFvMzwxi2W\nf2iJ58QWPPTmN5ykoLiFolZ83XGc2cUryaMWfC4MGgKrdj6hoK6ROC5t7vXZ\nmm9i\r\n=A2TP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js_5.3.0_1578342535049_0.7098842203650146"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.4.0": {
+      "name": "asn1.js",
+      "version": "5.4.0",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "lint-2560": "eslint --fix rfc/2560/*.js rfc/2560/test/*.js",
+        "lint-5280": "eslint --fix rfc/5280/*.js rfc/5280/test/*.js",
+        "lint": "eslint --fix lib/*.js lib/**/*.js lib/**/**/*.js && npm run lint-2560 && npm run lint-5280",
+        "mocha": "mocha --reporter spec test/*-test.js",
+        "test": "npm run mocha && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test && cd ../../ && npm run lint"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^7.0.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "gitHead": "1b16c1d812b30eb8bbf01c62d79589f7c12ee5c9",
+      "_id": "asn1.js@5.4.0",
+      "_nodeVersion": "13.9.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-1yGEHM7yefZ+V2CD/GpAK4PkVXcJdeEENgm4aGUWNhj40c2VDj8I9Y/JVHUZhaUpsWQNWe7lfgS/yk1GJxGzeQ==",
+        "shasum": "3d060565cf2d7a26b00a0353d2946e0429ffd5b7",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49593,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe64lnCRA9TVsSAnZWagAAPLgP/iYMIQS2JX8q6wRwvrU6\nWQSjuC9ral7aWIJqcJ3kB/FNIfZH3qXnr7xgyUlgM2niXA4vVOxstjqcnrxP\nMqKwVp+8ewJXKrdxadhFK4mrMOCzXSxXqT9Jza+f84uhYfxpu/iLPUpk0Qzx\nHW9a6C+4ojp4Gv2lfZpYTLHsFt8RhO34CBDV6BNOhhKS/9ZRnNWqYym44qGq\nLzyaMqz9eaSN+JVeN+vGf6hBVTA9BmXRcGKmooeHhKm4j5NzK4pMUSV8yPPB\nG0Y2P73iQ5d9YLax8EvJACeu9CQhvo4+3yQpLmce+JXIrKshvuoo5DvNcWWb\n0hMlmjlZ/9wthWo2pDFERRcEzG+M9WukDFgK14Xo382wZaa4PdgxqBwaVwUM\nOar4Z281CawQc7W+FWHMqyW5SnsGSijg8Dw8DyzLCh9xKISm10VXy2Gd+HVQ\n8tammxWTbJDFm3qfWdqaN9UWtRW8HXb/WJPr3rs6CO8hgwF5nHN3l1LgSuvX\nD6CIuh6zDAU57AD/JU/A4ltZuaAJ59aAZcG9pvv6EUL08RBQm8smMbD4Z7xA\nIxuH8E1REQjLKt4rmCsRQ8KWWtax3AzACr8p2r2gn6tg1ZTTYn49qigK8h4t\nH0NcTkqy86B5N3SGrlAmyiCsXaps4x3cNvuHFM2v9BkJs7lf+ZO+ST/LU1M/\nqrEk\r\n=IYEi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js_5.4.0_1592494439006_0.4664292817533007"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.4.1": {
+      "name": "asn1.js",
+      "version": "5.4.1",
+      "description": "ASN.1 encoder and decoder",
+      "main": "lib/asn1.js",
+      "scripts": {
+        "lint-2560": "eslint --fix rfc/2560/*.js rfc/2560/test/*.js",
+        "lint-5280": "eslint --fix rfc/5280/*.js rfc/5280/test/*.js",
+        "lint": "eslint --fix lib/*.js lib/**/*.js lib/**/**/*.js && npm run lint-2560 && npm run lint-5280",
+        "test": "mocha --reporter spec test/*-test.js && cd rfc/2560 && npm i && npm test && cd ../../rfc/5280 && npm i && npm test && cd ../../ && npm run lint"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+      },
+      "keywords": [
+        "asn.1",
+        "der"
+      ],
+      "author": {
+        "name": "Fedor Indutny"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/asn1.js/issues"
+      },
+      "homepage": "https://github.com/indutny/asn1.js",
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^7.0.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "gitHead": "a26f54f42df8d084b81748a6c5a97023e83b0e90",
+      "_id": "asn1.js@5.4.1",
+      "_nodeVersion": "13.9.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+        "shasum": "11a980b84ebb91781ce35b0fdc2ee294e3783f07",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49847,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe65JHCRA9TVsSAnZWagAAoPgP/0+NtCWOMZ9XLp95cwsF\n8fx95B68n2tGlaP6633w/020BXRwNgatsY1SUfKI02Qkj5eZGGDbWP1FRSvB\nOjypXfoe2MHq58Dq1vhilyB/KcRH01SnWHiSs/oRHZxRzF10NJewwZGH5ycV\n5Tql/mifruFEx7oi6QsNYUEKg6gTBT8Pxg3pU8k7480EtcWbHf1glrWAxVlX\n1Iwb4ePPnabexz2ilCUcQkvMyzdKPQNunrPD+an+HkYF0qhNNgbbUlr70Au5\nziO4eiXC7Z+Belc2WbGWLIyEt/28ww4yIWVID3gicZzJ4BLF+9KN91hd1kji\nLaYUBL4Tu/TAcx3GM2Xkd932GlcF2puBDkhR+TnK+a6FR4b/zlYfJV+9ZNXb\njG7mX6U0C4C1Ce8yV8p7gb32BorDG5Zb0lB6aVwYCVjfOIK/+zSVXHMoSTuE\nynOPcjpkQvVpCqdnush2Tv1hpyP3tfxSbhYO73N3W4l60cOPaevCPX56dxUp\nTZwj2bs7sS0viAh7H7zsutVJGCKnEXcb5wC1Dj2fWQuo9DXyGBN6qOlbdpJm\nwOpJpWlyGujv+PjcdByhYBFtTTzGesOIh3q73rxJRDyZ2FT2nIM4+kqBG7bQ\nK4ocizeTHsaHN6mkqwScq1M7HU+nc57/GqpOlFRhZKW4W8bOAM6GqPbvrVuW\nub04\r\n=q0DM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/asn1.js_5.4.1_1592496711484_0.8933560553409283"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# ASN1.js\n\nASN.1 DER Encoder/Decoder and DSL.\n\n## Example\n\nDefine model:\n\n```javascript\nvar asn = require('asn1.js');\n\nvar Human = asn.define('Human', function() {\n  this.seq().obj(\n    this.key('firstName').octstr(),\n    this.key('lastName').octstr(),\n    this.key('age').int(),\n    this.key('gender').enum({ 0: 'male', 1: 'female' }),\n    this.key('bio').seqof(Bio)\n  );\n});\n\nvar Bio = asn.define('Bio', function() {\n  this.seq().obj(\n    this.key('time').gentime(),\n    this.key('description').octstr()\n  );\n});\n```\n\nEncode data:\n\n```javascript\nvar output = Human.encode({\n  firstName: 'Thomas',\n  lastName: 'Anderson',\n  age: 28,\n  gender: 'male',\n  bio: [\n    {\n      time: +new Date('31 March 1999'),\n      description: 'freedom of mind'\n    }\n  ]\n}, 'der');\n```\n\nDecode data:\n\n```javascript\nvar human = Human.decode(output, 'der');\nconsole.log(human);\n/*\n{ firstName: <Buffer 54 68 6f 6d 61 73>,\n  lastName: <Buffer 41 6e 64 65 72 73 6f 6e>,\n  age: 28,\n  gender: 'male',\n  bio:\n   [ { time: 922820400000,\n       description: <Buffer 66 72 65 65 64 6f 6d 20 6f 66 20 6d 69 6e 64> } ] }\n*/\n```\n\n### Partial decode\n\nIts possible to parse data without stopping on first error. In order to do it,\nyou should call:\n\n```javascript\nvar human = Human.decode(output, 'der', { partial: true });\nconsole.log(human);\n/*\n{ result: { ... },\n  errors: [ ... ] }\n*/\n```\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2017.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "fedor.indutny",
+      "email": "fedor.indutny@gmail.com"
+    },
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-06-18T16:11:54.224Z",
+    "created": "2013-12-01T18:44:10.748Z",
+    "0.1.0": "2013-12-01T18:44:14.123Z",
+    "0.1.1": "2013-12-01T19:07:26.864Z",
+    "0.1.2": "2013-12-01T19:21:07.115Z",
+    "0.1.3": "2013-12-01T19:48:52.886Z",
+    "0.1.4": "2013-12-01T20:10:13.948Z",
+    "0.1.5": "2013-12-01T21:37:24.237Z",
+    "0.2.0": "2013-12-07T16:53:54.494Z",
+    "0.2.1": "2014-01-19T21:07:17.107Z",
+    "0.3.0": "2014-04-15T08:15:19.179Z",
+    "0.3.1": "2014-05-31T11:38:11.753Z",
+    "0.3.2": "2014-06-10T01:25:25.885Z",
+    "0.3.3": "2014-08-06T17:26:39.739Z",
+    "0.4.0": "2014-08-15T19:04:17.023Z",
+    "0.4.1": "2014-08-22T13:29:25.548Z",
+    "0.5.0": "2014-08-24T18:23:55.949Z",
+    "0.5.1": "2014-11-04T18:23:57.510Z",
+    "0.6.0": "2014-11-04T18:36:21.419Z",
+    "0.6.1": "2014-11-04T19:35:05.361Z",
+    "0.6.2": "2014-11-05T17:54:22.553Z",
+    "0.6.3": "2014-11-07T17:07:52.962Z",
+    "0.6.4": "2014-11-07T17:15:22.562Z",
+    "0.6.5": "2014-11-19T11:09:42.804Z",
+    "0.6.6": "2015-01-02T11:46:13.200Z",
+    "0.6.7": "2015-01-03T22:39:42.378Z",
+    "0.7.0": "2015-01-03T22:41:04.106Z",
+    "1.0.0": "2015-01-05T21:02:30.015Z",
+    "1.0.1": "2015-01-12T16:28:39.164Z",
+    "1.0.2": "2015-01-12T16:47:18.726Z",
+    "1.0.3": "2015-01-27T22:57:48.560Z",
+    "1.0.4": "2015-04-19T08:32:45.915Z",
+    "1.0.5": "2015-05-18T14:17:40.093Z",
+    "1.0.6": "2015-05-19T16:58:42.533Z",
+    "2.0.0": "2015-05-19T21:06:15.245Z",
+    "2.0.1": "2015-05-19T22:00:10.086Z",
+    "2.0.2": "2015-05-20T17:26:23.225Z",
+    "2.0.3": "2015-05-21T21:40:17.818Z",
+    "2.0.4": "2015-06-11T11:26:17.092Z",
+    "2.1.0": "2015-06-24T02:06:07.991Z",
+    "2.1.1": "2015-07-03T03:23:17.717Z",
+    "2.1.2": "2015-07-06T02:33:39.698Z",
+    "2.1.3": "2015-07-23T03:16:07.261Z",
+    "2.2.0": "2015-08-11T01:55:47.473Z",
+    "2.2.1": "2015-09-14T18:48:59.737Z",
+    "3.0.0": "2015-10-23T21:49:10.202Z",
+    "4.0.0": "2015-10-28T21:24:44.037Z",
+    "4.1.0": "2015-11-27T02:40:50.862Z",
+    "4.2.0": "2015-11-28T21:39:01.181Z",
+    "4.2.1": "2015-11-30T18:01:06.776Z",
+    "4.3.0": "2016-01-05T19:33:30.696Z",
+    "4.3.1": "2016-02-02T04:05:43.121Z",
+    "4.4.0": "2016-02-04T22:43:08.494Z",
+    "4.5.0": "2016-02-20T05:36:29.364Z",
+    "4.5.1": "2016-03-01T05:58:12.552Z",
+    "4.5.2": "2016-03-09T19:30:32.363Z",
+    "4.6.0": "2016-04-28T22:25:07.159Z",
+    "4.6.2": "2016-06-01T02:06:38.731Z",
+    "4.7.0": "2016-07-11T03:25:18.204Z",
+    "4.8.0": "2016-07-11T04:26:26.558Z",
+    "4.8.1": "2016-09-19T21:08:19.366Z",
+    "4.9.0": "2016-11-07T03:42:19.716Z",
+    "4.9.1": "2016-12-27T22:32:28.892Z",
+    "4.9.2": "2017-10-31T14:24:50.741Z",
+    "4.10.0": "2017-10-31T14:59:18.844Z",
+    "5.0.0": "2017-11-01T12:09:07.317Z",
+    "4.10.1": "2018-02-13T23:28:14.151Z",
+    "5.0.1": "2018-05-30T19:10:48.795Z",
+    "5.1.0": "2019-06-15T21:50:23.690Z",
+    "5.1.1": "2019-06-19T20:21:51.041Z",
+    "5.2.0": "2019-06-26T03:58:31.589Z",
+    "5.3.0": "2020-01-06T20:28:55.163Z",
+    "5.4.0": "2020-06-18T15:33:59.328Z",
+    "5.4.1": "2020-06-18T16:11:51.629Z"
+  },
+  "author": {
+    "name": "Fedor Indutny"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/asn1.js.git"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/indutny/asn1.js",
+  "keywords": [
+    "asn.1",
+    "der"
+  ],
+  "bugs": {
+    "url": "https://github.com/indutny/asn1.js/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "shanewholloway": true,
+    "sopov": true,
+    "ph4r05": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/asn1.js.min.json
+++ b/test/fixtures/registry-mocks/content/asn1.js.min.json
@@ -1,0 +1,1203 @@
+{
+  "name": "asn1.js",
+  "dist-tags": {
+    "latest": "5.4.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "asn1.js",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "c7513d88370ae96c35f994258cea9ae5dae8d9ce",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "asn1.js",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "c8361b8a66784ff769e75f4867b5ef7ac23dfb28",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "asn1.js",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "c686ba92c00fe621e3295f9525efb0cc904c6db9",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "asn1.js",
+      "version": "0.1.3",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "12a9ef54ee28ce6aae942a22ffb1aabbb4c8c624",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "asn1.js",
+      "version": "0.1.4",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "0a1d04de347d1e4e0a18f3699332d0ec4f0d0e97",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "asn1.js",
+      "version": "0.1.5",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "b899a455c84c1efe92042f4dd51da1dd024e5ba2",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.1.5.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "asn1.js",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "aeda878632eeca81a591b515b211c63e94db3466",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "asn1.js",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "245abfa4c2e9f7e711c3db63952124654f732990",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.2.1.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "asn1.js",
+      "version": "0.3.0",
+      "dependencies": {
+        "bignum": "~0.6.2"
+      },
+      "optionalDependencies": {
+        "bignum": "~0.6.2"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "d97908770e74708d68c551114fe652e6a2706cf8",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "asn1.js",
+      "version": "0.3.1",
+      "dependencies": {
+        "bignum": "~0.6.2"
+      },
+      "optionalDependencies": {
+        "bignum": "~0.6.2"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "d193bc68d4575c6167ae7cee2df197a29db77d6d",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.3.1.tgz"
+      }
+    },
+    "0.3.2": {
+      "name": "asn1.js",
+      "version": "0.3.2",
+      "dependencies": {
+        "bignum": "~0.6.2"
+      },
+      "optionalDependencies": {
+        "bignum": "~0.6.2"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "bff70d8a1c6981377161ab2986232134ebcd06ea",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.3.2.tgz"
+      }
+    },
+    "0.3.3": {
+      "name": "asn1.js",
+      "version": "0.3.3",
+      "dependencies": {
+        "bignum": "~0.6.2"
+      },
+      "optionalDependencies": {
+        "bignum": "~0.6.2"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "c61886867f1a3576e78a6af36bca4b6a16066752",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.3.3.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "asn1.js",
+      "version": "0.4.0",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "ae0770c94c162d96111bc339cdb78f34a0d05a1d",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.4.0.tgz"
+      }
+    },
+    "0.4.1": {
+      "name": "asn1.js",
+      "version": "0.4.1",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "005533905d223c3faf3ab6ea3b2457e262aea72f",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.4.1.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "asn1.js",
+      "version": "0.5.0",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "8af312d6ba9dcab592d9f9c679d98b2a97846ed7",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.5.0.tgz"
+      }
+    },
+    "0.5.1": {
+      "name": "asn1.js",
+      "version": "0.5.1",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "4357530cd1959f4433f1209aaacd2bbf3aa1d6e3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.5.1.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "asn1.js",
+      "version": "0.6.0",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "29bd86fb437fd5438cb73b73bb2f291c84e09c91",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.0.tgz"
+      }
+    },
+    "0.6.1": {
+      "name": "asn1.js",
+      "version": "0.6.1",
+      "dependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "optionalDependencies": {
+        "bn.js": "~0.13.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.14.0"
+      },
+      "dist": {
+        "shasum": "8e0de80781190d4677fd3266ea0d3a9e1cad47c6",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.1.tgz"
+      }
+    },
+    "0.6.2": {
+      "name": "asn1.js",
+      "version": "0.6.2",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "43b3e082a5f3da4b298831a3e260f1e21007d5a0",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.2.tgz"
+      }
+    },
+    "0.6.3": {
+      "name": "asn1.js",
+      "version": "0.6.3",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "0d05f96a42900d4ac7b9e49e9749b8e478ca6d22",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.3.tgz"
+      }
+    },
+    "0.6.4": {
+      "name": "asn1.js",
+      "version": "0.6.4",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "8c64bdab7e3c22c87cb9abc9351aafc89fdc9df3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.4.tgz"
+      }
+    },
+    "0.6.5": {
+      "name": "asn1.js",
+      "version": "0.6.5",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "92219d0eeaffa92bd9c26da38f66a990b63c4579",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.5.tgz"
+      }
+    },
+    "0.6.6": {
+      "name": "asn1.js",
+      "version": "0.6.6",
+      "dependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "0afd54a656498a526fdfd83d8f8d4d48b79d9ece",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.6.tgz"
+      }
+    },
+    "0.6.7": {
+      "name": "asn1.js",
+      "version": "0.6.7",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "6dbabf3f2acbd21396e6bbcce0be0467bca2490b",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.6.7.tgz"
+      }
+    },
+    "0.7.0": {
+      "name": "asn1.js",
+      "version": "0.7.0",
+      "dependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "c9364bb78f9ee6ed4bea6492a0b13a527113863c",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-0.7.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "asn1.js",
+      "version": "1.0.0",
+      "dependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "62aa7c36d18c32ec17883e40b5e2d719562ed01d",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "asn1.js",
+      "version": "1.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "f47221cd355d4de734b1c101453c29c8aed179f4",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "asn1.js",
+      "version": "1.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "967f8108b236b2bb056aaf8022316e88d3efe895",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "asn1.js",
+      "version": "1.0.3",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "281ba3ec1f2448fe765f92a4eecf883fe1364b54",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "asn1.js",
+      "version": "1.0.4",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "adc547dc24775be40db2ae921d6c990c387b32a8",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "asn1.js",
+      "version": "1.0.5",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^1.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "3ab3d08301d3c22a639d8834dcbd821322e9bd93",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.5.tgz"
+      }
+    },
+    "1.0.6": {
+      "name": "asn1.js",
+      "version": "1.0.6",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "f43ae7308495e17bd395f8c03fa400fef724da24",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.6.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "asn1.js",
+      "version": "2.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "61ed4bf805297c4ac18e438601c2da816ff4a096",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "asn1.js",
+      "version": "2.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "e3a616c6a561be263147d7b169de44878e6558e7",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "asn1.js",
+      "version": "2.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "747978a85a0616db94677db7fcd65fcf5443a649",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "asn1.js",
+      "version": "2.0.3",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "bc6104b08208770cd200fccc2ad71f921e821b57",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.3.tgz"
+      }
+    },
+    "2.0.4": {
+      "name": "asn1.js",
+      "version": "2.0.4",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "26840262220c1bf725a4707177ca4e09ab25a7c9",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.0.4.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "asn1.js",
+      "version": "2.1.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "bn.js": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "bn.js": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "cc136b756902ec511657cf6b2c0a87e9ea70a2c5",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.0.tgz"
+      }
+    },
+    "2.1.1": {
+      "name": "asn1.js",
+      "version": "2.1.1",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "6d12e413f38a0cd56ecdc4bfe95d20fdc54489a0",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.1.tgz"
+      }
+    },
+    "2.1.2": {
+      "name": "asn1.js",
+      "version": "2.1.2",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "733aacc4251eae95834df066b1e5168f25c1c4f3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.2.tgz"
+      }
+    },
+    "2.1.3": {
+      "name": "asn1.js",
+      "version": "2.1.3",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "a67e7d1d09a55152fa52a7bee5be962917bdfef5",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.1.3.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "asn1.js",
+      "version": "2.2.0",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "e4adb1126ba7be9f2ed816139193a163fd182d34",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.0.tgz"
+      }
+    },
+    "2.2.1": {
+      "name": "asn1.js",
+      "version": "2.2.1",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "c8ba4dd68e84431288126230cb2045bdfa9fbfe1",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-2.2.1.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "asn1.js",
+      "version": "3.0.0",
+      "dependencies": {
+        "bn.js": "^3.2.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "0724e4bb8f8fd533b1dbec8a07e77ea592f3f6f3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-3.0.0.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "asn1.js",
+      "version": "4.0.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "4fe967ace3ca32d88822c277ddbfa190c06b4a27",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.0.0.tgz"
+      }
+    },
+    "4.1.0": {
+      "name": "asn1.js",
+      "version": "4.1.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "c9d0dc81d4650ca8730156755f36a4e9d69806d3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.1.0.tgz"
+      }
+    },
+    "4.2.0": {
+      "name": "asn1.js",
+      "version": "4.2.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "d6f07de6d2b7f81afba1788f896af498b94d8d22",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.2.0.tgz"
+      }
+    },
+    "4.2.1": {
+      "name": "asn1.js",
+      "version": "4.2.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "75efd3770c00924ddb2c9530c049d98a4520c77b",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.2.1.tgz"
+      }
+    },
+    "4.3.0": {
+      "name": "asn1.js",
+      "version": "4.3.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "323ffbe1b7ca4e973e7b2ad9036972f972ade2a6",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.3.0.tgz"
+      }
+    },
+    "4.3.1": {
+      "name": "asn1.js",
+      "version": "4.3.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "f99ae59be6ca0c62cb2460f046debe695f5a23f3",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.3.1.tgz"
+      }
+    },
+    "4.4.0": {
+      "name": "asn1.js",
+      "version": "4.4.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "62f7b7556228a6ab9b9402072929591d1f5bfefb",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.4.0.tgz"
+      }
+    },
+    "4.5.0": {
+      "name": "asn1.js",
+      "version": "4.5.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "04cb9c021fd70fec7d6e8ffdb754a60d9f000681",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.0.tgz"
+      }
+    },
+    "4.5.1": {
+      "name": "asn1.js",
+      "version": "4.5.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "2e4aa5c5827e6f0ca28c61aa9d2bf5159e225861",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.1.tgz"
+      }
+    },
+    "4.5.2": {
+      "name": "asn1.js",
+      "version": "4.5.2",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "17492bdfd4bb5f1d7e56ab6b085297fee9e640e9",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.5.2.tgz"
+      }
+    },
+    "4.6.0": {
+      "name": "asn1.js",
+      "version": "4.6.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "dcf612443e28a4432ed950dab1ff99aafb332bbf",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.6.0.tgz"
+      }
+    },
+    "4.6.2": {
+      "name": "asn1.js",
+      "version": "4.6.2",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "c7c5a3444a45d40e7c56416400d00b33fd78247f",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.6.2.tgz"
+      }
+    },
+    "4.7.0": {
+      "name": "asn1.js",
+      "version": "4.7.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "7f8da532fe7faf632c1bef0a93acc4f157a55b70",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.7.0.tgz"
+      }
+    },
+    "4.8.0": {
+      "name": "asn1.js",
+      "version": "4.8.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "e0e04e9923319163be46aed9e5378973b161ef13",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.0.tgz"
+      }
+    },
+    "4.8.1": {
+      "name": "asn1.js",
+      "version": "4.8.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "3949b7f5fd1e8bedc13be3abebf477f93490c810",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.8.1.tgz"
+      }
+    },
+    "4.9.0": {
+      "name": "asn1.js",
+      "version": "4.9.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "f71a1243f3e79d46d7b07d7fbf4824ee73af054a",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.0.tgz"
+      }
+    },
+    "4.9.1": {
+      "name": "asn1.js",
+      "version": "4.9.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "shasum": "48ba240b45a9280e94748990ba597d216617fd40",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz"
+      }
+    },
+    "4.9.2": {
+      "name": "asn1.js",
+      "version": "4.9.2",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
+        "shasum": "8117ef4f7ed87cd8f89044b5bff97ac243a16c9a",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz"
+      }
+    },
+    "5.0.0": {
+      "name": "asn1.js",
+      "version": "5.0.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
+        "shasum": "2b0abbc7fa66dc0aadd06a4683c73608c32b0696",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz"
+      }
+    },
+    "4.10.1": {
+      "name": "asn1.js",
+      "version": "4.10.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+        "shasum": "b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+        "fileCount": 16,
+        "unpackedSize": 46647
+      }
+    },
+    "5.0.1": {
+      "name": "asn1.js",
+      "version": "5.0.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+        "shasum": "7668b56416953f0ce3421adbb3893ace59c96f59",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 48602,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbDvc6CRA9TVsSAnZWagAAMEgP/iJNToTMaop0HSwEvm64\nc/YisOWZbg5uxT72IT8l3WNdjypy9qevnk6gZtmzAyzz/dTmw10K9qAq67eX\na522dWHloDhQ9U0Q3zC6UsYubRB9tgNzYJcxzbLDMtDH4vUSupUDHIpkNJdd\nFG5zGgCzBbGMnjjvCzk+JYl3P/pgLpgDMCUEuvgEEudQfaSCcJDZ0zU6grVb\njGv1DPjsqu3IMPFncyCFGP92cgm+4OlmB1iw68yVkG31S6H0I6EBIkM3aGoW\nZiZA/AaVTgxVcKGZIAuqjZcK4JyeHCwWCR8Kg7CZqUuCifroLN1W0Mrf7YBZ\nCPiJlQAQ1+5NTyHTlXS9SlImB76CbsUi+CHrWgRP6agy1GVAdSC117pko6yp\nb+/lBdAAKdbI7Zt1G7dpStYT/zT3o29XBWmngXWBrnCtum0zXxLDuBNxXrDK\nDWCSv0c297iZupFdcoalhjRqpgW/T9cP4vuif5cqq/WySnH9Q3+av0NNxNXf\nxOpAJji32b2xTinp9gPeOEg28KjWnN0mVqezNcJligVFW4IMZa5nI3usi9xK\nkpZzPwFU8vACIo4cXoNUPXps6jV4tY+dUryUGmfTM+H+M6+Hv4czKCoXirnx\nol9vQfns0isr+nScNWDfRJPrtJ7L8akP5WT7YWg2FGvu5xHfrBajtfN3yzP1\nccC6\r\n=kiGw\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.0": {
+      "name": "asn1.js",
+      "version": "5.1.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "integrity": "sha512-kaJYnE3x2F0UG03mF97T2pPNPLznuXMn5wGKaCWFl95FCGYukliQNtgK6gEP1ojnpEDWuYS8fHbfD0MnYgBtlA==",
+        "shasum": "b14a2a76bc6c7d0fcd9a42cac4114fc0d8ad9bbd",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.1.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 48489,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdBWggCRA9TVsSAnZWagAAibwP/1UVTv3TKlWqFpSFrfoe\nbDbVbNV7v1KKb3RnpPrHnSSklkaFE4hQh59iJa/neQb0wtfCyx3dgF/RYd+D\n71Smc1QNx5/uOMmhYLuEUtzPh4IPjOfzkv4jq6c37F76tJiNdaQmhYV+HR3J\nsMIM3Wf9Pmg0ktVCthc3ghIXBZWHWG8PR46ccImnTN9714A69fkWX9Ivhd8Z\npKBlzmi4ExXY+jDtrhZJfX7ZjuMsHDGUHMdCmhe0gZcNyoJHYYfDitNRvdwX\nspDnRiG37+J7a7qTimmGLBTejs78YmgAW600uO9X6HZD1/zDvpM9244+WYj8\n9mls+97ekA2+NOc/37yKuHLHDN2BDqLG3xcCnEb/C7Ze6ZRItHJAoArZBSHI\nym+7WmT6qOo5o+9SIRe0ANUHPoYbivmU67bcsH9aGXO1+la7w3vYjPcbwTe1\nI//tQhVSfj3L497UCwR5WzgAVHMRAAd8gIfSo4bqzY0tBhMLJdilL8Qf2uqY\nFiaN4YY1DgJ/OqOgzreW5xvVJA56A4BjChqibMNrRF9X71xXWcK6KZjdyNd5\nOnPuUzsLjhMn/Yly+Fznakcm9BtONA5+6xBzfTcO2MXlmzxLHp6xp1pcIzGj\nphKillwv2H2XzmXo0LTC0nPk4I813aU10VPJrE7N8r5yWWh70ZPa9VMJakl1\n5F3U\r\n=KH5k\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.1": {
+      "name": "asn1.js",
+      "version": "5.1.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "integrity": "sha512-kkj0MRSG9Yo3B2BpnLwEk/Sc7oiLu3jmEPaxiwOb219+1j8q6zZocqQYncLlSjMGhAw+OCVks5iIwnFAHudczw==",
+        "shasum": "48e98850a6991f8e35b4d35afc51b1b898598a5e",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.1.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49501,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdCplfCRA9TVsSAnZWagAAn/MP/3QcRhHMiFITQ9hfXDNQ\nclvxXoVdjyjarO/Ra6BJnpjmW6kJ16EmN1BnFEDGrj8HE2NA6/+AtmTc0Zfe\ni4MrZTTFYofCT+ScK417Whba8ksbqUajGl4kNiK1/59FxT2dPmZ/zw94rco0\nxv6NKk6ivdu4Ka1RR0xIR1DrsVoSs0E800dgdk/L9d5MY+DPKIkpQDkKRGYx\ncaLxTSXVsfZQ7r9Z7JgO/8SuNjFks9jqCuHhxdWLrSoWKZ0wJIU2v6gWK5CO\n1ziEMf5wxTTu7pY2MBUR7iyarMZdUe/EScHwJciOJIj9v3ZGuWjnR9eh6sWf\nXHrOUcBFgEVOR8RJGxuFB6zdK+6kKGjcazBY4ptFo0gfFLMPsbTRM2X8PMFo\nJ5MQIvMjZy2QhTFTqmGiFaXZh9EOre9ecm9fspJxvcYd5nAm/yCuOngTeGv9\nP96c/6LvhZzEad6FySWMLgJXS90wnhf+dKrfKF8uuGZjgSHVrsq/Bo0LO5OJ\ncGNVP9kdauv8SBZweJjadmf5vimhbD/kX/1yAoO9rcaZKoEl6cHq21QUkI/s\np6aapji2xqD8E4TJ8PZe+YkdMAIfM7tzVUSbb7ydQQy0UUSKE37g7sJLn8rK\nSdhIBghuS24JElIw9RgjdFbxkNSlG6Ttt0nvQS/NHXYwP2ZGZ7EEtmQtT3At\n962V\r\n=HgcG\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.2.0": {
+      "name": "asn1.js",
+      "version": "5.2.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^2.3.4"
+      },
+      "dist": {
+        "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
+        "shasum": "292c0357f26a47802ac9727e8772c09c7fc9bd85",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49784,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdEu1oCRA9TVsSAnZWagAAklEP/R2LopPs8LRc5e89B2V5\n6nC/WgsF7JMRTDgGZkI+BMUiLQtk2w/Aleve8AQtmMTmgrG1mIGNtac4bUqB\na5uRQ2eFSQMeCqS9kx+yKGqE7IpM10FCBfQBQ+kJO4c+LUo791hEcZvkWsc4\nO7WaGkqj+0bMEjzJYMoufGfzvL9V+yCUMUtJuKRkZnYnBZqOiWqDlYH9cwvX\nbu/bYN9jHkCNRghztRoQgJ7vE2g8FFbBRZ6tmL3ONRRhkt8YXP48OXp9Aiqi\n26MaoNHIsQttHzPE8Qj7+L4JkyIB6ZP7D81Sr/FpNEnZC6ws5sBUadwkgv8K\nlVTE8Nu+aEgTgZpWdWTLuYuCIDXniDy2EHWm95gQWA/JlaGCVb7xv91t57z9\n/eY3xVs9CtqcMHbv+L9crX+5eMidakgbLgIU3HwkPe+K1KmhBfyxDWN791tT\nytKsVUN8mNAZI1skfRX/a19aTBM+fmVsp5U4AfVyhl7DhUfyAfPNS192ptGL\nqkzpmeiiqrL96Z1R+3E6qhTMCfJ0VdgGYIDXilso/V2407vrVXSSWFThm4Om\nScjN+K56M4C4xVIEichpwew7VKv7PJRNhvfBzWIm5usZdCmaTntG4L2fipkQ\nF66nfakuXqIVD/eJNiCarWIc0aCAoLGaWmkoxK3sJhYzXcgmkWuPaaOClvtN\nF6sw\r\n=tXFy\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.3.0": {
+      "name": "asn1.js",
+      "version": "5.3.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^7.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-WHnQJFcOrIWT1RLOkFFBQkFVvyt9BPOOrH+Dp152Zk4R993rSzXUGPmkybIcUFhHE2d/iHH+nCaOWVCDbO8fgA==",
+        "shasum": "439099fe9174e09cff5a54a9dda70260517e8689",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.3.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49847,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeE5iHCRA9TVsSAnZWagAAB3QQAKHvnK/b/oo32kNDb4gs\nNGUu+LTMOEeGCGtab1AfbL9PyeeymYm+rpWY1bS1zXo9hNzum6qKdswH/G3Z\nwQBUuSt3C8tkQ0GjCnyG04UmsW0fTUAewg+gMWKmOl3jPgOFNR5zeN9tr50s\nfu/ELYOVRu+VghWwONWPGvilSezczEp16XHIzsBLS0blYrYdNwK4ht5RfIdJ\nYj+tIM6NMrv0QGuXUdQsoxEkLf/RXfBQRDBdQS0eoJ68VgwfT91XAcawmT0n\nrrvkpvZ8JntumGj7lcwGa3DX1XYokxZwTVhQEjDozyeL8pHfRJWHvBonXbUh\n3diDiR/UlL1V26wO+Qxl2M4PA3qHXCIRnSL/OgsCKmWZL0NrCicQP0mDHmA/\nQwbHghxKQwSBp8372tJog9vcvm1Ws7ICtdqOpjF2mI+QMuTqf9Shks7UTV5n\nSyBJ7wAcEH86E0ksp/Lr7o5KKHGuGt/CNiA9HnAoIKIOJ+P3TI/IWMOY4x0a\nmc8f4PW+lKfgtu2RKnUm8PVTnB2BhnIH7ZoXp1w7gM57oXqh5yvKJfCS7Uuo\n0YmW7nQ1Cfv3qd1idCmrfGTUQ/AFBqNr5kcvFINpgCnwjw+bLRvFvMzwxi2W\nf2iJ58QWPPTmN5ykoLiFolZ83XGc2cUryaMWfC4MGgKrdj6hoK6ROC5t7vXZ\nmm9i\r\n=A2TP\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.4.0": {
+      "name": "asn1.js",
+      "version": "5.4.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^7.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-1yGEHM7yefZ+V2CD/GpAK4PkVXcJdeEENgm4aGUWNhj40c2VDj8I9Y/JVHUZhaUpsWQNWe7lfgS/yk1GJxGzeQ==",
+        "shasum": "3d060565cf2d7a26b00a0353d2946e0429ffd5b7",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49593,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe64lnCRA9TVsSAnZWagAAPLgP/iYMIQS2JX8q6wRwvrU6\nWQSjuC9ral7aWIJqcJ3kB/FNIfZH3qXnr7xgyUlgM2niXA4vVOxstjqcnrxP\nMqKwVp+8ewJXKrdxadhFK4mrMOCzXSxXqT9Jza+f84uhYfxpu/iLPUpk0Qzx\nHW9a6C+4ojp4Gv2lfZpYTLHsFt8RhO34CBDV6BNOhhKS/9ZRnNWqYym44qGq\nLzyaMqz9eaSN+JVeN+vGf6hBVTA9BmXRcGKmooeHhKm4j5NzK4pMUSV8yPPB\nG0Y2P73iQ5d9YLax8EvJACeu9CQhvo4+3yQpLmce+JXIrKshvuoo5DvNcWWb\n0hMlmjlZ/9wthWo2pDFERRcEzG+M9WukDFgK14Xo382wZaa4PdgxqBwaVwUM\nOar4Z281CawQc7W+FWHMqyW5SnsGSijg8Dw8DyzLCh9xKISm10VXy2Gd+HVQ\n8tammxWTbJDFm3qfWdqaN9UWtRW8HXb/WJPr3rs6CO8hgwF5nHN3l1LgSuvX\nD6CIuh6zDAU57AD/JU/A4ltZuaAJ59aAZcG9pvv6EUL08RBQm8smMbD4Z7xA\nIxuH8E1REQjLKt4rmCsRQ8KWWtax3AzACr8p2r2gn6tg1ZTTYn49qigK8h4t\nH0NcTkqy86B5N3SGrlAmyiCsXaps4x3cNvuHFM2v9BkJs7lf+ZO+ST/LU1M/\nqrEk\r\n=IYEi\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.4.1": {
+      "name": "asn1.js",
+      "version": "5.4.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.10.0",
+        "mocha": "^7.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+        "shasum": "11a980b84ebb91781ce35b0fdc2ee294e3783f07",
+        "tarball": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 49847,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe65JHCRA9TVsSAnZWagAAoPgP/0+NtCWOMZ9XLp95cwsF\n8fx95B68n2tGlaP6633w/020BXRwNgatsY1SUfKI02Qkj5eZGGDbWP1FRSvB\nOjypXfoe2MHq58Dq1vhilyB/KcRH01SnWHiSs/oRHZxRzF10NJewwZGH5ycV\n5Tql/mifruFEx7oi6QsNYUEKg6gTBT8Pxg3pU8k7480EtcWbHf1glrWAxVlX\n1Iwb4ePPnabexz2ilCUcQkvMyzdKPQNunrPD+an+HkYF0qhNNgbbUlr70Au5\nziO4eiXC7Z+Belc2WbGWLIyEt/28ww4yIWVID3gicZzJ4BLF+9KN91hd1kji\nLaYUBL4Tu/TAcx3GM2Xkd932GlcF2puBDkhR+TnK+a6FR4b/zlYfJV+9ZNXb\njG7mX6U0C4C1Ce8yV8p7gb32BorDG5Zb0lB6aVwYCVjfOIK/+zSVXHMoSTuE\nynOPcjpkQvVpCqdnush2Tv1hpyP3tfxSbhYO73N3W4l60cOPaevCPX56dxUp\nTZwj2bs7sS0viAh7H7zsutVJGCKnEXcb5wC1Dj2fWQuo9DXyGBN6qOlbdpJm\nwOpJpWlyGujv+PjcdByhYBFtTTzGesOIh3q73rxJRDyZ2FT2nIM4+kqBG7bQ\nK4ocizeTHsaHN6mkqwScq1M7HU+nc57/GqpOlFRhZKW4W8bOAM6GqPbvrVuW\nub04\r\n=q0DM\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-06-18T16:11:54.224Z"
+}

--- a/test/fixtures/registry-mocks/content/assert.json
+++ b/test/fixtures/registry-mocks/content/assert.json
@@ -1,0 +1,1074 @@
+{
+  "_id": "assert",
+  "_rev": "126-167aace826e534150b8e1f9962962375",
+  "name": "assert",
+  "description": "The assert module from Node.js, for the browser.",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.4.9": {
+      "author": {
+        "name": "narwhal.js",
+        "url": "http://narwhaljs.org"
+      },
+      "name": "assert",
+      "description": "Node.JS assert module",
+      "keywords": [
+        "ender",
+        "assert"
+      ],
+      "version": "0.4.9",
+      "homepage": "http://nodejs.org/docs/v0.4.9/api/assert.html",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/coolaj86/nodejs-libs-4-browser.git"
+      },
+      "main": "./assert.js",
+      "directories": {
+        "lib": "."
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      },
+      "dependencies": {
+        "util": ">= 0.4.9"
+      },
+      "devDependencies": {},
+      "_npmJsonOpts": {
+        "file": "/Users/coolaj86/.npm/assert/0.4.9/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "assert@0.4.9",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.15",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "45faff1a58f718508118873dead940c8b51db939",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-0.4.9.tgz"
+      },
+      "scripts": {}
+    },
+    "1.0.0": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.0.0",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.0"
+      },
+      "devDependencies": {
+        "mocha": "1.14.0"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.0.0",
+      "dist": {
+        "shasum": "11e0629e3bbc13e293bf79570c9febe98b2d7997",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.0.1",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.4",
+        "mocha": "1.14.0"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.0.1",
+      "dist": {
+        "shasum": "af89155b0d01a6dbc2c07803e8ecf94b605cb8f6",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.0.2",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9",
+        "mocha": "1.14.0"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.0.2",
+      "dist": {
+        "shasum": "aa45c4be60a06ffbf2fa88e81aec400e68de4da7",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.0.3",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.2"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9",
+        "mocha": "1.14.0"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.0.3",
+      "dist": {
+        "shasum": "b4876fe43cd32fa93679f49e082e5c47e0e42db1",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.1.0",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.2"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9",
+        "mocha": "1.14.0"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.1.0",
+      "dist": {
+        "shasum": "851f832b880525bb9f6c1bb1dfd93ea028247f23",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.1.1",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.2"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9",
+        "mocha": "1.14.0"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.1.1",
+      "dist": {
+        "shasum": "766549ef4a6014b1e19c7c53f9816eabda440760",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.1.2",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "zuul": "~1.10.2",
+        "mocha": "~1.21.4"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js"
+      },
+      "gitHead": "2c34238b6ad053068680be5372b96721dec48fcb",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.1.2",
+      "_shasum": "adaa04c46bb58c6dd1f294da3eb26e6228eb6e44",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "adaa04c46bb58c6dd1f294da3eb26e6228eb6e44",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.2.0",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "zuul": "~1.10.2",
+        "mocha": "~1.21.4"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js"
+      },
+      "gitHead": "d08b0bfb8ce5219594a1d4001d38da9ad561d251",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.2.0",
+      "_shasum": "26ecef6e9cde86d7817e4d9243deb9a191b9befa",
+      "_from": ".",
+      "_npmVersion": "2.1.12",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "26ecef6e9cde86d7817e4d9243deb9a191b9befa",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.3.0",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "zuul": "~1.10.2",
+        "mocha": "~1.21.4"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js"
+      },
+      "gitHead": "cc3c9020e9ca440bdc431f92570d676dd8a89a3c",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.3.0",
+      "_shasum": "03939a622582a812cc202320a0b9a56c9b815849",
+      "_from": ".",
+      "_npmVersion": "2.1.12",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "03939a622582a812cc202320a0b9a56c9b815849",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.4.0",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "buffer-shims": "1.0.0",
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "zuul": "~3.9.0",
+        "mocha": "~1.21.4"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test-node": "mocha --ui qunit test.js",
+        "test-browser": "zuul -- test.js",
+        "test": "npm run test-node && npm run test-browser",
+        "test-native": "TEST_NATIVE=true mocha --ui qunit test.js"
+      },
+      "gitHead": "e502eca15424e3118e0e01ffad3e057b274cfd13",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.4.0",
+      "_shasum": "a29a98e6febf47b8c31538637a8bf8373fed73e9",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.11.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "a29a98e6febf47b8c31538637a8bf8373fed73e9",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/assert-1.4.0.tgz_1463571352633_0.2970228053163737"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "assert",
+      "description": "commonjs assert - node.js api compatible",
+      "keywords": [
+        "assert"
+      ],
+      "version": "1.4.1",
+      "homepage": "https://github.com/defunctzombie/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/commonjs-assert.git"
+      },
+      "main": "./assert.js",
+      "dependencies": {
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.21.4",
+        "zuul": "~3.10.0",
+        "zuul-ngrok": "^4.0.0"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test-node": "mocha --ui qunit test.js",
+        "test-browser": "zuul -- test.js",
+        "test": "npm run test-node && npm run test-browser",
+        "test-native": "TEST_NATIVE=true mocha --ui qunit test.js",
+        "browser-local": "zuul --no-coverage --local 8000 -- test.js"
+      },
+      "gitHead": "ea25d53a51201cf268681c5ec37f7d51b2d82884",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/commonjs-assert/issues"
+      },
+      "_id": "assert@1.4.1",
+      "_shasum": "99912d591836b5a6f5b345c0f07eefc08fc65d91",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.11.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "99912d591836b5a6f5b345c0f07eefc08fc65d91",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/assert-1.4.1.tgz_1464703323424_0.46298269950784743"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "assert",
+      "description": "The node.js assert module, re-packaged for web browsers.",
+      "version": "1.5.0",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.21.4",
+        "zuul": "~3.10.0",
+        "zuul-ngrok": "^4.0.0"
+      },
+      "homepage": "https://github.com/browserify/commonjs-assert",
+      "keywords": [
+        "assert",
+        "browser"
+      ],
+      "license": "MIT",
+      "main": "./assert.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/commonjs-assert.git"
+      },
+      "scripts": {
+        "browser-local": "zuul --no-coverage --local 8000 -- test.js",
+        "test": "npm run test-node && npm run test-browser",
+        "test-browser": "zuul -- test.js",
+        "test-native": "TEST_NATIVE=true mocha --ui qunit test.js",
+        "test-node": "mocha --ui qunit test.js"
+      },
+      "gitHead": "8386769eb15077c84b5e46f772d41bcb0b40651c",
+      "bugs": {
+        "url": "https://github.com/browserify/commonjs-assert/issues"
+      },
+      "_id": "assert@1.5.0",
+      "_nodeVersion": "11.15.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+        "shasum": "55c109aaf6e0aefdb3dc4b71240c70bf574b18eb",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37541,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc0tLwCRA9TVsSAnZWagAA3KMP/36EqBpLfT+W0VFB+/PZ\nxYrq/iotOFfaAogM3HHe0ZEaEwHp/Cn6jiXtMB6gdQ4t62ar1rBXKb3ni+En\nmaSwcGBe+G/BFXGf8spavAAlAO53DbJR44yeqSzG54ptEEnbIy7KysNpTCSs\nuPWPeTSQkcJYY8qM3Jdqm2m+dAv+HEWNz7gOYz7E+X5xM/922eSqcfA5YM/k\nPzfvKAcpqwU3eVgoHQXLewGdkHkjU7jOM0eLgw5KXEWhg9ETr8qkip+CvG9u\nbvMNJGDJ/J8/kJQXF+546ck68A6FiRROnERSkebyhDa3LJzqm8Z1D7qLT3H6\nRjIim4Cb91CQdg7rRGMEc5W5q81NQHXddUB7L4ix/OCrv5R5DdyAvyZLjMJn\nzpHYVdIuZhbe6iwTuOsNJ2FjHe678LqrGcya4FAAuH6dn0IWr3+apUn7fJJU\nTNek4wywILe5ZmeBhbUKIMqUewXCardczMKyEJjyPzEcrvlUO2FKUT4FaKcE\naEfc2ZS5E5H9aqol2DkSmq+7hgW7Og39PHaUsiu+bJudjjZaebePuE2OGB7c\n5sBo4gTSD8sorxNuDowHMq2EP7ezsJAkE+6myOf2HHm/ArITPjR7GZWpn2C7\nHQaIZHX3y5436ETpIf6jCtfJjazP3idKKNyPnxkgXnCYEaF/IvODhU/zjGeK\nm6Tx\r\n=ojiR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/assert_1.5.0_1557320431576_0.12835773716482102"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "assert",
+      "version": "2.0.0",
+      "description": "The assert module from Node.js, for the browser.",
+      "main": "build/assert.js",
+      "license": "MIT",
+      "homepage": "https://github.com/browserify/commonjs-assert",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/browserify/commonjs-assert.git"
+      },
+      "scripts": {
+        "build": "babel assert.js test.js --out-dir build && babel internal --out-dir build/internal && babel test --out-dir build/test",
+        "prepare": "npm run build",
+        "dev": "babel assert.js test.js --watch --out-dir build & babel internal --watch --out-dir build/internal & babel test --watch --out-dir build/test",
+        "test": "npm run build && npm run test:nobuild",
+        "test:nobuild": "node build/test.js",
+        "test:source": "node test.js",
+        "test:browsers": "airtap build/test.js",
+        "test:browsers:local": "npm run test:browsers -- --local"
+      },
+      "keywords": [
+        "assert",
+        "browser"
+      ],
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.4",
+        "@babel/preset-env": "^7.4.4",
+        "airtap": "^2.0.2",
+        "array-fill": "^1.2.0",
+        "core-js": "^3.0.1",
+        "cross-env": "^5.2.0",
+        "object.entries": "^1.1.0",
+        "object.getownpropertydescriptors": "^2.0.3",
+        "tape": "^4.10.1"
+      },
+      "dependencies": {
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      },
+      "gitHead": "8969d8eaa74357b5285d99cdd4ade4d993a1c183",
+      "bugs": {
+        "url": "https://github.com/browserify/commonjs-assert/issues"
+      },
+      "_id": "assert@2.0.0",
+      "_nodeVersion": "12.0.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+        "shasum": "95fc1c616d48713510680f2eaf2d10dd22e02d32",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 75279,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1/zMCRA9TVsSAnZWagAAqHQP/jrIv4UgWPqoAFLuLshD\nKRcsLo/VhfQLeOX05qs93gkJUbinh8BeJOeshKJPzwSnuA1xsWRyXCepX/Yx\nB19AfPP8D/2HNDtI09zlWWJqgSmpnQjWBuKRd9YVvWOmkHp4+VZb0O7LoUUU\ni6RuzfNzo+Cq/eZZHnL9KU/Fags6yepdHP3e0KB+NmQKRZglYRAc0mYkLVTN\nbOgmshUhc+i+mtTnltRKFguZ3hYMj7KAE4O+znTswk44KTqoHjnTdarGdPbd\ngs5oT6SDHhlQnvUmPuiacjxkVYxv5yEjmz1baNQNsWm53YLTsxyoC3PZI6JA\nuNA6xezdxenXiSCieqf71DEHQCCNQ33d7G1OiFGmZU1FVV5utf5tBmTN7WSW\n4fupKdHjGGdysPM+z4xb5vbAMvsvImI9zF5AKxgZ/MGqa4MaNe6uNqZt03+/\nz5c/DNvReBcOO7tzUNLlbRdo96bUwOWEKxSQBv99M0g5cuSSfDoH1+wiP/BN\nhA6WDoWg5iIX/UFM534BBerZGxEPDEe5hoglb3krJII4uo26pj144lclPnFH\nm+p7lheOcxuitFegFcS5qm4lAKGVoaLklU7+fuZMZoAUVV/qPQ+IMsA3NVUD\nUKE2I6Zu+Fv3ZCTz/ugxwD5kEHJsyinmJmXgmtBRDkWrXWdY80MxkRwwyl18\nSj+W\r\n=xgzG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "coolaj86@gmail.com",
+          "name": "coolaj86"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "lukechilds",
+        "email": "lukechilds123@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/assert_2.0.0_1557658827738_0.4089903976730602"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "lukechilds123@gmail.com",
+      "name": "lukechilds"
+    },
+    {
+      "email": "substack@gmail.com",
+      "name": "substack"
+    },
+    {
+      "email": "renee@kooi.me",
+      "name": "goto-bus-stop"
+    },
+    {
+      "email": "ljharb@gmail.com",
+      "name": "ljharb"
+    },
+    {
+      "email": "coolaj86@gmail.com",
+      "name": "coolaj86"
+    },
+    {
+      "email": "shtylman@gmail.com",
+      "name": "defunctzombie"
+    }
+  ],
+  "time": {
+    "modified": "2020-04-09T09:52:36.059Z",
+    "created": "2011-06-30T00:30:08.354Z",
+    "0.4.9": "2011-06-30T00:30:08.699Z",
+    "1.0.0": "2013-11-22T18:46:47.035Z",
+    "1.0.1": "2013-12-18T02:20:33.846Z",
+    "1.0.2": "2013-12-19T03:18:16.080Z",
+    "1.0.3": "2013-12-20T15:27:42.122Z",
+    "1.1.0": "2013-12-29T04:37:51.334Z",
+    "1.1.1": "2014-02-07T17:13:56.404Z",
+    "1.1.2": "2014-08-29T03:33:31.188Z",
+    "1.2.0": "2014-12-21T18:24:52.866Z",
+    "1.3.0": "2014-12-24T02:46:30.815Z",
+    "1.4.0": "2016-05-18T11:35:54.924Z",
+    "1.4.1": "2016-05-31T14:02:04.361Z",
+    "1.5.0": "2019-05-08T13:00:31.722Z",
+    "2.0.0": "2019-05-12T11:00:27.859Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/browserify/commonjs-assert.git"
+  },
+  "users": {
+    "pid": true,
+    "gdbtek": true,
+    "japh": true,
+    "ninjatux": true,
+    "jmorris": true,
+    "kenjisan4u": true,
+    "craigsapp": true,
+    "simplyianm": true,
+    "rsp": true,
+    "heraklion": true,
+    "itonyyo": true,
+    "jeffb_incontact": true,
+    "davidchubbs": true,
+    "m0dred": true,
+    "po": true,
+    "liushoukai": true,
+    "jprempeh": true,
+    "fistynuts": true,
+    "vwal": true,
+    "craql": true,
+    "cfleschhut": true,
+    "almccann": true,
+    "hyteer": true,
+    "a1ip": true,
+    "zhanghaili": true,
+    "zombinary": true,
+    "shaddyhm": true,
+    "ondak": true,
+    "piecioshka": true,
+    "bapinney": true,
+    "ingpdw": true,
+    "yokubee": true,
+    "mickey815": true,
+    "phoenix-xsy": true,
+    "n0f3": true,
+    "gggauravgandhi": true,
+    "lianer": true,
+    "wangfeia": true,
+    "amazingandyyy": true,
+    "jota": true,
+    "olonam": true,
+    "wangnan0610": true,
+    "jirqoadai": true,
+    "mobeicaoyuan": true,
+    "stone_breaker": true,
+    "vitorluizc": true,
+    "bufke": true,
+    "ivan.marquez": true,
+    "ray0214": true,
+    "dada1134": true,
+    "ironheartbj18": true,
+    "karzanosman984": true,
+    "rocket0191": true,
+    "yinfxs": true,
+    "chinawolf_wyp": true,
+    "raycharles": true,
+    "kopepasah": true,
+    "arefm": true,
+    "marinear212": true,
+    "uojo": true,
+    "eb.coder": true,
+    "ivan.xu": true,
+    "justjavac": true,
+    "bhaskarmelkani": true,
+    "eijs": true,
+    "superchenney": true,
+    "eyson": true,
+    "gashira_e": true,
+    "tedyhy": true,
+    "salvationz": true,
+    "ryaned": true,
+    "limintu": true,
+    "maalthous": true,
+    "valenwave": true,
+    "wisetc": true
+  },
+  "readme": "# assert\n\n> The [`assert`](https://nodejs.org/api/assert.html) module from Node.js, for the browser.\n\n[![Build Status](https://travis-ci.org/browserify/commonjs-assert.svg?branch=master)](https://travis-ci.org/browserify/commonjs-assert)\n[![npm](https://img.shields.io/npm/dm/assert.svg)](https://www.npmjs.com/package/assert)\n[![npm](https://img.shields.io/npm/v/assert.svg)](https://www.npmjs.com/package/assert)\n\nWith browserify, simply `require('assert')` or use the `assert` global and you will get this module.\n\nThe goal is to provide an API that is as functionally identical to the [Node.js `assert` API](https://nodejs.org/api/assert.html) as possible. Read the [official docs](https://nodejs.org/api/assert.html) for API documentation.\n\n## Install\n\nTo use this module directly (without browserify), install it as a dependency:\n\n```\nnpm install assert\n```\n\n## Usage\n\nThe goal is to provide an API that is as functionally identical to the [Node.js `assert` API](https://nodejs.org/api/assert.html) as possible. Read the [official docs](https://nodejs.org/api/assert.html) for API documentation.\n\n### Inconsistencies with Node.js `assert`\n\nDue to differences between browsers, some error properties such as `message` and `stack` will be inconsistent. However the assertion behaviour is as close as possible to Node.js and the same error `code` will always be used.\n\n## Contributing\n\nTo contribute, work on the source files. Then build and run the tests against the built files. Be careful to not introduce syntax that will be transpiled down to unsupported syntax. For example, `for...of` loops will be transpiled to use `Symbol.iterator` which is unavailable in IE.\n\n### Build scripts\n\n#### `npm run build`\n\nBuilds the project into the `build` dir.\n\n#### `npm run dev`\n\nWatches source files for changes and rebuilds them into the `build` dir.\n\n#### `npm run test`\n\nBuilds the source files into the `build` dir and then runs the tests against the built project.\n\n#### `npm run test:nobuild`\n\nRuns the tests against the built project without rebuilding first.\n\nThis is useful if you're debugging in the transpiled code and want to re-run the tests without overwriting any changes you may have made.\n\n#### `npm run test:source`\n\nRuns the tests against the unbuilt source files.\n\nThis will only work on modern Node.js versions.\n\n#### `npm run test:browsers`\n\nRun browser tests against the all targets in the cloud.\n\nRequires airtap credentials to be configured on your machine.\n\n#### `npm run test:browsers:local`\n\nRun a local browser test server. No airtap configuration required.\n\nWhen paired with `npm run dev` any changes you make to the source files will be automatically transpiled and served on the next request to the test server.\n\n## License\n\nMIT © Joyent, Inc. and other Node contributors\n",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/browserify/commonjs-assert",
+  "keywords": [
+    "assert",
+    "browser"
+  ],
+  "bugs": {
+    "url": "https://github.com/browserify/commonjs-assert/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/assert.min.json
+++ b/test/fixtures/registry-mocks/content/assert.min.json
@@ -1,0 +1,244 @@
+{
+  "name": "assert",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.4.9": {
+      "name": "assert",
+      "version": "0.4.9",
+      "dependencies": {
+        "util": ">= 0.4.9"
+      },
+      "directories": {
+        "lib": "."
+      },
+      "dist": {
+        "shasum": "45faff1a58f718508118873dead940c8b51db939",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-0.4.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      }
+    },
+    "1.0.0": {
+      "name": "assert",
+      "version": "1.0.0",
+      "dependencies": {
+        "util": "0.10.0"
+      },
+      "devDependencies": {
+        "mocha": "1.14.0"
+      },
+      "dist": {
+        "shasum": "11e0629e3bbc13e293bf79570c9febe98b2d7997",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "assert",
+      "version": "1.0.1",
+      "dependencies": {
+        "util": "0.10.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.4",
+        "mocha": "1.14.0"
+      },
+      "dist": {
+        "shasum": "af89155b0d01a6dbc2c07803e8ecf94b605cb8f6",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "assert",
+      "version": "1.0.2",
+      "dependencies": {
+        "util": "0.10.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9",
+        "mocha": "1.14.0"
+      },
+      "dist": {
+        "shasum": "aa45c4be60a06ffbf2fa88e81aec400e68de4da7",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "assert",
+      "version": "1.0.3",
+      "dependencies": {
+        "util": "0.10.2"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9",
+        "mocha": "1.14.0"
+      },
+      "dist": {
+        "shasum": "b4876fe43cd32fa93679f49e082e5c47e0e42db1",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.0.3.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "assert",
+      "version": "1.1.0",
+      "dependencies": {
+        "util": "0.10.2"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9",
+        "mocha": "1.14.0"
+      },
+      "dist": {
+        "shasum": "851f832b880525bb9f6c1bb1dfd93ea028247f23",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "assert",
+      "version": "1.1.1",
+      "dependencies": {
+        "util": "0.10.2"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9",
+        "mocha": "1.14.0"
+      },
+      "dist": {
+        "shasum": "766549ef4a6014b1e19c7c53f9816eabda440760",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "assert",
+      "version": "1.1.2",
+      "dependencies": {
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "zuul": "~1.10.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "adaa04c46bb58c6dd1f294da3eb26e6228eb6e44",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "assert",
+      "version": "1.2.0",
+      "dependencies": {
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "zuul": "~1.10.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "26ecef6e9cde86d7817e4d9243deb9a191b9befa",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "assert",
+      "version": "1.3.0",
+      "dependencies": {
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "zuul": "~1.10.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "03939a622582a812cc202320a0b9a56c9b815849",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "assert",
+      "version": "1.4.0",
+      "dependencies": {
+        "buffer-shims": "1.0.0",
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "zuul": "~3.9.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "a29a98e6febf47b8c31538637a8bf8373fed73e9",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.4.0.tgz"
+      }
+    },
+    "1.4.1": {
+      "name": "assert",
+      "version": "1.4.1",
+      "dependencies": {
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.21.4",
+        "zuul": "~3.10.0",
+        "zuul-ngrok": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "99912d591836b5a6f5b345c0f07eefc08fc65d91",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "assert",
+      "version": "1.5.0",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
+      },
+      "devDependencies": {
+        "mocha": "~1.21.4",
+        "zuul": "~3.10.0",
+        "zuul-ngrok": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+        "shasum": "55c109aaf6e0aefdb3dc4b71240c70bf574b18eb",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37541,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc0tLwCRA9TVsSAnZWagAA3KMP/36EqBpLfT+W0VFB+/PZ\nxYrq/iotOFfaAogM3HHe0ZEaEwHp/Cn6jiXtMB6gdQ4t62ar1rBXKb3ni+En\nmaSwcGBe+G/BFXGf8spavAAlAO53DbJR44yeqSzG54ptEEnbIy7KysNpTCSs\nuPWPeTSQkcJYY8qM3Jdqm2m+dAv+HEWNz7gOYz7E+X5xM/922eSqcfA5YM/k\nPzfvKAcpqwU3eVgoHQXLewGdkHkjU7jOM0eLgw5KXEWhg9ETr8qkip+CvG9u\nbvMNJGDJ/J8/kJQXF+546ck68A6FiRROnERSkebyhDa3LJzqm8Z1D7qLT3H6\nRjIim4Cb91CQdg7rRGMEc5W5q81NQHXddUB7L4ix/OCrv5R5DdyAvyZLjMJn\nzpHYVdIuZhbe6iwTuOsNJ2FjHe678LqrGcya4FAAuH6dn0IWr3+apUn7fJJU\nTNek4wywILe5ZmeBhbUKIMqUewXCardczMKyEJjyPzEcrvlUO2FKUT4FaKcE\naEfc2ZS5E5H9aqol2DkSmq+7hgW7Og39PHaUsiu+bJudjjZaebePuE2OGB7c\n5sBo4gTSD8sorxNuDowHMq2EP7ezsJAkE+6myOf2HHm/ArITPjR7GZWpn2C7\nHQaIZHX3y5436ETpIf6jCtfJjazP3idKKNyPnxkgXnCYEaF/IvODhU/zjGeK\nm6Tx\r\n=ojiR\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "assert",
+      "version": "2.0.0",
+      "dependencies": {
+        "es6-object-assign": "^1.1.0",
+        "is-nan": "^1.2.1",
+        "object-is": "^1.0.1",
+        "util": "^0.12.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.4",
+        "@babel/preset-env": "^7.4.4",
+        "airtap": "^2.0.2",
+        "array-fill": "^1.2.0",
+        "core-js": "^3.0.1",
+        "cross-env": "^5.2.0",
+        "object.entries": "^1.1.0",
+        "object.getownpropertydescriptors": "^2.0.3",
+        "tape": "^4.10.1"
+      },
+      "dist": {
+        "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+        "shasum": "95fc1c616d48713510680f2eaf2d10dd22e02d32",
+        "tarball": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 75279,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1/zMCRA9TVsSAnZWagAAqHQP/jrIv4UgWPqoAFLuLshD\nKRcsLo/VhfQLeOX05qs93gkJUbinh8BeJOeshKJPzwSnuA1xsWRyXCepX/Yx\nB19AfPP8D/2HNDtI09zlWWJqgSmpnQjWBuKRd9YVvWOmkHp4+VZb0O7LoUUU\ni6RuzfNzo+Cq/eZZHnL9KU/Fags6yepdHP3e0KB+NmQKRZglYRAc0mYkLVTN\nbOgmshUhc+i+mtTnltRKFguZ3hYMj7KAE4O+znTswk44KTqoHjnTdarGdPbd\ngs5oT6SDHhlQnvUmPuiacjxkVYxv5yEjmz1baNQNsWm53YLTsxyoC3PZI6JA\nuNA6xezdxenXiSCieqf71DEHQCCNQ33d7G1OiFGmZU1FVV5utf5tBmTN7WSW\n4fupKdHjGGdysPM+z4xb5vbAMvsvImI9zF5AKxgZ/MGqa4MaNe6uNqZt03+/\nz5c/DNvReBcOO7tzUNLlbRdo96bUwOWEKxSQBv99M0g5cuSSfDoH1+wiP/BN\nhA6WDoWg5iIX/UFM534BBerZGxEPDEe5hoglb3krJII4uo26pj144lclPnFH\nm+p7lheOcxuitFegFcS5qm4lAKGVoaLklU7+fuZMZoAUVV/qPQ+IMsA3NVUD\nUKE2I6Zu+Fv3ZCTz/ugxwD5kEHJsyinmJmXgmtBRDkWrXWdY80MxkRwwyl18\nSj+W\r\n=xgzG\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-04-09T09:52:36.059Z"
+}

--- a/test/fixtures/registry-mocks/content/assign-symbols.json
+++ b/test/fixtures/registry-mocks/content/assign-symbols.json
@@ -1,0 +1,557 @@
+{
+  "_id": "assign-symbols",
+  "_rev": "8-b951b80feed3a69b6f3e2d5654d80b38",
+  "name": "assign-symbols",
+  "description": "Assign the enumerable es6 Symbol properties from one or more objects to the first object passed on the arguments. Can be used as a supplement to other extend, assign or merge methods as a polyfill for the Symbols part of the es6 Object.assign method.",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "assign-symbols",
+      "description": "Assign the enumerable symbol properties from an object (or objects) to the first object passed on the arguments.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/assign-symbols",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/assign-symbols.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/assign-symbols/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "keywords": [
+        "assign",
+        "symbols"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "assign-deep",
+            "mixin-deep",
+            "merge-deep",
+            "extend-shallow",
+            "clone-deep"
+          ]
+        }
+      },
+      "gitHead": "bc03ebf4d900b6c76257735997fd1b12f7401b75",
+      "_id": "assign-symbols@0.1.0",
+      "_shasum": "bbfa7c01087b543c81a5883bc106f8333b85d696",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bbfa7c01087b543c81a5883bc106f8333b85d696",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "assign-symbols",
+      "description": "Assign the enumerable es6 Symbol properties from an object (or objects) to the first object passed on the arguments. Can be used as a supplement to other extend, assign or merge methods as a polyfill for the Symbols part of the es6 Object.assign method.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/assign-symbols",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/assign-symbols.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/assign-symbols/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "keywords": [
+        "assign",
+        "symbols"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "assign-deep",
+            "mixin-deep",
+            "merge-deep",
+            "extend-shallow",
+            "clone-deep"
+          ]
+        }
+      },
+      "gitHead": "d89aa5d5433410b11c4e8ffb2bfa08be972d9b31",
+      "_id": "assign-symbols@0.1.1",
+      "_shasum": "cb025944ef4ec8a3693f086e9e112c74e3a0fed9",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cb025944ef4ec8a3693f086e9e112c74e3a0fed9",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "assign-symbols",
+      "description": "Assign the enumerable es6 Symbol properties from an object (or objects) to the first object passed on the arguments. Can be used as a supplement to other extend, assign or merge methods as a polyfill for the Symbols part of the es6 Object.assign method.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/assign-symbols",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/assign-symbols.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/assign-symbols/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "^3.0.0"
+      },
+      "keywords": [
+        "assign",
+        "symbols"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "assign-deep",
+            "mixin-deep",
+            "merge-deep",
+            "extend-shallow",
+            "clone-deep"
+          ]
+        }
+      },
+      "gitHead": "2df01f26fce8359fa75688eb89e2a1c65de6f237",
+      "_id": "assign-symbols@1.0.0",
+      "_shasum": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "0.12.18",
+      "_npmUser": {
+        "name": "phated",
+        "email": "blaine.bublitz@gmail.com"
+      },
+      "maintainers": [
+        {
+          "email": "blaine.bublitz@gmail.com",
+          "name": "phated"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "dist": {
+        "shasum": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/assign-symbols-1.0.0.tgz_1513723533378_0.7385613690130413"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "assign-symbols",
+      "description": "Assign the enumerable es6 Symbol properties from one or more objects to the first object passed on the arguments. Can be used as a supplement to other extend, assign or merge methods as a polyfill for the Symbols part of the es6 Object.assign method.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/assign-symbols",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/assign-symbols.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/assign-symbols/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0"
+      },
+      "keywords": [
+        "assign",
+        "es6",
+        "merge",
+        "mixin",
+        "polyfill",
+        "primitive",
+        "symbol",
+        "symbols"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "assign-deep",
+            "clone-deep",
+            "extend-shallow",
+            "merge-deep",
+            "mixin-deep"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "1429f75d37e3d4d3b6aff684350332fb77621d26",
+      "_id": "assign-symbols@2.0.0",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-WMsBhayErMFzT2Tl8pCafJAwRz5G/0qwjptjgdu5CKXbLOivPQJZoBhjvQmVe0CyQLu0mj4RPm7XPcAckKjnvg==",
+        "shasum": "00b308df5e2eb7a2e9262d9c9ad62838f7b42374",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8423,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaRwYCRA9TVsSAnZWagAAkSQP/jRZ70FZJOWO3tBvGDzY\n5Z1tFiotvrkb2zze/gh+Gl2R84MeaYyEBv5QXrKd3aOUXQbvjpNveQEDt7P3\narzf3mt9QmSqprHYO+BFSgsnp0R/CiHJiKQVRECAa92+6zCBqYpIwzL4Hpvt\nxTAgql5UxXjAif7JY0j8eov5g8gnBbVwz9Kn8ClhQ1McYZcjhP/fhrGv8DeT\ntSENH4rDxDTIjFL5fvzWOz7yzw2/kz5uplPWV0KZKMxnroKaMGAHOBiEwvm6\nKuKq3Q9Cb6oeTwrp86Ohkhy8VATqOuTL15FJjBG39rOgCT72PF/adQWfWKfR\nRfNTZ6jwgrOdlUDUdbqVCYwmbBrEBTAP1p8T156U+aijeGR30wPEtpk0nATC\npgJB4IUindtd+UYWA7idWidqJh+HG78F3Nm0W8T+RfdZuMiP/3d+9RbMCs6t\niJ0AridNXRdL4vv81gGpNVFPVIweDyCbGoUp313f+ah5VPhcWxSKNaS3Ljlx\nUv+NEePJ0/dpbrvlRIk4IMb6KrbG2jsIOYu0JbwLUJDsTzjJLAFUlN+IiQ1U\nZSzYuNdyGB8AMcAZFmi3njWEwD2zSFQIc/Z3FntJio6Pgd+hHjbhhrpCsMpq\npaXX5sHpSxccXspAvdhyt7IwXUnlbRlEt59OPap3REk+l3qx3xZouRDccGip\n/jnP\r\n=cZkM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        },
+        {
+          "email": "blaine.bublitz@gmail.com",
+          "name": "phated"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/assign-symbols_2.0.0_1533615127563_0.36901657182503"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "assign-symbols",
+      "description": "Assign the enumerable es6 Symbol properties from one or more objects to the first object passed on the arguments. Can be used as a supplement to other extend, assign or merge methods as a polyfill for the Symbols part of the es6 Object.assign method.",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/assign-symbols",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/assign-symbols.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/assign-symbols/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0"
+      },
+      "keywords": [
+        "assign",
+        "es6",
+        "merge",
+        "mixin",
+        "polyfill",
+        "primitive",
+        "symbol",
+        "symbols"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "assign-deep",
+            "clone-deep",
+            "extend-shallow",
+            "merge-deep",
+            "mixin-deep"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "1429f75d37e3d4d3b6aff684350332fb77621d26",
+      "_id": "assign-symbols@2.0.1",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-uh09B7h3U6d/uGzJfg0m+LzAEb9sqmTaWhmWNcSF+XbwtovzMoLEJohlEI9405lssJ5t3FyLs9HPL4ed67USbQ==",
+        "shasum": "ef45aabe7c80db94660252a4a529e9d6791081ec",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8423,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaR6ACRA9TVsSAnZWagAA4wQQAIwgQrcfMWm+IQdHpufA\n+0vezZrTOKF4D0og8/Tkm+Ne5TjX80PdBR2WuxrL3XGBSAl5DoZ/f0jXh/l4\nYvPwXVKyNl6Mp7hDOHUh6sm6/jpHsmGZqcN2tkAwJ/WKA4KTaLoUCCtaZri9\nT1DeepgwPmgQ2bhn+G/ZcBG05U+mmSYfGGMJqWm61ZIwTSddd0fbCw8WHta9\nA0kvO1Esyy5oqtUt2e4b8FxA7biE/52xvt+IvWCKdQX1ouXgvHtZFm3l4gE2\n8vJqLFYXgqDtsuEDlnephciLZuegNPCiBTzK6bAMEBC1NgcH3XzroHWxxuXw\nFjAmu7ObUSdrQ1p+D7vXEFfCei3iv4O5BvktiQAafSryhQ/bnBgjGOki25wq\neeiM/E3FkSzS9kGU+9oL8Gc30VcANQrmvDKLnQWnBudkg6BT2PlPtFzlEj26\naOjWtbKXdPBw3fptJn+R58yfe96UP4od8y804XyVUMoXYiM/OzV7zyDEiDZZ\nC6RExLB+0RB1rs7FfID3ay2OiGCBiO/xa2AIuq4uvylYeCxeLpIENZVdgNuQ\n5ZNhtfkobPAQyvw4ffd0awrZv8XTvkYejbaDPWVMyIs47ZW6xjtX3oIhQlJv\nj55hcZAXpch4giYsmah4ZI2EOUhIZgSIxlrZCCsKSdXzNcxZKkSb4pFAfHmA\nUNWe\r\n=WBpl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        },
+        {
+          "email": "blaine.bublitz@gmail.com",
+          "name": "phated"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/assign-symbols_2.0.1_1533615743929_0.31101681959925465"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.2": {
+      "name": "assign-symbols",
+      "description": "Assign the enumerable es6 Symbol properties from one or more objects to the first object passed on the arguments. Can be used as a supplement to other extend, assign or merge methods as a polyfill for the Symbols part of the es6 Object.assign method.",
+      "version": "2.0.2",
+      "homepage": "https://github.com/jonschlinkert/assign-symbols",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/assign-symbols.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/assign-symbols/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0"
+      },
+      "keywords": [
+        "assign",
+        "es6",
+        "merge",
+        "mixin",
+        "polyfill",
+        "primitive",
+        "symbol",
+        "symbols"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "assign-deep",
+            "clone-deep",
+            "extend-shallow",
+            "merge-deep",
+            "mixin-deep"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "026e7f6343eee45ec606d5a42291d1bf670ec802",
+      "_id": "assign-symbols@2.0.2",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-9sBQUQZMKFKcO/C3Bo6Rx4CQany0R0UeVcefNGRRdW2vbmaMOhV1sbmlXcQLcD56juLXbSGTBm0GGuvmrAF8pA==",
+        "shasum": "0fb9191dd9d617042746ecfc354f3a3d768a0c98",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8443,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbabo5CRA9TVsSAnZWagAAVt4P/0bC3q9T5EEwVrlR+kPv\nYLZPgNVpYgIus3wLt9r7lvKjJIr0xp6lRzT1sCTSZl7Tmdx5q26sJ5jnm0Fs\nvRlIPk+dIFF4KD7ZHmxInwrfPHWynveH+gYm8bTWaONU2hO8eiqvRkJk5RlY\nnxsvJH4wd8xM3F0laq6BR98yiUx1YwIjdoWXh0tqiGmv3Wjf2sm8OJ1n5xie\nCWAV6DCxysr+AFcH1y91gUKOatHMgJWmwIwBtTwrQS6wxkmxJWEvi6d7SsgB\nKI3c/ynEFnedrfiKr1NsSrEK961Dmiz8kdAPqfR75JVWDmGvD2M3iU7OD/8l\nfnP8rlLQjLuPHwDx1vc60Rni0H8Cs/g9f16v2nhDzmL+JNqs0PLy3PMcyXuk\nfy3URUlQ6U1gyLTOTIVxZSHkwJ7divYQ86KAMQGbzNSopvtx3dcNwSj6Ijxw\n6JmbmXfEW/Txpz8RHJTU6sMBy3ocqe9Z9tBhXAdwqm3LVdn6EMqZEuMrYHd6\ni98lLK0tnlIuCdaB23IXpYfrtX8ePkEZEA9gFEd07AZEvgUYYtPcPZdh4SBI\nCIH+tLY0Mf+zpJrl2p3bzbrdbAjoBNffBUeGA/EgzAK0sCbo9kwynLpCCEFp\nEnb2eRI4OmOMtyCzAg5Aao7wDv54+VjkjeIlYKPRmUa5UwuUTHo7AeVq39JO\n9tEB\r\n=5jR7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        },
+        {
+          "email": "blaine.bublitz@gmail.com",
+          "name": "phated"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/assign-symbols_2.0.2_1533655598273_0.6467931863618057"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# assign-symbols [![NPM version](https://img.shields.io/npm/v/assign-symbols.svg?style=flat)](https://www.npmjs.com/package/assign-symbols) [![NPM monthly downloads](https://img.shields.io/npm/dm/assign-symbols.svg?style=flat)](https://npmjs.org/package/assign-symbols) [![NPM total downloads](https://img.shields.io/npm/dt/assign-symbols.svg?style=flat)](https://npmjs.org/package/assign-symbols) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/assign-symbols.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/assign-symbols)\n\n> Assign the enumerable es6 Symbol properties from one or more objects to the first object passed on the arguments. Can be used as a supplement to other extend, assign or merge methods as a polyfill for the Symbols part of the es6 Object.assign method.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save assign-symbols\n```\n\n## About\n\n> A symbol is a unique and immutable data type and may be used as an identifier for object properties. The symbol object is an implicit object wrapper for the symbol primitive data type. - [Mozilla Developer docs for Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)\n\n## Usage\n\n```js\nconst assignSymbols = require('assign-symbols');\nlet target = {};\n\n// add a symbol to object \"one\"\nlet one = {};\nlet symbolOne = Symbol('aaa');\none[symbolOne] = 'bbb';\n\n// add a symbol to object \"two\"\nlet two = {};\nlet symbolTwo = Symbol('ccc');\ntwo[symbolTwo] = 'ddd';\n\n// assign symbols from objects \"one\" and \"two\" to object \"target\"\nassignSymbols(target, one, two);\n\nconsole.log(target[symbolOne]); //=> 'bbb'\nconsole.log(target[symbolTwo]); //=> 'ddd'\n```\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [assign-deep](https://www.npmjs.com/package/assign-deep): Deeply assign the enumerable properties and/or es6 Symbol properies of source objects to the target… [more](https://github.com/jonschlinkert/assign-deep) | [homepage](https://github.com/jonschlinkert/assign-deep \"Deeply assign the enumerable properties and/or es6 Symbol properies of source objects to the target (first) object.\")\n* [clone-deep](https://www.npmjs.com/package/clone-deep): Recursively (deep) clone JavaScript native types, like Object, Array, RegExp, Date as well as primitives. | [homepage](https://github.com/jonschlinkert/clone-deep \"Recursively (deep) clone JavaScript native types, like Object, Array, RegExp, Date as well as primitives.\")\n* [extend-shallow](https://www.npmjs.com/package/extend-shallow): Extend an object with the properties of additional objects. node.js/javascript util. | [homepage](https://github.com/jonschlinkert/extend-shallow \"Extend an object with the properties of additional objects. node.js/javascript util.\")\n* [merge-deep](https://www.npmjs.com/package/merge-deep): Recursively merge values in a javascript object. | [homepage](https://github.com/jonschlinkert/merge-deep \"Recursively merge values in a javascript object.\")\n* [mixin-deep](https://www.npmjs.com/package/mixin-deep): Deeply mix the properties of objects into the first object. Like merge-deep, but doesn't clone… [more](https://github.com/jonschlinkert/mixin-deep) | [homepage](https://github.com/jonschlinkert/mixin-deep \"Deeply mix the properties of objects into the first object. Like merge-deep, but doesn't clone. No dependencies.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 4 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 2 | [phated](https://github.com/phated) |\n\n### Author\n\n**Jon Schlinkert**\n\n* [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)\n* [GitHub Profile](https://github.com/jonschlinkert)\n* [Twitter Profile](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on August 06, 2018._",
+  "maintainers": [
+    {
+      "email": "blaine.bublitz@gmail.com",
+      "name": "phated"
+    },
+    {
+      "email": "github@sellside.com",
+      "name": "jonschlinkert"
+    },
+    {
+      "email": "brian.woodward@gmail.com",
+      "name": "doowb"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-01T06:07:08.904Z",
+    "created": "2015-11-06T05:18:26.962Z",
+    "0.1.0": "2015-11-06T05:18:26.962Z",
+    "0.1.1": "2015-11-06T05:27:22.236Z",
+    "1.0.0": "2017-12-19T22:45:34.190Z",
+    "2.0.0": "2018-08-07T04:12:07.665Z",
+    "2.0.1": "2018-08-07T04:22:23.999Z",
+    "2.0.2": "2018-08-07T15:26:38.594Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/assign-symbols",
+  "keywords": [
+    "assign",
+    "es6",
+    "merge",
+    "mixin",
+    "polyfill",
+    "primitive",
+    "symbol",
+    "symbols"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/assign-symbols.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/assign-symbols/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/assign-symbols.min.json
+++ b/test/fixtures/registry-mocks/content/assign-symbols.min.json
@@ -1,0 +1,108 @@
+{
+  "name": "assign-symbols",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "assign-symbols",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "bbfa7c01087b543c81a5883bc106f8333b85d696",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "assign-symbols",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "cb025944ef4ec8a3693f086e9e112c74e3a0fed9",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "assign-symbols",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "assign-symbols",
+      "version": "2.0.0",
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-WMsBhayErMFzT2Tl8pCafJAwRz5G/0qwjptjgdu5CKXbLOivPQJZoBhjvQmVe0CyQLu0mj4RPm7XPcAckKjnvg==",
+        "shasum": "00b308df5e2eb7a2e9262d9c9ad62838f7b42374",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8423,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaRwYCRA9TVsSAnZWagAAkSQP/jRZ70FZJOWO3tBvGDzY\n5Z1tFiotvrkb2zze/gh+Gl2R84MeaYyEBv5QXrKd3aOUXQbvjpNveQEDt7P3\narzf3mt9QmSqprHYO+BFSgsnp0R/CiHJiKQVRECAa92+6zCBqYpIwzL4Hpvt\nxTAgql5UxXjAif7JY0j8eov5g8gnBbVwz9Kn8ClhQ1McYZcjhP/fhrGv8DeT\ntSENH4rDxDTIjFL5fvzWOz7yzw2/kz5uplPWV0KZKMxnroKaMGAHOBiEwvm6\nKuKq3Q9Cb6oeTwrp86Ohkhy8VATqOuTL15FJjBG39rOgCT72PF/adQWfWKfR\nRfNTZ6jwgrOdlUDUdbqVCYwmbBrEBTAP1p8T156U+aijeGR30wPEtpk0nATC\npgJB4IUindtd+UYWA7idWidqJh+HG78F3Nm0W8T+RfdZuMiP/3d+9RbMCs6t\niJ0AridNXRdL4vv81gGpNVFPVIweDyCbGoUp313f+ah5VPhcWxSKNaS3Ljlx\nUv+NEePJ0/dpbrvlRIk4IMb6KrbG2jsIOYu0JbwLUJDsTzjJLAFUlN+IiQ1U\nZSzYuNdyGB8AMcAZFmi3njWEwD2zSFQIc/Z3FntJio6Pgd+hHjbhhrpCsMpq\npaXX5sHpSxccXspAvdhyt7IwXUnlbRlEt59OPap3REk+l3qx3xZouRDccGip\n/jnP\r\n=cZkM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "2.0.1": {
+      "name": "assign-symbols",
+      "version": "2.0.1",
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-uh09B7h3U6d/uGzJfg0m+LzAEb9sqmTaWhmWNcSF+XbwtovzMoLEJohlEI9405lssJ5t3FyLs9HPL4ed67USbQ==",
+        "shasum": "ef45aabe7c80db94660252a4a529e9d6791081ec",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8423,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaR6ACRA9TVsSAnZWagAA4wQQAIwgQrcfMWm+IQdHpufA\n+0vezZrTOKF4D0og8/Tkm+Ne5TjX80PdBR2WuxrL3XGBSAl5DoZ/f0jXh/l4\nYvPwXVKyNl6Mp7hDOHUh6sm6/jpHsmGZqcN2tkAwJ/WKA4KTaLoUCCtaZri9\nT1DeepgwPmgQ2bhn+G/ZcBG05U+mmSYfGGMJqWm61ZIwTSddd0fbCw8WHta9\nA0kvO1Esyy5oqtUt2e4b8FxA7biE/52xvt+IvWCKdQX1ouXgvHtZFm3l4gE2\n8vJqLFYXgqDtsuEDlnephciLZuegNPCiBTzK6bAMEBC1NgcH3XzroHWxxuXw\nFjAmu7ObUSdrQ1p+D7vXEFfCei3iv4O5BvktiQAafSryhQ/bnBgjGOki25wq\neeiM/E3FkSzS9kGU+9oL8Gc30VcANQrmvDKLnQWnBudkg6BT2PlPtFzlEj26\naOjWtbKXdPBw3fptJn+R58yfe96UP4od8y804XyVUMoXYiM/OzV7zyDEiDZZ\nC6RExLB+0RB1rs7FfID3ay2OiGCBiO/xa2AIuq4uvylYeCxeLpIENZVdgNuQ\n5ZNhtfkobPAQyvw4ffd0awrZv8XTvkYejbaDPWVMyIs47ZW6xjtX3oIhQlJv\nj55hcZAXpch4giYsmah4ZI2EOUhIZgSIxlrZCCsKSdXzNcxZKkSb4pFAfHmA\nUNWe\r\n=WBpl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "2.0.2": {
+      "name": "assign-symbols",
+      "version": "2.0.2",
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-9sBQUQZMKFKcO/C3Bo6Rx4CQany0R0UeVcefNGRRdW2vbmaMOhV1sbmlXcQLcD56juLXbSGTBm0GGuvmrAF8pA==",
+        "shasum": "0fb9191dd9d617042746ecfc354f3a3d768a0c98",
+        "tarball": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8443,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbabo5CRA9TVsSAnZWagAAVt4P/0bC3q9T5EEwVrlR+kPv\nYLZPgNVpYgIus3wLt9r7lvKjJIr0xp6lRzT1sCTSZl7Tmdx5q26sJ5jnm0Fs\nvRlIPk+dIFF4KD7ZHmxInwrfPHWynveH+gYm8bTWaONU2hO8eiqvRkJk5RlY\nnxsvJH4wd8xM3F0laq6BR98yiUx1YwIjdoWXh0tqiGmv3Wjf2sm8OJ1n5xie\nCWAV6DCxysr+AFcH1y91gUKOatHMgJWmwIwBtTwrQS6wxkmxJWEvi6d7SsgB\nKI3c/ynEFnedrfiKr1NsSrEK961Dmiz8kdAPqfR75JVWDmGvD2M3iU7OD/8l\nfnP8rlLQjLuPHwDx1vc60Rni0H8Cs/g9f16v2nhDzmL+JNqs0PLy3PMcyXuk\nfy3URUlQ6U1gyLTOTIVxZSHkwJ7divYQ86KAMQGbzNSopvtx3dcNwSj6Ijxw\n6JmbmXfEW/Txpz8RHJTU6sMBy3ocqe9Z9tBhXAdwqm3LVdn6EMqZEuMrYHd6\ni98lLK0tnlIuCdaB23IXpYfrtX8ePkEZEA9gFEd07AZEvgUYYtPcPZdh4SBI\nCIH+tLY0Mf+zpJrl2p3bzbrdbAjoBNffBUeGA/EgzAK0sCbo9kwynLpCCEFp\nEnb2eRI4OmOMtyCzAg5Aao7wDv54+VjkjeIlYKPRmUa5UwuUTHo7AeVq39JO\n9tEB\r\n=5jR7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "modified": "2019-01-01T06:07:08.904Z"
+}

--- a/test/fixtures/registry-mocks/content/async-each.json
+++ b/test/fixtures/registry-mocks/content/async-each.json
@@ -1,0 +1,685 @@
+{
+  "_id": "async-each",
+  "_rev": "28-c284bc3d9c196ea2133e51a88a8709b6",
+  "name": "async-each",
+  "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach / map function for JavaScript.",
+  "dist-tags": {
+    "latest": "1.0.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "async-each",
+      "repo": "paulmillr/async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach function for JavaScript.",
+      "version": "0.1.0",
+      "keywords": [
+        "async",
+        "forEach",
+        "each"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --require test/test_helpers.js"
+      },
+      "dependencies": {},
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@0.1.0",
+      "dist": {
+        "shasum": "e9a61a5a3e73c4a23d0b41a275aaa8626c547964",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.25",
+      "_npmUser": {
+        "name": "paulmillr",
+        "email": "paul@paulmillr.com"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "async-each",
+      "repo": "paulmillr/async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach function for JavaScript.",
+      "version": "0.1.1",
+      "keywords": [
+        "async",
+        "forEach",
+        "each"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --require test/test_helpers.js"
+      },
+      "dependencies": {},
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@0.1.1",
+      "dist": {
+        "shasum": "57ac387f448aa01700f1be8cd2e408253744096a",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.25",
+      "_npmUser": {
+        "name": "paulmillr",
+        "email": "paul@paulmillr.com"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "async-each",
+      "repo": "paulmillr/async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach function for JavaScript.",
+      "version": "0.1.2",
+      "keywords": [
+        "async",
+        "forEach",
+        "each"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --require test/test_helpers.js"
+      },
+      "dependencies": {},
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@0.1.2",
+      "dist": {
+        "shasum": "0c9a20a4e4a1b7af16c5e551aad50951f5b02208",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "paulmillr",
+        "email": "paul@paulmillr.com"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "async-each",
+      "repo": "paulmillr/async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach function for JavaScript.",
+      "version": "0.1.3",
+      "keywords": [
+        "async",
+        "forEach",
+        "each"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --require test/test_helpers.js"
+      },
+      "dependencies": {},
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@0.1.3",
+      "dist": {
+        "shasum": "01b72b9ae8803abd8d1875cf2f6d23bc84b7fa4d",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "paulmillr",
+        "email": "paul@paulmillr.com"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "async-each",
+      "repo": "paulmillr/async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach function for JavaScript.",
+      "version": "0.1.4",
+      "keywords": [
+        "async",
+        "forEach",
+        "each"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --require test/test_helpers.js"
+      },
+      "dependencies": {},
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@0.1.4",
+      "dist": {
+        "shasum": "3aa643ccb433e7b4b7c68621cbd6a5d8f0d124cd",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "paulmillr",
+        "email": "paul@paulmillr.com"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach / map function for JavaScript.",
+      "version": "0.1.5",
+      "keywords": [
+        "async",
+        "forEach",
+        "each",
+        "map",
+        "asynchronous",
+        "iteration",
+        "iterate",
+        "loop",
+        "parallel",
+        "concurrent",
+        "array",
+        "flow",
+        "control flow"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "dependencies": {},
+      "gitHead": "4ee6ce410c92bb873914576bf59d51d3ac0762c4",
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@0.1.5",
+      "scripts": {},
+      "_shasum": "2427b2d43e1b5eadf6a28b58b2f0e00baa8801a5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "es128",
+        "email": "elan.shanker+npm@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        },
+        {
+          "name": "es128",
+          "email": "elan.shanker+npm@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2427b2d43e1b5eadf6a28b58b2f0e00baa8801a5",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.6": {
+      "name": "async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach / map function for JavaScript.",
+      "version": "0.1.6",
+      "license": "MIT",
+      "keywords": [
+        "async",
+        "forEach",
+        "each",
+        "map",
+        "asynchronous",
+        "iteration",
+        "iterate",
+        "loop",
+        "parallel",
+        "concurrent",
+        "array",
+        "flow",
+        "control flow"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "dependencies": {},
+      "gitHead": "3da122b3e6fe84207bdca246e484a6a50462f190",
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@0.1.6",
+      "scripts": {},
+      "_shasum": "b67e99edcddf96541e44af56290cd7d5c6e70439",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "es128",
+        "email": "elan.shanker+npm@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        },
+        {
+          "name": "es128",
+          "email": "elan.shanker+npm@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b67e99edcddf96541e44af56290cd7d5c6e70439",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach / map function for JavaScript.",
+      "version": "1.0.0",
+      "license": "MIT",
+      "keywords": [
+        "async",
+        "forEach",
+        "each",
+        "map",
+        "asynchronous",
+        "iteration",
+        "iterate",
+        "loop",
+        "parallel",
+        "concurrent",
+        "array",
+        "flow",
+        "control flow"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "dependencies": {},
+      "gitHead": "89c02adfcff2946a5062e40167ebbb6f1ccfcfe0",
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@1.0.0",
+      "scripts": {},
+      "_shasum": "b5319226c29d99277df63c8aee04093aa5f1d39f",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "es128",
+        "email": "elan.shanker+npm@gmail.com"
+      },
+      "dist": {
+        "shasum": "b5319226c29d99277df63c8aee04093aa5f1d39f",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        },
+        {
+          "name": "es128",
+          "email": "elan.shanker+npm@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach / map function for JavaScript.",
+      "version": "1.0.1",
+      "license": "MIT",
+      "keywords": [
+        "async",
+        "forEach",
+        "each",
+        "map",
+        "asynchronous",
+        "iteration",
+        "iterate",
+        "loop",
+        "parallel",
+        "concurrent",
+        "array",
+        "flow",
+        "control flow"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "dependencies": {},
+      "gitHead": "f2342d85633d0dc1034a49387ca01c08c1189823",
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@1.0.1",
+      "scripts": {},
+      "_shasum": "19d386a1d9edc6e7c1c85d388aedbcc56d33602d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "paulmillr",
+        "email": "paul@paulmillr.com"
+      },
+      "maintainers": [
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        },
+        {
+          "name": "es128",
+          "email": "elan.shanker+npm@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "19d386a1d9edc6e7c1c85d388aedbcc56d33602d",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/async-each-1.0.1.tgz_1472080935649_0.032988218357786536"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach / map function for JavaScript.",
+      "version": "1.0.2",
+      "license": "MIT",
+      "keywords": [
+        "async",
+        "forEach",
+        "each",
+        "map",
+        "asynchronous",
+        "iteration",
+        "iterate",
+        "loop",
+        "parallel",
+        "concurrent",
+        "array",
+        "flow",
+        "control flow"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "http://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "dependencies": {},
+      "gitHead": "cc1a25b8e0792b330e819a66844c5d7e1c9e5d5c",
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@1.0.2",
+      "_nodeVersion": "11.10.0",
+      "_npmVersion": "6.8.0",
+      "dist": {
+        "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
+        "shasum": "8b8a7ca2a658f927e9f307d6d1a42f4199f0f735",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5597,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcicGyCRA9TVsSAnZWagAAQY4P/0lqV44e0dlFQ85v4Yib\nl6vFRWBfNLm6nTbuUHiltkm3jRN0fP8ujoxOHQT1q5PYvVa2jAFx6nnjAwri\nuxNSA062Arc3PMs//Qc9DuJScFuCmaWhZTC/8Cs+YgCB4vrA+hgh9MG28clW\n9rIr5pQQun9qY/MDGNjmNImaSS1AU4FviYHFXUi0M+2W/tGTETQKWeykyFQA\n/Oi+MjJJLUANjXjWRnXGci3QWtD93bD+G6LHSdSd+c971qY7D7iKeaGrMoZq\nkgoeZBRgfKcZEWDk6/7B1h+cyByFJXqfNTs+dP/xj/YecWkiXdobyLOo0FaI\nQVB68cCiy6OUuexMiMOr1W8MNO3GPwOletxJ+a1pB7haqGt3I6j0RSyBwdbZ\no6M4ypZ4rfkNAEpsLLBJOFIL0P446aesgS4IWwteZDsrjbkC8fbekLPME1Sw\nTjx2fV/jNfrP+raURlXB11THNe1Gv8js80Mcl7qQJwEM6DtNcMkVbZ8syOCQ\nhxA0CEXdRgy+svZKVRbQfjBxwjhPBo/pgTTW71Rkn8w9RaBTXD8Lax49R/pH\nrm0gEfRCY/h868dEL8Y6VJ/puWgg+TrDMCrtiNUdPgSGoD5Jf01xuOIfvX+a\nT99iWwmspSCZMmxRWMVwTeAxa4rjMGw8TfG/+VnrtjLd3jPxqY3oeAuSk7Ky\n2x24\r\n=i19K\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "es128",
+          "email": "elan.shanker+npm@gmail.com"
+        },
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "paulmillr",
+        "email": "paul@paulmillr.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/async-each_1.0.2_1552531890118_0.2552403988306451"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.3": {
+      "name": "async-each",
+      "description": "No-bullshit, ultra-simple, 35-lines-of-code async parallel forEach / map function for JavaScript.",
+      "version": "1.0.3",
+      "license": "MIT",
+      "keywords": [
+        "async",
+        "forEach",
+        "each",
+        "map",
+        "asynchronous",
+        "iteration",
+        "iterate",
+        "loop",
+        "parallel",
+        "concurrent",
+        "array",
+        "flow",
+        "control flow"
+      ],
+      "homepage": "https://github.com/paulmillr/async-each/",
+      "author": {
+        "name": "Paul Miller",
+        "url": "https://paulmillr.com/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/paulmillr/async-each.git"
+      },
+      "main": "index.js",
+      "dependencies": {},
+      "gitHead": "9c0980f671fd649e4523e15f5b281aaa5294409e",
+      "bugs": {
+        "url": "https://github.com/paulmillr/async-each/issues"
+      },
+      "_id": "async-each@1.0.3",
+      "_nodeVersion": "11.14.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+        "shasum": "b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+        "fileCount": 3,
+        "unpackedSize": 3952,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJctiX2CRA9TVsSAnZWagAA/g8P/3l1hRV4XdJKp9iqXQsF\nXVdLV1ZOxsjzKD9rS3kI8sSu7pQShKPnrQ5wb3Y4w54tt1KRXuc/M5Ot6VIu\niCoK15Emyxv1EF2ElzijJGBPd4t0xikLxD9I9zdvTeBPUrq520fAjbSppCAj\nT5vwqqs+rP7SaldAKhKZY+Y1f5vWCZejTib56zcbLnNF8RnsCkOhrm4ifqRi\nHj1LZZIe/QIaPbmzLmVCI7efS0EZj34rSaOtM3dr37KK6BdB5U1q5ekrhHNu\nWsZntYLV1b71zF1N2UqiAFz4nYohjhP7r5s1edoYXdmznROOPTV4M69FNfHK\n0Z/kLfcj3GZbNEnZ/AsTsMyhBujUmpcv+ZC38+J4RRogEFxHOijfIlTAtsBG\nzZ9M399QmRyE5JSCR+/6uwqUJgZDb24rGJkRpRylOSvDQddQz9w3dRZgLQgk\njpV0gu0nN6jCL/wHND3NdVQ78ytYVK8UngPIf0iKdlg8S0ufvl7uBslzXtfd\nbAwZb0Ox7v/HUPTcpQ8/B+uz2gd6QYFv5e2By9LN9x25h6vSOUc3BakWt1WG\nm4kJs3sdi4QwpHNXBJ31xbi9zsbd4WGiYYTSGfaVBPxhXTIU92twoT639393\n8br0QTyqXTKV1eJGERuehQe0e0XsjuhX5LjuNaGTBHiElQ+yrAo95fk7+09G\nlRPd\r\n=f3sq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "es128",
+          "email": "elan.shanker+npm@gmail.com"
+        },
+        {
+          "name": "paulmillr",
+          "email": "paul@paulmillr.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "paulmillr",
+        "email": "paul@paulmillr.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/async-each_1.0.3_1555441141683_0.24135928845425325"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# async-each\n\nNo-bullshit, ultra-simple, 35-lines-of-code async parallel forEach function for JavaScript.\n\nWe don't need junky 30K async libs. Really.\n\nFor browsers and node.js.\n\n## Installation\n* Just include async-each before your scripts.\n* `npm install async-each` if you’re using node.js.\n\n## Usage\n\n* `each(array, iterator, callback);` — `Array`, `Function`, `(optional) Function`\n* `iterator(item, next)` receives current item and a callback that will mark the item as done. `next` callback receives optional `error, transformedItem` arguments.\n* `callback(error, transformedArray)` optionally receives first error and transformed result `Array`.\n\n```javascript\nvar each = require('async-each');\neach(['a.js', 'b.js', 'c.js'], fs.readFile, function(error, contents) {\n  if (error) console.error(error);\n  console.log('Contents for a, b and c:', contents);\n});\n\n// Alternatively in browser:\nasyncEach(list, fn, callback);\n```\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2016 Paul Miller [(paulmillr.com)](http://paulmillr.com)\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the “Software”), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "es128",
+      "email": "elan.shanker+npm@gmail.com"
+    },
+    {
+      "name": "paulmillr",
+      "email": "paul@paulmillr.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-16T18:59:04.757Z",
+    "created": "2013-06-14T07:31:34.692Z",
+    "0.1.0": "2013-06-14T07:31:37.982Z",
+    "0.1.1": "2013-06-14T07:57:30.957Z",
+    "0.1.2": "2013-07-07T04:50:48.081Z",
+    "0.1.3": "2013-07-24T21:11:53.435Z",
+    "0.1.4": "2013-11-12T21:57:46.049Z",
+    "0.1.5": "2014-10-23T12:55:44.577Z",
+    "0.1.6": "2014-11-05T22:16:18.395Z",
+    "1.0.0": "2015-11-26T17:53:29.606Z",
+    "1.0.1": "2016-08-24T23:22:17.631Z",
+    "1.0.2": "2019-03-14T02:51:30.259Z",
+    "1.0.3": "2019-04-16T18:59:01.830Z"
+  },
+  "author": {
+    "name": "Paul Miller",
+    "url": "https://paulmillr.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/paulmillr/async-each.git"
+  },
+  "users": {
+    "tunnckocore": true,
+    "artskydj": true,
+    "jpepe": true,
+    "youstrive": true,
+    "pandao": true,
+    "nichoth": true,
+    "j.su": true,
+    "vonthar": true
+  },
+  "homepage": "https://github.com/paulmillr/async-each/",
+  "keywords": [
+    "async",
+    "forEach",
+    "each",
+    "map",
+    "asynchronous",
+    "iteration",
+    "iterate",
+    "loop",
+    "parallel",
+    "concurrent",
+    "array",
+    "flow",
+    "control flow"
+  ],
+  "bugs": {
+    "url": "https://github.com/paulmillr/async-each/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/async-each.min.json
+++ b/test/fixtures/registry-mocks/content/async-each.min.json
@@ -1,0 +1,105 @@
+{
+  "name": "async-each",
+  "dist-tags": {
+    "latest": "1.0.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "async-each",
+      "version": "0.1.0",
+      "dist": {
+        "shasum": "e9a61a5a3e73c4a23d0b41a275aaa8626c547964",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "async-each",
+      "version": "0.1.1",
+      "dist": {
+        "shasum": "57ac387f448aa01700f1be8cd2e408253744096a",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "async-each",
+      "version": "0.1.2",
+      "dist": {
+        "shasum": "0c9a20a4e4a1b7af16c5e551aad50951f5b02208",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "async-each",
+      "version": "0.1.3",
+      "dist": {
+        "shasum": "01b72b9ae8803abd8d1875cf2f6d23bc84b7fa4d",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "async-each",
+      "version": "0.1.4",
+      "dist": {
+        "shasum": "3aa643ccb433e7b4b7c68621cbd6a5d8f0d124cd",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "async-each",
+      "version": "0.1.5",
+      "dist": {
+        "shasum": "2427b2d43e1b5eadf6a28b58b2f0e00baa8801a5",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.5.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "async-each",
+      "version": "0.1.6",
+      "dist": {
+        "shasum": "b67e99edcddf96541e44af56290cd7d5c6e70439",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "async-each",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "b5319226c29d99277df63c8aee04093aa5f1d39f",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "async-each",
+      "version": "1.0.1",
+      "dist": {
+        "shasum": "19d386a1d9edc6e7c1c85d388aedbcc56d33602d",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "async-each",
+      "version": "1.0.2",
+      "dist": {
+        "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
+        "shasum": "8b8a7ca2a658f927e9f307d6d1a42f4199f0f735",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5597,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcicGyCRA9TVsSAnZWagAAQY4P/0lqV44e0dlFQ85v4Yib\nl6vFRWBfNLm6nTbuUHiltkm3jRN0fP8ujoxOHQT1q5PYvVa2jAFx6nnjAwri\nuxNSA062Arc3PMs//Qc9DuJScFuCmaWhZTC/8Cs+YgCB4vrA+hgh9MG28clW\n9rIr5pQQun9qY/MDGNjmNImaSS1AU4FviYHFXUi0M+2W/tGTETQKWeykyFQA\n/Oi+MjJJLUANjXjWRnXGci3QWtD93bD+G6LHSdSd+c971qY7D7iKeaGrMoZq\nkgoeZBRgfKcZEWDk6/7B1h+cyByFJXqfNTs+dP/xj/YecWkiXdobyLOo0FaI\nQVB68cCiy6OUuexMiMOr1W8MNO3GPwOletxJ+a1pB7haqGt3I6j0RSyBwdbZ\no6M4ypZ4rfkNAEpsLLBJOFIL0P446aesgS4IWwteZDsrjbkC8fbekLPME1Sw\nTjx2fV/jNfrP+raURlXB11THNe1Gv8js80Mcl7qQJwEM6DtNcMkVbZ8syOCQ\nhxA0CEXdRgy+svZKVRbQfjBxwjhPBo/pgTTW71Rkn8w9RaBTXD8Lax49R/pH\nrm0gEfRCY/h868dEL8Y6VJ/puWgg+TrDMCrtiNUdPgSGoD5Jf01xuOIfvX+a\nT99iWwmspSCZMmxRWMVwTeAxa4rjMGw8TfG/+VnrtjLd3jPxqY3oeAuSk7Ky\n2x24\r\n=i19K\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.3": {
+      "name": "async-each",
+      "version": "1.0.3",
+      "dist": {
+        "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+        "shasum": "b727dbf87d7651602f06f4d4ac387f47d91b0cbf",
+        "tarball": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+        "fileCount": 3,
+        "unpackedSize": 3952,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJctiX2CRA9TVsSAnZWagAA/g8P/3l1hRV4XdJKp9iqXQsF\nXVdLV1ZOxsjzKD9rS3kI8sSu7pQShKPnrQ5wb3Y4w54tt1KRXuc/M5Ot6VIu\niCoK15Emyxv1EF2ElzijJGBPd4t0xikLxD9I9zdvTeBPUrq520fAjbSppCAj\nT5vwqqs+rP7SaldAKhKZY+Y1f5vWCZejTib56zcbLnNF8RnsCkOhrm4ifqRi\nHj1LZZIe/QIaPbmzLmVCI7efS0EZj34rSaOtM3dr37KK6BdB5U1q5ekrhHNu\nWsZntYLV1b71zF1N2UqiAFz4nYohjhP7r5s1edoYXdmznROOPTV4M69FNfHK\n0Z/kLfcj3GZbNEnZ/AsTsMyhBujUmpcv+ZC38+J4RRogEFxHOijfIlTAtsBG\nzZ9M399QmRyE5JSCR+/6uwqUJgZDb24rGJkRpRylOSvDQddQz9w3dRZgLQgk\njpV0gu0nN6jCL/wHND3NdVQ78ytYVK8UngPIf0iKdlg8S0ufvl7uBslzXtfd\nbAwZb0Ox7v/HUPTcpQ8/B+uz2gd6QYFv5e2By9LN9x25h6vSOUc3BakWt1WG\nm4kJs3sdi4QwpHNXBJ31xbi9zsbd4WGiYYTSGfaVBPxhXTIU92twoT639393\n8br0QTyqXTKV1eJGERuehQe0e0XsjuhX5LjuNaGTBHiElQ+yrAo95fk7+09G\nlRPd\r\n=f3sq\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-04-16T18:59:04.757Z"
+}

--- a/test/fixtures/registry-mocks/content/async-limiter.json
+++ b/test/fixtures/registry-mocks/content/async-limiter.json
@@ -1,0 +1,253 @@
+{
+  "_id": "async-limiter",
+  "_rev": "3-7c7b194f129a478adab4e7afcf01fd6c",
+  "name": "async-limiter",
+  "description": "asynchronous function queue with adjustable concurrency",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "async-limiter",
+      "version": "1.0.0",
+      "description": "asynchronous function queue with adjustable concurrency",
+      "keywords": [
+        "throttle",
+        "async",
+        "limiter",
+        "asynchronous",
+        "job",
+        "task",
+        "concurrency",
+        "concurrent"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^4.6.1",
+        "eslint-plugin-mocha": "^4.11.0",
+        "intelli-espower-loader": "^1.0.1",
+        "istanbul": "^0.3.2",
+        "mocha": "^3.5.2",
+        "power-assert": "^1.4.4"
+      },
+      "scripts": {
+        "test": "mocha --R intelli-espower-loader test/",
+        "travis": "npm run lint && npm run coverage",
+        "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls",
+        "example": "node example",
+        "lint": "eslint ."
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/strml/async-limiter.git"
+      },
+      "author": {
+        "name": "Samuel Reed"
+      },
+      "license": "MIT",
+      "gitHead": "02c8b498279dc7cc1ecc1c4f6fc9ca320c0ce39b",
+      "bugs": {
+        "url": "https://github.com/strml/async-limiter/issues"
+      },
+      "homepage": "https://github.com/strml/async-limiter#readme",
+      "_id": "async-limiter@1.0.0",
+      "_npmVersion": "5.4.1",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "strml",
+        "email": "samuel.trace.reed@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+        "shasum": "78faed8c3d074ab81f22b4e985d79e8738f720f8",
+        "tarball": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "strml",
+          "email": "samuel.trace.reed@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/async-limiter-1.0.0.tgz_1505149068503_0.15003100014291704"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "async-limiter",
+      "version": "1.0.1",
+      "description": "asynchronous function queue with adjustable concurrency",
+      "keywords": [
+        "throttle",
+        "async",
+        "limiter",
+        "asynchronous",
+        "job",
+        "task",
+        "concurrency",
+        "concurrent"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "coveralls": "^3.0.3",
+        "eslint": "^5.16.0",
+        "eslint-plugin-mocha": "^5.3.0",
+        "intelli-espower-loader": "^1.0.1",
+        "mocha": "^6.1.4",
+        "nyc": "^14.1.1",
+        "power-assert": "^1.6.1"
+      },
+      "scripts": {
+        "test": "mocha --require intelli-espower-loader test/",
+        "travis": "npm run lint && npm run test",
+        "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
+        "example": "node example",
+        "lint": "eslint ."
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/strml/async-limiter.git"
+      },
+      "author": {
+        "name": "Samuel Reed"
+      },
+      "license": "MIT",
+      "gitHead": "f3bb66f26e69a5747a6483e32c775a02632020ee",
+      "bugs": {
+        "url": "https://github.com/strml/async-limiter/issues"
+      },
+      "homepage": "https://github.com/strml/async-limiter#readme",
+      "_id": "async-limiter@1.0.1",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+        "shasum": "dd379e94f0db8310b08291f9d64c3209766617fd",
+        "tarball": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6900,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdRFo5CRA9TVsSAnZWagAAE8EP/AoamQTvsA8uUcSUKc4L\nL7rKbbH4m5Cv1Z7qeBXLV3KJHI+dhn/mKU2hOpnXHgks5Az4ELlOX9O1vo9j\nLYtN8ZMGEkMIx+k7OcVexaXLcK9ALliEMNoNy4cIVc+exBS4eKFPmaEx5DmD\nNf+eCG6jkA9WY/kYSmFnus7C0B7d2PMdmtBZKdzWya9PAB5BYEoz3/GYhJZG\nEFYHmWKtMDB6LMSZ0FSXwABV6QXWn5kk3fXaPX1NtMHLw+QCT/sWt+0cOnIE\nak2s8WOry7Fsx5wXQmKbd8854LC+yVT1f7RR7eBhKAlTk74nwfNDr84UBJIr\n+0G0RdgISOzLghtRFu3SqYKynXTjdlycZG9vvcHW9oPGI2ZiC2cHuiqc4+K7\ndYX1HGQICjflTmb+RR0vGNXiy3v6YBWgpItdeziPO2K+0uN6SJr1BidQ8oKI\nd49psu/xNvMhdwOo19+/Bt7n7nT4uzej8K7uQO81BJC0ITeNfaC/z9M/4VOg\nFuixwvvzfs+/RABxzXKZqOMVlAnAb4U/PBcliklyUBeZ62PDkqnBxdrOekf5\nacstUU3K5bAaBV8taKHEa1+tqYUjVEcaolDDKgmO0dxD9FlKAMlhck9ildO7\nnjODiNgcSMUlMmHGUZCEvjSt1YptntzC0DHwxWUjszaR4p0Iz0c0AyOYGH7T\nRewy\r\n=MPQY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "strml",
+          "email": "samuel.trace.reed@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "strml",
+        "email": "samuel.trace.reed@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/async-limiter_1.0.1_1564760633070_0.6974331182093105"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "async-limiter",
+      "version": "2.0.0",
+      "description": "asynchronous function queue with adjustable concurrency",
+      "keywords": [
+        "throttle",
+        "async",
+        "limiter",
+        "asynchronous",
+        "job",
+        "task",
+        "concurrency",
+        "concurrent"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "coveralls": "^3.0.7",
+        "eslint": "^6.6.0",
+        "eslint-plugin-mocha": "^6.2.1",
+        "intelli-espower-loader": "^1.0.1",
+        "mocha": "^6.2.2",
+        "nyc": "^14.1.1",
+        "power-assert": "^1.6.1"
+      },
+      "scripts": {
+        "test": "mocha --require intelli-espower-loader test/",
+        "travis": "npm run lint && npm run test",
+        "coverage": "nyc npm test && nyc report --reporter=text-lcov | coveralls",
+        "example": "node example",
+        "lint": "eslint ."
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strml/async-limiter.git"
+      },
+      "author": {
+        "name": "Samuel Reed"
+      },
+      "license": "MIT",
+      "licenseText": "The MIT License (MIT)\nCopyright (c) 2017 Samuel Reed <samuel.trace.reed@gmail.com>\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+      "_id": "async-limiter@2.0.0",
+      "dist": {
+        "shasum": "ae693f11cac67f4ac5eb6e0c1512fb9b2c2e9ea8",
+        "integrity": "sha512-nyHFzvVaR+4mfHc90/VqOUQjlnk9+ioDxQfqDuqKnm3m9sIT7joVKW8dkxeaKpamMJ3MYD73t6M8PMKEWlQESQ==",
+        "tarball": "https://registry.npmjs.org/async-limiter/-/async-limiter-2.0.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 8589,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd1Xo5CRA9TVsSAnZWagAAyXQP/ibSfb7MvOeB9agWY9Mc\n3clrzvn3s4kiQp+exCa8zygVvxB1E7DL+DE7aw/G5WNgAL4yaX3h+0EBJu1k\n1cnni6UJ45n2rqJO7RoH8+KXiJpevP6450YpTgTz/LH/1EajytdMLwSyPdLh\n051wKmbtN0rvM0LqVAlhmdV+jzCPHHwQdFVBsLyXIJipqDnFBC6QpOXeCAUX\nO23dHH/0wB7jx8AeATXZ+mmFf5YHkWiR2BvGukSi/x3OHHzlZSI7aLLONbQs\nyLDBvYC8UfqoWuofcBwqCbD0RRCvNWBCcQAuIovbS+b61bQTT70eXi8WCih7\nUZoCyPy1jaZ111gKIX7zu0HJJv4lC+7xD7flvhJy1/67bncrVDfevltq7yK1\nxbksYT4fcybA38T4ZyXchZh8CPLQcC/yRwsi4B9+roDtz98ww+i5x6SA4HbL\n6PSVm36pSpxZu5tFpAfN/13MXMtn8ajTUU8/FvKOanOn7yBZYZ489lPPwbS/\nokUZNoh17tLyv6bIQ+M0dza5Y27IOaEmXEPSGj233hlQS32AIpS6DPD4JSEF\n069dc18X+hKUnFo7hyaHkHlWa92XwwTIA5N0hLoc5NbZCIengq8iqz93H9SD\nWkuWif9o0K+nebdI9Z/2JjGTei0NisnCsjBOYqK2FaKT5fXqDFUIRrupXoIO\nwCah\r\n=OJ/M\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "strml",
+          "email": "samuel.trace.reed@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "strml",
+        "email": "samuel.trace.reed@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/async-limiter_2.0.0_1574271544660_0.545457320987442"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Async-Limiter\n\nA module for limiting concurrent asynchronous actions in flight. Forked from [queue](https://github.com/jessetane/queue).\n\n[![npm](http://img.shields.io/npm/v/async-limiter.svg?style=flat-square)](http://www.npmjs.org/async-limiter)\n[![tests](https://img.shields.io/travis/STRML/async-limiter.svg?style=flat-square&branch=master)](https://travis-ci.org/STRML/async-limiter)\n[![coverage](https://img.shields.io/coveralls/STRML/async-limiter.svg?style=flat-square&branch=master)](https://coveralls.io/r/STRML/async-limiter)\n\nThis module exports a class `Limiter` that implements some of the `Array` API.\nPass async functions (ones that accept a callback or return a promise) to an instance's additive array methods.\n\n## Motivation\n\nCertain functions, like `zlib`, have [undesirable behavior](https://github.com/nodejs/node/issues/8871#issuecomment-250915913) when\nrun at infinite concurrency.\n\nIn this case, it is actually faster, and takes far less memory, to limit concurrency.\n\nThis module should do the absolute minimum work necessary to queue up functions. PRs are welcome that would\nmake this module faster or lighter, but new functionality is not desired.\n\nStyle should confirm to nodejs/node style.\n\n## Example\n\n``` javascript\nvar Limiter = require('async-limiter');\n\nvar t = new Limiter({ concurrency: 2 });\nvar results = [];\n\n// add jobs using the familiar Array API\nt.push(function(cb) {\n  results.push('two');\n  cb();\n});\n\nt.push(\n  function(cb) {\n    results.push('four');\n    cb();\n  },\n  function(cb) {\n    results.push('five');\n    cb();\n  }\n);\n\nt.unshift(function(cb) {\n  results.push('one');\n  cb();\n});\n\nt.splice(2, 0, function(cb) {\n  results.push('three');\n  cb();\n});\n\n// Jobs run automatically on the next tick.\n// If you want a callback when all are done, call 'onDone()'.\nt.onDone(function() {\n  console.log('all done:', results);\n});\n```\n\n## Zlib Example\n\n```js\nconst zlib = require('zlib');\nconst Limiter = require('async-limiter');\n\nconst message = { some: 'data' };\nconst payload = new Buffer(JSON.stringify(message));\n\n// Try with different concurrency values to see how this actually\n// slows significantly with higher concurrency!\n//\n// 5:        1398.607ms\n// 10:       1375.668ms\n// Infinity: 4423.300ms\n//\nconst t = new Limiter({ concurrency: 5 });\nfunction deflate(payload, cb) {\n  t.push(function(done) {\n    zlib.deflate(payload, function(err, buffer) {\n      done();\n      cb(err, buffer);\n    });\n  });\n}\n\nconsole.time('deflate');\nfor (let i = 0; i < 30000; ++i) {\n  deflate(payload, function(err, buffer) {});\n}\nt.onDone(function() {\n  console.timeEnd('deflate');\n});\n```\n\n## Install\n\n`npm install async-limiter`\n\n## Test\n\n`npm test`\n\n## API\n\n### `var t = new Limiter([opts])`\nConstructor. `opts` may contain inital values for:\n* `t.concurrency`\n\n## Instance methods\n\n### `t.onDone(fn)`\n`fn` will be called once and only once, when the queue is empty.\nIf the queue is empty on the next tick, `onDone()` will be called.\n\n## Instance methods mixed in from `Array`\nMozilla has docs on how these methods work [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).\n### `t.push(element1, ..., elementN)`\n### `t.unshift(element1, ..., elementN)`\n### `t.splice(index , howMany[, element1[, ...[, elementN]]])`\n\nOn the next tick, job processing will start.\n\n## Properties\n### `t.concurrency`\nMax number of jobs the queue should process concurrently, defaults to `Infinity`.\n\n### `t.length`\nJobs pending + jobs to process (readonly).\n\n",
+  "maintainers": [
+    {
+      "name": "strml",
+      "email": "samuel.trace.reed@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-11-20T17:39:09.289Z",
+    "created": "2017-09-11T16:57:49.546Z",
+    "1.0.0": "2017-09-11T16:57:49.546Z",
+    "1.0.1": "2019-08-02T15:43:53.217Z",
+    "2.0.0": "2019-11-20T17:39:05.353Z"
+  },
+  "keywords": [
+    "throttle",
+    "async",
+    "limiter",
+    "asynchronous",
+    "job",
+    "task",
+    "concurrency",
+    "concurrent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/strml/async-limiter.git"
+  },
+  "author": {
+    "name": "Samuel Reed"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "tzq1011": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/async-limiter.min.json
+++ b/test/fixtures/registry-mocks/content/async-limiter.min.json
@@ -1,0 +1,69 @@
+{
+  "name": "async-limiter",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "async-limiter",
+      "version": "1.0.0",
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^4.6.1",
+        "eslint-plugin-mocha": "^4.11.0",
+        "intelli-espower-loader": "^1.0.1",
+        "istanbul": "^0.3.2",
+        "mocha": "^3.5.2",
+        "power-assert": "^1.4.4"
+      },
+      "dist": {
+        "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+        "shasum": "78faed8c3d074ab81f22b4e985d79e8738f720f8",
+        "tarball": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "async-limiter",
+      "version": "1.0.1",
+      "devDependencies": {
+        "coveralls": "^3.0.3",
+        "eslint": "^5.16.0",
+        "eslint-plugin-mocha": "^5.3.0",
+        "intelli-espower-loader": "^1.0.1",
+        "mocha": "^6.1.4",
+        "nyc": "^14.1.1",
+        "power-assert": "^1.6.1"
+      },
+      "dist": {
+        "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+        "shasum": "dd379e94f0db8310b08291f9d64c3209766617fd",
+        "tarball": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6900,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdRFo5CRA9TVsSAnZWagAAE8EP/AoamQTvsA8uUcSUKc4L\nL7rKbbH4m5Cv1Z7qeBXLV3KJHI+dhn/mKU2hOpnXHgks5Az4ELlOX9O1vo9j\nLYtN8ZMGEkMIx+k7OcVexaXLcK9ALliEMNoNy4cIVc+exBS4eKFPmaEx5DmD\nNf+eCG6jkA9WY/kYSmFnus7C0B7d2PMdmtBZKdzWya9PAB5BYEoz3/GYhJZG\nEFYHmWKtMDB6LMSZ0FSXwABV6QXWn5kk3fXaPX1NtMHLw+QCT/sWt+0cOnIE\nak2s8WOry7Fsx5wXQmKbd8854LC+yVT1f7RR7eBhKAlTk74nwfNDr84UBJIr\n+0G0RdgISOzLghtRFu3SqYKynXTjdlycZG9vvcHW9oPGI2ZiC2cHuiqc4+K7\ndYX1HGQICjflTmb+RR0vGNXiy3v6YBWgpItdeziPO2K+0uN6SJr1BidQ8oKI\nd49psu/xNvMhdwOo19+/Bt7n7nT4uzej8K7uQO81BJC0ITeNfaC/z9M/4VOg\nFuixwvvzfs+/RABxzXKZqOMVlAnAb4U/PBcliklyUBeZ62PDkqnBxdrOekf5\nacstUU3K5bAaBV8taKHEa1+tqYUjVEcaolDDKgmO0dxD9FlKAMlhck9ildO7\nnjODiNgcSMUlMmHGUZCEvjSt1YptntzC0DHwxWUjszaR4p0Iz0c0AyOYGH7T\nRewy\r\n=MPQY\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "async-limiter",
+      "version": "2.0.0",
+      "devDependencies": {
+        "coveralls": "^3.0.7",
+        "eslint": "^6.6.0",
+        "eslint-plugin-mocha": "^6.2.1",
+        "intelli-espower-loader": "^1.0.1",
+        "mocha": "^6.2.2",
+        "nyc": "^14.1.1",
+        "power-assert": "^1.6.1"
+      },
+      "dist": {
+        "shasum": "ae693f11cac67f4ac5eb6e0c1512fb9b2c2e9ea8",
+        "integrity": "sha512-nyHFzvVaR+4mfHc90/VqOUQjlnk9+ioDxQfqDuqKnm3m9sIT7joVKW8dkxeaKpamMJ3MYD73t6M8PMKEWlQESQ==",
+        "tarball": "https://registry.npmjs.org/async-limiter/-/async-limiter-2.0.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 8589,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd1Xo5CRA9TVsSAnZWagAAyXQP/ibSfb7MvOeB9agWY9Mc\n3clrzvn3s4kiQp+exCa8zygVvxB1E7DL+DE7aw/G5WNgAL4yaX3h+0EBJu1k\n1cnni6UJ45n2rqJO7RoH8+KXiJpevP6450YpTgTz/LH/1EajytdMLwSyPdLh\n051wKmbtN0rvM0LqVAlhmdV+jzCPHHwQdFVBsLyXIJipqDnFBC6QpOXeCAUX\nO23dHH/0wB7jx8AeATXZ+mmFf5YHkWiR2BvGukSi/x3OHHzlZSI7aLLONbQs\nyLDBvYC8UfqoWuofcBwqCbD0RRCvNWBCcQAuIovbS+b61bQTT70eXi8WCih7\nUZoCyPy1jaZ111gKIX7zu0HJJv4lC+7xD7flvhJy1/67bncrVDfevltq7yK1\nxbksYT4fcybA38T4ZyXchZh8CPLQcC/yRwsi4B9+roDtz98ww+i5x6SA4HbL\n6PSVm36pSpxZu5tFpAfN/13MXMtn8ajTUU8/FvKOanOn7yBZYZ489lPPwbS/\nokUZNoh17tLyv6bIQ+M0dza5Y27IOaEmXEPSGj233hlQS32AIpS6DPD4JSEF\n069dc18X+hKUnFo7hyaHkHlWa92XwwTIA5N0hLoc5NbZCIengq8iqz93H9SD\nWkuWif9o0K+nebdI9Z/2JjGTei0NisnCsjBOYqK2FaKT5fXqDFUIRrupXoIO\nwCah\r\n=OJ/M\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-11-20T17:39:09.289Z"
+}

--- a/test/fixtures/registry-mocks/content/base64-js.json
+++ b/test/fixtures/registry-mocks/content/base64-js.json
@@ -1,0 +1,1529 @@
+{
+  "_id": "base64-js",
+  "_rev": "63-4f79b69e2188845b04562c9825366647",
+  "name": "base64-js",
+  "description": "Base64 encoding/decoding in pure JS",
+  "dist-tags": {
+    "latest": "1.5.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "0.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/deflate-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "cd test; node runner.js; cd -"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "_npmUser": {
+        "name": "beatgammit",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "_id": "base64-js@0.0.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.2",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "a0094eb63d2c01b094187f51ac9d82f2256a71ae",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "0.0.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/deflate-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "cd test; node runner.js; cd -"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "_npmUser": {
+        "name": "beatgammit",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "_id": "base64-js@0.0.2",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.2",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "024f0f72afa25b75f9c0ee73cd4f55ec1bed9784",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "0.0.3",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "cd test; node runner.js; cd -"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {},
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "_id": "base64-js@0.0.3",
+      "dist": {
+        "shasum": "6c3bfa8886c7b8d41b934544d5856aa4f13fbf5c",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "beatgammit",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "0.0.4",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "cd test; node runner.js; cd -"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {},
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "_id": "base64-js@0.0.4",
+      "dist": {
+        "shasum": "8eac03d51ff44cf297b4e5802168ddbec0dd1673",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "beatgammit",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "0.0.5",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "_id": "base64-js@0.0.5",
+      "dist": {
+        "shasum": "ec6d92297da0ef0eb4fa6aaeb0f67e74869c9731",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.6": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "0.0.6",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "_id": "base64-js@0.0.6",
+      "dist": {
+        "shasum": "7b859f79f0bbbd55867ba67a7fab397e24a20947",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.7": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "0.0.7",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "_id": "base64-js@0.0.7",
+      "_shasum": "54400dc91d696cec32a8a47902f971522fee8f48",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "beatgammit",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "54400dc91d696cec32a8a47902f971522fee8f48",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.8": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "0.0.8",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "gitHead": "b4a8a5fa9b0caeddb5ad94dd1108253d8f2a315f",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "_id": "base64-js@0.0.8",
+      "_shasum": "1101e9544f4a76b1bc3b26d452ca96d7a35e7978",
+      "_from": ".",
+      "_npmVersion": "2.1.16",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "1101e9544f4a76b1bc3b26d452ca96d7a35e7978",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^5.2.2",
+        "tape": "4.x"
+      },
+      "gitHead": "e89d48501fc2a976249e890a2ea8ec5b758a107d",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js#readme",
+      "_id": "base64-js@1.0.1",
+      "_shasum": "6926d1b194fbc737b8eed513756de2fcda7ea408",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "6926d1b194fbc737b8eed513756de2fcda7ea408",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.0.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^5.2.2",
+        "tape": "4.x"
+      },
+      "gitHead": "160c83a130b0acb848f6ac47f79c2a16dcbf20ec",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js#readme",
+      "_id": "base64-js@1.0.2",
+      "_shasum": "474211c95e6cf2a547db461e4f6778b51d08fa65",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "474211c95e6cf2a547db461e4f6778b51d08fa65",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.0.3",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "4.x"
+      },
+      "gitHead": "07a89130e6d9f064026535b9fa35b5483ed2e922",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js#readme",
+      "_id": "base64-js@1.0.3",
+      "_shasum": "1b0516f70bfc666868c89dccafb49290ecea562c",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "1b0516f70bfc666868c89dccafb49290ecea562c",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/base64-js-1.0.3.tgz_1455305751190_0.34513800288550556"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.0.4",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "4.x"
+      },
+      "gitHead": "f486d4d183b9b66cf291d537771b918de3d007e4",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js#readme",
+      "_id": "base64-js@1.0.4",
+      "_shasum": "6fbe874ff18e28822b84cc9fdc22d7dc5aad77c7",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "6fbe874ff18e28822b84cc9fdc22d7dc5aad77c7",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/base64-js-1.0.4.tgz_1455322912489_0.5761241426225752"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "^2.1.0",
+        "standard": "^6.0.5",
+        "tape": "4.x"
+      },
+      "gitHead": "ef6f7131ff4cf59ae7ed1695e2985372f01a3290",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js#readme",
+      "_id": "base64-js@1.1.0",
+      "_shasum": "5f91b0f64cdd2e20aa2f31f2b0e00a4198ed9271",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "5f91b0f64cdd2e20aa2f31f2b0e00a4198ed9271",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/base64-js-1.1.0.tgz_1456766218667_0.0795334242284298"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.1.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+        "test": "standard && tape test/*.js"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "^2.1.0",
+        "browserify": "^13.0.0",
+        "standard": "^6.0.5",
+        "tape": "4.x",
+        "uglify-js": "^2.6.2"
+      },
+      "gitHead": "638643fcef095be78b4004807421e397af8588a3",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js#readme",
+      "_id": "base64-js@1.1.1",
+      "_shasum": "91c13c7038671cd4529c8646fde60bf7e91bc808",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "91c13c7038671cd4529c8646fde60bf7e91bc808",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/base64-js-1.1.1.tgz_1456878579861_0.16074915719218552"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.1.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "main": "lib/b64.js",
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+        "test": "standard && tape test/*.js"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "^2.1.0",
+        "browserify": "^13.0.0",
+        "standard": "^6.0.5",
+        "tape": "4.x",
+        "uglify-js": "^2.6.2"
+      },
+      "gitHead": "75f9f00f6baeeae9c51e21f43c2a9c918978d52c",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js#readme",
+      "_id": "base64-js@1.1.2",
+      "_shasum": "d6400cac1c4c660976d90d07a04351d89395f5e8",
+      "_from": ".",
+      "_npmVersion": "2.14.20",
+      "_nodeVersion": "4.4.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "d6400cac1c4c660976d90d07a04351d89395f5e8",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/base64-js-1.1.2.tgz_1458813298889_0.6030721089337021"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "base64-js",
+      "version": "1.2.0",
+      "description": "Base64 encoding/decoding in pure JS",
+      "keywords": [
+        "base64"
+      ],
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "files": [
+        "test",
+        "index.js",
+        "base64js.min.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.0",
+        "browserify": "^13.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.6.2"
+      },
+      "gitHead": "18bb7b2f20af653e60ae186bd879d3c4e6e6d8e6",
+      "_id": "base64-js@1.2.0",
+      "_shasum": "a39992d723584811982be5e290bb6a53d86700f1",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.5.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "a39992d723584811982be5e290bb6a53d86700f1",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/base64-js-1.2.0.tgz_1474574119286_0.4763944323640317"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "base64-js",
+      "version": "1.2.1",
+      "description": "Base64 encoding/decoding in pure JS",
+      "keywords": [
+        "base64"
+      ],
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "files": [
+        "test",
+        "index.js",
+        "base64js.min.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^14.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.8.29"
+      },
+      "gitHead": "13d56bffa289ae3f406cb932c927461442a434ba",
+      "_id": "base64-js@1.2.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.1.2",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+        "shasum": "a91947da1f4a516ea38e5b4ec0ec3773675e0886",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/base64-js-1.2.1.tgz_1498100565880_0.40269751008599997"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "base64-js",
+      "version": "1.2.2",
+      "description": "Base64 encoding/decoding in pure JS",
+      "keywords": [
+        "base64"
+      ],
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "files": [
+        "test",
+        "index.js",
+        "base64js.min.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^14.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.8.29"
+      },
+      "gitHead": "3fe859849b7a6b6db8b1fe43df00e52aaf5a7da1",
+      "_id": "base64-js@1.2.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-Luyxwa4AD/yXqN4fa+0Z6oYZMIVudy3b+6My0/22vxwiuMw+aEG4KzXpjb2LxKlMoOu8u/RG24dCKurDtnHRPA==",
+        "shasum": "6e3b03a8f091affdbe297453268ca26570ae51f0",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 11900
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/base64-js_1.2.2_1518748732205_0.5429508600757593"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.3": {
+      "name": "base64-js",
+      "version": "1.2.3",
+      "description": "Base64 encoding/decoding in pure JS",
+      "keywords": [
+        "base64"
+      ],
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "files": [
+        "test",
+        "index.js",
+        "base64js.min.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^14.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.8.29"
+      },
+      "gitHead": "fa0905c66fe77b02fe20488639402c52b5c22343",
+      "_id": "base64-js@1.2.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+        "shasum": "fb13668233d9614cf5fb4bce95a9ba4096cdf801",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+        "fileCount": 8,
+        "unpackedSize": 12024
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/base64-js_1.2.3_1518749129931_0.1986327306540996"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.3.0": {
+      "name": "base64-js",
+      "version": "1.3.0",
+      "description": "Base64 encoding/decoding in pure JS",
+      "keywords": [
+        "base64"
+      ],
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "files": [
+        "test",
+        "index.js",
+        "base64js.min.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^14.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.8.29"
+      },
+      "gitHead": "09b98d0ffa6669aec30c2cbc52e84effae7be66b",
+      "_id": "base64-js@1.3.0",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+        "shasum": "cab1e6118f051095e58b5281aea8c1cd22bfc0e3",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 13019,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1n8/CRA9TVsSAnZWagAA8n8P/RZu7TXBAZ0H4jbzP/19\nhvX9fXm4NKjQG9nTLs9ebEdSBCqXoCf2vmqXdGVNthpxDOUlT1Md2R2h4omD\nTSk6mhMjI1mLybssv1YLPtlfSwt5Tuym3MIieC3i54wlxkH+Je5gOSyvQgFI\nobY57uli+cuii9iCgiJxvH0xePXne5aZGtLqWcqZpRbsg7KmPR7ACBj2PxRG\nlU0IZybTbVkFHvQEdNjGcBt+eHNB5ZWZADskXIfBGXr2nptQIIr7NDnEaSNK\nFmbirTKi9LZE5jq9ekNRx0vLIoYXnsL8LqaiNHXusWQRQhCp605KJuNT7sI8\nv/lp0+a4tUzRxrf6+IrQQ65SYRpIzU8t9xxAqpgLlGJN2bSmQCJggsuWmBGq\nJvIfxCuJTOT8adZeb2XnJrYbRVFAVWlGfTaRM6qEA1KKbnxPcmC4JsXe7J0A\n/VoBKNtUQ3h4+dPeKQF6m4DqHyvV3R2vYl7comah4YOP8nFwMhntcVpdhQTy\naQhTMArDeh1UevY7Y0/07OL4XWtNQXrpC9RzNtfpuH+OK1XpnBga327tuBTY\n4KRRaXBKHGccjHXwVh64fVqpEDA8pw3YLX5h0CmlD+6N0NaPm9xC2YWL/RBb\nFjDNM4Hoj3fR6hw0B2W6zIT8ouO8WHljKpdHfwVfc6J5xk7G+/rcT3+gNqpn\nabJ+\r\n=uE/8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/base64-js_1.3.0_1524006718050_0.18945706841846088"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.3.1": {
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.3.1",
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^16.3.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^3.6.0"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "keywords": [
+        "base64"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | uglifyjs -m > base64js.min.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "gitHead": "08a344d6ca13772acc42df2515312ceac75b5456",
+      "_id": "base64-js@1.3.1",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.10.2",
+      "dist": {
+        "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+        "shasum": "58ece8cb75dd07e71ed08c736abc5fac4dbf8df1",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9181,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdSQSCCRA9TVsSAnZWagAAXxkP/Rww2syGgfx2jR5jRkDe\nw4Y7Si6d0NbTJCM6hp2NNay1QIwudUqnLQ3+PZuCP+x0miXqugpSWA5f/bfz\nb8eWCkcOTEzx4LDutyU5V2LPJr+zTM59MMhmFtnoYuAe0lLFi6scMCYllgMr\nb/0YXz//JveRXRoZQxvnNv/Ls3zoYMTEBt3hIAoZBtK6J767U0idnHuJKNH6\nhtpq33DYFCnkW/nJcaDZLrP3L91RKQnaymA2/5K61aP0kr2Z+S+PFC6apMrY\nK4JOmpfVAeaFNeEylPuhS7tBvIGJIhIKqYvivPXISFpUY8uh9YMuBV3lGyiz\nFAeycuk3hTuyfby9XYstClsiH22MB2yr4UwcsF1vA1V9kOPri8DGJjVEVHgX\n8ABVsgmre9t2dp+xA6XH4gB7c/b349odpdympgO2woRq65vL1fL61nU/dYkO\nmPIqDDTPrd6KkY/G1s7K5wnSgG1SxN2zALdADzQWm2we1rFoYcCvGNCALqRr\nql5fE3Eya/C0tfSB2i82NSM2izyqmNfMjYwzqRh6InbI4l2HVKKr8UJ4t2b/\nkqxm51/+JThsBov+u+2woRKTpKDlO9V2XlpEO95CGcSBZ7XhB5OwfHONGbN/\nIKqa2oRJNaui5oYaf5BNI0//yqRkW2rghFpjIcS5uI8Lxwc22GU0SKEpEfFj\nZzHU\r\n=QxgS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/base64-js_1.3.1_1565066369546_0.47886809614728953"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.0": {
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.5.0",
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "typings": "index.d.ts",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "devDependencies": {
+        "babel-minify": "^0.5.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.3.0",
+        "standard": "*",
+        "tape": "4.x"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "keywords": [
+        "base64"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | minify > base64js.min.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "806f6c14983f059b09a858dfbab722ee1f2c4ebc",
+      "_id": "base64-js@1.5.0",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-Jrdy04F2EKcNggUDfubMUPNAZg2vMquLQSm8sKLYJvz40ClFL1S8GKyDshGkNsbNNE5Z+fQavzU7nSK1I9JUGA==",
+        "shasum": "2d03045876d9e2b68a7a0f87d6bd163595e3b6af",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 9708,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfq07gCRA9TVsSAnZWagAA9zYP/1RxDp+0U5SidtoDmoWs\ntbiLKPMY6gAK42TtzTAx82niBmsAv7x5eizg4Kn2ormxccTUh5cpC1Jm7sJy\nJxc1K0CiQjye/RL3Pp2hJK0kLK2ptDg16z2xrdoxvpVno4qJiC7LQqBJ5pun\nJkZ9gtFZG1bb0faz7IvtO5ArgWgw0JDQj1PKTuoV26Mji9t40tLRPz80vJKN\nQE6ZinkvN36zIblK1G6RXjXw2EB/Nk8StwMSUg1DelpUBeuzxfVXwmIfKmGR\njGMqlHR5qT1Rk8HVOFRPLBDqgRUpe3gq8BEy0cWFLgZ2NB8lwdiJmbA3iRL0\noIfUjW6NrOOskJ4Zkh/njp+LiCkhStsfqA6KahVB6Gxk5QfwIt7juJLZMG0v\noC1xeyk/Q6coxeWE6Lp/XIResUy9IJgT6cel3TX3hAWWc+2/O0r8Yfj6BK97\noAdQOFg4D7jEZ2bUl4bGj+YcdTSISj7PNe8Fa2CoM3a0/7L9J9h4RjwW8fo4\nGyeIlTy27A6MiMcXe6NF3a7YXKuE0n379Llg0CLmCmNT9LqyCJKa1OChjUrB\ntpRwVrzMVaHHP5ErzYJWxvrTZw7rz5vftqlDL5Usuf1XXX5+NMea5yQW7mTL\nrpCojqGHeCtygPbCO/ImqwOqlHJCTR9sX+syHWDfzziTlXUjgBe5pIwNqVdy\n/GW7\r\n=PH8h\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/base64-js_1.5.0_1605062367755_0.5675037817908752"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.1": {
+      "name": "base64-js",
+      "description": "Base64 encoding/decoding in pure JS",
+      "version": "1.5.1",
+      "author": {
+        "name": "T. Jameson Little",
+        "email": "t.jameson.little@gmail.com"
+      },
+      "typings": "index.d.ts",
+      "bugs": {
+        "url": "https://github.com/beatgammit/base64-js/issues"
+      },
+      "devDependencies": {
+        "babel-minify": "^0.5.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.3.0",
+        "standard": "*",
+        "tape": "4.x"
+      },
+      "homepage": "https://github.com/beatgammit/base64-js",
+      "keywords": [
+        "base64"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/beatgammit/base64-js.git"
+      },
+      "scripts": {
+        "build": "browserify -s base64js -r ./ | minify > base64js.min.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "88957c9943c7e2a0f03cdf73e71d579e433627d3",
+      "_id": "base64-js@1.5.1",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+        "shasum": "1b1b440160a5bf7ad40b650f095963481903930a",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 9624,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfrDycCRA9TVsSAnZWagAA4K4P/jUkg1tL6K4cH2vhbIAa\nlpaYlBFb6Gyr8HFuzdCUMrCJJdMo+dD36yOliFfGOUJFGrLg24T0OGt28VFK\nYSnAJkWKZf9e7pcJdwjXpzk/qlnGieN271x5VPSUrt7WDjEExV7icyldgnvs\niUzl68M3gq6e4AIAJEid5HXWDHE+FqZRLVQyw5gu8mo+AhFv2PHgZJ/6iUiA\nHCUrebU0+U2QcHkrmMs+NiLC+ND9wFg5z6cjP+NLyyWxhHyAD8cFXYzZmju2\ndGwJ2RGTmMhHt4wbK0St88xNh3LD8b1gohwlUFrl9dRXTnqrDL7io9cC9FIK\nd4qUsB2MPvT7QriDNx/wTzU0HTuHiLRjLi1ZRkBDuVwmmK7rerTKvQzblZTG\nhBPxuVebPqYd8826yK0ms2REW9yMx6MetBgo8aN35FWD68y0g+S1mABZpUJ4\nAxrbg78AvhvpmXYi4q3WEDWhW+KeNhJfzWutslsl3icpHHcS2fvOT/6GGQ6X\nT+rhFyB+AVQztxyGPRYzNtzn0W0TdCrrQQiIYL9f+VTRF9wI5aabRlsJYT5m\nnRxC5otbtLY6BcH09UbnrnMl8xbqXiRDgqHFZ+FK6B04MHMgZLjBpN6GZ6ur\nDF4OXCnjBiOG6uhm33YpSQ+uyToPQ213Uzu0wD8ADYv4pYrdBaPNnRrRUtnm\nDV1r\r\n=Eusy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "beatgammit",
+          "email": "t.jameson.little@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/base64-js_1.5.1_1605123228082_0.7874673993922778"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "base64-js\n=========\n\n`base64-js` does basic base64 encoding/decoding in pure JS.\n\n[![build status](https://secure.travis-ci.org/beatgammit/base64-js.png)](http://travis-ci.org/beatgammit/base64-js)\n\nMany browsers already have base64 encoding/decoding functionality, but it is for text data, not all-purpose binary data.\n\nSometimes encoding/decoding binary data in the browser is useful, and that is what this module does.\n\n## install\n\nWith [npm](https://npmjs.org) do:\n\n`npm install base64-js` and `var base64js = require('base64-js')`\n\nFor use in web browsers do:\n\n`<script src=\"base64js.min.js\"></script>`\n\n[Get supported base64-js with the Tidelift Subscription](https://tidelift.com/subscription/pkg/npm-base64-js?utm_source=npm-base64-js&utm_medium=referral&utm_campaign=readme)\n\n## methods\n\n`base64js` has three exposed functions, `byteLength`, `toByteArray` and `fromByteArray`, which both take a single argument.\n\n* `byteLength` - Takes a base64 string and returns length of byte array\n* `toByteArray` - Takes a base64 string and returns a byte array\n* `fromByteArray` - Takes a byte array and returns a base64 string\n\n## license\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "beatgammit",
+      "email": "t.jameson.little@gmail.com"
+    },
+    {
+      "name": "feross",
+      "email": "feross@feross.org"
+    }
+  ],
+  "time": {
+    "modified": "2020-11-11T19:33:50.451Z",
+    "created": "2011-11-26T00:08:51.996Z",
+    "0.0.1": "2011-11-26T00:08:55.134Z",
+    "0.0.2": "2011-11-26T22:06:33.304Z",
+    "0.0.3": "2013-09-21T22:30:59.736Z",
+    "0.0.4": "2013-09-21T22:42:04.050Z",
+    "0.0.5": "2014-01-08T03:30:14.309Z",
+    "0.0.6": "2014-01-08T07:32:26.633Z",
+    "0.0.7": "2014-06-06T21:52:52.474Z",
+    "0.0.8": "2014-12-31T02:56:22.275Z",
+    "1.0.1": "2016-01-05T22:43:49.607Z",
+    "1.0.2": "2016-01-09T02:51:50.377Z",
+    "1.0.3": "2016-02-12T19:35:54.596Z",
+    "1.0.4": "2016-02-13T00:21:55.643Z",
+    "1.1.0": "2016-02-29T17:17:00.146Z",
+    "1.1.1": "2016-03-02T00:29:40.487Z",
+    "1.1.2": "2016-03-24T09:54:59.307Z",
+    "1.2.0": "2016-09-22T19:55:21.036Z",
+    "1.2.1": "2017-06-22T03:02:45.961Z",
+    "1.2.2": "2018-02-16T02:38:52.391Z",
+    "1.2.3": "2018-02-16T02:45:30.027Z",
+    "1.3.0": "2018-04-17T23:11:58.124Z",
+    "1.3.1": "2019-08-06T04:39:29.775Z",
+    "1.5.0": "2020-11-11T02:39:27.839Z",
+    "1.5.1": "2020-11-11T19:33:48.234Z"
+  },
+  "author": {
+    "name": "T. Jameson Little",
+    "email": "t.jameson.little@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/beatgammit/base64-js.git"
+  },
+  "users": {
+    "garrickcheung": true,
+    "goodseller": true,
+    "vbv": true,
+    "pandao": true,
+    "loglo": true,
+    "gkucmierz": true,
+    "xueboren": true,
+    "shuoshubao": true,
+    "chinawolf_wyp": true,
+    "zixinliango": true,
+    "shanewholloway": true,
+    "panlw": true,
+    "dillonace": true,
+    "thejeshgn.com": true,
+    "thejeshgn": true,
+    "codeif": true,
+    "mik1986": true,
+    "koulmomo": true,
+    "kkho595": true,
+    "zuojiang": true,
+    "nisimjoseph": true
+  },
+  "homepage": "https://github.com/beatgammit/base64-js",
+  "bugs": {
+    "url": "https://github.com/beatgammit/base64-js/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "keywords": [
+    "base64"
+  ]
+}

--- a/test/fixtures/registry-mocks/content/base64-js.min.json
+++ b/test/fixtures/registry-mocks/content/base64-js.min.json
@@ -1,0 +1,380 @@
+{
+  "name": "base64-js",
+  "dist-tags": {
+    "latest": "1.5.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "base64-js",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "a0094eb63d2c01b094187f51ac9d82f2256a71ae",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "0.0.2": {
+      "name": "base64-js",
+      "version": "0.0.2",
+      "dist": {
+        "shasum": "024f0f72afa25b75f9c0ee73cd4f55ec1bed9784",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "0.0.3": {
+      "name": "base64-js",
+      "version": "0.0.3",
+      "dist": {
+        "shasum": "6c3bfa8886c7b8d41b934544d5856aa4f13fbf5c",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "0.0.4": {
+      "name": "base64-js",
+      "version": "0.0.4",
+      "dist": {
+        "shasum": "8eac03d51ff44cf297b4e5802168ddbec0dd1673",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "0.0.5": {
+      "name": "base64-js",
+      "version": "0.0.5",
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "ec6d92297da0ef0eb4fa6aaeb0f67e74869c9731",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "0.0.6": {
+      "name": "base64-js",
+      "version": "0.0.6",
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "7b859f79f0bbbd55867ba67a7fab397e24a20947",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "0.0.7": {
+      "name": "base64-js",
+      "version": "0.0.7",
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "54400dc91d696cec32a8a47902f971522fee8f48",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "0.0.8": {
+      "name": "base64-js",
+      "version": "0.0.8",
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "1101e9544f4a76b1bc3b26d452ca96d7a35e7978",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.0.1": {
+      "name": "base64-js",
+      "version": "1.0.1",
+      "devDependencies": {
+        "standard": "^5.2.2",
+        "tape": "4.x"
+      },
+      "dist": {
+        "shasum": "6926d1b194fbc737b8eed513756de2fcda7ea408",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.0.2": {
+      "name": "base64-js",
+      "version": "1.0.2",
+      "devDependencies": {
+        "standard": "^5.2.2",
+        "tape": "4.x"
+      },
+      "dist": {
+        "shasum": "474211c95e6cf2a547db461e4f6778b51d08fa65",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.0.3": {
+      "name": "base64-js",
+      "version": "1.0.3",
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "4.x"
+      },
+      "dist": {
+        "shasum": "1b0516f70bfc666868c89dccafb49290ecea562c",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.0.4": {
+      "name": "base64-js",
+      "version": "1.0.4",
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "4.x"
+      },
+      "dist": {
+        "shasum": "6fbe874ff18e28822b84cc9fdc22d7dc5aad77c7",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.0.4.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "base64-js",
+      "version": "1.1.0",
+      "devDependencies": {
+        "benchmark": "^2.1.0",
+        "standard": "^6.0.5",
+        "tape": "4.x"
+      },
+      "dist": {
+        "shasum": "5f91b0f64cdd2e20aa2f31f2b0e00a4198ed9271",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "base64-js",
+      "version": "1.1.1",
+      "devDependencies": {
+        "benchmark": "^2.1.0",
+        "browserify": "^13.0.0",
+        "standard": "^6.0.5",
+        "tape": "4.x",
+        "uglify-js": "^2.6.2"
+      },
+      "dist": {
+        "shasum": "91c13c7038671cd4529c8646fde60bf7e91bc808",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "base64-js",
+      "version": "1.1.2",
+      "devDependencies": {
+        "benchmark": "^2.1.0",
+        "browserify": "^13.0.0",
+        "standard": "^6.0.5",
+        "tape": "4.x",
+        "uglify-js": "^2.6.2"
+      },
+      "dist": {
+        "shasum": "d6400cac1c4c660976d90d07a04351d89395f5e8",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "base64-js",
+      "version": "1.2.0",
+      "devDependencies": {
+        "benchmark": "^2.1.0",
+        "browserify": "^13.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.6.2"
+      },
+      "dist": {
+        "shasum": "a39992d723584811982be5e290bb6a53d86700f1",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "base64-js",
+      "version": "1.2.1",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^14.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.8.29"
+      },
+      "dist": {
+        "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+        "shasum": "a91947da1f4a516ea38e5b4ec0ec3773675e0886",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "base64-js",
+      "version": "1.2.2",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^14.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.8.29"
+      },
+      "dist": {
+        "integrity": "sha512-Luyxwa4AD/yXqN4fa+0Z6oYZMIVudy3b+6My0/22vxwiuMw+aEG4KzXpjb2LxKlMoOu8u/RG24dCKurDtnHRPA==",
+        "shasum": "6e3b03a8f091affdbe297453268ca26570ae51f0",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 11900
+      }
+    },
+    "1.2.3": {
+      "name": "base64-js",
+      "version": "1.2.3",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^14.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.8.29"
+      },
+      "dist": {
+        "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+        "shasum": "fb13668233d9614cf5fb4bce95a9ba4096cdf801",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+        "fileCount": 8,
+        "unpackedSize": 12024
+      }
+    },
+    "1.3.0": {
+      "name": "base64-js",
+      "version": "1.3.0",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^14.0.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^2.8.29"
+      },
+      "dist": {
+        "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+        "shasum": "cab1e6118f051095e58b5281aea8c1cd22bfc0e3",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 13019,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1n8/CRA9TVsSAnZWagAA8n8P/RZu7TXBAZ0H4jbzP/19\nhvX9fXm4NKjQG9nTLs9ebEdSBCqXoCf2vmqXdGVNthpxDOUlT1Md2R2h4omD\nTSk6mhMjI1mLybssv1YLPtlfSwt5Tuym3MIieC3i54wlxkH+Je5gOSyvQgFI\nobY57uli+cuii9iCgiJxvH0xePXne5aZGtLqWcqZpRbsg7KmPR7ACBj2PxRG\nlU0IZybTbVkFHvQEdNjGcBt+eHNB5ZWZADskXIfBGXr2nptQIIr7NDnEaSNK\nFmbirTKi9LZE5jq9ekNRx0vLIoYXnsL8LqaiNHXusWQRQhCp605KJuNT7sI8\nv/lp0+a4tUzRxrf6+IrQQ65SYRpIzU8t9xxAqpgLlGJN2bSmQCJggsuWmBGq\nJvIfxCuJTOT8adZeb2XnJrYbRVFAVWlGfTaRM6qEA1KKbnxPcmC4JsXe7J0A\n/VoBKNtUQ3h4+dPeKQF6m4DqHyvV3R2vYl7comah4YOP8nFwMhntcVpdhQTy\naQhTMArDeh1UevY7Y0/07OL4XWtNQXrpC9RzNtfpuH+OK1XpnBga327tuBTY\n4KRRaXBKHGccjHXwVh64fVqpEDA8pw3YLX5h0CmlD+6N0NaPm9xC2YWL/RBb\nFjDNM4Hoj3fR6hw0B2W6zIT8ouO8WHljKpdHfwVfc6J5xk7G+/rcT3+gNqpn\nabJ+\r\n=uE/8\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.3.1": {
+      "name": "base64-js",
+      "version": "1.3.1",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "^16.3.0",
+        "standard": "*",
+        "tape": "4.x",
+        "uglify-js": "^3.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+        "shasum": "58ece8cb75dd07e71ed08c736abc5fac4dbf8df1",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9181,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdSQSCCRA9TVsSAnZWagAAXxkP/Rww2syGgfx2jR5jRkDe\nw4Y7Si6d0NbTJCM6hp2NNay1QIwudUqnLQ3+PZuCP+x0miXqugpSWA5f/bfz\nb8eWCkcOTEzx4LDutyU5V2LPJr+zTM59MMhmFtnoYuAe0lLFi6scMCYllgMr\nb/0YXz//JveRXRoZQxvnNv/Ls3zoYMTEBt3hIAoZBtK6J767U0idnHuJKNH6\nhtpq33DYFCnkW/nJcaDZLrP3L91RKQnaymA2/5K61aP0kr2Z+S+PFC6apMrY\nK4JOmpfVAeaFNeEylPuhS7tBvIGJIhIKqYvivPXISFpUY8uh9YMuBV3lGyiz\nFAeycuk3hTuyfby9XYstClsiH22MB2yr4UwcsF1vA1V9kOPri8DGJjVEVHgX\n8ABVsgmre9t2dp+xA6XH4gB7c/b349odpdympgO2woRq65vL1fL61nU/dYkO\nmPIqDDTPrd6KkY/G1s7K5wnSgG1SxN2zALdADzQWm2we1rFoYcCvGNCALqRr\nql5fE3Eya/C0tfSB2i82NSM2izyqmNfMjYwzqRh6InbI4l2HVKKr8UJ4t2b/\nkqxm51/+JThsBov+u+2woRKTpKDlO9V2XlpEO95CGcSBZ7XhB5OwfHONGbN/\nIKqa2oRJNaui5oYaf5BNI0//yqRkW2rghFpjIcS5uI8Lxwc22GU0SKEpEfFj\nZzHU\r\n=QxgS\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.5.0": {
+      "name": "base64-js",
+      "version": "1.5.0",
+      "devDependencies": {
+        "babel-minify": "^0.5.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.3.0",
+        "standard": "*",
+        "tape": "4.x"
+      },
+      "dist": {
+        "integrity": "sha512-Jrdy04F2EKcNggUDfubMUPNAZg2vMquLQSm8sKLYJvz40ClFL1S8GKyDshGkNsbNNE5Z+fQavzU7nSK1I9JUGA==",
+        "shasum": "2d03045876d9e2b68a7a0f87d6bd163595e3b6af",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 9708,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfq07gCRA9TVsSAnZWagAA9zYP/1RxDp+0U5SidtoDmoWs\ntbiLKPMY6gAK42TtzTAx82niBmsAv7x5eizg4Kn2ormxccTUh5cpC1Jm7sJy\nJxc1K0CiQjye/RL3Pp2hJK0kLK2ptDg16z2xrdoxvpVno4qJiC7LQqBJ5pun\nJkZ9gtFZG1bb0faz7IvtO5ArgWgw0JDQj1PKTuoV26Mji9t40tLRPz80vJKN\nQE6ZinkvN36zIblK1G6RXjXw2EB/Nk8StwMSUg1DelpUBeuzxfVXwmIfKmGR\njGMqlHR5qT1Rk8HVOFRPLBDqgRUpe3gq8BEy0cWFLgZ2NB8lwdiJmbA3iRL0\noIfUjW6NrOOskJ4Zkh/njp+LiCkhStsfqA6KahVB6Gxk5QfwIt7juJLZMG0v\noC1xeyk/Q6coxeWE6Lp/XIResUy9IJgT6cel3TX3hAWWc+2/O0r8Yfj6BK97\noAdQOFg4D7jEZ2bUl4bGj+YcdTSISj7PNe8Fa2CoM3a0/7L9J9h4RjwW8fo4\nGyeIlTy27A6MiMcXe6NF3a7YXKuE0n379Llg0CLmCmNT9LqyCJKa1OChjUrB\ntpRwVrzMVaHHP5ErzYJWxvrTZw7rz5vftqlDL5Usuf1XXX5+NMea5yQW7mTL\nrpCojqGHeCtygPbCO/ImqwOqlHJCTR9sX+syHWDfzziTlXUjgBe5pIwNqVdy\n/GW7\r\n=PH8h\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "1.5.1": {
+      "name": "base64-js",
+      "version": "1.5.1",
+      "devDependencies": {
+        "babel-minify": "^0.5.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.3.0",
+        "standard": "*",
+        "tape": "4.x"
+      },
+      "dist": {
+        "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+        "shasum": "1b1b440160a5bf7ad40b650f095963481903930a",
+        "tarball": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 9624,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfrDycCRA9TVsSAnZWagAA4K4P/jUkg1tL6K4cH2vhbIAa\nlpaYlBFb6Gyr8HFuzdCUMrCJJdMo+dD36yOliFfGOUJFGrLg24T0OGt28VFK\nYSnAJkWKZf9e7pcJdwjXpzk/qlnGieN271x5VPSUrt7WDjEExV7icyldgnvs\niUzl68M3gq6e4AIAJEid5HXWDHE+FqZRLVQyw5gu8mo+AhFv2PHgZJ/6iUiA\nHCUrebU0+U2QcHkrmMs+NiLC+ND9wFg5z6cjP+NLyyWxhHyAD8cFXYzZmju2\ndGwJ2RGTmMhHt4wbK0St88xNh3LD8b1gohwlUFrl9dRXTnqrDL7io9cC9FIK\nd4qUsB2MPvT7QriDNx/wTzU0HTuHiLRjLi1ZRkBDuVwmmK7rerTKvQzblZTG\nhBPxuVebPqYd8826yK0ms2REW9yMx6MetBgo8aN35FWD68y0g+S1mABZpUJ4\nAxrbg78AvhvpmXYi4q3WEDWhW+KeNhJfzWutslsl3icpHHcS2fvOT/6GGQ6X\nT+rhFyB+AVQztxyGPRYzNtzn0W0TdCrrQQiIYL9f+VTRF9wI5aabRlsJYT5m\nnRxC5otbtLY6BcH09UbnrnMl8xbqXiRDgqHFZ+FK6B04MHMgZLjBpN6GZ6ur\nDF4OXCnjBiOG6uhm33YpSQ+uyToPQ213Uzu0wD8ADYv4pYrdBaPNnRrRUtnm\nDV1r\r\n=Eusy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    }
+  },
+  "modified": "2020-11-11T19:33:50.451Z"
+}

--- a/test/fixtures/registry-mocks/content/batch.json
+++ b/test/fixtures/registry-mocks/content/batch.json
@@ -1,0 +1,715 @@
+{
+  "_id": "batch",
+  "_rev": "55-680c846e0b75864ca7a71828e3a81771",
+  "name": "batch",
+  "description": "Simple async batch with concurrency control and progress reporting.",
+  "dist-tags": {
+    "latest": "0.6.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "batch",
+      "version": "0.0.1",
+      "description": "Simple async batch",
+      "keywords": [],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "engines": {
+        "node": "0.4.x"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "batch@0.0.1",
+      "devDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "4abd5e273d3b0d07b41e2dc32a1e27978513b846",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "batch",
+      "version": "0.0.2",
+      "description": "Simple async batch",
+      "keywords": [],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "batch@0.0.2",
+      "devDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "fc558c82ded76cd8ddf049d2ba065f352d185f9c",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "batch",
+      "version": "0.0.3",
+      "description": "Simple async batch",
+      "keywords": [],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "batch@0.0.3",
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "4db7de56a489f3138f6e2ad73875b6acffffa424",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "batch",
+      "version": "0.1.0",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.1.0",
+      "dist": {
+        "shasum": "34ee7b3bf200a416cc05b967273513e6fe2cd808",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "batch",
+      "version": "0.1.1",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.1.1",
+      "dist": {
+        "shasum": "7550e96efb11c26db2032ca6f0ba6720e8cf971a",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "batch",
+      "version": "0.2.0",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.2.0",
+      "dist": {
+        "shasum": "22b09f1497a143ba688795cb3068a856f61871e9",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.2.0.tgz"
+      },
+      "_npmVersion": "1.1.61",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "batch",
+      "version": "0.2.1",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.2.1",
+      "dist": {
+        "shasum": "4463997bb4d5fd1c7a011548813e52aa189c2c79",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.2.1.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "batch",
+      "version": "0.3.0",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.3.0",
+      "dist": {
+        "shasum": "b194d2b3b7dc6cdd6ea1269728d8b9c985150cf7",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "batch",
+      "version": "0.3.1",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.3.1",
+      "dist": {
+        "shasum": "05ea40c288f0c56aef2a739507218426458cb7a0",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "batch",
+      "version": "0.3.2",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.3.2",
+      "dist": {
+        "shasum": "8f802c1358be2b33535f8808e0a23c9f0075733b",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.3.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "batch",
+      "version": "0.4.0",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.4.0",
+      "dist": {
+        "shasum": "bffe40bc117b73942da155bc77d8a36a21a6ac58",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.21",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "batch",
+      "version": "0.5.0",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "batch@0.5.0",
+      "dist": {
+        "shasum": "fd2e05a7a5d696b4db9314013e285d8ff3557ec3",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "batch",
+      "version": "0.5.1",
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/batch.git"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/batch/issues"
+      },
+      "homepage": "https://github.com/visionmedia/batch",
+      "_id": "batch@0.5.1",
+      "dist": {
+        "shasum": "36a4bab594c050fd7b507bca0db30c2d92af4ff2",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "batch",
+      "version": "0.5.2",
+      "licenses": [
+        {
+          "type": "MIT"
+        }
+      ],
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "browser": {
+        "emitter": "component-emitter"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/batch.git"
+      },
+      "gitHead": "cd69ea173754c0fbd3a7ab33e0a678e6909f3bf3",
+      "bugs": {
+        "url": "https://github.com/visionmedia/batch/issues"
+      },
+      "homepage": "https://github.com/visionmedia/batch",
+      "_id": "batch@0.5.2",
+      "scripts": {},
+      "_shasum": "546543dbe32118c83c7c7ca33a1f5c5d5ea963e9",
+      "_from": ".",
+      "_npmVersion": "2.1.14",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "546543dbe32118c83c7c7ca33a1f5c5d5ea963e9",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.3": {
+      "name": "batch",
+      "version": "0.5.3",
+      "licenses": [
+        {
+          "type": "MIT"
+        }
+      ],
+      "description": "Simple async batch",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "browser": {
+        "emitter": "events"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/batch.git"
+      },
+      "gitHead": "247f3ec041be32bb8ddc0816d2155b2391550084",
+      "bugs": {
+        "url": "https://github.com/visionmedia/batch/issues"
+      },
+      "homepage": "https://github.com/visionmedia/batch",
+      "_id": "batch@0.5.3",
+      "scripts": {},
+      "_shasum": "3f3414f380321743bfc1042f9a83ff1d5824d464",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "3f3414f380321743bfc1042f9a83ff1d5824d464",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "batch",
+      "description": "Simple async batch with concurrency control and progress reporting.",
+      "version": "0.6.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "browser": {
+        "emitter": "events"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/visionmedia/batch.git"
+      },
+      "gitHead": "09ca0c57db6c02801eda147830f04747eeef9f4f",
+      "bugs": {
+        "url": "https://github.com/visionmedia/batch/issues"
+      },
+      "homepage": "https://github.com/visionmedia/batch#readme",
+      "_id": "batch@0.6.0",
+      "scripts": {},
+      "_shasum": "cd6a5e555f53ae92b561899b2738089b0dd91b31",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "cd6a5e555f53ae92b561899b2738089b0dd91b31",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/batch-0.6.0.tgz_1490493912235_0.23688052222132683"
+      },
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "batch",
+      "description": "Simple async batch with concurrency control and progress reporting.",
+      "version": "0.6.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "browser": {
+        "emitter": "events"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/visionmedia/batch.git"
+      },
+      "gitHead": "577ea162b9be76e79d2fcc43c47ed573112e9892",
+      "bugs": {
+        "url": "https://github.com/visionmedia/batch/issues"
+      },
+      "homepage": "https://github.com/visionmedia/batch#readme",
+      "_id": "batch@0.6.1",
+      "scripts": {},
+      "_shasum": "dc34314f4e679318093fc760272525f94bf25c16",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "dc34314f4e679318093fc760272525f94bf25c16",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/batch-0.6.1.tgz_1494969108544_0.02703835256397724"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "\n# batch\n\n  Simple async batch with concurrency control and progress reporting.\n\n## Installation\n\n```\n$ npm install batch\n```\n\n## API\n\n```js\nvar Batch = require('batch')\n  , batch = new Batch;\n\nbatch.concurrency(4);\n\nids.forEach(function(id){\n  batch.push(function(done){\n    User.get(id, done);\n  });\n});\n\nbatch.on('progress', function(e){\n\n});\n\nbatch.end(function(err, users){\n\n});\n```\n\n### Progress events\n\n  Contain the \"job\" index, response value, duration information, and completion data.\n\n```\n{ index: 1,\n  value: 'bar',\n  pending: 2,\n  total: 3,\n  complete: 2,\n  percent: 66,\n  start: Thu Oct 04 2012 12:25:53 GMT-0700 (PDT),\n  end: Thu Oct 04 2012 12:25:53 GMT-0700 (PDT),\n  duration: 0 }\n```\n\n## License\n\n[MIT](LICENSE)\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "tjholowaychuk",
+      "email": "tj@vision-media.ca"
+    }
+  ],
+  "time": {
+    "modified": "2017-08-29T14:43:06.238Z",
+    "created": "2012-01-17T03:10:03.348Z",
+    "0.0.1": "2012-01-17T03:10:04.791Z",
+    "0.0.2": "2012-02-13T00:50:21.813Z",
+    "0.0.3": "2012-06-02T14:26:31.123Z",
+    "0.1.0": "2012-07-03T18:13:02.061Z",
+    "0.1.1": "2012-07-03T18:26:52.473Z",
+    "0.2.0": "2012-10-04T19:26:54.467Z",
+    "0.2.1": "2012-11-08T22:36:55.327Z",
+    "0.3.0": "2013-03-13T18:57:41.132Z",
+    "0.3.1": "2013-03-13T22:41:45.130Z",
+    "0.3.2": "2013-03-15T15:25:01.756Z",
+    "0.4.0": "2013-06-06T04:02:23.107Z",
+    "0.5.0": "2013-07-29T20:56:36.139Z",
+    "0.5.1": "2014-06-19T14:54:42.522Z",
+    "0.5.2": "2014-12-22T18:29:32.048Z",
+    "0.5.3": "2015-10-01T16:08:54.699Z",
+    "0.6.0": "2017-03-26T02:05:13.916Z",
+    "0.6.1": "2017-05-16T21:11:49.205Z"
+  },
+  "author": {
+    "name": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca"
+  },
+  "users": {
+    "tantrum": true,
+    "bat": true,
+    "haeck": true,
+    "micahjonas": true,
+    "parkerproject": true,
+    "markthethomas": true,
+    "joanmi": true
+  },
+  "homepage": "https://github.com/visionmedia/batch#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/visionmedia/batch.git"
+  },
+  "bugs": {
+    "url": "https://github.com/visionmedia/batch/issues"
+  },
+  "readmeFilename": "Readme.md",
+  "license": "MIT",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/batch.min.json
+++ b/test/fixtures/registry-mocks/content/batch.min.json
@@ -1,0 +1,222 @@
+{
+  "name": "batch",
+  "dist-tags": {
+    "latest": "0.6.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "batch",
+      "version": "0.0.1",
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "4abd5e273d3b0d07b41e2dc32a1e27978513b846",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "0.4.x"
+      }
+    },
+    "0.0.2": {
+      "name": "batch",
+      "version": "0.0.2",
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "fc558c82ded76cd8ddf049d2ba065f352d185f9c",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.3": {
+      "name": "batch",
+      "version": "0.0.3",
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "4db7de56a489f3138f6e2ad73875b6acffffa424",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.0.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "batch",
+      "version": "0.1.0",
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "34ee7b3bf200a416cc05b967273513e6fe2cd808",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "batch",
+      "version": "0.1.1",
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "7550e96efb11c26db2032ca6f0ba6720e8cf971a",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.1.1.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "batch",
+      "version": "0.2.0",
+      "dependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "22b09f1497a143ba688795cb3068a856f61871e9",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "batch",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "4463997bb4d5fd1c7a011548813e52aa189c2c79",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.2.1.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "batch",
+      "version": "0.3.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "b194d2b3b7dc6cdd6ea1269728d8b9c985150cf7",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "batch",
+      "version": "0.3.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "05ea40c288f0c56aef2a739507218426458cb7a0",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.3.1.tgz"
+      }
+    },
+    "0.3.2": {
+      "name": "batch",
+      "version": "0.3.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "8f802c1358be2b33535f8808e0a23c9f0075733b",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.3.2.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "batch",
+      "version": "0.4.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "bffe40bc117b73942da155bc77d8a36a21a6ac58",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.4.0.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "batch",
+      "version": "0.5.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "fd2e05a7a5d696b4db9314013e285d8ff3557ec3",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
+      }
+    },
+    "0.5.1": {
+      "name": "batch",
+      "version": "0.5.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "36a4bab594c050fd7b507bca0db30c2d92af4ff2",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
+      }
+    },
+    "0.5.2": {
+      "name": "batch",
+      "version": "0.5.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "546543dbe32118c83c7c7ca33a1f5c5d5ea963e9",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
+      }
+    },
+    "0.5.3": {
+      "name": "batch",
+      "version": "0.5.3",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "3f3414f380321743bfc1042f9a83ff1d5824d464",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "batch",
+      "version": "0.6.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "cd6a5e555f53ae92b561899b2738089b0dd91b31",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.6.0.tgz"
+      }
+    },
+    "0.6.1": {
+      "name": "batch",
+      "version": "0.6.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "dc34314f4e679318093fc760272525f94bf25c16",
+        "tarball": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz"
+      }
+    }
+  },
+  "modified": "2017-08-29T14:43:06.238Z"
+}

--- a/test/fixtures/registry-mocks/content/big.js.json
+++ b/test/fixtures/registry-mocks/content/big.js.json
@@ -1,0 +1,1946 @@
+{
+  "_id": "big.js",
+  "_rev": "61-ede9d58ad79495626f63a2ccd6d154c4",
+  "name": "big.js",
+  "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+  "dist-tags": {
+    "latest": "6.0.2"
+  },
+  "versions": {
+    "2.0.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "2.0.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "_id": "big.js@2.0.0",
+      "dist": {
+        "shasum": "e930d2f1968e0fdad4621b06d0c80f2edc938fdf",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.0.0.tgz"
+      },
+      "_from": "./",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "2.1.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "_id": "big.js@2.1.0",
+      "dist": {
+        "shasum": "4f19d802b44036697e4a335c1b39b6e6e57644b5",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "2.2.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "_id": "big.js@2.2.0",
+      "dist": {
+        "shasum": "c9027fa4f5e13da5b32a2c1e60ca94fe537906ca",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.4.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "2.4.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "_id": "big.js@2.4.0",
+      "dist": {
+        "shasum": "3015aa15c1166681a3ac75d0fefca5381f891a4d",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.4.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "2.4.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "_id": "big.js@2.4.1",
+      "dist": {
+        "shasum": "4992df4b1a397af3896ada65ff77d6d8deab8426",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.5.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "2.5.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "homepage": "https://github.com/MikeMcl/big.js",
+      "_id": "big.js@2.5.0",
+      "dist": {
+        "shasum": "6b4bdd89fd1238fef560b07f35a22486cea7bd56",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.5.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "2.5.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "homepage": "https://github.com/MikeMcl/big.js",
+      "_id": "big.js@2.5.1",
+      "dist": {
+        "shasum": "f3dbff02b6f561edb130925bf6d5f47163b061da",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.5.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "3.0.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "gitHead": "5afcb640507bf1ea1f4cf6b1f86bdf5d0cd6352c",
+      "homepage": "https://github.com/MikeMcl/big.js",
+      "_id": "big.js@3.0.0",
+      "_shasum": "ffe15b3a94542e799147e2dfcf12a8e3016ee1fc",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ffe15b3a94542e799147e2dfcf12a8e3016ee1fc",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "3.0.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "gitHead": "befa9634a1ce2a87ddd2b5e4e085bc8477f186df",
+      "homepage": "https://github.com/MikeMcl/big.js",
+      "_id": "big.js@3.0.1",
+      "_shasum": "e7790a8a15c810666b5485cebe3303d4918cc5a3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e7790a8a15c810666b5485cebe3303d4918cc5a3",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "3.0.2",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "files": [
+        "big.js",
+        "big.min.js"
+      ],
+      "gitHead": "4f53d153161304e4fa8955d531cf38521af43f84",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@3.0.2",
+      "_shasum": "72256a0b4f9fa48ca009800c51de5d1bc706aeab",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "72256a0b4f9fa48ca009800c51de5d1bc706aeab",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "3.1.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "files": [
+        "big.js",
+        "big.min.js"
+      ],
+      "gitHead": "68d84918079b2de00f7ff15815900325159c9d14",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@3.1.1",
+      "_shasum": "a9f3a4cb203af25fd48d7009839755c9bd3da7ce",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a9f3a4cb203af25fd48d7009839755c9bd3da7ce",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.2": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "3.1.2",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "files": [
+        "big.js",
+        "big.min.js"
+      ],
+      "gitHead": "4ce616252c60e1447d4abce960b905f0f53578e2",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@3.1.2",
+      "_shasum": "2bf22c0916b45545575ee9c8a75c8c82d0ca3843",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2bf22c0916b45545575ee9c8a75c8c82d0ca3843",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.3": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "3.1.3",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "./big",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs -o ./big.min.js ./big.js"
+      },
+      "files": [
+        "big.js",
+        "big.min.js"
+      ],
+      "gitHead": "86268e96b3dbf6db8ce319489f410277d9d4ea1b",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@3.1.3",
+      "_shasum": "4cada2193652eb3ca9ec8e55c9015669c9806978",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4cada2193652eb3ca9ec8e55c9015669c9806978",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "3.2.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big.js",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v3.2.0 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.min.js"
+      ],
+      "gitHead": "c6fadd083a296b6af7d1b4ffcc28d64b1e67ea58",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@3.2.0",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.1.3",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+        "shasum": "a5fc298b81b9e0dca2e458824784b65c52ba588e",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js-3.2.0.tgz_1505423690708_0.3612429953645915"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "4.0.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big.js",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v4.0.0 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.min.js"
+      ],
+      "gitHead": "e4e374f9fc8de782a6d6fcdbc4f53fcf69a4f484",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@4.0.0",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-/7E310GMBNF15bfktIB07hKv/qfhAl2XYrvQbUDHV8kMddcYpFAJkEGtrtZZFCVXHWYJReN4GRNZ6yn3evs0qg==",
+        "shasum": "a02208ebcde327a6ec29fd35a8a25fd81e17bf60",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js-4.0.0.tgz_1506547286588_0.1906373961828649"
+      },
+      "directories": {}
+    },
+    "4.0.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "4.0.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big.js",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v4.0.1 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.min.js"
+      ],
+      "gitHead": "dd21172cd1b3b6778959f2e3afe5ed7c4b0e127c",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@4.0.1",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-upfnV8uHh3t3hFCubvWx/2z0gzE3azRuaHJe32+p8qCumM/CgTI7Db5lT7dtFcScI0d9Idj00yBIsKyYnwqPOQ==",
+        "shasum": "ca7f6d8e4d3eea138a4071a0f12300b74ad503e1",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-4.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js-4.0.1.tgz_1506589308561_0.5277757453732193"
+      },
+      "directories": {}
+    },
+    "4.0.2": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "4.0.2",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big.js",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v4.0.2 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.min.js"
+      ],
+      "gitHead": "a0d21bb5f92c81172b790100575c608769e369cb",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@4.0.2",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-j2h3nqdkpVwMzIqrO1STr2f/X5Qxv2MI1f4Q3EyO/gU24IdZOhPJbH3UE6SYFBm4/ZkMAIrOHB17Z3heaQV+4A==",
+        "shasum": "22e26c05282104068e1ce62c43e45e9a5ec94690",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-4.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js-4.0.2.tgz_1506589704104_0.7237143772654235"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "5.0.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big.js",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v5.0.0 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.mjs",
+        "big.min.js"
+      ],
+      "gitHead": "8248fefc58bea2536b9d3237a17e3644036bd5f5",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@5.0.0",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-3kysvTYI3hwjinlCbxUjSB7ze9hUSbJIkT5SJNEfz7lcUeK0S6F64BJ1PPK5T7ifT8NLiyqmotV8fw6tu9QLKw==",
+        "shasum": "e59c7b3f46a33d262aae107fef761b51fa15f178",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js-5.0.0.tgz_1507895698593_0.3214968328829855"
+      },
+      "directories": {}
+    },
+    "5.0.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "5.0.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big.js",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v5.0.1 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.mjs",
+        "big.min.js"
+      ],
+      "gitHead": "5a3dc4dab51d3f1a92a4ddcb4026e74a37afcc8a",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@5.0.1",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-0raCSj7VA9CDHCrNcXk4z09Qc/fn3gQMSUJKiPNH+/ykkdd7QoJVsny2I2ILxGaPYkqRKgFDUkwWZdLPaZIiVw==",
+        "shasum": "176a7c0f347916ec3286ca27ad31ebf8d9fbed1b",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js-5.0.1.tgz_1507896944808_0.11894331243820488"
+      },
+      "directories": {}
+    },
+    "5.0.2": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "5.0.2",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big.js",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v5.0.2 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.mjs",
+        "big.min.js"
+      ],
+      "gitHead": "f7fe392ce23b0ce9f45e432240575e15cbb3727f",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@5.0.2",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.7.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-+wVWTDlARgqLk8AWy0IldP8k2wto6XjYaYZKErA+9lF09QU/mrX5fFEibDW0LLLmrt1rNmmUVUMVNp5f38wFIQ==",
+        "shasum": "09f5a20264475205fbaadbec631831921431419d",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js-5.0.2.tgz_1507931728655_0.6720920803491026"
+      },
+      "directories": {}
+    },
+    "5.0.3": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "5.0.3",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big.js",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v5.0.3 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.mjs",
+        "big.min.js"
+      ],
+      "gitHead": "8759c0f106ecfbe76096ebc97807aac88bdf29f8",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@5.0.3",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.7.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-av8LNZGBl4cg2r4ZhWqghJOxi2P8UCcWhdmrFgcHPMmUJ6jx1FbnyxjwL4URYzMK3QJg60qeMefQhv9G14oYKA==",
+        "shasum": "9679fb0a3599a7d3df397f855e89c4dba016960e",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js-5.0.3.tgz_1508796105587_0.6365872949827462"
+      },
+      "directories": {}
+    },
+    "5.1.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "5.1.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big",
+      "module": "big.mjs",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v5.1.1 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.mjs",
+        "big.min.js"
+      ],
+      "gitHead": "e64eb7833f6f84c3598f65f2a8c73b1b965c5cf5",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@5.1.1",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-rNvOVZ1u/W5KNk/Oit8KDV+LYnWTxG7jro3UBeTrQ3e9wW9n2eZl4PDFToAGIhsHgTuMNEMwd0xGzx5KOEzODQ==",
+        "shasum": "039cbcd23ef6190c5a0fc93cb224fa6f4fa643ec",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 61483,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbBJWrCRA9TVsSAnZWagAA+3cP/1nW8SQI0/xNS2+24ita\nNabW0xD28aVbNVlX3qGp9ReB/NPpgbVeG+0QDZg4e8o36vsYCAGhCDPlnTQ6\nhlnIit1edje4npsCtXESqcTw6Y3S9vbKwMyu3UHHIBKIqwctv+bSPO0FgmlE\nA8X15jnucxjZSBtviNS3nJF3teFH/WAz5bAwcHMgV8soy2QZM8OH7O36UR2c\naoZyFH+5B3vmsTtyyckWpeXqHVr+kClbTpupPa6lCFG8TmjNwKejrG9NVr30\n87OvrzgxMvS51rjX3nA8OUeICLZj3GLwk34sNzyzagJBlCdaqp3b2Y1A+c5v\ndUbw3dMY/y8AoWcHA0BEiBcbUSEoQrdNhJSOooNOHMYy+kUFBFwjpvFKsY7F\nRF9B9rrwAempWF/vb5aktmD7ngxvhzg1mj+XJ1PT0MvnoizEkFG5c1S2pzaI\nL2OQueY1+B2i7QN28a8G/yPGhlRMLJRLez4i2U3iW5wPbEPtq+efSeFtIYXn\nMHRgHOc8z+TabtG8FYgjYGxxfImKboPLW7DM1/Eqliu/1BJstaTVelV75bCV\nypDX6qGA/6+zPuYxyL/2oH9THV+LJy9zA0jKtFpHOeQLt4kXXnGd2/uCXRoF\niHgC5VtuK5207G5Y3gZYaDvrp7YL3K7cZVt4cscFX24lnHcWPnHeCfiqPD7U\nho9i\r\n=vLcm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js_5.1.1_1527027114928_0.2809987846094626"
+      },
+      "_hasShrinkwrap": false,
+      "deprecated": "See #95"
+    },
+    "5.1.2": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "5.1.2",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big",
+      "browser": "big.js",
+      "module": "big.mjs",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map doc/big.js.map -c -m -o big.min.js --preamble \"/* big.js v5.1.2 https://github.com/MikeMcl/big.js/LICENCE */\""
+      },
+      "files": [
+        "big.js",
+        "big.mjs",
+        "big.min.js"
+      ],
+      "gitHead": "b4db24d83856bc5ff83beecb37c53f05f0ab64da",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@5.1.2",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA==",
+        "shasum": "946c634f3efd9c8dcd98f953e96a5f389dac3fec",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
+        "fileCount": 7,
+        "unpackedSize": 61622,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbBoElCRA9TVsSAnZWagAAYxcQAJKZLPwXf7GJJ+lfXAg3\nW835kauJqdLxabnsIw+mzh4m3M/DaAq3TQFgvHV9C2ffmsEK/uRnKLbBmAmM\nr8zs/b9nXbhvMFvH2L6wqyuXk3td5BeWwHTEvfQJPf8vFgXHqYb2RatQezHk\nGOB+qhvyh1S6KR6Wapfbcgv9dZuGc6iCMwbe78npd9UfsApbxwvHUm8csWHI\n5Ei5ETK2F+Tizm1SwjZ5zBaqqeR01yLxVdEHCFeWiGEnK53/fg9o+82za2UK\nAsfkoK39Y4gEk9vTpCiMFK+TSXfdKQsFR0lCvz49+uQW5VOjpRoY7hpub6nd\niEIHjWyCxo9e1Z+DXoEvYTLqEsZKfSX3P9uUczgQSJS57HFcQCtyPI+U2li/\nf1xt1krkJehdHLSjZj+UzsH6AUZFIUkZFt1VNsPCSuVkJKur95n1yEAPCgxd\nVEDkHi6tuDisbkzmxPDwgVwJotuxhEa8WTG0uDZK3X1MS4jmSHJ9NJSDtwdc\nDbbAOtwrR9iJ5G55QG5xZWk1xA0f1K5pYwlX5Y2JybbWxZKDDOpI430/SD/L\n+w5tY9EDDovKoJuhhTA8/I56I/OWozVMThY+NuwmZGVlUJ6VEihI8tj6wmdf\n6Bs8cpaaG5qZfNG8lmO01iQxMnj8ekTBrb+3hFUpTBbM1H3VU/hZEsM4DErb\nUfqX\r\n=u9WM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js_5.1.2_1527152932714_0.9364007547380433"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "5.2.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big",
+      "browser": "big.js",
+      "module": "big.mjs",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map -c -m -o big.min.js",
+        "postinstall": "opencollective postinstall"
+      },
+      "dependencies": {
+        "opencollective": "^1.0.3"
+      },
+      "collective": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      },
+      "gitHead": "3e525eb5c8396c7fd06e4206b5534bc374ecfa15",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@5.2.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-k8S+ioyE06BcIcS29R3M7YbbmmcGh0DWfMY6JnZ3n4hhEv/lIRS2qRPCqUoHiGIXlrrRBKJtTbw8Fwp92bGOZA==",
+        "shasum": "0abb06f3acd00509e8385ebe20b1b41419612cb9",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.2.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 63878,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbv5H8CRA9TVsSAnZWagAAkpUP/3RpDuCvyrPDMJLJkiI3\n5yYChasUdnSzKb5QcKycMJKxs67YyYzH5HrwFLCHHWh1BrECrZWwJsHGVMFK\nTCLUcqV+8WA39yfMaL18A4947XRAsjNns3Kwc5o2vxVk0ts02LXL2f1L0Ue1\nL2rDAMXwcB15p+u066ccQ4I9yGY4Wc0F1nalrxX9tH+GIrpYrzIIAw6vMKR6\nLVxFWxUL7oqTP5z8/8xO7BRoN3NU9E4zp5Zfol+/sW5DNhGdTrjSRHitvYje\ndmrFAuKHT7s6QAFUTdidqOtk8iqLNgZqHuY3ak+UmPX3gzqga8A79nfAtEVl\nrv+gGAXbPQ7Kw6BlbvF9EauM6uzZysNseBbuFen1t16pr4qM3Kmx5M7kjomx\nM0YYh6ejNVaNrwC09v+G7fk76+jPmFr5JqJWWUS/PIeNNKNyicjDT56PovOa\nxheuKb3mtKy6gOeXCCeFj5/zq1Air1nsFb/t4TewyD2Rt/xxVajCwW4QEsLp\nPCvK7YfsU4JOs8asuq417HMtkmXWJY2lNYck6T5ZjjhdgORIpSn0gMBhPgHy\nYbNneQ+hWjZHD/1dhfnQfyl92VQfVm6/ARCEmpmUB2/lVyQlTXVRc1RD+gZj\nLrbaR4GnqmC624n0VoFi5wUd7KRUm9CBld4A7EBHqWClnduuYE/JxCkPSmZq\n6DD9\r\n=F5pS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js_5.2.1_1539281404023_0.2352306490180982"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.2": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "5.2.2",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big",
+      "browser": "big.js",
+      "module": "big.mjs",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/every-test.js",
+        "build": "uglifyjs big.js --source-map -c -m -o big.min.js"
+      },
+      "collective": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      },
+      "gitHead": "01b3ce3a6b0ba7b42442ea48ec4ffc88d1669ec4",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@5.2.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.12.0",
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+        "shasum": "65f0af382f578bcdc742bd9c281e9cb2d7768328",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+        "fileCount": 7,
+        "unpackedSize": 63868,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbyGX+CRA9TVsSAnZWagAAMVkP/0i7Uxy+BYPfzIwv0ZCE\nxZYqjdM46sToRgTVzoY5T0/pm0Cx9APg4+XHRTCKV/7/jx9aZyxYMboxaVVE\nPwEj+0580L/Rw9ymbrOagveg5lnEwXQunpCQD9OvCHlDJkQU6udeRnW9r67o\nq6drSuhCT+6b2l/PAxmbN7V8hYjhf9+1zwVNOAdGJ9o3//UCVNvMovX5Omz8\nzdROqXsuqb0L0KiqLjkNDI3VkYiRHTU2aSPQBOySa4TnBB2sr23N5N2YUylA\nB1Ouwi1Rm05F/IPpPMuOOUPzoZ29lKqOVHxVfNBHt0yg9unCI3+75YP614jz\nNoRebWIvcvlDOn6OLpc64D7uywygkudMVbeHQaps59e7ATzsRohqm2hwmEIt\nL9d9yFgAV9ypIi61P5R5cNaawalrXGAGUB0gSnyzbOpsfIj9B2qDSG9+G8Zw\nPb5xYt3B3Lh2+zLYBKToIkJPZxtuKK0949PpUkbVM0yF2m3DqT0tGsfl4Iq1\nrM0bGg1+6EuyJs5o47jJP4CfE1vQlC/LcZGedMQNbPm7Av4xoV5QAhJjJdcq\nTz6lMa1/CFy6tfbCmm+MRH3jGrrM8dN78PyWZLQmeM3Jc+ltYjYbl6j/5w0a\ncpNN0CZ9H43uyFszbFwI+2OS48WtAiAbqHE8tXFMJty7DHQNaOfurGDbnL3h\niov9\r\n=O4RU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js_5.2.2_1539859966247_0.4536733471360548"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.0": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "6.0.0",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big",
+      "browser": "big.js",
+      "module": "big.mjs",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/runner.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      },
+      "gitHead": "db8091b5802229f7896727100425fc07d496d1bc",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@6.0.0",
+      "_nodeVersion": "14.11.0",
+      "_npmVersion": "6.14.6",
+      "dist": {
+        "integrity": "sha512-PGsJX+jhBY5qaGOymm4V1QMM2oOCtfGdW8CxgbDTg17C/qHeW89jhx6Kpda3vS0uPHFT6sEhwbb5tlc0wmA+wQ==",
+        "shasum": "d3806d83d93d67faaf29bfca2d2c45d02160da04",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-6.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 61091,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfbdqBCRA9TVsSAnZWagAA97wQAJC44E8FHf5Jwzkme8lF\nygNN2A2t14ujidkVpXh1F+dCSTa0He7ehOLGY0scgW+qmP7K1KwKa4UUNU5x\nr/Q7m8UpIa3fQLgcMuCp6dOb1vrawshohozsvo/Q3d4VumKCCc57JGjjjrRr\nFdRGtMOa8NeNWLbjBqztsjt6kNWJuLyQynPCwXhjluKvbB0JCGjddSunXVR+\nBv4TvU6LrpnB7bgLQvEEVOnjIm5TvcpZSSsmBAKc9jSpkQ6YNmLBUswnAypO\n3tDKLVpL+7FYBlYZKkJJYXlpwahzHRMu5tA/I1rxisPXTfpd35ziSzRi4WIg\nZ0viniaqUEnQerxEVSiiOLoQih2C7IPKDPxFr8Yulz/9bAgnhNzr9XFH23Re\n2f+P7DjfGQbnWxchFWIZQp3zuAqBInIw+AXVKUBEFxgoJdXeBUAchl2a/UvS\nST0b50qjA/9poyyijbqbKhX5/m+9/i/Ome6Za7/zG5TQea1BLqDEXTX2+o9z\nd1CE/TIl8p3rmXQJucqIJ1K+btWP1oA52Zf/iliDo6g3cFq+NahJ3B+vybCC\n6YHBrxkYNCy4wc47LHHhprFj/2AIIYC4lrqP1vZXLvMzLEIbxruXENATD6/T\n6sAMMf29zgxj11DZkhwzNNQ1eiVRgGS5SyUcQs4l4M+r0AyLWe5oMDhz4wus\nrjSz\r\n=2H28\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js_6.0.0_1601034881200_0.08805361706704318"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.1": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "6.0.1",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big",
+      "browser": "big.js",
+      "module": "big.mjs",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/runner.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      },
+      "gitHead": "e82dd1d5f62fe13159b7488e74b7b23861e1ac9e",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@6.0.1",
+      "_nodeVersion": "14.11.0",
+      "_npmVersion": "6.14.6",
+      "dist": {
+        "integrity": "sha512-o2EROPS1CEOLYNJKDRvmfVxpP9YTQxBSW0nJrpCpBjB5TEg3XYUt+WZHqrOVi/53GcQk8KFfNE08ZLpiD4iA2A==",
+        "shasum": "9e0a2e8b1825ce006cd4a096d6f294738cd5cff6",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-6.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 61155,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfdOUxCRA9TVsSAnZWagAAW9YP/1O3fe537fsUrU0mMthu\nMFlNMB04ya61PueIvwJSOgBvrjq1yTtbZCWhtmED4/v7OwhAMeewKNx9d1L8\nqYBMX8r94tKzIniR+zFNe1bBhbOqjgC0KnISWlKoOE2gzREXZAs+ZgnVa7HC\n78QAh5tN2KQ7JqO0+VVJN+92j857Rv3TOekZ5r5D6x53Rz/jvBdTfihQ06ZT\ndAVZBYIldezaeO+PescJtuO0ezTL0cqHdgK4d8s/tfUzajkIJsY0zEJrGeg/\nNgfRFcn4IH/90ZWaqukrz6XBHQy929ATeF52K5pQUmk6EBT7827HkVpQ+lc1\n5pFaepgEiz0CkWAmMJiSRevekGPN2mAOgULwskFhluAqg9nGcyKRIj8nGxA8\nlp84vDRPUnlaFlT1UgPODby+ge94f/JV/CVGPzDT3G3epR+PKP4oS2gmmIap\n6Z764mr8iKFlhTgmUKV6BbnC4iSzMZq7HJxqS5INjYLsSwIYwkmW+g92xO9g\nzVZMzD67tPd14Dt70SEyMBLQ9FKVr140p6eOyW3dfjDX/ljltYQixGfkEwIA\nNbvnUw32le/91IrzrBcmLhN7sXpuc3gPXDBZ7z5gJ+PhJY2o3S5eeTzxhoAD\n06kDks0FNk4CFdrwdDlk6rA6fYqiW0+/lBTMHzWqDLeh1alI2LwOFiaVgPVf\nm7PB\r\n=aFjx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js_6.0.1_1601496368564_0.6093894820613375"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.2": {
+      "name": "big.js",
+      "description": "A small, fast, easy-to-use library for arbitrary-precision decimal arithmetic",
+      "version": "6.0.2",
+      "keywords": [
+        "arbitrary",
+        "precision",
+        "arithmetic",
+        "big",
+        "number",
+        "decimal",
+        "float",
+        "biginteger",
+        "bigdecimal",
+        "bignumber",
+        "bigint",
+        "bignum"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/MikeMcl/big.js.git"
+      },
+      "main": "big",
+      "browser": "big.js",
+      "module": "big.mjs",
+      "author": {
+        "name": "Michael Mclaughlin",
+        "email": "M8ch88l@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/MikeMcl/big.js/issues"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test/runner.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      },
+      "gitHead": "581037601e596234f0bbc340165d62750cf7ac8b",
+      "homepage": "https://github.com/MikeMcl/big.js#readme",
+      "_id": "big.js@6.0.2",
+      "_nodeVersion": "14.11.0",
+      "_npmVersion": "6.14.6",
+      "dist": {
+        "integrity": "sha512-5PQYFp5ZrznQwD7cNgUHZwpC0gm/Pmh2GiUMSW4KurSXEtjLUVAXnmxYnM2W1X0Dx9JFAcvYJ4IQ+dchanp5VA==",
+        "shasum": "af54d7678630aa4ce5d62f43ed44d1a3c9faf803",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-6.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 60841,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfnWOfCRA9TVsSAnZWagAA7icP/01dMY2NN5ttkA8dlgPi\nnlhHH5YQOx1iYq6EcLyvKqM2AKUcv/FqkPh8UMzATsJqzAqdj/7je2ytvVC9\nRek4ojTOKmAOIG+HlswqP6exNYeetFEcNsPqgoCcx24sUs1Aw7WwGYr6tnky\n+lNNbgmmv4CqpSMwh3BNxHKqUoy55ojxhHloegTsUiEojx0FjfElDVzLDCKL\n4NEK1YIAYMnLfJE3S1L+Fw2x6QcQB3lROjBDiYTQtcIHiebo96pa5g4fhZVN\nBnxIP2EIwtle4YqCBqdJ9tKyTmJzDllb3zt20cPRPR7RG0QdIlIO40GxBNsp\nNzRro0d83v91dXBoqHLwIN07Nte6j8ynlW47Xvh/0i9+2kwzd5uaS567oNBL\nP5fvL/iOXq1pn2gBhvVTgq8RGljk99W9rF5fZLKvw9kMArMiQ+BvfCkh+/wl\n1pZ576msa/iQ+E6Dd9ZEF87sV1xF1FGHAUd4kkMlrOKTMCw3q6JJYnkf794G\nUPc3XUFX5cI2klygUS9tArG+KrE6HUmToblVNCV00WKg+RKay9kasArlh0h+\n/prnVcLU6/Gk81DxXAVtHgpXJ375FmR15rySd7/zQbw61envlNA9/65MAr7v\n0BUkpPZCKpNcwvhB7cgyUrRiDYIgE2c1w0WdRe0JwUDuj+spEC7UUKIbdurm\nW2RQ\r\n=M8Tz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mikemcl",
+          "email": "M8ch88l@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "mikemcl",
+        "email": "M8ch88l@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/big.js_6.0.2_1604150175411_0.32915851971082777"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# big.js\r\n\r\n**A small, fast JavaScript library for arbitrary-precision decimal arithmetic.**\r\n\r\n[![npm version](https://img.shields.io/npm/v/big.js.svg)](https://www.npmjs.com/package/big.js)\r\n[![npm downloads](https://img.shields.io/npm/dw/big.js)](https://www.npmjs.com/package/big.js)\r\n\r\n## Features\r\n\r\n- Simple API\r\n- Faster, smaller and easier-to-use than JavaScript versions of Java's BigDecimal\r\n- Only 6 KB minified\r\n- Replicates the `toExponential`, `toFixed` and `toPrecision` methods of JavaScript Numbers\r\n- Stores values in an accessible decimal floating point format\r\n- Comprehensive [documentation](http://mikemcl.github.io/big.js/) and test set\r\n- No dependencies\r\n- Uses ECMAScript 3 only, so works in all browsers\r\n\r\nThe little sister to [bignumber.js](https://github.com/MikeMcl/bignumber.js/) and [decimal.js](https://github.com/MikeMcl/decimal.js/). See [here](https://github.com/MikeMcl/big.js/wiki) for some notes on the difference between them.\r\n\r\n## Install\r\n\r\nThe library is the single JavaScript file *big.js* or the ES module *big.mjs*.\r\n\r\n### Browsers\r\n\r\nAdd Big to global scope:\r\n\r\n```html\r\n<script src='path/to/big.js'></script>\r\n```\r\n\r\nES module:\r\n\r\n```html\r\n<script type='module'>\r\nimport Big from './path/to/big.mjs';\r\n```\r\n\r\nGet a minified version from a CDN:\r\n\r\n```html\r\n<script src='https://cdn.jsdelivr.net/npm/big.js@6.0.0/big.min.js'></script>\r\n```\r\n\r\n### [Node.js](http://nodejs.org)\r\n\r\n```bash\r\n$ npm install big.js\r\n```\r\n\r\nCommonJS:\r\n\r\n```javascript\r\nconst Big = require('big.js');\r\n```\r\n\r\nES module:\r\n\r\n```javascript\r\nimport Big from 'big.js';\r\n```\r\n\r\n### [Deno](https://deno.land/)\r\n\r\n```javascript\r\nimport Big from 'https://raw.githubusercontent.com/mikemcl/big.js/v6.0.0/big.mjs';\r\nimport Big from 'https://unpkg.com/big.js@6.0.0/big.mjs';\r\n```\r\n\r\n## Use\r\n\r\n*In the code examples below, semicolons and `toString` calls are not shown.*\r\n\r\nThe library exports a single constructor function, `Big`.\r\n\r\nA Big number is created from a primitive number, string, or other Big number.\r\n\r\n```javascript\r\nx = new Big(123.4567)\r\ny = Big('123456.7e-3')                 // 'new' is optional\r\nz = new Big(x)\r\nx.eq(y) && x.eq(z) && y.eq(z)          // true\r\n```\r\n\r\nIn Big strict mode, creating a Big number from a primitive number is disallowed.\r\n\r\n```javascript\r\nBig.strict = true\r\nx = new Big(1)                         // TypeError: [big.js] Invalid number\r\ny = new Big('1.0000000000000001')\r\ny.toNumber()                           // Error: [big.js] Imprecise conversion\r\n```\r\n\r\nA Big number is immutable in the sense that it is not changed by its methods.\r\n\r\n```javascript\r\n0.3 - 0.1                              // 0.19999999999999998\r\nx = new Big(0.3)\r\nx.minus(0.1)                           // \"0.2\"\r\nx                                      // \"0.3\"\r\n```\r\n\r\nThe methods that return a Big number can be chained.\r\n\r\n```javascript\r\nx.div(y).plus(z).times(9).minus('1.234567801234567e+8').plus(976.54321).div('2598.11772')\r\nx.sqrt().div(y).pow(3).gt(y.mod(z))    // true\r\n```\r\n\r\nLike JavaScript's Number type, there are `toExponential`, `toFixed` and `toPrecision` methods.\r\n\r\n```javascript\r\nx = new Big(255.5)\r\nx.toExponential(5)                     // \"2.55500e+2\"\r\nx.toFixed(5)                           // \"255.50000\"\r\nx.toPrecision(5)                       // \"255.50\"\r\n```\r\n\r\nThe arithmetic methods always return the exact result except `div`, `sqrt` and `pow`\r\n(with negative exponent), as these methods involve division.\r\n\r\nThe maximum number of decimal places and the rounding mode used to round the results of these methods is determined by the value of the `DP` and `RM` properties of the `Big` number constructor.\r\n\r\n```javascript\r\nBig.DP = 10\r\nBig.RM = 1\r\n\r\nx = new Big(2);\r\ny = new Big(3);\r\nz = x.div(y)                           // \"0.6666666667\"\r\nz.sqrt()                               // \"0.8164965809\"\r\nz.pow(-3)                              // \"3.3749999995\"\r\nz.times(z)                             // \"0.44444444448888888889\"\r\nz.times(z).round(10)                   // \"0.4444444445\"\r\n```\r\n\r\nThe value of a Big number is stored in a decimal floating point format in terms of a coefficient, exponent and sign.\r\n\r\n```javascript\r\nx = new Big(-123.456);\r\nx.c                                    // [1,2,3,4,5,6]    coefficient (i.e. significand)\r\nx.e                                    // 2                exponent\r\nx.s                                    // -1               sign\r\n```\r\n\r\nFor advanced usage, multiple Big number constructors can be created, each with an independent configuration.\r\n\r\nFor further information see the [API](http://mikemcl.github.io/big.js/) reference documentation.\r\n\r\n## Minify\r\n\r\nTo minify using, for example, npm and [terser](https://github.com/terser/terse)\r\n\r\n```bash\r\n$ npm install -g terser\r\n```\r\n\r\n```bash\r\n$ terser big.js -c -m -o big.min.js\r\n```\r\n\r\n## Test\r\n\r\nThe *test* directory contains the test scripts for each Big number method.\r\n\r\nThe tests can be run with Node.js or a browser.\r\n\r\nRun all the tests:\r\n\r\n```bash\r\n$ npm test\r\n```\r\n\r\nTest a single method:\r\n\r\n```bash\r\n$ node test/toFixed\r\n```\r\n\r\nFor the browser, see *runner.html* and *test.html* in the *test/browser* directory.\r\n\r\n*big-vs-number.html* is a old application that enables some of the methods of big.js to be compared with those of JavaScript's Number type.\r\n\r\n## TypeScript\r\n\r\nThe [DefinitelyTyped](https://github.com/borisyankov/DefinitelyTyped) project has a Typescript type definitions file for big.js.\r\n\r\n```bash\r\n$ npm install --save-dev @types/big.js\r\n```\r\n\r\nAny questions about the TypeScript type definitions file should be addressed to the DefinitelyTyped project.\r\n\r\n## Licence\r\n\r\n[MIT](LICENCE.md)\r\n\r\n## Contributors\r\n\r\n<a href=\"graphs/contributors\"><img src=\"https://opencollective.com/bigjs/contributors.svg?width=890&button=false\" /></a>\r\n\r\n## Financial supporters\r\n\r\nThank you to all who have supported this project via [Open Collective](https://opencollective.com/bigjs), particularly [Coinbase](https://www.coinbase.com/).\r\n\r\n<img src=\"https://opencollective.com/bigjs/sponsor/0/avatar.svg\">\r\n",
+  "maintainers": [
+    {
+      "name": "mikemcl",
+      "email": "M8ch88l@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-31T13:16:18.319Z",
+    "created": "2013-05-13T16:39:49.673Z",
+    "2.0.0": "2013-05-13T16:40:29.852Z",
+    "2.1.0": "2013-06-26T21:25:53.562Z",
+    "2.2.0": "2013-07-11T15:52:46.890Z",
+    "2.4.0": "2013-09-19T10:03:47.023Z",
+    "2.4.1": "2013-11-29T10:23:51.693Z",
+    "2.5.0": "2014-01-26T15:23:27.909Z",
+    "2.5.1": "2014-06-08T22:59:24.273Z",
+    "3.0.0": "2014-12-10T19:47:41.045Z",
+    "3.0.1": "2015-02-18T13:53:20.971Z",
+    "3.0.2": "2015-05-12T09:25:15.921Z",
+    "3.1.1": "2015-06-12T19:57:00.633Z",
+    "3.1.2": "2015-06-12T20:12:33.962Z",
+    "3.1.3": "2015-06-14T22:45:57.834Z",
+    "3.2.0": "2017-09-14T21:14:51.849Z",
+    "4.0.0": "2017-09-27T21:21:27.625Z",
+    "4.0.1": "2017-09-28T09:01:49.716Z",
+    "4.0.2": "2017-09-28T09:08:25.360Z",
+    "5.0.0": "2017-10-13T11:54:59.704Z",
+    "5.0.1": "2017-10-13T12:15:45.954Z",
+    "5.0.2": "2017-10-13T21:55:29.718Z",
+    "5.0.3": "2017-10-23T22:01:47.080Z",
+    "5.1.0": "2018-05-22T11:09:13.725Z",
+    "5.1.1": "2018-05-22T22:11:55.022Z",
+    "5.1.2": "2018-05-24T09:08:52.828Z",
+    "5.2.1": "2018-10-11T18:10:04.202Z",
+    "5.2.2": "2018-10-18T10:52:46.395Z",
+    "6.0.0": "2020-09-25T11:54:41.368Z",
+    "6.0.1": "2020-09-30T20:06:08.685Z",
+    "6.0.2": "2020-10-31T13:16:15.621Z"
+  },
+  "author": {
+    "name": "Michael Mclaughlin",
+    "email": "M8ch88l@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MikeMcl/big.js.git"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/MikeMcl/big.js#readme",
+  "keywords": [
+    "arbitrary",
+    "precision",
+    "arithmetic",
+    "big",
+    "number",
+    "decimal",
+    "float",
+    "biginteger",
+    "bigdecimal",
+    "bignumber",
+    "bigint",
+    "bignum"
+  ],
+  "bugs": {
+    "url": "https://github.com/MikeMcl/big.js/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "ctd1500": true,
+    "caffeinewriter": true,
+    "trusktr": true,
+    "ferrari": true,
+    "terrychan": true,
+    "sam16": true,
+    "astraloverflow": true,
+    "dwqs": true,
+    "guzgarcia": true,
+    "leizongmin": true,
+    "ganeshkbhat": true,
+    "zhangaz1": true,
+    "janez89": true,
+    "mrxf": true,
+    "m-ahmadi": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/big.js.min.json
+++ b/test/fixtures/registry-mocks/content/big.js.min.json
@@ -1,0 +1,370 @@
+{
+  "name": "big.js",
+  "dist-tags": {
+    "latest": "6.0.2"
+  },
+  "versions": {
+    "2.0.0": {
+      "name": "big.js",
+      "version": "2.0.0",
+      "dist": {
+        "shasum": "e930d2f1968e0fdad4621b06d0c80f2edc938fdf",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.0": {
+      "name": "big.js",
+      "version": "2.1.0",
+      "dist": {
+        "shasum": "4f19d802b44036697e4a335c1b39b6e6e57644b5",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.2.0": {
+      "name": "big.js",
+      "version": "2.2.0",
+      "dist": {
+        "shasum": "c9027fa4f5e13da5b32a2c1e60ca94fe537906ca",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.4.0": {
+      "name": "big.js",
+      "version": "2.4.0",
+      "dist": {
+        "shasum": "3015aa15c1166681a3ac75d0fefca5381f891a4d",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.4.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.4.1": {
+      "name": "big.js",
+      "version": "2.4.1",
+      "dist": {
+        "shasum": "4992df4b1a397af3896ada65ff77d6d8deab8426",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.4.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.5.0": {
+      "name": "big.js",
+      "version": "2.5.0",
+      "dist": {
+        "shasum": "6b4bdd89fd1238fef560b07f35a22486cea7bd56",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.5.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.5.1": {
+      "name": "big.js",
+      "version": "2.5.1",
+      "dist": {
+        "shasum": "f3dbff02b6f561edb130925bf6d5f47163b061da",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-2.5.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0": {
+      "name": "big.js",
+      "version": "3.0.0",
+      "dist": {
+        "shasum": "ffe15b3a94542e799147e2dfcf12a8e3016ee1fc",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.1": {
+      "name": "big.js",
+      "version": "3.0.1",
+      "dist": {
+        "shasum": "e7790a8a15c810666b5485cebe3303d4918cc5a3",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.2": {
+      "name": "big.js",
+      "version": "3.0.2",
+      "dist": {
+        "shasum": "72256a0b4f9fa48ca009800c51de5d1bc706aeab",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.1.1": {
+      "name": "big.js",
+      "version": "3.1.1",
+      "dist": {
+        "shasum": "a9f3a4cb203af25fd48d7009839755c9bd3da7ce",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.1.2": {
+      "name": "big.js",
+      "version": "3.1.2",
+      "dist": {
+        "shasum": "2bf22c0916b45545575ee9c8a75c8c82d0ca3843",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.1.3": {
+      "name": "big.js",
+      "version": "3.1.3",
+      "dist": {
+        "shasum": "4cada2193652eb3ca9ec8e55c9015669c9806978",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.0": {
+      "name": "big.js",
+      "version": "3.2.0",
+      "dist": {
+        "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+        "shasum": "a5fc298b81b9e0dca2e458824784b65c52ba588e",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "4.0.0": {
+      "name": "big.js",
+      "version": "4.0.0",
+      "dist": {
+        "integrity": "sha512-/7E310GMBNF15bfktIB07hKv/qfhAl2XYrvQbUDHV8kMddcYpFAJkEGtrtZZFCVXHWYJReN4GRNZ6yn3evs0qg==",
+        "shasum": "a02208ebcde327a6ec29fd35a8a25fd81e17bf60",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-4.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "4.0.1": {
+      "name": "big.js",
+      "version": "4.0.1",
+      "dist": {
+        "integrity": "sha512-upfnV8uHh3t3hFCubvWx/2z0gzE3azRuaHJe32+p8qCumM/CgTI7Db5lT7dtFcScI0d9Idj00yBIsKyYnwqPOQ==",
+        "shasum": "ca7f6d8e4d3eea138a4071a0f12300b74ad503e1",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-4.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "4.0.2": {
+      "name": "big.js",
+      "version": "4.0.2",
+      "dist": {
+        "integrity": "sha512-j2h3nqdkpVwMzIqrO1STr2f/X5Qxv2MI1f4Q3EyO/gU24IdZOhPJbH3UE6SYFBm4/ZkMAIrOHB17Z3heaQV+4A==",
+        "shasum": "22e26c05282104068e1ce62c43e45e9a5ec94690",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-4.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "5.0.0": {
+      "name": "big.js",
+      "version": "5.0.0",
+      "dist": {
+        "integrity": "sha512-3kysvTYI3hwjinlCbxUjSB7ze9hUSbJIkT5SJNEfz7lcUeK0S6F64BJ1PPK5T7ifT8NLiyqmotV8fw6tu9QLKw==",
+        "shasum": "e59c7b3f46a33d262aae107fef761b51fa15f178",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "5.0.1": {
+      "name": "big.js",
+      "version": "5.0.1",
+      "dist": {
+        "integrity": "sha512-0raCSj7VA9CDHCrNcXk4z09Qc/fn3gQMSUJKiPNH+/ykkdd7QoJVsny2I2ILxGaPYkqRKgFDUkwWZdLPaZIiVw==",
+        "shasum": "176a7c0f347916ec3286ca27ad31ebf8d9fbed1b",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "5.0.2": {
+      "name": "big.js",
+      "version": "5.0.2",
+      "dist": {
+        "integrity": "sha512-+wVWTDlARgqLk8AWy0IldP8k2wto6XjYaYZKErA+9lF09QU/mrX5fFEibDW0LLLmrt1rNmmUVUMVNp5f38wFIQ==",
+        "shasum": "09f5a20264475205fbaadbec631831921431419d",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "5.0.3": {
+      "name": "big.js",
+      "version": "5.0.3",
+      "dist": {
+        "integrity": "sha512-av8LNZGBl4cg2r4ZhWqghJOxi2P8UCcWhdmrFgcHPMmUJ6jx1FbnyxjwL4URYzMK3QJg60qeMefQhv9G14oYKA==",
+        "shasum": "9679fb0a3599a7d3df397f855e89c4dba016960e",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.0.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "5.1.1": {
+      "name": "big.js",
+      "version": "5.1.1",
+      "dist": {
+        "integrity": "sha512-rNvOVZ1u/W5KNk/Oit8KDV+LYnWTxG7jro3UBeTrQ3e9wW9n2eZl4PDFToAGIhsHgTuMNEMwd0xGzx5KOEzODQ==",
+        "shasum": "039cbcd23ef6190c5a0fc93cb224fa6f4fa643ec",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 61483,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbBJWrCRA9TVsSAnZWagAA+3cP/1nW8SQI0/xNS2+24ita\nNabW0xD28aVbNVlX3qGp9ReB/NPpgbVeG+0QDZg4e8o36vsYCAGhCDPlnTQ6\nhlnIit1edje4npsCtXESqcTw6Y3S9vbKwMyu3UHHIBKIqwctv+bSPO0FgmlE\nA8X15jnucxjZSBtviNS3nJF3teFH/WAz5bAwcHMgV8soy2QZM8OH7O36UR2c\naoZyFH+5B3vmsTtyyckWpeXqHVr+kClbTpupPa6lCFG8TmjNwKejrG9NVr30\n87OvrzgxMvS51rjX3nA8OUeICLZj3GLwk34sNzyzagJBlCdaqp3b2Y1A+c5v\ndUbw3dMY/y8AoWcHA0BEiBcbUSEoQrdNhJSOooNOHMYy+kUFBFwjpvFKsY7F\nRF9B9rrwAempWF/vb5aktmD7ngxvhzg1mj+XJ1PT0MvnoizEkFG5c1S2pzaI\nL2OQueY1+B2i7QN28a8G/yPGhlRMLJRLez4i2U3iW5wPbEPtq+efSeFtIYXn\nMHRgHOc8z+TabtG8FYgjYGxxfImKboPLW7DM1/Eqliu/1BJstaTVelV75bCV\nypDX6qGA/6+zPuYxyL/2oH9THV+LJy9zA0jKtFpHOeQLt4kXXnGd2/uCXRoF\niHgC5VtuK5207G5Y3gZYaDvrp7YL3K7cZVt4cscFX24lnHcWPnHeCfiqPD7U\nho9i\r\n=vLcm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "deprecated": "See #95"
+    },
+    "5.1.2": {
+      "name": "big.js",
+      "version": "5.1.2",
+      "dist": {
+        "integrity": "sha512-qG6ZOc1lY84Bn8p/z9xvJisj9F4PRyo0pOGqGNYc7gS3p1WciS/3XcLuNI3Z/yYZpMNFhHeX3YNENwgrQq0NTA==",
+        "shasum": "946c634f3efd9c8dcd98f953e96a5f389dac3fec",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.1.2.tgz",
+        "fileCount": 7,
+        "unpackedSize": 61622,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbBoElCRA9TVsSAnZWagAAYxcQAJKZLPwXf7GJJ+lfXAg3\nW835kauJqdLxabnsIw+mzh4m3M/DaAq3TQFgvHV9C2ffmsEK/uRnKLbBmAmM\nr8zs/b9nXbhvMFvH2L6wqyuXk3td5BeWwHTEvfQJPf8vFgXHqYb2RatQezHk\nGOB+qhvyh1S6KR6Wapfbcgv9dZuGc6iCMwbe78npd9UfsApbxwvHUm8csWHI\n5Ei5ETK2F+Tizm1SwjZ5zBaqqeR01yLxVdEHCFeWiGEnK53/fg9o+82za2UK\nAsfkoK39Y4gEk9vTpCiMFK+TSXfdKQsFR0lCvz49+uQW5VOjpRoY7hpub6nd\niEIHjWyCxo9e1Z+DXoEvYTLqEsZKfSX3P9uUczgQSJS57HFcQCtyPI+U2li/\nf1xt1krkJehdHLSjZj+UzsH6AUZFIUkZFt1VNsPCSuVkJKur95n1yEAPCgxd\nVEDkHi6tuDisbkzmxPDwgVwJotuxhEa8WTG0uDZK3X1MS4jmSHJ9NJSDtwdc\nDbbAOtwrR9iJ5G55QG5xZWk1xA0f1K5pYwlX5Y2JybbWxZKDDOpI430/SD/L\n+w5tY9EDDovKoJuhhTA8/I56I/OWozVMThY+NuwmZGVlUJ6VEihI8tj6wmdf\n6Bs8cpaaG5qZfNG8lmO01iQxMnj8ekTBrb+3hFUpTBbM1H3VU/hZEsM4DErb\nUfqX\r\n=u9WM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "5.2.1": {
+      "name": "big.js",
+      "version": "5.2.1",
+      "dependencies": {
+        "opencollective": "^1.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-k8S+ioyE06BcIcS29R3M7YbbmmcGh0DWfMY6JnZ3n4hhEv/lIRS2qRPCqUoHiGIXlrrRBKJtTbw8Fwp92bGOZA==",
+        "shasum": "0abb06f3acd00509e8385ebe20b1b41419612cb9",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.2.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 63878,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbv5H8CRA9TVsSAnZWagAAkpUP/3RpDuCvyrPDMJLJkiI3\n5yYChasUdnSzKb5QcKycMJKxs67YyYzH5HrwFLCHHWh1BrECrZWwJsHGVMFK\nTCLUcqV+8WA39yfMaL18A4947XRAsjNns3Kwc5o2vxVk0ts02LXL2f1L0Ue1\nL2rDAMXwcB15p+u066ccQ4I9yGY4Wc0F1nalrxX9tH+GIrpYrzIIAw6vMKR6\nLVxFWxUL7oqTP5z8/8xO7BRoN3NU9E4zp5Zfol+/sW5DNhGdTrjSRHitvYje\ndmrFAuKHT7s6QAFUTdidqOtk8iqLNgZqHuY3ak+UmPX3gzqga8A79nfAtEVl\nrv+gGAXbPQ7Kw6BlbvF9EauM6uzZysNseBbuFen1t16pr4qM3Kmx5M7kjomx\nM0YYh6ejNVaNrwC09v+G7fk76+jPmFr5JqJWWUS/PIeNNKNyicjDT56PovOa\nxheuKb3mtKy6gOeXCCeFj5/zq1Air1nsFb/t4TewyD2Rt/xxVajCwW4QEsLp\nPCvK7YfsU4JOs8asuq417HMtkmXWJY2lNYck6T5ZjjhdgORIpSn0gMBhPgHy\nYbNneQ+hWjZHD/1dhfnQfyl92VQfVm6/ARCEmpmUB2/lVyQlTXVRc1RD+gZj\nLrbaR4GnqmC624n0VoFi5wUd7KRUm9CBld4A7EBHqWClnduuYE/JxCkPSmZq\n6DD9\r\n=F5pS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "hasInstallScript": true
+    },
+    "5.2.2": {
+      "name": "big.js",
+      "version": "5.2.2",
+      "dist": {
+        "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+        "shasum": "65f0af382f578bcdc742bd9c281e9cb2d7768328",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+        "fileCount": 7,
+        "unpackedSize": 63868,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbyGX+CRA9TVsSAnZWagAAMVkP/0i7Uxy+BYPfzIwv0ZCE\nxZYqjdM46sToRgTVzoY5T0/pm0Cx9APg4+XHRTCKV/7/jx9aZyxYMboxaVVE\nPwEj+0580L/Rw9ymbrOagveg5lnEwXQunpCQD9OvCHlDJkQU6udeRnW9r67o\nq6drSuhCT+6b2l/PAxmbN7V8hYjhf9+1zwVNOAdGJ9o3//UCVNvMovX5Omz8\nzdROqXsuqb0L0KiqLjkNDI3VkYiRHTU2aSPQBOySa4TnBB2sr23N5N2YUylA\nB1Ouwi1Rm05F/IPpPMuOOUPzoZ29lKqOVHxVfNBHt0yg9unCI3+75YP614jz\nNoRebWIvcvlDOn6OLpc64D7uywygkudMVbeHQaps59e7ATzsRohqm2hwmEIt\nL9d9yFgAV9ypIi61P5R5cNaawalrXGAGUB0gSnyzbOpsfIj9B2qDSG9+G8Zw\nPb5xYt3B3Lh2+zLYBKToIkJPZxtuKK0949PpUkbVM0yF2m3DqT0tGsfl4Iq1\nrM0bGg1+6EuyJs5o47jJP4CfE1vQlC/LcZGedMQNbPm7Av4xoV5QAhJjJdcq\nTz6lMa1/CFy6tfbCmm+MRH3jGrrM8dN78PyWZLQmeM3Jc+ltYjYbl6j/5w0a\ncpNN0CZ9H43uyFszbFwI+2OS48WtAiAbqHE8tXFMJty7DHQNaOfurGDbnL3h\niov9\r\n=O4RU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "6.0.0": {
+      "name": "big.js",
+      "version": "6.0.0",
+      "dist": {
+        "integrity": "sha512-PGsJX+jhBY5qaGOymm4V1QMM2oOCtfGdW8CxgbDTg17C/qHeW89jhx6Kpda3vS0uPHFT6sEhwbb5tlc0wmA+wQ==",
+        "shasum": "d3806d83d93d67faaf29bfca2d2c45d02160da04",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-6.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 61091,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfbdqBCRA9TVsSAnZWagAA97wQAJC44E8FHf5Jwzkme8lF\nygNN2A2t14ujidkVpXh1F+dCSTa0He7ehOLGY0scgW+qmP7K1KwKa4UUNU5x\nr/Q7m8UpIa3fQLgcMuCp6dOb1vrawshohozsvo/Q3d4VumKCCc57JGjjjrRr\nFdRGtMOa8NeNWLbjBqztsjt6kNWJuLyQynPCwXhjluKvbB0JCGjddSunXVR+\nBv4TvU6LrpnB7bgLQvEEVOnjIm5TvcpZSSsmBAKc9jSpkQ6YNmLBUswnAypO\n3tDKLVpL+7FYBlYZKkJJYXlpwahzHRMu5tA/I1rxisPXTfpd35ziSzRi4WIg\nZ0viniaqUEnQerxEVSiiOLoQih2C7IPKDPxFr8Yulz/9bAgnhNzr9XFH23Re\n2f+P7DjfGQbnWxchFWIZQp3zuAqBInIw+AXVKUBEFxgoJdXeBUAchl2a/UvS\nST0b50qjA/9poyyijbqbKhX5/m+9/i/Ome6Za7/zG5TQea1BLqDEXTX2+o9z\nd1CE/TIl8p3rmXQJucqIJ1K+btWP1oA52Zf/iliDo6g3cFq+NahJ3B+vybCC\n6YHBrxkYNCy4wc47LHHhprFj/2AIIYC4lrqP1vZXLvMzLEIbxruXENATD6/T\n6sAMMf29zgxj11DZkhwzNNQ1eiVRgGS5SyUcQs4l4M+r0AyLWe5oMDhz4wus\nrjSz\r\n=2H28\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
+    "6.0.1": {
+      "name": "big.js",
+      "version": "6.0.1",
+      "dist": {
+        "integrity": "sha512-o2EROPS1CEOLYNJKDRvmfVxpP9YTQxBSW0nJrpCpBjB5TEg3XYUt+WZHqrOVi/53GcQk8KFfNE08ZLpiD4iA2A==",
+        "shasum": "9e0a2e8b1825ce006cd4a096d6f294738cd5cff6",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-6.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 61155,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfdOUxCRA9TVsSAnZWagAAW9YP/1O3fe537fsUrU0mMthu\nMFlNMB04ya61PueIvwJSOgBvrjq1yTtbZCWhtmED4/v7OwhAMeewKNx9d1L8\nqYBMX8r94tKzIniR+zFNe1bBhbOqjgC0KnISWlKoOE2gzREXZAs+ZgnVa7HC\n78QAh5tN2KQ7JqO0+VVJN+92j857Rv3TOekZ5r5D6x53Rz/jvBdTfihQ06ZT\ndAVZBYIldezaeO+PescJtuO0ezTL0cqHdgK4d8s/tfUzajkIJsY0zEJrGeg/\nNgfRFcn4IH/90ZWaqukrz6XBHQy929ATeF52K5pQUmk6EBT7827HkVpQ+lc1\n5pFaepgEiz0CkWAmMJiSRevekGPN2mAOgULwskFhluAqg9nGcyKRIj8nGxA8\nlp84vDRPUnlaFlT1UgPODby+ge94f/JV/CVGPzDT3G3epR+PKP4oS2gmmIap\n6Z764mr8iKFlhTgmUKV6BbnC4iSzMZq7HJxqS5INjYLsSwIYwkmW+g92xO9g\nzVZMzD67tPd14Dt70SEyMBLQ9FKVr140p6eOyW3dfjDX/ljltYQixGfkEwIA\nNbvnUw32le/91IrzrBcmLhN7sXpuc3gPXDBZ7z5gJ+PhJY2o3S5eeTzxhoAD\n06kDks0FNk4CFdrwdDlk6rA6fYqiW0+/lBTMHzWqDLeh1alI2LwOFiaVgPVf\nm7PB\r\n=aFjx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
+    "6.0.2": {
+      "name": "big.js",
+      "version": "6.0.2",
+      "dist": {
+        "integrity": "sha512-5PQYFp5ZrznQwD7cNgUHZwpC0gm/Pmh2GiUMSW4KurSXEtjLUVAXnmxYnM2W1X0Dx9JFAcvYJ4IQ+dchanp5VA==",
+        "shasum": "af54d7678630aa4ce5d62f43ed44d1a3c9faf803",
+        "tarball": "https://registry.npmjs.org/big.js/-/big.js-6.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 60841,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfnWOfCRA9TVsSAnZWagAA7icP/01dMY2NN5ttkA8dlgPi\nnlhHH5YQOx1iYq6EcLyvKqM2AKUcv/FqkPh8UMzATsJqzAqdj/7je2ytvVC9\nRek4ojTOKmAOIG+HlswqP6exNYeetFEcNsPqgoCcx24sUs1Aw7WwGYr6tnky\n+lNNbgmmv4CqpSMwh3BNxHKqUoy55ojxhHloegTsUiEojx0FjfElDVzLDCKL\n4NEK1YIAYMnLfJE3S1L+Fw2x6QcQB3lROjBDiYTQtcIHiebo96pa5g4fhZVN\nBnxIP2EIwtle4YqCBqdJ9tKyTmJzDllb3zt20cPRPR7RG0QdIlIO40GxBNsp\nNzRro0d83v91dXBoqHLwIN07Nte6j8ynlW47Xvh/0i9+2kwzd5uaS567oNBL\nP5fvL/iOXq1pn2gBhvVTgq8RGljk99W9rF5fZLKvw9kMArMiQ+BvfCkh+/wl\n1pZ576msa/iQ+E6Dd9ZEF87sV1xF1FGHAUd4kkMlrOKTMCw3q6JJYnkf794G\nUPc3XUFX5cI2klygUS9tArG+KrE6HUmToblVNCV00WKg+RKay9kasArlh0h+\n/prnVcLU6/Gk81DxXAVtHgpXJ375FmR15rySd7/zQbw61envlNA9/65MAr7v\n0BUkpPZCKpNcwvhB7cgyUrRiDYIgE2c1w0WdRe0JwUDuj+spEC7UUKIbdurm\nW2RQ\r\n=M8Tz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    }
+  },
+  "modified": "2020-10-31T13:16:18.319Z"
+}

--- a/test/fixtures/registry-mocks/content/bindings.json
+++ b/test/fixtures/registry-mocks/content/bindings.json
@@ -1,0 +1,1023 @@
+{
+  "_id": "bindings",
+  "_rev": "65-b8adcff19f24c3a370fc855ab2804495",
+  "name": "bindings",
+  "description": "Helper module for loading your native module's .node file",
+  "dist-tags": {
+    "latest": "1.5.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.0.1",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.0.1",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.6.9",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "47d7d976e541539cb997c2728d0dc3fef461b976",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.1.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.1.0",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.6.9",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "34c516b389c2ed39c06bd1d8212bc43f400f8d56",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.1.1",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.1.1",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.6.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "212a9c27336e9d2122405ad0b19fc37f1779eedd",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.2.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.2.0",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.7.2",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "50425eebdcbd39cc8257b11e33d1c2babc3feb7b",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.2.1",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.2.1",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.7.2",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "cc314e1b6bb575b980df3d107f82f96a60e3e607",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.2.2",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.2.2",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.1",
+      "_nodeVersion": "v0.7.3",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "3e646cd70134d7beb688c18942016c3ed7b0a720",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.2.3",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.2.3",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.1",
+      "_nodeVersion": "v0.6.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "658de98121f38da6bcd699e8c8877e7136f7dca5",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.4": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.2.4",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.2.4",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.1",
+      "_nodeVersion": "v0.6.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "0b147402a7198e7d7e644d13412676d73eb5a3fe",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's bindings in a cross-platform way",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.3.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "TooTallNate",
+        "email": "nathan@tootallnate.net"
+      },
+      "_id": "bindings@0.3.0",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.1",
+      "_nodeVersion": "v0.6.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "2d01b7061ca312c6600c9b512404fd3ef99c06f3",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "bindings",
+      "description": "node-bindings ============= ### Helper module for loading your native module's bindings in a cross-platform way.",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp"
+      ],
+      "version": "0.4.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "engines": {
+        "node": "*"
+      },
+      "_id": "bindings@0.4.0",
+      "dist": {
+        "shasum": "3ec1bc8aebe77c908b63908c15bd1613c865057c",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.0.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "_id": "bindings@1.0.0",
+      "dist": {
+        "shasum": "c3ccde60e9de6807c6f1aa4ef4843af29191c828",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.1.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "_id": "bindings@1.1.0",
+      "dist": {
+        "shasum": "f3cc4deec19fe31f255864eb1e6ffad857266ef0",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.12",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.1.1",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/node-bindings/issues"
+      },
+      "_id": "bindings@1.1.1",
+      "dist": {
+        "shasum": "951f7ae010302ffc50b265b124032017ed2bf6f3",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.2.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/node-bindings/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/node-bindings",
+      "_id": "bindings@1.2.0",
+      "dist": {
+        "shasum": "c224fc5b349a84043779f97a6271d9d70da7636f",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.2.1",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/node-bindings/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/node-bindings",
+      "license": "MIT",
+      "gitHead": "e404152ee27f8478ccbc7122ee051246e8e5ec02",
+      "_id": "bindings@1.2.1",
+      "scripts": {},
+      "_shasum": "14ad6113812d2d37d72e67b4cacb4bb726505f11",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "maintainers": [
+        {
+          "name": "TooTallNate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "dist": {
+        "shasum": "14ad6113812d2d37d72e67b4cacb4bb726505f11",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.3.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/node-bindings/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/node-bindings",
+      "license": "MIT",
+      "gitHead": "7fd065ee85386ad3d074d2506e03abe8f9b1588b",
+      "_id": "bindings@1.3.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.1.3",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "dist": {
+        "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+        "shasum": "b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "nathan@tootallnate.net",
+          "name": "tootallnate"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bindings-1.3.0.tgz_1500923768710_0.3334669852629304"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.3.1",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/node-bindings/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/node-bindings",
+      "license": "MIT",
+      "gitHead": "81ba74973e97ff2e42aa4bbae8de057ae62e9387",
+      "_id": "bindings@1.3.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "dist": {
+        "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
+        "shasum": "21fc7c6d67c18516ec5aaa2815b145ff77b26ea5",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+        "fileCount": 3,
+        "unpackedSize": 9107,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb/FxZCRA9TVsSAnZWagAAhVQP/jQl2mQD1vWSzK5/xAf5\njtcv2Vhixd7Tp8a/ZzjU1e/hKWa7GtlGgKd1c5T3LcPuBJYOXDIH8VRtWo3U\n9xxQl9+1E2JuA8p9Yps/HwKGbOSTPtYft8i6w0S9RgpTXpwM5duDOso9bPLC\nqUmP6zaD71FOx6g5f9vlw8NL9pHTANLcHEqV2m8YWDSEXRTC8dUw3qnYtvAd\nfGy9lpw/JQaC4QGny5xuy4u+cfuP6WIyWusM72jQKWIr1tdGrGPWDApLqH5j\nEVuC10tt5bkN4qzW59BZ74YRr42SEraC/UZt6d4rzHc8N2rGoNiCg0zIBNgb\nYTbiF9aIFq9gnU0Zn97idQZ33Gk5Ici4IS4/JGwQhjJ1u2zj0qnVV7uE7BIm\nJazUdbPvKbYGRZqOXEJYe8lhkvuwzud94bLDi5k0whTX3cdVm1iP8gHMXn7R\nB1D4yZZRUP8/e/m/2jDX+FNi3IenmX+vAQGPi6myTeaedbP8q/PN3XPBdRZ+\nSQ+Oie89Lj5v4m1cMErNWl9n9E71me8d8a3Yn9Tu+2o1w/FGvVmXEuCjD3qL\nVCyoeXYSsewCsknRoUr+ST8v0UnmL6g1crbUtBxaFNwcubjvddb45FkEK2r1\n5RR/yg6ZU0sZ+2KR/XLI26mG/sLP/y9tKA7XEMOj406h8mNi3N1fFcKbHmU/\nYaFQ\r\n=z9PJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "nathan@tootallnate.net",
+          "name": "tootallnate"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bindings_1.3.1_1543265368475_0.5592200215369445"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.4.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/node-bindings/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/node-bindings",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      },
+      "gitHead": "e1213580fa8fc308114f1f0c38725d627937c5b2",
+      "_id": "bindings@1.4.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "dist": {
+        "integrity": "sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==",
+        "shasum": "909efa49f2ebe07ecd3cb136778f665052040127",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.4.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 11128,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcSOE7CRA9TVsSAnZWagAAHPsQAJlhGhAXnyI5bPhXia5F\nYnMO6gDwWdu+nj+i6Cf348sMJ/mjBsDdU8LpWCk0d50BSYpG5s9ObC/aC3QT\n5lMKq9ENExLl171VgP2LSNW3Q96Eqnj9imYQC/To1Vd7QEGcSH7Am45yI6UA\nU4Trj/g8h2dKUcqUrfuoYiMPb4kTS5+eU5nCd9uIxyJa+hgrgeJ8GjNIMzks\nMnoFrJwcPChd55yH8UDfy6rTPvixqSPdtGbyyypcAmAOZptIpNVoRIuEKcj/\n/q6RwYcMzc75dRFDRkd3uHEBM5XdyWHtBSWIPCzVr5Ld+7x/P3g2yLiUgLmj\njNykprjacj3L/fYqY6ltulXZiRsPKLNCLChtILLrMcuDVzcARITJEmiFMkmt\nkdOOZk8qKl2cGt2+YFV236piSUTYfp3N+D3SYVrgW/27lgc/v3IqvbtFwdV5\ntA93F0u6BRcCa9sgNl1ZXCrXE92/QeiYo0JXsElASKVMtmRYwqRVwk9E7q1t\nAnhdRu9b4UNxbi5TTA3v36KsOfgboPL9ln9uNB+bfWbbASICgT8VOQSHBoeH\nF0pzWJv/zKzpmQR+8NVy69dBmCz3dLX6YqrvTf+qnI6U/bDS3qTl20Ez4PfU\n0a8DoVRA3xBz0rgmEVqPYM4Tzt0cwCueumoMDsJ3cBBr/07b7+3+GZSw1Yy/\n48dv\r\n=1BNK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "nathan@tootallnate.net",
+          "name": "tootallnate"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bindings_1.4.0_1548280122416_0.6999840321496205"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.0": {
+      "name": "bindings",
+      "description": "Helper module for loading your native module's .node file",
+      "keywords": [
+        "native",
+        "addon",
+        "bindings",
+        "gyp",
+        "waf",
+        "c",
+        "c++"
+      ],
+      "version": "1.5.0",
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://tootallnate.net"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/node-bindings.git"
+      },
+      "main": "./bindings.js",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/node-bindings/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/node-bindings",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      },
+      "gitHead": "bcdc7cadf839ef84c9bd9e21c697f2a727b2b1d3",
+      "_id": "bindings@1.5.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "dist": {
+        "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+        "shasum": "10353c9e945334bc0511a6d90b38fbc7c9c504df",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 11230,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcdxU0CRA9TVsSAnZWagAA8woP/iZQzUdSp2KE6NlY8BIs\nX6bpJ0taAvKOPpmyf173+PRd3csu4POuROZYQRS0SH62XApfwJEm/4N9GwnM\nJlky/urUw9py0w/U5hVejperQcgyovc5f1Wjr6VB8Rj+uuH/hnnEqa5ExQZv\n6BDsFgPf4B1TIBladuqra6EDkLCLD5jX8rlhDVCnQwwJcgrpYRz8W6jmO3p6\nvypvViUQyC/9R1lpecxaQk5aKZQnS6+CMXeYCUI0DzksqC0ZtuRQVL0akJ47\nFF+naaaOcJO0SnqJ/KVbfQcp//KzAaj0prq324UvZCtOteZgyfLUclzQ6DeW\noS7fnWHD83gDaqVQzm4TH7I4OnTizh+A4jpcaMEGFEeROXwC/SlR/S/sUBj4\n25Gfrp9PDAZL/j5w0RNi9zZZSQfPgcVMv9kTnSzOcp80drLAZYuotRqvtRNq\nxwUSmB8maQLjW/m2ZREvMb31vmDanpqy/Ve3VkepwM/uPjduwsChb9QT3veq\nlNraiUCX4lLBHcy00xTHq0R14EI2klC954Ao97+LLlwfb2Vb9D/V3OmlauRu\nDZGQAVR5Z0OteKGeNQUFuM+f819THz0Uixba9XbbAmJq8u8SLK/3TzwOt4Hz\nWpxLogiRd021itDxKElr33Mtb4FbR7dnbQxkfu36y6WRIRF3oJH1JUMhHRYc\npGp7\r\n=e5yW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "nathan@tootallnate.net",
+          "name": "tootallnate"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bindings_1.5.0_1551308084120_0.9910986257879217"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "node-bindings\n=============\n### Helper module for loading your native module's `.node` file\n\nThis is a helper module for authors of Node.js native addon modules.\nIt is basically the \"swiss army knife\" of `require()`ing your native module's\n`.node` file.\n\nThroughout the course of Node's native addon history, addons have ended up being\ncompiled in a variety of different places, depending on which build tool and which\nversion of node was used. To make matters worse, now the `gyp` build tool can\nproduce either a __Release__ or __Debug__ build, each being built into different\nlocations.\n\nThis module checks _all_ the possible locations that a native addon would be built\nat, and returns the first one that loads successfully.\n\n\nInstallation\n------------\n\nInstall with `npm`:\n\n``` bash\n$ npm install --save bindings\n```\n\nOr add it to the `\"dependencies\"` section of your `package.json` file.\n\n\nExample\n-------\n\n`require()`ing the proper bindings file for the current node version, platform\nand architecture is as simple as:\n\n``` js\nvar bindings = require('bindings')('binding.node')\n\n// Use your bindings defined in your C files\nbindings.your_c_function()\n```\n\n\nNice Error Output\n-----------------\n\nWhen the `.node` file could not be loaded, `node-bindings` throws an Error with\na nice error message telling you exactly what was tried. You can also check the\n`err.tries` Array property.\n\n```\nError: Could not load the bindings file. Tried:\n → /Users/nrajlich/ref/build/binding.node\n → /Users/nrajlich/ref/build/Debug/binding.node\n → /Users/nrajlich/ref/build/Release/binding.node\n → /Users/nrajlich/ref/out/Debug/binding.node\n → /Users/nrajlich/ref/Debug/binding.node\n → /Users/nrajlich/ref/out/Release/binding.node\n → /Users/nrajlich/ref/Release/binding.node\n → /Users/nrajlich/ref/build/default/binding.node\n → /Users/nrajlich/ref/compiled/0.8.2/darwin/x64/binding.node\n    at bindings (/Users/nrajlich/ref/node_modules/bindings/bindings.js:84:13)\n    at Object.<anonymous> (/Users/nrajlich/ref/lib/ref.js:5:47)\n    at Module._compile (module.js:449:26)\n    at Object.Module._extensions..js (module.js:467:10)\n    at Module.load (module.js:356:32)\n    at Function.Module._load (module.js:312:12)\n    ...\n```\n\nThe searching for the `.node` file will originate from the first directory in which has a `package.json` file is found.\n\nLicense\n-------\n\n(The MIT License)\n\nCopyright (c) 2012 Nathan Rajlich &lt;nathan@tootallnate.net&gt;\n\nPermission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n'Software'), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "email": "nathan@tootallnate.net",
+      "name": "tootallnate"
+    }
+  ],
+  "time": {
+    "modified": "2019-02-27T22:54:46.886Z",
+    "created": "2012-01-28T22:29:53.409Z",
+    "0.0.1": "2012-01-28T22:29:54.674Z",
+    "0.1.0": "2012-01-30T05:21:01.149Z",
+    "0.1.1": "2012-02-04T00:12:39.290Z",
+    "0.2.0": "2012-02-07T01:33:09.621Z",
+    "0.2.1": "2012-02-07T02:38:46.274Z",
+    "0.2.2": "2012-02-12T01:46:40.563Z",
+    "0.2.3": "2012-02-14T17:28:06.105Z",
+    "0.2.4": "2012-02-15T18:40:22.228Z",
+    "0.3.0": "2012-02-28T19:39:05.034Z",
+    "0.4.0": "2012-06-25T18:40:06.605Z",
+    "1.0.0": "2012-07-18T18:49:12.866Z",
+    "1.1.0": "2013-03-07T09:16:27.293Z",
+    "1.1.1": "2013-07-11T05:05:03.115Z",
+    "1.2.0": "2014-04-04T06:27:01.504Z",
+    "1.2.1": "2014-06-28T18:13:25.303Z",
+    "1.3.0": "2017-07-24T19:16:08.991Z",
+    "1.3.1": "2018-11-26T20:49:28.621Z",
+    "1.4.0": "2019-01-23T21:48:42.499Z",
+    "1.5.0": "2019-02-27T22:54:44.325Z"
+  },
+  "author": {
+    "name": "Nathan Rajlich",
+    "email": "nathan@tootallnate.net",
+    "url": "http://tootallnate.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/TooTallNate/node-bindings.git"
+  },
+  "users": {
+    "fgribreau": true,
+    "werle": true,
+    "tootallnate": true,
+    "stdarg": true,
+    "jalcine": true,
+    "guananddu": true,
+    "mastayoda": true,
+    "whitelynx": true,
+    "panlw": true,
+    "pgilad": true,
+    "pandao": true,
+    "magicxiao85": true,
+    "cocopas": true,
+    "lestad": true,
+    "princetoad": true,
+    "evanjbowling": true,
+    "lukicdarkoo": true,
+    "nohomey": true,
+    "steel1990": true,
+    "kodekracker": true,
+    "zwwggg": true,
+    "2lach": true,
+    "xtx1130": true,
+    "sn0wdr1am": true
+  },
+  "homepage": "https://github.com/TooTallNate/node-bindings",
+  "keywords": [
+    "native",
+    "addon",
+    "bindings",
+    "gyp",
+    "waf",
+    "c",
+    "c++"
+  ],
+  "bugs": {
+    "url": "https://github.com/TooTallNate/node-bindings/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/bindings.min.json
+++ b/test/fixtures/registry-mocks/content/bindings.min.json
@@ -1,0 +1,210 @@
+{
+  "name": "bindings",
+  "dist-tags": {
+    "latest": "1.5.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "bindings",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "47d7d976e541539cb997c2728d0dc3fef461b976",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.1.0": {
+      "name": "bindings",
+      "version": "0.1.0",
+      "dist": {
+        "shasum": "34c516b389c2ed39c06bd1d8212bc43f400f8d56",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.1.1": {
+      "name": "bindings",
+      "version": "0.1.1",
+      "dist": {
+        "shasum": "212a9c27336e9d2122405ad0b19fc37f1779eedd",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.2.0": {
+      "name": "bindings",
+      "version": "0.2.0",
+      "dist": {
+        "shasum": "50425eebdcbd39cc8257b11e33d1c2babc3feb7b",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.2.1": {
+      "name": "bindings",
+      "version": "0.2.1",
+      "dist": {
+        "shasum": "cc314e1b6bb575b980df3d107f82f96a60e3e607",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.2": {
+      "name": "bindings",
+      "version": "0.2.2",
+      "dist": {
+        "shasum": "3e646cd70134d7beb688c18942016c3ed7b0a720",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.3": {
+      "name": "bindings",
+      "version": "0.2.3",
+      "dist": {
+        "shasum": "658de98121f38da6bcd699e8c8877e7136f7dca5",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.4": {
+      "name": "bindings",
+      "version": "0.2.4",
+      "dist": {
+        "shasum": "0b147402a7198e7d7e644d13412676d73eb5a3fe",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.2.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.3.0": {
+      "name": "bindings",
+      "version": "0.3.0",
+      "dist": {
+        "shasum": "2d01b7061ca312c6600c9b512404fd3ef99c06f3",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.3.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.0": {
+      "name": "bindings",
+      "version": "0.4.0",
+      "dist": {
+        "shasum": "3ec1bc8aebe77c908b63908c15bd1613c865057c",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-0.4.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.0": {
+      "name": "bindings",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "c3ccde60e9de6807c6f1aa4ef4843af29191c828",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "bindings",
+      "version": "1.1.0",
+      "dist": {
+        "shasum": "f3cc4deec19fe31f255864eb1e6ffad857266ef0",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "bindings",
+      "version": "1.1.1",
+      "dist": {
+        "shasum": "951f7ae010302ffc50b265b124032017ed2bf6f3",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "bindings",
+      "version": "1.2.0",
+      "dist": {
+        "shasum": "c224fc5b349a84043779f97a6271d9d70da7636f",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "bindings",
+      "version": "1.2.1",
+      "dist": {
+        "shasum": "14ad6113812d2d37d72e67b4cacb4bb726505f11",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "bindings",
+      "version": "1.3.0",
+      "dist": {
+        "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+        "shasum": "b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
+      }
+    },
+    "1.3.1": {
+      "name": "bindings",
+      "version": "1.3.1",
+      "dist": {
+        "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
+        "shasum": "21fc7c6d67c18516ec5aaa2815b145ff77b26ea5",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+        "fileCount": 3,
+        "unpackedSize": 9107,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb/FxZCRA9TVsSAnZWagAAhVQP/jQl2mQD1vWSzK5/xAf5\njtcv2Vhixd7Tp8a/ZzjU1e/hKWa7GtlGgKd1c5T3LcPuBJYOXDIH8VRtWo3U\n9xxQl9+1E2JuA8p9Yps/HwKGbOSTPtYft8i6w0S9RgpTXpwM5duDOso9bPLC\nqUmP6zaD71FOx6g5f9vlw8NL9pHTANLcHEqV2m8YWDSEXRTC8dUw3qnYtvAd\nfGy9lpw/JQaC4QGny5xuy4u+cfuP6WIyWusM72jQKWIr1tdGrGPWDApLqH5j\nEVuC10tt5bkN4qzW59BZ74YRr42SEraC/UZt6d4rzHc8N2rGoNiCg0zIBNgb\nYTbiF9aIFq9gnU0Zn97idQZ33Gk5Ici4IS4/JGwQhjJ1u2zj0qnVV7uE7BIm\nJazUdbPvKbYGRZqOXEJYe8lhkvuwzud94bLDi5k0whTX3cdVm1iP8gHMXn7R\nB1D4yZZRUP8/e/m/2jDX+FNi3IenmX+vAQGPi6myTeaedbP8q/PN3XPBdRZ+\nSQ+Oie89Lj5v4m1cMErNWl9n9E71me8d8a3Yn9Tu+2o1w/FGvVmXEuCjD3qL\nVCyoeXYSsewCsknRoUr+ST8v0UnmL6g1crbUtBxaFNwcubjvddb45FkEK2r1\n5RR/yg6ZU0sZ+2KR/XLI26mG/sLP/y9tKA7XEMOj406h8mNi3N1fFcKbHmU/\nYaFQ\r\n=z9PJ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.4.0": {
+      "name": "bindings",
+      "version": "1.4.0",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==",
+        "shasum": "909efa49f2ebe07ecd3cb136778f665052040127",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.4.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 11128,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcSOE7CRA9TVsSAnZWagAAHPsQAJlhGhAXnyI5bPhXia5F\nYnMO6gDwWdu+nj+i6Cf348sMJ/mjBsDdU8LpWCk0d50BSYpG5s9ObC/aC3QT\n5lMKq9ENExLl171VgP2LSNW3Q96Eqnj9imYQC/To1Vd7QEGcSH7Am45yI6UA\nU4Trj/g8h2dKUcqUrfuoYiMPb4kTS5+eU5nCd9uIxyJa+hgrgeJ8GjNIMzks\nMnoFrJwcPChd55yH8UDfy6rTPvixqSPdtGbyyypcAmAOZptIpNVoRIuEKcj/\n/q6RwYcMzc75dRFDRkd3uHEBM5XdyWHtBSWIPCzVr5Ld+7x/P3g2yLiUgLmj\njNykprjacj3L/fYqY6ltulXZiRsPKLNCLChtILLrMcuDVzcARITJEmiFMkmt\nkdOOZk8qKl2cGt2+YFV236piSUTYfp3N+D3SYVrgW/27lgc/v3IqvbtFwdV5\ntA93F0u6BRcCa9sgNl1ZXCrXE92/QeiYo0JXsElASKVMtmRYwqRVwk9E7q1t\nAnhdRu9b4UNxbi5TTA3v36KsOfgboPL9ln9uNB+bfWbbASICgT8VOQSHBoeH\nF0pzWJv/zKzpmQR+8NVy69dBmCz3dLX6YqrvTf+qnI6U/bDS3qTl20Ez4PfU\n0a8DoVRA3xBz0rgmEVqPYM4Tzt0cwCueumoMDsJ3cBBr/07b7+3+GZSw1Yy/\n48dv\r\n=1BNK\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.5.0": {
+      "name": "bindings",
+      "version": "1.5.0",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+        "shasum": "10353c9e945334bc0511a6d90b38fbc7c9c504df",
+        "tarball": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 11230,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcdxU0CRA9TVsSAnZWagAA8woP/iZQzUdSp2KE6NlY8BIs\nX6bpJ0taAvKOPpmyf173+PRd3csu4POuROZYQRS0SH62XApfwJEm/4N9GwnM\nJlky/urUw9py0w/U5hVejperQcgyovc5f1Wjr6VB8Rj+uuH/hnnEqa5ExQZv\n6BDsFgPf4B1TIBladuqra6EDkLCLD5jX8rlhDVCnQwwJcgrpYRz8W6jmO3p6\nvypvViUQyC/9R1lpecxaQk5aKZQnS6+CMXeYCUI0DzksqC0ZtuRQVL0akJ47\nFF+naaaOcJO0SnqJ/KVbfQcp//KzAaj0prq324UvZCtOteZgyfLUclzQ6DeW\noS7fnWHD83gDaqVQzm4TH7I4OnTizh+A4jpcaMEGFEeROXwC/SlR/S/sUBj4\n25Gfrp9PDAZL/j5w0RNi9zZZSQfPgcVMv9kTnSzOcp80drLAZYuotRqvtRNq\nxwUSmB8maQLjW/m2ZREvMb31vmDanpqy/Ve3VkepwM/uPjduwsChb9QT3veq\nlNraiUCX4lLBHcy00xTHq0R14EI2klC954Ao97+LLlwfb2Vb9D/V3OmlauRu\nDZGQAVR5Z0OteKGeNQUFuM+f819THz0Uixba9XbbAmJq8u8SLK/3TzwOt4Hz\nWpxLogiRd021itDxKElr33Mtb4FbR7dnbQxkfu36y6WRIRF3oJH1JUMhHRYc\npGp7\r\n=e5yW\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-02-27T22:54:46.886Z"
+}

--- a/test/fixtures/registry-mocks/content/bn.js.json
+++ b/test/fixtures/registry-mocks/content/bn.js.json
@@ -1,0 +1,6720 @@
+{
+  "_id": "bn.js",
+  "_rev": "202-728bb75d54f9f08d1880b111e70dbe1f",
+  "name": "bn.js",
+  "description": "Big number implementation in pure javascript",
+  "dist-tags": {
+    "latest": "5.1.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "bn.js",
+      "version": "0.1.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.1.0",
+      "_shasum": "f84d2ec045bdd4cc0513de8ad4ea84dfeb8b1941",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f84d2ec045bdd4cc0513de8ad4ea84dfeb8b1941",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "bn.js",
+      "version": "0.1.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.1.1",
+      "_shasum": "5afef3393cd9d4c85b65f68c013a7695bef1a90a",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5afef3393cd9d4c85b65f68c013a7695bef1a90a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "bn.js",
+      "version": "0.1.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.1.2",
+      "_shasum": "04b88b9f38fdff6fd54a64ed6813144b0e1b6bef",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "04b88b9f38fdff6fd54a64ed6813144b0e1b6bef",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "bn.js",
+      "version": "0.1.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.1.3",
+      "_shasum": "f3b9c51881c104d50854aae94d6c616ef11c5fd9",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f3b9c51881c104d50854aae94d6c616ef11c5fd9",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "bn.js",
+      "version": "0.1.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.1.4",
+      "_shasum": "3248e2c78aa4a74acdfff9b2d36d0bf2588f28a2",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3248e2c78aa4a74acdfff9b2d36d0bf2588f28a2",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "bn.js",
+      "version": "0.1.5",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.1.5",
+      "_shasum": "e5cfb803b073351d0aa2023167cfa44b2409f69a",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e5cfb803b073351d0aa2023167cfa44b2409f69a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.6": {
+      "name": "bn.js",
+      "version": "0.1.6",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.1.6",
+      "_shasum": "9323232e200d36b2117a2d384e83352a6795ac9a",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9323232e200d36b2117a2d384e83352a6795ac9a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.7": {
+      "name": "bn.js",
+      "version": "0.1.7",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.1.7",
+      "_shasum": "73c61ccd47656b084f3989346b5d1c51af412afe",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "73c61ccd47656b084f3989346b5d1c51af412afe",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "bn.js",
+      "version": "0.2.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.2.0",
+      "_shasum": "37ab22ba8da3a0fbfb226c935c6283b67e606ca0",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "37ab22ba8da3a0fbfb226c935c6283b67e606ca0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "bn.js",
+      "version": "0.2.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.2.1",
+      "_shasum": "e8b156a4754e58f636009b9e51e1022856aa30e4",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e8b156a4754e58f636009b9e51e1022856aa30e4",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "bn.js",
+      "version": "0.2.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.2.2",
+      "_shasum": "4ce53679e69a3be43ab0c8e5278c07e7f177a5e7",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4ce53679e69a3be43ab0c8e5278c07e7f177a5e7",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "bn.js",
+      "version": "0.3.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.3.0",
+      "_shasum": "5ff529ddaacb88d8c8b9a747b844b7bb7c61bf06",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5ff529ddaacb88d8c8b9a747b844b7bb7c61bf06",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "bn.js",
+      "version": "0.3.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.3.1",
+      "_shasum": "0250ea3bd957619cac0db864fef8f007f74ac1ba",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0250ea3bd957619cac0db864fef8f007f74ac1ba",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "bn.js",
+      "version": "0.4.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.4.0",
+      "_shasum": "4ded6119c06e20a992e1b0f7b12d727bed504b3a",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4ded6119c06e20a992e1b0f7b12d727bed504b3a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "bn.js",
+      "version": "0.4.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.4.1",
+      "_shasum": "c40b142b262e25006581f88e2c63b85ad935b10d",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c40b142b262e25006581f88e2c63b85ad935b10d",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "bn.js",
+      "version": "0.4.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.4.2",
+      "_shasum": "70ffd0ca1d96dc1fd7f52a8e7ab1735cf72e9e7c",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "70ffd0ca1d96dc1fd7f52a8e7ab1735cf72e9e7c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.3": {
+      "name": "bn.js",
+      "version": "0.4.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.4.3",
+      "_shasum": "7ceb6014ad1233aeef96177f4482c0c5b3d11715",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7ceb6014ad1233aeef96177f4482c0c5b3d11715",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.4": {
+      "name": "bn.js",
+      "version": "0.4.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.4.4",
+      "_shasum": "de75bf4b0e529da86588ecf905e05266a2c50987",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "de75bf4b0e529da86588ecf905e05266a2c50987",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "bn.js",
+      "version": "0.5.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.5.0",
+      "_shasum": "ea39b8377fe9502d2da8d9d397a764ef7b6939e3",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ea39b8377fe9502d2da8d9d397a764ef7b6939e3",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "bn.js",
+      "version": "0.5.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.5.1",
+      "_shasum": "15eb1df6b3321fc397e0774e51b8f7ecabde2332",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "15eb1df6b3321fc397e0774e51b8f7ecabde2332",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "bn.js",
+      "version": "0.5.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.5.2",
+      "_shasum": "bc636c01716148c61765a90f7aab8074a5c8128b",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bc636c01716148c61765a90f7aab8074a5c8128b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.3": {
+      "name": "bn.js",
+      "version": "0.5.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.5.3",
+      "_shasum": "4f8a69ac49b34009852d99a4751e2d7af45c80b3",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4f8a69ac49b34009852d99a4751e2d7af45c80b3",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.4": {
+      "name": "bn.js",
+      "version": "0.5.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.5.4",
+      "_shasum": "46882b5e6a8b4c68c32b78061c7cb8a1bc7f91b8",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "46882b5e6a8b4c68c32b78061c7cb8a1bc7f91b8",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "bn.js",
+      "version": "0.6.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.6.0",
+      "_shasum": "4467c0e7efe7a6c08e19c12b6d12c897c3a3cea8",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4467c0e7efe7a6c08e19c12b6d12c897c3a3cea8",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "bn.js",
+      "version": "0.7.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.7.0",
+      "_shasum": "5e6575294229d7cde9ed0b09826c475a730f851e",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5e6575294229d7cde9ed0b09826c475a730f851e",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "bn.js",
+      "version": "0.7.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.7.1",
+      "_shasum": "7ae54498718445caa319f1cfd29dfd89ef3d431c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7ae54498718445caa319f1cfd29dfd89ef3d431c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.7.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "bn.js",
+      "version": "0.8.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.8.0",
+      "_shasum": "61b62da5efc982d482f742dad2c8b80159d77008",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "61b62da5efc982d482f742dad2c8b80159d77008",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "bn.js",
+      "version": "0.8.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.8.1",
+      "_shasum": "0fd50fc287c2b8f24fc0383623de2ddffb9440ad",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0fd50fc287c2b8f24fc0383623de2ddffb9440ad",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "bn.js",
+      "version": "0.9.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.9.0",
+      "_shasum": "808464cfcd06a2c8a25aeaa46d670948e46fabae",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "808464cfcd06a2c8a25aeaa46d670948e46fabae",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "bn.js",
+      "version": "0.10.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.10.0",
+      "_shasum": "e2fd7835a6ff4eb0653404e1eb6795ce5063180a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e2fd7835a6ff4eb0653404e1eb6795ce5063180a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.1": {
+      "name": "bn.js",
+      "version": "0.10.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.10.1",
+      "_shasum": "fd1416194ac1b12a7bf096341103214258e68fef",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fd1416194ac1b12a7bf096341103214258e68fef",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "bn.js",
+      "version": "0.11.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.11.0",
+      "_shasum": "a47da9f1fb3d0ec84ca267dc3b0e63c206aafb6c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a47da9f1fb3d0ec84ca267dc3b0e63c206aafb6c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.1": {
+      "name": "bn.js",
+      "version": "0.11.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.11.1",
+      "_shasum": "4e6c9659794e1a3923c25c0ccd82cd0320f9c597",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4e6c9659794e1a3923c25c0ccd82cd0320f9c597",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.2": {
+      "name": "bn.js",
+      "version": "0.11.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.11.2",
+      "_shasum": "981ad5439c0eae102e30687eb0d14f24001d26c9",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "981ad5439c0eae102e30687eb0d14f24001d26c9",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.3": {
+      "name": "bn.js",
+      "version": "0.11.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.11.3",
+      "_shasum": "527f4bfb8a16c6298a7684678939ad08b66203a1",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "527f4bfb8a16c6298a7684678939ad08b66203a1",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.4": {
+      "name": "bn.js",
+      "version": "0.11.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.11.4",
+      "_shasum": "c3107d589e3fe057fa92b70cdc86e7b4025c85a5",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c3107d589e3fe057fa92b70cdc86e7b4025c85a5",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.5": {
+      "name": "bn.js",
+      "version": "0.11.5",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.11.5",
+      "_shasum": "e48368dc4e1b25025cb6ff747cf7229a256826ff",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e48368dc4e1b25025cb6ff747cf7229a256826ff",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.6": {
+      "name": "bn.js",
+      "version": "0.11.6",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.11.6",
+      "_shasum": "ec5fc50991ac298970b7e1cb7ba58382e4b940e8",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ec5fc50991ac298970b7e1cb7ba58382e4b940e8",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.7": {
+      "name": "bn.js",
+      "version": "0.11.7",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.11.7",
+      "_shasum": "7c5be037ccd45afc3136c7af92466c93d4ce5a56",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7c5be037ccd45afc3136c7af92466c93d4ce5a56",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.12.0": {
+      "name": "bn.js",
+      "version": "0.12.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.12.0",
+      "_shasum": "ce6646bd82cbbfdd5f7b7ce5522f3c3360b85214",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ce6646bd82cbbfdd5f7b7ce5522f3c3360b85214",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.12.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.0": {
+      "name": "bn.js",
+      "version": "0.13.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.13.0",
+      "_shasum": "c5b43590d6bd89f93d663c23df9400abb234be20",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c5b43590d6bd89f93d663c23df9400abb234be20",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.13.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.1": {
+      "name": "bn.js",
+      "version": "0.13.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.13.1",
+      "_shasum": "996073b90419167146f9cfc0747e6f4f2858e87c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "996073b90419167146f9cfc0747e6f4f2858e87c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.13.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.2": {
+      "name": "bn.js",
+      "version": "0.13.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.13.2",
+      "_shasum": "84020e7362df295b211e8ae10c2937cb78e5795d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "84020e7362df295b211e8ae10c2937cb78e5795d",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.13.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.3": {
+      "name": "bn.js",
+      "version": "0.13.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "bn.js@0.13.3",
+      "_shasum": "357d832db5aa511701fac9d03698ec792ddaaed0",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "357d832db5aa511701fac9d03698ec792ddaaed0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.13.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.14.0": {
+      "name": "bn.js",
+      "version": "0.14.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "e66b7b33a17637be6d3fdfd304a846bea43ebfdc",
+      "_id": "bn.js@0.14.0",
+      "_shasum": "285e0b6bd312de0d6dd62fd5f520497506aec851",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "285e0b6bd312de0d6dd62fd5f520497506aec851",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.14.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.14.1": {
+      "name": "bn.js",
+      "version": "0.14.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "db7768946cb2c141424509d4d9a88f20635ad4a5",
+      "_id": "bn.js@0.14.1",
+      "_shasum": "1b6631d73a54b08986ac98761e838b4c343fa6b5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1b6631d73a54b08986ac98761e838b4c343fa6b5",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.14.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.14.2": {
+      "name": "bn.js",
+      "version": "0.14.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "f97710d43fb46897528b15862a0e0316bc19e8a8",
+      "_id": "bn.js@0.14.2",
+      "_shasum": "9480914aeff2a30b599c066040af84e1bb11ded1",
+      "_from": ".",
+      "_npmVersion": "2.1.2",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9480914aeff2a30b599c066040af84e1bb11ded1",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.14.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.0": {
+      "name": "bn.js",
+      "version": "0.15.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "59013d8cd1658459a6c5eb08dd97776476a7e44f",
+      "_id": "bn.js@0.15.0",
+      "_shasum": "4574c7c128c730f4ab845073b9288e0d2039f3de",
+      "_from": ".",
+      "_npmVersion": "2.1.2",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4574c7c128c730f4ab845073b9288e0d2039f3de",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.1": {
+      "name": "bn.js",
+      "version": "0.15.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "13042cedeb921b743b9d16b701036e735158d18b",
+      "_id": "bn.js@0.15.1",
+      "_shasum": "3f4bf5e3d05cdcbc11576bc248070bce722e60da",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3f4bf5e3d05cdcbc11576bc248070bce722e60da",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.2": {
+      "name": "bn.js",
+      "version": "0.15.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "4bdf3e6362a175871b1ac2fe50cd5bce19d6234d",
+      "_id": "bn.js@0.15.2",
+      "_shasum": "a83b283accdacbf28e89774747cac352216f886a",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a83b283accdacbf28e89774747cac352216f886a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.16.0": {
+      "name": "bn.js",
+      "version": "0.16.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "c6e4bd0744d4cf913071ae3ece7942e253dabd56",
+      "_id": "bn.js@0.16.0",
+      "_shasum": "5b6f7ea86ec2f8e065dee2b4d5f1540314bf523e",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5b6f7ea86ec2f8e065dee2b4d5f1540314bf523e",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.16.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.16.1": {
+      "name": "bn.js",
+      "version": "0.16.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "48b5a38fe4b02c2931e9f528e124a6ef8505e11d",
+      "_id": "bn.js@0.16.1",
+      "_shasum": "5f9e74fc53abfd3bb74020b824b83a599f8a9c6f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5f9e74fc53abfd3bb74020b824b83a599f8a9c6f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.16.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "bn.js",
+      "version": "1.0.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "9707d9cdc96f8a7ab654e4abb874a7880b5be937",
+      "_id": "bn.js@1.0.0",
+      "_shasum": "01e39f8c13f981c468b673caf0632f726d54713f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "01e39f8c13f981c468b673caf0632f726d54713f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "bn.js",
+      "version": "1.1.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "3d09af28f8c79b77b129a21bbd61cb870bb7208d",
+      "_id": "bn.js@1.1.0",
+      "_shasum": "3bcebb538c8221a1bbf109b9d1978f026c02c297",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "1.0.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3bcebb538c8221a1bbf109b9d1978f026c02c297",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "bn.js",
+      "version": "1.1.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "63e3c558faed462009475773170444b676c6a885",
+      "_id": "bn.js@1.1.1",
+      "_shasum": "7a9d15b1fac825469bf18c70d5a1ec9b3ee1da1a",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7a9d15b1fac825469bf18c70d5a1ec9b3ee1da1a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "bn.js",
+      "version": "1.2.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "73f6c068939a12df2d891bafac20662539bc1edf",
+      "_id": "bn.js@1.2.1",
+      "_shasum": "db61852c756cd3e48d9e5b58af159e43e4936262",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "db61852c756cd3e48d9e5b58af159e43e4936262",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "bn.js",
+      "version": "1.2.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "1415d64015857a2b55e5405935b617bede473b1a",
+      "_id": "bn.js@1.2.2",
+      "_shasum": "43847951eae2cba604535fad8c6c9a18e8565489",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43847951eae2cba604535fad8c6c9a18e8565489",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "bn.js",
+      "version": "1.2.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "785973786a822ead008f3a0f5ed1f3a28808530b",
+      "_id": "bn.js@1.2.3",
+      "_shasum": "4e40df87acf0ac1d100ee0bec5e831a850da75d0",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4e40df87acf0ac1d100ee0bec5e831a850da75d0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.4": {
+      "name": "bn.js",
+      "version": "1.2.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "588c3b6eb9f0b4d8b6ab09fd50a503e0c9ef919d",
+      "_id": "bn.js@1.2.4",
+      "_shasum": "7ccaddc03f0b5ef5c58b4d22b2e296fa0eb8c6e2",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7ccaddc03f0b5ef5c58b4d22b2e296fa0eb8c6e2",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "bn.js",
+      "version": "1.3.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "3d156a29566f2172b39ebcc0ec00cc3af4c205f8",
+      "_id": "bn.js@1.3.0",
+      "_shasum": "0db4cbf96f8f23b742f5bcb9d1aa7a9994a05e83",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0db4cbf96f8f23b742f5bcb9d1aa7a9994a05e83",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "bn.js",
+      "version": "2.0.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "e3a312a489f2b3c0c396de8bbbcd6e9438cf2288",
+      "_id": "bn.js@2.0.0",
+      "_shasum": "825c4107f7fa789378ee1b0d86be0503d7ac743b",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "825c4107f7fa789378ee1b0d86be0503d7ac743b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "bn.js",
+      "version": "2.0.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "2064828bf744d5da8ae0f9a2e38ff8d5dbf21b72",
+      "_id": "bn.js@2.0.1",
+      "_shasum": "ae9bbb5dde3e0031071c6dbc814ec7b4fc9a1e78",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "1.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ae9bbb5dde3e0031071c6dbc814ec7b4fc9a1e78",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "bn.js",
+      "version": "2.0.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "2ea7a1f61e953634b5cfb6c4c886c8d06e26c48a",
+      "_id": "bn.js@2.0.2",
+      "_shasum": "c23b96588b5aadf8aec83698ffc703b396e4999e",
+      "_from": ".",
+      "_npmVersion": "2.7.0",
+      "_nodeVersion": "1.5.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c23b96588b5aadf8aec83698ffc703b396e4999e",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "bn.js",
+      "version": "2.0.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/bn.js"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "7178cd22cc649077eeebb259952f0897da483397",
+      "_id": "bn.js@2.0.3",
+      "_shasum": "88922f1d693cfdc8260c606a3aaabfc98d25815f",
+      "_from": ".",
+      "_npmVersion": "2.7.3",
+      "_nodeVersion": "1.6.3",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "88922f1d693cfdc8260c606a3aaabfc98d25815f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "bn.js",
+      "version": "2.0.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "2b34a1849a4acf0528a3ce7053870112fc04ec6c",
+      "_id": "bn.js@2.0.4",
+      "_shasum": "220a7cd677f7f1bfa93627ff4193776fe7819480",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "1.8.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "220a7cd677f7f1bfa93627ff4193776fe7819480",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.5": {
+      "name": "bn.js",
+      "version": "2.0.5",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "d6cc9c154bbab0a3a269ffcf0518a468fd508ab7",
+      "_id": "bn.js@2.0.5",
+      "_shasum": "5f4b12a26ec4eb8ac895a9349980a254cfd3eb65",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5f4b12a26ec4eb8ac895a9349980a254cfd3eb65",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "bn.js",
+      "version": "2.1.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "d6aba1e70b0256d979c86c1b443387d8d1d0de56",
+      "_id": "bn.js@2.1.0",
+      "_shasum": "f8a280fe6c60dbc4684bc70bb20b68ae60f94efd",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f8a280fe6c60dbc4684bc70bb20b68ae60f94efd",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "bn.js",
+      "version": "2.2.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "de1c1d3f813f21af0b51f3effb2bd15f87bb9383",
+      "_id": "bn.js@2.2.0",
+      "_shasum": "12162bc2ae71fc40a5626c33438f3a875cd37625",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "12162bc2ae71fc40a5626c33438f3a875cd37625",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "bn.js",
+      "version": "3.0.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "9f12bcdf2031d11b6e57d3b00252c191764e1e5a",
+      "_id": "bn.js@3.0.0",
+      "_shasum": "8d68f48d7c2b75263e0c2684aec768d5c358ff25",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8d68f48d7c2b75263e0c2684aec768d5c358ff25",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "bn.js",
+      "version": "3.0.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "977c0113446c4fadc0d5a4f61898e6260b84d149",
+      "_id": "bn.js@3.0.1",
+      "_shasum": "855c7a7b4b92592e87ac4ac0b782624cb28a517f",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "855c7a7b4b92592e87ac4ac0b782624cb28a517f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "bn.js",
+      "version": "3.1.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "1ed82855acf8be7ee39e6070c3c212b77acf1e79",
+      "_id": "bn.js@3.1.0",
+      "_shasum": "bb633298b0cc0ba763426a18863a9bcba5f6e0d0",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bb633298b0cc0ba763426a18863a9bcba5f6e0d0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.1": {
+      "name": "bn.js",
+      "version": "3.1.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "128ae63ed9a0c8eb27e444139107937b7c9bffad",
+      "_id": "bn.js@3.1.1",
+      "_shasum": "cd8390de8d02865104f21601c72c1404290a094f",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cd8390de8d02865104f21601c72c1404290a094f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.2": {
+      "name": "bn.js",
+      "version": "3.1.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "8e7af57a2af06145b1b75646cfb39e6d4bb4c533",
+      "_id": "bn.js@3.1.2",
+      "_shasum": "530e8e63398ac2dbd4762484a0b00d9cbb78be9c",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "530e8e63398ac2dbd4762484a0b00d9cbb78be9c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.0": {
+      "name": "bn.js",
+      "version": "3.2.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "49915f5039c3dc919feb6b47a7dd91761deeab0e",
+      "_id": "bn.js@3.2.0",
+      "_shasum": "b55c0978e2b815cca86474f6e67ee01aba7449df",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b55c0978e2b815cca86474f6e67ee01aba7449df",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.3.0": {
+      "name": "bn.js",
+      "version": "3.3.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "29a9e67bd2eaaeaa400ccaef86196232a940a3dd",
+      "_id": "bn.js@3.3.0",
+      "_shasum": "1138e577889fdc97bbdab51844f2190dfc0ae3d7",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "1138e577889fdc97bbdab51844f2190dfc0ae3d7",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "bn.js",
+      "version": "4.0.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "00a9206a36e1cfb0e983cdcd56ae2013452048c3",
+      "_id": "bn.js@4.0.0",
+      "_shasum": "da4c1258fc389a423cd07aa0a393958ca9c35476",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "da4c1258fc389a423cd07aa0a393958ca9c35476",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.1.0": {
+      "name": "bn.js",
+      "version": "4.1.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "1dd4cfe431392dac557e98c1d0e8610bb710092b",
+      "_id": "bn.js@4.1.0",
+      "_shasum": "35105abe0809c082007744650b8234b2f9c9ada3",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "35105abe0809c082007744650b8234b2f9c9ada3",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.1.1": {
+      "name": "bn.js",
+      "version": "4.1.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "c2486ee50de3317c5e792fa37a3d615779c0aa6d",
+      "_id": "bn.js@4.1.1",
+      "_shasum": "ad1c416107dc2d565aed54814bcfbb44f8a25909",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "ad1c416107dc2d565aed54814bcfbb44f8a25909",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.2.0": {
+      "name": "bn.js",
+      "version": "4.2.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && jscs lib/*.js test/*.js && jshint lib/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "401e3e1671b6772998a358327ecd3d9ebda2b542",
+      "_id": "bn.js@4.2.0",
+      "_shasum": "67fe8e2e6637ae4bb8447876c8562a8a7d9ca402",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "67fe8e2e6637ae4bb8447876c8562a8a7d9ca402",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.3.0": {
+      "name": "bn.js",
+      "version": "4.3.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && jscs lib/*.js test/*.js && jshint lib/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "13e63cfdcf85d798c0ef2582ef661881d9d78e9e",
+      "_id": "bn.js@4.3.0",
+      "_shasum": "c6ffb4a18b0867195f990c0051a8f93d69f7ec90",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "c6ffb4a18b0867195f990c0051a8f93d69f7ec90",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.4.0": {
+      "name": "bn.js",
+      "version": "4.4.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "jscs lib/*.js test/*.js && jshint lib/*.js",
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "dfd6dcc5950b47d46116e6360d200269742ff897",
+      "_id": "bn.js@4.4.0",
+      "_shasum": "b196a96e7ab08a7a3eca9c66390390da3a980eb6",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "b196a96e7ab08a7a3eca9c66390390da3a980eb6",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.5.0": {
+      "name": "bn.js",
+      "version": "4.5.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "jscs lib/*.js test/*.js && jshint lib/*.js",
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "4c8e71d179b177de2cd244d428cc31f8e60341d7",
+      "_id": "bn.js@4.5.0",
+      "_shasum": "b995be6db2484af988111af08c9d6aca6755178f",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "b995be6db2484af988111af08c9d6aca6755178f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.5.1": {
+      "name": "bn.js",
+      "version": "4.5.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "jscs lib/*.js test/*.js && jshint lib/*.js",
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "98f2267a32e00dfd853dd42b6f2a9082ee696533",
+      "_id": "bn.js@4.5.1",
+      "_shasum": "d9e973b101a82c86fb289c51e416e1888538ee16",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "d9e973b101a82c86fb289c51e416e1888538ee16",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.5.2": {
+      "name": "bn.js",
+      "version": "4.5.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "jscs lib/*.js test/*.js && jshint lib/*.js",
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "4533326cad7d32d597a1a382d048f8bd36f42874",
+      "_id": "bn.js@4.5.2",
+      "_shasum": "bb9e3df54abe3e118d4754195cc74926545489e0",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "bb9e3df54abe3e118d4754195cc74926545489e0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.0": {
+      "name": "bn.js",
+      "version": "4.6.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "jscs lib/*.js test/*.js && jshint lib/*.js",
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "02483e4fbd50dfb214a3aaee077132ced32e44eb",
+      "_id": "bn.js@4.6.0",
+      "_shasum": "6b649bf3608cb09eba9b91b6fcbb79b0a1aa0c16",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "6b649bf3608cb09eba9b91b6fcbb79b0a1aa0c16",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.1": {
+      "name": "bn.js",
+      "version": "4.6.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "jscs lib/*.js test/*.js && jshint lib/*.js",
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "gitHead": "21179921ba70384d026686377a6a0259368f7de4",
+      "_id": "bn.js@4.6.1",
+      "_shasum": "54495a5719abd8f5bb800f6354068029108d5f3b",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "54495a5719abd8f5bb800f6354068029108d5f3b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.2": {
+      "name": "bn.js",
+      "version": "4.6.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "abdaf3836c374b4a01e7c528422759e7dca1586a",
+      "_id": "bn.js@4.6.2",
+      "_shasum": "f3f77bc657f7ec926c8d02df0883543970c90778",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "f3f77bc657f7ec926c8d02df0883543970c90778",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.3": {
+      "name": "bn.js",
+      "version": "4.6.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "d6209a73db26a3cf90c23026aa75c2bc88beefaf",
+      "_id": "bn.js@4.6.3",
+      "_shasum": "37c166833a7ebf5eba1a08f9c66b6a20fe3ae178",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "37c166833a7ebf5eba1a08f9c66b6a20fe3ae178",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.4": {
+      "name": "bn.js",
+      "version": "4.6.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "c9d5ab8106d27c95c0e00c5651603bd35b279938",
+      "_id": "bn.js@4.6.4",
+      "_shasum": "67b1ec994775d87652e350c62adbb66e7c05bc50",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "67b1ec994775d87652e350c62adbb66e7c05bc50",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.5": {
+      "name": "bn.js",
+      "version": "4.6.5",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "62edbc5c94586329378f40b8f42315c228d0dd6c",
+      "_id": "bn.js@4.6.5",
+      "_shasum": "130d65bf411a6de727e9193a0219ad2e19efd943",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "130d65bf411a6de727e9193a0219ad2e19efd943",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.6": {
+      "name": "bn.js",
+      "version": "4.6.6",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "e82b88e2f11fe22c75f62b434d2f841e7fd619c6",
+      "_id": "bn.js@4.6.6",
+      "_shasum": "ee9631479d1b7e56f3108670d7b024949882c92b",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "ee9631479d1b7e56f3108670d7b024949882c92b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.7.0": {
+      "name": "bn.js",
+      "version": "4.7.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "c3203573c2c16445b755e805dc284b0152354ab2",
+      "_id": "bn.js@4.7.0",
+      "_shasum": "6f2c5b626aa971c5937ae4131b81db111fa5fb0e",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "6f2c5b626aa971c5937ae4131b81db111fa5fb0e",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.8.0": {
+      "name": "bn.js",
+      "version": "4.8.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "ee3c4423614f1edb175e342288d40075944d625b",
+      "_id": "bn.js@4.8.0",
+      "_shasum": "c775509ea4e42365630660edf1d30d1a9a1f4440",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "c775509ea4e42365630660edf1d30d1a9a1f4440",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.8.1": {
+      "name": "bn.js",
+      "version": "4.8.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "4c29a5a01ae50a80515490f0e7fd3b23a0039eb4",
+      "_id": "bn.js@4.8.1",
+      "_shasum": "e8cb1c43a09a6f2f5541b920f714f268307ed73f",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "e8cb1c43a09a6f2f5541b920f714f268307ed73f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.8.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.9.0": {
+      "name": "bn.js",
+      "version": "4.9.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "browser": {
+        "buffer": false
+      },
+      "gitHead": "3e49f61adc0328347a784aa4199652ad7f7f8f8d",
+      "_id": "bn.js@4.9.0",
+      "_shasum": "a51e8356ff87f24249429bffc415e386dbbc2211",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "a51e8356ff87f24249429bffc415e386dbbc2211",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.9.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.10.0": {
+      "name": "bn.js",
+      "version": "4.10.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "2fbe7a3683aca9a6a09697a9af2ea7a05d42bf06",
+      "_id": "bn.js@4.10.0",
+      "_shasum": "0f94c26328bc11da325d0080c572c5a83f23f8b1",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "0f94c26328bc11da325d0080c572c5a83f23f8b1",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.10.1": {
+      "name": "bn.js",
+      "version": "4.10.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "cc4108fbd3d03b3529817047e4f9763191a1bf1e",
+      "_id": "bn.js@4.10.1",
+      "_shasum": "743347a61e4dbc269fb034b9edfdb69fb9bf5b15",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "743347a61e4dbc269fb034b9edfdb69fb9bf5b15",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.10.1.tgz_1454625418354_0.7797625181265175"
+      },
+      "directories": {}
+    },
+    "4.10.2": {
+      "name": "bn.js",
+      "version": "4.10.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "a9935e7d7d7c339247e610b0884e6ab39c3eda11",
+      "_id": "bn.js@4.10.2",
+      "_shasum": "2777e05bee0d688ac85e61a90177c0e1e5d8a765",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "2777e05bee0d688ac85e61a90177c0e1e5d8a765",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.10.2.tgz_1454985807797_0.9658701049629599"
+      },
+      "directories": {}
+    },
+    "4.10.3": {
+      "name": "bn.js",
+      "version": "4.10.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "dc8ddfe05574763e2b1f3730528d224ab04d61f3",
+      "_id": "bn.js@4.10.3",
+      "_shasum": "5a0322c6a4eb187ff37a025b922354d565537433",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "5a0322c6a4eb187ff37a025b922354d565537433",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.10.3.tgz_1454986084401_0.5097152111120522"
+      },
+      "directories": {}
+    },
+    "4.10.4": {
+      "name": "bn.js",
+      "version": "4.10.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "3f6639d6139f971ea935d961e40eab64d3f1319c",
+      "_id": "bn.js@4.10.4",
+      "_shasum": "bdac295b21e006d0d164a81ee787a2c5f2c681f1",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "bdac295b21e006d0d164a81ee787a2c5f2c681f1",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.10.4.tgz_1456535510503_0.6464059818536043"
+      },
+      "directories": {}
+    },
+    "4.10.5": {
+      "name": "bn.js",
+      "version": "4.10.5",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "3acbd00e713343257ed2af2e310297cbe43eea79",
+      "_id": "bn.js@4.10.5",
+      "_shasum": "42baacbd9dfa08073515308184142b6675055f3a",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "42baacbd9dfa08073515308184142b6675055f3a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.10.5.tgz_1456812297609_0.7403083790559322"
+      },
+      "directories": {}
+    },
+    "4.11.0": {
+      "name": "bn.js",
+      "version": "4.11.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "e670ab2360a6f37994014d85a07849c81817c1b0",
+      "_id": "bn.js@4.11.0",
+      "_shasum": "eb24783e0e77a943640fa387095b1c7b4f50d140",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "eb24783e0e77a943640fa387095b1c7b4f50d140",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.11.0.tgz_1457462409781_0.5053171752952039"
+      },
+      "directories": {}
+    },
+    "4.11.1": {
+      "name": "bn.js",
+      "version": "4.11.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "79a0711162f9bc6ec558f652d1373f57c67a5803",
+      "_id": "bn.js@4.11.1",
+      "_shasum": "ff1c52c52fd371e9d91419439bac5cfba2b41798",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "ff1c52c52fd371e9d91419439bac5cfba2b41798",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.11.1.tgz_1458945313396_0.22287913062609732"
+      },
+      "directories": {}
+    },
+    "4.11.2": {
+      "name": "bn.js",
+      "version": "4.11.2",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "f99d2031b0e6e7853c5ef91c525b58180b521af7",
+      "_id": "bn.js@4.11.2",
+      "_shasum": "c586a31dac8ea4bc162dd17609e8bf5fc594dddf",
+      "_from": ".",
+      "_npmVersion": "3.8.5",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "c586a31dac8ea4bc162dd17609e8bf5fc594dddf",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.11.2.tgz_1460487819472_0.8633945770561695"
+      },
+      "directories": {}
+    },
+    "4.11.3": {
+      "name": "bn.js",
+      "version": "4.11.3",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "9d0d0e33fa523935660870dfb5fde36ea42d0ad3",
+      "_id": "bn.js@4.11.3",
+      "_shasum": "bfd45360d339b173f39b628445d2f5d02cb61dd4",
+      "_from": ".",
+      "_npmVersion": "3.8.5",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "bfd45360d339b173f39b628445d2f5d02cb61dd4",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.11.3.tgz_1460489117929_0.07140995422378182"
+      },
+      "directories": {}
+    },
+    "4.11.4": {
+      "name": "bn.js",
+      "version": "4.11.4",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "a611ba47a333e7ead5230ffbfc438dfa4182abac",
+      "_id": "bn.js@4.11.4",
+      "_shasum": "59f0735fa52ff7f00e2cdd1ad207b7c8603d374d",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "59f0735fa52ff7f00e2cdd1ad207b7c8603d374d",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.11.4.tgz_1465158746866_0.5330686524976045"
+      },
+      "directories": {}
+    },
+    "4.11.5": {
+      "name": "bn.js",
+      "version": "4.11.5",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "ba3ef070439aadec15188dade3af0a6fb6c8d7fc",
+      "_id": "bn.js@4.11.5",
+      "_shasum": "d4572591b6bf70ef60f76790d6c2e92d8979350a",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "d4572591b6bf70ef60f76790d6c2e92d8979350a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.11.5.tgz_1468442223722_0.023275399347767234"
+      },
+      "directories": {}
+    },
+    "4.11.6": {
+      "name": "bn.js",
+      "version": "4.11.6",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "e4a82134c89ed85b0c3a03da7fabc016206898a4",
+      "_id": "bn.js@4.11.6",
+      "_shasum": "53344adb14617a13f6e8dd2ce28905d1c0ba3215",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "53344adb14617a13f6e8dd2ce28905d1c0ba3215",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/bn.js-4.11.6.tgz_1470100429753_0.28054949711076915"
+      },
+      "directories": {}
+    },
+    "4.11.7": {
+      "name": "bn.js",
+      "version": "4.11.7",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "163ca3a1b720ff531e1289d73f3efafdb275e860",
+      "_id": "bn.js@4.11.7",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
+        "shasum": "ddb048e50d9482790094c13eb3fcfc833ce7ab46",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bn.js-4.11.7.tgz_1498003732650_0.5582865925971419"
+      },
+      "directories": {}
+    },
+    "4.11.8": {
+      "name": "bn.js",
+      "version": "4.11.8",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "browser": {
+        "buffer": false
+      },
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "c69b4ae8e789e10f7f91811cd4937949ff0d4768",
+      "_id": "bn.js@4.11.8",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+        "shasum": "2cde09eb5ee341f484746bb0309b3253b1b1442f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bn.js-4.11.8.tgz_1502144504238_0.6009391283150762"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "bn.js",
+      "version": "5.0.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "browser": {
+        "buffer": false
+      },
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "8a8d9bad8f7170b1f2bd48ebb2bc97f1e39beb74",
+      "_id": "bn.js@5.0.0",
+      "_nodeVersion": "12.6.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-bVwDX8AF+72fIUNuARelKAlQUNtPOfG2fRxorbVvFk4zpHbqLrPdOGfVg5vrKwVzLLePqPBiATaOZNELQzmS0A==",
+        "shasum": "5c3d398021b3ddb548c1296a16f857e908f35c70",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 97122,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdIhsWCRA9TVsSAnZWagAAS+MP/2i5OI3bS12VM9klRJ6M\nhnJBNgTn1YWXvL+B/OtnTY9tyZGL3fvKgF/8E9zYqxWzlMpVIQvUzOSgXZfb\nYDUkmGrQqqYTZHH6fvN4+QX98x50w6EixsWNBZD8IW0ncKSqnKsug8HKBhPJ\nfDAzXfAk6fl2FS2ivMuMEs0vKb5JVbhVFYyZAjblWzNo1HYkTDf1EJ7WI535\nrqFzewU9IhwScc6o6pWTfiZoQR3RNX0Yi2eKNsIwKz0n1mWA2dWAhbWzsQek\nEgjKwf0Xd6EewtpXOarPkWgx8Hqh8m4dVxvmkGLTUTCg02ySNCOJy9Pw3R0d\nHPsd8NclNa83x2OdhNK9pwHcAYNT6emk42cDeM5kVFfzatJbiryLGVgGirmM\nHCWbRjG19BmhrRsz+XbM9pN6GKZKMyjH7kxNvFFTq+UOBoEYLp4JCkdO6WOP\nsARR5kKoxI5y9lgksU3kfpNoUVvuptFr/HY+f1nKZZ5ahSQb0e3I/DnF6WfX\n0yqnzQLYFXks+ibssEukcbtkm2Y17X5uaM30HGiGc8Bp5gueGZy1Efcr/YgN\nsB0rTJtdsxBPePTuiCmzHT5lPtwXuGtnZJFW/5lsKNwT7mHf3URr8abJ6XRH\nclH3y7jAvNiThrwQAptemXQo0remYDqPosvqVxyYR8rdL49+3UWucG1xWzAf\nbAvH\r\n=Ip9d\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "fanatid@ya.ru",
+          "name": "fanatid"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        }
+      ],
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bn.js_5.0.0_1562516246137_0.5055850292623076"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.0": {
+      "name": "bn.js",
+      "version": "5.1.0",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "standardx",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "browser": {
+        "buffer": false
+      },
+      "devDependencies": {
+        "babel-eslint": "^10.0.2",
+        "mocha": "^6.1.4",
+        "standardx": "^4.0.0"
+      },
+      "standardx": {
+        "parser": "babel-eslint"
+      },
+      "eslintConfig": {
+        "rules": {
+          "semi": [
+            2,
+            "always"
+          ],
+          "no-extra-semi": 2
+        }
+      },
+      "gitHead": "4fd44401e07e2a95abf69b6d7268a4c5d8a3790a",
+      "_id": "bn.js@5.1.0",
+      "_nodeVersion": "13.5.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-NiyuqJjtPhXcJDc8I+YeyZceSMViT39AvuFJCH3ieMcOsRvZsp2luMrGSnQaqN6HVJMvSgydLnkvw5N4xvuIoQ==",
+        "shasum": "7ef3e4af5d85a8d70d7077cb7d44bfc5cd6e6039",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 99370,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeAH4PCRA9TVsSAnZWagAAYtwP/1keFfynEN0e01kVuqz5\n+Oj6kRNZtc9u9ub0rWcvPyIHNZhmgVGiwJQrpVe7v72Fc85o98MbrNhdSuVC\n7ctBh9eo9nTQP0zfSbLOmmEqqzewdZkpbv2Vscnyt2XOE10aM5IPhseXKkXG\nOnRUSEh7uqV2iDtnCg7tdhxnjTvdz3z9MFpqThnynp2XZbPuIkrhtD1gm445\nUaCqlhDqs2+mHvEWEX9wuEk8l3x5QE7WXFvg3u8HzLX6KIIW4Nnme75Le/rS\ntoBnP6IUqnjZZaC2klhoU0XkBseRJCt4enFEO+H0Gchv/QcUK5+XNbWbOXkT\nxHtO6gzAF6XMASMMifE0NN6JYkugmCofooEefefYqQqGJseX3ypAzJxsqiLP\n2apXTiN4JcB8U/eqFUgXcGgZ7yCzBkAvr0BkakHHYeTplY+syKjVlNG5LMDi\nlyGkbXY91potyl/Td7+GqkJzZtrMtvhjIooY5Nch46AAs34r2QqWpovNqu2N\nc0v5K5an8Keu180lasV9XQKIyN7iV8UAru7MuirDy557GQbuHodPmdaiLt72\nZ2XKr1myzPyvRHTjU8glBrw1pANV/tENkcSojCZ0W2wuCrRzFrhlwhbKv/05\n/5P3nSgdWEfphslgcsoDjlgMd9QyPpF2ow197ebyKB9v/v5z8j8g2XDNh1oR\n47Ys\r\n=adzZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "fanatid@ya.ru",
+          "name": "fanatid"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        }
+      ],
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bn.js_5.1.0_1577090574659_0.9110694812152826"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.1": {
+      "name": "bn.js",
+      "version": "5.1.1",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "standardx",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "browser": {
+        "buffer": false
+      },
+      "devDependencies": {
+        "babel-eslint": "^10.0.2",
+        "mocha": "^6.1.4",
+        "standardx": "^4.0.0"
+      },
+      "standardx": {
+        "parser": "babel-eslint"
+      },
+      "gitHead": "aff3260968b30a51fcb449037f040ec3919c2582",
+      "_id": "bn.js@5.1.1",
+      "_nodeVersion": "13.5.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
+        "shasum": "48efc4031a9c4041b9c99c6941d903463ab62eb5",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 99435,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeAnYHCRA9TVsSAnZWagAAhy4P/iy/wA+bV/hAQQJ3HDnz\n+AORYJqTs3RSNmjC0XXjtzJ+V0EVHFCYxvS3zjGE1HC7y2s5Yr9h1Z5sKob0\nLjiwk9/p9uDKnUZQrgVfECyjfGhTfRQeP9qr9tTuS88RmsZa0d65mAHeYys7\n9E1m9v6cJG+WXPjxiqa2Jj1ojDlxIwtDwgflJ9HcX6k5ijMTfvaegl1uNxlb\nvwI6GW/NxpnDH6+WkZflvPz0MAYeLTgevwYiGzZ55fYApJRkPihXNQ+0p6N2\ntAjStS9s7ZvrYL868iTVgczYz2oQKptpm9cR5V2D0GYJOrlj543FPAHs8fXI\nyvVzmOJ7zYkR88436oW8pM78wuGynBk0jdZrKiPP0myHiw1T2KR/GEak/NMd\n3HEicGhMNhDNzLVDQK+alMVbCOFtYyGpIHzEJstgw43eJFwS207NW940fMlg\npm/FVk6U0KBp3TKxck6DnCYPvGj5OzFBaJTQ/R0F3YT5gRquxvTfKR7Au8mK\nkRtHQezsbICAIqASjbWD7qt0pIOXWYM4IHAFMcFtI+uCA/oQOqGr9aptPugW\nzQMBgJHDE/rCV1pM55M4pHpLR/+5Rstj5y2IZjkSmHKgOMzwNsgepBYo8lYQ\nOx/jocepWqdVx4cRe1bpTZ90TIR4LfZOrPwoK24gGUxx1f+tyN32fAq0AEg5\ny/Kh\r\n=CoW5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "fanatid@ya.ru",
+          "name": "fanatid"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        }
+      ],
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bn.js_5.1.1_1577219590763_0.7182015200211254"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.11.9": {
+      "name": "bn.js",
+      "version": "4.11.9",
+      "description": "Big number implementation in pure javascript",
+      "main": "lib/bn.js",
+      "scripts": {
+        "lint": "semistandard",
+        "unit": "mocha --reporter=spec test/*-test.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "keywords": [
+        "BN",
+        "BigNum",
+        "Big number",
+        "Modulo",
+        "Montgomery"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "homepage": "https://github.com/indutny/bn.js",
+      "browser": {
+        "buffer": false
+      },
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "gitHead": "a8d027601c09793c459fba2aacffd4731c2d8147",
+      "_id": "bn.js@4.11.9",
+      "_nodeVersion": "14.1.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+        "shasum": "26d556829458f9d1e81fc48952493d0ba3507828",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+        "fileCount": 5,
+        "unpackedSize": 99486,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexUkOCRA9TVsSAnZWagAAO+UP/3370+j9QtcUoZ7gykhN\nDcyidyo3TYOFPUKFaQJSic4/GIb5GulNnN1nq+T1R5hXM9W3HzPphFpn+nZh\nI60bB0XZ7Cc6XuGNelApMVQR+xwD0wz2hlEw7zjiCIC4kSrzSe1f9nalRhnn\naIHbwxcRHg6oRRpRLE2HHAfMXHwGz8yxL6NFTJpkUi02XS2C1biXjvJvQ518\n2QyjfRR6xZqMqQkFav/V/70R+GJTA57loG4kvh2AXC1HvqEihe6Hzo35RB+O\nVAet71GK+cDaj+v+O0wLMQoGy6t605hz610VcQOyN10w0iibEQusmHCjiGe3\nsZEFmlWhKmTTmRy0m/GFOpNpgQESaPEK8SC5p/PZcLF5dnrI5RQV3QkQVZTS\nCK83RdKgZNEXoizf2qaay0dJBitIvHQqruS73yF6fi+ReDs79sKPtthpcmVE\nz5duL0KoCj/HeQDL1Bsleh2JDvXNxNlCHlw8UcQAqhtn/9l60IU8nyZAsXol\nBa1aD7SH5vyHTmpjBTIJ7+4TCBVkNwy6r07cNMTQuCBWL6ZqQGr9d1wnCtSl\nEzbRcw9SqbmZzWZPfHQj+o75Vd/ocME7TvzrbPBNo+T1oruT6AO+GfuhMHx5\nVFSkdGQ8OhHpXYp32z3afPrvDJyktrFGfR43/D6DbwQlD8ZMOEaH8TsJuq3S\nTqVa\r\n=O+nX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "fanatid@ya.ru",
+          "name": "fanatid"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        }
+      ],
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bn.js_4.11.9_1589987598187_0.1394580593508219"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.2": {
+      "name": "bn.js",
+      "version": "5.1.2",
+      "description": "Big number implementation in pure javascript",
+      "keywords": [
+        "BN",
+        "Big number",
+        "BigNum",
+        "Modulo",
+        "Montgomery"
+      ],
+      "homepage": "https://github.com/indutny/bn.js",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "main": "lib/bn.js",
+      "browser": {
+        "buffer": false
+      },
+      "scripts": {
+        "lint": "standardx",
+        "test": "npm run lint && npm run unit",
+        "unit": "mocha --reporter=spec test/*-test.js"
+      },
+      "devDependencies": {
+        "babel-eslint": "^10.0.3",
+        "mocha": "^7.0.1",
+        "standardx": "^5.0.0"
+      },
+      "standardx": {
+        "parser": "babel-eslint"
+      },
+      "gitHead": "5707aed66c02ae10f8c7d59f5244fcce1c24cdb6",
+      "_id": "bn.js@5.1.2",
+      "_nodeVersion": "14.1.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+        "shasum": "c9686902d3c9a27729f43ab10f9d79c2004da7b0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 99671,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexUu2CRA9TVsSAnZWagAAEN8P/A+IUTjS9A4bNpsvqjSN\nRxOKNrFZ8anIzg2aIA4ormDE2BxqtdWOYwRk/v3XU7vFNTvq+xjwfK5bRNU5\ns/EyOqd94QYnv5VLRhaqDJ6lYfV29F45YJf7AHMdNb75gxtblLEwDFchtsqd\nxuKEdCXwWm/xuqoLuAwkaPABBSfkzmJ5RWQiZ2up+9mefQLdcumKPmRkV7VF\nm0dNHgH9X2sTNH3p+D7oj9/gHc0gvsSee1Pr6rTicvf9QGR4g5m4t7XOFsZM\nC6gIZtE81tP06WyJUglnNwqCHc/0WMc7FDvaVsKgP8DoK8WrDurpQBoJjhyl\np8hKdfe9rs+dAYz/GTy6wi2iTgjFnNR0kGfIfFV69JdUilbgTwaV91qHilU4\nK3k6i+mP7m3QEJEe39j/e0oxt0HVA/Nw5p4Q6T5HY6x3EmFNakEb4KHq4Pna\nD8bJVLF4liZc+AWxXoSF2OjqRcfBVO24zn6Iaqpq/ayKv+OLXd8cOh65cJtt\n9bsDp7FR64euikH+5DJPtkbM2ZiK40LmcTGhBG7intL8OCZRSi6uysU6k+6p\nj8KnX5vCncsCBuphIbopT2fm4vwNx79VdeIKU+LSiyF30U1OkMjd1UI1GFDj\nqzqGOjbRfZUnBrCc2yAuXeJWrIQL94qnEgppfkahKkSLV/IYIAktoNhIYT4R\n3d1k\r\n=t+IV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "fanatid@ya.ru",
+          "name": "fanatid"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        }
+      ],
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bn.js_5.1.2_1589988278167_0.011166882823891111"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.3": {
+      "name": "bn.js",
+      "version": "5.1.3",
+      "description": "Big number implementation in pure javascript",
+      "keywords": [
+        "BN",
+        "Big number",
+        "BigNum",
+        "Modulo",
+        "Montgomery"
+      ],
+      "homepage": "https://github.com/indutny/bn.js",
+      "bugs": {
+        "url": "https://github.com/indutny/bn.js/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/bn.js.git"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "main": "lib/bn.js",
+      "browser": {
+        "buffer": false
+      },
+      "scripts": {
+        "lint": "standardx",
+        "test": "npm run lint && npm run unit",
+        "unit": "mocha --reporter=spec test/*-test.js"
+      },
+      "devDependencies": {
+        "babel-eslint": "^10.0.3",
+        "mocha": "^7.0.1",
+        "standardx": "^5.0.0"
+      },
+      "standardx": {
+        "parser": "babel-eslint"
+      },
+      "gitHead": "c39161e9a056cac6ae9819ab11065550980df432",
+      "_id": "bn.js@5.1.3",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
+        "shasum": "beca005408f642ebebea80b042b4d18d2ac0ee6b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+        "fileCount": 4,
+        "unpackedSize": 99849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfNtI+CRA9TVsSAnZWagAAGGIP/REWDwd6Gz6PfLMPEYab\nvNfXOOhGrBtGuwOdqrsR7PJPzlqJmuxeSp8LVEgvIg+tuFSsgN8MG+9i/9V1\nZ2eXwKbMT8fK3JmVSeozHyPTE5LrXLv4vMFFdBikbo+wx3LrCs9ImEe7sHnQ\nqR/nI6r9Gw1Jtk1hWhIEt36QazxXluOl/YwgQmKBh6EWW8Lel0BxlQt0sZvt\nVeVI3Aw1JSplRZqmaaxuxivUOcj1/0u+c+YdknVRbEwKa2ZoggYraS/7rkP1\nLw86a0Mqsg/0+F1867kZSoaJqfaJZXVFCQzLaAGIJMDhgajzOdmmduL/93HU\nCoNbiL6PHhfkSio/K5eg3DHaRztStxZPJJ14coA0GyJUPksiOCYH7q+kJ37S\nbcRI3yxQStWB33v/u43F5k/rlnRLu37hBF/YqpCif0LM6fo9A+9pQLeINzH+\niahtEAXHiaPPR7z/QwWQzSBv7lnaQABdtKxzPPzUZ3Fnxnw7lnebAsZj3MTJ\nYYHZT2ZcWaDWkmSqGw/Q2KnbQirp6b5dl4iKG6VdN3RbCye2GsqLjsvj5HOH\n4+62KEW4UUdt6lTvc2dzgCBUt6wqpjpv6zWFgMdMftPkmlSaRSnBu8ynhtde\nM45dHTVhdNoAZqLAxBWuYXFePkiHBUEBsfg34qJkKpYP7EhTju9Fk6i4Rsi/\nMiud\r\n=pJG5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "fanatid@ya.ru",
+          "name": "fanatid"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        }
+      ],
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bn.js_5.1.3_1597428286361_0.6498235391056579"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# <img src=\"./logo.png\" alt=\"bn.js\" width=\"160\" height=\"160\" />\n\n> BigNum in pure javascript\n\n[![Build Status](https://secure.travis-ci.org/indutny/bn.js.png)](http://travis-ci.org/indutny/bn.js)\n\n## Install\n`npm install --save bn.js`\n\n## Usage\n\n```js\nconst BN = require('bn.js');\n\nvar a = new BN('dead', 16);\nvar b = new BN('101010', 2);\n\nvar res = a.add(b);\nconsole.log(res.toString(10));  // 57047\n```\n\n**Note**: decimals are not supported in this library.\n\n## Notation\n\n### Prefixes\n\nThere are several prefixes to instructions that affect the way the work. Here\nis the list of them in the order of appearance in the function name:\n\n* `i` - perform operation in-place, storing the result in the host object (on\n  which the method was invoked). Might be used to avoid number allocation costs\n* `u` - unsigned, ignore the sign of operands when performing operation, or\n  always return positive value. Second case applies to reduction operations\n  like `mod()`. In such cases if the result will be negative - modulo will be\n  added to the result to make it positive\n\n### Postfixes\n\n* `n` - the argument of the function must be a plain JavaScript\n  Number. Decimals are not supported.\n* `rn` - both argument and return value of the function are plain JavaScript\n  Numbers. Decimals are not supported.\n\n### Examples\n\n* `a.iadd(b)` - perform addition on `a` and `b`, storing the result in `a`\n* `a.umod(b)` - reduce `a` modulo `b`, returning positive value\n* `a.iushln(13)` - shift bits of `a` left by 13\n\n## Instructions\n\nPrefixes/postfixes are put in parens at the of the line. `endian` - could be\neither `le` (little-endian) or `be` (big-endian).\n\n### Utilities\n\n* `a.clone()` - clone number\n* `a.toString(base, length)` - convert to base-string and pad with zeroes\n* `a.toNumber()` - convert to Javascript Number (limited to 53 bits)\n* `a.toJSON()` - convert to JSON compatible hex string (alias of `toString(16)`)\n* `a.toArray(endian, length)` - convert to byte `Array`, and optionally zero\n  pad to length, throwing if already exceeding\n* `a.toArrayLike(type, endian, length)` - convert to an instance of `type`,\n  which must behave like an `Array`\n* `a.toBuffer(endian, length)` - convert to Node.js Buffer (if available). For\n  compatibility with browserify and similar tools, use this instead:\n  `a.toArrayLike(Buffer, endian, length)`\n* `a.bitLength()` - get number of bits occupied\n* `a.zeroBits()` - return number of less-significant consequent zero bits\n  (example: `1010000` has 4 zero bits)\n* `a.byteLength()` - return number of bytes occupied\n* `a.isNeg()` - true if the number is negative\n* `a.isEven()` - no comments\n* `a.isOdd()` - no comments\n* `a.isZero()` - no comments\n* `a.cmp(b)` - compare numbers and return `-1` (a `<` b), `0` (a `==` b), or `1` (a `>` b)\n  depending on the comparison result (`ucmp`, `cmpn`)\n* `a.lt(b)` - `a` less than `b` (`n`)\n* `a.lte(b)` - `a` less than or equals `b` (`n`)\n* `a.gt(b)` - `a` greater than `b` (`n`)\n* `a.gte(b)` - `a` greater than or equals `b` (`n`)\n* `a.eq(b)` - `a` equals `b` (`n`)\n* `a.toTwos(width)` - convert to two's complement representation, where `width` is bit width\n* `a.fromTwos(width)` - convert from two's complement representation, where `width` is the bit width\n* `BN.isBN(object)` - returns true if the supplied `object` is a BN.js instance\n* `BN.max(a, b)` - return `a` if `a` bigger than `b`\n* `BN.min(a, b)` - return `a` if `a` less than `b`\n\n### Arithmetics\n\n* `a.neg()` - negate sign (`i`)\n* `a.abs()` - absolute value (`i`)\n* `a.add(b)` - addition (`i`, `n`, `in`)\n* `a.sub(b)` - subtraction (`i`, `n`, `in`)\n* `a.mul(b)` - multiply (`i`, `n`, `in`)\n* `a.sqr()` - square (`i`)\n* `a.pow(b)` - raise `a` to the power of `b`\n* `a.div(b)` - divide (`divn`, `idivn`)\n* `a.mod(b)` - reduct (`u`, `n`) (but no `umodn`)\n* `a.divRound(b)` - rounded division\n\n### Bit operations\n\n* `a.or(b)` - or (`i`, `u`, `iu`)\n* `a.and(b)` - and (`i`, `u`, `iu`, `andln`) (NOTE: `andln` is going to be replaced\n  with `andn` in future)\n* `a.xor(b)` - xor (`i`, `u`, `iu`)\n* `a.setn(b)` - set specified bit to `1`\n* `a.shln(b)` - shift left (`i`, `u`, `iu`)\n* `a.shrn(b)` - shift right (`i`, `u`, `iu`)\n* `a.testn(b)` - test if specified bit is set\n* `a.maskn(b)` - clear bits with indexes higher or equal to `b` (`i`)\n* `a.bincn(b)` - add `1 << b` to the number\n* `a.notn(w)` - not (for the width specified by `w`) (`i`)\n\n### Reduction\n\n* `a.gcd(b)` - GCD\n* `a.egcd(b)` - Extended GCD results (`{ a: ..., b: ..., gcd: ... }`)\n* `a.invm(b)` - inverse `a` modulo `b`\n\n## Fast reduction\n\nWhen doing lots of reductions using the same modulo, it might be beneficial to\nuse some tricks: like [Montgomery multiplication][0], or using special algorithm\nfor [Mersenne Prime][1].\n\n### Reduction context\n\nTo enable this tricks one should create a reduction context:\n\n```js\nvar red = BN.red(num);\n```\nwhere `num` is just a BN instance.\n\nOr:\n\n```js\nvar red = BN.red(primeName);\n```\n\nWhere `primeName` is either of these [Mersenne Primes][1]:\n\n* `'k256'`\n* `'p224'`\n* `'p192'`\n* `'p25519'`\n\nOr:\n\n```js\nvar red = BN.mont(num);\n```\n\nTo reduce numbers with [Montgomery trick][0]. `.mont()` is generally faster than\n`.red(num)`, but slower than `BN.red(primeName)`.\n\n### Converting numbers\n\nBefore performing anything in reduction context - numbers should be converted\nto it. Usually, this means that one should:\n\n* Convert inputs to reducted ones\n* Operate on them in reduction context\n* Convert outputs back from the reduction context\n\nHere is how one may convert numbers to `red`:\n\n```js\nvar redA = a.toRed(red);\n```\nWhere `red` is a reduction context created using instructions above\n\nHere is how to convert them back:\n\n```js\nvar a = redA.fromRed();\n```\n\n### Red instructions\n\nMost of the instructions from the very start of this readme have their\ncounterparts in red context:\n\n* `a.redAdd(b)`, `a.redIAdd(b)`\n* `a.redSub(b)`, `a.redISub(b)`\n* `a.redShl(num)`\n* `a.redMul(b)`, `a.redIMul(b)`\n* `a.redSqr()`, `a.redISqr()`\n* `a.redSqrt()` - square root modulo reduction context's prime\n* `a.redInvm()` - modular inverse of the number\n* `a.redNeg()`\n* `a.redPow(b)` - modular exponentiation\n\n### Number Size\n\nOptimized for elliptic curves that work with 256-bit numbers.\nThere is no limitation on the size of the numbers.\n\n## LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2015.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n\n[0]: https://en.wikipedia.org/wiki/Montgomery_modular_multiplication\n[1]: https://en.wikipedia.org/wiki/Mersenne_prime\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "fanatid@ya.ru",
+      "name": "fanatid"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-14T18:04:48.737Z",
+    "created": "2014-04-26T12:02:08.664Z",
+    "0.1.0": "2014-04-26T12:02:08.664Z",
+    "0.1.1": "2014-04-26T16:17:31.993Z",
+    "0.1.2": "2014-04-26T19:13:06.288Z",
+    "0.1.3": "2014-04-27T07:29:52.784Z",
+    "0.1.4": "2014-04-27T09:05:04.582Z",
+    "0.1.5": "2014-04-27T09:39:06.590Z",
+    "0.1.6": "2014-04-27T09:51:57.909Z",
+    "0.1.7": "2014-04-27T19:16:50.428Z",
+    "0.2.0": "2014-04-29T09:37:04.108Z",
+    "0.2.1": "2014-05-01T11:51:01.209Z",
+    "0.2.2": "2014-05-02T07:08:10.445Z",
+    "0.3.0": "2014-05-04T10:14:12.981Z",
+    "0.3.1": "2014-05-04T10:23:33.420Z",
+    "0.4.0": "2014-05-08T23:44:17.669Z",
+    "0.4.1": "2014-05-09T07:28:15.726Z",
+    "0.4.2": "2014-05-10T18:18:48.731Z",
+    "0.4.3": "2014-05-11T08:15:56.212Z",
+    "0.4.4": "2014-05-13T15:46:36.948Z",
+    "0.5.0": "2014-05-16T16:54:04.262Z",
+    "0.5.1": "2014-05-16T17:21:50.486Z",
+    "0.5.2": "2014-05-17T04:59:17.054Z",
+    "0.5.3": "2014-05-17T05:17:34.568Z",
+    "0.5.4": "2014-05-17T08:36:50.044Z",
+    "0.6.0": "2014-05-17T16:03:50.679Z",
+    "0.7.0": "2014-05-18T12:23:43.579Z",
+    "0.7.1": "2014-05-18T13:24:33.969Z",
+    "0.8.0": "2014-05-21T19:20:24.963Z",
+    "0.8.1": "2014-05-22T07:37:09.499Z",
+    "0.9.0": "2014-05-23T09:23:46.647Z",
+    "0.10.0": "2014-05-23T14:23:32.517Z",
+    "0.10.1": "2014-05-24T17:16:25.994Z",
+    "0.11.0": "2014-05-25T11:24:03.725Z",
+    "0.11.1": "2014-05-25T11:26:27.397Z",
+    "0.11.2": "2014-05-25T14:50:42.547Z",
+    "0.11.3": "2014-05-26T14:29:55.249Z",
+    "0.11.4": "2014-05-26T22:18:03.826Z",
+    "0.11.5": "2014-05-27T18:54:19.494Z",
+    "0.11.6": "2014-05-31T22:54:51.425Z",
+    "0.11.7": "2014-06-03T14:29:15.911Z",
+    "0.12.0": "2014-06-12T03:06:07.286Z",
+    "0.13.0": "2014-06-17T23:04:06.483Z",
+    "0.13.1": "2014-06-25T04:21:16.743Z",
+    "0.13.2": "2014-06-25T04:23:23.546Z",
+    "0.13.3": "2014-07-15T17:16:41.996Z",
+    "0.14.0": "2014-09-08T14:12:58.061Z",
+    "0.14.1": "2014-09-25T10:23:58.634Z",
+    "0.14.2": "2014-10-30T03:37:25.835Z",
+    "0.15.0": "2014-11-02T19:39:36.499Z",
+    "0.15.1": "2014-11-06T09:46:12.963Z",
+    "0.15.2": "2014-11-07T09:15:33.327Z",
+    "0.16.0": "2014-11-27T16:00:19.372Z",
+    "0.16.1": "2015-01-04T11:59:54.274Z",
+    "1.0.0": "2015-01-05T20:51:38.804Z",
+    "1.0.1": "2015-01-26T11:48:32.586Z",
+    "1.1.0": "2015-01-26T14:00:45.345Z",
+    "1.1.1": "2015-02-06T01:49:31.923Z",
+    "1.2.0": "2015-02-06T16:16:00.709Z",
+    "1.2.1": "2015-02-06T17:16:07.245Z",
+    "1.2.2": "2015-02-06T21:08:14.147Z",
+    "1.2.3": "2015-02-07T00:37:57.005Z",
+    "1.2.4": "2015-02-07T02:05:31.709Z",
+    "1.3.0": "2015-02-08T14:00:37.975Z",
+    "2.0.0": "2015-02-09T20:43:49.879Z",
+    "2.0.1": "2015-03-02T04:45:57.831Z",
+    "2.0.2": "2015-03-20T20:40:53.333Z",
+    "2.0.3": "2015-03-26T17:09:59.064Z",
+    "2.0.4": "2015-04-30T08:57:35.086Z",
+    "2.0.5": "2015-05-10T18:19:30.793Z",
+    "2.1.0": "2015-06-25T02:14:56.941Z",
+    "2.2.0": "2015-07-03T22:31:24.993Z",
+    "3.0.0": "2015-07-07T22:55:36.377Z",
+    "3.0.1": "2015-07-07T23:41:00.710Z",
+    "3.1.0": "2015-07-16T04:31:52.200Z",
+    "3.1.1": "2015-07-16T05:36:22.720Z",
+    "3.1.2": "2015-08-25T01:03:24.157Z",
+    "3.2.0": "2015-10-01T19:30:29.233Z",
+    "3.3.0": "2015-10-27T17:13:09.802Z",
+    "4.0.0": "2015-10-28T02:16:29.043Z",
+    "4.1.0": "2015-10-29T00:30:57.551Z",
+    "4.1.1": "2015-11-01T15:49:06.890Z",
+    "4.2.0": "2015-11-18T15:53:16.929Z",
+    "4.3.0": "2015-11-22T01:45:42.475Z",
+    "4.4.0": "2015-11-29T18:22:50.584Z",
+    "4.5.0": "2015-12-04T01:51:41.732Z",
+    "4.5.1": "2015-12-11T05:08:56.766Z",
+    "4.5.2": "2015-12-15T01:28:18.631Z",
+    "4.6.0": "2015-12-19T22:34:44.626Z",
+    "4.6.1": "2015-12-19T22:35:43.579Z",
+    "4.6.2": "2016-01-04T14:12:05.962Z",
+    "4.6.3": "2016-01-13T20:31:50.699Z",
+    "4.6.4": "2016-01-14T04:04:54.082Z",
+    "4.6.5": "2016-01-21T23:27:37.737Z",
+    "4.6.6": "2016-01-22T18:32:37.102Z",
+    "4.7.0": "2016-01-24T21:33:11.645Z",
+    "4.8.0": "2016-01-25T02:59:41.209Z",
+    "4.8.1": "2016-01-25T20:30:27.338Z",
+    "4.9.0": "2016-01-27T21:16:47.740Z",
+    "4.10.0": "2016-02-01T04:39:01.687Z",
+    "4.10.1": "2016-02-04T22:38:04.222Z",
+    "4.10.2": "2016-02-09T02:43:30.749Z",
+    "4.10.3": "2016-02-09T02:48:07.303Z",
+    "4.10.4": "2016-02-27T01:11:51.858Z",
+    "4.10.5": "2016-03-01T06:05:02.722Z",
+    "4.11.0": "2016-03-08T18:40:14.077Z",
+    "4.11.1": "2016-03-25T22:35:14.294Z",
+    "4.11.2": "2016-04-12T19:03:41.857Z",
+    "4.11.3": "2016-04-12T19:25:19.482Z",
+    "4.11.4": "2016-06-05T20:32:29.149Z",
+    "4.11.5": "2016-07-13T20:37:05.929Z",
+    "4.11.6": "2016-08-02T01:13:50.698Z",
+    "4.11.7": "2017-06-21T00:08:53.725Z",
+    "4.11.8": "2017-08-07T22:21:45.304Z",
+    "5.0.0": "2019-07-07T16:17:26.258Z",
+    "5.1.0": "2019-12-23T08:42:54.791Z",
+    "5.1.1": "2019-12-24T20:33:10.907Z",
+    "4.11.9": "2020-05-20T15:13:18.347Z",
+    "5.1.2": "2020-05-20T15:24:38.341Z",
+    "5.1.3": "2020-08-14T18:04:46.507Z"
+  },
+  "homepage": "https://github.com/indutny/bn.js",
+  "keywords": [
+    "BN",
+    "Big number",
+    "BigNum",
+    "Modulo",
+    "Montgomery"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/bn.js.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/bn.js/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "nickleefly": true,
+    "antimatter15": true,
+    "leodutra": true,
+    "ruiquelhas": true,
+    "langri-sha": true,
+    "ferrari": true,
+    "seangenabe": true,
+    "erikvold": true,
+    "thejeshgn.com": true,
+    "thejeshgn": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/bn.js.min.json
+++ b/test/fixtures/registry-mocks/content/bn.js.min.json
@@ -1,0 +1,1451 @@
+{
+  "name": "bn.js",
+  "dist-tags": {
+    "latest": "5.1.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "bn.js",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "f84d2ec045bdd4cc0513de8ad4ea84dfeb8b1941",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "bn.js",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "5afef3393cd9d4c85b65f68c013a7695bef1a90a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "bn.js",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "04b88b9f38fdff6fd54a64ed6813144b0e1b6bef",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "bn.js",
+      "version": "0.1.3",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "f3b9c51881c104d50854aae94d6c616ef11c5fd9",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "bn.js",
+      "version": "0.1.4",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "3248e2c78aa4a74acdfff9b2d36d0bf2588f28a2",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "bn.js",
+      "version": "0.1.5",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "e5cfb803b073351d0aa2023167cfa44b2409f69a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.5.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "bn.js",
+      "version": "0.1.6",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "9323232e200d36b2117a2d384e83352a6795ac9a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.6.tgz"
+      }
+    },
+    "0.1.7": {
+      "name": "bn.js",
+      "version": "0.1.7",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "73c61ccd47656b084f3989346b5d1c51af412afe",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.1.7.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "bn.js",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "37ab22ba8da3a0fbfb226c935c6283b67e606ca0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "bn.js",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "e8b156a4754e58f636009b9e51e1022856aa30e4",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "bn.js",
+      "version": "0.2.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "4ce53679e69a3be43ab0c8e5278c07e7f177a5e7",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.2.2.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "bn.js",
+      "version": "0.3.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "5ff529ddaacb88d8c8b9a747b844b7bb7c61bf06",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "bn.js",
+      "version": "0.3.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "0250ea3bd957619cac0db864fef8f007f74ac1ba",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.3.1.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "bn.js",
+      "version": "0.4.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "4ded6119c06e20a992e1b0f7b12d727bed504b3a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.0.tgz"
+      }
+    },
+    "0.4.1": {
+      "name": "bn.js",
+      "version": "0.4.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "c40b142b262e25006581f88e2c63b85ad935b10d",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.1.tgz"
+      }
+    },
+    "0.4.2": {
+      "name": "bn.js",
+      "version": "0.4.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "70ffd0ca1d96dc1fd7f52a8e7ab1735cf72e9e7c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.2.tgz"
+      }
+    },
+    "0.4.3": {
+      "name": "bn.js",
+      "version": "0.4.3",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "7ceb6014ad1233aeef96177f4482c0c5b3d11715",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.3.tgz"
+      }
+    },
+    "0.4.4": {
+      "name": "bn.js",
+      "version": "0.4.4",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "de75bf4b0e529da86588ecf905e05266a2c50987",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.4.4.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "bn.js",
+      "version": "0.5.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "ea39b8377fe9502d2da8d9d397a764ef7b6939e3",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.0.tgz"
+      }
+    },
+    "0.5.1": {
+      "name": "bn.js",
+      "version": "0.5.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "15eb1df6b3321fc397e0774e51b8f7ecabde2332",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.1.tgz"
+      }
+    },
+    "0.5.2": {
+      "name": "bn.js",
+      "version": "0.5.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "bc636c01716148c61765a90f7aab8074a5c8128b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.2.tgz"
+      }
+    },
+    "0.5.3": {
+      "name": "bn.js",
+      "version": "0.5.3",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "4f8a69ac49b34009852d99a4751e2d7af45c80b3",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.3.tgz"
+      }
+    },
+    "0.5.4": {
+      "name": "bn.js",
+      "version": "0.5.4",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "46882b5e6a8b4c68c32b78061c7cb8a1bc7f91b8",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.5.4.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "bn.js",
+      "version": "0.6.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "4467c0e7efe7a6c08e19c12b6d12c897c3a3cea8",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.6.0.tgz"
+      }
+    },
+    "0.7.0": {
+      "name": "bn.js",
+      "version": "0.7.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "5e6575294229d7cde9ed0b09826c475a730f851e",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.7.0.tgz"
+      }
+    },
+    "0.7.1": {
+      "name": "bn.js",
+      "version": "0.7.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "7ae54498718445caa319f1cfd29dfd89ef3d431c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.7.1.tgz"
+      }
+    },
+    "0.8.0": {
+      "name": "bn.js",
+      "version": "0.8.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "61b62da5efc982d482f742dad2c8b80159d77008",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.8.0.tgz"
+      }
+    },
+    "0.8.1": {
+      "name": "bn.js",
+      "version": "0.8.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "0fd50fc287c2b8f24fc0383623de2ddffb9440ad",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.8.1.tgz"
+      }
+    },
+    "0.9.0": {
+      "name": "bn.js",
+      "version": "0.9.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "808464cfcd06a2c8a25aeaa46d670948e46fabae",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.9.0.tgz"
+      }
+    },
+    "0.10.0": {
+      "name": "bn.js",
+      "version": "0.10.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "e2fd7835a6ff4eb0653404e1eb6795ce5063180a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.10.0.tgz"
+      }
+    },
+    "0.10.1": {
+      "name": "bn.js",
+      "version": "0.10.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "fd1416194ac1b12a7bf096341103214258e68fef",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.10.1.tgz"
+      }
+    },
+    "0.11.0": {
+      "name": "bn.js",
+      "version": "0.11.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "a47da9f1fb3d0ec84ca267dc3b0e63c206aafb6c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.0.tgz"
+      }
+    },
+    "0.11.1": {
+      "name": "bn.js",
+      "version": "0.11.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "4e6c9659794e1a3923c25c0ccd82cd0320f9c597",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.1.tgz"
+      }
+    },
+    "0.11.2": {
+      "name": "bn.js",
+      "version": "0.11.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "981ad5439c0eae102e30687eb0d14f24001d26c9",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.2.tgz"
+      }
+    },
+    "0.11.3": {
+      "name": "bn.js",
+      "version": "0.11.3",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "527f4bfb8a16c6298a7684678939ad08b66203a1",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.3.tgz"
+      }
+    },
+    "0.11.4": {
+      "name": "bn.js",
+      "version": "0.11.4",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "c3107d589e3fe057fa92b70cdc86e7b4025c85a5",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.4.tgz"
+      }
+    },
+    "0.11.5": {
+      "name": "bn.js",
+      "version": "0.11.5",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "e48368dc4e1b25025cb6ff747cf7229a256826ff",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.5.tgz"
+      }
+    },
+    "0.11.6": {
+      "name": "bn.js",
+      "version": "0.11.6",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "ec5fc50991ac298970b7e1cb7ba58382e4b940e8",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.6.tgz"
+      }
+    },
+    "0.11.7": {
+      "name": "bn.js",
+      "version": "0.11.7",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "7c5be037ccd45afc3136c7af92466c93d4ce5a56",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.11.7.tgz"
+      }
+    },
+    "0.12.0": {
+      "name": "bn.js",
+      "version": "0.12.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "ce6646bd82cbbfdd5f7b7ce5522f3c3360b85214",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.12.0.tgz"
+      }
+    },
+    "0.13.0": {
+      "name": "bn.js",
+      "version": "0.13.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "c5b43590d6bd89f93d663c23df9400abb234be20",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.13.0.tgz"
+      }
+    },
+    "0.13.1": {
+      "name": "bn.js",
+      "version": "0.13.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "996073b90419167146f9cfc0747e6f4f2858e87c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.13.1.tgz"
+      }
+    },
+    "0.13.2": {
+      "name": "bn.js",
+      "version": "0.13.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "84020e7362df295b211e8ae10c2937cb78e5795d",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.13.2.tgz"
+      }
+    },
+    "0.13.3": {
+      "name": "bn.js",
+      "version": "0.13.3",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "357d832db5aa511701fac9d03698ec792ddaaed0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.13.3.tgz"
+      }
+    },
+    "0.14.0": {
+      "name": "bn.js",
+      "version": "0.14.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "285e0b6bd312de0d6dd62fd5f520497506aec851",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.14.0.tgz"
+      }
+    },
+    "0.14.1": {
+      "name": "bn.js",
+      "version": "0.14.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "1b6631d73a54b08986ac98761e838b4c343fa6b5",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.14.1.tgz"
+      }
+    },
+    "0.14.2": {
+      "name": "bn.js",
+      "version": "0.14.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "9480914aeff2a30b599c066040af84e1bb11ded1",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.14.2.tgz"
+      }
+    },
+    "0.15.0": {
+      "name": "bn.js",
+      "version": "0.15.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "4574c7c128c730f4ab845073b9288e0d2039f3de",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.0.tgz"
+      }
+    },
+    "0.15.1": {
+      "name": "bn.js",
+      "version": "0.15.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "3f4bf5e3d05cdcbc11576bc248070bce722e60da",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.1.tgz"
+      }
+    },
+    "0.15.2": {
+      "name": "bn.js",
+      "version": "0.15.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "a83b283accdacbf28e89774747cac352216f886a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.15.2.tgz"
+      }
+    },
+    "0.16.0": {
+      "name": "bn.js",
+      "version": "0.16.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "5b6f7ea86ec2f8e065dee2b4d5f1540314bf523e",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.16.0.tgz"
+      }
+    },
+    "0.16.1": {
+      "name": "bn.js",
+      "version": "0.16.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "5f9e74fc53abfd3bb74020b824b83a599f8a9c6f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-0.16.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "bn.js",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "01e39f8c13f981c468b673caf0632f726d54713f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "bn.js",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "3bcebb538c8221a1bbf109b9d1978f026c02c297",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "bn.js",
+      "version": "1.1.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "7a9d15b1fac825469bf18c70d5a1ec9b3ee1da1a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.1.1.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "bn.js",
+      "version": "1.2.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "db61852c756cd3e48d9e5b58af159e43e4936262",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "bn.js",
+      "version": "1.2.2",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "43847951eae2cba604535fad8c6c9a18e8565489",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.2.2.tgz"
+      }
+    },
+    "1.2.3": {
+      "name": "bn.js",
+      "version": "1.2.3",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "4e40df87acf0ac1d100ee0bec5e831a850da75d0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.2.3.tgz"
+      }
+    },
+    "1.2.4": {
+      "name": "bn.js",
+      "version": "1.2.4",
+      "devDependencies": {
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "7ccaddc03f0b5ef5c58b4d22b2e296fa0eb8c6e2",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.2.4.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "bn.js",
+      "version": "1.3.0",
+      "devDependencies": {
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "0db4cbf96f8f23b742f5bcb9d1aa7a9994a05e83",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "bn.js",
+      "version": "2.0.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "825c4107f7fa789378ee1b0d86be0503d7ac743b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "bn.js",
+      "version": "2.0.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "ae9bbb5dde3e0031071c6dbc814ec7b4fc9a1e78",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "bn.js",
+      "version": "2.0.2",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "c23b96588b5aadf8aec83698ffc703b396e4999e",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "bn.js",
+      "version": "2.0.3",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "88922f1d693cfdc8260c606a3aaabfc98d25815f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.3.tgz"
+      }
+    },
+    "2.0.4": {
+      "name": "bn.js",
+      "version": "2.0.4",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "220a7cd677f7f1bfa93627ff4193776fe7819480",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.4.tgz"
+      }
+    },
+    "2.0.5": {
+      "name": "bn.js",
+      "version": "2.0.5",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "5f4b12a26ec4eb8ac895a9349980a254cfd3eb65",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.0.5.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "bn.js",
+      "version": "2.1.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "f8a280fe6c60dbc4684bc70bb20b68ae60f94efd",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.1.0.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "bn.js",
+      "version": "2.2.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "12162bc2ae71fc40a5626c33438f3a875cd37625",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-2.2.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "bn.js",
+      "version": "3.0.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "8d68f48d7c2b75263e0c2684aec768d5c358ff25",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "bn.js",
+      "version": "3.0.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "855c7a7b4b92592e87ac4ac0b782624cb28a517f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.0.1.tgz"
+      }
+    },
+    "3.1.0": {
+      "name": "bn.js",
+      "version": "3.1.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "bb633298b0cc0ba763426a18863a9bcba5f6e0d0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.1.0.tgz"
+      }
+    },
+    "3.1.1": {
+      "name": "bn.js",
+      "version": "3.1.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "cd8390de8d02865104f21601c72c1404290a094f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.1.1.tgz"
+      }
+    },
+    "3.1.2": {
+      "name": "bn.js",
+      "version": "3.1.2",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "530e8e63398ac2dbd4762484a0b00d9cbb78be9c",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.1.2.tgz"
+      }
+    },
+    "3.2.0": {
+      "name": "bn.js",
+      "version": "3.2.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "b55c0978e2b815cca86474f6e67ee01aba7449df",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.2.0.tgz"
+      }
+    },
+    "3.3.0": {
+      "name": "bn.js",
+      "version": "3.3.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "1138e577889fdc97bbdab51844f2190dfc0ae3d7",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-3.3.0.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "bn.js",
+      "version": "4.0.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "da4c1258fc389a423cd07aa0a393958ca9c35476",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.0.0.tgz"
+      }
+    },
+    "4.1.0": {
+      "name": "bn.js",
+      "version": "4.1.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "35105abe0809c082007744650b8234b2f9c9ada3",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.1.0.tgz"
+      }
+    },
+    "4.1.1": {
+      "name": "bn.js",
+      "version": "4.1.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "ad1c416107dc2d565aed54814bcfbb44f8a25909",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.1.1.tgz"
+      }
+    },
+    "4.2.0": {
+      "name": "bn.js",
+      "version": "4.2.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "67fe8e2e6637ae4bb8447876c8562a8a7d9ca402",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.2.0.tgz"
+      }
+    },
+    "4.3.0": {
+      "name": "bn.js",
+      "version": "4.3.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "c6ffb4a18b0867195f990c0051a8f93d69f7ec90",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.3.0.tgz"
+      }
+    },
+    "4.4.0": {
+      "name": "bn.js",
+      "version": "4.4.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "b196a96e7ab08a7a3eca9c66390390da3a980eb6",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.4.0.tgz"
+      }
+    },
+    "4.5.0": {
+      "name": "bn.js",
+      "version": "4.5.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "b995be6db2484af988111af08c9d6aca6755178f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.5.0.tgz"
+      }
+    },
+    "4.5.1": {
+      "name": "bn.js",
+      "version": "4.5.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "d9e973b101a82c86fb289c51e416e1888538ee16",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.5.1.tgz"
+      }
+    },
+    "4.5.2": {
+      "name": "bn.js",
+      "version": "4.5.2",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "bb9e3df54abe3e118d4754195cc74926545489e0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.5.2.tgz"
+      }
+    },
+    "4.6.0": {
+      "name": "bn.js",
+      "version": "4.6.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "6b649bf3608cb09eba9b91b6fcbb79b0a1aa0c16",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.0.tgz"
+      }
+    },
+    "4.6.1": {
+      "name": "bn.js",
+      "version": "4.6.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "jscs": "^1.11.1",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "54495a5719abd8f5bb800f6354068029108d5f3b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.1.tgz"
+      }
+    },
+    "4.6.2": {
+      "name": "bn.js",
+      "version": "4.6.2",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "f3f77bc657f7ec926c8d02df0883543970c90778",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.2.tgz"
+      }
+    },
+    "4.6.3": {
+      "name": "bn.js",
+      "version": "4.6.3",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "37c166833a7ebf5eba1a08f9c66b6a20fe3ae178",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.3.tgz"
+      }
+    },
+    "4.6.4": {
+      "name": "bn.js",
+      "version": "4.6.4",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "67b1ec994775d87652e350c62adbb66e7c05bc50",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.4.tgz"
+      }
+    },
+    "4.6.5": {
+      "name": "bn.js",
+      "version": "4.6.5",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "130d65bf411a6de727e9193a0219ad2e19efd943",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.5.tgz"
+      }
+    },
+    "4.6.6": {
+      "name": "bn.js",
+      "version": "4.6.6",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "ee9631479d1b7e56f3108670d7b024949882c92b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.6.6.tgz"
+      }
+    },
+    "4.7.0": {
+      "name": "bn.js",
+      "version": "4.7.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "6f2c5b626aa971c5937ae4131b81db111fa5fb0e",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.7.0.tgz"
+      }
+    },
+    "4.8.0": {
+      "name": "bn.js",
+      "version": "4.8.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "c775509ea4e42365630660edf1d30d1a9a1f4440",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.8.0.tgz"
+      }
+    },
+    "4.8.1": {
+      "name": "bn.js",
+      "version": "4.8.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "e8cb1c43a09a6f2f5541b920f714f268307ed73f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.8.1.tgz"
+      }
+    },
+    "4.9.0": {
+      "name": "bn.js",
+      "version": "4.9.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "a51e8356ff87f24249429bffc415e386dbbc2211",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.9.0.tgz"
+      }
+    },
+    "4.10.0": {
+      "name": "bn.js",
+      "version": "4.10.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "0f94c26328bc11da325d0080c572c5a83f23f8b1",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.0.tgz"
+      }
+    },
+    "4.10.1": {
+      "name": "bn.js",
+      "version": "4.10.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "743347a61e4dbc269fb034b9edfdb69fb9bf5b15",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.1.tgz"
+      }
+    },
+    "4.10.2": {
+      "name": "bn.js",
+      "version": "4.10.2",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "2777e05bee0d688ac85e61a90177c0e1e5d8a765",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.2.tgz"
+      }
+    },
+    "4.10.3": {
+      "name": "bn.js",
+      "version": "4.10.3",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "5a0322c6a4eb187ff37a025b922354d565537433",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.3.tgz"
+      }
+    },
+    "4.10.4": {
+      "name": "bn.js",
+      "version": "4.10.4",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "bdac295b21e006d0d164a81ee787a2c5f2c681f1",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.4.tgz"
+      }
+    },
+    "4.10.5": {
+      "name": "bn.js",
+      "version": "4.10.5",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "42baacbd9dfa08073515308184142b6675055f3a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.10.5.tgz"
+      }
+    },
+    "4.11.0": {
+      "name": "bn.js",
+      "version": "4.11.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "eb24783e0e77a943640fa387095b1c7b4f50d140",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.0.tgz"
+      }
+    },
+    "4.11.1": {
+      "name": "bn.js",
+      "version": "4.11.1",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "ff1c52c52fd371e9d91419439bac5cfba2b41798",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.1.tgz"
+      }
+    },
+    "4.11.2": {
+      "name": "bn.js",
+      "version": "4.11.2",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "c586a31dac8ea4bc162dd17609e8bf5fc594dddf",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.2.tgz"
+      }
+    },
+    "4.11.3": {
+      "name": "bn.js",
+      "version": "4.11.3",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "bfd45360d339b173f39b628445d2f5d02cb61dd4",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.3.tgz"
+      }
+    },
+    "4.11.4": {
+      "name": "bn.js",
+      "version": "4.11.4",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "59f0735fa52ff7f00e2cdd1ad207b7c8603d374d",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.4.tgz"
+      }
+    },
+    "4.11.5": {
+      "name": "bn.js",
+      "version": "4.11.5",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "d4572591b6bf70ef60f76790d6c2e92d8979350a",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.5.tgz"
+      }
+    },
+    "4.11.6": {
+      "name": "bn.js",
+      "version": "4.11.6",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "53344adb14617a13f6e8dd2ce28905d1c0ba3215",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
+      }
+    },
+    "4.11.7": {
+      "name": "bn.js",
+      "version": "4.11.7",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
+        "shasum": "ddb048e50d9482790094c13eb3fcfc833ce7ab46",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz"
+      }
+    },
+    "4.11.8": {
+      "name": "bn.js",
+      "version": "4.11.8",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+        "shasum": "2cde09eb5ee341f484746bb0309b3253b1b1442f",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz"
+      }
+    },
+    "5.0.0": {
+      "name": "bn.js",
+      "version": "5.0.0",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-bVwDX8AF+72fIUNuARelKAlQUNtPOfG2fRxorbVvFk4zpHbqLrPdOGfVg5vrKwVzLLePqPBiATaOZNELQzmS0A==",
+        "shasum": "5c3d398021b3ddb548c1296a16f857e908f35c70",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 97122,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdIhsWCRA9TVsSAnZWagAAS+MP/2i5OI3bS12VM9klRJ6M\nhnJBNgTn1YWXvL+B/OtnTY9tyZGL3fvKgF/8E9zYqxWzlMpVIQvUzOSgXZfb\nYDUkmGrQqqYTZHH6fvN4+QX98x50w6EixsWNBZD8IW0ncKSqnKsug8HKBhPJ\nfDAzXfAk6fl2FS2ivMuMEs0vKb5JVbhVFYyZAjblWzNo1HYkTDf1EJ7WI535\nrqFzewU9IhwScc6o6pWTfiZoQR3RNX0Yi2eKNsIwKz0n1mWA2dWAhbWzsQek\nEgjKwf0Xd6EewtpXOarPkWgx8Hqh8m4dVxvmkGLTUTCg02ySNCOJy9Pw3R0d\nHPsd8NclNa83x2OdhNK9pwHcAYNT6emk42cDeM5kVFfzatJbiryLGVgGirmM\nHCWbRjG19BmhrRsz+XbM9pN6GKZKMyjH7kxNvFFTq+UOBoEYLp4JCkdO6WOP\nsARR5kKoxI5y9lgksU3kfpNoUVvuptFr/HY+f1nKZZ5ahSQb0e3I/DnF6WfX\n0yqnzQLYFXks+ibssEukcbtkm2Y17X5uaM30HGiGc8Bp5gueGZy1Efcr/YgN\nsB0rTJtdsxBPePTuiCmzHT5lPtwXuGtnZJFW/5lsKNwT7mHf3URr8abJ6XRH\nclH3y7jAvNiThrwQAptemXQo0remYDqPosvqVxyYR8rdL49+3UWucG1xWzAf\nbAvH\r\n=Ip9d\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.0": {
+      "name": "bn.js",
+      "version": "5.1.0",
+      "devDependencies": {
+        "babel-eslint": "^10.0.2",
+        "mocha": "^6.1.4",
+        "standardx": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-NiyuqJjtPhXcJDc8I+YeyZceSMViT39AvuFJCH3ieMcOsRvZsp2luMrGSnQaqN6HVJMvSgydLnkvw5N4xvuIoQ==",
+        "shasum": "7ef3e4af5d85a8d70d7077cb7d44bfc5cd6e6039",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 99370,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeAH4PCRA9TVsSAnZWagAAYtwP/1keFfynEN0e01kVuqz5\n+Oj6kRNZtc9u9ub0rWcvPyIHNZhmgVGiwJQrpVe7v72Fc85o98MbrNhdSuVC\n7ctBh9eo9nTQP0zfSbLOmmEqqzewdZkpbv2Vscnyt2XOE10aM5IPhseXKkXG\nOnRUSEh7uqV2iDtnCg7tdhxnjTvdz3z9MFpqThnynp2XZbPuIkrhtD1gm445\nUaCqlhDqs2+mHvEWEX9wuEk8l3x5QE7WXFvg3u8HzLX6KIIW4Nnme75Le/rS\ntoBnP6IUqnjZZaC2klhoU0XkBseRJCt4enFEO+H0Gchv/QcUK5+XNbWbOXkT\nxHtO6gzAF6XMASMMifE0NN6JYkugmCofooEefefYqQqGJseX3ypAzJxsqiLP\n2apXTiN4JcB8U/eqFUgXcGgZ7yCzBkAvr0BkakHHYeTplY+syKjVlNG5LMDi\nlyGkbXY91potyl/Td7+GqkJzZtrMtvhjIooY5Nch46AAs34r2QqWpovNqu2N\nc0v5K5an8Keu180lasV9XQKIyN7iV8UAru7MuirDy557GQbuHodPmdaiLt72\nZ2XKr1myzPyvRHTjU8glBrw1pANV/tENkcSojCZ0W2wuCrRzFrhlwhbKv/05\n/5P3nSgdWEfphslgcsoDjlgMd9QyPpF2ow197ebyKB9v/v5z8j8g2XDNh1oR\n47Ys\r\n=adzZ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.1": {
+      "name": "bn.js",
+      "version": "5.1.1",
+      "devDependencies": {
+        "babel-eslint": "^10.0.2",
+        "mocha": "^6.1.4",
+        "standardx": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
+        "shasum": "48efc4031a9c4041b9c99c6941d903463ab62eb5",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 99435,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeAnYHCRA9TVsSAnZWagAAhy4P/iy/wA+bV/hAQQJ3HDnz\n+AORYJqTs3RSNmjC0XXjtzJ+V0EVHFCYxvS3zjGE1HC7y2s5Yr9h1Z5sKob0\nLjiwk9/p9uDKnUZQrgVfECyjfGhTfRQeP9qr9tTuS88RmsZa0d65mAHeYys7\n9E1m9v6cJG+WXPjxiqa2Jj1ojDlxIwtDwgflJ9HcX6k5ijMTfvaegl1uNxlb\nvwI6GW/NxpnDH6+WkZflvPz0MAYeLTgevwYiGzZ55fYApJRkPihXNQ+0p6N2\ntAjStS9s7ZvrYL868iTVgczYz2oQKptpm9cR5V2D0GYJOrlj543FPAHs8fXI\nyvVzmOJ7zYkR88436oW8pM78wuGynBk0jdZrKiPP0myHiw1T2KR/GEak/NMd\n3HEicGhMNhDNzLVDQK+alMVbCOFtYyGpIHzEJstgw43eJFwS207NW940fMlg\npm/FVk6U0KBp3TKxck6DnCYPvGj5OzFBaJTQ/R0F3YT5gRquxvTfKR7Au8mK\nkRtHQezsbICAIqASjbWD7qt0pIOXWYM4IHAFMcFtI+uCA/oQOqGr9aptPugW\nzQMBgJHDE/rCV1pM55M4pHpLR/+5Rstj5y2IZjkSmHKgOMzwNsgepBYo8lYQ\nOx/jocepWqdVx4cRe1bpTZ90TIR4LfZOrPwoK24gGUxx1f+tyN32fAq0AEg5\ny/Kh\r\n=CoW5\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.11.9": {
+      "name": "bn.js",
+      "version": "4.11.9",
+      "devDependencies": {
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "semistandard": "^7.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+        "shasum": "26d556829458f9d1e81fc48952493d0ba3507828",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+        "fileCount": 5,
+        "unpackedSize": 99486,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexUkOCRA9TVsSAnZWagAAO+UP/3370+j9QtcUoZ7gykhN\nDcyidyo3TYOFPUKFaQJSic4/GIb5GulNnN1nq+T1R5hXM9W3HzPphFpn+nZh\nI60bB0XZ7Cc6XuGNelApMVQR+xwD0wz2hlEw7zjiCIC4kSrzSe1f9nalRhnn\naIHbwxcRHg6oRRpRLE2HHAfMXHwGz8yxL6NFTJpkUi02XS2C1biXjvJvQ518\n2QyjfRR6xZqMqQkFav/V/70R+GJTA57loG4kvh2AXC1HvqEihe6Hzo35RB+O\nVAet71GK+cDaj+v+O0wLMQoGy6t605hz610VcQOyN10w0iibEQusmHCjiGe3\nsZEFmlWhKmTTmRy0m/GFOpNpgQESaPEK8SC5p/PZcLF5dnrI5RQV3QkQVZTS\nCK83RdKgZNEXoizf2qaay0dJBitIvHQqruS73yF6fi+ReDs79sKPtthpcmVE\nz5duL0KoCj/HeQDL1Bsleh2JDvXNxNlCHlw8UcQAqhtn/9l60IU8nyZAsXol\nBa1aD7SH5vyHTmpjBTIJ7+4TCBVkNwy6r07cNMTQuCBWL6ZqQGr9d1wnCtSl\nEzbRcw9SqbmZzWZPfHQj+o75Vd/ocME7TvzrbPBNo+T1oruT6AO+GfuhMHx5\nVFSkdGQ8OhHpXYp32z3afPrvDJyktrFGfR43/D6DbwQlD8ZMOEaH8TsJuq3S\nTqVa\r\n=O+nX\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.2": {
+      "name": "bn.js",
+      "version": "5.1.2",
+      "devDependencies": {
+        "babel-eslint": "^10.0.3",
+        "mocha": "^7.0.1",
+        "standardx": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+        "shasum": "c9686902d3c9a27729f43ab10f9d79c2004da7b0",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 99671,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexUu2CRA9TVsSAnZWagAAEN8P/A+IUTjS9A4bNpsvqjSN\nRxOKNrFZ8anIzg2aIA4ormDE2BxqtdWOYwRk/v3XU7vFNTvq+xjwfK5bRNU5\ns/EyOqd94QYnv5VLRhaqDJ6lYfV29F45YJf7AHMdNb75gxtblLEwDFchtsqd\nxuKEdCXwWm/xuqoLuAwkaPABBSfkzmJ5RWQiZ2up+9mefQLdcumKPmRkV7VF\nm0dNHgH9X2sTNH3p+D7oj9/gHc0gvsSee1Pr6rTicvf9QGR4g5m4t7XOFsZM\nC6gIZtE81tP06WyJUglnNwqCHc/0WMc7FDvaVsKgP8DoK8WrDurpQBoJjhyl\np8hKdfe9rs+dAYz/GTy6wi2iTgjFnNR0kGfIfFV69JdUilbgTwaV91qHilU4\nK3k6i+mP7m3QEJEe39j/e0oxt0HVA/Nw5p4Q6T5HY6x3EmFNakEb4KHq4Pna\nD8bJVLF4liZc+AWxXoSF2OjqRcfBVO24zn6Iaqpq/ayKv+OLXd8cOh65cJtt\n9bsDp7FR64euikH+5DJPtkbM2ZiK40LmcTGhBG7intL8OCZRSi6uysU6k+6p\nj8KnX5vCncsCBuphIbopT2fm4vwNx79VdeIKU+LSiyF30U1OkMjd1UI1GFDj\nqzqGOjbRfZUnBrCc2yAuXeJWrIQL94qnEgppfkahKkSLV/IYIAktoNhIYT4R\n3d1k\r\n=t+IV\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.3": {
+      "name": "bn.js",
+      "version": "5.1.3",
+      "devDependencies": {
+        "babel-eslint": "^10.0.3",
+        "mocha": "^7.0.1",
+        "standardx": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
+        "shasum": "beca005408f642ebebea80b042b4d18d2ac0ee6b",
+        "tarball": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+        "fileCount": 4,
+        "unpackedSize": 99849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfNtI+CRA9TVsSAnZWagAAGGIP/REWDwd6Gz6PfLMPEYab\nvNfXOOhGrBtGuwOdqrsR7PJPzlqJmuxeSp8LVEgvIg+tuFSsgN8MG+9i/9V1\nZ2eXwKbMT8fK3JmVSeozHyPTE5LrXLv4vMFFdBikbo+wx3LrCs9ImEe7sHnQ\nqR/nI6r9Gw1Jtk1hWhIEt36QazxXluOl/YwgQmKBh6EWW8Lel0BxlQt0sZvt\nVeVI3Aw1JSplRZqmaaxuxivUOcj1/0u+c+YdknVRbEwKa2ZoggYraS/7rkP1\nLw86a0Mqsg/0+F1867kZSoaJqfaJZXVFCQzLaAGIJMDhgajzOdmmduL/93HU\nCoNbiL6PHhfkSio/K5eg3DHaRztStxZPJJ14coA0GyJUPksiOCYH7q+kJ37S\nbcRI3yxQStWB33v/u43F5k/rlnRLu37hBF/YqpCif0LM6fo9A+9pQLeINzH+\niahtEAXHiaPPR7z/QwWQzSBv7lnaQABdtKxzPPzUZ3Fnxnw7lnebAsZj3MTJ\nYYHZT2ZcWaDWkmSqGw/Q2KnbQirp6b5dl4iKG6VdN3RbCye2GsqLjsvj5HOH\n4+62KEW4UUdt6lTvc2dzgCBUt6wqpjpv6zWFgMdMftPkmlSaRSnBu8ynhtde\nM45dHTVhdNoAZqLAxBWuYXFePkiHBUEBsfg34qJkKpYP7EhTju9Fk6i4Rsi/\nMiud\r\n=pJG5\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-08-14T18:04:48.737Z"
+}

--- a/test/fixtures/registry-mocks/content/body-parser.json
+++ b/test/fixtures/registry-mocks/content/body-parser.json
@@ -1,0 +1,6501 @@
+{
+  "_id": "body-parser",
+  "_rev": "797-d40874abb51980e4f3423a73daed1335",
+  "name": "body-parser",
+  "description": "Node.js body parsing middleware",
+  "dist-tags": {
+    "latest": "1.19.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "body-parser",
+      "description": "Connect's body parsing middleware",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "dependencies": {
+        "raw-body": "~1.1.2",
+        "qs": "~0.6.6"
+      },
+      "devDependencies": {
+        "connect": "*",
+        "mocha": "*",
+        "should": "*",
+        "supertest": "*"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.0.0",
+      "dist": {
+        "shasum": "95c8a2861cd150dc195d50840ea4614149455e80",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "body-parser",
+      "description": "Connect's body parsing middleware",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "dependencies": {
+        "raw-body": "~1.1.2",
+        "qs": "~0.6.6"
+      },
+      "devDependencies": {
+        "connect": "*",
+        "mocha": "*",
+        "should": "*",
+        "supertest": "*"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.0.1",
+      "dist": {
+        "shasum": "08a2d025ea286f982d5107ea8a2ba953708620e3",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "body-parser",
+      "description": "Connect's body parsing middleware",
+      "version": "1.0.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "type-is": "~1.1.0",
+        "raw-body": "~1.1.2",
+        "qs": "~0.6.6"
+      },
+      "devDependencies": {
+        "connect": "*",
+        "mocha": "*",
+        "should": "*",
+        "supertest": "*"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.0.2",
+      "dist": {
+        "shasum": "3461479a3278fe00fcaebec3314bb54fc4f7b47c",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "body-parser",
+      "description": "Connect's body parsing middleware",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "type-is": "1.1.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.1.0",
+      "dist": {
+        "shasum": "e6a3c46063b329dab0eb7a31bdc1dca3b3185ab9",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "type-is": "1.1.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.1.1",
+      "dist": {
+        "shasum": "cf3cc10d885e91fc0ffa35a47ecad858238fb880",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.1.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "type-is": "1.1.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.1.2",
+      "dist": {
+        "shasum": "c943b64c4cd3c44dc96a4681b02cd54ff29e8cd7",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "type-is": "1.2.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.2.0",
+      "dist": {
+        "shasum": "f6247cc88d4c673c30a926d74fe36c177b9846e0",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.2.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "type-is": "1.2.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.2.1",
+      "_shasum": "917beee35a88e9f6893728bf1a542111d7d1eb28",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "917beee35a88e9f6893728bf1a542111d7d1eb28",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.2.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "qs": "0.6.6",
+        "raw-body": "1.1.6",
+        "type-is": "1.2.0"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.2.2",
+      "dist": {
+        "shasum": "6106373cc1d34d559ebcfdb582e4e37d4312acfb",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.3.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "qs": "0.6.6",
+        "raw-body": "1.1.6",
+        "type-is": "1.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.3.0",
+      "_shasum": "1a651cb9993a01a65531ae38395ceb0199dd7e3c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1a651cb9993a01a65531ae38395ceb0199dd7e3c",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.3.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "qs": "0.6.6",
+        "raw-body": "1.1.6",
+        "type-is": "1.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "gitHead": "6c0a1dc628d98bfa586a424f93a45f431e3c6641",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.3.1",
+      "_shasum": "1a74513fc7897d70db56589e0d03f0a13f1bfa94",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1a74513fc7897d70db56589e0d03f0a13f1bfa94",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.4.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.3.0",
+        "iconv-lite": "0.4.3",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.2.2",
+        "type-is": "1.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.4.0",
+      "dist": {
+        "shasum": "31274668441c2b00bab6ca50a173442d8bac1382",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.4.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.3.0",
+        "iconv-lite": "0.4.3",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.2.2",
+        "type-is": "1.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.4.1",
+      "dist": {
+        "shasum": "29146acc104a353e8cb07b7b3666d2d829bed6b0",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.4.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.3.0",
+        "iconv-lite": "0.4.3",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.2.2",
+        "type-is": "1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.4.2",
+      "dist": {
+        "shasum": "e748603c5f79eb06bd75434e219258986328aae7",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.3": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.4.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.3.0",
+        "iconv-lite": "0.4.3",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.2.2",
+        "type-is": "1.3.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.4.3",
+      "dist": {
+        "shasum": "4727952cff4af0773eefa4b226c2f4122f5e234d",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.5.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.2",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.5.0",
+      "dist": {
+        "shasum": "c6fce2483c9eeb49ab349ff25a92d336d91055b9",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.5.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.3",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.5.1",
+      "dist": {
+        "shasum": "8d2eb95e987d274ef02fcf56567b3f3a31749c51",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.5.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.5.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.5.2",
+      "dist": {
+        "shasum": "beebacac741b83f62c9137d5685196e1a44304ab",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.5.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.6.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.0.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0a96b14ae61fd579b23c8abd2e88f265dcd48098",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.6.0",
+      "_shasum": "d02a9d373c7349c281a8b76b41d6bbf60ef2d3f6",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d02a9d373c7349c281a8b76b41d6bbf60ef2d3f6",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.6.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.1.0",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ac01f78038549e16588ee24eec9e47891e9c5a09",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.6.1",
+      "_shasum": "3894580ab743e2c2611fec695bae60a883ea6f3b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3894580ab743e2c2611fec695bae60a883ea6f3b",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.6.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.2.0",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "2be2282144cf5c6aa7698186a764eedfe3a71ee9",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.6.2",
+      "_shasum": "38952b4fd534395ab3034e9bb40bbdf3dd99c4ce",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "38952b4fd534395ab3034e9bb40bbdf3dd99c4ce",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.3": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.6.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.2.1",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "bb7c924c6d700da0218188f9a3358f98804a9752",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.6.3",
+      "_shasum": "db3b270bd3ebce5da4d2d2021653454b24861a79",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "db3b270bd3ebce5da4d2d2021653454b24861a79",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.4": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.6.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "44abd9a37b89700469b6ecf550d81f34e5cdde99",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.6.4",
+      "_shasum": "befd799cc361a46d34e181f5f881f421a1f3b4c1",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "befd799cc361a46d34e181f5f881f421a1f3b4c1",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.5": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.6.5",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "1.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0d42013b30a6784a7e86dd387a2aa5d17b5b01cb",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.6.5",
+      "_shasum": "536f01e08ee2b6df6a941d6c8c9647ee99ee4de7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "536f01e08ee2b6df6a941d6c8c9647ee99ee4de7",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.6": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.6.6",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.0",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "a9cea305c30ca08e45492a9627ae9849ff28e6f2",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.6.6",
+      "_shasum": "abfead725f1983631ce94b8e3e9a297d1ab703fb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "abfead725f1983631ce94b8e3e9a297d1ab703fb",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.7": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.6.7",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "30a08ab015555171985e7a047ddfc21178f02e30",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.6.7",
+      "_shasum": "82306becadf44543e826b3907eae93f0237c4e5c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "82306becadf44543e826b3907eae93f0237c4e5c",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.7.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "9e3906d7fd3ac0d0d01d828774051ae28a64f17a",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.7.0",
+      "_shasum": "6a245ea5b32d8e1e0d43bec8344b264ba4b36541",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6a245ea5b32d8e1e0d43bec8344b264ba4b36541",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.8.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.3",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "17d73ae0ec6fc1f21f932849fa7103f37c67c718",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.8.0",
+      "_shasum": "20b3a3d3553a6835d7373456dd9da8720759b306",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "20b3a3d3553a6835d7373456dd9da8720759b306",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.8.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.3",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "df508da4f4c37ae6553638f95333b0ac1e8365cf",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.8.1",
+      "_shasum": "f9f96d221c435c95d18aeaad2bcdea1371902aad",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f9f96d221c435c95d18aeaad2bcdea1371902aad",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.8.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.5",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.3",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "caf6e06cf7b4e3d31717e75e31dc2efc873a1047",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.8.2",
+      "_shasum": "cb55519e748f2ac89bd3c8e34cb759d391c4d67d",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cb55519e748f2ac89bd3c8e34cb759d391c4d67d",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.3": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.8.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.5",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.4",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "b4131a69a898ec4238679bc8bad7aa5359a7ecc7",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.8.3",
+      "_shasum": "922b82e6448d654f2f5197574ceacefc04a6a8af",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "922b82e6448d654f2f5197574ceacefc04a6a8af",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.4": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.8.4",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.5",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.4",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "e12078f4b7cf2cf3925304b16c6fd66522f72c40",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.8.4",
+      "_shasum": "d497e04bc13b3f9a8bd8c70bb0cdc16f2e028898",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d497e04bc13b3f9a8bd8c70bb0cdc16f2e028898",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.9.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.4",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "263f602e6ae34add6332c1eb4caa808893b0b711",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.9.0",
+      "_shasum": "95d72943b1a4f67f56bbac9e0dcc837b68703605",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "95d72943b1a4f67f56bbac9e0dcc837b68703605",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.9.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.1.1",
+        "qs": "2.3.0",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ebabe092af34b6995d43662654d9de1f2bf2ab86",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.9.1",
+      "_shasum": "650a3047591fa9bb3cec191cb53933a468aa57aa",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "650a3047591fa9bb3cec191cb53933a468aa57aa",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.9.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.1.1",
+        "qs": "2.3.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "efb1e7d1749a743515ca0f191ee214e8c2902bac",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.9.2",
+      "_shasum": "07f52cf104939118bedcba689002017271ef3c0e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "07f52cf104939118bedcba689002017271ef3c0e",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.3": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.9.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.5",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.1.1",
+        "qs": "2.3.3",
+        "raw-body": "1.3.1",
+        "type-is": "~1.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "810c089057c004eeb1f54d638bdb8a15acc09d06",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.9.3",
+      "_shasum": "edfacd4fcfad87dfe74f861a5cc712900aef2623",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "edfacd4fcfad87dfe74f861a5cc712900aef2623",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.10.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.5",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.1.1",
+        "qs": "2.3.3",
+        "raw-body": "1.3.1",
+        "type-is": "~1.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "methods": "~1.1.0",
+        "mocha": "~2.0.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "bdee22aed4f516580c791b1fb1112f6cbc6bcffb",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.10.0",
+      "_shasum": "f884d11839af09e3c61e5011059e29cbfe452085",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f884d11839af09e3c61e5011059e29cbfe452085",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.10.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.5",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.1",
+        "type-is": "~1.5.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "methods": "~1.1.1",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "2dae9e45447108c7280538878c3f59c656f30bd9",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.10.1",
+      "_shasum": "af0c7156b128d946f3c43f5fe0364da00cfa7391",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "af0c7156b128d946f3c43f5fe0364da00cfa7391",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.10.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.6",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.2",
+        "type-is": "~1.5.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "methods": "~1.1.1",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "1fbb94d61e3435865db6092e7f6685436aecb858",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.10.2",
+      "_shasum": "405d465fcd3ccf0ea8a35adbf1055f6e98316bd1",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "405d465fcd3ccf0ea8a35adbf1055f6e98316bd1",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.11.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.11.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.6",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.2",
+        "type-is": "~1.5.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "methods": "~1.1.1",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "bc783dd7aade9a40ba3cd1ec4c65439b8e99d66e",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.11.0",
+      "_shasum": "29f876cb608efa54e9b2185fe8105efc9219a7f3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "29f876cb608efa54e9b2185fe8105efc9219a7f3",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.11.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.12.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.12.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.7",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.3",
+        "type-is": "~1.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "methods": "~1.1.1",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "9ec4d920fc0fbfc8351ff528d19b24d80612e3e0",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.12.0",
+      "_shasum": "9750fc3cc1080b34a13d18c79840cd559979fce5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9750fc3cc1080b34a13d18c79840cd559979fce5",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.12.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.12.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.7",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.3",
+        "type-is": "~1.6.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.8",
+        "methods": "~1.1.1",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "b500848a82da89c0810859c2b86a4bd33a7a9983",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.12.1",
+      "_shasum": "4b9b4c67e8eb5ccac7c9eef3fbd6694e721ae002",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4b9b4c67e8eb5ccac7c9eef3fbd6694e721ae002",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.12.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.12.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.7",
+        "on-finished": "~2.2.0",
+        "qs": "2.4.1",
+        "raw-body": "1.3.3",
+        "type-is": "~1.6.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.8",
+        "methods": "~1.1.1",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ec92683bbb469f63da8b584c37e7708ed76b09e2",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.12.2",
+      "_shasum": "698368fb4dfc57a05bff1ddb1bebeba3bd2c0e87",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "698368fb4dfc57a05bff1ddb1bebeba3bd2c0e87",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.12.3": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.12.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.1.3",
+        "depd": "~1.0.1",
+        "iconv-lite": "0.4.8",
+        "on-finished": "~2.2.0",
+        "qs": "2.4.1",
+        "raw-body": "1.3.4",
+        "type-is": "~1.6.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "methods": "~1.1.1",
+        "mocha": "~2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "5addd8e18e0a72795f9ab93e867d3e50f3429910",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.12.3",
+      "_shasum": "5f40bf17e7823be6895d4d35582752e36cf97f71",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5f40bf17e7823be6895d4d35582752e36cf97f71",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.12.4": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.12.4",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "iconv-lite": "0.4.8",
+        "on-finished": "~2.2.1",
+        "qs": "2.4.2",
+        "raw-body": "~2.0.1",
+        "type-is": "~1.6.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "methods": "~1.1.1",
+        "mocha": "~2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "faba6ae19686d82133e188707b9b77649f45d3b0",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.12.4",
+      "_shasum": "090700c4ba28862a8520ef378395fdee5f61c229",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "090700c4ba28862a8520ef378395fdee5f61c229",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.13.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.13.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.10",
+        "on-finished": "~2.3.0",
+        "qs": "3.1.0",
+        "raw-body": "~2.1.1",
+        "type-is": "~1.6.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "aa8617b3893300ad52cb19d279ef62ccc99c1394",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.13.0",
+      "_shasum": "b6dca73da8c4a9f68b0e64d29acac39dd3ad9a9e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b6dca73da8c4a9f68b0e64d29acac39dd3ad9a9e",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.13.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.13.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.10",
+        "on-finished": "~2.3.0",
+        "qs": "2.4.2",
+        "raw-body": "~2.1.1",
+        "type-is": "~1.6.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "bf6c1465fe9e36e04668d8129c0fbb8a9b375060",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.13.1",
+      "_shasum": "f07218bc2c4b5e36ca261557c9465481b29ecdcd",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f07218bc2c4b5e36ca261557c9465481b29ecdcd",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.13.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.13.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.11",
+        "on-finished": "~2.3.0",
+        "qs": "4.0.0",
+        "raw-body": "~2.1.2",
+        "type-is": "~1.6.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "b31df3e7550c6fadef6823a020f527ab73bfec33",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.13.2",
+      "_shasum": "229262a4fd2e402dfb88d99bc27d8be31307e7e9",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "229262a4fd2e402dfb88d99bc27d8be31307e7e9",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.13.3": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.13.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.11",
+        "on-finished": "~2.3.0",
+        "qs": "4.0.0",
+        "raw-body": "~2.1.2",
+        "type-is": "~1.6.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "79d0972bd18247071326105bfb36539830b61b76",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.13.3",
+      "_shasum": "c08cf330c3358e151016a05746f13f029c97fa97",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c08cf330c3358e151016a05746f13f029c97fa97",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.14.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.14.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.11",
+        "on-finished": "~2.3.0",
+        "qs": "5.1.0",
+        "raw-body": "~2.1.3",
+        "type-is": "~1.6.8"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "a438bed510877e36724b1716bd6f55a15a1155d2",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.14.0",
+      "_shasum": "a7a10138547a75bfcacc20472404630c2fa6b0ff",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a7a10138547a75bfcacc20472404630c2fa6b0ff",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.14.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.14.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.12",
+        "on-finished": "~2.3.0",
+        "qs": "5.1.0",
+        "raw-body": "~2.1.4",
+        "type-is": "~1.6.9"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "7847af6e5a36129eea0e0becfbcc521b839313ae",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.14.1",
+      "_shasum": "ffe921eba3ce8f191e2a8a8803844bd025f3c6dc",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ffe921eba3ce8f191e2a8a8803844bd025f3c6dc",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.14.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.14.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "2.2.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.13",
+        "on-finished": "~2.3.0",
+        "qs": "5.2.0",
+        "raw-body": "~2.1.5",
+        "type-is": "~1.6.10"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "methods": "~1.1.1",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ef5d85d8344f08b21f70a7d90082e7eea3ccdf99",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.14.2",
+      "_shasum": "1015cb1fe2c443858259581db53332f8d0cf50f9",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1015cb1fe2c443858259581db53332f8d0cf50f9",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.15.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.15.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/body-parser"
+      },
+      "dependencies": {
+        "bytes": "2.2.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.4.0",
+        "iconv-lite": "0.4.13",
+        "on-finished": "~2.3.0",
+        "qs": "6.1.0",
+        "raw-body": "~2.1.5",
+        "type-is": "~1.6.11"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "methods": "1.1.2",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "5b4fabe344e5b3df9e9157c7e9b9e6f5706b1cec",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser",
+      "_id": "body-parser@1.15.0",
+      "_shasum": "8168abaeaf9e77e300f7b3aef4df4b46e9b21b35",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8168abaeaf9e77e300f7b3aef4df4b46e9b21b35",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/body-parser-1.15.0.tgz_1455156407766_0.14806043729186058"
+      },
+      "directories": {}
+    },
+    "1.15.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.15.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "2.3.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.4.0",
+        "iconv-lite": "0.4.13",
+        "on-finished": "~2.3.0",
+        "qs": "6.1.0",
+        "raw-body": "~2.1.6",
+        "type-is": "~1.6.12"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "methods": "1.1.2",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "e701380ab9b862bbf2223e4df4835a15e4e1ff66",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.15.1",
+      "_shasum": "9bceef0669b8f8b943f0ad8ce5d95716bd740fd2",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "9bceef0669b8f8b943f0ad8ce5d95716bd740fd2",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/body-parser-1.15.1.tgz_1462512908287_0.2557021768298"
+      },
+      "directories": {}
+    },
+    "1.15.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.15.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.5.0",
+        "iconv-lite": "0.4.13",
+        "on-finished": "~2.3.0",
+        "qs": "6.2.0",
+        "raw-body": "~2.1.7",
+        "type-is": "~1.6.13"
+      },
+      "devDependencies": {
+        "eslint": "2.13.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "3c8218446d919a5e87fa696971fb7f69b10afc1c",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.15.2",
+      "_shasum": "d7578cf4f1d11d5f6ea804cef35dc7a7ff6dae67",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d7578cf4f1d11d5f6ea804cef35dc7a7ff6dae67",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/body-parser-1.15.2.tgz_1466393694089_0.7908455491997302"
+      },
+      "directories": {}
+    },
+    "1.16.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.16.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.5.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.2.1",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.14"
+      },
+      "devDependencies": {
+        "eslint": "3.13.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "c5a73d51483310f8443043d3927c2557993f3416",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.16.0",
+      "_shasum": "924a5e472c6229fb9d69b85a20d5f2532dec788b",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "924a5e472c6229fb9d69b85a20d5f2532dec788b",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/body-parser-1.16.0.tgz_1484710891328_0.08588228072039783"
+      },
+      "directories": {}
+    },
+    "1.16.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.16.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "http-errors": "~1.5.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.2.1",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.14"
+      },
+      "devDependencies": {
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "7b630f701d084267a8b9883b27f627014e003d47",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.16.1",
+      "_shasum": "51540d045adfa7a0c6995a014bb6b1ed9b802329",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "51540d045adfa7a0c6995a014bb6b1ed9b802329",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/body-parser-1.16.1.tgz_1486777002177_0.4995518890209496"
+      },
+      "directories": {}
+    },
+    "1.17.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.17.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "http-errors": "~1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.3.1",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.14"
+      },
+      "devDependencies": {
+        "eslint": "3.16.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "79bc93911501b0d048dea39a13ab7384b2cb43f1",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.17.0",
+      "_shasum": "d956ae2d756ae10bb784187725ea5a249430febd",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d956ae2d756ae10bb784187725ea5a249430febd",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/body-parser-1.17.0.tgz_1488406215099_0.9978320009540766"
+      },
+      "directories": {}
+    },
+    "1.17.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.17.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "http-errors": "~1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.14"
+      },
+      "devDependencies": {
+        "eslint": "3.17.0",
+        "eslint-config-standard": "7.0.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0f1bed0543d34c8de07385157b8183509d1100aa",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.17.1",
+      "_shasum": "75b3bc98ddd6e7e0d8ffe750dfaca5c66993fa47",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "75b3bc98ddd6e7e0d8ffe750dfaca5c66993fa47",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/body-parser-1.17.1.tgz_1488807088817_0.47385501372627914"
+      },
+      "directories": {}
+    },
+    "1.17.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.17.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.7",
+        "depd": "~1.1.0",
+        "http-errors": "~1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.0.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "77b74312edb46b2e8d8df0c8436aaba396a721e9",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.17.2",
+      "_shasum": "f8892abc8f9e627d42aedafbca66bf5ab99104ee",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "f8892abc8f9e627d42aedafbca66bf5ab99104ee",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/body-parser-1.17.2.tgz_1495083464528_0.912320519099012"
+      },
+      "directories": {}
+    },
+    "1.18.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.18.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.18",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.0",
+        "raw-body": "2.3.1",
+        "type-is": "~1.6.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "adfa01c1c58102292e353fe4ee7558a4581fb539",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.18.0",
+      "_shasum": "d3b224d467fa2ce8d43589c0245043267c093634",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d3b224d467fa2ce8d43589c0245043267c093634",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/body-parser-1.18.0.tgz_1504930645505_0.6018156714271754"
+      },
+      "directories": {}
+    },
+    "1.18.1": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.18.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d041563376670707cc693968995ff731adefe4cf",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.18.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-KL2pZpGvy6xuZHgYUznB1Zfw4AoGMApfRanT5NafeLvglbaSM+4CCtmlyYOv66oYXqvKL1xpaFb94V/AZVUnYg==",
+        "shasum": "9c1629370bcfd42917f30641a2dcbe2ec50d4c26",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/body-parser-1.18.1.tgz_1505230250261_0.44409058685414493"
+      },
+      "directories": {}
+    },
+    "1.18.2": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.18.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "b2659a7af3b413a2d1df274bef409fe6cdcf6b8f",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.18.2",
+      "_shasum": "87678a19d84b47d859b83199bd59bce222b10454",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "87678a19d84b47d859b83199bd59bce222b10454",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/body-parser-1.18.2.tgz_1506099009907_0.5088193896226585"
+      },
+      "directories": {}
+    },
+    "1.18.3": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.18.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      },
+      "devDependencies": {
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.11.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.7.0",
+        "eslint-plugin-standard": "3.1.0",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.1.2",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "lib/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "e6ccf98015fece0851c0c673fc2776c30ad79e5d",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.18.3",
+      "_shasum": "5b292198ffdd553b3a0f20ded0592b956955c8b4",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.14.2",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "5b292198ffdd553b3a0f20ded0592b956955c8b4",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+        "fileCount": 10,
+        "unpackedSize": 55897,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa+cRxCRA9TVsSAnZWagAAr+wP/jRF3kZaSUPcjTUOxoqN\nlSEgHs4ISF5j2kqTPeArKhG5cgmvygc9gRtNdjtfLGHbQAjyZtA8tzBdsXZG\n3KuehVC9hf/eUIeQbVTjaxrgX0jevrF4igcmM4tRI17JzFvq1+oCz9aAk99e\n3SljKbwvFPopbM5F5BraVbOpIYCO140dVVBrV9gHOBb+65hme0PzfBdru/Bg\nZ1UnDi9l/lEGhCy+HFlSGw+T9ev0KcgzcslA/9vJBAFyYMXVfFFI+jY2+O4P\nJ35s40gbQ1V/idGM4IfmCg5IhwmvpJ902bpXJEokVgGKcw/mMv3TQpBKov2I\nOxAIIRLr2w/1Kl2d8+jMLcbkIoSD7wutdV5i+rsUR5XJURbsDuitYJbcRvJw\n5MS0bQ5aVI83TOr/35z8671ciWqpM+Ru+7eiMjQzgUOWt2qKuOB0Bi/xhr8J\nXGWbqLwl1PWxJXgGJqAJ7rvXNOmAexqJmyk1mPHDJnpjaFRKnCpDrUbuX4Cm\nw52bjMIW+wYC/zKnUMCJ+5n4gBw0jWzFUsoTCses91YZHMDVNb1tOo2Sjbwp\nxLKIWDuNDQC3lxfuCSxC7Qe3PayQGnOCwoP3o6GM89YFAhFOWgPvgBpvjfWm\niJlgG/dUsGIAY3Gz0i7abBGyeJJAuA+CwFpfERMcEE4HwcJhzOrG7g0prSD9\n3nNl\r\n=47oB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/body-parser_1.18.3_1526318192390_0.5591283803389704"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.19.0": {
+      "name": "body-parser",
+      "description": "Node.js body parsing middleware",
+      "version": "1.19.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/body-parser.git"
+      },
+      "dependencies": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "6.1.4",
+        "safe-buffer": "5.1.2",
+        "supertest": "4.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/"
+      },
+      "gitHead": "998b265db57a80ae75ea51c55f6a191e2d168a60",
+      "bugs": {
+        "url": "https://github.com/expressjs/body-parser/issues"
+      },
+      "homepage": "https://github.com/expressjs/body-parser#readme",
+      "_id": "body-parser@1.19.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+        "shasum": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 56375,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwnuMCRA9TVsSAnZWagAA2zMP/3i2Q8pQBJx4azFOeuub\n/s3F445wJrDoAKA+6zSOLFMYYasZ0iF60NoE4taDupDF1hzpC4gCYgy9ZezQ\n75kKKBC48jCQP6Urx1tj6VUPzWqG6xdQMjhZpXrkK+EF5XYtAspb8+YSxaw4\nzf4atEm+7Q3N1qwvyfi8T/KQaK7WV6wC513pXTZv8SCtetX/4jBJwA4uUqLh\nXbuO5GcsjNEDmfX91YFKbb2+TvL2kuJkxVVdjeVv+UDLAs8AL+6afVJTe2vB\nmY+9CmSN2egWYDEXgpIowRTXzvasLJ8kQQH0dhseRrnF/k8cxX61VsT0MYEB\nd7mVyXFJE2WrN/HgiVCa9XSzLNn2bp/tyoz3W8TTSCqWOaY2cgbpFBUcBqWY\nmZSkqGqBj0lAJ3qMJw9tfIKiGtLEqsBwRoHTt6yQRsPTTD0wY3WzQTzedpS7\nPKEPDqrqMhDJpjv7vHZyP0E85lSYoDAMYPQ33fYvNbiuIMU4eDxoNJWUImXJ\nTN3uRKDn9QeE8mLTeglLVIu5+4FrDQNNjK6HHcetM89H8F4FGxGl090/H07x\nqc9A2Fe2yCeM6BICsO3BIRt0eClHS6jD15tMDbx9hx4Z4Qt+IgTn0NS4Ebj7\nW1V7qu/d6ajepEVd2kCXQkvJvslxzIGDxXo6OvTN757kROAWoYZNyGefqnou\nHXEH\r\n=IvFh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/body-parser_1.19.0_1556249483843_0.8465662994525756"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# body-parser\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nNode.js body parsing middleware.\n\nParse incoming request bodies in a middleware before your handlers, available\nunder the `req.body` property.\n\n**Note** As `req.body`'s shape is based on user-controlled input, all\nproperties and values in this object are untrusted and should be validated\nbefore trusting. For example, `req.body.foo.toString()` may fail in multiple\nways, for example the `foo` property may not be there or may not be a string,\nand `toString` may not be a function and instead a string or other user input.\n\n[Learn about the anatomy of an HTTP transaction in Node.js](https://nodejs.org/en/docs/guides/anatomy-of-an-http-transaction/).\n\n_This does not handle multipart bodies_, due to their complex and typically\nlarge nature. For multipart bodies, you may be interested in the following\nmodules:\n\n  * [busboy](https://www.npmjs.org/package/busboy#readme) and\n    [connect-busboy](https://www.npmjs.org/package/connect-busboy#readme)\n  * [multiparty](https://www.npmjs.org/package/multiparty#readme) and\n    [connect-multiparty](https://www.npmjs.org/package/connect-multiparty#readme)\n  * [formidable](https://www.npmjs.org/package/formidable#readme)\n  * [multer](https://www.npmjs.org/package/multer#readme)\n\nThis module provides the following parsers:\n\n  * [JSON body parser](#bodyparserjsonoptions)\n  * [Raw body parser](#bodyparserrawoptions)\n  * [Text body parser](#bodyparsertextoptions)\n  * [URL-encoded form body parser](#bodyparserurlencodedoptions)\n\nOther body parsers you might be interested in:\n\n- [body](https://www.npmjs.org/package/body#readme)\n- [co-body](https://www.npmjs.org/package/co-body#readme)\n\n## Installation\n\n```sh\n$ npm install body-parser\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar bodyParser = require('body-parser')\n```\n\nThe `bodyParser` object exposes various factories to create middlewares. All\nmiddlewares will populate the `req.body` property with the parsed body when\nthe `Content-Type` request header matches the `type` option, or an empty\nobject (`{}`) if there was no body to parse, the `Content-Type` was not matched,\nor an error occurred.\n\nThe various errors returned by this module are described in the\n[errors section](#errors).\n\n### bodyParser.json([options])\n\nReturns middleware that only parses `json` and only looks at requests where\nthe `Content-Type` header matches the `type` option. This parser accepts any\nUnicode encoding of the body and supports automatic inflation of `gzip` and\n`deflate` encodings.\n\nA new `body` object containing the parsed data is populated on the `request`\nobject after the middleware (i.e. `req.body`).\n\n#### Options\n\nThe `json` function takes an optional `options` object that may contain any of\nthe following keys:\n\n##### inflate\n\nWhen set to `true`, then deflated (compressed) bodies will be inflated; when\n`false`, deflated bodies are rejected. Defaults to `true`.\n\n##### limit\n\nControls the maximum request body size. If this is a number, then the value\nspecifies the number of bytes; if it is a string, the value is passed to the\n[bytes](https://www.npmjs.com/package/bytes) library for parsing. Defaults\nto `'100kb'`.\n\n##### reviver\n\nThe `reviver` option is passed directly to `JSON.parse` as the second\nargument. You can find more information on this argument\n[in the MDN documentation about JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter).\n\n##### strict\n\nWhen set to `true`, will only accept arrays and objects; when `false` will\naccept anything `JSON.parse` accepts. Defaults to `true`.\n\n##### type\n\nThe `type` option is used to determine what media type the middleware will\nparse. This option can be a string, array of strings, or a function. If not a\nfunction, `type` option is passed directly to the\n[type-is](https://www.npmjs.org/package/type-is#readme) library and this can\nbe an extension name (like `json`), a mime type (like `application/json`), or\na mime type with a wildcard (like `*/*` or `*/json`). If a function, the `type`\noption is called as `fn(req)` and the request is parsed if it returns a truthy\nvalue. Defaults to `application/json`.\n\n##### verify\n\nThe `verify` option, if supplied, is called as `verify(req, res, buf, encoding)`,\nwhere `buf` is a `Buffer` of the raw request body and `encoding` is the\nencoding of the request. The parsing can be aborted by throwing an error.\n\n### bodyParser.raw([options])\n\nReturns middleware that parses all bodies as a `Buffer` and only looks at\nrequests where the `Content-Type` header matches the `type` option. This\nparser supports automatic inflation of `gzip` and `deflate` encodings.\n\nA new `body` object containing the parsed data is populated on the `request`\nobject after the middleware (i.e. `req.body`). This will be a `Buffer` object\nof the body.\n\n#### Options\n\nThe `raw` function takes an optional `options` object that may contain any of\nthe following keys:\n\n##### inflate\n\nWhen set to `true`, then deflated (compressed) bodies will be inflated; when\n`false`, deflated bodies are rejected. Defaults to `true`.\n\n##### limit\n\nControls the maximum request body size. If this is a number, then the value\nspecifies the number of bytes; if it is a string, the value is passed to the\n[bytes](https://www.npmjs.com/package/bytes) library for parsing. Defaults\nto `'100kb'`.\n\n##### type\n\nThe `type` option is used to determine what media type the middleware will\nparse. This option can be a string, array of strings, or a function.\nIf not a function, `type` option is passed directly to the\n[type-is](https://www.npmjs.org/package/type-is#readme) library and this\ncan be an extension name (like `bin`), a mime type (like\n`application/octet-stream`), or a mime type with a wildcard (like `*/*` or\n`application/*`). If a function, the `type` option is called as `fn(req)`\nand the request is parsed if it returns a truthy value. Defaults to\n`application/octet-stream`.\n\n##### verify\n\nThe `verify` option, if supplied, is called as `verify(req, res, buf, encoding)`,\nwhere `buf` is a `Buffer` of the raw request body and `encoding` is the\nencoding of the request. The parsing can be aborted by throwing an error.\n\n### bodyParser.text([options])\n\nReturns middleware that parses all bodies as a string and only looks at\nrequests where the `Content-Type` header matches the `type` option. This\nparser supports automatic inflation of `gzip` and `deflate` encodings.\n\nA new `body` string containing the parsed data is populated on the `request`\nobject after the middleware (i.e. `req.body`). This will be a string of the\nbody.\n\n#### Options\n\nThe `text` function takes an optional `options` object that may contain any of\nthe following keys:\n\n##### defaultCharset\n\nSpecify the default character set for the text content if the charset is not\nspecified in the `Content-Type` header of the request. Defaults to `utf-8`.\n\n##### inflate\n\nWhen set to `true`, then deflated (compressed) bodies will be inflated; when\n`false`, deflated bodies are rejected. Defaults to `true`.\n\n##### limit\n\nControls the maximum request body size. If this is a number, then the value\nspecifies the number of bytes; if it is a string, the value is passed to the\n[bytes](https://www.npmjs.com/package/bytes) library for parsing. Defaults\nto `'100kb'`.\n\n##### type\n\nThe `type` option is used to determine what media type the middleware will\nparse. This option can be a string, array of strings, or a function. If not\na function, `type` option is passed directly to the\n[type-is](https://www.npmjs.org/package/type-is#readme) library and this can\nbe an extension name (like `txt`), a mime type (like `text/plain`), or a mime\ntype with a wildcard (like `*/*` or `text/*`). If a function, the `type`\noption is called as `fn(req)` and the request is parsed if it returns a\ntruthy value. Defaults to `text/plain`.\n\n##### verify\n\nThe `verify` option, if supplied, is called as `verify(req, res, buf, encoding)`,\nwhere `buf` is a `Buffer` of the raw request body and `encoding` is the\nencoding of the request. The parsing can be aborted by throwing an error.\n\n### bodyParser.urlencoded([options])\n\nReturns middleware that only parses `urlencoded` bodies and only looks at\nrequests where the `Content-Type` header matches the `type` option. This\nparser accepts only UTF-8 encoding of the body and supports automatic\ninflation of `gzip` and `deflate` encodings.\n\nA new `body` object containing the parsed data is populated on the `request`\nobject after the middleware (i.e. `req.body`). This object will contain\nkey-value pairs, where the value can be a string or array (when `extended` is\n`false`), or any type (when `extended` is `true`).\n\n#### Options\n\nThe `urlencoded` function takes an optional `options` object that may contain\nany of the following keys:\n\n##### extended\n\nThe `extended` option allows to choose between parsing the URL-encoded data\nwith the `querystring` library (when `false`) or the `qs` library (when\n`true`). The \"extended\" syntax allows for rich objects and arrays to be\nencoded into the URL-encoded format, allowing for a JSON-like experience\nwith URL-encoded. For more information, please\n[see the qs library](https://www.npmjs.org/package/qs#readme).\n\nDefaults to `true`, but using the default has been deprecated. Please\nresearch into the difference between `qs` and `querystring` and choose the\nappropriate setting.\n\n##### inflate\n\nWhen set to `true`, then deflated (compressed) bodies will be inflated; when\n`false`, deflated bodies are rejected. Defaults to `true`.\n\n##### limit\n\nControls the maximum request body size. If this is a number, then the value\nspecifies the number of bytes; if it is a string, the value is passed to the\n[bytes](https://www.npmjs.com/package/bytes) library for parsing. Defaults\nto `'100kb'`.\n\n##### parameterLimit\n\nThe `parameterLimit` option controls the maximum number of parameters that\nare allowed in the URL-encoded data. If a request contains more parameters\nthan this value, a 413 will be returned to the client. Defaults to `1000`.\n\n##### type\n\nThe `type` option is used to determine what media type the middleware will\nparse. This option can be a string, array of strings, or a function. If not\na function, `type` option is passed directly to the\n[type-is](https://www.npmjs.org/package/type-is#readme) library and this can\nbe an extension name (like `urlencoded`), a mime type (like\n`application/x-www-form-urlencoded`), or a mime type with a wildcard (like\n`*/x-www-form-urlencoded`). If a function, the `type` option is called as\n`fn(req)` and the request is parsed if it returns a truthy value. Defaults\nto `application/x-www-form-urlencoded`.\n\n##### verify\n\nThe `verify` option, if supplied, is called as `verify(req, res, buf, encoding)`,\nwhere `buf` is a `Buffer` of the raw request body and `encoding` is the\nencoding of the request. The parsing can be aborted by throwing an error.\n\n## Errors\n\nThe middlewares provided by this module create errors depending on the error\ncondition during parsing. The errors will typically have a `status`/`statusCode`\nproperty that contains the suggested HTTP response code, an `expose` property\nto determine if the `message` property should be displayed to the client, a\n`type` property to determine the type of error without matching against the\n`message`, and a `body` property containing the read body, if available.\n\nThe following are the common errors emitted, though any error can come through\nfor various reasons.\n\n### content encoding unsupported\n\nThis error will occur when the request had a `Content-Encoding` header that\ncontained an encoding but the \"inflation\" option was set to `false`. The\n`status` property is set to `415`, the `type` property is set to\n`'encoding.unsupported'`, and the `charset` property will be set to the\nencoding that is unsupported.\n\n### request aborted\n\nThis error will occur when the request is aborted by the client before reading\nthe body has finished. The `received` property will be set to the number of\nbytes received before the request was aborted and the `expected` property is\nset to the number of expected bytes. The `status` property is set to `400`\nand `type` property is set to `'request.aborted'`.\n\n### request entity too large\n\nThis error will occur when the request body's size is larger than the \"limit\"\noption. The `limit` property will be set to the byte limit and the `length`\nproperty will be set to the request body's length. The `status` property is\nset to `413` and the `type` property is set to `'entity.too.large'`.\n\n### request size did not match content length\n\nThis error will occur when the request's length did not match the length from\nthe `Content-Length` header. This typically occurs when the request is malformed,\ntypically when the `Content-Length` header was calculated based on characters\ninstead of bytes. The `status` property is set to `400` and the `type` property\nis set to `'request.size.invalid'`.\n\n### stream encoding should not be set\n\nThis error will occur when something called the `req.setEncoding` method prior\nto this middleware. This module operates directly on bytes only and you cannot\ncall `req.setEncoding` when using this module. The `status` property is set to\n`500` and the `type` property is set to `'stream.encoding.set'`.\n\n### too many parameters\n\nThis error will occur when the content of the request exceeds the configured\n`parameterLimit` for the `urlencoded` parser. The `status` property is set to\n`413` and the `type` property is set to `'parameters.too.many'`.\n\n### unsupported charset \"BOGUS\"\n\nThis error will occur when the request had a charset parameter in the\n`Content-Type` header, but the `iconv-lite` module does not support it OR the\nparser does not support it. The charset is contained in the message as well\nas in the `charset` property. The `status` property is set to `415`, the\n`type` property is set to `'charset.unsupported'`, and the `charset` property\nis set to the charset that is unsupported.\n\n### unsupported content encoding \"bogus\"\n\nThis error will occur when the request had a `Content-Encoding` header that\ncontained an unsupported encoding. The encoding is contained in the message\nas well as in the `encoding` property. The `status` property is set to `415`,\nthe `type` property is set to `'encoding.unsupported'`, and the `encoding`\nproperty is set to the encoding that is unsupported.\n\n## Examples\n\n### Express/Connect top-level generic\n\nThis example demonstrates adding a generic JSON and URL-encoded parser as a\ntop-level middleware, which will parse the bodies of all incoming requests.\nThis is the simplest setup.\n\n```js\nvar express = require('express')\nvar bodyParser = require('body-parser')\n\nvar app = express()\n\n// parse application/x-www-form-urlencoded\napp.use(bodyParser.urlencoded({ extended: false }))\n\n// parse application/json\napp.use(bodyParser.json())\n\napp.use(function (req, res) {\n  res.setHeader('Content-Type', 'text/plain')\n  res.write('you posted:\\n')\n  res.end(JSON.stringify(req.body, null, 2))\n})\n```\n\n### Express route-specific\n\nThis example demonstrates adding body parsers specifically to the routes that\nneed them. In general, this is the most recommended way to use body-parser with\nExpress.\n\n```js\nvar express = require('express')\nvar bodyParser = require('body-parser')\n\nvar app = express()\n\n// create application/json parser\nvar jsonParser = bodyParser.json()\n\n// create application/x-www-form-urlencoded parser\nvar urlencodedParser = bodyParser.urlencoded({ extended: false })\n\n// POST /login gets urlencoded bodies\napp.post('/login', urlencodedParser, function (req, res) {\n  res.send('welcome, ' + req.body.username)\n})\n\n// POST /api/users gets JSON bodies\napp.post('/api/users', jsonParser, function (req, res) {\n  // create user in req.body\n})\n```\n\n### Change accepted type for parsers\n\nAll the parsers accept a `type` option which allows you to change the\n`Content-Type` that the middleware will parse.\n\n```js\nvar express = require('express')\nvar bodyParser = require('body-parser')\n\nvar app = express()\n\n// parse various different custom JSON types as JSON\napp.use(bodyParser.json({ type: 'application/*+json' }))\n\n// parse some custom thing into a Buffer\napp.use(bodyParser.raw({ type: 'application/vnd.custom-type' }))\n\n// parse an HTML body into a string\napp.use(bodyParser.text({ type: 'text/html' }))\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/body-parser.svg\n[npm-url]: https://npmjs.org/package/body-parser\n[travis-image]: https://img.shields.io/travis/expressjs/body-parser/master.svg\n[travis-url]: https://travis-ci.org/expressjs/body-parser\n[coveralls-image]: https://img.shields.io/coveralls/expressjs/body-parser/master.svg\n[coveralls-url]: https://coveralls.io/r/expressjs/body-parser?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/body-parser.svg\n[downloads-url]: https://npmjs.org/package/body-parser\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-11-29T09:32:43.816Z",
+    "created": "2014-01-06T08:25:15.060Z",
+    "1.0.0": "2014-01-06T08:25:15.060Z",
+    "1.0.1": "2014-03-20T22:25:27.731Z",
+    "1.0.2": "2014-04-14T23:26:30.844Z",
+    "1.1.0": "2014-05-11T01:46:04.793Z",
+    "1.1.1": "2014-05-11T04:24:04.602Z",
+    "1.1.2": "2014-05-11T17:45:44.773Z",
+    "1.2.0": "2014-05-12T03:54:56.041Z",
+    "1.2.1": "2014-05-27T04:07:41.457Z",
+    "1.2.2": "2014-05-27T16:25:38.834Z",
+    "1.3.0": "2014-05-31T22:56:36.899Z",
+    "1.3.1": "2014-06-12T03:08:52.518Z",
+    "1.4.0": "2014-06-19T21:52:05.878Z",
+    "1.4.1": "2014-06-19T22:35:08.600Z",
+    "1.4.2": "2014-06-20T02:10:50.530Z",
+    "1.4.3": "2014-06-20T03:13:32.310Z",
+    "1.5.0": "2014-07-21T02:01:17.715Z",
+    "1.5.1": "2014-07-26T20:42:25.306Z",
+    "1.5.2": "2014-07-27T19:20:54.802Z",
+    "1.6.0": "2014-08-06T03:32:28.565Z",
+    "1.6.1": "2014-08-06T21:57:16.941Z",
+    "1.6.2": "2014-08-07T14:33:30.042Z",
+    "1.6.3": "2014-08-11T01:27:18.704Z",
+    "1.6.4": "2014-08-15T02:58:30.772Z",
+    "1.6.5": "2014-08-17T03:44:13.585Z",
+    "1.6.6": "2014-08-27T18:18:13.747Z",
+    "1.6.7": "2014-08-30T04:58:59.287Z",
+    "1.7.0": "2014-09-02T02:43:05.238Z",
+    "1.8.0": "2014-09-06T02:33:55.121Z",
+    "1.8.1": "2014-09-08T06:41:37.882Z",
+    "1.8.2": "2014-09-16T06:23:04.092Z",
+    "1.8.3": "2014-09-20T05:30:50.329Z",
+    "1.8.4": "2014-09-24T05:16:03.920Z",
+    "1.9.0": "2014-09-24T17:35:07.468Z",
+    "1.9.1": "2014-10-23T03:51:35.787Z",
+    "1.9.2": "2014-10-28T04:05:47.581Z",
+    "1.9.3": "2014-11-22T04:24:38.976Z",
+    "1.10.0": "2014-12-03T05:39:28.947Z",
+    "1.10.1": "2015-01-02T02:44:06.199Z",
+    "1.10.2": "2015-01-21T06:37:52.188Z",
+    "1.11.0": "2015-01-31T05:36:16.137Z",
+    "1.12.0": "2015-02-14T04:51:30.494Z",
+    "1.12.1": "2015-03-16T05:41:57.037Z",
+    "1.12.2": "2015-03-17T03:36:57.043Z",
+    "1.12.3": "2015-04-16T03:56:11.396Z",
+    "1.12.4": "2015-05-11T06:05:37.622Z",
+    "1.13.0": "2015-06-15T00:49:47.887Z",
+    "1.13.1": "2015-06-16T19:00:56.953Z",
+    "1.13.2": "2015-07-06T03:19:18.019Z",
+    "1.13.3": "2015-07-31T19:04:44.557Z",
+    "1.14.0": "2015-09-16T16:40:54.186Z",
+    "1.14.1": "2015-09-28T04:49:56.763Z",
+    "1.14.2": "2015-12-16T23:43:48.529Z",
+    "1.15.0": "2016-02-11T02:06:51.428Z",
+    "1.15.1": "2016-05-06T05:35:09.934Z",
+    "1.15.2": "2016-06-20T03:34:56.363Z",
+    "1.16.0": "2017-01-18T03:41:33.243Z",
+    "1.16.1": "2017-02-11T01:36:42.896Z",
+    "1.17.0": "2017-03-01T22:10:17.219Z",
+    "1.17.1": "2017-03-06T13:31:29.554Z",
+    "1.17.2": "2017-05-18T04:57:45.982Z",
+    "1.18.0": "2017-09-09T04:17:26.738Z",
+    "1.18.1": "2017-09-12T15:30:51.470Z",
+    "1.18.2": "2017-09-22T16:50:10.944Z",
+    "1.18.3": "2018-05-14T17:16:32.445Z",
+    "1.19.0": "2019-04-26T03:31:23.981Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/expressjs/body-parser#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/expressjs/body-parser.git"
+  },
+  "bugs": {
+    "url": "https://github.com/expressjs/body-parser/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "83057396": true,
+    "sironfoot": true,
+    "summer": true,
+    "runningtalus": true,
+    "markymark": true,
+    "matteospampani": true,
+    "brianhanifin": true,
+    "mr.raindrop": true,
+    "mswanson1524": true,
+    "bret": true,
+    "franck.lahaye": true,
+    "kingcron": true,
+    "orangeclk": true,
+    "shawn_ljw": true,
+    "imzhi": true,
+    "salvatorelab": true,
+    "sergiodxa": true,
+    "dofy": true,
+    "swmoon203": true,
+    "uniquerockrz": true,
+    "baiej214": true,
+    "dvk": true,
+    "alexandermac": true,
+    "damocles": true,
+    "tsm91": true,
+    "javimaravillas": true,
+    "h4des": true,
+    "lucasmciruzzi": true,
+    "meme": true,
+    "moxiaohe": true,
+    "clunt": true,
+    "f124275809": true,
+    "dlpowless": true,
+    "ayoungh": true,
+    "nadimix": true,
+    "haeck": true,
+    "andreaspag": true,
+    "x_soth": true,
+    "drdanryan": true,
+    "mccarter": true,
+    "robermac": true,
+    "tiendq": true,
+    "wangnan0610": true,
+    "markthethomas": true,
+    "julienverkest": true,
+    "qbylucky": true,
+    "manxisuo": true,
+    "docksteaderluke": true,
+    "vboctor": true,
+    "rugare": true,
+    "drewigg": true,
+    "jamescostian": true,
+    "akiva": true,
+    "subchen": true,
+    "simplyianm": true,
+    "dongxu": true,
+    "ftornik": true,
+    "mistertakaashi": true,
+    "lifecube": true,
+    "flyslow": true,
+    "nickleefly": true,
+    "amovah": true,
+    "pengzhisun": true,
+    "godion": true,
+    "arnold-almeida": true,
+    "kai_": true,
+    "alexkval": true,
+    "mkiser": true,
+    "staraple": true,
+    "softwind": true,
+    "iamwiz": true,
+    "richfoxton": true,
+    "damianof": true,
+    "ergunozyurt": true,
+    "chaseshu": true,
+    "glebec": true,
+    "nikitka_m": true,
+    "luuhoangnam": true,
+    "nex": true,
+    "liulei224": true,
+    "largaah": true,
+    "bpatel": true,
+    "mano.rajesh": true,
+    "xngiser": true,
+    "freshlogic": true,
+    "dustinphipps": true,
+    "johnny.young": true,
+    "m412c0": true,
+    "yeahoffline": true,
+    "emreparlayan42": true,
+    "jeffb_incontact": true,
+    "boyw165": true,
+    "koulmomo": true,
+    "dwayneford": true,
+    "behumble": true,
+    "justincann": true,
+    "sixertoy": true,
+    "stephn_r": true,
+    "arifulhb": true,
+    "jyounce": true,
+    "keanodejs": true,
+    "hema": true,
+    "edwin_estrada": true,
+    "nketchum": true,
+    "nichoth": true,
+    "jonatasnona": true,
+    "vwal": true,
+    "devdebonair": true,
+    "esundahl": true,
+    "mjurincic": true,
+    "lherediawoodward": true,
+    "ruyadorno": true,
+    "grantcarthew": true,
+    "nmccready": true,
+    "jerkovicl": true,
+    "knoja4": true,
+    "ral.amgstromg": true,
+    "markstos": true,
+    "viktorivanov": true,
+    "cspotcode": true,
+    "kparkov": true,
+    "iliyat": true,
+    "wzbg": true,
+    "phajej": true,
+    "kungkk": true,
+    "ramzesucr": true,
+    "linuxwizard": true,
+    "wkaifang": true,
+    "davincho": true,
+    "fleischer": true,
+    "xeoneux": true,
+    "crazyjingling": true,
+    "nielsgl": true,
+    "windhamdavid": true,
+    "vbv": true,
+    "jonabasque": true,
+    "sigkill(9)": true,
+    "matiasmarani": true,
+    "almccann": true,
+    "piyushmakhija": true,
+    "cascadejs": true,
+    "bapinney": true,
+    "josejaguirre": true,
+    "antanst": true,
+    "christopher.urquidi": true,
+    "raskawa": true,
+    "volving": true,
+    "monkeymonk": true,
+    "xenohunter": true,
+    "elessarkrin": true,
+    "imd92": true,
+    "freeface": true,
+    "bian17888": true,
+    "carlosvillademor": true,
+    "richardcfelix": true,
+    "faelcorreia": true,
+    "ongmin": true,
+    "sopepos": true,
+    "apedz": true,
+    "cfleschhut": true,
+    "brandonccx": true,
+    "rbartoli": true,
+    "jamesbedont": true,
+    "zainy": true,
+    "msjcaetano": true,
+    "animustechnology": true,
+    "janez89": true,
+    "justinliao": true,
+    "sneakysnakeman": true,
+    "davidbraun": true,
+    "dimps": true,
+    "urbantumbleweed": true,
+    "djamseed": true,
+    "jabbalaci": true,
+    "yatsu": true,
+    "novalu": true,
+    "paragi": true,
+    "swookie": true,
+    "hyteer": true,
+    "bruinebeer": true,
+    "vishwasc": true,
+    "mightymia": true,
+    "ansuman": true,
+    "crusaderltd": true,
+    "kaveh.ghaboosi": true,
+    "flozz": true,
+    "psmorrow": true,
+    "vleesbrood": true,
+    "ryanlee": true,
+    "nerdybeast": true,
+    "starknode": true,
+    "mikemimik": true,
+    "monjer": true,
+    "honpery": true,
+    "ristostevcev": true,
+    "figroc": true,
+    "garrickajo": true,
+    "philiiiiiipp": true,
+    "fgarrido": true,
+    "goodnighthsu": true,
+    "kodekracker": true,
+    "xufz": true,
+    "alvajc": true,
+    "zhanghaili": true,
+    "ghe1219": true,
+    "geooogle": true,
+    "zbreakstone": true,
+    "gracheff": true,
+    "gejiawen": true,
+    "lakipatel": true,
+    "foto": true,
+    "richard534": true,
+    "sternelee": true,
+    "kikna": true,
+    "nolanthorn": true,
+    "chrisx": true,
+    "rubiadias": true,
+    "sammok2003": true,
+    "jasonwang1888": true,
+    "asm2hex": true,
+    "xu_q90": true,
+    "peter__orosz": true,
+    "igorissen": true,
+    "landy2014": true,
+    "sammffl": true,
+    "tfentonz": true,
+    "werdyin": true,
+    "marlongrape": true,
+    "sammyteahan": true,
+    "elviopita": true,
+    "princetoad": true,
+    "isik": true,
+    "ifeature": true,
+    "lorenazohar": true,
+    "faryangsh": true,
+    "mkiramu": true,
+    "mrbgit": true,
+    "obouchari": true,
+    "zhenzhuquan": true,
+    "alahmadiq8": true,
+    "grahamjpark": true,
+    "kmaric": true,
+    "djeck": true,
+    "danielbankhead": true,
+    "zhongyuan": true,
+    "siirial": true,
+    "fasdgoc": true,
+    "pmasa": true,
+    "ansing100": true,
+    "encloud": true,
+    "xudaolong": true,
+    "junjiansyu": true,
+    "apwn": true,
+    "duskalbatross": true,
+    "juangotama": true,
+    "christopherritter": true,
+    "bourne": true,
+    "moamaoa": true,
+    "roman-io": true,
+    "luismoramedina": true,
+    "manneken28": true,
+    "x0000ff": true,
+    "nanikore": true,
+    "alin.alexa": true,
+    "marcobiedermann": true,
+    "koskokos": true,
+    "anhurtado": true,
+    "creativ073": true,
+    "jonva": true,
+    "moueza": true,
+    "ggomma": true,
+    "lhard": true,
+    "sergoh": true,
+    "mluberry": true,
+    "studi11": true,
+    "kjarisk": true,
+    "samersm": true,
+    "vzg03566": true,
+    "scotchulous": true,
+    "stephenhuh": true,
+    "joelwallis": true,
+    "mryeol": true,
+    "ymk": true,
+    "ryansalvador": true,
+    "apopek": true,
+    "jcarlos": true,
+    "robba.jt": true,
+    "mobeicaoyuan": true,
+    "codevelopit": true,
+    "dralc": true,
+    "simon-yukuan": true,
+    "scottfreecode": true,
+    "roxnz": true,
+    "adrian110288": true,
+    "bigglesatlarge": true,
+    "jmsherry": true,
+    "dburdese": true,
+    "djviolin": true,
+    "phoenixsoul": true,
+    "dabin": true,
+    "tmurngon": true,
+    "slmcassio": true,
+    "kistoryg": true,
+    "hyokosdeveloper": true,
+    "awhmandan": true,
+    "wuyangwang": true,
+    "quafoo": true,
+    "ognjen.jevremovic": true,
+    "13lank.null": true,
+    "chunxchun": true,
+    "fsepulveda": true,
+    "ab.moon": true,
+    "khurshedyu": true,
+    "suhaib.affan": true,
+    "hodd": true,
+    "tonyljl526": true,
+    "kunalgaurav18": true,
+    "sansgumen": true,
+    "geduardcatalin": true,
+    "muroc": true,
+    "fahadjadoon": true,
+    "ibambo": true,
+    "dzhou777": true,
+    "dawn_scroll": true,
+    "dgray0229": true,
+    "nusmql": true,
+    "jetbug123": true,
+    "langri-sha": true,
+    "vasiltehanov": true,
+    "soulevans07": true,
+    "techyone": true,
+    "tedyhy": true,
+    "richard_san": true,
+    "leondacosta": true,
+    "adamdreszer": true,
+    "dickeysprogramming": true,
+    "a.sanchez": true,
+    "ma-ha": true,
+    "shanewholloway": true,
+    "jirwong": true,
+    "bradleybossard": true,
+    "nicohe": true,
+    "bsara": true,
+    "wfcookie": true,
+    "gui0704": true,
+    "evegreen": true,
+    "rocket0191": true,
+    "sako73": true,
+    "albertofdzm": true,
+    "largepuma": true,
+    "atulmy": true,
+    "danielye": true,
+    "tamer1an": true,
+    "panos277": true,
+    "adeelp": true,
+    "yaphtes.ks": true,
+    "sopov": true,
+    "augiethornton": true,
+    "evdokimovm": true,
+    "mauriciolauffer": true,
+    "brdjx": true,
+    "sgvinci": true,
+    "cschmitz81": true,
+    "serge-nikitin": true,
+    "olonam": true,
+    "devnka": true,
+    "frankl83": true,
+    "panlw": true,
+    "miloc": true,
+    "isa424": true,
+    "satoru": true,
+    "isenricho": true,
+    "yong_a": true,
+    "madalozzo": true,
+    "rlafferty": true,
+    "nicomf1982": true,
+    "qjawe": true,
+    "masterofweb": true,
+    "koobitor": true,
+    "lightway82": true,
+    "chinawolf_wyp": true,
+    "chinjon": true,
+    "dnero": true,
+    "nate-river": true,
+    "thomas.li": true,
+    "tomchao": true,
+    "diogocapela": true,
+    "junos": true,
+    "abpeinado": true,
+    "lvpeng101": true,
+    "milan322": true,
+    "jaguarj": true,
+    "tdevm": true,
+    "htc2ubusiness": true,
+    "devossa": true,
+    "beatwinthewave": true,
+    "leonardorb": true,
+    "thetimmaeh": true,
+    "vicsandoli": true,
+    "nguyenmanhdat2903": true,
+    "desmondddd": true,
+    "zaks": true,
+    "claudio76": true,
+    "gpuente": true,
+    "mife": true,
+    "jakedalus": true,
+    "malloryerik": true,
+    "dylanh724": true,
+    "hektve87": true,
+    "shadyshrif": true,
+    "chiaychang": true,
+    "sommardnaiel": true,
+    "chatm": true,
+    "ray0214": true,
+    "ys_sidson_aidson": true,
+    "sibawite": true,
+    "pddivine": true,
+    "shoonia": true,
+    "bigbird92": true,
+    "karzanosman984": true,
+    "seasons521": true,
+    "grabantot": true,
+    "viperchin": true,
+    "fengmiaosen": true,
+    "ironheartbj18": true,
+    "toszter": true,
+    "lwk": true,
+    "kulyk404": true,
+    "cantuga": true,
+    "elevenlui": true,
+    "lijq123": true,
+    "vjudge": true,
+    "nbuchanan": true,
+    "kuzmicheff": true,
+    "manojkhannakm": true,
+    "cygik": true,
+    "mknparreira": true,
+    "wozhizui": true,
+    "greganswer": true,
+    "felegz": true,
+    "livarion": true,
+    "abhijitkalta": true,
+    "kevinhassan": true,
+    "ukuli": true,
+    "pl0x": true,
+    "sidkb": true,
+    "lukaswilkeer": true,
+    "asj1992": true,
+    "wayn": true,
+    "javadtyb": true,
+    "zerouikit": true,
+    "leelandmiller": true,
+    "cetincem": true,
+    "adriasb": true,
+    "thangakumar": true,
+    "swift2728": true,
+    "winfredzhu": true,
+    "seanr": true,
+    "andrewlam": true,
+    "nisimjoseph": true,
+    "luffy84217": true,
+    "_~": true,
+    "starlord40k": true,
+    "fmfsaisai": true,
+    "zeroth007": true,
+    "~arnold": true,
+    "chenphoenix": true,
+    "wesleylhandy": true,
+    "scalz": true,
+    "alanson": true,
+    "paulkolesnyk": true,
+    "marinear212": true,
+    "isayme": true,
+    "sayansaha": true,
+    "lqweb": true,
+    "ldq-first": true,
+    "processbrain": true,
+    "jerrywu12": true,
+    "asfrom30": true,
+    "nayuki": true,
+    "rayjshin": true,
+    "npmmurali": true,
+    "mateussampsouza": true,
+    "hexcola": true,
+    "tiggem1993": true,
+    "bart1208": true,
+    "suryasaripalli": true,
+    "itcorp": true,
+    "svoss24": true,
+    "allendale": true,
+    "omar84": true,
+    "deivbid": true,
+    "waldrupm": true,
+    "robinblomberg": true,
+    "t0ngt0n9": true,
+    "cbetancourt": true,
+    "nestor": true,
+    "enzoaliatis": true,
+    "trinup": true,
+    "guiyuzhao": true,
+    "iamninad": true,
+    "ehrig": true,
+    "guogai": true,
+    "wfalkwallace": true,
+    "joey.dossche": true,
+    "highgravity": true,
+    "pajamasam": true,
+    "wallenberg12": true,
+    "dnp1204": true,
+    "jakedemonaco": true,
+    "kwabenaberko": true,
+    "alshamiri2": true,
+    "bumsuk": true,
+    "tpkn": true,
+    "dccunni171": true,
+    "matthiasgrune": true,
+    "renz0": true,
+    "sdove1": true,
+    "rubenjose75": true,
+    "hduhdc": true,
+    "leor": true,
+    "henriesteves": true,
+    "kkho595": true,
+    "mahamdani": true,
+    "bauhuynh2020": true,
+    "coolhector": true,
+    "shahabkhalvati": true,
+    "jirqoadai": true,
+    "keybouh": true,
+    "tevins": true,
+    "gabriel.fojo": true,
+    "paulhanna33": true,
+    "touskar": true,
+    "maxwelldu": true,
+    "kremr": true,
+    "hanhq": true,
+    "panzhiyong": true,
+    "ookangzheng": true,
+    "asadm2706": true,
+    "lgh06": true,
+    "ezeikel": true,
+    "lotspecter": true,
+    "manavsaxena": true,
+    "laoshaw": true,
+    "71emj1": true,
+    "helcat": true,
+    "nguyenvanhoang26041994": true,
+    "pengliu": true,
+    "asawq2006": true,
+    "benigro": true,
+    "shivayl": true,
+    "tranceyos2419": true,
+    "avivharuzi": true,
+    "thomashzhu": true,
+    "yb1997": true,
+    "akshay.vs9543": true,
+    "technolojay": true,
+    "gabriel_hansson": true,
+    "schacker": true,
+    "ryaned": true,
+    "imaginegenesis": true,
+    "madeo": true,
+    "isaacdagel": true,
+    "alicebox": true,
+    "renchiliu": true,
+    "ashco": true,
+    "mrhuangyuhui": true,
+    "udaygowda": true,
+    "salvationz": true,
+    "rochejul": true,
+    "obsessiveprogrammer": true,
+    "bengi": true,
+    "he313572052": true,
+    "ralphkay": true,
+    "arvi": true,
+    "genbuhase": true,
+    "midascreed": true,
+    "dadoumda": true,
+    "elitelegendary": true,
+    "rabahtahraoui": true,
+    "tdmalone": true,
+    "karnavpargi": true,
+    "gpmetheny": true,
+    "edmondnow": true,
+    "tangshingkwan": true,
+    "shedule": true,
+    "dgavilez": true,
+    "cmangos": true,
+    "luoyjx": true,
+    "kogakure": true,
+    "endsoul": true,
+    "mohokh67": true,
+    "calvinmuthig": true,
+    "danielwthomas": true,
+    "rparris": true,
+    "felipeferreirasilva": true,
+    "arbest": true,
+    "abuelwafa": true,
+    "kepler": true,
+    "renjie18": true,
+    "mohsinnadeem": true,
+    "destemidosistemas": true,
+    "maxblock": true,
+    "gamersdelight": true,
+    "huthaifah": true,
+    "kagerjay": true,
+    "fearnbuster": true,
+    "johniexu": true,
+    "krabello": true,
+    "wandyezj": true,
+    "tcrowe": true,
+    "juanf03": true,
+    "ahillier": true,
+    "habiiev": true,
+    "rapomon": true,
+    "vivekrp": true
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/body-parser.min.json
+++ b/test/fixtures/registry-mocks/content/body-parser.min.json
@@ -1,0 +1,1811 @@
+{
+  "name": "body-parser",
+  "dist-tags": {
+    "latest": "1.19.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "body-parser",
+      "version": "1.0.0",
+      "dependencies": {
+        "raw-body": "~1.1.2",
+        "qs": "~0.6.6"
+      },
+      "devDependencies": {
+        "connect": "*",
+        "mocha": "*",
+        "should": "*",
+        "supertest": "*"
+      },
+      "dist": {
+        "shasum": "95c8a2861cd150dc195d50840ea4614149455e80",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "body-parser",
+      "version": "1.0.1",
+      "dependencies": {
+        "raw-body": "~1.1.2",
+        "qs": "~0.6.6"
+      },
+      "devDependencies": {
+        "connect": "*",
+        "mocha": "*",
+        "should": "*",
+        "supertest": "*"
+      },
+      "dist": {
+        "shasum": "08a2d025ea286f982d5107ea8a2ba953708620e3",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "body-parser",
+      "version": "1.0.2",
+      "dependencies": {
+        "type-is": "~1.1.0",
+        "raw-body": "~1.1.2",
+        "qs": "~0.6.6"
+      },
+      "devDependencies": {
+        "connect": "*",
+        "mocha": "*",
+        "should": "*",
+        "supertest": "*"
+      },
+      "dist": {
+        "shasum": "3461479a3278fe00fcaebec3314bb54fc4f7b47c",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "body-parser",
+      "version": "1.1.0",
+      "dependencies": {
+        "type-is": "1.1.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "dist": {
+        "shasum": "e6a3c46063b329dab0eb7a31bdc1dca3b3185ab9",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.1": {
+      "name": "body-parser",
+      "version": "1.1.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "type-is": "1.1.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "dist": {
+        "shasum": "cf3cc10d885e91fc0ffa35a47ecad858238fb880",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.2": {
+      "name": "body-parser",
+      "version": "1.1.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "type-is": "1.1.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "dist": {
+        "shasum": "c943b64c4cd3c44dc96a4681b02cd54ff29e8cd7",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.0": {
+      "name": "body-parser",
+      "version": "1.2.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "type-is": "1.2.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "dist": {
+        "shasum": "f6247cc88d4c673c30a926d74fe36c177b9846e0",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.1": {
+      "name": "body-parser",
+      "version": "1.2.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "type-is": "1.2.0",
+        "raw-body": "1.1.4",
+        "qs": "0.6.6"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "dist": {
+        "shasum": "917beee35a88e9f6893728bf1a542111d7d1eb28",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.2": {
+      "name": "body-parser",
+      "version": "1.2.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "qs": "0.6.6",
+        "raw-body": "1.1.6",
+        "type-is": "1.2.0"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "dist": {
+        "shasum": "6106373cc1d34d559ebcfdb582e4e37d4312acfb",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.3.0": {
+      "name": "body-parser",
+      "version": "1.3.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "qs": "0.6.6",
+        "raw-body": "1.1.6",
+        "type-is": "1.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "supertest": "~0.12.1"
+      },
+      "dist": {
+        "shasum": "1a651cb9993a01a65531ae38395ceb0199dd7e3c",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.3.1": {
+      "name": "body-parser",
+      "version": "1.3.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "qs": "0.6.6",
+        "raw-body": "1.1.6",
+        "type-is": "1.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "1a74513fc7897d70db56589e0d03f0a13f1bfa94",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.4.0": {
+      "name": "body-parser",
+      "version": "1.4.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.3.0",
+        "iconv-lite": "0.4.3",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.2.2",
+        "type-is": "1.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "31274668441c2b00bab6ca50a173442d8bac1382",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.4.1": {
+      "name": "body-parser",
+      "version": "1.4.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.3.0",
+        "iconv-lite": "0.4.3",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.2.2",
+        "type-is": "1.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "29146acc104a353e8cb07b7b3666d2d829bed6b0",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.4.2": {
+      "name": "body-parser",
+      "version": "1.4.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.3.0",
+        "iconv-lite": "0.4.3",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.2.2",
+        "type-is": "1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "e748603c5f79eb06bd75434e219258986328aae7",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.4.3": {
+      "name": "body-parser",
+      "version": "1.4.3",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.3.0",
+        "iconv-lite": "0.4.3",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.2.2",
+        "type-is": "1.3.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "4727952cff4af0773eefa4b226c2f4122f5e234d",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.4.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.5.0": {
+      "name": "body-parser",
+      "version": "1.5.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.2",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "c6fce2483c9eeb49ab349ff25a92d336d91055b9",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.5.1": {
+      "name": "body-parser",
+      "version": "1.5.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.3",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "8d2eb95e987d274ef02fcf56567b3f3a31749c51",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.5.2": {
+      "name": "body-parser",
+      "version": "1.5.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "0.6.6",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "beebacac741b83f62c9137d5685196e1a44304ab",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.6.0": {
+      "name": "body-parser",
+      "version": "1.6.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.0.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "d02a9d373c7349c281a8b76b41d6bbf60ef2d3f6",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.6.1": {
+      "name": "body-parser",
+      "version": "1.6.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.1.0",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "3894580ab743e2c2611fec695bae60a883ea6f3b",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.6.2": {
+      "name": "body-parser",
+      "version": "1.6.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.2.0",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "38952b4fd534395ab3034e9bb40bbdf3dd99c4ce",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.6.3": {
+      "name": "body-parser",
+      "version": "1.6.3",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.2.1",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "db3b270bd3ebce5da4d2d2021653454b24861a79",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.6.4": {
+      "name": "body-parser",
+      "version": "1.6.4",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "qs": "1.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "befd799cc361a46d34e181f5f881f421a1f3b4c1",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.6.5": {
+      "name": "body-parser",
+      "version": "1.6.5",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "1.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "536f01e08ee2b6df6a941d6c8c9647ee99ee4de7",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.6.6": {
+      "name": "body-parser",
+      "version": "1.6.6",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.0",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "abfead725f1983631ce94b8e3e9a297d1ab703fb",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.6.7": {
+      "name": "body-parser",
+      "version": "1.6.7",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "82306becadf44543e826b3907eae93f0237c4e5c",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.6.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.7.0": {
+      "name": "body-parser",
+      "version": "1.7.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.3.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "6a245ea5b32d8e1e0d43bec8344b264ba4b36541",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.8.0": {
+      "name": "body-parser",
+      "version": "1.8.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.2.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.3",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "20b3a3d3553a6835d7373456dd9da8720759b306",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.8.1": {
+      "name": "body-parser",
+      "version": "1.8.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.4",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.3",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "f9f96d221c435c95d18aeaad2bcdea1371902aad",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.8.2": {
+      "name": "body-parser",
+      "version": "1.8.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.5",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.3",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "cb55519e748f2ac89bd3c8e34cb759d391c4d67d",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.8.3": {
+      "name": "body-parser",
+      "version": "1.8.3",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.5",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.4",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "922b82e6448d654f2f5197574ceacefc04a6a8af",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.8.4": {
+      "name": "body-parser",
+      "version": "1.8.4",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "0.4.5",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.4",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "d497e04bc13b3f9a8bd8c70bb0cdc16f2e028898",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.9.0": {
+      "name": "body-parser",
+      "version": "1.9.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "2.1.0",
+        "qs": "2.2.4",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "95d72943b1a4f67f56bbac9e0dcc837b68703605",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.9.1": {
+      "name": "body-parser",
+      "version": "1.9.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.1.1",
+        "qs": "2.3.0",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "650a3047591fa9bb3cec191cb53933a468aa57aa",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.9.2": {
+      "name": "body-parser",
+      "version": "1.9.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.4",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.1.1",
+        "qs": "2.3.2",
+        "raw-body": "1.3.0",
+        "type-is": "~1.5.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "07f52cf104939118bedcba689002017271ef3c0e",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.9.3": {
+      "name": "body-parser",
+      "version": "1.9.3",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.5",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.1.1",
+        "qs": "2.3.3",
+        "raw-body": "1.3.1",
+        "type-is": "~1.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "edfacd4fcfad87dfe74f861a5cc712900aef2623",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.9.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.10.0": {
+      "name": "body-parser",
+      "version": "1.10.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.5",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.1.1",
+        "qs": "2.3.3",
+        "raw-body": "1.3.1",
+        "type-is": "~1.5.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "methods": "~1.1.0",
+        "mocha": "~2.0.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "f884d11839af09e3c61e5011059e29cbfe452085",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.10.1": {
+      "name": "body-parser",
+      "version": "1.10.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.5",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.1",
+        "type-is": "~1.5.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "methods": "~1.1.1",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "af0c7156b128d946f3c43f5fe0364da00cfa7391",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.10.2": {
+      "name": "body-parser",
+      "version": "1.10.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.6",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.2",
+        "type-is": "~1.5.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "methods": "~1.1.1",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "405d465fcd3ccf0ea8a35adbf1055f6e98316bd1",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.10.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.11.0": {
+      "name": "body-parser",
+      "version": "1.11.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.6",
+        "media-typer": "0.3.0",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.2",
+        "type-is": "~1.5.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "methods": "~1.1.1",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "29f876cb608efa54e9b2185fe8105efc9219a7f3",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.11.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.12.0": {
+      "name": "body-parser",
+      "version": "1.12.0",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.7",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.3",
+        "type-is": "~1.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "methods": "~1.1.1",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "9750fc3cc1080b34a13d18c79840cd559979fce5",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.12.1": {
+      "name": "body-parser",
+      "version": "1.12.1",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.7",
+        "on-finished": "~2.2.0",
+        "qs": "2.3.3",
+        "raw-body": "1.3.3",
+        "type-is": "~1.6.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.8",
+        "methods": "~1.1.1",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "4b9b4c67e8eb5ccac7c9eef3fbd6694e721ae002",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.12.2": {
+      "name": "body-parser",
+      "version": "1.12.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "iconv-lite": "0.4.7",
+        "on-finished": "~2.2.0",
+        "qs": "2.4.1",
+        "raw-body": "1.3.3",
+        "type-is": "~1.6.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.8",
+        "methods": "~1.1.1",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "698368fb4dfc57a05bff1ddb1bebeba3bd2c0e87",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.12.3": {
+      "name": "body-parser",
+      "version": "1.12.3",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.1.3",
+        "depd": "~1.0.1",
+        "iconv-lite": "0.4.8",
+        "on-finished": "~2.2.0",
+        "qs": "2.4.1",
+        "raw-body": "1.3.4",
+        "type-is": "~1.6.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "methods": "~1.1.1",
+        "mocha": "~2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "5f40bf17e7823be6895d4d35582752e36cf97f71",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.12.4": {
+      "name": "body-parser",
+      "version": "1.12.4",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "iconv-lite": "0.4.8",
+        "on-finished": "~2.2.1",
+        "qs": "2.4.2",
+        "raw-body": "~2.0.1",
+        "type-is": "~1.6.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "methods": "~1.1.1",
+        "mocha": "~2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "090700c4ba28862a8520ef378395fdee5f61c229",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.13.0": {
+      "name": "body-parser",
+      "version": "1.13.0",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.10",
+        "on-finished": "~2.3.0",
+        "qs": "3.1.0",
+        "raw-body": "~2.1.1",
+        "type-is": "~1.6.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "b6dca73da8c4a9f68b0e64d29acac39dd3ad9a9e",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.13.1": {
+      "name": "body-parser",
+      "version": "1.13.1",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.10",
+        "on-finished": "~2.3.0",
+        "qs": "2.4.2",
+        "raw-body": "~2.1.1",
+        "type-is": "~1.6.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "f07218bc2c4b5e36ca261557c9465481b29ecdcd",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.13.2": {
+      "name": "body-parser",
+      "version": "1.13.2",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.11",
+        "on-finished": "~2.3.0",
+        "qs": "4.0.0",
+        "raw-body": "~2.1.2",
+        "type-is": "~1.6.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "229262a4fd2e402dfb88d99bc27d8be31307e7e9",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.13.3": {
+      "name": "body-parser",
+      "version": "1.13.3",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.11",
+        "on-finished": "~2.3.0",
+        "qs": "4.0.0",
+        "raw-body": "~2.1.2",
+        "type-is": "~1.6.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "c08cf330c3358e151016a05746f13f029c97fa97",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.13.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.14.0": {
+      "name": "body-parser",
+      "version": "1.14.0",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.11",
+        "on-finished": "~2.3.0",
+        "qs": "5.1.0",
+        "raw-body": "~2.1.3",
+        "type-is": "~1.6.8"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "a7a10138547a75bfcacc20472404630c2fa6b0ff",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.14.1": {
+      "name": "body-parser",
+      "version": "1.14.1",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.12",
+        "on-finished": "~2.3.0",
+        "qs": "5.1.0",
+        "raw-body": "~2.1.4",
+        "type-is": "~1.6.9"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "methods": "~1.1.1",
+        "mocha": "2.2.5",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "ffe921eba3ce8f191e2a8a8803844bd025f3c6dc",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.14.2": {
+      "name": "body-parser",
+      "version": "1.14.2",
+      "dependencies": {
+        "bytes": "2.2.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.3.1",
+        "iconv-lite": "0.4.13",
+        "on-finished": "~2.3.0",
+        "qs": "5.2.0",
+        "raw-body": "~2.1.5",
+        "type-is": "~1.6.10"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "methods": "~1.1.1",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "1015cb1fe2c443858259581db53332f8d0cf50f9",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.15.0": {
+      "name": "body-parser",
+      "version": "1.15.0",
+      "dependencies": {
+        "bytes": "2.2.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.4.0",
+        "iconv-lite": "0.4.13",
+        "on-finished": "~2.3.0",
+        "qs": "6.1.0",
+        "raw-body": "~2.1.5",
+        "type-is": "~1.6.11"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "methods": "1.1.2",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "8168abaeaf9e77e300f7b3aef4df4b46e9b21b35",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.15.1": {
+      "name": "body-parser",
+      "version": "1.15.1",
+      "dependencies": {
+        "bytes": "2.3.0",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.4.0",
+        "iconv-lite": "0.4.13",
+        "on-finished": "~2.3.0",
+        "qs": "6.1.0",
+        "raw-body": "~2.1.6",
+        "type-is": "~1.6.12"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "methods": "1.1.2",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "9bceef0669b8f8b943f0ad8ce5d95716bd740fd2",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.15.2": {
+      "name": "body-parser",
+      "version": "1.15.2",
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.5.0",
+        "iconv-lite": "0.4.13",
+        "on-finished": "~2.3.0",
+        "qs": "6.2.0",
+        "raw-body": "~2.1.7",
+        "type-is": "~1.6.13"
+      },
+      "devDependencies": {
+        "eslint": "2.13.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "d7578cf4f1d11d5f6ea804cef35dc7a7ff6dae67",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.16.0": {
+      "name": "body-parser",
+      "version": "1.16.0",
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.0",
+        "depd": "~1.1.0",
+        "http-errors": "~1.5.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.2.1",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.14"
+      },
+      "devDependencies": {
+        "eslint": "3.13.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "924a5e472c6229fb9d69b85a20d5f2532dec788b",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.16.1": {
+      "name": "body-parser",
+      "version": "1.16.1",
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "http-errors": "~1.5.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.2.1",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.14"
+      },
+      "devDependencies": {
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "51540d045adfa7a0c6995a014bb6b1ed9b802329",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.16.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.17.0": {
+      "name": "body-parser",
+      "version": "1.17.0",
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "http-errors": "~1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.3.1",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.14"
+      },
+      "devDependencies": {
+        "eslint": "3.16.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "d956ae2d756ae10bb784187725ea5a249430febd",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.17.1": {
+      "name": "body-parser",
+      "version": "1.17.1",
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "http-errors": "~1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.14"
+      },
+      "devDependencies": {
+        "eslint": "3.17.0",
+        "eslint-config-standard": "7.0.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "75b3bc98ddd6e7e0d8ffe750dfaca5c66993fa47",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.17.2": {
+      "name": "body-parser",
+      "version": "1.17.2",
+      "dependencies": {
+        "bytes": "2.4.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.7",
+        "depd": "~1.1.0",
+        "http-errors": "~1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "~2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "~2.2.0",
+        "type-is": "~1.6.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.0.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "f8892abc8f9e627d42aedafbca66bf5ab99104ee",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.18.0": {
+      "name": "body-parser",
+      "version": "1.18.0",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.2",
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.18",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.0",
+        "raw-body": "2.3.1",
+        "type-is": "~1.6.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "d3b224d467fa2ce8d43589c0245043267c093634",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.18.1": {
+      "name": "body-parser",
+      "version": "1.18.1",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-KL2pZpGvy6xuZHgYUznB1Zfw4AoGMApfRanT5NafeLvglbaSM+4CCtmlyYOv66oYXqvKL1xpaFb94V/AZVUnYg==",
+        "shasum": "9c1629370bcfd42917f30641a2dcbe2ec50d4c26",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.18.2": {
+      "name": "body-parser",
+      "version": "1.18.2",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "87678a19d84b47d859b83199bd59bce222b10454",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.18.3": {
+      "name": "body-parser",
+      "version": "1.18.3",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      },
+      "devDependencies": {
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.11.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.7.0",
+        "eslint-plugin-standard": "3.1.0",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "2.5.3",
+        "safe-buffer": "5.1.2",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "5b292198ffdd553b3a0f20ded0592b956955c8b4",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+        "fileCount": 10,
+        "unpackedSize": 55897,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa+cRxCRA9TVsSAnZWagAAr+wP/jRF3kZaSUPcjTUOxoqN\nlSEgHs4ISF5j2kqTPeArKhG5cgmvygc9gRtNdjtfLGHbQAjyZtA8tzBdsXZG\n3KuehVC9hf/eUIeQbVTjaxrgX0jevrF4igcmM4tRI17JzFvq1+oCz9aAk99e\n3SljKbwvFPopbM5F5BraVbOpIYCO140dVVBrV9gHOBb+65hme0PzfBdru/Bg\nZ1UnDi9l/lEGhCy+HFlSGw+T9ev0KcgzcslA/9vJBAFyYMXVfFFI+jY2+O4P\nJ35s40gbQ1V/idGM4IfmCg5IhwmvpJ902bpXJEokVgGKcw/mMv3TQpBKov2I\nOxAIIRLr2w/1Kl2d8+jMLcbkIoSD7wutdV5i+rsUR5XJURbsDuitYJbcRvJw\n5MS0bQ5aVI83TOr/35z8671ciWqpM+Ru+7eiMjQzgUOWt2qKuOB0Bi/xhr8J\nXGWbqLwl1PWxJXgGJqAJ7rvXNOmAexqJmyk1mPHDJnpjaFRKnCpDrUbuX4Cm\nw52bjMIW+wYC/zKnUMCJ+5n4gBw0jWzFUsoTCses91YZHMDVNb1tOo2Sjbwp\nxLKIWDuNDQC3lxfuCSxC7Qe3PayQGnOCwoP3o6GM89YFAhFOWgPvgBpvjfWm\niJlgG/dUsGIAY3Gz0i7abBGyeJJAuA+CwFpfERMcEE4HwcJhzOrG7g0prSD9\n3nNl\r\n=47oB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.19.0": {
+      "name": "body-parser",
+      "version": "1.19.0",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "methods": "1.1.2",
+        "mocha": "6.1.4",
+        "safe-buffer": "5.1.2",
+        "supertest": "4.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+        "shasum": "96b2709e57c9c4e09a6fd66a8fd979844f69f08a",
+        "tarball": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 56375,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwnuMCRA9TVsSAnZWagAA2zMP/3i2Q8pQBJx4azFOeuub\n/s3F445wJrDoAKA+6zSOLFMYYasZ0iF60NoE4taDupDF1hzpC4gCYgy9ZezQ\n75kKKBC48jCQP6Urx1tj6VUPzWqG6xdQMjhZpXrkK+EF5XYtAspb8+YSxaw4\nzf4atEm+7Q3N1qwvyfi8T/KQaK7WV6wC513pXTZv8SCtetX/4jBJwA4uUqLh\nXbuO5GcsjNEDmfX91YFKbb2+TvL2kuJkxVVdjeVv+UDLAs8AL+6afVJTe2vB\nmY+9CmSN2egWYDEXgpIowRTXzvasLJ8kQQH0dhseRrnF/k8cxX61VsT0MYEB\nd7mVyXFJE2WrN/HgiVCa9XSzLNn2bp/tyoz3W8TTSCqWOaY2cgbpFBUcBqWY\nmZSkqGqBj0lAJ3qMJw9tfIKiGtLEqsBwRoHTt6yQRsPTTD0wY3WzQTzedpS7\nPKEPDqrqMhDJpjv7vHZyP0E85lSYoDAMYPQ33fYvNbiuIMU4eDxoNJWUImXJ\nTN3uRKDn9QeE8mLTeglLVIu5+4FrDQNNjK6HHcetM89H8F4FGxGl090/H07x\nqc9A2Fe2yCeM6BICsO3BIRt0eClHS6jD15tMDbx9hx4Z4Qt+IgTn0NS4Ebj7\nW1V7qu/d6ajepEVd2kCXQkvJvslxzIGDxXo6OvTN757kROAWoYZNyGefqnou\nHXEH\r\n=IvFh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-11-29T09:32:43.816Z"
+}

--- a/test/fixtures/registry-mocks/content/bonjour.json
+++ b/test/fixtures/registry-mocks/content/bonjour.json
@@ -1,0 +1,928 @@
+{
+  "_id": "bonjour",
+  "_rev": "23-11d74546c593958ecd83b02d801958bc",
+  "name": "bonjour",
+  "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+  "dist-tags": {
+    "latest": "3.5.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "bonjour",
+      "version": "1.0.0",
+      "description": "a Sails application",
+      "dependencies": {
+        "sails": "0.9.4",
+        "grunt": "0.4.1",
+        "sails-disk": "~0.9.0",
+        "ejs": "0.8.4",
+        "optimist": "0.3.4",
+        "request": "~2.27.0"
+      },
+      "scripts": {
+        "start": "node app.js",
+        "debug": "node debug app.js"
+      },
+      "main": "app.js",
+      "repository": "",
+      "author": "",
+      "license": "",
+      "_id": "bonjour@1.0.0",
+      "dist": {
+        "shasum": "9c9445248ecd4beedf78aeafad271f64f6e1feb9",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "balderdashy",
+        "email": "mike@balderdash.co"
+      },
+      "maintainers": [
+        {
+          "name": "balderdashy",
+          "email": "mike@balderdash.co"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "bonjour",
+      "version": "2.0.0",
+      "description": "A Bonjour/Zeroconf protocol implementation in JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "mdns-txt": "^1.0.0",
+        "multicast-dns": "^4.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.2"
+      },
+      "scripts": {
+        "test": "standard && tape test/service.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        55.6809588,
+        12.57191
+      ],
+      "gitHead": "b46e67446223f7d3c11ada4352aa7687f1599fbd",
+      "_id": "bonjour@2.0.0",
+      "_shasum": "00ecd28aa298db4f9aee2ce9da839a1441a8f58f",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "00ecd28aa298db4f9aee2ce9da839a1441a8f58f",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "bonjour",
+      "version": "3.0.0",
+      "description": "A Bonjour/Zeroconf protocol implementation in JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        53.5462394,
+        10.0150485
+      ],
+      "gitHead": "79c342b342aba75c8caecb02ae4c7af0a1eafbf7",
+      "_id": "bonjour@3.0.0",
+      "_shasum": "53b5d031449c1f5a96e0ff9c0be865cd5aea18df",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "53b5d031449c1f5a96e0ff9c0be865cd5aea18df",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "bonjour",
+      "version": "3.0.1",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "dns-equal": "^1.0.0",
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        56.00998453265667,
+        11.96187322358469
+      ],
+      "gitHead": "a1c55090b3d75ab0e870e7be8a0e5b8ff2ef5984",
+      "_id": "bonjour@3.0.1",
+      "_shasum": "4f1020bda6b507a6fde7efec158a25a6e703154e",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "4f1020bda6b507a6fde7efec158a25a6e703154e",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "bonjour",
+      "version": "3.1.0",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "dns-equal": "^1.0.0",
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        59.992475702944795,
+        11.08010022705082
+      ],
+      "gitHead": "b0c7842105ee8115e642dd3c075415e18073293e",
+      "_id": "bonjour@3.1.0",
+      "_shasum": "57cf1c3f1a17ed5d07345773051ce1a1fb3582e8",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "57cf1c3f1a17ed5d07345773051ce1a1fb3582e8",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.0": {
+      "name": "bonjour",
+      "version": "3.2.0",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "dns-equal": "^1.0.0",
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        55.6667216,
+        12.5799133
+      ],
+      "gitHead": "4c2d85626b649c29aabe3b9baea7a2bb4a153e5b",
+      "_id": "bonjour@3.2.0",
+      "_shasum": "2c01244a4dc46fb875ee75dc6ffd7a303f543887",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "2c01244a4dc46fb875ee75dc6ffd7a303f543887",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.1": {
+      "name": "bonjour",
+      "version": "3.2.1",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "array-flatten": "^2.0.0",
+        "dns-equal": "^1.0.0",
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        55.6665113,
+        12.580161
+      ],
+      "gitHead": "543214037caed28afa8b22c5d971956ac9b442b8",
+      "_id": "bonjour@3.2.1",
+      "_shasum": "5a4c148223c2473657167bd887088b96218fbcb5",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "5a4c148223c2473657167bd887088b96218fbcb5",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.2.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/bonjour-3.2.1.tgz_1456739202772_0.8810477105434984"
+      },
+      "directories": {}
+    },
+    "3.2.2": {
+      "name": "bonjour",
+      "version": "3.2.2",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "array-flatten": "^2.0.0",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.1",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        55.6665535,
+        12.5801863
+      ],
+      "gitHead": "821db40546d46e7aed46fe12655b0462b63b4c47",
+      "_id": "bonjour@3.2.2",
+      "_shasum": "4f5bd4c10cfcd9f7fb659ecfde8f6682f05cd6dc",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "4f5bd4c10cfcd9f7fb659ecfde8f6682f05cd6dc",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.2.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/bonjour-3.2.2.tgz_1456770719339_0.5535003917757422"
+      },
+      "directories": {}
+    },
+    "3.3.0": {
+      "name": "bonjour",
+      "version": "3.3.0",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "array-flatten": "^2.0.0",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.1",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        55.6808085,
+        12.5719105
+      ],
+      "gitHead": "d6f5759dec702fda1af053127e01cab206926faa",
+      "_id": "bonjour@3.3.0",
+      "_shasum": "20cd443fdde3f74e579577d4e8e9aa46e1f64c3a",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "20cd443fdde3f74e579577d4e8e9aa46e1f64c3a",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.3.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/bonjour-3.3.0.tgz_1461187377832_0.2997572396416217"
+      },
+      "directories": {}
+    },
+    "3.3.1": {
+      "name": "bonjour",
+      "version": "3.3.1",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "array-flatten": "^2.1.0",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        52.5308832,
+        13.3838183
+      ],
+      "gitHead": "1e9c12ee27bb453f332bd9561ead0909dbb84586",
+      "_id": "bonjour@3.3.1",
+      "_shasum": "7494237fb6ec11cc2e8c0eb71386357c15059a5e",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "7494237fb6ec11cc2e8c0eb71386357c15059a5e",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.3.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/bonjour-3.3.1.tgz_1462051268827_0.2535813821014017"
+      },
+      "directories": {}
+    },
+    "3.4.0": {
+      "name": "bonjour",
+      "version": "3.4.0",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        55.6877288,
+        12.5955495
+      ],
+      "gitHead": "b865400c2a2b57f06b8f888f5d7c4c5064c279ae",
+      "_id": "bonjour@3.4.0",
+      "_shasum": "fd97cb64aa2d4c1d5b973d122b2198f5790aab90",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "fd97cb64aa2d4c1d5b973d122b2198f5790aab90",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.4.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/bonjour-3.4.0.tgz_1462562731096_0.9826692077331245"
+      },
+      "directories": {}
+    },
+    "3.5.0": {
+      "name": "bonjour",
+      "version": "3.5.0",
+      "description": "A Bonjour/Zeroconf implementation in pure JavaScript",
+      "main": "index.js",
+      "dependencies": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "scripts": {
+        "test": "standard && tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/bonjour.git"
+      },
+      "keywords": [
+        "bonjour",
+        "zeroconf",
+        "zero",
+        "configuration",
+        "mdns",
+        "dns",
+        "service",
+        "discovery",
+        "multicast",
+        "broadcast",
+        "dns-sd"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/bonjour/issues"
+      },
+      "homepage": "https://github.com/watson/bonjour",
+      "coordinates": [
+        55.68250900965318,
+        12.586377442991648
+      ],
+      "gitHead": "416412bc13bc269800784792494ecbe7642c4bef",
+      "_id": "bonjour@3.5.0",
+      "_shasum": "8e890a183d8ee9a2393b3844c691a42bcf7bc9f5",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "8e890a183d8ee9a2393b3844c691a42bcf7bc9f5",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/bonjour-3.5.0.tgz_1462615076654_0.2484443129505962"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# bonjour\n\nA Bonjour/Zeroconf protocol implementation in pure JavaScript. Publish\nservices on the local network or discover existing services using\nmulticast DNS.\n\n[![Build status](https://travis-ci.org/watson/bonjour.svg?branch=master)](https://travis-ci.org/watson/bonjour)\n[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)\n\n## Installation\n\n```\nnpm install bonjour\n```\n\n## Usage\n\n```js\nvar bonjour = require('bonjour')()\n\n// advertise an HTTP server on port 3000\nbonjour.publish({ name: 'My Web Server', type: 'http', port: 3000 })\n\n// browse for all http services\nbonjour.find({ type: 'http' }, function (service) {\n  console.log('Found an HTTP server:', service)\n})\n```\n\n## API\n\n### Initializing\n\n```js\nvar bonjour = require('bonjour')([options])\n```\n\nThe `options` are optional and will be used when initializing the\nunderlying multicast-dns server. For details see [the multicast-dns\ndocumentation](https://github.com/mafintosh/multicast-dns#mdns--multicastdnsoptions).\n\n### Publishing\n\n#### `var service = bonjour.publish(options)`\n\nPublishes a new service.\n\nOptions are:\n\n- `name` (string)\n- `host` (string, optional) - defaults to local hostname\n- `port` (number)\n- `type` (string)\n- `subtypes` (array of strings, optional)\n- `protocol` (string, optional) - `udp` or `tcp` (default)\n- `txt` (object, optional) - a key/value object to broadcast as the TXT\n  record\n\nIANA maintains a [list of official service types and port\nnumbers](http://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml).\n\n#### `bonjour.unpublishAll([callback])`\n\nUnpublish all services. The optional `callback` will be called when the\nservices have been unpublished.\n\n#### `bonjour.destroy()`\n\nDestroy the mdns instance. Closes the udp socket.\n\n### Browser\n\n#### `var browser = bonjour.find(options[, onup])`\n\nListen for services advertised on the network. An optional callback can\nbe provided as the 2nd argument and will be added as an event listener\nfor the `up` event.\n\nOptions (all optional):\n\n- `type` (string)\n- `subtypes` (array of strings)\n- `protocol` (string) - defaults to `tcp`\n- `txt` (object) - passed into [dns-txt\n  module](https://github.com/watson/dns-txt) contructor. Set to `{\n  binary: true }` if you want to keep the TXT records in binary\n\n#### `var browser = bonjour.findOne(options[, callback])`\n\nListen for and call the `callback` with the first instance of a service\nmatching the `options`. If no `callback` is given, it's expected that\nyou listen for the `up` event. The returned `browser` will automatically\nstop it self after the first matching service.\n\nOptions are the same as given in the `browser.find` function.\n\n#### `Event: up`\n\nEmitted every time a new service is found that matches the browser.\n\n#### `Event: down`\n\nEmitted every time an existing service emmits a goodbye message.\n\n#### `browser.services`\n\nAn array of services known by the browser to be online.\n\n#### `browser.start()`\n\nStart looking for matching services.\n\n#### `browser.stop()`\n\nStop looking for matching services.\n\n#### `browser.update()`\n\nBroadcast the query again.\n\n### Service\n\n#### `Event: up`\n\nEmitted when the service is up.\n\n#### `Event: error`\n\nEmitted if an error occurrs while publishing the service.\n\n#### `service.stop([callback])`\n\nUnpublish the service. The optional `callback` will be called when the\nservice have been unpublished.\n\n#### `service.start()`\n\nPublish the service.\n\n#### `service.name`\n\nThe name of the service, e.g. `Apple TV`.\n\n#### `service.type`\n\nThe type of the service, e.g. `http`.\n\n#### `service.subtypes`\n\nAn array of subtypes. Note that this property might be `null`.\n\n#### `service.protocol`\n\nThe protocol used by the service, e.g. `tcp`.\n\n#### `service.host`\n\nThe hostname or ip address where the service resides.\n\n#### `service.port`\n\nThe port on which the service listens, e.g. `5000`.\n\n#### `service.fqdn`\n\nThe fully qualified domain name of the service. E.g. if given the name\n`Foo Bar`, the type `http` and the protocol `tcp`, the `service.fqdn`\nproperty will be `Foo Bar._http._tcp.local`.\n\n#### `service.txt`\n\nThe TXT record advertised by the service (a key/value object). Note that\nthis property might be `null`.\n\n#### `service.published`\n\nA boolean indicating if the service is currently published.\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "watson",
+      "email": "w@tson.dk"
+    }
+  ],
+  "time": {
+    "modified": "2018-01-17T10:29:01.987Z",
+    "created": "2013-10-03T17:58:46.826Z",
+    "1.0.0": "2013-10-03T17:58:50.007Z",
+    "2.0.0": "2015-12-14T20:27:07.614Z",
+    "3.0.0": "2015-12-29T19:12:35.432Z",
+    "3.0.1": "2016-01-10T16:53:18.786Z",
+    "3.1.0": "2016-01-18T06:46:49.660Z",
+    "3.2.0": "2016-01-23T17:56:58.837Z",
+    "3.2.1": "2016-02-29T09:46:45.804Z",
+    "3.2.2": "2016-02-29T18:32:01.123Z",
+    "3.3.0": "2016-04-20T21:22:58.934Z",
+    "3.3.1": "2016-04-30T21:21:11.223Z",
+    "3.4.0": "2016-05-06T19:25:32.727Z",
+    "3.5.0": "2016-05-07T09:57:57.679Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/watson/bonjour",
+  "keywords": [
+    "bonjour",
+    "zeroconf",
+    "zero",
+    "configuration",
+    "mdns",
+    "dns",
+    "service",
+    "discovery",
+    "multicast",
+    "broadcast",
+    "dns-sd"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/watson/bonjour.git"
+  },
+  "author": {
+    "name": "Thomas Watson Steen",
+    "email": "w@tson.dk",
+    "url": "https://twitter.com/wa7son"
+  },
+  "bugs": {
+    "url": "https://github.com/watson/bonjour/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "yrocq": true,
+    "phgyorgygulyas": true,
+    "m80126colin": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/bonjour.min.json
+++ b/test/fixtures/registry-mocks/content/bonjour.min.json
@@ -1,0 +1,239 @@
+{
+  "name": "bonjour",
+  "dist-tags": {
+    "latest": "3.5.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "bonjour",
+      "version": "1.0.0",
+      "dependencies": {
+        "sails": "0.9.4",
+        "grunt": "0.4.1",
+        "sails-disk": "~0.9.0",
+        "ejs": "0.8.4",
+        "optimist": "0.3.4",
+        "request": "~2.27.0"
+      },
+      "dist": {
+        "shasum": "9c9445248ecd4beedf78aeafad271f64f6e1feb9",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "bonjour",
+      "version": "2.0.0",
+      "dependencies": {
+        "mdns-txt": "^1.0.0",
+        "multicast-dns": "^4.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.2"
+      },
+      "dist": {
+        "shasum": "00ecd28aa298db4f9aee2ce9da839a1441a8f58f",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-2.0.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "bonjour",
+      "version": "3.0.0",
+      "dependencies": {
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "53b5d031449c1f5a96e0ff9c0be865cd5aea18df",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "bonjour",
+      "version": "3.0.1",
+      "dependencies": {
+        "dns-equal": "^1.0.0",
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "4f1020bda6b507a6fde7efec158a25a6e703154e",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.0.1.tgz"
+      }
+    },
+    "3.1.0": {
+      "name": "bonjour",
+      "version": "3.1.0",
+      "dependencies": {
+        "dns-equal": "^1.0.0",
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "57cf1c3f1a17ed5d07345773051ce1a1fb3582e8",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.1.0.tgz"
+      }
+    },
+    "3.2.0": {
+      "name": "bonjour",
+      "version": "3.2.0",
+      "dependencies": {
+        "dns-equal": "^1.0.0",
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "2c01244a4dc46fb875ee75dc6ffd7a303f543887",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.2.0.tgz"
+      }
+    },
+    "3.2.1": {
+      "name": "bonjour",
+      "version": "3.2.1",
+      "dependencies": {
+        "array-flatten": "^2.0.0",
+        "dns-equal": "^1.0.0",
+        "mdns-txt": "^2.0.0",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "5a4c148223c2473657167bd887088b96218fbcb5",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.2.1.tgz"
+      }
+    },
+    "3.2.2": {
+      "name": "bonjour",
+      "version": "3.2.2",
+      "dependencies": {
+        "array-flatten": "^2.0.0",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.1",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "4f5bd4c10cfcd9f7fb659ecfde8f6682f05cd6dc",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.2.2.tgz"
+      }
+    },
+    "3.3.0": {
+      "name": "bonjour",
+      "version": "3.3.0",
+      "dependencies": {
+        "array-flatten": "^2.0.0",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.1",
+        "multicast-dns": "^5.0.0",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "20cd443fdde3f74e579577d4e8e9aa46e1f64c3a",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.3.0.tgz"
+      }
+    },
+    "3.3.1": {
+      "name": "bonjour",
+      "version": "3.3.1",
+      "dependencies": {
+        "array-flatten": "^2.1.0",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "7494237fb6ec11cc2e8c0eb71386357c15059a5e",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.3.1.tgz"
+      }
+    },
+    "3.4.0": {
+      "name": "bonjour",
+      "version": "3.4.0",
+      "dependencies": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "fd97cb64aa2d4c1d5b973d122b2198f5790aab90",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.4.0.tgz"
+      }
+    },
+    "3.5.0": {
+      "name": "bonjour",
+      "version": "3.5.0",
+      "dependencies": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      },
+      "devDependencies": {
+        "after-all": "^2.0.2",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "8e890a183d8ee9a2393b3844c691a42bcf7bc9f5",
+        "tarball": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz"
+      }
+    }
+  },
+  "modified": "2018-01-17T10:29:01.987Z"
+}

--- a/test/fixtures/registry-mocks/content/brorand.json
+++ b/test/fixtures/registry-mocks/content/brorand.json
@@ -1,0 +1,617 @@
+{
+  "_id": "brorand",
+  "_rev": "16-24e78d45ca110323f7e2c6aa26d22c9c",
+  "name": "brorand",
+  "description": "Random number generator for browsers and node.js",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "brorand",
+      "version": "1.0.1",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/brorand"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "gitHead": "dd4ab8f59410d655963920c8a767cc01e5cab361",
+      "_id": "brorand@1.0.1",
+      "_shasum": "c77a5521dcd2e955f40c00f7d00fbe6a0c6fb313",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c77a5521dcd2e955f40c00f7d00fbe6a0c6fb313",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "brorand",
+      "version": "1.0.2",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/brorand"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "optionalDependencies": {
+        "randy.js": "^1.5.1"
+      },
+      "gitHead": "2e4bd3c926d446fd3298a3e6ae5e145069955d7f",
+      "dependencies": {
+        "randy.js": "^1.5.1"
+      },
+      "_id": "brorand@1.0.2",
+      "_shasum": "d94c39f5dd37fa1d984462544e00b0d4b63705a4",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d94c39f5dd37fa1d984462544e00b0d4b63705a4",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "brorand",
+      "version": "1.0.3",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/brorand"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "gitHead": "3cf9b2978b2c18a8feeadc62049a1a2861a530bd",
+      "_id": "brorand@1.0.3",
+      "_shasum": "03d280ae9a93695f2c6b13aed710cf17a7ae6962",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "03d280ae9a93695f2c6b13aed710cf17a7ae6962",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "brorand",
+      "version": "1.0.4",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/brorand"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "gitHead": "ced954466d786a8d6c2d49114a3b9b65388e547c",
+      "_id": "brorand@1.0.4",
+      "_shasum": "ffee2db32e22b60f38ee8828cffc41b60ea35cb4",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ffee2db32e22b60f38ee8828cffc41b60ea35cb4",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "brorand",
+      "version": "1.0.5",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/brorand"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "gitHead": "571027e0ffa1119c720bcdb8aa9c987f63beb5a6",
+      "_id": "brorand@1.0.5",
+      "_shasum": "07b54ca30286abd1718a0e2a830803efdc9bfa04",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "07b54ca30286abd1718a0e2a830803efdc9bfa04",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "brorand",
+      "version": "1.0.6",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/brorand.git"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "browser": {
+        "crypto": false
+      },
+      "gitHead": "f077f0a95c627f2707d7b7699ccddca308a58d15",
+      "_id": "brorand@1.0.6",
+      "_shasum": "4028706b915f91f7b349a2e0bf3c376039d216e5",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "4028706b915f91f7b349a2e0bf3c376039d216e5",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/brorand-1.0.6.tgz_1473323651066_0.41867022518999875"
+      },
+      "directories": {}
+    },
+    "1.0.7": {
+      "name": "brorand",
+      "version": "1.0.7",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/brorand.git"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "browser": {
+        "crypto": false
+      },
+      "gitHead": "8d5de11ca922e2382e3876221cb07a3e8567f498",
+      "_id": "brorand@1.0.7",
+      "_shasum": "6677fa5e4901bdbf9c9ec2a748e28dca407a9bfc",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "6677fa5e4901bdbf9c9ec2a748e28dca407a9bfc",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/brorand-1.0.7.tgz_1486421795037_0.6743347148876637"
+      },
+      "directories": {}
+    },
+    "1.0.8": {
+      "name": "brorand",
+      "version": "1.0.8",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/brorand.git"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "browser": {
+        "crypto": false
+      },
+      "gitHead": "4bd181f44bdb7c2006cf6016c2ad8c5cd0117fe2",
+      "_id": "brorand@1.0.8",
+      "_shasum": "2c2fe4082fbfed85fc3507b997482065400e0747",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "2c2fe4082fbfed85fc3507b997482065400e0747",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/brorand-1.0.8.tgz_1487799210726_0.276269624941051"
+      },
+      "directories": {}
+    },
+    "1.0.9": {
+      "name": "brorand",
+      "version": "1.0.9",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/brorand.git"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "browser": {
+        "crypto": false
+      },
+      "gitHead": "c3f39069ca3108c6a893c8471f35c165e951735f",
+      "_id": "brorand@1.0.9",
+      "_shasum": "90afcee4020641b87136cb92b6efb60b6316ada1",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "90afcee4020641b87136cb92b6efb60b6316ada1",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/brorand-1.0.9.tgz_1487799387572_0.12808308168314397"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "brorand",
+      "version": "1.1.0",
+      "description": "Random number generator for browsers and node.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/brorand.git"
+      },
+      "keywords": [
+        "Random",
+        "RNG",
+        "browser",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/brorand/issues"
+      },
+      "homepage": "https://github.com/indutny/brorand",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "browser": {
+        "crypto": false
+      },
+      "gitHead": "ddc4f9344287769d7e2c2ea987d26bbeec5456b4",
+      "_id": "brorand@1.1.0",
+      "_shasum": "12c25efe40a45e3c323eb8675a0a0ce57b22371f",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "12c25efe40a45e3c323eb8675a0a0ce57b22371f",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/brorand-1.1.0.tgz_1487799559972_0.5302366453688592"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# Brorand\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2014.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-02-22T21:39:22.072Z",
+    "created": "2014-11-05T17:05:00.269Z",
+    "1.0.1": "2014-11-05T17:05:00.269Z",
+    "1.0.2": "2014-11-07T14:52:57.839Z",
+    "1.0.3": "2014-11-07T15:03:19.052Z",
+    "1.0.4": "2014-11-07T15:08:12.128Z",
+    "1.0.5": "2014-11-19T17:54:12.742Z",
+    "1.0.6": "2016-09-08T08:34:12.644Z",
+    "1.0.7": "2017-02-06T22:56:35.699Z",
+    "1.0.8": "2017-02-22T21:33:32.764Z",
+    "1.0.9": "2017-02-22T21:36:28.258Z",
+    "1.1.0": "2017-02-22T21:39:22.072Z"
+  },
+  "homepage": "https://github.com/indutny/brorand",
+  "keywords": [
+    "Random",
+    "RNG",
+    "browser",
+    "crypto"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/brorand.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/brorand/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "detj": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/brorand.min.json
+++ b/test/fixtures/registry-mocks/content/brorand.min.json
@@ -1,0 +1,125 @@
+{
+  "name": "brorand",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "brorand",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "c77a5521dcd2e955f40c00f7d00fbe6a0c6fb313",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "brorand",
+      "version": "1.0.2",
+      "dependencies": {
+        "randy.js": "^1.5.1"
+      },
+      "optionalDependencies": {
+        "randy.js": "^1.5.1"
+      },
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "d94c39f5dd37fa1d984462544e00b0d4b63705a4",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "brorand",
+      "version": "1.0.3",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "03d280ae9a93695f2c6b13aed710cf17a7ae6962",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "brorand",
+      "version": "1.0.4",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "ffee2db32e22b60f38ee8828cffc41b60ea35cb4",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "brorand",
+      "version": "1.0.5",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "07b54ca30286abd1718a0e2a830803efdc9bfa04",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.5.tgz"
+      }
+    },
+    "1.0.6": {
+      "name": "brorand",
+      "version": "1.0.6",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "4028706b915f91f7b349a2e0bf3c376039d216e5",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.6.tgz"
+      }
+    },
+    "1.0.7": {
+      "name": "brorand",
+      "version": "1.0.7",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "6677fa5e4901bdbf9c9ec2a748e28dca407a9bfc",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.7.tgz"
+      }
+    },
+    "1.0.8": {
+      "name": "brorand",
+      "version": "1.0.8",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "2c2fe4082fbfed85fc3507b997482065400e0747",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.8.tgz"
+      }
+    },
+    "1.0.9": {
+      "name": "brorand",
+      "version": "1.0.9",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "90afcee4020641b87136cb92b6efb60b6316ada1",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.0.9.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "brorand",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "12c25efe40a45e3c323eb8675a0a0ce57b22371f",
+        "tarball": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+      }
+    }
+  },
+  "modified": "2017-02-22T21:39:22.072Z"
+}

--- a/test/fixtures/registry-mocks/content/browserify-aes.json
+++ b/test/fixtures/registry-mocks/content/browserify-aes.json
@@ -1,0 +1,1794 @@
+{
+  "_id": "browserify-aes",
+  "_rev": "53-01da6ebf5ecf3826bf5a3be0624fea7c",
+  "name": "browserify-aes",
+  "description": "aes, for browserify",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "browserify-aes",
+      "version": "0.0.0",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "duplexer2": "0.0.2"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "_id": "browserify-aes@0.0.0",
+      "dist": {
+        "shasum": "af2dd3155e9e6a5ae86dcf0f29391a3ece55e1f4",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ]
+    },
+    "0.1.0": {
+      "name": "browserify-aes",
+      "version": "0.1.0",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "duplexer2": "0.0.2"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "_id": "browserify-aes@0.1.0",
+      "dist": {
+        "shasum": "36ace6b260459d8ad306c26d66681be3c67d54f1",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ]
+    },
+    "0.2.0": {
+      "name": "browserify-aes",
+      "version": "0.2.0",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "duplexer2": "0.0.2"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "_id": "browserify-aes@0.2.0",
+      "dist": {
+        "shasum": "04cd8ac6104bb1c99ebdea040d8ad1972e563292",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ]
+    },
+    "0.2.1": {
+      "name": "browserify-aes",
+      "version": "0.2.1",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "duplexer2": "0.0.2"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "gitHead": "6d117a8db53f61d6c765e65b58225ebaf8b4879e",
+      "_id": "browserify-aes@0.2.1",
+      "_shasum": "93ec05e085d1bee8159401c1ffb552a718a8ae7f",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "93ec05e085d1bee8159401c1ffb552a718a8ae7f",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "browserify-aes",
+      "version": "0.2.2",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "_id": "browserify-aes@0.2.2",
+      "dist": {
+        "shasum": "e6396db2bbac19ea2632da3accd367bf561c199e",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ]
+    },
+    "0.3.0": {
+      "name": "browserify-aes",
+      "version": "0.3.0",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "_id": "browserify-aes@0.3.0",
+      "dist": {
+        "shasum": "b419eb1d0ba212103fb67851299643af8492fd6c",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ]
+    },
+    "0.4.0": {
+      "name": "browserify-aes",
+      "version": "0.4.0",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "_id": "browserify-aes@0.4.0",
+      "dist": {
+        "shasum": "067149b668df31c4b58533e02d01e806d8608e2c",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ]
+    },
+    "0.5.0": {
+      "name": "browserify-aes",
+      "version": "0.5.0",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "_id": "browserify-aes@0.5.0",
+      "dist": {
+        "shasum": "a58d6a7a440b575aa7f1c1726fe1df172b973a9b",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ]
+    },
+    "0.6.0": {
+      "name": "browserify-aes",
+      "version": "0.6.0",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "_id": "browserify-aes@0.6.0",
+      "dist": {
+        "shasum": "07df03037306a94f453da08cbaf1b42afcc3b18f",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ]
+    },
+    "0.6.1": {
+      "name": "browserify-aes",
+      "version": "0.6.1",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "gitHead": "4ce42880f95a8fd95c05ecfbc1214134a8f1696b",
+      "_id": "browserify-aes@0.6.1",
+      "_shasum": "a7466136ffcb0a2a955d98afa8dc2ced6dc6c004",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a7466136ffcb0a2a955d98afa8dc2ced6dc6c004",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.6.1.tgz"
+      }
+    },
+    "0.7.1": {
+      "name": "browserify-aes",
+      "version": "0.7.1",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "gitHead": "991dc0f09a06bd4b82066db15e60b27fe816ac4f",
+      "_id": "browserify-aes@0.7.1",
+      "_shasum": "40e3542bd5ef1e1e0243072650710de866e46a0d",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "40e3542bd5ef1e1e0243072650710de866e46a0d",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.7.1.tgz"
+      }
+    },
+    "0.7.2": {
+      "name": "browserify-aes",
+      "version": "0.7.2",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "gitHead": "1bf29868497e73bab37fdbc642cbfc20c8116e25",
+      "_id": "browserify-aes@0.7.2",
+      "_shasum": "bdee40de0bb607b4f8794a9e23ee69eedc59ca47",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bdee40de0bb607b4f8794a9e23ee69eedc59ca47",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.7.2.tgz"
+      }
+    },
+    "0.7.3": {
+      "name": "browserify-aes",
+      "version": "0.7.3",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "gitHead": "2808b98c06f1b93566f01f71ff0fe29b20c81277",
+      "_id": "browserify-aes@0.7.3",
+      "_shasum": "d39a16bdc5e42cb54cf9c3e860dfb0c6c53534fe",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d39a16bdc5e42cb54cf9c3e860dfb0c6c53534fe",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.7.3.tgz"
+      }
+    },
+    "0.8.0": {
+      "name": "browserify-aes",
+      "version": "0.8.0",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "gitHead": "11c13d00f23b675356c716eadf2cc84d1148b9e0",
+      "_id": "browserify-aes@0.8.0",
+      "_shasum": "77887bae1f2539899c84dce10a9bf8a3ac40398a",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "77887bae1f2539899c84dce10a9bf8a3ac40398a",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.0.tgz"
+      }
+    },
+    "0.8.1": {
+      "name": "browserify-aes",
+      "version": "0.8.1",
+      "description": "aes, for browserify",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-aes",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "gitHead": "8bf9886a900b7fce19ea2b82a5d0762e278483dc",
+      "_id": "browserify-aes@0.8.1",
+      "_shasum": "05902c0db3817b7f67f1668f74efb14ee900801d",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "05902c0db3817b7f67f1668f74efb14ee900801d",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "browserify-aes",
+      "version": "1.0.0",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "gitHead": "67c90814f512df1ef2330a2156c24dc854fa99a5",
+      "_id": "browserify-aes@1.0.0",
+      "_shasum": "582efc30561166f89855fcdc945b686919848b62",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "582efc30561166f89855fcdc945b686919848b62",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "browserify-aes",
+      "version": "1.0.1",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "standard && node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "gitHead": "5f0fe487d8028daf740a48965a0b37bc9afbbbc3",
+      "_id": "browserify-aes@1.0.1",
+      "_shasum": "796543bab86b84688cb58db1dee164bd1bb2af27",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "796543bab86b84688cb58db1dee164bd1bb2af27",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "browserify-aes",
+      "version": "1.0.2",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "standard && node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "gitHead": "8e1364cab35081814a7e46b7f85651df39725e48",
+      "_id": "browserify-aes@1.0.2",
+      "_shasum": "3309c3f45426d226747c070827b6ef92c98a9fdb",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.4.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3309c3f45426d226747c070827b6ef92c98a9fdb",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "browserify-aes",
+      "version": "1.0.3",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "standard && node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "gitHead": "92262abda78d990b92df6f01af9b8808b28e16c3",
+      "_id": "browserify-aes@1.0.3",
+      "_shasum": "c5d03d36fb3fcbaa549a71ee602f91c4e5657cff",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.5.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c5d03d36fb3fcbaa549a71ee602f91c4e5657cff",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "browserify-aes",
+      "version": "1.0.4",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "standard && node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "gitHead": "7bace27bfe83bee11646ec2b411c76b76697ad0c",
+      "_id": "browserify-aes@1.0.4",
+      "_shasum": "f233838d6f1759599960c0a19e85ca1630f4bb6e",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "4.1.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "f233838d6f1759599960c0a19e85ca1630f4bb6e",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ]
+    },
+    "1.0.5": {
+      "name": "browserify-aes",
+      "version": "1.0.5",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "standard && node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "gitHead": "d45d4674a0949a28745dfe48afc4d4984dfe56fa",
+      "_id": "browserify-aes@1.0.5",
+      "_shasum": "447e7e4671fceb575f6bb16c7f31a20924f0c303",
+      "_from": ".",
+      "_npmVersion": "3.3.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "447e7e4671fceb575f6bb16c7f31a20924f0c303",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ]
+    },
+    "1.0.6": {
+      "name": "browserify-aes",
+      "version": "1.0.6",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "standard && node test/index.js|tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "gitHead": "51f8b9055371c045af448fa07bacaae3df6c8e51",
+      "_id": "browserify-aes@1.0.6",
+      "_shasum": "5e7725dbdef1fd5930d4ebab48567ce451c48a0a",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "5e7725dbdef1fd5930d4ebab48567ce451c48a0a",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ]
+    },
+    "1.0.7": {
+      "name": "browserify-aes",
+      "version": "1.0.7",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "standard": "standard",
+        "unit": "node test/index.js | tspec",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "gitHead": "77262c65c386790808b06d9ebd949d96259d22f0",
+      "_id": "browserify-aes@1.0.7",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-cnClT3H8JOM0OutZkiLFo8fjXkImHA3gERZyixrT96pdcbYO0QsZ/+Q5mbwBnzBovycHx9Dfa4Cu2fFXcKPmhQ==",
+        "shasum": "cf6ecb9c6a651d720c9e28b37bc87d10d35d6dbe",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-aes-1.0.7.tgz_1504606968820_0.154796598944813"
+      }
+    },
+    "1.0.8": {
+      "name": "browserify-aes",
+      "version": "1.0.8",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "standard": "standard",
+        "unit": "node test/index.js | tspec",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "gitHead": "845b5d173bb5243cc0a79f5bdd9044a5c5de462c",
+      "_id": "browserify-aes@1.0.8",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+        "shasum": "c8fa3b1b7585bb7ba77c5560b60996ddec6d5309",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-aes-1.0.8.tgz_1504610053961_0.5263194553554058"
+      }
+    },
+    "1.1.0": {
+      "name": "browserify-aes",
+      "version": "1.1.0",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "standard": "standard",
+        "unit": "node test/index.js | tspec",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "gitHead": "a6311163477932f035807691314e104da1ba8370",
+      "_id": "browserify-aes@1.1.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-W2bIMLYoZ9oow7TyePpMJk9l9LY7O3R61a/68bVCDOtnJynnwe3ZeW2IzzSkrQnPKNdJrxVDn3ALZNisSBwb7g==",
+        "shasum": "1d2ad62a8b479f23f0ab631c1be86a82dbccbe48",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-aes-1.1.0.tgz_1507833281191_0.3169722533784807"
+      }
+    },
+    "1.1.1": {
+      "name": "browserify-aes",
+      "version": "1.1.1",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "standard": "standard",
+        "unit": "node test/index.js | tspec",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "gitHead": "235f3d120dfb45ea13bcfff83c5e9c485c48dc71",
+      "_id": "browserify-aes@1.1.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+        "shasum": "38b7ab55edb806ff2dcda1a7f1620773a477c49f",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-aes-1.1.1.tgz_1508416355286_0.8882713539060205"
+      }
+    },
+    "1.2.0": {
+      "name": "browserify-aes",
+      "version": "1.2.0",
+      "description": "aes, for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "standard": "standard",
+        "unit": "node test/index.js | tspec",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-aes.git"
+      },
+      "keywords": [
+        "aes",
+        "crypto",
+        "browserify"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-aes",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "gitHead": "aff6836a7017aa9e55289aec357ddb199e15bd98",
+      "_id": "browserify-aes@1.2.0",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+        "shasum": "326734642f403dabc3003209853bb70ad428ef48",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+        "fileCount": 22,
+        "unpackedSize": 29767
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-aes_1.2.0_1522765396670_0.4253645800545085"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# browserify-aes\n[![Build Status](https://travis-ci.org/crypto-browserify/browserify-aes.svg)](https://travis-ci.org/crypto-browserify/browserify-aes)\n\nNode style aes for use in the browser.\nImplements:\n\n - createCipher\n - createCipheriv\n - createDecipher\n - createDecipheriv\n - getCiphers\n\nIn node.js, the `crypto` implementation is used, in browsers it falls back to a pure JavaScript implementation.\n\nMuch of this library has been taken from the aes implementation in [triplesec](https://github.com/keybase/triplesec),  a partial derivation of [crypto-js](https://code.google.com/p/crypto-js/).\n\n`EVP_BytesToKey` is a straight up port of the same function from OpenSSL as there is literally no documenation on it beyond it using 'undocumented extensions' for longer keys.\n\n## LICENSE [MIT](LICENSE)\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-01T10:51:29.823Z",
+    "created": "2014-10-15T21:24:21.295Z",
+    "0.0.0": "2014-10-15T21:24:21.295Z",
+    "0.1.0": "2014-10-16T13:55:12.697Z",
+    "0.2.0": "2014-10-16T19:09:27.713Z",
+    "0.2.1": "2014-10-16T22:34:59.912Z",
+    "0.2.2": "2014-10-17T12:54:15.473Z",
+    "0.3.0": "2014-10-20T12:26:39.571Z",
+    "0.4.0": "2014-10-28T20:10:54.971Z",
+    "0.5.0": "2014-11-11T20:10:48.011Z",
+    "0.6.0": "2014-11-11T23:52:37.022Z",
+    "0.6.1": "2014-12-01T14:13:47.295Z",
+    "0.7.1": "2014-12-23T15:31:45.034Z",
+    "0.7.2": "2014-12-23T16:11:51.496Z",
+    "0.7.3": "2015-01-03T14:19:57.999Z",
+    "0.8.0": "2015-01-04T18:29:11.912Z",
+    "0.8.1": "2015-01-05T16:16:00.973Z",
+    "1.0.0": "2015-01-19T15:26:54.948Z",
+    "1.0.1": "2015-05-21T05:50:21.062Z",
+    "1.0.2": "2015-07-20T15:58:16.167Z",
+    "1.0.3": "2015-08-07T16:34:08.671Z",
+    "1.0.4": "2015-09-23T18:24:06.555Z",
+    "1.0.5": "2015-09-27T23:21:28.118Z",
+    "1.0.6": "2016-01-21T19:50:40.204Z",
+    "1.0.7": "2017-09-05T10:22:48.884Z",
+    "1.0.8": "2017-09-05T11:14:14.083Z",
+    "1.1.0": "2017-10-12T18:34:42.123Z",
+    "1.1.1": "2017-10-19T12:32:36.201Z",
+    "1.2.0": "2018-04-03T14:23:16.754Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/browserify-aes",
+  "keywords": [
+    "aes",
+    "crypto",
+    "browserify"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/crypto-browserify/browserify-aes.git"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/browserify-aes/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "leonning": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/browserify-aes.min.json
+++ b/test/fixtures/registry-mocks/content/browserify-aes.min.json
@@ -1,0 +1,558 @@
+{
+  "name": "browserify-aes",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "browserify-aes",
+      "version": "0.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "duplexer2": "0.0.2"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "af2dd3155e9e6a5ae86dcf0f29391a3ece55e1f4",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.0.0.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "browserify-aes",
+      "version": "0.1.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "duplexer2": "0.0.2"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "36ace6b260459d8ad306c26d66681be3c67d54f1",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "browserify-aes",
+      "version": "0.2.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "duplexer2": "0.0.2"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "04cd8ac6104bb1c99ebdea040d8ad1972e563292",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "browserify-aes",
+      "version": "0.2.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "duplexer2": "0.0.2"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "93ec05e085d1bee8159401c1ffb552a718a8ae7f",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "browserify-aes",
+      "version": "0.2.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "e6396db2bbac19ea2632da3accd367bf561c199e",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.2.2.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "browserify-aes",
+      "version": "0.3.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "b419eb1d0ba212103fb67851299643af8492fd6c",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.3.0.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "browserify-aes",
+      "version": "0.4.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "067149b668df31c4b58533e02d01e806d8608e2c",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "browserify-aes",
+      "version": "0.5.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "a58d6a7a440b575aa7f1c1726fe1df172b973a9b",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.5.0.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "browserify-aes",
+      "version": "0.6.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "07df03037306a94f453da08cbaf1b42afcc3b18f",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.6.0.tgz"
+      }
+    },
+    "0.6.1": {
+      "name": "browserify-aes",
+      "version": "0.6.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "a7466136ffcb0a2a955d98afa8dc2ced6dc6c004",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.6.1.tgz"
+      }
+    },
+    "0.7.1": {
+      "name": "browserify-aes",
+      "version": "0.7.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "40e3542bd5ef1e1e0243072650710de866e46a0d",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.7.1.tgz"
+      }
+    },
+    "0.7.2": {
+      "name": "browserify-aes",
+      "version": "0.7.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "bdee40de0bb607b4f8794a9e23ee69eedc59ca47",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.7.2.tgz"
+      }
+    },
+    "0.7.3": {
+      "name": "browserify-aes",
+      "version": "0.7.3",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "d39a16bdc5e42cb54cf9c3e860dfb0c6c53534fe",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.7.3.tgz"
+      }
+    },
+    "0.8.0": {
+      "name": "browserify-aes",
+      "version": "0.8.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "77887bae1f2539899c84dce10a9bf8a3ac40398a",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.0.tgz"
+      }
+    },
+    "0.8.1": {
+      "name": "browserify-aes",
+      "version": "0.8.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "05902c0db3817b7f67f1668f74efb14ee900801d",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-0.8.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "browserify-aes",
+      "version": "1.0.0",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.0",
+        "tap-spec": "^1.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "582efc30561166f89855fcdc945b686919848b62",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "browserify-aes",
+      "version": "1.0.1",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "796543bab86b84688cb58db1dee164bd1bb2af27",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "browserify-aes",
+      "version": "1.0.2",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "3309c3f45426d226747c070827b6ef92c98a9fdb",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "browserify-aes",
+      "version": "1.0.3",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "c5d03d36fb3fcbaa549a71ee602f91c4e5657cff",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "browserify-aes",
+      "version": "1.0.4",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "f233838d6f1759599960c0a19e85ca1630f4bb6e",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "browserify-aes",
+      "version": "1.0.5",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "447e7e4671fceb575f6bb16c7f31a20924f0c303",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.5.tgz"
+      }
+    },
+    "1.0.6": {
+      "name": "browserify-aes",
+      "version": "1.0.6",
+      "dependencies": {
+        "buffer-xor": "^1.0.2",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap-spec": "^1.0.0",
+        "tape": "^3.0.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "5e7725dbdef1fd5930d4ebab48567ce451c48a0a",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz"
+      }
+    },
+    "1.0.7": {
+      "name": "browserify-aes",
+      "version": "1.0.7",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-cnClT3H8JOM0OutZkiLFo8fjXkImHA3gERZyixrT96pdcbYO0QsZ/+Q5mbwBnzBovycHx9Dfa4Cu2fFXcKPmhQ==",
+        "shasum": "cf6ecb9c6a651d720c9e28b37bc87d10d35d6dbe",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.7.tgz"
+      }
+    },
+    "1.0.8": {
+      "name": "browserify-aes",
+      "version": "1.0.8",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+        "shasum": "c8fa3b1b7585bb7ba77c5560b60996ddec6d5309",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "browserify-aes",
+      "version": "1.1.0",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-W2bIMLYoZ9oow7TyePpMJk9l9LY7O3R61a/68bVCDOtnJynnwe3ZeW2IzzSkrQnPKNdJrxVDn3ALZNisSBwb7g==",
+        "shasum": "1d2ad62a8b479f23f0ab631c1be86a82dbccbe48",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "browserify-aes",
+      "version": "1.1.1",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+        "shasum": "38b7ab55edb806ff2dcda1a7f1620773a477c49f",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "browserify-aes",
+      "version": "1.2.0",
+      "dependencies": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^9.0.0",
+        "tap-spec": "^4.1.1",
+        "tape": "^4.6.3"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+        "shasum": "326734642f403dabc3003209853bb70ad428ef48",
+        "tarball": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+        "fileCount": 22,
+        "unpackedSize": 29767
+      }
+    }
+  },
+  "modified": "2019-01-01T10:51:29.823Z"
+}

--- a/test/fixtures/registry-mocks/content/browserify-cipher.json
+++ b/test/fixtures/registry-mocks/content/browserify-cipher.json
@@ -1,0 +1,152 @@
+{
+  "_id": "browserify-cipher",
+  "_rev": "2-4115eadb0ddd4997c7b5918ab258c262",
+  "name": "browserify-cipher",
+  "description": "ciphers for the browser",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "browserify-cipher",
+      "version": "1.0.0",
+      "description": "ciphers for the browser",
+      "main": "index.js",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      },
+      "browser": "browser.js",
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/browserify-cipher.git"
+      },
+      "gitHead": "a293143d06e1aa03aee035521c3379e9402c3074",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-cipher/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-cipher#readme",
+      "_id": "browserify-cipher@1.0.0",
+      "_shasum": "9988244874bf5ed4e28da95666dcd66ac8fc363a",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "9988244874bf5ed4e28da95666dcd66ac8fc363a",
+        "tarball": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "browserify-cipher",
+      "version": "1.0.1",
+      "description": "ciphers for the browser",
+      "main": "index.js",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      },
+      "browser": "browser.js",
+      "devDependencies": {
+        "standard": "^10.0.2",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/browserify-cipher.git"
+      },
+      "gitHead": "79b8cb5b5c78ff328a4e537cfe8374f1daa5cd8b",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-cipher/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-cipher#readme",
+      "_id": "browserify-cipher@1.0.1",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+        "shasum": "8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0",
+        "tarball": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6445
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-cipher_1.0.1_1523448336743_0.22997879907065655"
+      }
+    }
+  },
+  "readme": "browserify-cipher\n===\n\n[![Build Status](https://travis-ci.org/crypto-browserify/browserify-cipher.svg)](https://travis-ci.org/crypto-browserify/browserify-cipher)\n\nProvides createCipher, createDecipher, createCipheriv, createDecipheriv and\ngetCiphers for the browserify.  Includes AES and DES ciphers.\n",
+  "maintainers": [
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-04-11T12:05:38.042Z",
+    "created": "2015-09-27T18:37:38.639Z",
+    "1.0.0": "2015-09-27T18:37:38.639Z",
+    "1.0.1": "2018-04-11T12:05:37.638Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/browserify-cipher#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/crypto-browserify/browserify-cipher.git"
+  },
+  "author": {
+    "name": "Calvin Metcalf",
+    "email": "calvin.metcalf@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/browserify-cipher/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/browserify-cipher.min.json
+++ b/test/fixtures/registry-mocks/content/browserify-cipher.min.json
@@ -1,0 +1,48 @@
+{
+  "name": "browserify-cipher",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "browserify-cipher",
+      "version": "1.0.0",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "9988244874bf5ed4e28da95666dcd66ac8fc363a",
+        "tarball": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "browserify-cipher",
+      "version": "1.0.1",
+      "dependencies": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^10.0.2",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+        "shasum": "8d6474c1b870bfdabcd3bcfcc1934a10e94f15f0",
+        "tarball": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6445
+      }
+    }
+  },
+  "modified": "2018-04-11T12:05:38.042Z"
+}

--- a/test/fixtures/registry-mocks/content/browserify-des.json
+++ b/test/fixtures/registry-mocks/content/browserify-des.json
@@ -1,0 +1,211 @@
+{
+  "_id": "browserify-des",
+  "_rev": "3-8e2ab9d52a9a1bc156dc5c3549f41880",
+  "name": "browserify-des",
+  "description": "browserify-des ===",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "browserify-des",
+      "version": "1.0.0",
+      "description": "browserify-des ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-des.git"
+      },
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-des/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-des#readme",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "ec4fc6ad180ab43efe687bdb6e84100d048c9c53",
+      "_id": "browserify-des@1.0.0",
+      "_shasum": "daa277717470922ed2fe18594118a175439721dd",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "daa277717470922ed2fe18594118a175439721dd",
+        "tarball": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "browserify-des",
+      "version": "1.0.1",
+      "description": "browserify-des ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-des.git"
+      },
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-des/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-des#readme",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "706b93774021bdab8f4e4b5f07702f21e798dc31",
+      "_id": "browserify-des@1.0.1",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+        "shasum": "3343124db6d7ad53e26a8826318712bdc8450f9c",
+        "tarball": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 4850
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-des_1.0.1_1523448127837_0.608715787158207"
+      }
+    },
+    "1.0.2": {
+      "name": "browserify-des",
+      "version": "1.0.2",
+      "description": "browserify-des ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-des.git"
+      },
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-des/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-des#readme",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "08937ef8fa24e56fdf831fa36e9a54958fe64819",
+      "_id": "browserify-des@1.0.2",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+        "shasum": "3af4f1f59839403572f1c66204375f7a7f703e9c",
+        "tarball": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6267,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbRMuGCRA9TVsSAnZWagAA94kP/0S2jnDAL6LTpyr7fHlO\n/u5buNKNsq+1MOd6tKSs9FPlKVtLMBBaCKekrnMJbFD7YBiMY8W1XF3IVjGs\n5bWzaDrte2PegvOFonf8woaOXeuIommb5hzFg2zsX7crPImJwy9xiARZuoCN\nH//JWvAjHh1PaxVU0qzkPJ0IH/Z1MeyKvSBziDJhuQzswhVnwiMoPaQUE0vf\nzj4Wi/B0RCc/okReBadVnMfKbVd9FwVaDe+/tUkF6v5IOqcgxCyEoxHsOJB8\nP5wvfH5WWZZmjFamlwLWjRSR9xdQNY9iK41MaO7v8ySABZsptcJIB2vgN18a\nutPgzQziRWGwmVmS1FX5SU9oLUYAxN4xy58L6Uid0vfWLBmmE6yF6jVF49XJ\n8keHCCK1kyPcSO7cjmV1hlX8YyLyREOzl6cDTLk7uXGyIoqavsdbiKQ6fFUv\nBmRwH6DRIpmhzbKxG+UxoO8ICPKnwap5caBhN/jcc6zqNvhQz664CngilX62\nSqrC8GZzCcEzC/50U+F3ahUUuTPRYd3jMOUBLbeqH8t9QiMoZY8NgP/t2uzE\nJG+G5BGB2wQLv0veVupwKKzmR8hpFXt5nygjbVWGhbrKuSGckbDV4iYJw/CZ\nHhxNoJakuYB9vY6YP8sW+lApHNkTkJfCl0DPqBxr4uv32GkevZVKiydp1NqX\nEp95\r\n=aID6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-des_1.0.2_1531235206342_0.9678048470099503"
+      }
+    }
+  },
+  "readme": "browserify-des\n===\n\n[![Build Status](https://travis-ci.org/crypto-browserify/browserify-des.svg)](https://travis-ci.org/crypto-browserify/browserify-des)\n\nDES for browserify\n",
+  "maintainers": [
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-07-10T15:06:54.587Z",
+    "created": "2015-09-27T17:31:03.293Z",
+    "1.0.0": "2015-09-27T17:31:03.293Z",
+    "1.0.1": "2018-04-11T12:02:07.915Z",
+    "1.0.2": "2018-07-10T15:06:46.481Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/browserify-des#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/browserify-des.git"
+  },
+  "author": {
+    "name": "Calvin Metcalf",
+    "email": "calvin.metcalf@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/browserify-des/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/browserify-des.min.json
+++ b/test/fixtures/registry-mocks/content/browserify-des.min.json
@@ -1,0 +1,71 @@
+{
+  "name": "browserify-des",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "browserify-des",
+      "version": "1.0.0",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "daa277717470922ed2fe18594118a175439721dd",
+        "tarball": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "browserify-des",
+      "version": "1.0.1",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
+        "shasum": "3343124db6d7ad53e26a8826318712bdc8450f9c",
+        "tarball": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 4850
+      }
+    },
+    "1.0.2": {
+      "name": "browserify-des",
+      "version": "1.0.2",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+        "shasum": "3af4f1f59839403572f1c66204375f7a7f703e9c",
+        "tarball": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6267,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbRMuGCRA9TVsSAnZWagAA94kP/0S2jnDAL6LTpyr7fHlO\n/u5buNKNsq+1MOd6tKSs9FPlKVtLMBBaCKekrnMJbFD7YBiMY8W1XF3IVjGs\n5bWzaDrte2PegvOFonf8woaOXeuIommb5hzFg2zsX7crPImJwy9xiARZuoCN\nH//JWvAjHh1PaxVU0qzkPJ0IH/Z1MeyKvSBziDJhuQzswhVnwiMoPaQUE0vf\nzj4Wi/B0RCc/okReBadVnMfKbVd9FwVaDe+/tUkF6v5IOqcgxCyEoxHsOJB8\nP5wvfH5WWZZmjFamlwLWjRSR9xdQNY9iK41MaO7v8ySABZsptcJIB2vgN18a\nutPgzQziRWGwmVmS1FX5SU9oLUYAxN4xy58L6Uid0vfWLBmmE6yF6jVF49XJ\n8keHCCK1kyPcSO7cjmV1hlX8YyLyREOzl6cDTLk7uXGyIoqavsdbiKQ6fFUv\nBmRwH6DRIpmhzbKxG+UxoO8ICPKnwap5caBhN/jcc6zqNvhQz664CngilX62\nSqrC8GZzCcEzC/50U+F3ahUUuTPRYd3jMOUBLbeqH8t9QiMoZY8NgP/t2uzE\nJG+G5BGB2wQLv0veVupwKKzmR8hpFXt5nygjbVWGhbrKuSGckbDV4iYJw/CZ\nHhxNoJakuYB9vY6YP8sW+lApHNkTkJfCl0DPqBxr4uv32GkevZVKiydp1NqX\nEp95\r\n=aID6\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2018-07-10T15:06:54.587Z"
+}

--- a/test/fixtures/registry-mocks/content/browserify-rsa.json
+++ b/test/fixtures/registry-mocks/content/browserify-rsa.json
@@ -1,0 +1,520 @@
+{
+  "_id": "browserify-rsa",
+  "_rev": "24-fde8d7a1d845e62d1b3362b111fed881",
+  "name": "browserify-rsa",
+  "description": "RSA for browserify",
+  "dist-tags": {
+    "latest": "4.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "browserify-rsa",
+      "version": "1.0.0",
+      "description": "browserify-rsa ====",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": "",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:calvinmetcalf/browserify-rsa.git"
+      },
+      "gitHead": "ceb731f7d56e4aba5440b99709dda6c2cb38b5dc",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-rsa/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-rsa",
+      "_id": "browserify-rsa@1.0.0",
+      "_shasum": "bcfd798b92c00b084f31456241bd21cd2b572409",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bcfd798b92c00b084f31456241bd21cd2b572409",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "browserify-rsa",
+      "version": "1.1.0",
+      "description": "browserify-rsa ==== [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-rsa.svg)](https://travis-ci.org/calvinmetcalf/browserify-rsa)",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "author": "",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:calvinmetcalf/browserify-rsa.git"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^1.2.0"
+      },
+      "gitHead": "240e16c3b116dca1a63e463f494bd3447abb3b8a",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-rsa/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-rsa",
+      "_id": "browserify-rsa@1.1.0",
+      "_shasum": "c8262236d86ec4cf472d8fc0b839344dec3c0741",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c8262236d86ec4cf472d8fc0b839344dec3c0741",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "browserify-rsa",
+      "version": "1.1.1",
+      "description": "browserify-rsa ==== [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-rsa.svg)](https://travis-ci.org/calvinmetcalf/browserify-rsa)",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "author": "",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:calvinmetcalf/browserify-rsa.git"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^1.2.0"
+      },
+      "gitHead": "4f48f8733048a7115a7459c6c0152b3550e0f08f",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-rsa/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-rsa",
+      "_id": "browserify-rsa@1.1.1",
+      "_shasum": "d7c952e12e44192680613ea7f3baa83af585c8ad",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d7c952e12e44192680613ea7f3baa83af585c8ad",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "browserify-rsa",
+      "version": "2.0.0",
+      "description": "browserify-rsa ==== [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-rsa.svg)](https://travis-ci.org/calvinmetcalf/browserify-rsa)",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "author": "",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:calvinmetcalf/browserify-rsa.git"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^3.0.0"
+      },
+      "gitHead": "f0f7efebf5a0dce46cec9f396f21e215328a0c88",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-rsa/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-rsa",
+      "_id": "browserify-rsa@2.0.0",
+      "_shasum": "b3e4f6d03a07db4408bfd9dbc0fef323bfe1bdcb",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "1.0.4",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b3e4f6d03a07db4408bfd9dbc0fef323bfe1bdcb",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "browserify-rsa",
+      "version": "2.0.1",
+      "description": "browserify-rsa ==== [![Build Status](https://travis-ci.org/crypto-browserify/browserify-rsa.svg)](https://travis-ci.org/crypto-browserify/browserify-rsa)",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "author": "",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:calvinmetcalf/browserify-rsa.git"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^3.0.0"
+      },
+      "gitHead": "130a777e463ebde28794645611c099c6685f44bf",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-rsa/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-rsa",
+      "_id": "browserify-rsa@2.0.1",
+      "_shasum": "9e6ec3e5bca3fdd11c9a93c14d2bb146470083bc",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9e6ec3e5bca3fdd11c9a93c14d2bb146470083bc",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "browserify-rsa",
+      "version": "3.0.0",
+      "description": "RSA for browserify",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "author": "",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^3.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/calvinmetcalf/browserify-rsa.git"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^3.0.0"
+      },
+      "gitHead": "b0c488809895150afb073cd3274ff82c80d3d2e0",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-rsa/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-rsa#readme",
+      "_id": "browserify-rsa@3.0.0",
+      "_shasum": "9e8ea73e4eb1038aa0291ec4c25d1c41753133fc",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "3.3.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "9e8ea73e4eb1038aa0291ec4c25d1c41753133fc",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "browserify-rsa",
+      "version": "4.0.0",
+      "description": "RSA for browserify",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "author": "",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/calvinmetcalf/browserify-rsa.git"
+      },
+      "devDependencies": {
+        "parse-asn1": "^5.0.0",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "c6465e2cecc9872b80e77ffe6dfce993991db142",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-rsa/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-rsa#readme",
+      "_id": "browserify-rsa@4.0.0",
+      "_shasum": "a72c5e33833fd576c3ccd3d1d5fe61c48fdd974d",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "a72c5e33833fd576c3ccd3d1d5fe61c48fdd974d",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.1": {
+      "name": "browserify-rsa",
+      "version": "4.0.1",
+      "description": "RSA for browserify",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "author": "",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/browserify-rsa.git"
+      },
+      "devDependencies": {
+        "parse-asn1": "^5.0.0",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "63b22b3306a8a55b6c2d4f34e2c331db0c8398e7",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-rsa/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-rsa#readme",
+      "_id": "browserify-rsa@4.0.1",
+      "_shasum": "21e0abfaf6f2029cf2fafb133567a701d4135524",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "21e0abfaf6f2029cf2fafb133567a701d4135524",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/browserify-rsa-4.0.1.tgz_1456441196079_0.6414434532634914"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "browserify-rsa\n====\n[![Build Status](https://travis-ci.org/crypto-browserify/browserify-rsa.svg)](https://travis-ci.org/crypto-browserify/browserify-rsa)\n\nRSA private decryption/signing using chinese remainder and blinding.\n\nAPI\n====\n\nGive it a message as a buffer and a private key (as decoded by https://www.npmjs.com/package/parse-asn1) and it returns encrypted data as a buffer.\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-01T10:53:58.815Z",
+    "created": "2014-12-22T15:58:02.766Z",
+    "1.0.0": "2014-12-22T15:58:02.766Z",
+    "1.1.0": "2014-12-22T18:59:01.867Z",
+    "1.1.1": "2015-01-06T12:47:10.377Z",
+    "1.2.0": "2015-01-28T15:10:33.718Z",
+    "2.0.0": "2015-01-28T17:36:03.303Z",
+    "2.0.1": "2015-05-21T02:56:00.897Z",
+    "3.0.0": "2015-10-26T22:37:16.706Z",
+    "4.0.0": "2015-10-29T14:15:37.450Z",
+    "4.0.1": "2016-02-25T22:59:56.886Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/browserify-rsa#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/crypto-browserify/browserify-rsa.git"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/browserify-rsa/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md"
+}

--- a/test/fixtures/registry-mocks/content/browserify-rsa.min.json
+++ b/test/fixtures/registry-mocks/content/browserify-rsa.min.json
@@ -1,0 +1,137 @@
+{
+  "name": "browserify-rsa",
+  "dist-tags": {
+    "latest": "4.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "browserify-rsa",
+      "version": "1.0.0",
+      "dependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "dist": {
+        "shasum": "bcfd798b92c00b084f31456241bd21cd2b572409",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "browserify-rsa",
+      "version": "1.1.0",
+      "dependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^1.2.0"
+      },
+      "dist": {
+        "shasum": "c8262236d86ec4cf472d8fc0b839344dec3c0741",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "browserify-rsa",
+      "version": "1.1.1",
+      "dependencies": {
+        "bn.js": "^1.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^1.2.0"
+      },
+      "dist": {
+        "shasum": "d7c952e12e44192680613ea7f3baa83af585c8ad",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "browserify-rsa",
+      "version": "2.0.0",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "b3e4f6d03a07db4408bfd9dbc0fef323bfe1bdcb",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "browserify-rsa",
+      "version": "2.0.1",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "9e6ec3e5bca3fdd11c9a93c14d2bb146470083bc",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-2.0.1.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "browserify-rsa",
+      "version": "3.0.0",
+      "dependencies": {
+        "bn.js": "^3.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3",
+        "parse-asn1": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "9e8ea73e4eb1038aa0291ec4c25d1c41753133fc",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-3.0.0.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "browserify-rsa",
+      "version": "4.0.0",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "parse-asn1": "^5.0.0",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "a72c5e33833fd576c3ccd3d1d5fe61c48fdd974d",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.0.tgz"
+      }
+    },
+    "4.0.1": {
+      "name": "browserify-rsa",
+      "version": "4.0.1",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "parse-asn1": "^5.0.0",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "21e0abfaf6f2029cf2fafb133567a701d4135524",
+        "tarball": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2019-01-01T10:53:58.815Z"
+}

--- a/test/fixtures/registry-mocks/content/browserify-sign.json
+++ b/test/fixtures/registry-mocks/content/browserify-sign.json
@@ -1,0 +1,1931 @@
+{
+  "_id": "browserify-sign",
+  "_rev": "59-cfdc3e7f3b6265aeace0c3c47fe29a18",
+  "name": "browserify-sign",
+  "description": "adds node crypto signing for browsers",
+  "dist-tags": {
+    "latest": "4.2.1"
+  },
+  "versions": {
+    "2.0.0": {
+      "name": "browserify-sign",
+      "version": "2.0.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "pemstrip": "0.0.1",
+        "asn1.js-rfc3280": "^0.5.1",
+        "inherits": "^2.0.1",
+        "bn.js": "^0.15.2",
+        "asn1.js": "^0.6.4",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "7e9b91446c335d41e9e53466f8b4e07b697570ac",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.0.0",
+      "_shasum": "47ce26f16c3a8db376e712494b5b636c6c6a2b5c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "47ce26f16c3a8db376e712494b5b636c6c6a2b5c",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "browserify-sign",
+      "version": "2.1.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "pemstrip": "0.0.1",
+        "asn1.js-rfc3280": "^0.5.1",
+        "inherits": "^2.0.1",
+        "bn.js": "^0.15.2",
+        "asn1.js": "^0.6.4",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "89e0d6a002c5cdd8b00e1dcd02426d8e9da6dbe8",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.1.0",
+      "_shasum": "fec84a266e6fbd0f65c4fef03654f7919f23b21f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fec84a266e6fbd0f65c4fef03654f7919f23b21f",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "browserify-sign",
+      "version": "2.2.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "pemstrip": "0.0.1",
+        "asn1.js-rfc3280": "^0.5.1",
+        "inherits": "^2.0.1",
+        "bn.js": "^0.15.2",
+        "asn1.js": "^0.6.4",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "7f687cfa64c5af7b30cfeb931b6e3b6a1c59c552",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.2.0",
+      "_shasum": "713cc6cfe19db071b51e67ce954a32189a04bbd6",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "713cc6cfe19db071b51e67ce954a32189a04bbd6",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "browserify-sign",
+      "version": "2.3.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "pemstrip": "0.0.1",
+        "asn1.js-rfc3280": "^0.5.1",
+        "inherits": "^2.0.1",
+        "bn.js": "^0.15.2",
+        "asn1.js": "^0.6.4",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "db1be5c08096e0f5a32f99ad61dff59af62bc7bd",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.3.0",
+      "_shasum": "a716d57ed7014be8d7321e556c9dbba096956917",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a716d57ed7014be8d7321e556c9dbba096956917",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.4.0": {
+      "name": "browserify-sign",
+      "version": "2.4.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^0.6.4",
+        "asn1.js-rfc3280": "^0.5.1",
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "pemstrip": "0.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "59b99ba6aa5c0d4e9650fcfa6222e04830b46108",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.4.0",
+      "_shasum": "55bef52192091216336db4fb0bcc88c1d8f049fd",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "55bef52192091216336db4fb0bcc88c1d8f049fd",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.5.0": {
+      "name": "browserify-sign",
+      "version": "2.5.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^0.6.4",
+        "asn1.js-rfc3280": "^0.5.1",
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "pemstrip": "0.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "1af0e3881ee9130994a594c09f4344e0e235dac9",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.5.0",
+      "_shasum": "5d3481bf05bca06fbf13c6a36f29d0a51b0025f5",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5d3481bf05bca06fbf13c6a36f29d0a51b0025f5",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.5.1": {
+      "name": "browserify-sign",
+      "version": "2.5.1",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^0.6.4",
+        "asn1.js-rfc3280": "^0.5.1",
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "pemstrip": "0.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "9163dd196fed00bee66f10c23de2e72de6ff3406",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.5.1",
+      "_shasum": "f0c659f322384937c242a245f37eedd900480894",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f0c659f322384937c242a245f37eedd900480894",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.5.2": {
+      "name": "browserify-sign",
+      "version": "2.5.2",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.0.0",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "21525ed562af9736ab362372c60a28bafbde4404",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.5.2",
+      "_shasum": "77fba78b7464e7b9746fc845d77fc59fbcd8bf23",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "77fba78b7464e7b9746fc845d77fc59fbcd8bf23",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.6.0": {
+      "name": "browserify-sign",
+      "version": "2.6.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "36e5387dd0a99ea52f40c9fc142c9e00274aac3a",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.6.0",
+      "_shasum": "35def87585f0d8f4b116783a55e1a3711a2c48e3",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "35def87585f0d8f4b116783a55e1a3711a2c48e3",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.6.1": {
+      "name": "browserify-sign",
+      "version": "2.6.1",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "8a965442c625e4edb220efef18a0d77e25646802",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.6.1",
+      "_shasum": "2b6e2dc4d6f87015406ba968064888b76d8e6cb7",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.34",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2b6e2dc4d6f87015406ba968064888b76d8e6cb7",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.7.0": {
+      "name": "browserify-sign",
+      "version": "2.7.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^0.15.2",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "0b04a7d66105651e7538b2b5ff4676bb8959850b",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.7.0",
+      "_shasum": "3beafdff58ddcbfee7b522db7c47ae57588607e9",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3beafdff58ddcbfee7b522db7c47ae57588607e9",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.7.1": {
+      "name": "browserify-sign",
+      "version": "2.7.1",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "428976af41a630bae8c9c973ddfc79ef160d78c5",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.7.1",
+      "_shasum": "d07e11ccc13e7461034d96b8807c97a0209a2a31",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d07e11ccc13e7461034d96b8807c97a0209a2a31",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.7.2": {
+      "name": "browserify-sign",
+      "version": "2.7.2",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "899ab2cfc45ffb0a2b0f32d292eb5e32eba77ee5",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.7.2",
+      "_shasum": "e6aa1903c3023cd83e794304e57134b94df6ec36",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e6aa1903c3023cd83e794304e57134b94df6ec36",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.7.3": {
+      "name": "browserify-sign",
+      "version": "2.7.3",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "caa2c3a7861e85756a9db3cfadc6ae28d4a4a61c",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.7.3",
+      "_shasum": "9d62187583658d8c88620faab22334846b47d97b",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9d62187583658d8c88620faab22334846b47d97b",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.7.4": {
+      "name": "browserify-sign",
+      "version": "2.7.4",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "7a8987c6667af21591d79bb8e4df0e14e2afb566",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.7.4",
+      "_shasum": "843a1f09dddd883111439faa71c35b8afd20c3f6",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "843a1f09dddd883111439faa71c35b8afd20c3f6",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.7.5": {
+      "name": "browserify-sign",
+      "version": "2.7.5",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^1.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "ef5d2b807f07b2162581127eee9762a3fc144aaa",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.7.5",
+      "_shasum": "92fce12b47775547f2887d7c5282856c163715b2",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "92fce12b47775547f2887d7c5282856c163715b2",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.8.0": {
+      "name": "browserify-sign",
+      "version": "2.8.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/calvinmetcalf/browserify-sign.svg)](https://travis-ci.org/calvinmetcalf/browserify-sign) ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^1.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "76b146a2bc02fbdc37be54d408e2e540b0211fe5",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/browserify-sign",
+      "_id": "browserify-sign@2.8.0",
+      "_shasum": "655975c12006d02b59181da9ab73f856c63c9aa4",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "655975c12006d02b59181da9ab73f856c63c9aa4",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "browserify-sign",
+      "version": "3.0.0",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/crypto-browserify/browserify-sign.svg)](https://travis-ci.org/crypto-browserify/browserify-sign) ===",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^1.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "6c04eec2c6eebee21c577cbdbec153c91cfe9473",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-sign",
+      "_id": "browserify-sign@3.0.0",
+      "_shasum": "dfd89e22c75ba4b0dc37cfda1d39b96f79123c55",
+      "_from": ".",
+      "_npmVersion": "2.7.0",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dfd89e22c75ba4b0dc37cfda1d39b96f79123c55",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "browserify-sign",
+      "version": "3.0.1",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/crypto-browserify/browserify-sign.svg)](https://travis-ci.org/crypto-browserify/browserify-sign) ===",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^1.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "7846def389d0de3ed38b3e0debe80533728cf751",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-sign",
+      "_id": "browserify-sign@3.0.1",
+      "_shasum": "e1bdf7ca50d575d22e57705c60b3033846dc96bf",
+      "_from": ".",
+      "_npmVersion": "2.7.0",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e1bdf7ca50d575d22e57705c60b3033846dc96bf",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "browserify-sign",
+      "version": "3.0.2",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/crypto-browserify/browserify-sign.svg)](https://travis-ci.org/crypto-browserify/browserify-sign) ===",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^3.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "b346c239b6e25045664340d08ab04b2522213bf5",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-sign",
+      "_id": "browserify-sign@3.0.2",
+      "_shasum": "751ced7ac76e7b719efa6fc3f04ecfa6ea7de88d",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "751ced7ac76e7b719efa6fc3f04ecfa6ea7de88d",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.3": {
+      "name": "browserify-sign",
+      "version": "3.0.3",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/crypto-browserify/browserify-sign.svg)](https://travis-ci.org/crypto-browserify/browserify-sign) ===",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^3.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "a68231af6b263f2b0746a586190585fc7a45e7dc",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@3.0.3",
+      "_shasum": "dbd912bed24295ab92f8ef6f918e71912ad91f41",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dbd912bed24295ab92f8ef6f918e71912ad91f41",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.8": {
+      "name": "browserify-sign",
+      "version": "3.0.8",
+      "description": "browserify-sign [![Build Status](https://travis-ci.org/crypto-browserify/browserify-sign.svg)](https://travis-ci.org/crypto-browserify/browserify-sign) ===",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "unit": "node test/index.js | tspec",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^3.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "243fac9e1ba49440a0a9edfd912a2bfea324149a",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@3.0.8",
+      "_shasum": "a5cc9a2f84005ddc37775b7c56bdabd987e69025",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.2.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "a5cc9a2f84005ddc37775b7c56bdabd987e69025",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "browserify-sign",
+      "version": "4.0.0",
+      "description": "adds node crypto signing for browsers",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "unit": "node test/index.js | tspec",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "7e4d3cf65624fbf58c027835a5e2c70de19cd640",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@4.0.0",
+      "_shasum": "10773910c3c206d5420a46aad8694f820b85968f",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "10773910c3c206d5420a46aad8694f820b85968f",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.1": {
+      "name": "browserify-sign",
+      "version": "4.0.1",
+      "description": "adds node crypto signing for browsers",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "license": "ISC",
+      "files": [
+        "browser",
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "scripts": {
+        "coverage": "nyc npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "browser": "browser/index.js",
+      "gitHead": "4e502308f6f2e1cb0b6e1e0b9b3c50c149f644dd",
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@4.0.1",
+      "_shasum": "824070f3b53fbbd07ccf2e398abe423483e0601e",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "824070f3b53fbbd07ccf2e398abe423483e0601e",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/browserify-sign-4.0.1.tgz_1490638012415_0.6559046404436231"
+      },
+      "directories": {}
+    },
+    "4.0.2": {
+      "name": "browserify-sign",
+      "version": "4.0.2",
+      "description": "adds node crypto signing for browsers",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "license": "ISC",
+      "files": [
+        "browser",
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "scripts": {
+        "coverage": "nyc npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "browser": "browser/index.js",
+      "gitHead": "0f9b74f4d96b5f4279f427beeffdcc5525ff196d",
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@4.0.2",
+      "_shasum": "b3a9507b270b90d110fe3b7bede5fc10249f7518",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "b3a9507b270b90d110fe3b7bede5fc10249f7518",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/browserify-sign-4.0.2.tgz_1490641364499_0.5541884624399245"
+      },
+      "directories": {}
+    },
+    "4.0.3": {
+      "name": "browserify-sign",
+      "version": "4.0.3",
+      "description": "adds node crypto signing for browsers",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "license": "ISC",
+      "files": [
+        "browser",
+        "index.js",
+        "algos.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "scripts": {
+        "coverage": "nyc npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "browser": "browser/index.js",
+      "gitHead": "de9d6b2bb9a9e3c04b9ada8b86492e7944d0b468",
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@4.0.3",
+      "_shasum": "b41d5330ba52d5c67855773e273dd3cf14a7e497",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "b41d5330ba52d5c67855773e273dd3cf14a7e497",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/browserify-sign-4.0.3.tgz_1490641680509_0.6111230396199971"
+      },
+      "directories": {}
+    },
+    "4.0.4": {
+      "name": "browserify-sign",
+      "version": "4.0.4",
+      "description": "adds node crypto signing for browsers",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "license": "ISC",
+      "files": [
+        "browser",
+        "index.js",
+        "algos.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "scripts": {
+        "coverage": "nyc npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "browser": "browser/index.js",
+      "gitHead": "44a10f6edf5df9dade14cf5600392417da6f966b",
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@4.0.4",
+      "_shasum": "aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/browserify-sign-4.0.4.tgz_1490702810443_0.7301043279003352"
+      },
+      "directories": {}
+    },
+    "4.1.0": {
+      "name": "browserify-sign",
+      "version": "4.1.0",
+      "description": "adds node crypto signing for browsers",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "license": "ISC",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "scripts": {
+        "coverage": "nyc npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0"
+      },
+      "devDependencies": {
+        "nyc": "^15.0.1",
+        "standard": "^14.3.3",
+        "tape": "^5.0.0"
+      },
+      "browser": "browser/index.js",
+      "gitHead": "aa6a963e173b004637386134a7ef143c138f0ce8",
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@4.1.0",
+      "_nodeVersion": "12.16.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
+        "shasum": "4fe971b379a5aeb4925e06779f9fa1f41d249d70",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 14408,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJesWH6CRA9TVsSAnZWagAA/nUP/iqMyRg/Fd34+JmXAgNA\nEUR5WlW02OK/qrySzA5DVkOxnNU7qTb6m8R+OHCIRh2KGUBuNLe3BoH6rAPM\nIEQquOkWDP8h0twwDSn8DFNvkHNDO7aO7DbH7tID8pqUXAFw5IihkDgKzmhY\na1G0Z4f+7krjc0RNM9CubuUVqmVNWba7XE+veqSGLtRQyzvoKxN/7w2+0z1+\nOpE/+nzj43rEgkeCtk1jR/K2RNeJ6u2UrLV9BIz2ZV9e4Gx/grbOitXDobUB\n3TMghunUTsYBOnJDuQVEHqbHdbu2U15nVd0huSzn91nSteOy4dYM3rEbaw8+\nVphU3E5yaOQns/tTIpngGHGobzHiVzGR3Gn5AWwueDX8iFO1TKNc5KYLcTAv\nV0ee4v5Dskz20KpvVZQB0Ju2DzTAxWZi/gXjXSCnD/3qsyt+lMnXhazEIsoU\ne4QsU8PEhyF/IQhXNKFusB5NAPy5guneUYTa0Q9FUkPDsV935QXpg+BhY0CJ\nLBFk+VGRQCEgdr6LSzKJvG43GwrelLwiu9nYrumpGI5J5N2X1V/UMHy85sOo\nb8hZoQEl90Gc3CBXCCnIYh9t4Q2IGF7Mpbgm9kED/odmatnkvrrl07iz2k4f\nZSZ9kTscfzN0x9u25Ggu4lvlLDnfHVdnvuEjSscm6hz2wS/m5f5bqXPW+2kA\n4Ac8\r\n=19mf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-sign_4.1.0_1588683257542_0.6200496226034777"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.0": {
+      "name": "browserify-sign",
+      "version": "4.2.0",
+      "description": "adds node crypto signing for browsers",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "license": "ISC",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "scripts": {
+        "coverage": "nyc npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "devDependencies": {
+        "nyc": "^15.0.1",
+        "standard": "^14.3.3",
+        "tape": "^5.0.0"
+      },
+      "browser": "browser/index.js",
+      "gitHead": "eeb0c1ee7e4c326d17ba31d5e683cb4e75d763b2",
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@4.2.0",
+      "_nodeVersion": "12.16.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
+        "shasum": "545d0b1b07e6b2c99211082bf1b12cce7a0b0e11",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 14452,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJewqeuCRA9TVsSAnZWagAA/8sQAJrT8H/PvRZ264BCMxcs\nBexT77GbQMKYZisyvbt0a6KgrLquJVYUB7UBflUFNWx1iEgAM7TuzDoKJU+6\ndKt0iyNCBu2KHInYrFpa09vo8gC8ST/1SFAOJA2lc7IHWEt/8q+ajFm2xS0+\nkY6TfMqce0KrUMarNLhwnW67c0zuOv11mBZ7Jydb1UU26O+ocP4ThQzFY+N6\ndxjLEeOTyw5a1WMsjiWKwxn0omJTMStIViGpB+c9gGW/jstEZ/JZllYA9rjE\nMi8ZN6Duz/zAFacePpU9iTnZsCFkWX+bzEBrIWuRBw7aQMUO8tjPYMkHvgtQ\nur3ST5M9LQHrSBdP/BBabRdKxj/7g8zuy5vuvq5Zu3W3+jtsmCAEmHm7H4a0\nBD2cMPSLtLlZUMJNxHb8zbLja0Do7ZKk6cDggEOFJ40aHtA0EvPmBA8XrjO2\nJ+P8ElxQsUfFbz3wFGbJwR5gw93wlo/APnWMY9MMmmlbSp3AIdHwgH+4hXy+\nuQRHPYnTxahgi+S+aoJDTvFlua3IkNQDyotnNCnAE/Xe7fpM4UgL8yeCpE29\nNcjsuICB5t+VOSHsPm2ZH3orpYI+HAOw7tvqnJJG5eUVXN7WrNLfwyWrtZ1s\nVLoGZxtQ3kOWPGp11m2eB0Ic7ZsP7a9emqRyeI6rQRbJz+dP8udpqVCOEsTM\n0pq5\r\n=/VWv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-sign_4.2.0_1589815213333_0.8678416046326589"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.1": {
+      "name": "browserify-sign",
+      "version": "4.2.1",
+      "description": "adds node crypto signing for browsers",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+      },
+      "license": "ISC",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/browserify-sign.git"
+      },
+      "scripts": {
+        "coverage": "nyc npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "devDependencies": {
+        "nyc": "^15.0.1",
+        "standard": "^14.3.3",
+        "tape": "^5.0.0"
+      },
+      "browser": "browser/index.js",
+      "gitHead": "266b780b8ab112bd12e4ef330d9b4a65b76350e7",
+      "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+      "_id": "browserify-sign@4.2.1",
+      "_nodeVersion": "12.16.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+        "shasum": "eaf4add46dd54be3bb3b36c0cf15abbeba7956c3",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+        "fileCount": 10,
+        "unpackedSize": 14452,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKYmPCRA9TVsSAnZWagAARLMQAJoHZ0CR5l4iSvW4s04y\nJDZ4vMMlgY2ybA+Ga1McoBVPUUX0vu4ASoHbi3dB8/mU78FK/QaGWaMebTMe\nNOqQfn7BymmJPZK9NlRQZqM2wXKz3kmK7+lfqr9ughhK5o8nrZBGCUqT6ZeH\napHxpPOhnkJnXwSWQcEGRYU3Vjc6QaI764z2bO1hR/MBE+fMwofTm4Z3Sd6y\nC9ziVmLzNZnAGyp3sauyjHcnMXk2uZq7ygThQRVGR2mujaV6wVPnMeJuzetP\n2t93dAHcBeTJdTalgrtp+BiOgn4ddhglqLdSXt3CxsQOeWMyvKK8OMD8I4Ep\ncJrAxGTzNFPR8abkICinYClL1LkbKwmCrhxxWcz9Z912lvL602edftjf4Y40\nqw0US3NFXK2YDt25DTRTr4+ediNaraziUslF0xlF3i35cXGu5kWATdNizQWK\nXB8TLPlqtpPwyRYK72XW/aYhn0NQimmiQuNA9R6O94yt0eeGG3dLJ8XujSSa\nYlKmj/skYA/kBKJHrQ48la8+LcOVn87ON0ysatjn8llAQ1pTJy4eMpUJr5+2\n72+C7VFMkG8YzSXMnWBzH2NN+yHcly8SdnNs/S5c57odeaEA+jDzaupY2Hon\nB7mMwmlCmzZs7n/dhKLNmx3I8ZLlLncM7DWbswJMssLwTjQcDrZTYUpLuq1F\nJkpn\r\n=+x2T\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-sign_4.2.1_1596557711307_0.5090745071049647"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# browserify-sign\n\n[![NPM Package](https://img.shields.io/npm/v/browserify-sign.svg?style=flat-square)](https://www.npmjs.org/package/browserify-sign)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/browserify-sign.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/browserify-sign)\n[![Dependency status](https://img.shields.io/david/crypto-browserify/browserify-sign.svg?style=flat-square)](https://david-dm.org/crypto-browserify/browserify-sign#info=dependencies)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nA package to duplicate the functionality of node's crypto public key functions, much of this is based on [Fedor Indutny's](https://github.com/indutny) work on [indutny/tls.js](https://github.com/indutny/tls.js).\n\n## LICENSE\n\nISC\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-04T16:15:13.667Z",
+    "created": "2014-11-15T18:34:16.875Z",
+    "2.0.0": "2014-11-15T18:34:16.875Z",
+    "2.1.0": "2014-11-15T20:09:54.203Z",
+    "2.2.0": "2014-11-15T21:54:56.788Z",
+    "2.3.0": "2014-11-15T23:39:54.784Z",
+    "2.4.0": "2014-11-16T16:28:59.318Z",
+    "2.5.0": "2014-11-25T19:56:42.483Z",
+    "2.5.1": "2014-12-09T21:29:39.931Z",
+    "2.5.2": "2014-12-17T12:32:11.905Z",
+    "2.6.0": "2014-12-18T21:59:02.799Z",
+    "2.6.1": "2014-12-19T16:39:56.238Z",
+    "2.7.0": "2014-12-22T19:43:52.147Z",
+    "2.7.1": "2015-01-03T13:53:38.951Z",
+    "2.7.2": "2015-01-05T16:07:22.300Z",
+    "2.7.3": "2015-01-06T12:45:33.731Z",
+    "2.7.4": "2015-01-06T12:53:52.136Z",
+    "2.7.5": "2015-01-06T13:04:33.294Z",
+    "2.8.0": "2015-01-12T13:57:09.285Z",
+    "3.0.0": "2015-03-10T12:00:05.459Z",
+    "3.0.1": "2015-03-11T12:49:07.390Z",
+    "3.0.2": "2015-05-21T02:57:05.421Z",
+    "3.0.3": "2015-08-07T19:12:02.206Z",
+    "3.0.8": "2015-09-05T14:55:23.049Z",
+    "4.0.0": "2015-11-02T14:20:48.429Z",
+    "4.0.1": "2017-03-27T18:06:54.308Z",
+    "4.0.2": "2017-03-27T19:02:46.583Z",
+    "4.0.3": "2017-03-27T19:08:01.158Z",
+    "4.0.4": "2017-03-28T12:06:52.609Z",
+    "4.1.0": "2020-05-05T12:54:17.742Z",
+    "4.2.0": "2020-05-18T15:20:13.797Z",
+    "4.2.1": "2020-08-04T16:15:11.470Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/browserify-sign#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/browserify-sign.git"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/browserify-sign/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "kapluni": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/browserify-sign.min.json
+++ b/test/fixtures/registry-mocks/content/browserify-sign.min.json
@@ -1,0 +1,640 @@
+{
+  "name": "browserify-sign",
+  "dist-tags": {
+    "latest": "4.2.1"
+  },
+  "versions": {
+    "2.0.0": {
+      "name": "browserify-sign",
+      "version": "2.0.0",
+      "dependencies": {
+        "pemstrip": "0.0.1",
+        "asn1.js-rfc3280": "^0.5.1",
+        "inherits": "^2.0.1",
+        "bn.js": "^0.15.2",
+        "asn1.js": "^0.6.4",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "47ce26f16c3a8db376e712494b5b636c6c6a2b5c",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.0.0.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "browserify-sign",
+      "version": "2.1.0",
+      "dependencies": {
+        "pemstrip": "0.0.1",
+        "asn1.js-rfc3280": "^0.5.1",
+        "inherits": "^2.0.1",
+        "bn.js": "^0.15.2",
+        "asn1.js": "^0.6.4",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "fec84a266e6fbd0f65c4fef03654f7919f23b21f",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.1.0.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "browserify-sign",
+      "version": "2.2.0",
+      "dependencies": {
+        "pemstrip": "0.0.1",
+        "asn1.js-rfc3280": "^0.5.1",
+        "inherits": "^2.0.1",
+        "bn.js": "^0.15.2",
+        "asn1.js": "^0.6.4",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "713cc6cfe19db071b51e67ce954a32189a04bbd6",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.2.0.tgz"
+      }
+    },
+    "2.3.0": {
+      "name": "browserify-sign",
+      "version": "2.3.0",
+      "dependencies": {
+        "pemstrip": "0.0.1",
+        "asn1.js-rfc3280": "^0.5.1",
+        "inherits": "^2.0.1",
+        "bn.js": "^0.15.2",
+        "asn1.js": "^0.6.4",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "a716d57ed7014be8d7321e556c9dbba096956917",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.3.0.tgz"
+      }
+    },
+    "2.4.0": {
+      "name": "browserify-sign",
+      "version": "2.4.0",
+      "dependencies": {
+        "asn1.js": "^0.6.4",
+        "asn1.js-rfc3280": "^0.5.1",
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "pemstrip": "0.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "55bef52192091216336db4fb0bcc88c1d8f049fd",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.4.0.tgz"
+      }
+    },
+    "2.5.0": {
+      "name": "browserify-sign",
+      "version": "2.5.0",
+      "dependencies": {
+        "asn1.js": "^0.6.4",
+        "asn1.js-rfc3280": "^0.5.1",
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "pemstrip": "0.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "5d3481bf05bca06fbf13c6a36f29d0a51b0025f5",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.5.0.tgz"
+      }
+    },
+    "2.5.1": {
+      "name": "browserify-sign",
+      "version": "2.5.1",
+      "dependencies": {
+        "asn1.js": "^0.6.4",
+        "asn1.js-rfc3280": "^0.5.1",
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "pemstrip": "0.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "f0c659f322384937c242a245f37eedd900480894",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.5.1.tgz"
+      }
+    },
+    "2.5.2": {
+      "name": "browserify-sign",
+      "version": "2.5.2",
+      "dependencies": {
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.0.0",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "77fba78b7464e7b9746fc845d77fc59fbcd8bf23",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.5.2.tgz"
+      }
+    },
+    "2.6.0": {
+      "name": "browserify-sign",
+      "version": "2.6.0",
+      "dependencies": {
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0",
+        "readable-stream": "^1.0.33"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "35def87585f0d8f4b116783a55e1a3711a2c48e3",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.6.0.tgz"
+      }
+    },
+    "2.6.1": {
+      "name": "browserify-sign",
+      "version": "2.6.1",
+      "dependencies": {
+        "bn.js": "^0.15.2",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "2b6e2dc4d6f87015406ba968064888b76d8e6cb7",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.6.1.tgz"
+      }
+    },
+    "2.7.0": {
+      "name": "browserify-sign",
+      "version": "2.7.0",
+      "dependencies": {
+        "bn.js": "^0.15.2",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "3beafdff58ddcbfee7b522db7c47ae57588607e9",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.0.tgz"
+      }
+    },
+    "2.7.1": {
+      "name": "browserify-sign",
+      "version": "2.7.1",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "d07e11ccc13e7461034d96b8807c97a0209a2a31",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.1.tgz"
+      }
+    },
+    "2.7.2": {
+      "name": "browserify-sign",
+      "version": "2.7.2",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "e6aa1903c3023cd83e794304e57134b94df6ec36",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.2.tgz"
+      }
+    },
+    "2.7.3": {
+      "name": "browserify-sign",
+      "version": "2.7.3",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "9d62187583658d8c88620faab22334846b47d97b",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.3.tgz"
+      }
+    },
+    "2.7.4": {
+      "name": "browserify-sign",
+      "version": "2.7.4",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^0.15.14",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "843a1f09dddd883111439faa71c35b8afd20c3f6",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.4.tgz"
+      }
+    },
+    "2.7.5": {
+      "name": "browserify-sign",
+      "version": "2.7.5",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^1.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "92fce12b47775547f2887d7c5282856c163715b2",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.7.5.tgz"
+      }
+    },
+    "2.8.0": {
+      "name": "browserify-sign",
+      "version": "2.8.0",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "elliptic": "^1.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "655975c12006d02b59181da9ab73f856c63c9aa4",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "browserify-sign",
+      "version": "3.0.0",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^1.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "dfd89e22c75ba4b0dc37cfda1d39b96f79123c55",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "browserify-sign",
+      "version": "3.0.1",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^1.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "e1bdf7ca50d575d22e57705c60b3033846dc96bf",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.1.tgz"
+      }
+    },
+    "3.0.2": {
+      "name": "browserify-sign",
+      "version": "3.0.2",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^3.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "751ced7ac76e7b719efa6fc3f04ecfa6ea7de88d",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.2.tgz"
+      }
+    },
+    "3.0.3": {
+      "name": "browserify-sign",
+      "version": "3.0.3",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^3.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "dbd912bed24295ab92f8ef6f918e71912ad91f41",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.3.tgz"
+      }
+    },
+    "3.0.8": {
+      "name": "browserify-sign",
+      "version": "3.0.8",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^3.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "shasum": "a5cc9a2f84005ddc37775b7c56bdabd987e69025",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-3.0.8.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "browserify-sign",
+      "version": "4.0.0",
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.3",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "shasum": "10773910c3c206d5420a46aad8694f820b85968f",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz"
+      }
+    },
+    "4.0.1": {
+      "name": "browserify-sign",
+      "version": "4.0.1",
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "824070f3b53fbbd07ccf2e398abe423483e0601e",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.1.tgz"
+      }
+    },
+    "4.0.2": {
+      "name": "browserify-sign",
+      "version": "4.0.2",
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "b3a9507b270b90d110fe3b7bede5fc10249f7518",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.2.tgz"
+      }
+    },
+    "4.0.3": {
+      "name": "browserify-sign",
+      "version": "4.0.3",
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "b41d5330ba52d5c67855773e273dd3cf14a7e497",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.3.tgz"
+      }
+    },
+    "4.0.4": {
+      "name": "browserify-sign",
+      "version": "4.0.4",
+      "dependencies": {
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "aa4eb68e5d7b658baa6bf6a57e630cbd7a93d298",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz"
+      }
+    },
+    "4.1.0": {
+      "name": "browserify-sign",
+      "version": "4.1.0",
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0"
+      },
+      "devDependencies": {
+        "nyc": "^15.0.1",
+        "standard": "^14.3.3",
+        "tape": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
+        "shasum": "4fe971b379a5aeb4925e06779f9fa1f41d249d70",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 14408,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJesWH6CRA9TVsSAnZWagAA/nUP/iqMyRg/Fd34+JmXAgNA\nEUR5WlW02OK/qrySzA5DVkOxnNU7qTb6m8R+OHCIRh2KGUBuNLe3BoH6rAPM\nIEQquOkWDP8h0twwDSn8DFNvkHNDO7aO7DbH7tID8pqUXAFw5IihkDgKzmhY\na1G0Z4f+7krjc0RNM9CubuUVqmVNWba7XE+veqSGLtRQyzvoKxN/7w2+0z1+\nOpE/+nzj43rEgkeCtk1jR/K2RNeJ6u2UrLV9BIz2ZV9e4Gx/grbOitXDobUB\n3TMghunUTsYBOnJDuQVEHqbHdbu2U15nVd0huSzn91nSteOy4dYM3rEbaw8+\nVphU3E5yaOQns/tTIpngGHGobzHiVzGR3Gn5AWwueDX8iFO1TKNc5KYLcTAv\nV0ee4v5Dskz20KpvVZQB0Ju2DzTAxWZi/gXjXSCnD/3qsyt+lMnXhazEIsoU\ne4QsU8PEhyF/IQhXNKFusB5NAPy5guneUYTa0Q9FUkPDsV935QXpg+BhY0CJ\nLBFk+VGRQCEgdr6LSzKJvG43GwrelLwiu9nYrumpGI5J5N2X1V/UMHy85sOo\nb8hZoQEl90Gc3CBXCCnIYh9t4Q2IGF7Mpbgm9kED/odmatnkvrrl07iz2k4f\nZSZ9kTscfzN0x9u25Ggu4lvlLDnfHVdnvuEjSscm6hz2wS/m5f5bqXPW+2kA\n4Ac8\r\n=19mf\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.2.0": {
+      "name": "browserify-sign",
+      "version": "4.2.0",
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "devDependencies": {
+        "nyc": "^15.0.1",
+        "standard": "^14.3.3",
+        "tape": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==",
+        "shasum": "545d0b1b07e6b2c99211082bf1b12cce7a0b0e11",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 14452,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJewqeuCRA9TVsSAnZWagAA/8sQAJrT8H/PvRZ264BCMxcs\nBexT77GbQMKYZisyvbt0a6KgrLquJVYUB7UBflUFNWx1iEgAM7TuzDoKJU+6\ndKt0iyNCBu2KHInYrFpa09vo8gC8ST/1SFAOJA2lc7IHWEt/8q+ajFm2xS0+\nkY6TfMqce0KrUMarNLhwnW67c0zuOv11mBZ7Jydb1UU26O+ocP4ThQzFY+N6\ndxjLEeOTyw5a1WMsjiWKwxn0omJTMStIViGpB+c9gGW/jstEZ/JZllYA9rjE\nMi8ZN6Duz/zAFacePpU9iTnZsCFkWX+bzEBrIWuRBw7aQMUO8tjPYMkHvgtQ\nur3ST5M9LQHrSBdP/BBabRdKxj/7g8zuy5vuvq5Zu3W3+jtsmCAEmHm7H4a0\nBD2cMPSLtLlZUMJNxHb8zbLja0Do7ZKk6cDggEOFJ40aHtA0EvPmBA8XrjO2\nJ+P8ElxQsUfFbz3wFGbJwR5gw93wlo/APnWMY9MMmmlbSp3AIdHwgH+4hXy+\nuQRHPYnTxahgi+S+aoJDTvFlua3IkNQDyotnNCnAE/Xe7fpM4UgL8yeCpE29\nNcjsuICB5t+VOSHsPm2ZH3orpYI+HAOw7tvqnJJG5eUVXN7WrNLfwyWrtZ1s\nVLoGZxtQ3kOWPGp11m2eB0Ic7ZsP7a9emqRyeI6rQRbJz+dP8udpqVCOEsTM\n0pq5\r\n=/VWv\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.2.1": {
+      "name": "browserify-sign",
+      "version": "4.2.1",
+      "dependencies": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "devDependencies": {
+        "nyc": "^15.0.1",
+        "standard": "^14.3.3",
+        "tape": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+        "shasum": "eaf4add46dd54be3bb3b36c0cf15abbeba7956c3",
+        "tarball": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+        "fileCount": 10,
+        "unpackedSize": 14452,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKYmPCRA9TVsSAnZWagAARLMQAJoHZ0CR5l4iSvW4s04y\nJDZ4vMMlgY2ybA+Ga1McoBVPUUX0vu4ASoHbi3dB8/mU78FK/QaGWaMebTMe\nNOqQfn7BymmJPZK9NlRQZqM2wXKz3kmK7+lfqr9ughhK5o8nrZBGCUqT6ZeH\napHxpPOhnkJnXwSWQcEGRYU3Vjc6QaI764z2bO1hR/MBE+fMwofTm4Z3Sd6y\nC9ziVmLzNZnAGyp3sauyjHcnMXk2uZq7ygThQRVGR2mujaV6wVPnMeJuzetP\n2t93dAHcBeTJdTalgrtp+BiOgn4ddhglqLdSXt3CxsQOeWMyvKK8OMD8I4Ep\ncJrAxGTzNFPR8abkICinYClL1LkbKwmCrhxxWcz9Z912lvL602edftjf4Y40\nqw0US3NFXK2YDt25DTRTr4+ediNaraziUslF0xlF3i35cXGu5kWATdNizQWK\nXB8TLPlqtpPwyRYK72XW/aYhn0NQimmiQuNA9R6O94yt0eeGG3dLJ8XujSSa\nYlKmj/skYA/kBKJHrQ48la8+LcOVn87ON0ysatjn8llAQ1pTJy4eMpUJr5+2\n72+C7VFMkG8YzSXMnWBzH2NN+yHcly8SdnNs/S5c57odeaEA+jDzaupY2Hon\nB7mMwmlCmzZs7n/dhKLNmx3I8ZLlLncM7DWbswJMssLwTjQcDrZTYUpLuq1F\nJkpn\r\n=+x2T\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-08-04T16:15:13.667Z"
+}

--- a/test/fixtures/registry-mocks/content/browserify-zlib.json
+++ b/test/fixtures/registry-mocks/content/browserify-zlib.json
@@ -1,0 +1,488 @@
+{
+  "_id": "browserify-zlib",
+  "_rev": "18-9b4cd3672713756514c7de6458b9121b",
+  "name": "browserify-zlib",
+  "description": "Full zlib module for the browser",
+  "dist-tags": {
+    "latest": "0.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "browserify-zlib",
+      "version": "0.1.0",
+      "description": "Full zlib module for browserify",
+      "main": "src/index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "pako": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browserify": {
+        "transform": [
+          "brfs"
+        ]
+      },
+      "scripts": {
+        "test": "node_modules/tape/bin/tape test/*.js"
+      },
+      "author": {
+        "name": "Devon Govett",
+        "email": "devongovett@gmail.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/devongovett/browserify-zlib.git"
+      },
+      "bugs": {
+        "url": "https://github.com/devongovett/browserify-zlib/issues"
+      },
+      "homepage": "https://github.com/devongovett/browserify-zlib",
+      "_id": "browserify-zlib@0.1.0",
+      "dist": {
+        "shasum": "a40c53f9f4224f3309d066526454444242a95a78",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "devongovett",
+        "email": "devongovett@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "devongovett",
+          "email": "devongovett@gmail.com"
+        }
+      ]
+    },
+    "0.1.1": {
+      "name": "browserify-zlib",
+      "version": "0.1.1",
+      "description": "Full zlib module for browserify",
+      "keywords": [
+        "zlib",
+        "browserify"
+      ],
+      "main": "src/index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "pako": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browserify": {
+        "transform": [
+          "brfs"
+        ]
+      },
+      "scripts": {
+        "test": "node_modules/tape/bin/tape test/*.js"
+      },
+      "author": {
+        "name": "Devon Govett",
+        "email": "devongovett@gmail.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/devongovett/browserify-zlib.git"
+      },
+      "bugs": {
+        "url": "https://github.com/devongovett/browserify-zlib/issues"
+      },
+      "homepage": "https://github.com/devongovett/browserify-zlib",
+      "_id": "browserify-zlib@0.1.1",
+      "dist": {
+        "shasum": "7269597b088d3423fdb9ee187bec6bfa3ce7dfda",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "devongovett",
+        "email": "devongovett@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "devongovett",
+          "email": "devongovett@gmail.com"
+        }
+      ]
+    },
+    "0.1.2": {
+      "name": "browserify-zlib",
+      "version": "0.1.2",
+      "description": "Full zlib module for browserify",
+      "keywords": [
+        "zlib",
+        "browserify"
+      ],
+      "main": "src/index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "pako": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "scripts": {
+        "test": "node_modules/tape/bin/tape test/*.js"
+      },
+      "author": {
+        "name": "Devon Govett",
+        "email": "devongovett@gmail.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/devongovett/browserify-zlib.git"
+      },
+      "bugs": {
+        "url": "https://github.com/devongovett/browserify-zlib/issues"
+      },
+      "homepage": "https://github.com/devongovett/browserify-zlib",
+      "_id": "browserify-zlib@0.1.2",
+      "dist": {
+        "shasum": "c1d729228628f5baad5e61fc26df8aa5b055a053",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "devongovett",
+        "email": "devongovett@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "devongovett",
+          "email": "devongovett@gmail.com"
+        }
+      ]
+    },
+    "0.1.3": {
+      "name": "browserify-zlib",
+      "version": "0.1.3",
+      "description": "Full zlib module for browserify",
+      "keywords": [
+        "zlib",
+        "browserify"
+      ],
+      "main": "src/index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "pako": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "scripts": {
+        "test": "node_modules/tape/bin/tape test/*.js"
+      },
+      "author": {
+        "name": "Devon Govett",
+        "email": "devongovett@gmail.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/devongovett/browserify-zlib.git"
+      },
+      "bugs": {
+        "url": "https://github.com/devongovett/browserify-zlib/issues"
+      },
+      "homepage": "https://github.com/devongovett/browserify-zlib",
+      "_id": "browserify-zlib@0.1.3",
+      "dist": {
+        "shasum": "17b22692922d2d8ce9b1ec1e2092b103aa8ec516",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "devongovett",
+        "email": "devongovett@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "devongovett",
+          "email": "devongovett@gmail.com"
+        }
+      ]
+    },
+    "0.1.4": {
+      "name": "browserify-zlib",
+      "version": "0.1.4",
+      "description": "Full zlib module for browserify",
+      "keywords": [
+        "zlib",
+        "browserify"
+      ],
+      "main": "src/index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "pako": "~0.2.0"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "scripts": {
+        "test": "node_modules/tape/bin/tape test/*.js"
+      },
+      "author": {
+        "name": "Devon Govett",
+        "email": "devongovett@gmail.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/devongovett/browserify-zlib.git"
+      },
+      "bugs": {
+        "url": "https://github.com/devongovett/browserify-zlib/issues"
+      },
+      "homepage": "https://github.com/devongovett/browserify-zlib",
+      "_id": "browserify-zlib@0.1.4",
+      "dist": {
+        "shasum": "bb35f8a519f600e0fa6b8485241c979d0141fb2d",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "devongovett",
+        "email": "devongovett@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "devongovett",
+          "email": "devongovett@gmail.com"
+        }
+      ]
+    },
+    "0.2.0": {
+      "name": "browserify-zlib",
+      "version": "0.2.0",
+      "description": "Full zlib module for the browser",
+      "keywords": [
+        "zlib",
+        "browserify"
+      ],
+      "main": "lib/index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "pako": "~1.0.5"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "babel-cli": "^6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babelify": "^7.3.0",
+        "brfs": "^1.4.3",
+        "browserify": "^14.4.0",
+        "exec-glob": "^1.2.2",
+        "glob": "^7.1.2",
+        "karma": "^1.7.0",
+        "karma-chrome-launcher": "^2.1.1",
+        "karma-firefox-launcher": "^1.0.1",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-own-reporter": "^1.1.2",
+        "karma-phantomjs-launcher": "^1.0.4",
+        "mocha": "^3.4.2",
+        "phantomjs-prebuilt": "^2.1.14",
+        "standard": "^10.0.2",
+        "watchify": "^3.9.0"
+      },
+      "scripts": {
+        "build": "babel src --out-dir lib",
+        "lint": "standard \"*.js\" \"!(node_modules|lib)/!(*test-zlib*|index).js\"",
+        "pretest": "npm run build",
+        "test": "npm run test:node && npm run test:browser",
+        "test:node": "node node_modules/exec-glob node \"test/test-*\"",
+        "pretest:browser": "node test/build",
+        "test:browser": "karma start --single-run=true karma.conf.js"
+      },
+      "babel": {
+        "plugins": [
+          "transform-es2015-arrow-functions",
+          "transform-es2015-block-scoping",
+          "transform-es2015-template-literals"
+        ]
+      },
+      "author": {
+        "name": "Devon Govett",
+        "email": "devongovett@gmail.com"
+      },
+      "homepage": "https://github.com/devongovett/browserify-zlib",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/devongovett/browserify-zlib.git"
+      },
+      "bugs": {
+        "url": "https://github.com/devongovett/browserify-zlib/issues"
+      },
+      "gitHead": "6257713c1dc3b69d781a43c10e58a6d75875eef8",
+      "_id": "browserify-zlib@0.2.0",
+      "_npmVersion": "5.0.0",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "dignifiedquire",
+        "email": "dignifiedquire@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+        "shasum": "2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "dignifiedquire@gmail.com",
+          "name": "dignifiedquire"
+        },
+        {
+          "email": "devongovett@gmail.com",
+          "name": "devongovett"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/browserify-zlib-0.2.0.tgz_1496505724707_0.4081235988996923"
+      }
+    }
+  },
+  "readme": "# browserify-zlib\n\n[![Travis CI](https://travis-ci.org/devongovett/browserify-zlib.svg?branch=master)](https://travis-ci.org/devongovett/browserify-zlib)\n[![Dependency Status](https://david-dm.org/devongovett/browserify-zlib.svg?style=flat-square)](https://david-dm.org/devongovett/browserify-zlib) [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)\n\n## Description\n\nEmulates Node's [zlib](https://nodejs.org/api/zlib.html) module for the browser. Can be used as a drop in replacement with [Browserify](http://browserify.org) and [webpack](http://webpack.github.io/).\n\nThe heavy lifting is done using [pako](https://github.com/nodeca/pako). The code in this module is modeled closely after the code in the source of Node core to get as much compatability as possible.\n\n## API\n\nhttps://nodejs.org/api/zlib.html\n\n## Not implemented\n\nThe following options/methods are not supported because pako does not support them yet.\n\n* The `params` method\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "email": "dignifiedquire@gmail.com",
+      "name": "dignifiedquire"
+    },
+    {
+      "email": "devongovett@gmail.com",
+      "name": "devongovett"
+    }
+  ],
+  "time": {
+    "modified": "2017-12-14T15:58:43.534Z",
+    "created": "2014-04-08T08:07:54.154Z",
+    "0.1.0": "2014-04-08T08:07:54.154Z",
+    "0.1.1": "2014-04-08T08:19:40.535Z",
+    "0.1.2": "2014-04-08T19:51:36.949Z",
+    "0.1.3": "2014-04-08T20:05:53.507Z",
+    "0.1.4": "2014-04-18T07:20:57.938Z",
+    "0.2.0": "2017-06-03T16:02:05.764Z"
+  },
+  "homepage": "https://github.com/devongovett/browserify-zlib",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/devongovett/browserify-zlib.git"
+  },
+  "author": {
+    "name": "Devon Govett",
+    "email": "devongovett@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/devongovett/browserify-zlib/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "keywords": [
+    "zlib",
+    "browserify"
+  ],
+  "users": {
+    "wenbing": true,
+    "leonning": true,
+    "simplyianm": true,
+    "shanewholloway": true,
+    "stephan.hoyer": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/browserify-zlib.min.json
+++ b/test/fixtures/registry-mocks/content/browserify-zlib.min.json
@@ -1,0 +1,136 @@
+{
+  "name": "browserify-zlib",
+  "dist-tags": {
+    "latest": "0.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "browserify-zlib",
+      "version": "0.1.0",
+      "dependencies": {
+        "pako": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "a40c53f9f4224f3309d066526454444242a95a78",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "browserify-zlib",
+      "version": "0.1.1",
+      "dependencies": {
+        "pako": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "7269597b088d3423fdb9ee187bec6bfa3ce7dfda",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "browserify-zlib",
+      "version": "0.1.2",
+      "dependencies": {
+        "pako": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "c1d729228628f5baad5e61fc26df8aa5b055a053",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "browserify-zlib",
+      "version": "0.1.3",
+      "dependencies": {
+        "pako": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "17b22692922d2d8ce9b1ec1e2092b103aa8ec516",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "browserify-zlib",
+      "version": "0.1.4",
+      "dependencies": {
+        "pako": "~0.2.0"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "brfs": "^1.0.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "bb35f8a519f600e0fa6b8485241c979d0141fb2d",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "browserify-zlib",
+      "version": "0.2.0",
+      "dependencies": {
+        "pako": "~1.0.5"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "babel-cli": "^6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babelify": "^7.3.0",
+        "brfs": "^1.4.3",
+        "browserify": "^14.4.0",
+        "exec-glob": "^1.2.2",
+        "glob": "^7.1.2",
+        "karma": "^1.7.0",
+        "karma-chrome-launcher": "^2.1.1",
+        "karma-firefox-launcher": "^1.0.1",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-own-reporter": "^1.1.2",
+        "karma-phantomjs-launcher": "^1.0.4",
+        "mocha": "^3.4.2",
+        "phantomjs-prebuilt": "^2.1.14",
+        "standard": "^10.0.2",
+        "watchify": "^3.9.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+        "shasum": "2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f",
+        "tarball": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz"
+      }
+    }
+  },
+  "modified": "2017-12-14T15:58:43.534Z"
+}

--- a/test/fixtures/registry-mocks/content/buffer-indexof.json
+++ b/test/fixtures/registry-mocks/content/buffer-indexof.json
@@ -1,0 +1,409 @@
+{
+  "_id": "buffer-indexof",
+  "_rev": "13-cf272bc2c8ae296c237b46592313380f",
+  "name": "buffer-indexof",
+  "description": "find the index of a buffer in a buffer",
+  "dist-tags": {
+    "latest": "1.1.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "buffer-indexof",
+      "description": "find the index of a buffer in a buffe",
+      "version": "0.0.0",
+      "repository": {
+        "url": "git://github.com/soldair/node-buffer-indexof.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "author": {
+        "name": "Ryan Day"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.1.0"
+      },
+      "bugs": {
+        "url": "https://github.com/soldair/node-buffer-indexof/issues"
+      },
+      "_id": "buffer-indexof@0.0.0",
+      "dist": {
+        "shasum": "f9eb3eb95f03a171554bb127450b20f64aa8e5c2",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "soldair",
+        "email": "soldair@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "soldair",
+          "email": "soldair@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "buffer-indexof",
+      "description": "find the index of a buffer in a buffe",
+      "version": "0.0.1",
+      "repository": {
+        "url": "git://github.com/soldair/node-buffer-indexof.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "author": {
+        "name": "Ryan Day"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.1.0"
+      },
+      "bugs": {
+        "url": "https://github.com/soldair/node-buffer-indexof/issues"
+      },
+      "_id": "buffer-indexof@0.0.1",
+      "dist": {
+        "shasum": "54dda191a531250309d13b646fc1c80adeee5cf9",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "soldair",
+        "email": "soldair@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "soldair",
+          "email": "soldair@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "buffer-indexof",
+      "description": "find the index of a buffer in a buffe",
+      "version": "0.0.2",
+      "repository": {
+        "url": "git://github.com/soldair/node-buffer-indexof.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "author": {
+        "name": "Ryan Day"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.1.0"
+      },
+      "gitHead": "277ab0cedaf14f6d6ae18571e9dd4d0dea1981a0",
+      "bugs": {
+        "url": "https://github.com/soldair/node-buffer-indexof/issues"
+      },
+      "homepage": "https://github.com/soldair/node-buffer-indexof",
+      "_id": "buffer-indexof@0.0.2",
+      "_shasum": "ed0f36b7ae166a66a7cd174c0467ae8dedf008f5",
+      "_from": ".",
+      "_npmVersion": "1.4.20",
+      "_npmUser": {
+        "name": "soldair",
+        "email": "soldair@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "soldair",
+          "email": "soldair@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ed0f36b7ae166a66a7cd174c0467ae8dedf008f5",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "buffer-indexof",
+      "description": "find the index of a buffer in a buffer",
+      "version": "1.0.0",
+      "repository": {
+        "url": "git://github.com/soldair/node-buffer-indexof.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "author": {
+        "name": "Ryan Day"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.1.0"
+      },
+      "gitHead": "0a087d8bbeadfaa1d89f8362f205b89699c1660c",
+      "bugs": {
+        "url": "https://github.com/soldair/node-buffer-indexof/issues"
+      },
+      "homepage": "https://github.com/soldair/node-buffer-indexof#readme",
+      "_id": "buffer-indexof@1.0.0",
+      "_shasum": "0f23779be8134b56251bb91f7fe4850a2e7be6ff",
+      "_from": ".",
+      "_npmVersion": "2.13.4",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "soldair",
+        "email": "soldair@gmail.com"
+      },
+      "dist": {
+        "shasum": "0f23779be8134b56251bb91f7fe4850a2e7be6ff",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "soldair",
+          "email": "soldair@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "buffer-indexof",
+      "description": "find the index of a buffer in a buffer",
+      "version": "1.0.1",
+      "repository": {
+        "url": "git://github.com/soldair/node-buffer-indexof.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "author": {
+        "name": "Ryan Day"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "^1.1.3",
+        "tape": "~1.1.0"
+      },
+      "gitHead": "7c33f8df621ac9fbd81c4ac577daca24a2e997e0",
+      "bugs": {
+        "url": "https://github.com/soldair/node-buffer-indexof/issues"
+      },
+      "homepage": "https://github.com/soldair/node-buffer-indexof#readme",
+      "_id": "buffer-indexof@1.0.1",
+      "_shasum": "410b99b2a16b429768693c3ab4de28dc5e126eb4",
+      "_from": ".",
+      "_npmVersion": "3.9.0",
+      "_nodeVersion": "4.4.4",
+      "_npmUser": {
+        "name": "soldair",
+        "email": "soldair@gmail.com"
+      },
+      "dist": {
+        "shasum": "410b99b2a16b429768693c3ab4de28dc5e126eb4",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "soldair",
+          "email": "soldair@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-indexof-1.0.1.tgz_1472477114459_0.530846269801259"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "buffer-indexof",
+      "description": "find the index of a buffer in a buffer",
+      "version": "1.0.2",
+      "repository": {
+        "url": "git://github.com/soldair/node-buffer-indexof.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "author": {
+        "name": "Ryan Day"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "^1.1.3",
+        "tape": "~1.1.0"
+      },
+      "gitHead": "1e13002692b7bc14726bee3097ed2f501841451a",
+      "bugs": {
+        "url": "https://github.com/soldair/node-buffer-indexof/issues"
+      },
+      "homepage": "https://github.com/soldair/node-buffer-indexof#readme",
+      "_id": "buffer-indexof@1.0.2",
+      "_shasum": "7fff11985ce51fe9ff07c40121ad301781587cdf",
+      "_from": ".",
+      "_npmVersion": "3.9.0",
+      "_nodeVersion": "4.4.4",
+      "_npmUser": {
+        "name": "soldair",
+        "email": "soldair@gmail.com"
+      },
+      "dist": {
+        "shasum": "7fff11985ce51fe9ff07c40121ad301781587cdf",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "soldair",
+          "email": "soldair@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-indexof-1.0.2.tgz_1472562186192_0.4908682357054204"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "buffer-indexof",
+      "description": "find the index of a buffer in a buffer",
+      "version": "1.1.0",
+      "repository": {
+        "url": "git://github.com/soldair/node-buffer-indexof.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "author": {
+        "name": "Ryan Day"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "^1.1.3",
+        "tape": "~1.1.0"
+      },
+      "gitHead": "cd1520a3a363b7f5cc231cf06b246d3fc582e92f",
+      "bugs": {
+        "url": "https://github.com/soldair/node-buffer-indexof/issues"
+      },
+      "homepage": "https://github.com/soldair/node-buffer-indexof#readme",
+      "_id": "buffer-indexof@1.1.0",
+      "_shasum": "f54f647c4f4e25228baa656a2e57e43d5f270982",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.5.0",
+      "_npmUser": {
+        "name": "soldair",
+        "email": "soldair@gmail.com"
+      },
+      "dist": {
+        "shasum": "f54f647c4f4e25228baa656a2e57e43d5f270982",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "soldair",
+          "email": "soldair@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-indexof-1.1.0.tgz_1473953571047_0.6959979394450784"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "buffer-indexof",
+      "description": "find the index of a buffer in a buffer",
+      "version": "1.1.1",
+      "repository": {
+        "url": "git://github.com/soldair/node-buffer-indexof.git"
+      },
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "author": {
+        "name": "Ryan Day"
+      },
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "^1.1.3",
+        "tape": "~1.1.0"
+      },
+      "gitHead": "9b17551f5f6949358358644757c406f4134ced5c",
+      "bugs": {
+        "url": "https://github.com/soldair/node-buffer-indexof/issues"
+      },
+      "homepage": "https://github.com/soldair/node-buffer-indexof#readme",
+      "_id": "buffer-indexof@1.1.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.9.4",
+      "_npmUser": {
+        "name": "soldair",
+        "email": "soldair@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+        "shasum": "52fabcc6a606d1a00302802648ef68f639da268c",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "soldair",
+          "email": "soldair@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer-indexof-1.1.1.tgz_1503366011678_0.98643086431548"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "[![Build Status](https://secure.travis-ci.org/soldair/node-buffer-indexof.png)](http://travis-ci.org/soldair/node-buffer-indexof)\n \n\nbuffer-indexof\n===================\n\nfind the index of a buffer in a buffer. should behave like String.indexOf etc.\n\n```js\n\nvar bindexOf = require('buffer-indexof');\n\nvar newLineBuffer = new Buffer(\"\\n\");\n\nvar b = new Buffer(\"hi\\nho\\nsilver\");\n\n\nbindexOf(b,newLineBuffer) === 2\n\n// you can also start from index\n\nbindexOf(b,newLineBuffer,3) === 5\n\n// no match === -1\n\nbindexOf(b,newLineBuffer,6) === -1\n\n\n```\n\nCHANGELOG\n----------\n\n- 1.0.0\n  - fixed issue finding multibyte needles in haystack.  thanks @imulus\n- 1.0.1\n  - fixed failing to find partial matches as pointed out by @bahaa-aidi in #2\n",
+  "maintainers": [
+    {
+      "name": "soldair",
+      "email": "soldair@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-11-27T05:57:28.386Z",
+    "created": "2013-09-18T23:54:58.413Z",
+    "0.0.0": "2013-09-18T23:54:59.523Z",
+    "0.0.1": "2013-09-19T16:26:20.124Z",
+    "0.0.2": "2014-08-22T03:09:19.834Z",
+    "1.0.0": "2015-08-10T19:02:56.289Z",
+    "1.0.1": "2016-08-29T13:25:16.040Z",
+    "1.0.2": "2016-08-30T13:03:07.608Z",
+    "1.1.0": "2016-09-15T15:32:52.426Z",
+    "1.1.1": "2017-08-22T01:40:11.758Z"
+  },
+  "author": {
+    "name": "Ryan Day"
+  },
+  "repository": {
+    "url": "git://github.com/soldair/node-buffer-indexof.git"
+  },
+  "homepage": "https://github.com/soldair/node-buffer-indexof#readme",
+  "bugs": {
+    "url": "https://github.com/soldair/node-buffer-indexof/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "users": {
+    "heineiuo": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/buffer-indexof.min.json
+++ b/test/fixtures/registry-mocks/content/buffer-indexof.min.json
@@ -1,0 +1,102 @@
+{
+  "name": "buffer-indexof",
+  "dist-tags": {
+    "latest": "1.1.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "buffer-indexof",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tape": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "f9eb3eb95f03a171554bb127450b20f64aa8e5c2",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "buffer-indexof",
+      "version": "0.0.1",
+      "devDependencies": {
+        "tape": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "54dda191a531250309d13b646fc1c80adeee5cf9",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "buffer-indexof",
+      "version": "0.0.2",
+      "devDependencies": {
+        "tape": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "ed0f36b7ae166a66a7cd174c0467ae8dedf008f5",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-0.0.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "buffer-indexof",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "0f23779be8134b56251bb91f7fe4850a2e7be6ff",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "buffer-indexof",
+      "version": "1.0.1",
+      "devDependencies": {
+        "chalk": "^1.1.3",
+        "tape": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "410b99b2a16b429768693c3ab4de28dc5e126eb4",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "buffer-indexof",
+      "version": "1.0.2",
+      "devDependencies": {
+        "chalk": "^1.1.3",
+        "tape": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "7fff11985ce51fe9ff07c40121ad301781587cdf",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "buffer-indexof",
+      "version": "1.1.0",
+      "devDependencies": {
+        "chalk": "^1.1.3",
+        "tape": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "f54f647c4f4e25228baa656a2e57e43d5f270982",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "buffer-indexof",
+      "version": "1.1.1",
+      "devDependencies": {
+        "chalk": "^1.1.3",
+        "tape": "~1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+        "shasum": "52fabcc6a606d1a00302802648ef68f639da268c",
+        "tarball": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz"
+      }
+    }
+  },
+  "modified": "2017-11-27T05:57:28.386Z"
+}

--- a/test/fixtures/registry-mocks/content/buffer-xor.json
+++ b/test/fixtures/registry-mocks/content/buffer-xor.json
@@ -1,0 +1,497 @@
+{
+  "_id": "buffer-xor",
+  "_rev": "7-7bd58f23a2bd19386fdb5299e862a293",
+  "name": "buffer-xor",
+  "description": "A simple module for bitwise-xor on buffers",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "buffer-xor",
+      "version": "1.0.0",
+      "description": "buffer-xor",
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script unit",
+        "unit": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dcousens/buffer-xor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/dcousens/buffer-xor/issues"
+      },
+      "homepage": "https://github.com/dcousens/buffer-xor",
+      "keywords": [
+        "bits",
+        "bitwise",
+        "buffer",
+        "buffer-xor",
+        "crypto",
+        "inline",
+        "math",
+        "memory",
+        "performance",
+        "xor"
+      ],
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "gitHead": "92dfa299b905bcf6b3cfe79b13b982c236c23940",
+      "_id": "buffer-xor@1.0.0",
+      "_shasum": "f465d14bce87deecb6ab09aad686fabdffb7b5ea",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "maintainers": [
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f465d14bce87deecb6ab09aad686fabdffb7b5ea",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "buffer-xor",
+      "version": "1.0.1",
+      "description": "buffer-xor",
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script unit",
+        "unit": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dcousens/node-buffer-xor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/dcousens/node-buffer-xor/issues"
+      },
+      "homepage": "https://github.com/dcousens/node-buffer-xor",
+      "keywords": [
+        "bits",
+        "bitwise",
+        "buffer",
+        "buffer-xor",
+        "crypto",
+        "inline",
+        "math",
+        "memory",
+        "performance",
+        "xor"
+      ],
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "gitHead": "3c08bdde2a5596cadba750ba323864628081b027",
+      "_id": "buffer-xor@1.0.1",
+      "_shasum": "484c6b8824616ffc0f3b7c573964bc63cb919312",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "maintainers": [
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "484c6b8824616ffc0f3b7c573964bc63cb919312",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "buffer-xor",
+      "version": "1.0.2",
+      "description": "buffer-xor",
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script unit",
+        "unit": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/buffer-xor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/buffer-xor/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/buffer-xor",
+      "keywords": [
+        "bits",
+        "bitwise",
+        "buffer",
+        "buffer-xor",
+        "crypto",
+        "inline",
+        "math",
+        "memory",
+        "performance",
+        "xor"
+      ],
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "gitHead": "79c37eb7669b62639b0f4b018aaf155e72d7e204",
+      "_id": "buffer-xor@1.0.2",
+      "_shasum": "231e44571f644bde0789026f61de6e923167124a",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "maintainers": [
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "231e44571f644bde0789026f61de6e923167124a",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "buffer-xor",
+      "version": "1.0.3",
+      "description": "A simple module for bitwise-xor on buffers",
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script unit",
+        "unit": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/buffer-xor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/buffer-xor/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/buffer-xor",
+      "keywords": [
+        "bits",
+        "bitwise",
+        "buffer",
+        "buffer-xor",
+        "crypto",
+        "inline",
+        "math",
+        "memory",
+        "performance",
+        "xor"
+      ],
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "gitHead": "8f92b79a8b8133c26a7ae1af09b2c84ec6e3f426",
+      "_id": "buffer-xor@1.0.3",
+      "_shasum": "26e61ed1422fb70dd42e6e36729ed51d855fe8d9",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "26e61ed1422fb70dd42e6e36729ed51d855fe8d9",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "buffer-xor",
+      "version": "2.0.0",
+      "description": "A simple module for bitwise-xor on buffers",
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script unit",
+        "unit": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/buffer-xor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/buffer-xor/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/buffer-xor",
+      "keywords": [
+        "bits",
+        "bitwise",
+        "buffer",
+        "buffer-xor",
+        "crypto",
+        "inline",
+        "math",
+        "memory",
+        "performance",
+        "xor"
+      ],
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "gitHead": "83025b66219da45f75463a3a1431abb4f5ed127e",
+      "_id": "buffer-xor@2.0.0",
+      "_shasum": "617efcb4361324b96725313e75d5413da32c7a62",
+      "_from": ".",
+      "_npmVersion": "3.8.0",
+      "_nodeVersion": "5.8.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "617efcb4361324b96725313e75d5413da32c7a62",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-xor-2.0.0.tgz_1457737083942_0.2049625653307885"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "buffer-xor",
+      "version": "2.0.1",
+      "description": "A simple module for bitwise-xor on buffers",
+      "files": [
+        "index.js",
+        "inplace.js"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run standard && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/buffer-xor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/buffer-xor/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/buffer-xor",
+      "keywords": [
+        "bits",
+        "bitwise",
+        "buffer",
+        "buffer-xor",
+        "crypto",
+        "inline",
+        "math",
+        "memory",
+        "performance",
+        "xor"
+      ],
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "standard": "*",
+        "tape": "*"
+      },
+      "gitHead": "5b2d03d4661236924902a299cc073347c358708d",
+      "_id": "buffer-xor@2.0.1",
+      "_shasum": "ba4d421d30b91a1440441f39f26d8a235e43b8d0",
+      "_from": ".",
+      "_npmVersion": "3.8.0",
+      "_nodeVersion": "5.8.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "ba4d421d30b91a1440441f39f26d8a235e43b8d0",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-xor-2.0.1.tgz_1457846300724_0.5908564073033631"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "buffer-xor",
+      "version": "2.0.2",
+      "description": "A simple module for bitwise-xor on buffers",
+      "files": [
+        "index.js",
+        "inplace.js"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run standard && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/buffer-xor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/buffer-xor/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/buffer-xor",
+      "keywords": [
+        "bits",
+        "bitwise",
+        "buffer",
+        "buffer-xor",
+        "crypto",
+        "inline",
+        "math",
+        "memory",
+        "performance",
+        "xor"
+      ],
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "standard": "*",
+        "tape": "*"
+      },
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "gitHead": "9ccb25fcb6afa96d23e96da837e7d3379475a954",
+      "_id": "buffer-xor@2.0.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+        "shasum": "34f7c64f04c777a1f8aac5e661273bb9dd320289",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer-xor-2.0.2.tgz_1503323198580_0.12606958695687354"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# buffer-xor\n\n[![NPM Package](https://img.shields.io/npm/v/buffer-xor.svg?style=flat-square)](https://www.npmjs.org/package/buffer-xor)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/buffer-xor.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/buffer-xor)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nA simple module for bitwise-xor on buffers.\n\n\n## Examples\n\n``` javascript\nvar xor = require('buffer-xor')\nvar a = new Buffer('00ff0f', 'hex')\nvar b = new Buffer('f0f0', 'hex')\n\nconsole.log(xor(a, b))\n// => <Buffer f0 0f 0f>\n```\n\n\nOr for those seeking those few extra cycles, perform the operation in place with\n`xorInplace`:\n\n_NOTE: `xorInplace` won't xor past the bounds of the buffer it mutates so make\nsure it is long enough!_\n\n``` javascript\nvar xorInplace = require('buffer-xor/inplace')\nvar a = new Buffer('00ff0f', 'hex')\nvar b = new Buffer('f0f0', 'hex')\n\nconsole.log(xorInplace(a, b))\n// => <Buffer f0 0f 0f>\n\n// See that a has been mutated\nconsole.log(a)\n// => <Buffer f0 0f 0f>\n```\n\n\n## License [MIT](LICENSE)\n",
+  "maintainers": [
+    {
+      "name": "dcousens",
+      "email": "email@dcousens.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-08-21T13:46:38.904Z",
+    "created": "2015-05-21T05:17:46.626Z",
+    "1.0.0": "2015-05-21T05:17:46.626Z",
+    "1.0.1": "2015-05-21T05:19:08.254Z",
+    "1.0.2": "2015-05-21T05:21:50.497Z",
+    "1.0.3": "2015-09-25T07:15:16.477Z",
+    "2.0.0": "2016-03-11T22:58:04.390Z",
+    "2.0.1": "2016-03-13T05:18:21.254Z",
+    "2.0.2": "2017-08-21T13:46:38.904Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/buffer-xor",
+  "keywords": [
+    "bits",
+    "bitwise",
+    "buffer",
+    "buffer-xor",
+    "crypto",
+    "inline",
+    "math",
+    "memory",
+    "performance",
+    "xor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/buffer-xor.git"
+  },
+  "author": {
+    "name": "Daniel Cousens"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/buffer-xor/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/buffer-xor.min.json
+++ b/test/fixtures/registry-mocks/content/buffer-xor.min.json
@@ -1,0 +1,97 @@
+{
+  "name": "buffer-xor",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "buffer-xor",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "dist": {
+        "shasum": "f465d14bce87deecb6ab09aad686fabdffb7b5ea",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "buffer-xor",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "dist": {
+        "shasum": "484c6b8824616ffc0f3b7c573964bc63cb919312",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "buffer-xor",
+      "version": "1.0.2",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "dist": {
+        "shasum": "231e44571f644bde0789026f61de6e923167124a",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "buffer-xor",
+      "version": "1.0.3",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "dist": {
+        "shasum": "26e61ed1422fb70dd42e6e36729ed51d855fe8d9",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "buffer-xor",
+      "version": "2.0.0",
+      "devDependencies": {
+        "mocha": "*",
+        "standard": "*"
+      },
+      "dist": {
+        "shasum": "617efcb4361324b96725313e75d5413da32c7a62",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "buffer-xor",
+      "version": "2.0.1",
+      "devDependencies": {
+        "standard": "*",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "ba4d421d30b91a1440441f39f26d8a235e43b8d0",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "buffer-xor",
+      "version": "2.0.2",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "standard": "*",
+        "tape": "*"
+      },
+      "dist": {
+        "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
+        "shasum": "34f7c64f04c777a1f8aac5e661273bb9dd320289",
+        "tarball": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-2.0.2.tgz"
+      }
+    }
+  },
+  "modified": "2017-08-21T13:46:38.904Z"
+}

--- a/test/fixtures/registry-mocks/content/buffer.json
+++ b/test/fixtures/registry-mocks/content/buffer.json
@@ -1,0 +1,9804 @@
+{
+  "_id": "buffer",
+  "_rev": "176-f442975b354dca9841769139feca8c2a",
+  "name": "buffer",
+  "description": "Node.js Buffer API, for the browser",
+  "dist-tags": {
+    "latest": "6.0.2"
+  },
+  "versions": {
+    "2.1.1": {
+      "name": "buffer",
+      "description": "Node.js buffer API that works in the browser",
+      "version": "2.1.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/native-buffer-browserify/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/native-buffer-browserify.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.1",
+      "dist": {
+        "shasum": "f5ae3a059e367994ebae8babd0c13495d07f0999",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/native-buffer-browserify/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/native-buffer-browserify.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.2",
+      "dist": {
+        "shasum": "db239d9d20f06217b01d1803d043fdbd63a4e5a4",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.3": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.3",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/native-buffer-browserify/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/native-buffer-browserify.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.3",
+      "dist": {
+        "shasum": "ba4bb542ea753589886ad18f1a5e0537bd543761",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.4": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.4",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/native-buffer-browserify/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/native-buffer-browserify.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.4",
+      "dist": {
+        "shasum": "0283e62870b4f450b636e00eb9fd527cd9ae1341",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.5": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.5",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.5",
+      "dist": {
+        "shasum": "15373190bc584061de5cbc155db82a0dc1a462de",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.6": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.6",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.6",
+      "dist": {
+        "shasum": "7704440344bd2a24e78e03940754cd02e8e30aa7",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.7": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.7",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.7",
+      "dist": {
+        "shasum": "958161f6a68ae690d14040ffc90f513d0ce4e768",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.8": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.8",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.8",
+      "dist": {
+        "shasum": "8e13c9f98914b1d52ac0f529fabfe2b361b6587d",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.9": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.9",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.9",
+      "dist": {
+        "shasum": "58e465c7da09901e1e22e1af9d3df6a6e4041cc9",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.10": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.10",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "_id": "buffer@2.1.10",
+      "dist": {
+        "shasum": "1ff0004281ba7b1c7d755016bfc188fb24867a6c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.11": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.11",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.1.11",
+      "dist": {
+        "shasum": "a0291a4e7291c60c07cd6928bac4f7f4e1611b4a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.12": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.12",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.1.12",
+      "dist": {
+        "shasum": "da6270d276406da92cdf357b5fb09e1edc547f22",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.12.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.13": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.1.13",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.1.13",
+      "dist": {
+        "shasum": "c88838ebf79f30b8b4a707788470bea8a62c2355",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.13.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.2.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.2.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.2.0",
+      "_shasum": "d19d0ab2bdea90d06a5c7bae0675b6fb6ea1aa5c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "d19d0ab2bdea90d06a5c7bae0675b6fb6ea1aa5c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.2.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.3.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.3.0",
+      "_shasum": "fe817aa92f962b591a2b9a013e6a01a9ef3ebd02",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "fe817aa92f962b591a2b9a013e6a01a9ef3ebd02",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.3.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "863b2f3690ccb4e076aaf2bf6028e943af849484",
+      "_id": "buffer@2.3.1",
+      "_shasum": "7f89c89d62e4e207fd0f10181918314330c88ee9",
+      "_from": ".",
+      "_npmVersion": "1.4.13",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "7f89c89d62e4e207fd0f10181918314330c88ee9",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.3.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "homepage": "http://feross.org",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.3.2",
+      "_shasum": "05f14d173c73d24f21045a9f83e1c396ae34d74b",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "05f14d173c73d24f21045a9f83e1c396ae34d74b",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.3": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.3.3",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "73f5f9780aebd4240bbe01a8ac77314fd28ff7fd",
+      "_id": "buffer@2.3.3",
+      "_shasum": "eabd37c725a67ecab17a29dc3ae2b50cbd181181",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "eabd37c725a67ecab17a29dc3ae2b50cbd181181",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.3.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.4": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.3.4",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.3.4",
+      "_shasum": "7e4af5a23c15e13fcbfd5c5a1ec974cb61668a4c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "7e4af5a23c15e13fcbfd5c5a1ec974cb61668a4c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.4.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.4.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.4.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.4.0",
+      "_shasum": "2df0569b20a7ea00e3ab43f90acfaa64a756f9f6",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "2df0569b20a7ea00e3ab43f90acfaa64a756f9f6",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.4.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.5.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.5.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "582b9bac3594d01954866e45606cce76ea9503d7",
+      "_id": "buffer@2.5.0",
+      "_shasum": "ee451ce8cd122dc922027674338dcef9e0eadd9a",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "ee451ce8cd122dc922027674338dcef9e0eadd9a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.5.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.5.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.5.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "3b7954e95ddbe5cb787f865f5f553a9fba4b86f3",
+      "_id": "buffer@2.5.1",
+      "_shasum": "00c6fec92134c0e3326bf3b33e76390800e00299",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "00c6fec92134c0e3326bf3b33e76390800e00299",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.5.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.6.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.6.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "tape": "^2.14.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.6.0",
+      "_shasum": "63a301efecda11a858ed31394eaefa63be73287d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "63a301efecda11a858ed31394eaefa63be73287d",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.6.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.6.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.6.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "tape": "^2.14.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "perf-node": "node perf/comparison/bracket-notation.js && node perf/comparison/concat.js && node perf/comparison/copy-big.js && node perf/comparison/copy.js && node perf/comparison/new.js && node perf/comparison/readDoubleBE.js && node perf/comparison/readFloatBE.js && node perf/comparison/readUInt32LE.js && node perf/comparison/slice.js && node perf/comparison/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.6.1",
+      "_shasum": "c1dcbb37b6f814433d5da789639980d7651fbe39",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "c1dcbb37b6f814433d5da789639980d7651fbe39",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.6.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.6.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.6.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "is-nan": "^1.0.1",
+        "tape": "^2.14.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "perf-node": "node perf/comparison/bracket-notation.js && node perf/comparison/concat.js && node perf/comparison/copy-big.js && node perf/comparison/copy.js && node perf/comparison/new.js && node perf/comparison/readDoubleBE.js && node perf/comparison/readFloatBE.js && node perf/comparison/readUInt32LE.js && node perf/comparison/slice.js && node perf/comparison/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.6.2",
+      "_shasum": "bd552e3b834a80ae2fd8e80c2087eceec7353ad3",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "bd552e3b834a80ae2fd8e80c2087eceec7353ad3",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.6.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.7.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.7.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "is-nan": "^1.0.1",
+        "tape": "^2.14.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "prepublish": "./bundle.sh",
+        "perf": "cd perf/solo && browserify --debug readUInt32BE.js > bundle.js && open index.html",
+        "perf-node": "node perf/comparison/bracket-notation.js && node perf/comparison/concat.js && node perf/comparison/copy-big.js && node perf/comparison/copy.js && node perf/comparison/new.js && node perf/comparison/readDoubleBE.js && node perf/comparison/readFloatBE.js && node perf/comparison/readUInt32LE.js && node perf/comparison/slice.js && node perf/comparison/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "_id": "buffer@2.7.0",
+      "_shasum": "02dfe9655c097f63e03c1b1714ca6e3d83d87bb2",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "02dfe9655c097f63e03c1b1714ca6e3d83d87bb2",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.7.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.8.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.8.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "is-nan": "^1.0.1",
+        "tape": "^2.14.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "fbecb716ccbcfeefbd53f9feed2c970236b06124",
+      "_id": "buffer@2.8.0",
+      "_shasum": "f6b5aa5822b51507af1da77c65921386ca215478",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "f6b5aa5822b51507af1da77c65921386ca215478",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.8.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.8.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.8.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^6.2.0",
+        "is-nan": "^1.0.1",
+        "tape": "^3.0.1",
+        "zuul": "^1.12.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "2e04bb00bf3d4b1ea2b2c1801b3423f48b1e39cb",
+      "_id": "buffer@2.8.1",
+      "_shasum": "6c632bf47cb7ec86509254ed42ab080937986114",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "6c632bf47cb7ec86509254ed42ab080937986114",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.8.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.8.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.8.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^6.2.0",
+        "is-nan": "^1.0.1",
+        "tape": "^3.0.1",
+        "zuul": "^1.12.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "30387775a76229d8c39298b0e857ac158b8782ae",
+      "_id": "buffer@2.8.2",
+      "_shasum": "d73c214c0334384dc29b04ee0ff5f5527c7974e7",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "d73c214c0334384dc29b04ee0ff5f5527c7974e7",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "3.0.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.0.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^7.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^1.12.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "580e30376ab273d7314243a9a98bf9c3a600b93a",
+      "_id": "buffer@3.0.0",
+      "_shasum": "38a0925db67e125cd6c7a34c25afbf3e46117b7a",
+      "_from": ".",
+      "_npmVersion": "2.1.12",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "38a0925db67e125cd6c7a34c25afbf3e46117b7a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.0.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.0.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.0.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^7.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^1.12.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "7be200aea0ce70e3eaf7798a1b63325f6978e46a",
+      "_id": "buffer@3.0.1",
+      "_shasum": "d2743fff2b1d92ad532dd5716ecd9217838dfb3e",
+      "_from": ".",
+      "_npmVersion": "2.1.16",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "d2743fff2b1d92ad532dd5716ecd9217838dfb3e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.0.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.0.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.0.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^7.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^1.12.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/es6/*.js",
+          "perf/*.js"
+        ]
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "50398b7ce6ed5c256b050479782bce2dcde4a011",
+      "_id": "buffer@3.0.2",
+      "_shasum": "4f6513750dbe278300fa903da9d7b4b1745b480e",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "4f6513750dbe278300fa903da9d7b4b1745b480e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.0.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.0.3": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.0.3",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^7.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^1.12.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/es6/*.js",
+          "perf/*.js"
+        ]
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "5b50c8e641e87021f0d368eb3273baf39fa33af3",
+      "_id": "buffer@3.0.3",
+      "_shasum": "93d8a236e8ee37941cdaf801eb8cd4117192ece6",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "1.2.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "93d8a236e8ee37941cdaf801eb8cd4117192ece6",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.0.3.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.1.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.1.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/es6/*.js",
+          "perf/*.js"
+        ]
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "268ef0a9230e0bcf53de7b43d6e6dca81ad6d4d6",
+      "_id": "buffer@3.1.0",
+      "_shasum": "525ca35ba81f1b240072c312ac3b6477da6fe10b",
+      "_from": ".",
+      "_npmVersion": "2.7.0",
+      "_nodeVersion": "1.5.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "525ca35ba81f1b240072c312ac3b6477da6fe10b",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.1.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.1.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.1.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "6535f1789cddf6c9dbc60e85ef4d5a455afc6beb",
+      "_id": "buffer@3.1.1",
+      "_shasum": "c2ab41165bd3cf22077af7404e4b6a42df6c1b6e",
+      "_from": ".",
+      "_npmVersion": "2.7.0",
+      "_nodeVersion": "1.5.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "c2ab41165bd3cf22077af7404e4b6a42df6c1b6e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.1.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.1.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.1.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "8aad53291695224b82845facce8d15c69dedd59b",
+      "_id": "buffer@3.1.2",
+      "_shasum": "1c679611b961edf16b9c4daf44fb66beb9daa9f0",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "1.6.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "1c679611b961edf16b9c4daf44fb66beb9daa9f0",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.2.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.2.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^3.6.1",
+        "tape": "^4.0.0",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "4d72d149e969ba7b6988a1ab1b36703fd7ca3837",
+      "_id": "buffer@3.2.0",
+      "_shasum": "18ff6e56a51412774ef65b0ec059898319f0c0f4",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "18ff6e56a51412774ef65b0ec059898319f0c0f4",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.2.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.2.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.2.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^3.6.1",
+        "tape": "^4.0.0",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "b9d9372418395565b3f398a391e5c554c2877251",
+      "_id": "buffer@3.2.1",
+      "_shasum": "2ed75374e505cacd2517a51d6b354954b2c59c05",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "1.8.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "2ed75374e505cacd2517a51d6b354954b2c59c05",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.2.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.2.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.2.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^10.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^3.6.1",
+        "tape": "^4.0.0",
+        "through2": "^0.6.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "0b25bfb16c0b4dfb0656fe1d2daa09a3c15c6dcd",
+      "_id": "buffer@3.2.2",
+      "_shasum": "15d3ead5b994e8170e228540d7ff1286c25aa53b",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "15d3ead5b994e8170e228540d7ff1286c25aa53b",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.2.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.3.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.3.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^10.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^4.3.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "414f1804a76755919e450e1cddcdd4a76c00a3a1",
+      "_id": "buffer@3.3.0",
+      "_shasum": "f0b86b9c24492f4b621f8e0da7a75cf74e4d9bc9",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "2.3.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "f0b86b9c24492f4b621f8e0da7a75cf74e4d9bc9",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.3.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.3.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.3.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^10.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^4.3.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "2faa3e5a76c68923b0bd1660f9016ab12170f0a0",
+      "_id": "buffer@3.3.1",
+      "_shasum": "c87bf2db2aa8e82f78d41fcfb82b40bb033bf44e",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "c87bf2db2aa8e82f78d41fcfb82b40bb033bf44e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.3.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.3.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^10.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^4.3.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "f4927defc0092e52aa6b6e77814d2930d01a2b6f",
+      "_id": "buffer@3.3.2",
+      "_shasum": "cf64be33cba8e62a98e67276429a4f3b5ece5f81",
+      "_from": ".",
+      "_npmVersion": "2.13.2",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "cf64be33cba8e62a98e67276429a4f3b5ece5f81",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.3.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.4.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.4.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "07014a3b0ea8ec11117710d3505fbb5446d6460b",
+      "_id": "buffer@3.4.0",
+      "_shasum": "7ded568ab4faaaa35246af2fe26522317f0d1ee7",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "7ded568ab4faaaa35246af2fe26522317f0d1ee7",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.4.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.4.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.4.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "39f91335057725b22a1d76347f6cdbef6f564789",
+      "_id": "buffer@3.4.1",
+      "_shasum": "bfe6597d5b1adb7e9749e479d14bab6150fcf1d9",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "bfe6597d5b1adb7e9749e479d14bab6150fcf1d9",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.4.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.4.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.4.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "2a9b4284efb4d78d22b48f822fa67c463d920ce5",
+      "_id": "buffer@3.4.2",
+      "_shasum": "2276a34ca2e4052a0fc606bb9a19f2d19af93518",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "2276a34ca2e4052a0fc606bb9a19f2d19af93518",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.4.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.4.3": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.4.3",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "5ac05a575dc18be18ba91e9f1e93e53b98d5d435",
+      "_id": "buffer@3.4.3",
+      "_shasum": "b35ec60e7e06ab42b6fb020f45f07e7c58ca9f3a",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "2.1.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "b35ec60e7e06ab42b6fb020f45f07e7c58ca9f3a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.4.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.5.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "84ec676ec1915d7c5dbafd5a288219ebd55c09f9",
+      "_id": "buffer@3.5.0",
+      "_shasum": "809127f9b4b6e22cfa5bc12857fef12c5b51c5e5",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "809127f9b4b6e22cfa5bc12857fef12c5b51c5e5",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.5.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "2b3c6a6b3b95716147ceeb2f2f0209ddaa47fd18",
+      "_id": "buffer@3.5.1",
+      "_shasum": "0549d54138f82c0fbef643307e654052ec987fe0",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.2",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "0549d54138f82c0fbef643307e654052ec987fe0",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.5.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "d1c1e280da5501ca0aa4e13e0da0af32151c556f",
+      "_id": "buffer@3.5.2",
+      "_shasum": "184a1016a31c2f0628c7ca0f717cea9863a552cc",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "184a1016a31c2f0628c7ca0f717cea9863a552cc",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.3": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.5.3",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "1c66c1b6e752cc27e281f6b7c8c8ecd6161f9ed3",
+      "_id": "buffer@3.5.3",
+      "_shasum": "38152c7df9ae8275b54a8800ea6dc504696690b4",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.1.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "38152c7df9ae8275b54a8800ea6dc504696690b4",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.4": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.5.4",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^0.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "0355b5c05100562cffc8d560971b0cb08e404417",
+      "_id": "buffer@3.5.4",
+      "_shasum": "dddda17eecf7843e1064f43f5cdb4346528a9d49",
+      "_from": ".",
+      "_npmVersion": "3.5.0",
+      "_nodeVersion": "5.1.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "dddda17eecf7843e1064f43f5cdb4346528a9d49",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.5": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.5.5",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "d767d6c63ee9f6141ca388dcfe5e7655dd9d1012",
+      "_id": "buffer@3.5.5",
+      "_shasum": "f7c55f7c2c634aa00efaabd864969a44eba82cf4",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "f7c55f7c2c634aa00efaabd864969a44eba82cf4",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.6.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.6.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "73e77e481f6ebc7a97be87468ddf9e8daf72a93c",
+      "_id": "buffer@3.6.0",
+      "_shasum": "a72c936f77b96bf52f5f7e7b467180628551defb",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "a72c936f77b96bf52f5f7e7b467180628551defb",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "4.0.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.0.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "ada621b6a1c08ea79e30dfe0a9594511b08e6b64",
+      "_id": "buffer@4.0.0",
+      "_shasum": "88db5491021ab319cbdc6faf5d3c720fb887ea74",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "88db5491021ab319cbdc6faf5d3c720fb887ea74",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.1.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.1.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "a7ce52860bf764a56c5388217194c46356ac2dd9",
+      "_id": "buffer@4.1.0",
+      "_shasum": "272bff7142f4135eda982567fa2d964878e33483",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "272bff7142f4135eda982567fa2d964878e33483",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.2.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.2.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "bb1691412301f576c697d32e1bdbf0ca348f681e",
+      "_id": "buffer@4.2.0",
+      "_shasum": "599a2f911f6cb2879a8f2ef138de045e89330c0b",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "599a2f911f6cb2879a8f2ef138de045e89330c0b",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.3.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.3.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "e52c33af77a79060c4d423a5447bd77c331ee9c9",
+      "_id": "buffer@4.3.0",
+      "_shasum": "b09b39dbee314233104d7d0cbd6edf928d89e4bd",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "b09b39dbee314233104d7d0cbd6edf928d89e4bd",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.3.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.3.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "96b30755e433bbd350fad307006bd14091754ad2",
+      "_id": "buffer@4.3.1",
+      "_shasum": "0e65fd01cc3e9154d152f6b3c934b5b8a1b6733c",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.2.4",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "0e65fd01cc3e9154d152f6b3c934b5b8a1b6733c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.4.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.4.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "37800d0e1e15668b6baebabfc61e29e248aa93bf",
+      "_id": "buffer@4.4.0",
+      "_shasum": "cf9b5949fcfe93400cc17035d962843d35410e15",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.2.6",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "cf9b5949fcfe93400cc17035d962843d35410e15",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.5.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.5.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^6.0.5",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "0c409fc59e038a3b8d988cd5b3ccc7dc72001c5d",
+      "_id": "buffer@4.5.0",
+      "_shasum": "fb5d78719e9c49b30ced84e36d4a622430f84cac",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "fb5d78719e9c49b30ced84e36d4a622430f84cac",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-4.5.0.tgz_1455608387841_0.41181276459246874"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.5.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.5.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^6.0.5",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "b9781a9434aaaa3d3099e7281c15a6a5f51c9b51",
+      "_id": "buffer@4.5.1",
+      "_shasum": "237b5bdef693c4c332385c1ded4ef4646e232d73",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.2",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "237b5bdef693c4c332385c1ded4ef4646e232d73",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-4.5.1.tgz_1458788498069_0.22429057699628174"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.6.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.6.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^6.0.5",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "caf10c7b2f209d8ed3df7fe32e475be3d6819625",
+      "_id": "buffer@4.6.0",
+      "_shasum": "fe50a7de503ebaad1b568d05967207be4024c348",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "fe50a7de503ebaad1b568d05967207be4024c348",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-4.6.0.tgz_1461134201214_0.012851420091465116"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.7.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.7.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "a1cab29b7aed04b221622efec2f6bf47f989314f",
+      "_id": "buffer@4.7.0",
+      "_shasum": "f32ca787cbaac88a62b230f7040ee431655c71f3",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "f32ca787cbaac88a62b230f7040ee431655c71f3",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-4.7.0.tgz_1466732113659_0.4496456526685506"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.7.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.7.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "1aa54804c7cad3df0418ddd7cbdb3c4d37dd07f3",
+      "_id": "buffer@4.7.1",
+      "_shasum": "6e5235437edb46ea2d4596d6396116b1548bca60",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "6e5235437edb46ea2d4596d6396116b1548bca60",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.7.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-4.7.1.tgz_1468566371042_0.9159472172614187"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.8.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.8.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "02b0eb31459b245e4ac5cfbd837e902796b1a425",
+      "_id": "buffer@4.8.0",
+      "_shasum": "d6e5022de9ee6c4af67767eece1e7993599b009f",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "d6e5022de9ee6c4af67767eece1e7993599b009f",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-4.8.0.tgz_1470644936861_0.3429739410057664"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.9.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.9.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "38fb25bc04e3cfd7d1e86325d899f19610eb96d5",
+      "_id": "buffer@4.9.0",
+      "_shasum": "f114fd8db10a51549964b88499ec2727ecc66f19",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "f114fd8db10a51549964b88499ec2727ecc66f19",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.9.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-4.9.0.tgz_1470646910012_0.8597736358642578"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.9.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.9.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js && OBJECT_IMPL=true tape test/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "2152e6ac4f8b47dc46eba44e07fad7c9d3e30563",
+      "_id": "buffer@4.9.1",
+      "_shasum": "6d1bb601b07a4efced97094132093027c95bc298",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.4.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "6d1bb601b07a4efced97094132093027c95bc298",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-4.9.1.tgz_1471491999032_0.9881124331150204"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "5.0.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "617ce169cf44b8ec1071dd4ef67a1fef669c3bdf",
+      "_id": "buffer@5.0.0",
+      "_shasum": "a65f428104a402563108d06b9c85a2f0c9713652",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.5.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "a65f428104a402563108d06b9c85a2f0c9713652",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-5.0.0.tgz_1474943916676_0.4056296891067177"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "83a5575f05f332b438c545091036542b717a1888",
+      "_id": "buffer@5.0.1",
+      "_shasum": "28165188f46d451b516b8be3e611b00029573486",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "28165188f46d451b516b8be3e611b00029573486",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/buffer-5.0.1.tgz_1478506442847_0.6941425669938326"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "d14a864f68f80ff1c6b591929da5d03d81af7cc5",
+      "_id": "buffer@5.0.2",
+      "_shasum": "41d0407ff76782e9ec19f52f88e237ce6bb0de6d",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "41d0407ff76782e9ec19f52f88e237ce6bb0de6d",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-5.0.2.tgz_1480720208927_0.706338755087927"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.3": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.3",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "de56df89422ad1e9c3bebbd86b9fec21b27427b2",
+      "_id": "buffer@5.0.3",
+      "_shasum": "90d5b2dbcef4004e7e307d0e488595a302e1f8fd",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "90d5b2dbcef4004e7e307d0e488595a302e1f8fd",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-5.0.3.tgz_1486071661746_0.7777809230610728"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.4": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.4",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "051039c1e0d08476bab10f6b5d62adec229f6971",
+      "_id": "buffer@5.0.4",
+      "_shasum": "d76fee8f6dbe7c112d6312e492ed9979127b34dd",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "d76fee8f6dbe7c112d6312e492ed9979127b34dd",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-5.0.4.tgz_1486617250999_0.9144826866686344"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.5": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.5",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "706a59cbb6bf2e7de701aefba437951ec6c0fb2a",
+      "_id": "buffer@5.0.5",
+      "_shasum": "35c9393244a90aff83581063d16f0882cecc9418",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "35c9393244a90aff83581063d16f0882cecc9418",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-5.0.5.tgz_1486678297324_0.04846473457291722"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.6": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.6",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "cf0c27e9bc645fdcfeefaac9f8da0172475a5277",
+      "_id": "buffer@5.0.6",
+      "_shasum": "2ea669f7eec0b6eda05b08f8b5ff661b28573588",
+      "_from": ".",
+      "_npmVersion": "4.4.4",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "2ea669f7eec0b6eda05b08f8b5ff661b28573588",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/buffer-5.0.6.tgz_1491419123937_0.48741885321214795"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.7": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.7",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "a50b8e35991255b21dbad23a189fd32d66b6868c",
+      "_id": "buffer@5.0.7",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.1.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-NeeHXWh5pCbPQCt2/6rLvXqapZfVsqw/YgRgaHpT3H9Uzgs+S0lSg5SQzouIuDvcmlQRqBe8hOO2scKCu3cxrg==",
+        "shasum": "570a290b625cf2603290c1149223d27ccf04db97",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer-5.0.7.tgz_1501897534750_0.6458459889981896"
+      },
+      "directories": {},
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.8": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.0.8",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "8bba72251eeb636cfcc9a7d3d3fe690f205bf4a8",
+      "_id": "buffer@5.0.8",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
+        "shasum": "84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer-5.0.8.tgz_1506728927930_0.79850033367984"
+      },
+      "directories": {}
+    },
+    "5.1.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.1.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "9c74805b314ed7824fa4f585a583be3626ae157c",
+      "_id": "buffer@5.1.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+        "shasum": "c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+        "fileCount": 39,
+        "unpackedSize": 244377
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.1.0_1518765399884_0.7736473989237913"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.2.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "0.1.0",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^3.3.12"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "e55ff09a8ce79348d52b3e06812dcc025982bcd0",
+      "_id": "buffer@5.2.0",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "8.11.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
+        "shasum": "53cf98241100099e9eeae20ee6d51d21b16e541e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 80664,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbWsbmCRA9TVsSAnZWagAAickQAJjmubcAFTynFv1CowJJ\ndbANxMnhp0u9Nb4O7v+s53gXJMXophzhREJhVVhXDJQaLDnPjISydxNh4jqF\nDezSPr0J8SgeF45lfNh2ofEd8w4/UsiRSJYy0Vs9+b3RIUpzFQw6YU3Hyslr\nq4A8eM3q35CrLrIaFjvIAsIo0PHLhGbt1NNhGYdFV/hSC8dbw8WsUX1F7cfJ\n7T2JakP7OnQ9XtJNK9UXsyU+dMhVuobK3e6MhJYX1F8kmRbQc4TlLYRL8Xr5\nkoQl827DW8Pg6LiAbFTDtebHvt5N6gNh6uCwlSbD2xXAuBTInEvFesX9xv3v\n9rvry+0mYPK6QNhyycwWgzSfIs6BrpkLiAATDh2ynvFo1CfJa1U+cGV957WY\nmLM7GiNgXueyvTXP7rjqS+wYDd3sUlnNN5/4j/weFKAGvGZNArpXipIxESxR\nolhK4gBtkrDborY0LCfWRkCkKuvU89YVcsj4ge3KjxUuA6xOXmYvl7LWXv5P\nhL4jE9AXwJvnPgTX8rq7ZpIq2AgpxYnukda2LdxhIKjHjzOWId6aZkCJ+Epg\n6uUxG5YIJ8hf8yv7hcKdFNsuSCOjfRbH2dJi5GsyXjAyliMYb5g9I5/GN0ex\n8jlZmPUshNseErCdIUcXGf/0k83AdoqlmaNDleGFN8iTyyCG0y1RwEaKc5bj\nJ8O9\r\n=EuCg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.2.0_1532675814278_0.7465353563167112"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.2.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "0.1.0",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^3.4.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "c8e3dc7af4e9367bcb14efd3d95c0bf467a67bee",
+      "_id": "buffer@5.2.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+        "shasum": "dd57fa0f109ac59c602479044dca7b8b3d0b71d6",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 79940,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbiGVzCRA9TVsSAnZWagAApaIP/Rb4pP0x+Xzpm6ZbyG99\nzIOkTnEol19cZnAiJzDhN1bSZ0IgsORBWIpILvKj8RzL7EPRacZ1zJOAKBY8\nXKqFaS1JvdOa9O0T2pbPWSdaPu3PCLTay3AZTWN7Bjl6i4hbQ/EFi/VHcZU/\nEhXqaaqwZUmX2+5ouxpZxLveYD5vLJwvb5Vz7aQ11gyN6dkVh4jx20gAbuWI\n+gF44ry3efHIreDDGWP9+i9d6dsFQXX+GtkepOQYa/gdBmJSuOKy5PM8ukFR\nvplR11Q2LvjpA7Dv7IbP5XlCfmzdcZKvTFrDnjZqSnSAB6/OnFGKOe1/nm1s\nXvRbduy3sRZ0Pxpo+eZojl/Z06wqYgi/ri4qQTtErfTMKAVTy3HrsusK0SHI\n0/ymBiHVt6j9JJD3kK9APx6bUmqjkQlHB1TPdXSUefyyWYPsdyD17D1rhrfD\ne+sQxdTS4p4R7hh1exudk6XVlZt7CuH3NZnDMK2VqjKFFerOMjzDRn5y2upg\nIWoqrblFHoP1NZO3QMq7sRn7JfIg5/bJfZhZhbhosAo98a/vc3a/6Mm/amus\nvexzOvdlDrw4fWWUNW5ESGZ32Ub8B+lZVzuv4XX1N6W4n5LanGO/QcR76WRB\noD8NfTj7QrvnInk3DttX+MtWdQW1eUaa9gBBnUqIoULMo+hraw1AbRhBJMBe\nZKQs\r\n=nd43\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.2.1_1535665522800_0.02050128191672096"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.3.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.3.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "c70a8489ac825f6f2872ea2d08f44081f04526e9",
+      "_id": "buffer@5.3.0",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.10.2",
+      "dist": {
+        "integrity": "sha512-XykNc84nIOC32vZ9euOKbmGAP69JUkXDtBQfLq88c8/6J/gZi/t14A+l/p/9EM2TcT5xNC1MKPCrvO3LVUpVPw==",
+        "shasum": "5f9fa5fefe3939888d0fdbf7d964e2a8531fd69c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.3.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 80315,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdUMt0CRA9TVsSAnZWagAAxDIP/RqzE+RhusHDB3D3nlPm\nfAdOWACfvhxguBHFqbp9LrfAhDSnDA4yZVI0p6CEFutDEkNeeHlvsqMK3/oh\npm45eAj9YszKPmTH4nx3UzdoG1xrzE2ztIC3MOOSXaL/hVyZO3kSATG+8K0b\nMlzb1rN1mBjxE+HlCRkdKfCsQpL3wrKbmCminW0b8T+2/9fiOByt9nQQtfhC\nMLgMowxQ6fpuSa95whegwpfMH3SKrT8yMY69kPoQsWWfU1Ft9jtefLo3I8lP\nsMq+Zs7m/lM0zHF0ipr8Q8Rc3UrXYNA2kVxwn13D20DnVUXSWFtEfcAADXw/\nmzeS+WYh3DOP4TyCvaKBSGSHotpa9+xUJPpjpIpFFMpR6P4hNTgHrObUsoCZ\ngdmf+aO6W+kkzRrBIXBFN8GXb8hJAd8iObI6tz73d/QWxrDpkHh3Gcvugvla\nGosrP+n6mLazzDNw3Wq/IGQg2zQ+/Mcf8QKrq1CKTcA67u8aSunrLf5RoIOA\nC5f5k80RJRmAGFKYS7TG/r7qyiMtvsORREXGTfOchE+5wXYoTBp0dTb9KMZB\niHJXb9saXR8e3Eku444V3kQIsYyPYlKW0jdM9BjkZCeGolFGZ0t0QOStAahW\ntKWuXisB1CeOEiZqg+hmKuDcG0z5FwtzcnGEdzPKXjiJUwhG/mYYdTQiqBNN\n1lBL\r\n=Ar2H\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.3.0_1565576051937_0.9965722667003907"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.4.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.4.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "fd0246ea00d318f3640ea782bfb499cc1eefae71",
+      "_id": "buffer@5.4.0",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.10.2",
+      "dist": {
+        "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+        "shasum": "33294f5c1f26e08461e528b69fa06de3c45cbd8c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 80550,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdUxxgCRA9TVsSAnZWagAA9MkP/jYowna1Q7Cn58n4qY5O\nyUPWMY/YyxJjKC5AYMepwjiuMOjIvB0oWuONvlYLRapgam5qg7GTUy6Jctwp\ncxnNZH1rYxmUziF+YAT75GdSszbNWSXqF5v/+X19gogs0ijLEGpX8wiWvzHJ\nxsHd0FYj7zVZQHeM8CNrp+bUH9rAqqg/v76pgO7M5wMelJjri3ZQxCHNQL0W\n1aJkMNGm/0om9SfI16gKdUMXyORYfeUP5EaU+39Fi07su8kMufQk3Y7+dRlh\nP5rqNBFs/Y2BtZz2CQqSzAjanJNdqVWA9KM/AtZCvExQUV4jhg8IMCWJ3sVK\nXqTG8kBu9h9ar9Z1GFRQOX0gSnXVvxqTPcwDJOM4azNHOeWdO7ToJws1QLb/\nc5x6dbhwoqsDv+bsnCvt5KqHqvZ7CUeP15hrQUIpjJVG4qne7OXSs1Le0uiB\nGo3wKlTHQzSiuuTOxc3pP5t2nd5wpiHp7v+1DlmVgO8GzYWbFak3EDJp4YyP\npq0E/VbBUuyJLoM72SMbfYKzXM/2x2660xpkzThiqZbwVY/Ivx4QlxDQG+pf\nmq8XPhSycZj9InI9zWzTrIMKVBidBSHuWRLqoPnnLKFOTQxsb7/ordaqTAme\nZJ/ylwEpDksAlv5FVTptvdQ25UNjFOyqcpbdqZYPWZeNJe6but/Ke3xo4zWM\nRARj\r\n=Ba0Y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.4.0_1565727839847_0.992790683292089"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.4.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.4.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "6719b400ca602759c2bd0345b8490b5689078ce4",
+      "_id": "buffer@5.4.1",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.11.2",
+      "dist": {
+        "integrity": "sha512-boQoQJ3Xqnh3XtUK+3NPcL/HOOMA133IyYBLsh9nWxH6XBGsBJVv/yhlZoIDu9it7LdGSWhdbn5jKR+slIflmg==",
+        "shasum": "d5e8e2c5dae9d695fd7ac985d02ca33f3c148114",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.4.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 80971,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZaIcCRA9TVsSAnZWagAAlPUP/2lEsKdi6RznPpcxfR3w\n6wuB2/qnVfhH6hRAZyqkGhCV0zLbB9zThvpQ8ikQi99N8wH81CCmOFP2D19j\nITL2WK+1nHr46tzONNDQh8i/+DRq+9Cw7/tDNwDRarxHhBW7bVctXENFDUU1\nreZf0uyVeOBOZ5528kRpeR+CLZ503EK9W2oSRiOrfGtL1xPuxdcfChgmsRIV\n2FAdO1kCgMrrgpKgAofFBECjnso4aFixJrgYfcMqd36Vq3R/9ba9xX6zT1eT\n/qoFE5TQl71/yzvqs7yq4boWDln3/hYqQvC2rZ0I4UNu0CFMcaf4m60w/tH/\nysWxsZ+Gl4/HKBaL+IiQR6xhTQcLokPYkz6GxldaFEhF0frCtyacWSzL0Pbj\nQMEscO9vy7Oyv+iNKzAnp45a1qnB4Thz7BfEr3wsXYE3XkX2XX2WA3JwBEsk\nE8h/hxlBMV8fm3BKl2ASnKqbw5IYlfxDa9DmhyMcuXdh9SDkqGo340D0sI3V\nwcNyb2Hoi2Hs1KT3ZBEHEpDbKXvTLqrF1cqRTmIzozlS0Am5AuvMUxzBN+/v\nwSvegdF2Oww4NnUJg0J0GnW1gvCb5dz3scYiwzYYAcBUKQZllzxoq6E21FWT\np4HM503DEa9LwRW+VvhnK3kGWnnJTPSvfBrGz5NwBzxDO+Ie2KijWfLi60N9\n68wh\r\n=GX+z\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.4.1_1566941723558_0.11852010978929828"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.4.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.4.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "b3dbaab202e043f7ecfb4cca9d594d60b0d80381",
+      "_id": "buffer@5.4.2",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.11.2",
+      "dist": {
+        "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
+        "shasum": "2012872776206182480eccb2c0fba5f672a2efef",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 81019,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZaVRCRA9TVsSAnZWagAAx/UP/jONb435bF3g8mH+o2VP\n+OT7vZRztcf1EPf/pCCXbzz0cPSA4IFPWo0kC7PutuCebNyRZ8tRhyXK4ITw\ni5MZU2of8ifVdJcddq01M1FEweSOkqJF3qV0PdH3JbMrHksdDycYovr3Y2j2\nfuLMZIzE+HejuTS59+2inG12X4rHNGDk2xAdrncSTw1CqdOQv23qNyYuOPLi\nw2PS6z0iCtxgGOec3D+005IZiuvjOTGD4Zd9JvOJuJWs6tyd+pMh79vb6BUv\nQ2qBNIKQTGYygk4swB+1HKlHCosIbFyLRrb0kVrmlTUXHpdkgUX4JRX9PoB1\nnIYFq8LHHtV5gAYo+/nyGHkMX1/Lr8bVxzlgAC6Y9LXyQsd76g1hkDAoaZdk\nhdYj4sjGET7E0fzVY0ivRiZmowez+TW1VYxaaR/4+6sZmO48r2zBle5bATcF\nIh+GUEsoW7ACj/oTxDixpcYt6xae6Ax9R7MCCAGJ9VH0xuVpT/HlYsoZo29U\nwdvorPJjEuG00B8SrCzdLt6ydrtU0NmCZ6Pxhawb1U8HktUYgYkpX0Rx30uC\nk9jCMa4oJb2CJPOXD5F5V7ZMdE4F2E7Hccp8rnwoqTQoBeI5y/QZXLj0D2Li\neO1vIxxDRNOS6xNfQR3bfMJRAhCnhITmYGQw6hXBsJSh9zV6I5AsQNBdp+ml\n/OKK\r\n=XbvD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.4.2_1566942544516_0.9141900465307107"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.4.3": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.4.3",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "gitHead": "c7f5cd77aaa7640f98c46c1b52b9b0006284c5c0",
+      "_id": "buffer@5.4.3",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+        "shasum": "3fbc9c69eb713d323e3fc1a895eee0710c072115",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 81315,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdebOfCRA9TVsSAnZWagAAsBYP/A0hWN/J0ODf9AOzghpa\n2T5nMRuQcm3unE5n8iqn41FECFqXkViCDDfMun9Vqv36BlIeWcoKwtSX0QQm\nammIevFOxJme4OecdukGZyHAuSd/mWTU7/jPfUetiCnGaj9ygGtL8gSvN8ZQ\n62ZYqS1ojB4UZlAiOeOdJ6wJpy48eWb7sqkwurVh21FnRGmAcU7sh3+c8zsD\nqUamZfmtG0jUaoOYMVGzfJlSIdl+lQds9b/WDetzUvylICYNXD4tVF2x7uv2\n6XrdFDneHrKZhK8Ilz/jS8qNXBohVLeOWTt+ACflxZJfJmaK172E2l5Yer0Q\nZZOmuMSm9ce5pq+xLCZJolItogVvl5gki3zlWGQehpkfLUU09HKukp+qaggo\nhuQXu5+fu0NLv+Ne2XZgqqbioaoVWwxgFWy5Hu/HOb5dD63XDNC+8Rq/EGQ1\n4tDJGVsPbDAwjiN8XcAIYJGOLRWTFk8A1qOeGhCheNPSTBde2mbi/I+nL1HG\nbCb7FkEXq3PrqT1nkEGyR4cePLkeprl6Q2a8lAneO/aTpiNrC/GJUjm1ZXub\nmOxO3UAC//uFbRAXE4JiyK2gGIRlz9noAjpW9CcQPz9Se8HrNKqQx25mEYdt\nhCB72lF772j/jm4gONYuz+3DrarXZLbRZ2nswYSB44yELPEmXg/ytFhoc9lT\ndoCw\r\n=BVmF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.4.3_1568256927004_0.36045588201420076"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.9.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "4.9.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "zuul --ui tape -- test/*.js",
+        "test-browser-es5-local": "zuul --ui tape --local -- test/*.js",
+        "test-browser-es6": "zuul --ui tape -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "zuul --ui tape --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js && OBJECT_IMPL=true tape test/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "gitHead": "da2e3fcbf0416b79ec0c56c348bc7efd98d9ff37",
+      "_id": "buffer@4.9.2",
+      "_nodeVersion": "10.17.0",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+        "shasum": "230ead344002988644841ab0244af8c44bbe3ef8",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+        "fileCount": 44,
+        "unpackedSize": 263614,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdxf6FCRA9TVsSAnZWagAA660P+wZtHWkkW9B2l52L+V/a\nUFtrTs5IiovWKeAmzOempmiAhHtEdt/eId3KVqjvm4tbfgskxttoPUqgGNq2\nu/MpmlV3HDcWdrrtkSFOo2uy++yJs8cdLVUSUdybP3NhXPwMdfVFIGfFbE45\nhDsNLFtLJfJQSi/Ctq3F3IKvA2kep0V+21l4vrtP/eBFtsWQIZMet/GyeMl+\nOcDrFuKICk2JOlZPRqe2cIW2VEQHDPXfBV2b9KxO++UPsS3VZv4BwNb2iOLJ\nOQDSld+Ey4PcXvZMVZ4tnOX1MPDcWgF/++cORZA8u+e4fLh96QHgufUuYGbD\nMlPiD/mTlNvY/wgOV8rRBm51kN49FklFcYhphdTr3yyEO1h4Kzx9K94+Nskk\nADU+v9LBBSsYRNnNItHQl8YKteHK9qBU3nRRAEnTaFxGT8GAcpc7lKPqbbLq\neaoHQeCo7Y8jldoliwGwIl6CMMZCl3Dcymtr9h1tfc2SlupV3Qp/ysSfnTM9\n+5XJ/ZJ77OyxOtGj2vNdtT79j9PVRTdocFEA3cyX6/86J9rIR2MAD31SLucy\nSCs45oBfD76mOfqjveKL69TT2AqVB3n21AFdINW1TiUhiWlpC5qDjwU8lJmW\n24EhaDZ9Drux0wZdbU765UablzliLMt9y4K+/fgEVYGNh57oU8lGLEW6q3il\niXF0\r\n=2RLl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_4.9.2_1573256836349_0.9392586515103449"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.6.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "3.6.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "standard && node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js test/node/*.js",
+        "test-browser-local": "zuul --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js test/node-es6/*.js && OBJECT_IMPL=true tape test/*.js test/node/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/*.js",
+          "test/node-es6/*.js",
+          "test/_polyfill.js",
+          "perf/*.js"
+        ]
+      },
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "gitHead": "26ae942c0462e8a32b2a33136f3291f1013b7216",
+      "_id": "buffer@3.6.2",
+      "_nodeVersion": "10.17.0",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-c3M77NkHJxS0zx/ErxXhDLr1v3y2MDXPeTJPvLNOaIYJ4ymHBUFQ9EXzt9HYuqAJllMoNb/EZ8hIiulnQFAUuQ==",
+        "shasum": "d83b530100c4a2c598bfc8ae24fff29812cf49de",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.6.2.tgz",
+        "fileCount": 30,
+        "unpackedSize": 144773,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdxf7ECRA9TVsSAnZWagAAEooQAJWxb5pdfCwaYVd+WasB\njQlJ5DMKBRQ1t9eNWxlkLt3u96EjGlzxpXywZxYY34H8v1ESMthyMU+eJnmh\nap0IaEduaTHprimM5+wDSYpEjRiEzEmdVtnoRnk9v7DhHjKSb9L84hOQKQlG\ndaVOgeBS6a/lNIEEW0nc1OmUYInyt7cUKeMG+ybnXRFQtFwyr9jkw04skaPW\nR1mnBMJPAEv9flvcqkWNX4B0ahRhwRBV14uCirYjFsjFufSaJTgGG8xH08Tf\nhj7oC20CHtQtpH1Jt6fdcpBR5fEWjusdIhwxfWvbaMXm1BNWIh3BLKvqloD0\noMrqMhHbAujWRqFFlAFyyslp6Lvy0tFP2Ntc7hrbCA4kxNN2uB9oghwMYmp4\nJqm4jAieSuGBU+2cB3QDfgUnIAkd9KNGlRHPoPJ+mONDb1MBLmZw/d7LLbkL\ngaQ9+bKHWHED+e2y38HigVvLy7rhO9oPl50nWB0D1tDJ1+8o5cyISznydomT\njdhR7Nbh3Gzm3Tn4TtxF3mKJBtAFFkkmf7aI+Jv9LTu3jL3wSjwirTieGE+X\nZfdKjDJGhXcajvy0D7+8whs2yn6Qlq0tsq1j2mKSnxF6ZQplyQ6S04kp5dad\nmSMQzPpvYZWbPAupJYX/DIxeJspzRFPvAIzPMRbMI6nXZx7wxf7E6Xzvxta0\na/tn\r\n=bT4a\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_3.6.2_1573256900455_0.2627936746707136"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.8.3": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "2.8.3",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^6.2.0",
+        "is-nan": "^1.0.1",
+        "tape": "^3.0.1",
+        "zuul": "^1.12.0"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "keywords": [
+        "buffer",
+        "browserify",
+        "compatible",
+        "browser",
+        "arraybuffer",
+        "uint8array",
+        "dataview"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "test": "node ./bin/test.js",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js && OBJECT_IMPL=true tape test/*.js",
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/12.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "gitHead": "088fc8a3cc5460e3517f9faee89c848c315ce59d",
+      "_id": "buffer@2.8.3",
+      "_nodeVersion": "10.17.0",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-dyatqxbSWlkhnG5lthQ7TDh2NfShsKesnKiGyt5DmiJfvKJ1zBq1AvC3+neSY565BziAiYwbothV2tizAr2WRg==",
+        "shasum": "74ad36487fff7413f4a6fdfb299e38ef3612ff47",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.8.3.tgz",
+        "fileCount": 19,
+        "unpackedSize": 68341,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdxf9eCRA9TVsSAnZWagAAoGUP/0GidML9yDVJ7sFH5+R1\nVomYSzAluq6RlBJrsEgrTa4caPmMnUMCt5PHb1oYaoUUJaBrG94nxHz02XJj\nIWBRmZAXLPTREeF9aDBd+pAspSfoVs9v8uzMUcaNF6pfTgdKU3Stv8MHZ5I6\nN2YxLS8y8Cyuom0FKtJv3WsxAnJwNDYfu6rx1w4KKR1pbK0yt2liCY4pBGpK\ngmDCW8/XeuW9UVs2Wz0nifWNa9E+OSU/+Te7orXM34f0R5lkC3l5KYfKXQJo\n4V/4ppyGd1AHC2oFoT0dO1smHPxeNATZEgH3IaKBRBSlYHq3LWDTyG34pyQ9\nFbzT8CspySKlsrL1AroMHtKBTw2ZSewsbgMHIYXEQ7ew9lPZMxntyj1kEBiz\nVDzjRvDtew7MMTjZyzFPmZWJQnYU9rlSzt7XsV470XewO5/hDteMaYLUwc98\n83sr/8AA5LsrZmUVP2mHcMuUdUwbB4BBUIjKsfUZPbpPpO8+Zc9z0H0PZM6p\n6jfJ0IU2W3GQ8fkDLprrBwAFa+w3BpFYLM1AFnGANBKFMGIX6ORPiGR00jxT\n0p4Q13jtGzeUR7C59GCgUAtvHwNKZ1HPYpeoZ6zO14n4sIoqUz8qqDSK9hEd\nbeqVmfdwaOiPhNqa/Tbk5ULKD0mxOu7Haa5CNl0yUnAEMI0jmwokcr0tj1eO\nCL0U\r\n=pv6t\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_2.8.3_1573257054078_0.17965496499842715"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.5.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.5.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ],
+        "globals": [
+          "SharedArrayBuffer"
+        ]
+      },
+      "gitHead": "b0a6de5f2131c3e339f14801bb342d16d580ac5f",
+      "_id": "buffer@5.5.0",
+      "_nodeVersion": "12.14.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+        "shasum": "9c3caa3d623c33dd1c7ef584b89b88bf9c9bc1ce",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 82061,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeYqq+CRA9TVsSAnZWagAAsVYQAI/paHnOYhfxZj+ooYAq\no1iRv3lUGee0z3qs8lZw4IK2BOgM50vh09p+9EXiTDNxPfoCeivu7k+K/vKq\n1Z0NyKK74Fo4kIC6zdTj7kZHKemITK1IRmIjY806SrtkNj+6bKKz+1A2sKZ4\n5n3va+QoDm2dte9Sx8sdQV+6Rql7ZgapFh8I2cjN/kg8KvULzbUPRYtWHU0t\nCQIjSeBiiFfP1rCcg6+ys0+MlM/iHsggh9BC4UMxtgi0ISwLN8xbk28uC4Ar\nmSH97DMj3OitRgNNnrWWDNfJTKy5Z3w/7bLuxoWNPpAQKDicUtdUZL/inQHN\nJlFPjR844t0O6XvivQfbvxFoOnx7jFSLQUhd1g/bM1kE7BiXTajREjdAZNdY\nd5/4zavqewlKuP6T1511yXwLxESyGxxinu+Dr8YdGI4B56pnHxdgEQrv+8ET\nOG6IBm45Vt9ocFjYEjraS2zFUkHKOZvlzHu8Njye3a0uCEF5eDIQS6weO+/6\nxrv3dVqOpxY3VQ/iiGHktZIfX91k94EEad3yta5S94wqGZhvi3Np1rWrI/EB\nwpZ0+MIgBegK67Ebp0viTzmit/wbG+SOXg2m3Kh+z3dgplksLzU9WVM01TJf\nUBvLwwGqiA1v52TMDwn02ABL3mNbjk5A0OnAQy0D8HI5y19YCqaHCXOLjzIv\nwZaR\r\n=jRQQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.5.0_1583524541733_0.9409099275946293"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.6.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.6.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ],
+        "globals": [
+          "SharedArrayBuffer"
+        ]
+      },
+      "gitHead": "d7b15a178294ebc85368aac87b0831dc48d6fba8",
+      "_id": "buffer@5.6.0",
+      "_nodeVersion": "13.12.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+        "shasum": "a31749dc7d81d84db08abf937b6b8c4033f62786",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 81740,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJelk8SCRA9TVsSAnZWagAAYcMQAICQS02OwuDr6T1BPVPR\nLazVSpJZaIrnoVDIl7n85fNFezaE1Y3z6ywtJOdgB3C/NXst7lb+nrFEVpIP\nUVE6q1BeB4tdHoqGmJS5cAdjtJjH37NuNFJ0Cg+xlYILSQK9HJF316oiJLhm\n4wV6P7UwALHmYWO51DglSrQN1Jn4ZOJ2Y43yn5NJiBW9RPnWX76iflau2CI+\n8RO6AF/TGK/7gyWk+9LpL6QNHtrder/p8NwDiHYnwibzvdJasdQaX1bDbPEV\npjDWTUZ0JdmJJChFE4JMXCa9x/Mkc3xBmtXT8jyJWVLIHTePwrnQGoWF1Zo4\nckFUGDjumU+Ilsu9Ojy2Nr/l0J1wiIl09aIirtPbnWrc/LbMHnKUWMX2aevg\nUEBzpnmpwFNKtdAQ7OnJk+EfgzG1Wozik505dJiAuikXwj/gUL9PZkSBseSf\nnDYT8oa5XMj8DCN4IDKWM4UDbrjQEd86ciJawClpHmA/swAk6x2SVEnPv1Cn\n+hvsLEu9HlW0G8CT1HYrCa77kkPuhJHWsbFPZAx3Nku2QfvaleevzcQ4TKfh\nB9Ua4Dfx4zM4zbC14qoOk+ho2StuDsok4DknfR8x3Ca8wAUsAHYQukngm7y2\nhbKpHOogklo+rsJJXcUdkYwO0Z7OlckWiKHEvpx8tasviOWFuDg20hFcwIEA\n9cAE\r\n=TDZl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.6.0_1586908946240_0.442043685850807"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.6.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.6.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "https://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.4",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.3"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ],
+        "globals": [
+          "SharedArrayBuffer"
+        ]
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "78ec2f29ffb2fb15148c8cb65587914b1f106cd8",
+      "_id": "buffer@5.6.1",
+      "_nodeVersion": "14.14.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-2z15UUHpS9/3tk9mY/q+Rl3rydOi7yMp5XWNQnRvoz+mJwiv8brqYwp9a+nOCtma6dwuEIxljD8W3ysVBZ05Vg==",
+        "shasum": "b99419405f4290a7a1f20b51037cee9f1fbd7f6a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.6.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 82052,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfk0EOCRA9TVsSAnZWagAAW1sP/0rMR0DjY6XpTxOn7/u+\na0yifMJRI34XCMPdPRy96odNpyRQw3QCIXm3WWJTXcffeQY2KFZhauinkvRO\np1ac530US1Lphyorj1o5bLHezN3NrCRgdqNgzRZreYob45+0lb5qQkJqF28C\nxigLFbff6LphKpgpJlWvXiux3kfsCQn/OikuPr17c1JeLefdeQZ9yG4yV93U\nl99OolRlvaCbtMPb19m2I0qaeF5A4EzKu9mgfxde5S2aKroDpO22CF2/315H\nLw2b75lP6Sc6Wkf45VR+74HNpI/v8tGvU3RkDcFLBrRV6/HP2neNEtIwXa0G\n7SDiQGjySDK02SAtUzLnOMus1tkGL1Nga7SiHZnc1Mw34GXdV2neDQN78ddb\nyRHCdHk5P8C4Ivdw6sbEAR66KP/e3SyWQ4YJ+a0qK/ScN2BPjbGSIHbi7qWn\n7JDkFKmuV0DiGVA0q8hh9JHqz5kYfhma2UPkp3KECSqWgeTnHW83VAJSoRHa\ndxebXiXaJ7o6mvg+rs2BW2HKNN7bcI8ECkeQHHq2beqlcN2W63OTHhRIu2D3\n93CNbISm8NOphy157j8Hca5XLhOwsp+t2JY6n9jSohwDoki3yoBvPD0uLxTO\nkemL0C29CxBcKg8l++4WgddPO7VAygqF7/iTIpaekGwRBPAKycmjZ7b4fQbM\nX5FP\r\n=Vrd/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.6.1_1603485966012_0.9445442552371313"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.7.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.7.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "https://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.4",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.3"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ],
+        "globals": [
+          "SharedArrayBuffer"
+        ]
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "b0713925abe5686d1e0b0a8310f58dc97cdb5fce",
+      "_id": "buffer@5.7.0",
+      "_nodeVersion": "14.14.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
+        "shasum": "88afbd29fc89fa7b58e82b39206f31f2cf34feed",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 82374,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmJfqCRA9TVsSAnZWagAA6ukP/2Qy877Da8y5l75Uz4GO\ni3qyfkpElZHpLv4cd8gjrGBNWKqunJDbn57Y0xqpD1YZzEsnZot4eXP7IEXM\nlB8frADd7LtU/QHXgSj0ZFDiqOtUW60Enb4A2TpFmbbSF7XpQHDafv4IKKwO\nRtCyuL0yC1IaSu1pL6UPoVXnOnDHIjEKHfhKNGfdKtsQPFCrucz/Ciwr033H\nGIcX+xfPI4umh4DUgJ6WpZKurXlNCKCPou59skptogG+YI+Dkk0Tp1VAErRI\nHCb7tGPYWRGGK1F+gb4F7Wyid0HvtgIWigpEBm/BY72ImLWE6l2C5y6WDROv\nuIn91d7IplNGMwjrgSNmv9/EZ77bEx/PLC38YAhalRF/zxTjF4V7JwVUKzAf\nA1T6VrvZGrkNLZNLD/l9HJns6pkNZqGVK9fWvar1lAIryh04YP61yG0JaqAR\nrcEfeGJ4rBKgN3jytem6GU6Q2/W4jitW6lFDNBRugGLK1jiJWSLlGoDJwReJ\n+urC1NKVQBy2KfY2SEYGqxPb8BjSECUHSatpz3c9yaa+kEkcbSE6pqP/gi6U\n2OdXvZKFsHGd0mnxNJQR6rmGFUbNOKQl4hbmm44rXNx/4jkjOf49+CIAkblT\n6z+6ABEj11SP5kx0NzDCSvYTaxR6fJr7Vnq56SR/fxKK6zZTNRVRevyf6fHt\ncfbl\r\n=pfy3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.7.0_1603835881428_0.5387066206933739"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.0": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "6.0.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "https://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.5",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-old": "airtap -- test/*.js",
+        "test-browser-old-local": "airtap --local -- test/*.js",
+        "test-browser-new": "airtap -- test/*.js test/node/*.js",
+        "test-browser-new-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "f44c2f25148d40395edda67aa465ff7bd98cd987",
+      "_id": "buffer@6.0.0",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-Sxdxq98A+Y9kRjO/3+mc2IAxIyTAKqzBiYKpeo5EluWnw9535rI4fN8DeMGsiQqpqqaWtFtTdxQgHnku6IEjCA==",
+        "shasum": "5af63d0ccb2a3f72ceb347344a43a610c7dd583c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-6.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 90560,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfonQzCRA9TVsSAnZWagAAiQoP/3rN6ELD/8W6eeVypYKp\nHlB3Wuc6bjDMXzWm5XiezUxsYGUv7xtU0ecl/wAc17w49md0BucHfCDlA44g\ntD4O36B6FtvoPagIa5ABsW4RDVWpUNazfs/vHtBxlFXj4MqUlTKbF5X9ovFi\nqrNSSkq3aIqd3WXEnBbHxFR2xz+ed7OIZy4V4TOASh11rkF5XzkLtCvcx8xk\nzQvNOHWKQiPS6hXVamkOpPpb5zhUTxzGC8Aze8z255zLhA0cdsUyk8oMO4fQ\nAOKQ3V0z/9tuzXUp2d1Ps9ZzLKrYaZh67d+W7MZMAVJjWpM891L/jokQP6np\n/lMBEpbd+MeO7Na/MF1avhbO6/87JAy+srpgnAsGR22tIZOzjhkrJMC/wzJ3\nvgbUapWP6FHQ//9QkJbgN9R7PcRP+hgjog3kEkQoBCMp7mSh8K/RX+m/0Lda\nlMIixk85KvIzNQJEnxLiDp7oVoEyI32z/ieLi6w3LQTouEFjZfFZZvp3XPpy\nL2+5GglNm1nWfA4+e3f2BRxtSFTjsvJQYx16XQLQk3Ily8xpDqzzc+88ZSDU\nzsvRCh+19J2ZZ/ygOziODZbt/HKkJza6hKUMg6hUHN+N27/jmOxebDKZprQ0\nQ0GBtS6Pyy04ENY72j/hYVh7ct2W01XVYdJmpRtt7B+Gkp8ZE3uXMg2ozHtw\nh5xt\r\n=14xG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_6.0.0_1604482099132_0.19426225783131246"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.7.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "5.7.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "https://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.4",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.3"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-es5": "airtap -- test/*.js",
+        "test-browser-es5-local": "airtap --local -- test/*.js",
+        "test-browser-es6": "airtap -- test/*.js test/node/*.js",
+        "test-browser-es6-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ],
+        "globals": [
+          "SharedArrayBuffer"
+        ]
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "edc667080ba3220ac35d4d1f64f2a78d89127c1b",
+      "_id": "buffer@5.7.1",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+        "shasum": "ba62e7c13133053582197160851a8f648e99eed0",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 82527,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfoyJoCRA9TVsSAnZWagAAiH8P/1CL/bEXlza64QzxZAgI\nYTF6rLWBxO3mypgWxbhnzZ/m/AeU0a4iH2wIY7GYOgs9LYK2bu1vnM729z2P\nNsxHqt7rHwREOQGbE/zQW23/5DT3BFiZWyLQqkv40IuE90yPCsZHQSnF6geY\nRGSqRKS7ebmlxt7k4Ao9/NqC+jrsezAM6hShhHdPx4wkZ3MnZYK1w9O8t1eI\nymRxtVWpTe5N8Qa02KdVja5O/muH9TR5131hC4JzbUN7sv7drn+8NPBHIOK2\nDVans5leF9nilMmSBV2s6F0v4aHyIEJiEiRPwWAJXNsdzZ72crnHWtaHSnaq\n/PkrQHQUmo0HNVyC009Ke0ajISdxoS36o3ZTdSbIY2p9Dr1CR7geX3QF8UiH\nhKWUch3MgrVOY0SkHWGDgVsmMVGuT6D7RBD3g2G7QTmkBUQIUZZ3S55V1Q98\njMWjbgXm/+gc7cteuKLMH06N7Bct34XQS/6/A5P6GFQuvtAPFC/sgg78uapp\nqzZ0cNA2IdobxvpeOsMDE190HGQwcjV3k593+Iem7Im3H3O6W6yxEPTjJIam\nFK+i0N0lzoeFJ94qJBUDJwxN24T+actNlHbZ6n6MwzpIZ+vQMhSfk611cXl8\n/9c0OrhHMqnOYq/dNQEcOgyl9aqjKKEkOLF0YKwIoe5R4nY0lxVbEjmNDwfv\nTvqT\r\n=tlSl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_5.7.1_1604526695408_0.6185328367244336"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.1": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "6.0.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "https://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.5",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-old": "airtap -- test/*.js",
+        "test-browser-old-local": "airtap --local -- test/*.js",
+        "test-browser-new": "airtap -- test/*.js test/node/*.js",
+        "test-browser-new-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "74899b7fbd0e3247931fa3cfb9fc27e96a995d21",
+      "_id": "buffer@6.0.1",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
+        "shasum": "3cbea8c1463e5a0779e30b66d4c88c6ffa182ac2",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 90758,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfoyQbCRA9TVsSAnZWagAA79QP/0FmXUivbhefRptMkySE\nfr7zZTN+bMh/q+ohi7LQswzxUnYppC5HwUvdPxtzSi5EiJcjJXtVJJbm84F+\ncq4w2uookAsC7q9jLUpRDHooZF/GBeisMEBSqpL2n2EOb09T3NM0wwvPeSz7\ng6YoII9RgZhYLhRMdEpXNfqwz6H3Cb1DQCc3fLowxY03gjHqUDVGlfUtVw/K\nOZ//YCwf+dad4WhO07xaUrv9jk7xhrATi4yFHlsakMhfbKpzhnkJSgbzWsDP\ng9wm9pZ20VC2zAT44xiJuL3ve1WahtuBHGYYUH1EiDs3k4Jpl8itmPa43NZf\n8TWFzWpjyr5QY/+Cu7eMu4gkMDsriYU1PbzTUMsueQ6YpRIHl1596xn5biGY\nEA0SJHx6eDFoGkvQC9ZnkohKxYXnUm2L9UhDIU42LzWYH8SoTNCsHOQQtZ5J\nVACgPfKOuJN67RYSvvIG1cqwrFl/HcRepqPgZo687+ivq4+FgCMgnTeRU8rf\nFSZMd/eqvPax995F13HK06dh3qtug/LqUJGGshfk1d9NBmF1OqZTJJVvV5jV\nKcXunFHG61LP30BbKkAJq8D3msYu34/0O/NrmFgnZlatxNn37cf+qf9BUVu7\nuKxkzooyh7BL6gzPWR7WDLajHdzjqOEC7Yh5hpoxeCmQfitoZq4fLkfsdKoA\nD2kQ\r\n=87m6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_6.0.1_1604527130847_0.03636976423334981"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.2": {
+      "name": "buffer",
+      "description": "Node.js Buffer API, for the browser",
+      "version": "6.0.2",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "https://feross.org"
+      },
+      "bugs": {
+        "url": "https://github.com/feross/buffer/issues"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.5",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.5"
+      },
+      "homepage": "https://github.com/feross/buffer",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/buffer"
+          }
+        }
+      },
+      "keywords": [
+        "arraybuffer",
+        "browser",
+        "browserify",
+        "buffer",
+        "compatible",
+        "dataview",
+        "uint8array"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/buffer.git"
+      },
+      "scripts": {
+        "perf": "browserify --debug perf/bracket-notation.js > perf/bundle.js && open perf/index.html",
+        "perf-node": "node perf/bracket-notation.js && node perf/concat.js && node perf/copy-big.js && node perf/copy.js && node perf/new-big.js && node perf/new.js && node perf/readDoubleBE.js && node perf/readFloatBE.js && node perf/readUInt32LE.js && node perf/slice.js && node perf/writeFloatBE.js",
+        "size": "browserify -r ./ | uglifyjs -c -m | gzip | wc -c",
+        "test": "standard && node ./bin/test.js",
+        "test-browser-old": "airtap -- test/*.js",
+        "test-browser-old-local": "airtap --local -- test/*.js",
+        "test-browser-new": "airtap -- test/*.js test/node/*.js",
+        "test-browser-new-local": "airtap --local -- test/*.js test/node/*.js",
+        "test-node": "tape test/*.js test/node/*.js",
+        "update-authors": "./bin/update-authors.sh"
+      },
+      "standard": {
+        "ignore": [
+          "test/node/**/*.js",
+          "test/common.js",
+          "test/_polyfill.js",
+          "perf/**/*.js"
+        ]
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "2b1286b3e0c61f22d68c9f7bdca2c11012d87dfe",
+      "_id": "buffer@6.0.2",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-XeXCUm+F7uY7fIzq4pKy+BLbZk4SgYS5xwlZOFYD3UEcAD+PwOoTaFr/SaXvhR1yRa8SKyPSZ7LNX4N65w7h8A==",
+        "shasum": "ca9ab87dffd0e864977f541f09844f06a60a8acd",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-6.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 91215,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfqbz3CRA9TVsSAnZWagAA+3QP+QHnoLf4xolJPRTcRfwX\nr86JM7uEaSvr0dqffG+a1O0qfZxyFYZesCiM3DMUd4KA6IOJLesWOP/Cw/d5\nXgumNd5I+3YyvmnAPnCYAxwVK7+EdhwHDoPWcn1WR6dPElHfdbzixed+8IZt\nQO8vB7JDKuT9b8bnob6WDXFwHf5cvieTY+4BbpDseOwK1/XnUoFxvQbJbxX7\nwaacfMp8lnKvtA+ROqhj2VH88BGm5fwibukg2qz8b7xLNhxHp2aqvLn26HWD\nJBsmyrKxhv5UYIW3UF3mRMLhhvYhm8rIF8CkWIXfegIW76WW1czEaw78bUi4\nr5VzDgzXT7TKwy1ZII6jirzXj62Eo3KasB/oPIWeBCNyOLx0WwrFvQHIEoEK\nktgohiZqBz9RhPU9BLmrY5l5SC3WoJVDcQGyXEwfnwRnXRrVL2ODFleHlxY9\nFxV6T0Ckff5GH6kLIzNM0NDyPhszf/Jsi8/jZCwu6q2P5uX27UbTfpTmu8Mj\nlgIIGiqaYvEvB2wGYPoZ5LqSunI2R8zlCugQi+jlMdApDZgxzqCZtUuUwEuJ\ngJvYJhAqU++xGdYxcIAMuVMRS9OrjrNI/VIU/G0mIhxZr4H8OsT9q0cbfju3\n4ca6wB/xesPInXMkotTLWY3mk0tSirmYzfgX2BmflEpqloMnhCgJml+HG306\n/8UK\r\n=p30X\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/buffer_6.0.2_1604959479363_0.43853673897423606"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# buffer [![travis][travis-image]][travis-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url] [![javascript style guide][standard-image]][standard-url]\n\n[travis-image]: https://img.shields.io/travis/feross/buffer/master.svg\n[travis-url]: https://travis-ci.org/feross/buffer\n[npm-image]: https://img.shields.io/npm/v/buffer.svg\n[npm-url]: https://npmjs.org/package/buffer\n[downloads-image]: https://img.shields.io/npm/dm/buffer.svg\n[downloads-url]: https://npmjs.org/package/buffer\n[standard-image]: https://img.shields.io/badge/code_style-standard-brightgreen.svg\n[standard-url]: https://standardjs.com\n\n#### The buffer module from [node.js](https://nodejs.org/), for the browser.\n\n[![saucelabs][saucelabs-image]][saucelabs-url]\n\n[saucelabs-image]: https://saucelabs.com/browser-matrix/buffer.svg\n[saucelabs-url]: https://saucelabs.com/u/buffer\n\nWith [browserify](http://browserify.org), simply `require('buffer')` or use the `Buffer` global and you will get this module.\n\nThe goal is to provide an API that is 100% identical to\n[node's Buffer API](https://nodejs.org/api/buffer.html). Read the\n[official docs](https://nodejs.org/api/buffer.html) for the full list of properties,\ninstance methods, and class methods that are supported.\n\n## features\n\n- Manipulate binary data like a boss, in all browsers!\n- Super fast. Backed by Typed Arrays (`Uint8Array`/`ArrayBuffer`, not `Object`)\n- Extremely small bundle size (**6.75KB minified + gzipped**, 51.9KB with comments)\n- Excellent browser support (Chrome, Firefox, Edge, Safari 11+, iOS 11+, Android, etc.)\n- Preserves Node API exactly, with one minor difference (see below)\n- Square-bracket `buf[4]` notation works!\n- Does not modify any browser prototypes or put anything on `window`\n- Comprehensive test suite (including all buffer tests from node.js core)\n\n## install\n\nTo use this module directly (without browserify), install it:\n\n```bash\nnpm install buffer\n```\n\nThis module was previously called **native-buffer-browserify**, but please use **buffer**\nfrom now on.\n\nIf you do not use a bundler, you can use the [standalone script](https://bundle.run/buffer).\n\n## usage\n\nThe module's API is identical to node's `Buffer` API. Read the\n[official docs](https://nodejs.org/api/buffer.html) for the full list of properties,\ninstance methods, and class methods that are supported.\n\nAs mentioned above, `require('buffer')` or use the `Buffer` global with\n[browserify](http://browserify.org) and this module will automatically be included\nin your bundle. Almost any npm module will work in the browser, even if it assumes that\nthe node `Buffer` API will be available.\n\nTo depend on this module explicitly (without browserify), require it like this:\n\n```js\nvar Buffer = require('buffer/').Buffer  // note: the trailing slash is important!\n```\n\nTo require this module explicitly, use `require('buffer/')` which tells the node.js module\nlookup algorithm (also used by browserify) to use the **npm module** named `buffer`\ninstead of the **node.js core** module named `buffer`!\n\n\n## how does it work?\n\nThe Buffer constructor returns instances of `Uint8Array` that have their prototype\nchanged to `Buffer.prototype`. Furthermore, `Buffer` is a subclass of `Uint8Array`,\nso the returned instances will have all the node `Buffer` methods and the\n`Uint8Array` methods. Square bracket notation works as expected -- it returns a\nsingle octet.\n\nThe `Uint8Array` prototype remains unmodified.\n\n\n## tracking the latest node api\n\nThis module tracks the Buffer API in the latest (unstable) version of node.js. The Buffer\nAPI is considered **stable** in the\n[node stability index](https://nodejs.org/docs/latest/api/documentation.html#documentation_stability_index),\nso it is unlikely that there will ever be breaking changes.\nNonetheless, when/if the Buffer API changes in node, this module's API will change\naccordingly.\n\n## related packages\n\n- [`buffer-reverse`](https://www.npmjs.com/package/buffer-reverse) - Reverse a buffer\n- [`buffer-xor`](https://www.npmjs.com/package/buffer-xor) - Bitwise xor a buffer\n- [`is-buffer`](https://www.npmjs.com/package/is-buffer) - Determine if an object is a Buffer without including the whole `Buffer` package\n\n## conversion packages\n\n### convert typed array to buffer\n\nUse [`typedarray-to-buffer`](https://www.npmjs.com/package/typedarray-to-buffer) to convert any kind of typed array to a `Buffer`. Does not perform a copy, so it's super fast.\n\n### convert buffer to typed array\n\n`Buffer` is a subclass of `Uint8Array` (which is a typed array). So there is no need to explicitly convert to typed array. Just use the buffer as a `Uint8Array`.\n\n### convert blob to buffer\n\nUse [`blob-to-buffer`](https://www.npmjs.com/package/blob-to-buffer) to convert a `Blob` to a `Buffer`.\n\n### convert buffer to blob\n\nTo convert a `Buffer` to a `Blob`, use the `Blob` constructor:\n\n```js\nvar blob = new Blob([ buffer ])\n```\n\nOptionally, specify a mimetype:\n\n```js\nvar blob = new Blob([ buffer ], { type: 'text/html' })\n```\n\n### convert arraybuffer to buffer\n\nTo convert an `ArrayBuffer` to a `Buffer`, use the `Buffer.from` function. Does not perform a copy, so it's super fast.\n\n```js\nvar buffer = Buffer.from(arrayBuffer)\n```\n\n### convert buffer to arraybuffer\n\nTo convert a `Buffer` to an `ArrayBuffer`, use the `.buffer` property (which is present on all `Uint8Array` objects):\n\n```js\nvar arrayBuffer = buffer.buffer.slice(\n  buffer.byteOffset, buffer.byteOffset + buffer.byteLength\n)\n```\n\nAlternatively, use the [`to-arraybuffer`](https://www.npmjs.com/package/to-arraybuffer) module.\n\n## performance\n\nSee perf tests in `/perf`.\n\n`BrowserBuffer` is the browser `buffer` module (this repo). `Uint8Array` is included as a\nsanity check (since `BrowserBuffer` uses `Uint8Array` under the hood, `Uint8Array` will\nalways be at least a bit faster). Finally, `NodeBuffer` is the node.js buffer module,\nwhich is included to compare against.\n\nNOTE: Performance has improved since these benchmarks were taken. PR welcome to update the README.\n\n### Chrome 38\n\n| Method | Operations | Accuracy | Sampled | Fastest |\n|:-------|:-----------|:---------|:--------|:-------:|\n| BrowserBuffer#bracket-notation | 11,457,464 ops/sec | ±0.86% | 66 | ✓ |\n| Uint8Array#bracket-notation | 10,824,332 ops/sec | ±0.74% | 65 | |\n| | | | |\n| BrowserBuffer#concat | 450,532 ops/sec | ±0.76% | 68 | |\n| Uint8Array#concat | 1,368,911 ops/sec | ±1.50% | 62 | ✓ |\n| | | | |\n| BrowserBuffer#copy(16000) | 903,001 ops/sec | ±0.96% | 67 | |\n| Uint8Array#copy(16000) | 1,422,441 ops/sec | ±1.04% | 66 | ✓ |\n| | | | |\n| BrowserBuffer#copy(16) | 11,431,358 ops/sec | ±0.46% | 69 | |\n| Uint8Array#copy(16) | 13,944,163 ops/sec | ±1.12% | 68 | ✓ |\n| | | | |\n| BrowserBuffer#new(16000) | 106,329 ops/sec | ±6.70% | 44 | |\n| Uint8Array#new(16000) | 131,001 ops/sec | ±2.85% | 31 | ✓ |\n| | | | |\n| BrowserBuffer#new(16) | 1,554,491 ops/sec | ±1.60% | 65 | |\n| Uint8Array#new(16) | 6,623,930 ops/sec | ±1.66% | 65 | ✓ |\n| | | | |\n| BrowserBuffer#readDoubleBE | 112,830 ops/sec | ±0.51% | 69 | ✓ |\n| DataView#getFloat64 | 93,500 ops/sec | ±0.57% | 68 | |\n| | | | |\n| BrowserBuffer#readFloatBE | 146,678 ops/sec | ±0.95% | 68 | ✓ |\n| DataView#getFloat32 | 99,311 ops/sec | ±0.41% | 67 | |\n| | | | |\n| BrowserBuffer#readUInt32LE | 843,214 ops/sec | ±0.70% | 69 | ✓ |\n| DataView#getUint32 | 103,024 ops/sec | ±0.64% | 67 | |\n| | | | |\n| BrowserBuffer#slice | 1,013,941 ops/sec | ±0.75% | 67 | |\n| Uint8Array#subarray | 1,903,928 ops/sec | ±0.53% | 67 | ✓ |\n| | | | |\n| BrowserBuffer#writeFloatBE | 61,387 ops/sec | ±0.90% | 67 | |\n| DataView#setFloat32 | 141,249 ops/sec | ±0.40% | 66 | ✓ |\n\n\n### Firefox 33\n\n| Method | Operations | Accuracy | Sampled | Fastest |\n|:-------|:-----------|:---------|:--------|:-------:|\n| BrowserBuffer#bracket-notation | 20,800,421 ops/sec | ±1.84% | 60 | |\n| Uint8Array#bracket-notation | 20,826,235 ops/sec | ±2.02% | 61 | ✓ |\n| | | | |\n| BrowserBuffer#concat | 153,076 ops/sec | ±2.32% | 61 | |\n| Uint8Array#concat | 1,255,674 ops/sec | ±8.65% | 52 | ✓ |\n| | | | |\n| BrowserBuffer#copy(16000) | 1,105,312 ops/sec | ±1.16% | 63 | |\n| Uint8Array#copy(16000) | 1,615,911 ops/sec | ±0.55% | 66 | ✓ |\n| | | | |\n| BrowserBuffer#copy(16) | 16,357,599 ops/sec | ±0.73% | 68 | |\n| Uint8Array#copy(16) | 31,436,281 ops/sec | ±1.05% | 68 | ✓ |\n| | | | |\n| BrowserBuffer#new(16000) | 52,995 ops/sec | ±6.01% | 35 | |\n| Uint8Array#new(16000) | 87,686 ops/sec | ±5.68% | 45 | ✓ |\n| | | | |\n| BrowserBuffer#new(16) | 252,031 ops/sec | ±1.61% | 66 | |\n| Uint8Array#new(16) | 8,477,026 ops/sec | ±0.49% | 68 | ✓ |\n| | | | |\n| BrowserBuffer#readDoubleBE | 99,871 ops/sec | ±0.41% | 69 | |\n| DataView#getFloat64 | 285,663 ops/sec | ±0.70% | 68 | ✓ |\n| | | | |\n| BrowserBuffer#readFloatBE | 115,540 ops/sec | ±0.42% | 69 | |\n| DataView#getFloat32 | 288,722 ops/sec | ±0.82% | 68 | ✓ |\n| | | | |\n| BrowserBuffer#readUInt32LE | 633,926 ops/sec | ±1.08% | 67 | ✓ |\n| DataView#getUint32 | 294,808 ops/sec | ±0.79% | 64 | |\n| | | | |\n| BrowserBuffer#slice | 349,425 ops/sec | ±0.46% | 69 | |\n| Uint8Array#subarray | 5,965,819 ops/sec | ±0.60% | 65 | ✓ |\n| | | | |\n| BrowserBuffer#writeFloatBE | 59,980 ops/sec | ±0.41% | 67 | |\n| DataView#setFloat32 | 317,634 ops/sec | ±0.63% | 68 | ✓ |\n\n### Safari 8\n\n| Method | Operations | Accuracy | Sampled | Fastest |\n|:-------|:-----------|:---------|:--------|:-------:|\n| BrowserBuffer#bracket-notation | 10,279,729 ops/sec | ±2.25% | 56 | ✓ |\n| Uint8Array#bracket-notation | 10,030,767 ops/sec | ±2.23% | 59 | |\n| | | | |\n| BrowserBuffer#concat | 144,138 ops/sec | ±1.38% | 65 | |\n| Uint8Array#concat | 4,950,764 ops/sec | ±1.70% | 63 | ✓ |\n| | | | |\n| BrowserBuffer#copy(16000) | 1,058,548 ops/sec | ±1.51% | 64 | |\n| Uint8Array#copy(16000) | 1,409,666 ops/sec | ±1.17% | 65 | ✓ |\n| | | | |\n| BrowserBuffer#copy(16) | 6,282,529 ops/sec | ±1.88% | 58 | |\n| Uint8Array#copy(16) | 11,907,128 ops/sec | ±2.87% | 58 | ✓ |\n| | | | |\n| BrowserBuffer#new(16000) | 101,663 ops/sec | ±3.89% | 57 | |\n| Uint8Array#new(16000) | 22,050,818 ops/sec | ±6.51% | 46 | ✓ |\n| | | | |\n| BrowserBuffer#new(16) | 176,072 ops/sec | ±2.13% | 64 | |\n| Uint8Array#new(16) | 24,385,731 ops/sec | ±5.01% | 51 | ✓ |\n| | | | |\n| BrowserBuffer#readDoubleBE | 41,341 ops/sec | ±1.06% | 67 | |\n| DataView#getFloat64 | 322,280 ops/sec | ±0.84% | 68 | ✓ |\n| | | | |\n| BrowserBuffer#readFloatBE | 46,141 ops/sec | ±1.06% | 65 | |\n| DataView#getFloat32 | 337,025 ops/sec | ±0.43% | 69 | ✓ |\n| | | | |\n| BrowserBuffer#readUInt32LE | 151,551 ops/sec | ±1.02% | 66 | |\n| DataView#getUint32 | 308,278 ops/sec | ±0.94% | 67 | ✓ |\n| | | | |\n| BrowserBuffer#slice | 197,365 ops/sec | ±0.95% | 66 | |\n| Uint8Array#subarray | 9,558,024 ops/sec | ±3.08% | 58 | ✓ |\n| | | | |\n| BrowserBuffer#writeFloatBE | 17,518 ops/sec | ±1.03% | 63 | |\n| DataView#setFloat32 | 319,751 ops/sec | ±0.48% | 68 | ✓ |\n\n\n### Node 0.11.14\n\n| Method | Operations | Accuracy | Sampled | Fastest |\n|:-------|:-----------|:---------|:--------|:-------:|\n| BrowserBuffer#bracket-notation | 10,489,828 ops/sec | ±3.25% | 90 | |\n| Uint8Array#bracket-notation | 10,534,884 ops/sec | ±0.81% | 92 | ✓ |\n| NodeBuffer#bracket-notation | 10,389,910 ops/sec | ±0.97% | 87 | |\n| | | | |\n| BrowserBuffer#concat | 487,830 ops/sec | ±2.58% | 88 | |\n| Uint8Array#concat | 1,814,327 ops/sec | ±1.28% | 88 | ✓ |\n| NodeBuffer#concat | 1,636,523 ops/sec | ±1.88% | 73 | |\n| | | | |\n| BrowserBuffer#copy(16000) | 1,073,665 ops/sec | ±0.77% | 90 | |\n| Uint8Array#copy(16000) | 1,348,517 ops/sec | ±0.84% | 89 | ✓ |\n| NodeBuffer#copy(16000) | 1,289,533 ops/sec | ±0.82% | 93 | |\n| | | | |\n| BrowserBuffer#copy(16) | 12,782,706 ops/sec | ±0.74% | 85 | |\n| Uint8Array#copy(16) | 14,180,427 ops/sec | ±0.93% | 92 | ✓ |\n| NodeBuffer#copy(16) | 11,083,134 ops/sec | ±1.06% | 89 | |\n| | | | |\n| BrowserBuffer#new(16000) | 141,678 ops/sec | ±3.30% | 67 | |\n| Uint8Array#new(16000) | 161,491 ops/sec | ±2.96% | 60 | |\n| NodeBuffer#new(16000) | 292,699 ops/sec | ±3.20% | 55 | ✓ |\n| | | | |\n| BrowserBuffer#new(16) | 1,655,466 ops/sec | ±2.41% | 82 | |\n| Uint8Array#new(16) | 14,399,926 ops/sec | ±0.91% | 94 | ✓ |\n| NodeBuffer#new(16) | 3,894,696 ops/sec | ±0.88% | 92 | |\n| | | | |\n| BrowserBuffer#readDoubleBE | 109,582 ops/sec | ±0.75% | 93 | ✓ |\n| DataView#getFloat64 | 91,235 ops/sec | ±0.81% | 90 | |\n| NodeBuffer#readDoubleBE | 88,593 ops/sec | ±0.96% | 81 | |\n| | | | |\n| BrowserBuffer#readFloatBE | 139,854 ops/sec | ±1.03% | 85 | ✓ |\n| DataView#getFloat32 | 98,744 ops/sec | ±0.80% | 89 | |\n| NodeBuffer#readFloatBE | 92,769 ops/sec | ±0.94% | 93 | |\n| | | | |\n| BrowserBuffer#readUInt32LE | 710,861 ops/sec | ±0.82% | 92 | |\n| DataView#getUint32 | 117,893 ops/sec | ±0.84% | 91 | |\n| NodeBuffer#readUInt32LE | 851,412 ops/sec | ±0.72% | 93 | ✓ |\n| | | | |\n| BrowserBuffer#slice | 1,673,877 ops/sec | ±0.73% | 94 | |\n| Uint8Array#subarray | 6,919,243 ops/sec | ±0.67% | 90 | ✓ |\n| NodeBuffer#slice | 4,617,604 ops/sec | ±0.79% | 93 | |\n| | | | |\n| BrowserBuffer#writeFloatBE | 66,011 ops/sec | ±0.75% | 93 | |\n| DataView#setFloat32 | 127,760 ops/sec | ±0.72% | 93 | ✓ |\n| NodeBuffer#writeFloatBE | 103,352 ops/sec | ±0.83% | 93 | |\n\n### iojs 1.8.1\n\n| Method | Operations | Accuracy | Sampled | Fastest |\n|:-------|:-----------|:---------|:--------|:-------:|\n| BrowserBuffer#bracket-notation | 10,990,488 ops/sec | ±1.11% | 91 | |\n| Uint8Array#bracket-notation | 11,268,757 ops/sec | ±0.65% | 97 | |\n| NodeBuffer#bracket-notation | 11,353,260 ops/sec | ±0.83% | 94 | ✓ |\n| | | | |\n| BrowserBuffer#concat | 378,954 ops/sec | ±0.74% | 94 | |\n| Uint8Array#concat | 1,358,288 ops/sec | ±0.97% | 87 | |\n| NodeBuffer#concat | 1,934,050 ops/sec | ±1.11% | 78 | ✓ |\n| | | | |\n| BrowserBuffer#copy(16000) | 894,538 ops/sec | ±0.56% | 84 | |\n| Uint8Array#copy(16000) | 1,442,656 ops/sec | ±0.71% | 96 | |\n| NodeBuffer#copy(16000) | 1,457,898 ops/sec | ±0.53% | 92 | ✓ |\n| | | | |\n| BrowserBuffer#copy(16) | 12,870,457 ops/sec | ±0.67% | 95 | |\n| Uint8Array#copy(16) | 16,643,989 ops/sec | ±0.61% | 93 | ✓ |\n| NodeBuffer#copy(16) | 14,885,848 ops/sec | ±0.74% | 94 | |\n| | | | |\n| BrowserBuffer#new(16000) | 109,264 ops/sec | ±4.21% | 63 | |\n| Uint8Array#new(16000) | 138,916 ops/sec | ±1.87% | 61 | |\n| NodeBuffer#new(16000) | 281,449 ops/sec | ±3.58% | 51 | ✓ |\n| | | | |\n| BrowserBuffer#new(16) | 1,362,935 ops/sec | ±0.56% | 99 | |\n| Uint8Array#new(16) | 6,193,090 ops/sec | ±0.64% | 95 | ✓ |\n| NodeBuffer#new(16) | 4,745,425 ops/sec | ±1.56% | 90 | |\n| | | | |\n| BrowserBuffer#readDoubleBE | 118,127 ops/sec | ±0.59% | 93 | ✓ |\n| DataView#getFloat64 | 107,332 ops/sec | ±0.65% | 91 | |\n| NodeBuffer#readDoubleBE | 116,274 ops/sec | ±0.94% | 95 | |\n| | | | |\n| BrowserBuffer#readFloatBE | 150,326 ops/sec | ±0.58% | 95 | ✓ |\n| DataView#getFloat32 | 110,541 ops/sec | ±0.57% | 98 | |\n| NodeBuffer#readFloatBE | 121,599 ops/sec | ±0.60% | 87 | |\n| | | | |\n| BrowserBuffer#readUInt32LE | 814,147 ops/sec | ±0.62% | 93 | |\n| DataView#getUint32 | 137,592 ops/sec | ±0.64% | 90 | |\n| NodeBuffer#readUInt32LE | 931,650 ops/sec | ±0.71% | 96 | ✓ |\n| | | | |\n| BrowserBuffer#slice | 878,590 ops/sec | ±0.68% | 93 | |\n| Uint8Array#subarray | 2,843,308 ops/sec | ±1.02% | 90 | |\n| NodeBuffer#slice | 4,998,316 ops/sec | ±0.68% | 90 | ✓ |\n| | | | |\n| BrowserBuffer#writeFloatBE | 65,927 ops/sec | ±0.74% | 93 | |\n| DataView#setFloat32 | 139,823 ops/sec | ±0.97% | 89 | ✓ |\n| NodeBuffer#writeFloatBE | 135,763 ops/sec | ±0.65% | 96 | |\n| | | | |\n\n## Testing the project\n\nFirst, install the project:\n\n    npm install\n\nThen, to run tests in Node.js, run:\n\n    npm run test-node\n\nTo test locally in a browser, you can run:\n\n    npm run test-browser-es5-local # For ES5 browsers that don't support ES6\n    npm run test-browser-es6-local # For ES6 compliant browsers\n\nThis will print out a URL that you can then open in a browser to run the tests, using [airtap](https://www.npmjs.com/package/airtap).\n\nTo run automated browser tests using Saucelabs, ensure that your `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables are set, then run:\n\n    npm test\n\nThis is what's run in Travis, to check against various browsers. The list of browsers is kept in the `bin/airtap-es5.yml` and `bin/airtap-es6.yml` files.\n\n## JavaScript Standard Style\n\nThis module uses [JavaScript Standard Style](https://github.com/feross/standard).\n\n[![JavaScript Style Guide](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nTo test that the code conforms to the style, `npm install` and run:\n\n    ./node_modules/.bin/standard\n\n## credit\n\nThis was originally forked from [buffer-browserify](https://github.com/toots/buffer-browserify).\n\n## Security Policies and Procedures\n\nThe `buffer` team and community take all security bugs in `buffer` seriously. Please see our [security policies and procedures](https://github.com/feross/security) document to learn how to report issues.\n\n## license\n\nMIT. Copyright (C) [Feross Aboukhadijeh](http://feross.org), and other contributors. Originally forked from an MIT-licensed module by Romain Beauxis.\n",
+  "maintainers": [
+    {
+      "name": "feross",
+      "email": "feross@feross.org"
+    }
+  ],
+  "time": {
+    "modified": "2020-11-09T22:04:41.864Z",
+    "created": "2014-02-07T03:37:21.186Z",
+    "2.1.1": "2014-02-07T03:37:21.186Z",
+    "2.1.2": "2014-02-07T05:28:27.645Z",
+    "2.1.3": "2014-02-07T05:55:42.114Z",
+    "2.1.4": "2014-02-16T02:56:20.611Z",
+    "2.1.5": "2014-03-07T06:11:30.082Z",
+    "2.1.6": "2014-04-05T18:54:07.959Z",
+    "2.1.7": "2014-04-05T18:55:05.902Z",
+    "2.1.8": "2014-04-08T07:38:41.091Z",
+    "2.1.9": "2014-04-08T08:00:27.847Z",
+    "2.1.10": "2014-04-08T09:03:19.837Z",
+    "2.1.11": "2014-04-10T03:58:22.929Z",
+    "2.1.12": "2014-04-10T09:29:30.226Z",
+    "2.1.13": "2014-04-18T04:28:13.958Z",
+    "2.2.0": "2014-05-08T00:07:26.982Z",
+    "2.3.0": "2014-05-08T00:24:52.527Z",
+    "2.3.1": "2014-05-27T01:45:04.094Z",
+    "2.3.2": "2014-05-30T18:43:18.527Z",
+    "2.3.3": "2014-06-30T06:42:56.917Z",
+    "2.3.4": "2014-07-17T05:25:21.687Z",
+    "2.4.0": "2014-07-17T06:03:58.447Z",
+    "2.5.0": "2014-07-22T08:47:44.782Z",
+    "2.5.1": "2014-09-11T19:46:34.086Z",
+    "2.6.0": "2014-09-12T00:16:46.979Z",
+    "2.6.1": "2014-09-12T00:37:03.251Z",
+    "2.6.2": "2014-09-12T00:51:56.485Z",
+    "2.7.0": "2014-09-12T11:16:57.773Z",
+    "2.8.0": "2014-10-29T04:44:59.979Z",
+    "2.8.1": "2014-10-31T03:43:56.161Z",
+    "2.8.2": "2014-12-07T20:18:22.355Z",
+    "3.0.0": "2014-12-24T10:27:31.308Z",
+    "3.0.1": "2014-12-31T06:46:01.572Z",
+    "3.0.2": "2015-02-11T23:03:49.996Z",
+    "3.0.3": "2015-02-19T03:13:37.092Z",
+    "3.1.0": "2015-03-09T22:40:27.507Z",
+    "3.1.1": "2015-03-11T23:57:28.729Z",
+    "3.1.2": "2015-03-20T23:34:08.534Z",
+    "3.2.0": "2015-04-21T10:37:25.517Z",
+    "3.2.1": "2015-04-23T00:08:55.786Z",
+    "3.2.2": "2015-05-05T02:09:44.928Z",
+    "3.3.0": "2015-06-30T23:36:17.170Z",
+    "3.3.1": "2015-07-07T19:58:25.131Z",
+    "3.3.2": "2015-08-04T13:59:16.564Z",
+    "3.4.0": "2015-08-05T12:49:17.977Z",
+    "3.4.1": "2015-08-06T12:26:28.753Z",
+    "3.4.2": "2015-08-13T11:17:25.638Z",
+    "3.4.3": "2015-08-22T13:07:55.979Z",
+    "3.5.0": "2015-09-16T06:31:16.526Z",
+    "3.5.1": "2015-10-07T02:30:54.211Z",
+    "3.5.2": "2015-11-14T07:13:16.682Z",
+    "3.5.3": "2015-12-01T00:43:07.592Z",
+    "3.5.4": "2015-12-06T03:01:41.615Z",
+    "3.5.5": "2015-12-11T11:22:05.267Z",
+    "3.6.0": "2015-12-25T06:38:12.168Z",
+    "4.0.0": "2016-01-02T23:19:46.748Z",
+    "4.1.0": "2016-01-09T17:25:14.745Z",
+    "4.2.0": "2016-01-11T15:02:21.180Z",
+    "4.3.0": "2016-01-12T22:59:30.743Z",
+    "4.3.1": "2016-01-27T14:41:44.278Z",
+    "4.4.0": "2016-01-28T22:34:04.751Z",
+    "4.5.0": "2016-02-16T07:39:49.767Z",
+    "4.5.1": "2016-03-24T03:01:38.458Z",
+    "4.6.0": "2016-04-20T06:36:41.602Z",
+    "4.7.0": "2016-06-24T01:35:17.067Z",
+    "4.7.1": "2016-07-15T07:06:11.537Z",
+    "4.8.0": "2016-08-08T08:28:59.948Z",
+    "4.9.0": "2016-08-08T09:01:53.151Z",
+    "4.9.1": "2016-08-18T03:46:39.280Z",
+    "5.0.0": "2016-09-27T02:38:39.348Z",
+    "5.0.1": "2016-11-07T08:14:03.098Z",
+    "5.0.2": "2016-12-02T23:10:11.301Z",
+    "5.0.3": "2017-02-02T21:41:03.760Z",
+    "5.0.4": "2017-02-09T05:14:13.118Z",
+    "5.0.5": "2017-02-09T22:11:39.215Z",
+    "5.0.6": "2017-04-05T19:05:26.129Z",
+    "5.0.7": "2017-08-05T01:45:34.970Z",
+    "5.0.8": "2017-09-29T23:48:48.079Z",
+    "5.1.0": "2018-02-16T07:16:40.013Z",
+    "5.2.0": "2018-07-27T07:16:54.371Z",
+    "5.2.1": "2018-08-30T21:45:22.928Z",
+    "5.3.0": "2019-08-12T02:14:12.056Z",
+    "5.4.0": "2019-08-13T20:24:00.050Z",
+    "5.4.1": "2019-08-27T21:35:23.713Z",
+    "5.4.2": "2019-08-27T21:49:04.642Z",
+    "5.4.3": "2019-09-12T02:55:27.156Z",
+    "4.9.2": "2019-11-08T23:47:16.446Z",
+    "3.6.2": "2019-11-08T23:48:20.601Z",
+    "2.8.3": "2019-11-08T23:50:54.246Z",
+    "5.5.0": "2020-03-06T19:55:41.858Z",
+    "5.6.0": "2020-04-15T00:02:26.412Z",
+    "5.6.1": "2020-10-23T20:46:06.127Z",
+    "5.7.0": "2020-10-27T21:58:01.617Z",
+    "6.0.0": "2020-11-04T09:28:19.229Z",
+    "5.7.1": "2020-11-04T21:51:35.578Z",
+    "6.0.1": "2020-11-04T21:58:51.060Z",
+    "6.0.2": "2020-11-09T22:04:39.557Z"
+  },
+  "readmeFilename": "README.md",
+  "users": {
+    "holgerkoser": true,
+    "guybrush": true,
+    "bmpvieira": true,
+    "simplyianm": true,
+    "qodefox": true,
+    "vbv": true,
+    "pandao": true,
+    "po": true,
+    "timdp": true,
+    "mfellner": true,
+    "demopark": true,
+    "gamr": true,
+    "hr.": true,
+    "arssly": true,
+    "roxnz": true,
+    "tdmalone": true,
+    "feross": true,
+    "shanewholloway": true,
+    "monjer": true,
+    "xinwangwang": true,
+    "thejeshgn.com": true,
+    "thejeshgn": true,
+    "chinawolf_wyp": true,
+    "pid": true,
+    "kiaratto": true,
+    "sunshine1988": true,
+    "solenw_in": true,
+    "hualei": true,
+    "tcrowe": true
+  },
+  "homepage": "https://github.com/feross/buffer",
+  "keywords": [
+    "arraybuffer",
+    "browser",
+    "browserify",
+    "buffer",
+    "compatible",
+    "dataview",
+    "uint8array"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/feross/buffer.git"
+  },
+  "contributors": [
+    {
+      "name": "Romain Beauxis",
+      "email": "toots@rastageeks.org"
+    },
+    {
+      "name": "James Halliday",
+      "email": "mail@substack.net"
+    }
+  ],
+  "author": {
+    "name": "Feross Aboukhadijeh",
+    "email": "feross@feross.org",
+    "url": "https://feross.org"
+  },
+  "bugs": {
+    "url": "https://github.com/feross/buffer/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/buffer.min.json
+++ b/test/fixtures/registry-mocks/content/buffer.min.json
@@ -1,0 +1,2435 @@
+{
+  "name": "buffer",
+  "dist-tags": {
+    "latest": "6.0.2"
+  },
+  "versions": {
+    "2.1.1": {
+      "name": "buffer",
+      "version": "2.1.1",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "f5ae3a059e367994ebae8babd0c13495d07f0999",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.2": {
+      "name": "buffer",
+      "version": "2.1.2",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "db239d9d20f06217b01d1803d043fdbd63a4e5a4",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.3": {
+      "name": "buffer",
+      "version": "2.1.3",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "ba4bb542ea753589886ad18f1a5e0537bd543761",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.3.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.4": {
+      "name": "buffer",
+      "version": "2.1.4",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "0283e62870b4f450b636e00eb9fd527cd9ae1341",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.4.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.5": {
+      "name": "buffer",
+      "version": "2.1.5",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "15373190bc584061de5cbc155db82a0dc1a462de",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.5.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.6": {
+      "name": "buffer",
+      "version": "2.1.6",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "7704440344bd2a24e78e03940754cd02e8e30aa7",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.6.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.7": {
+      "name": "buffer",
+      "version": "2.1.7",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "958161f6a68ae690d14040ffc90f513d0ce4e768",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.7.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.8": {
+      "name": "buffer",
+      "version": "2.1.8",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "*",
+        "browserify": "3.x",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "8e13c9f98914b1d52ac0f529fabfe2b361b6587d",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.8.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.9": {
+      "name": "buffer",
+      "version": "2.1.9",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "dist": {
+        "shasum": "58e465c7da09901e1e22e1af9d3df6a6e4041cc9",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.9.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.10": {
+      "name": "buffer",
+      "version": "2.1.10",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "dist": {
+        "shasum": "1ff0004281ba7b1c7d755016bfc188fb24867a6c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.10.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.11": {
+      "name": "buffer",
+      "version": "2.1.11",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "dist": {
+        "shasum": "a0291a4e7291c60c07cd6928bac4f7f4e1611b4a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.11.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.12": {
+      "name": "buffer",
+      "version": "2.1.12",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "dist": {
+        "shasum": "da6270d276406da92cdf357b5fb09e1edc547f22",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.12.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.1.13": {
+      "name": "buffer",
+      "version": "2.1.13",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "dist": {
+        "shasum": "c88838ebf79f30b8b4a707788470bea8a62c2355",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.1.13.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.2.0": {
+      "name": "buffer",
+      "version": "2.2.0",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "dist": {
+        "shasum": "d19d0ab2bdea90d06a5c7bae0675b6fb6ea1aa5c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.2.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.0": {
+      "name": "buffer",
+      "version": "2.3.0",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.x",
+        "browserify": "3.x",
+        "tape": "2.x"
+      },
+      "dist": {
+        "shasum": "fe817aa92f962b591a2b9a013e6a01a9ef3ebd02",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.1": {
+      "name": "buffer",
+      "version": "2.3.1",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "dist": {
+        "shasum": "7f89c89d62e4e207fd0f10181918314330c88ee9",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.2": {
+      "name": "buffer",
+      "version": "2.3.2",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "dist": {
+        "shasum": "05f14d173c73d24f21045a9f83e1c396ae34d74b",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.3": {
+      "name": "buffer",
+      "version": "2.3.3",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "dist": {
+        "shasum": "eabd37c725a67ecab17a29dc3ae2b50cbd181181",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.3.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.3.4": {
+      "name": "buffer",
+      "version": "2.3.4",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "dist": {
+        "shasum": "7e4af5a23c15e13fcbfd5c5a1ec974cb61668a4c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.3.4.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.4.0": {
+      "name": "buffer",
+      "version": "2.4.0",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "dist": {
+        "shasum": "2df0569b20a7ea00e3ab43f90acfaa64a756f9f6",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.4.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.5.0": {
+      "name": "buffer",
+      "version": "2.5.0",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "dist": {
+        "shasum": "ee451ce8cd122dc922027674338dcef9e0eadd9a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.5.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.5.1": {
+      "name": "buffer",
+      "version": "2.5.1",
+      "dependencies": {
+        "base64-js": "~0.0.4",
+        "ieee754": "~1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^3.46.0",
+        "tape": "^2.12.3"
+      },
+      "dist": {
+        "shasum": "00c6fec92134c0e3326bf3b33e76390800e00299",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.5.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.6.0": {
+      "name": "buffer",
+      "version": "2.6.0",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "tape": "^2.14.0"
+      },
+      "dist": {
+        "shasum": "63a301efecda11a858ed31394eaefa63be73287d",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.6.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.6.1": {
+      "name": "buffer",
+      "version": "2.6.1",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "tape": "^2.14.0"
+      },
+      "dist": {
+        "shasum": "c1dcbb37b6f814433d5da789639980d7651fbe39",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.6.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.6.2": {
+      "name": "buffer",
+      "version": "2.6.2",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "is-nan": "^1.0.1",
+        "tape": "^2.14.0"
+      },
+      "dist": {
+        "shasum": "bd552e3b834a80ae2fd8e80c2087eceec7353ad3",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.6.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.7.0": {
+      "name": "buffer",
+      "version": "2.7.0",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "is-nan": "^1.0.1",
+        "tape": "^2.14.0"
+      },
+      "dist": {
+        "shasum": "02dfe9655c097f63e03c1b1714ca6e3d83d87bb2",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.7.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.8.0": {
+      "name": "buffer",
+      "version": "2.8.0",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^5.11.1",
+        "is-nan": "^1.0.1",
+        "tape": "^2.14.0"
+      },
+      "dist": {
+        "shasum": "f6b5aa5822b51507af1da77c65921386ca215478",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.8.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.8.1": {
+      "name": "buffer",
+      "version": "2.8.1",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^6.2.0",
+        "is-nan": "^1.0.1",
+        "tape": "^3.0.1",
+        "zuul": "^1.12.0"
+      },
+      "dist": {
+        "shasum": "6c632bf47cb7ec86509254ed42ab080937986114",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.8.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "2.8.2": {
+      "name": "buffer",
+      "version": "2.8.2",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^6.2.0",
+        "is-nan": "^1.0.1",
+        "tape": "^3.0.1",
+        "zuul": "^1.12.0"
+      },
+      "dist": {
+        "shasum": "d73c214c0334384dc29b04ee0ff5f5527c7974e7",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.8.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v2.8.3 or newer"
+    },
+    "3.0.0": {
+      "name": "buffer",
+      "version": "3.0.0",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^7.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^1.12.0"
+      },
+      "dist": {
+        "shasum": "38a0925db67e125cd6c7a34c25afbf3e46117b7a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.0.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.0.1": {
+      "name": "buffer",
+      "version": "3.0.1",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^7.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^1.12.0"
+      },
+      "dist": {
+        "shasum": "d2743fff2b1d92ad532dd5716ecd9217838dfb3e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.0.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.0.2": {
+      "name": "buffer",
+      "version": "3.0.2",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^7.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^1.12.0"
+      },
+      "dist": {
+        "shasum": "4f6513750dbe278300fa903da9d7b4b1745b480e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.0.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.0.3": {
+      "name": "buffer",
+      "version": "3.0.3",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^7.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^1.12.0"
+      },
+      "dist": {
+        "shasum": "93d8a236e8ee37941cdaf801eb8cd4117192ece6",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.0.3.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.1.0": {
+      "name": "buffer",
+      "version": "3.1.0",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "525ca35ba81f1b240072c312ac3b6477da6fe10b",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.1.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.1.1": {
+      "name": "buffer",
+      "version": "3.1.1",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "c2ab41165bd3cf22077af7404e4b6a42df6c1b6e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.1.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.1.2": {
+      "name": "buffer",
+      "version": "3.1.2",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^2.0.0",
+        "tape": "^3.0.1",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "1c679611b961edf16b9c4daf44fb66beb9daa9f0",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.1.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.2.0": {
+      "name": "buffer",
+      "version": "3.2.0",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^3.6.1",
+        "tape": "^4.0.0",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "18ff6e56a51412774ef65b0ec059898319f0c0f4",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.2.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.2.1": {
+      "name": "buffer",
+      "version": "3.2.1",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^9.0.3",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^3.6.1",
+        "tape": "^4.0.0",
+        "through2": "^0.6.3",
+        "zuul": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "2ed75374e505cacd2517a51d6b354954b2c59c05",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.2.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.2.2": {
+      "name": "buffer",
+      "version": "3.2.2",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^10.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^0.3.2",
+        "standard": "^3.6.1",
+        "tape": "^4.0.0",
+        "through2": "^0.6.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "15d3ead5b994e8170e228540d7ff1286c25aa53b",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.2.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.3.0": {
+      "name": "buffer",
+      "version": "3.3.0",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^10.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^4.3.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "f0b86b9c24492f4b621f8e0da7a75cf74e4d9bc9",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.3.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.3.1": {
+      "name": "buffer",
+      "version": "3.3.1",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^10.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^4.3.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "c87bf2db2aa8e82f78d41fcfb82b40bb033bf44e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.3.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.3.2": {
+      "name": "buffer",
+      "version": "3.3.2",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^10.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^4.3.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "cf64be33cba8e62a98e67276429a4f3b5ece5f81",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.3.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.4.0": {
+      "name": "buffer",
+      "version": "3.4.0",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "7ded568ab4faaaa35246af2fe26522317f0d1ee7",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.4.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.4.1": {
+      "name": "buffer",
+      "version": "3.4.1",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "bfe6597d5b1adb7e9749e479d14bab6150fcf1d9",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.4.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.4.2": {
+      "name": "buffer",
+      "version": "3.4.2",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "2276a34ca2e4052a0fc606bb9a19f2d19af93518",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.4.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.4.3": {
+      "name": "buffer",
+      "version": "3.4.3",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "b35ec60e7e06ab42b6fb020f45f07e7c58ca9f3a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.4.3.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.0": {
+      "name": "buffer",
+      "version": "3.5.0",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "809127f9b4b6e22cfa5bc12857fef12c5b51c5e5",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.1": {
+      "name": "buffer",
+      "version": "3.5.1",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "0549d54138f82c0fbef643307e654052ec987fe0",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.2": {
+      "name": "buffer",
+      "version": "3.5.2",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^11.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "184a1016a31c2f0628c7ca0f717cea9863a552cc",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.3": {
+      "name": "buffer",
+      "version": "3.5.3",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "38152c7df9ae8275b54a8800ea6dc504696690b4",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.3.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.4": {
+      "name": "buffer",
+      "version": "3.5.4",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^0.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "dddda17eecf7843e1064f43f5cdb4346528a9d49",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.4.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.5.5": {
+      "name": "buffer",
+      "version": "3.5.5",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "f7c55f7c2c634aa00efaabd864969a44eba82cf4",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "3.6.0": {
+      "name": "buffer",
+      "version": "3.6.0",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "a72c936f77b96bf52f5f7e7b467180628551defb",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v3.6.2 or newer"
+    },
+    "4.0.0": {
+      "name": "buffer",
+      "version": "4.0.0",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "88db5491021ab319cbdc6faf5d3c720fb887ea74",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.0.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.1.0": {
+      "name": "buffer",
+      "version": "4.1.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "272bff7142f4135eda982567fa2d964878e33483",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.1.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.2.0": {
+      "name": "buffer",
+      "version": "4.2.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "599a2f911f6cb2879a8f2ef138de045e89330c0b",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.2.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.3.0": {
+      "name": "buffer",
+      "version": "4.3.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "b09b39dbee314233104d7d0cbd6edf928d89e4bd",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.3.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.3.1": {
+      "name": "buffer",
+      "version": "4.3.1",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "0e65fd01cc3e9154d152f6b3c934b5b8a1b6733c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.3.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.4.0": {
+      "name": "buffer",
+      "version": "4.4.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "typedarray-to-buffer": "^3.0.4",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "cf9b5949fcfe93400cc17035d962843d35410e15",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.4.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.5.0": {
+      "name": "buffer",
+      "version": "4.5.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^6.0.5",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "fb5d78719e9c49b30ced84e36d4a622430f84cac",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.5.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.5.1": {
+      "name": "buffer",
+      "version": "4.5.1",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^6.0.5",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "237b5bdef693c4c332385c1ded4ef4646e232d73",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.5.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.6.0": {
+      "name": "buffer",
+      "version": "4.6.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^6.0.5",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "fe50a7de503ebaad1b568d05967207be4024c348",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.6.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.7.0": {
+      "name": "buffer",
+      "version": "4.7.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "f32ca787cbaac88a62b230f7040ee431655c71f3",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.7.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.7.1": {
+      "name": "buffer",
+      "version": "4.7.1",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "6e5235437edb46ea2d4596d6396116b1548bca60",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.7.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.8.0": {
+      "name": "buffer",
+      "version": "4.8.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "d6e5022de9ee6c4af67767eece1e7993599b009f",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.8.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.9.0": {
+      "name": "buffer",
+      "version": "4.9.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "f114fd8db10a51549964b88499ec2727ecc66f19",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.9.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "4.9.1": {
+      "name": "buffer",
+      "version": "4.9.1",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "6d1bb601b07a4efced97094132093027c95bc298",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v4.9.2 or newer"
+    },
+    "5.0.0": {
+      "name": "buffer",
+      "version": "5.0.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "a65f428104a402563108d06b9c85a2f0c9713652",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.0.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.1": {
+      "name": "buffer",
+      "version": "5.0.1",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "28165188f46d451b516b8be3e611b00029573486",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.1.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.2": {
+      "name": "buffer",
+      "version": "5.0.2",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "41d0407ff76782e9ec19f52f88e237ce6bb0de6d",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.2.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.3": {
+      "name": "buffer",
+      "version": "5.0.3",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "90d5b2dbcef4004e7e307d0e488595a302e1f8fd",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.3.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.4": {
+      "name": "buffer",
+      "version": "5.0.4",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "d76fee8f6dbe7c112d6312e492ed9979127b34dd",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.4.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.5": {
+      "name": "buffer",
+      "version": "5.0.5",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "35c9393244a90aff83581063d16f0882cecc9418",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.5.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.6": {
+      "name": "buffer",
+      "version": "5.0.6",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "2ea669f7eec0b6eda05b08f8b5ff661b28573588",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.7": {
+      "name": "buffer",
+      "version": "5.0.7",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-NeeHXWh5pCbPQCt2/6rLvXqapZfVsqw/YgRgaHpT3H9Uzgs+S0lSg5SQzouIuDvcmlQRqBe8hOO2scKCu3cxrg==",
+        "shasum": "570a290b625cf2603290c1149223d27ccf04db97",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.7.tgz"
+      },
+      "deprecated": "This version of 'buffer' is out-of-date. You must update to v5.0.8 or newer"
+    },
+    "5.0.8": {
+      "name": "buffer",
+      "version": "5.0.8",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
+        "shasum": "84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz"
+      }
+    },
+    "5.1.0": {
+      "name": "buffer",
+      "version": "5.1.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^14.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^2.7.3",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+        "shasum": "c913e43678c7cb7c8bd16afbcddb6c5505e8f9fe",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+        "fileCount": 39,
+        "unpackedSize": 244377
+      }
+    },
+    "5.2.0": {
+      "name": "buffer",
+      "version": "5.2.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "0.1.0",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^3.3.12"
+      },
+      "dist": {
+        "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
+        "shasum": "53cf98241100099e9eeae20ee6d51d21b16e541e",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 80664,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbWsbmCRA9TVsSAnZWagAAickQAJjmubcAFTynFv1CowJJ\ndbANxMnhp0u9Nb4O7v+s53gXJMXophzhREJhVVhXDJQaLDnPjISydxNh4jqF\nDezSPr0J8SgeF45lfNh2ofEd8w4/UsiRSJYy0Vs9+b3RIUpzFQw6YU3Hyslr\nq4A8eM3q35CrLrIaFjvIAsIo0PHLhGbt1NNhGYdFV/hSC8dbw8WsUX1F7cfJ\n7T2JakP7OnQ9XtJNK9UXsyU+dMhVuobK3e6MhJYX1F8kmRbQc4TlLYRL8Xr5\nkoQl827DW8Pg6LiAbFTDtebHvt5N6gNh6uCwlSbD2xXAuBTInEvFesX9xv3v\n9rvry+0mYPK6QNhyycwWgzSfIs6BrpkLiAATDh2ynvFo1CfJa1U+cGV957WY\nmLM7GiNgXueyvTXP7rjqS+wYDd3sUlnNN5/4j/weFKAGvGZNArpXipIxESxR\nolhK4gBtkrDborY0LCfWRkCkKuvU89YVcsj4ge3KjxUuA6xOXmYvl7LWXv5P\nhL4jE9AXwJvnPgTX8rq7ZpIq2AgpxYnukda2LdxhIKjHjzOWId6aZkCJ+Epg\n6uUxG5YIJ8hf8yv7hcKdFNsuSCOjfRbH2dJi5GsyXjAyliMYb5g9I5/GN0ex\n8jlZmPUshNseErCdIUcXGf/0k83AdoqlmaNDleGFN8iTyyCG0y1RwEaKc5bj\nJ8O9\r\n=EuCg\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.2.1": {
+      "name": "buffer",
+      "version": "5.2.1",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "0.1.0",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "uglify-js": "^3.4.5"
+      },
+      "dist": {
+        "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+        "shasum": "dd57fa0f109ac59c602479044dca7b8b3d0b71d6",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 79940,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbiGVzCRA9TVsSAnZWagAApaIP/Rb4pP0x+Xzpm6ZbyG99\nzIOkTnEol19cZnAiJzDhN1bSZ0IgsORBWIpILvKj8RzL7EPRacZ1zJOAKBY8\nXKqFaS1JvdOa9O0T2pbPWSdaPu3PCLTay3AZTWN7Bjl6i4hbQ/EFi/VHcZU/\nEhXqaaqwZUmX2+5ouxpZxLveYD5vLJwvb5Vz7aQ11gyN6dkVh4jx20gAbuWI\n+gF44ry3efHIreDDGWP9+i9d6dsFQXX+GtkepOQYa/gdBmJSuOKy5PM8ukFR\nvplR11Q2LvjpA7Dv7IbP5XlCfmzdcZKvTFrDnjZqSnSAB6/OnFGKOe1/nm1s\nXvRbduy3sRZ0Pxpo+eZojl/Z06wqYgi/ri4qQTtErfTMKAVTy3HrsusK0SHI\n0/ymBiHVt6j9JJD3kK9APx6bUmqjkQlHB1TPdXSUefyyWYPsdyD17D1rhrfD\ne+sQxdTS4p4R7hh1exudk6XVlZt7CuH3NZnDMK2VqjKFFerOMjzDRn5y2upg\nIWoqrblFHoP1NZO3QMq7sRn7JfIg5/bJfZhZhbhosAo98a/vc3a/6Mm/amus\nvexzOvdlDrw4fWWUNW5ESGZ32Ub8B+lZVzuv4XX1N6W4n5LanGO/QcR76WRB\noD8NfTj7QrvnInk3DttX+MtWdQW1eUaa9gBBnUqIoULMo+hraw1AbRhBJMBe\nZKQs\r\n=nd43\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.3.0": {
+      "name": "buffer",
+      "version": "5.3.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "dist": {
+        "integrity": "sha512-XykNc84nIOC32vZ9euOKbmGAP69JUkXDtBQfLq88c8/6J/gZi/t14A+l/p/9EM2TcT5xNC1MKPCrvO3LVUpVPw==",
+        "shasum": "5f9fa5fefe3939888d0fdbf7d964e2a8531fd69c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.3.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 80315,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdUMt0CRA9TVsSAnZWagAAxDIP/RqzE+RhusHDB3D3nlPm\nfAdOWACfvhxguBHFqbp9LrfAhDSnDA4yZVI0p6CEFutDEkNeeHlvsqMK3/oh\npm45eAj9YszKPmTH4nx3UzdoG1xrzE2ztIC3MOOSXaL/hVyZO3kSATG+8K0b\nMlzb1rN1mBjxE+HlCRkdKfCsQpL3wrKbmCminW0b8T+2/9fiOByt9nQQtfhC\nMLgMowxQ6fpuSa95whegwpfMH3SKrT8yMY69kPoQsWWfU1Ft9jtefLo3I8lP\nsMq+Zs7m/lM0zHF0ipr8Q8Rc3UrXYNA2kVxwn13D20DnVUXSWFtEfcAADXw/\nmzeS+WYh3DOP4TyCvaKBSGSHotpa9+xUJPpjpIpFFMpR6P4hNTgHrObUsoCZ\ngdmf+aO6W+kkzRrBIXBFN8GXb8hJAd8iObI6tz73d/QWxrDpkHh3Gcvugvla\nGosrP+n6mLazzDNw3Wq/IGQg2zQ+/Mcf8QKrq1CKTcA67u8aSunrLf5RoIOA\nC5f5k80RJRmAGFKYS7TG/r7qyiMtvsORREXGTfOchE+5wXYoTBp0dTb9KMZB\niHJXb9saXR8e3Eku444V3kQIsYyPYlKW0jdM9BjkZCeGolFGZ0t0QOStAahW\ntKWuXisB1CeOEiZqg+hmKuDcG0z5FwtzcnGEdzPKXjiJUwhG/mYYdTQiqBNN\n1lBL\r\n=Ar2H\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.4.0": {
+      "name": "buffer",
+      "version": "5.4.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "dist": {
+        "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
+        "shasum": "33294f5c1f26e08461e528b69fa06de3c45cbd8c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 80550,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdUxxgCRA9TVsSAnZWagAA9MkP/jYowna1Q7Cn58n4qY5O\nyUPWMY/YyxJjKC5AYMepwjiuMOjIvB0oWuONvlYLRapgam5qg7GTUy6Jctwp\ncxnNZH1rYxmUziF+YAT75GdSszbNWSXqF5v/+X19gogs0ijLEGpX8wiWvzHJ\nxsHd0FYj7zVZQHeM8CNrp+bUH9rAqqg/v76pgO7M5wMelJjri3ZQxCHNQL0W\n1aJkMNGm/0om9SfI16gKdUMXyORYfeUP5EaU+39Fi07su8kMufQk3Y7+dRlh\nP5rqNBFs/Y2BtZz2CQqSzAjanJNdqVWA9KM/AtZCvExQUV4jhg8IMCWJ3sVK\nXqTG8kBu9h9ar9Z1GFRQOX0gSnXVvxqTPcwDJOM4azNHOeWdO7ToJws1QLb/\nc5x6dbhwoqsDv+bsnCvt5KqHqvZ7CUeP15hrQUIpjJVG4qne7OXSs1Le0uiB\nGo3wKlTHQzSiuuTOxc3pP5t2nd5wpiHp7v+1DlmVgO8GzYWbFak3EDJp4YyP\npq0E/VbBUuyJLoM72SMbfYKzXM/2x2660xpkzThiqZbwVY/Ivx4QlxDQG+pf\nmq8XPhSycZj9InI9zWzTrIMKVBidBSHuWRLqoPnnLKFOTQxsb7/ordaqTAme\nZJ/ylwEpDksAlv5FVTptvdQ25UNjFOyqcpbdqZYPWZeNJe6but/Ke3xo4zWM\nRARj\r\n=Ba0Y\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.4.1": {
+      "name": "buffer",
+      "version": "5.4.1",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "dist": {
+        "integrity": "sha512-boQoQJ3Xqnh3XtUK+3NPcL/HOOMA133IyYBLsh9nWxH6XBGsBJVv/yhlZoIDu9it7LdGSWhdbn5jKR+slIflmg==",
+        "shasum": "d5e8e2c5dae9d695fd7ac985d02ca33f3c148114",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.4.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 80971,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZaIcCRA9TVsSAnZWagAAlPUP/2lEsKdi6RznPpcxfR3w\n6wuB2/qnVfhH6hRAZyqkGhCV0zLbB9zThvpQ8ikQi99N8wH81CCmOFP2D19j\nITL2WK+1nHr46tzONNDQh8i/+DRq+9Cw7/tDNwDRarxHhBW7bVctXENFDUU1\nreZf0uyVeOBOZ5528kRpeR+CLZ503EK9W2oSRiOrfGtL1xPuxdcfChgmsRIV\n2FAdO1kCgMrrgpKgAofFBECjnso4aFixJrgYfcMqd36Vq3R/9ba9xX6zT1eT\n/qoFE5TQl71/yzvqs7yq4boWDln3/hYqQvC2rZ0I4UNu0CFMcaf4m60w/tH/\nysWxsZ+Gl4/HKBaL+IiQR6xhTQcLokPYkz6GxldaFEhF0frCtyacWSzL0Pbj\nQMEscO9vy7Oyv+iNKzAnp45a1qnB4Thz7BfEr3wsXYE3XkX2XX2WA3JwBEsk\nE8h/hxlBMV8fm3BKl2ASnKqbw5IYlfxDa9DmhyMcuXdh9SDkqGo340D0sI3V\nwcNyb2Hoi2Hs1KT3ZBEHEpDbKXvTLqrF1cqRTmIzozlS0Am5AuvMUxzBN+/v\nwSvegdF2Oww4NnUJg0J0GnW1gvCb5dz3scYiwzYYAcBUKQZllzxoq6E21FWT\np4HM503DEa9LwRW+VvhnK3kGWnnJTPSvfBrGz5NwBzxDO+Ie2KijWfLi60N9\n68wh\r\n=GX+z\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.4.2": {
+      "name": "buffer",
+      "version": "5.4.2",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "dist": {
+        "integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
+        "shasum": "2012872776206182480eccb2c0fba5f672a2efef",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 81019,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZaVRCRA9TVsSAnZWagAAx/UP/jONb435bF3g8mH+o2VP\n+OT7vZRztcf1EPf/pCCXbzz0cPSA4IFPWo0kC7PutuCebNyRZ8tRhyXK4ITw\ni5MZU2of8ifVdJcddq01M1FEweSOkqJF3qV0PdH3JbMrHksdDycYovr3Y2j2\nfuLMZIzE+HejuTS59+2inG12X4rHNGDk2xAdrncSTw1CqdOQv23qNyYuOPLi\nw2PS6z0iCtxgGOec3D+005IZiuvjOTGD4Zd9JvOJuJWs6tyd+pMh79vb6BUv\nQ2qBNIKQTGYygk4swB+1HKlHCosIbFyLRrb0kVrmlTUXHpdkgUX4JRX9PoB1\nnIYFq8LHHtV5gAYo+/nyGHkMX1/Lr8bVxzlgAC6Y9LXyQsd76g1hkDAoaZdk\nhdYj4sjGET7E0fzVY0ivRiZmowez+TW1VYxaaR/4+6sZmO48r2zBle5bATcF\nIh+GUEsoW7ACj/oTxDixpcYt6xae6Ax9R7MCCAGJ9VH0xuVpT/HlYsoZo29U\nwdvorPJjEuG00B8SrCzdLt6ydrtU0NmCZ6Pxhawb1U8HktUYgYkpX0Rx30uC\nk9jCMa4oJb2CJPOXD5F5V7ZMdE4F2E7Hccp8rnwoqTQoBeI5y/QZXLj0D2Li\neO1vIxxDRNOS6xNfQR3bfMJRAhCnhITmYGQw6hXBsJSh9zV6I5AsQNBdp+ml\n/OKK\r\n=XbvD\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.4.3": {
+      "name": "buffer",
+      "version": "5.4.3",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "dist": {
+        "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+        "shasum": "3fbc9c69eb713d323e3fc1a895eee0710c072115",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 81315,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdebOfCRA9TVsSAnZWagAAsBYP/A0hWN/J0ODf9AOzghpa\n2T5nMRuQcm3unE5n8iqn41FECFqXkViCDDfMun9Vqv36BlIeWcoKwtSX0QQm\nammIevFOxJme4OecdukGZyHAuSd/mWTU7/jPfUetiCnGaj9ygGtL8gSvN8ZQ\n62ZYqS1ojB4UZlAiOeOdJ6wJpy48eWb7sqkwurVh21FnRGmAcU7sh3+c8zsD\nqUamZfmtG0jUaoOYMVGzfJlSIdl+lQds9b/WDetzUvylICYNXD4tVF2x7uv2\n6XrdFDneHrKZhK8Ilz/jS8qNXBohVLeOWTt+ACflxZJfJmaK172E2l5Yer0Q\nZZOmuMSm9ce5pq+xLCZJolItogVvl5gki3zlWGQehpkfLUU09HKukp+qaggo\nhuQXu5+fu0NLv+Ne2XZgqqbioaoVWwxgFWy5Hu/HOb5dD63XDNC+8Rq/EGQ1\n4tDJGVsPbDAwjiN8XcAIYJGOLRWTFk8A1qOeGhCheNPSTBde2mbi/I+nL1HG\nbCb7FkEXq3PrqT1nkEGyR4cePLkeprl6Q2a8lAneO/aTpiNrC/GJUjm1ZXub\nmOxO3UAC//uFbRAXE4JiyK2gGIRlz9noAjpW9CcQPz9Se8HrNKqQx25mEYdt\nhCB72lF772j/jm4gONYuz+3DrarXZLbRZ2nswYSB44yELPEmXg/ytFhoc9lT\ndoCw\r\n=BVmF\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.9.2": {
+      "name": "buffer",
+      "version": "4.9.2",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.0.0",
+        "browserify": "^13.0.0",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^1.1.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+        "shasum": "230ead344002988644841ab0244af8c44bbe3ef8",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+        "fileCount": 44,
+        "unpackedSize": 263614,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdxf6FCRA9TVsSAnZWagAA660P+wZtHWkkW9B2l52L+V/a\nUFtrTs5IiovWKeAmzOempmiAhHtEdt/eId3KVqjvm4tbfgskxttoPUqgGNq2\nu/MpmlV3HDcWdrrtkSFOo2uy++yJs8cdLVUSUdybP3NhXPwMdfVFIGfFbE45\nhDsNLFtLJfJQSi/Ctq3F3IKvA2kep0V+21l4vrtP/eBFtsWQIZMet/GyeMl+\nOcDrFuKICk2JOlZPRqe2cIW2VEQHDPXfBV2b9KxO++UPsS3VZv4BwNb2iOLJ\nOQDSld+Ey4PcXvZMVZ4tnOX1MPDcWgF/++cORZA8u+e4fLh96QHgufUuYGbD\nMlPiD/mTlNvY/wgOV8rRBm51kN49FklFcYhphdTr3yyEO1h4Kzx9K94+Nskk\nADU+v9LBBSsYRNnNItHQl8YKteHK9qBU3nRRAEnTaFxGT8GAcpc7lKPqbbLq\neaoHQeCo7Y8jldoliwGwIl6CMMZCl3Dcymtr9h1tfc2SlupV3Qp/ysSfnTM9\n+5XJ/ZJ77OyxOtGj2vNdtT79j9PVRTdocFEA3cyX6/86J9rIR2MAD31SLucy\nSCs45oBfD76mOfqjveKL69TT2AqVB3n21AFdINW1TiUhiWlpC5qDjwU8lJmW\n24EhaDZ9Drux0wZdbU765UablzliLMt9y4K+/fgEVYGNh57oU8lGLEW6q3il\niXF0\r\n=2RLl\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.6.2": {
+      "name": "buffer",
+      "version": "3.6.2",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^12.0.1",
+        "concat-stream": "^1.4.7",
+        "hyperquest": "^1.0.1",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "^5.0.0",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-c3M77NkHJxS0zx/ErxXhDLr1v3y2MDXPeTJPvLNOaIYJ4ymHBUFQ9EXzt9HYuqAJllMoNb/EZ8hIiulnQFAUuQ==",
+        "shasum": "d83b530100c4a2c598bfc8ae24fff29812cf49de",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-3.6.2.tgz",
+        "fileCount": 30,
+        "unpackedSize": 144773,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdxf7ECRA9TVsSAnZWagAAEooQAJWxb5pdfCwaYVd+WasB\njQlJ5DMKBRQ1t9eNWxlkLt3u96EjGlzxpXywZxYY34H8v1ESMthyMU+eJnmh\nap0IaEduaTHprimM5+wDSYpEjRiEzEmdVtnoRnk9v7DhHjKSb9L84hOQKQlG\ndaVOgeBS6a/lNIEEW0nc1OmUYInyt7cUKeMG+ybnXRFQtFwyr9jkw04skaPW\nR1mnBMJPAEv9flvcqkWNX4B0ahRhwRBV14uCirYjFsjFufSaJTgGG8xH08Tf\nhj7oC20CHtQtpH1Jt6fdcpBR5fEWjusdIhwxfWvbaMXm1BNWIh3BLKvqloD0\noMrqMhHbAujWRqFFlAFyyslp6Lvy0tFP2Ntc7hrbCA4kxNN2uB9oghwMYmp4\nJqm4jAieSuGBU+2cB3QDfgUnIAkd9KNGlRHPoPJ+mONDb1MBLmZw/d7LLbkL\ngaQ9+bKHWHED+e2y38HigVvLy7rhO9oPl50nWB0D1tDJ1+8o5cyISznydomT\njdhR7Nbh3Gzm3Tn4TtxF3mKJBtAFFkkmf7aI+Jv9LTu3jL3wSjwirTieGE+X\nZfdKjDJGhXcajvy0D7+8whs2yn6Qlq0tsq1j2mKSnxF6ZQplyQ6S04kp5dad\nmSMQzPpvYZWbPAupJYX/DIxeJspzRFPvAIzPMRbMI6nXZx7wxf7E6Xzvxta0\na/tn\r\n=bT4a\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.8.3": {
+      "name": "buffer",
+      "version": "2.8.3",
+      "dependencies": {
+        "base64-js": "0.0.7",
+        "ieee754": "^1.1.4",
+        "is-array": "^1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "^1.0.0",
+        "browserify": "^6.2.0",
+        "is-nan": "^1.0.1",
+        "tape": "^3.0.1",
+        "zuul": "^1.12.0"
+      },
+      "dist": {
+        "integrity": "sha512-dyatqxbSWlkhnG5lthQ7TDh2NfShsKesnKiGyt5DmiJfvKJ1zBq1AvC3+neSY565BziAiYwbothV2tizAr2WRg==",
+        "shasum": "74ad36487fff7413f4a6fdfb299e38ef3612ff47",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-2.8.3.tgz",
+        "fileCount": 19,
+        "unpackedSize": 68341,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdxf9eCRA9TVsSAnZWagAAoGUP/0GidML9yDVJ7sFH5+R1\nVomYSzAluq6RlBJrsEgrTa4caPmMnUMCt5PHb1oYaoUUJaBrG94nxHz02XJj\nIWBRmZAXLPTREeF9aDBd+pAspSfoVs9v8uzMUcaNF6pfTgdKU3Stv8MHZ5I6\nN2YxLS8y8Cyuom0FKtJv3WsxAnJwNDYfu6rx1w4KKR1pbK0yt2liCY4pBGpK\ngmDCW8/XeuW9UVs2Wz0nifWNa9E+OSU/+Te7orXM34f0R5lkC3l5KYfKXQJo\n4V/4ppyGd1AHC2oFoT0dO1smHPxeNATZEgH3IaKBRBSlYHq3LWDTyG34pyQ9\nFbzT8CspySKlsrL1AroMHtKBTw2ZSewsbgMHIYXEQ7ew9lPZMxntyj1kEBiz\nVDzjRvDtew7MMTjZyzFPmZWJQnYU9rlSzt7XsV470XewO5/hDteMaYLUwc98\n83sr/8AA5LsrZmUVP2mHcMuUdUwbB4BBUIjKsfUZPbpPpO8+Zc9z0H0PZM6p\n6jfJ0IU2W3GQ8fkDLprrBwAFa+w3BpFYLM1AFnGANBKFMGIX6ORPiGR00jxT\n0p4Q13jtGzeUR7C59GCgUAtvHwNKZ1HPYpeoZ6zO14n4sIoqUz8qqDSK9hEd\nbeqVmfdwaOiPhNqa/Tbk5ULKD0mxOu7Haa5CNl0yUnAEMI0jmwokcr0tj1eO\nCL0U\r\n=pv6t\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.5.0": {
+      "name": "buffer",
+      "version": "5.5.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "dist": {
+        "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+        "shasum": "9c3caa3d623c33dd1c7ef584b89b88bf9c9bc1ce",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 82061,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeYqq+CRA9TVsSAnZWagAAsVYQAI/paHnOYhfxZj+ooYAq\no1iRv3lUGee0z3qs8lZw4IK2BOgM50vh09p+9EXiTDNxPfoCeivu7k+K/vKq\n1Z0NyKK74Fo4kIC6zdTj7kZHKemITK1IRmIjY806SrtkNj+6bKKz+1A2sKZ4\n5n3va+QoDm2dte9Sx8sdQV+6Rql7ZgapFh8I2cjN/kg8KvULzbUPRYtWHU0t\nCQIjSeBiiFfP1rCcg6+ys0+MlM/iHsggh9BC4UMxtgi0ISwLN8xbk28uC4Ar\nmSH97DMj3OitRgNNnrWWDNfJTKy5Z3w/7bLuxoWNPpAQKDicUtdUZL/inQHN\nJlFPjR844t0O6XvivQfbvxFoOnx7jFSLQUhd1g/bM1kE7BiXTajREjdAZNdY\nd5/4zavqewlKuP6T1511yXwLxESyGxxinu+Dr8YdGI4B56pnHxdgEQrv+8ET\nOG6IBm45Vt9ocFjYEjraS2zFUkHKOZvlzHu8Njye3a0uCEF5eDIQS6weO+/6\nxrv3dVqOpxY3VQ/iiGHktZIfX91k94EEad3yta5S94wqGZhvi3Np1rWrI/EB\nwpZ0+MIgBegK67Ebp0viTzmit/wbG+SOXg2m3Kh+z3dgplksLzU9WVM01TJf\nUBvLwwGqiA1v52TMDwn02ABL3mNbjk5A0OnAQy0D8HI5y19YCqaHCXOLjzIv\nwZaR\r\n=jRQQ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.6.0": {
+      "name": "buffer",
+      "version": "5.6.0",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.0.0",
+        "browserify": "^16.1.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "is-nan": "^1.0.1",
+        "split": "^1.0.0",
+        "standard": "*",
+        "tape": "^4.0.0",
+        "through2": "^3.0.1",
+        "uglify-js": "^3.4.5"
+      },
+      "dist": {
+        "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+        "shasum": "a31749dc7d81d84db08abf937b6b8c4033f62786",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 81740,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJelk8SCRA9TVsSAnZWagAAYcMQAICQS02OwuDr6T1BPVPR\nLazVSpJZaIrnoVDIl7n85fNFezaE1Y3z6ywtJOdgB3C/NXst7lb+nrFEVpIP\nUVE6q1BeB4tdHoqGmJS5cAdjtJjH37NuNFJ0Cg+xlYILSQK9HJF316oiJLhm\n4wV6P7UwALHmYWO51DglSrQN1Jn4ZOJ2Y43yn5NJiBW9RPnWX76iflau2CI+\n8RO6AF/TGK/7gyWk+9LpL6QNHtrder/p8NwDiHYnwibzvdJasdQaX1bDbPEV\npjDWTUZ0JdmJJChFE4JMXCa9x/Mkc3xBmtXT8jyJWVLIHTePwrnQGoWF1Zo4\nckFUGDjumU+Ilsu9Ojy2Nr/l0J1wiIl09aIirtPbnWrc/LbMHnKUWMX2aevg\nUEBzpnmpwFNKtdAQ7OnJk+EfgzG1Wozik505dJiAuikXwj/gUL9PZkSBseSf\nnDYT8oa5XMj8DCN4IDKWM4UDbrjQEd86ciJawClpHmA/swAk6x2SVEnPv1Cn\n+hvsLEu9HlW0G8CT1HYrCa77kkPuhJHWsbFPZAx3Nku2QfvaleevzcQ4TKfh\nB9Ua4Dfx4zM4zbC14qoOk+ho2StuDsok4DknfR8x3Ca8wAUsAHYQukngm7y2\nhbKpHOogklo+rsJJXcUdkYwO0Z7OlckWiKHEvpx8tasviOWFuDg20hFcwIEA\n9cAE\r\n=TDZl\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.6.1": {
+      "name": "buffer",
+      "version": "5.6.1",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.4",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.3"
+      },
+      "dist": {
+        "integrity": "sha512-2z15UUHpS9/3tk9mY/q+Rl3rydOi7yMp5XWNQnRvoz+mJwiv8brqYwp9a+nOCtma6dwuEIxljD8W3ysVBZ05Vg==",
+        "shasum": "b99419405f4290a7a1f20b51037cee9f1fbd7f6a",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.6.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 82052,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfk0EOCRA9TVsSAnZWagAAW1sP/0rMR0DjY6XpTxOn7/u+\na0yifMJRI34XCMPdPRy96odNpyRQw3QCIXm3WWJTXcffeQY2KFZhauinkvRO\np1ac530US1Lphyorj1o5bLHezN3NrCRgdqNgzRZreYob45+0lb5qQkJqF28C\nxigLFbff6LphKpgpJlWvXiux3kfsCQn/OikuPr17c1JeLefdeQZ9yG4yV93U\nl99OolRlvaCbtMPb19m2I0qaeF5A4EzKu9mgfxde5S2aKroDpO22CF2/315H\nLw2b75lP6Sc6Wkf45VR+74HNpI/v8tGvU3RkDcFLBrRV6/HP2neNEtIwXa0G\n7SDiQGjySDK02SAtUzLnOMus1tkGL1Nga7SiHZnc1Mw34GXdV2neDQN78ddb\nyRHCdHk5P8C4Ivdw6sbEAR66KP/e3SyWQ4YJ+a0qK/ScN2BPjbGSIHbi7qWn\n7JDkFKmuV0DiGVA0q8hh9JHqz5kYfhma2UPkp3KECSqWgeTnHW83VAJSoRHa\ndxebXiXaJ7o6mvg+rs2BW2HKNN7bcI8ECkeQHHq2beqlcN2W63OTHhRIu2D3\n93CNbISm8NOphy157j8Hca5XLhOwsp+t2JY6n9jSohwDoki3yoBvPD0uLxTO\nkemL0C29CxBcKg8l++4WgddPO7VAygqF7/iTIpaekGwRBPAKycmjZ7b4fQbM\nX5FP\r\n=Vrd/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "5.7.0": {
+      "name": "buffer",
+      "version": "5.7.0",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.4",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.3"
+      },
+      "dist": {
+        "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
+        "shasum": "88afbd29fc89fa7b58e82b39206f31f2cf34feed",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 82374,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmJfqCRA9TVsSAnZWagAA6ukP/2Qy877Da8y5l75Uz4GO\ni3qyfkpElZHpLv4cd8gjrGBNWKqunJDbn57Y0xqpD1YZzEsnZot4eXP7IEXM\nlB8frADd7LtU/QHXgSj0ZFDiqOtUW60Enb4A2TpFmbbSF7XpQHDafv4IKKwO\nRtCyuL0yC1IaSu1pL6UPoVXnOnDHIjEKHfhKNGfdKtsQPFCrucz/Ciwr033H\nGIcX+xfPI4umh4DUgJ6WpZKurXlNCKCPou59skptogG+YI+Dkk0Tp1VAErRI\nHCb7tGPYWRGGK1F+gb4F7Wyid0HvtgIWigpEBm/BY72ImLWE6l2C5y6WDROv\nuIn91d7IplNGMwjrgSNmv9/EZ77bEx/PLC38YAhalRF/zxTjF4V7JwVUKzAf\nA1T6VrvZGrkNLZNLD/l9HJns6pkNZqGVK9fWvar1lAIryh04YP61yG0JaqAR\nrcEfeGJ4rBKgN3jytem6GU6Q2/W4jitW6lFDNBRugGLK1jiJWSLlGoDJwReJ\n+urC1NKVQBy2KfY2SEYGqxPb8BjSECUHSatpz3c9yaa+kEkcbSE6pqP/gi6U\n2OdXvZKFsHGd0mnxNJQR6rmGFUbNOKQl4hbmm44rXNx/4jkjOf49+CIAkblT\n6z+6ABEj11SP5kx0NzDCSvYTaxR6fJr7Vnq56SR/fxKK6zZTNRVRevyf6fHt\ncfbl\r\n=pfy3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "6.0.0": {
+      "name": "buffer",
+      "version": "6.0.0",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.5",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.5"
+      },
+      "dist": {
+        "integrity": "sha512-Sxdxq98A+Y9kRjO/3+mc2IAxIyTAKqzBiYKpeo5EluWnw9535rI4fN8DeMGsiQqpqqaWtFtTdxQgHnku6IEjCA==",
+        "shasum": "5af63d0ccb2a3f72ceb347344a43a610c7dd583c",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-6.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 90560,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfonQzCRA9TVsSAnZWagAAiQoP/3rN6ELD/8W6eeVypYKp\nHlB3Wuc6bjDMXzWm5XiezUxsYGUv7xtU0ecl/wAc17w49md0BucHfCDlA44g\ntD4O36B6FtvoPagIa5ABsW4RDVWpUNazfs/vHtBxlFXj4MqUlTKbF5X9ovFi\nqrNSSkq3aIqd3WXEnBbHxFR2xz+ed7OIZy4V4TOASh11rkF5XzkLtCvcx8xk\nzQvNOHWKQiPS6hXVamkOpPpb5zhUTxzGC8Aze8z255zLhA0cdsUyk8oMO4fQ\nAOKQ3V0z/9tuzXUp2d1Ps9ZzLKrYaZh67d+W7MZMAVJjWpM891L/jokQP6np\n/lMBEpbd+MeO7Na/MF1avhbO6/87JAy+srpgnAsGR22tIZOzjhkrJMC/wzJ3\nvgbUapWP6FHQ//9QkJbgN9R7PcRP+hgjog3kEkQoBCMp7mSh8K/RX+m/0Lda\nlMIixk85KvIzNQJEnxLiDp7oVoEyI32z/ieLi6w3LQTouEFjZfFZZvp3XPpy\nL2+5GglNm1nWfA4+e3f2BRxtSFTjsvJQYx16XQLQk3Ily8xpDqzzc+88ZSDU\nzsvRCh+19J2ZZ/ygOziODZbt/HKkJza6hKUMg6hUHN+N27/jmOxebDKZprQ0\nQ0GBtS6Pyy04ENY72j/hYVh7ct2W01XVYdJmpRtt7B+Gkp8ZE3uXMg2ozHtw\nh5xt\r\n=14xG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "5.7.1": {
+      "name": "buffer",
+      "version": "5.7.1",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.4",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.3"
+      },
+      "dist": {
+        "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+        "shasum": "ba62e7c13133053582197160851a8f648e99eed0",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 82527,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfoyJoCRA9TVsSAnZWagAAiH8P/1CL/bEXlza64QzxZAgI\nYTF6rLWBxO3mypgWxbhnzZ/m/AeU0a4iH2wIY7GYOgs9LYK2bu1vnM729z2P\nNsxHqt7rHwREOQGbE/zQW23/5DT3BFiZWyLQqkv40IuE90yPCsZHQSnF6geY\nRGSqRKS7ebmlxt7k4Ao9/NqC+jrsezAM6hShhHdPx4wkZ3MnZYK1w9O8t1eI\nymRxtVWpTe5N8Qa02KdVja5O/muH9TR5131hC4JzbUN7sv7drn+8NPBHIOK2\nDVans5leF9nilMmSBV2s6F0v4aHyIEJiEiRPwWAJXNsdzZ72crnHWtaHSnaq\n/PkrQHQUmo0HNVyC009Ke0ajISdxoS36o3ZTdSbIY2p9Dr1CR7geX3QF8UiH\nhKWUch3MgrVOY0SkHWGDgVsmMVGuT6D7RBD3g2G7QTmkBUQIUZZ3S55V1Q98\njMWjbgXm/+gc7cteuKLMH06N7Bct34XQS/6/A5P6GFQuvtAPFC/sgg78uapp\nqzZ0cNA2IdobxvpeOsMDE190HGQwcjV3k593+Iem7Im3H3O6W6yxEPTjJIam\nFK+i0N0lzoeFJ94qJBUDJwxN24T+actNlHbZ6n6MwzpIZ+vQMhSfk611cXl8\n/9c0OrhHMqnOYq/dNQEcOgyl9aqjKKEkOLF0YKwIoe5R4nY0lxVbEjmNDwfv\nTvqT\r\n=tlSl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "6.0.1": {
+      "name": "buffer",
+      "version": "6.0.1",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.5",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.5"
+      },
+      "dist": {
+        "integrity": "sha512-rVAXBwEcEoYtxnHSO5iWyhzV/O1WMtkUYWlfdLS7FjU4PnSJJHEfHXi/uHPI5EwltmOA794gN3bm3/pzuctWjQ==",
+        "shasum": "3cbea8c1463e5a0779e30b66d4c88c6ffa182ac2",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-6.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 90758,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfoyQbCRA9TVsSAnZWagAA79QP/0FmXUivbhefRptMkySE\nfr7zZTN+bMh/q+ohi7LQswzxUnYppC5HwUvdPxtzSi5EiJcjJXtVJJbm84F+\ncq4w2uookAsC7q9jLUpRDHooZF/GBeisMEBSqpL2n2EOb09T3NM0wwvPeSz7\ng6YoII9RgZhYLhRMdEpXNfqwz6H3Cb1DQCc3fLowxY03gjHqUDVGlfUtVw/K\nOZ//YCwf+dad4WhO07xaUrv9jk7xhrATi4yFHlsakMhfbKpzhnkJSgbzWsDP\ng9wm9pZ20VC2zAT44xiJuL3ve1WahtuBHGYYUH1EiDs3k4Jpl8itmPa43NZf\n8TWFzWpjyr5QY/+Cu7eMu4gkMDsriYU1PbzTUMsueQ6YpRIHl1596xn5biGY\nEA0SJHx6eDFoGkvQC9ZnkohKxYXnUm2L9UhDIU42LzWYH8SoTNCsHOQQtZ5J\nVACgPfKOuJN67RYSvvIG1cqwrFl/HcRepqPgZo687+ivq4+FgCMgnTeRU8rf\nFSZMd/eqvPax995F13HK06dh3qtug/LqUJGGshfk1d9NBmF1OqZTJJVvV5jV\nKcXunFHG61LP30BbKkAJq8D3msYu34/0O/NrmFgnZlatxNn37cf+qf9BUVu7\nuKxkzooyh7BL6gzPWR7WDLajHdzjqOEC7Yh5hpoxeCmQfitoZq4fLkfsdKoA\nD2kQ\r\n=87m6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "6.0.2": {
+      "name": "buffer",
+      "version": "6.0.2",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "benchmark": "^2.1.4",
+        "browserify": "^17.0.0",
+        "concat-stream": "^2.0.0",
+        "hyperquest": "^2.1.3",
+        "is-buffer": "^2.0.5",
+        "is-nan": "^1.3.0",
+        "split": "^1.0.1",
+        "standard": "*",
+        "tape": "^5.0.1",
+        "through2": "^4.0.2",
+        "uglify-js": "^3.11.5"
+      },
+      "dist": {
+        "integrity": "sha512-XeXCUm+F7uY7fIzq4pKy+BLbZk4SgYS5xwlZOFYD3UEcAD+PwOoTaFr/SaXvhR1yRa8SKyPSZ7LNX4N65w7h8A==",
+        "shasum": "ca9ab87dffd0e864977f541f09844f06a60a8acd",
+        "tarball": "https://registry.npmjs.org/buffer/-/buffer-6.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 91215,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfqbz3CRA9TVsSAnZWagAA+3QP+QHnoLf4xolJPRTcRfwX\nr86JM7uEaSvr0dqffG+a1O0qfZxyFYZesCiM3DMUd4KA6IOJLesWOP/Cw/d5\nXgumNd5I+3YyvmnAPnCYAxwVK7+EdhwHDoPWcn1WR6dPElHfdbzixed+8IZt\nQO8vB7JDKuT9b8bnob6WDXFwHf5cvieTY+4BbpDseOwK1/XnUoFxvQbJbxX7\nwaacfMp8lnKvtA+ROqhj2VH88BGm5fwibukg2qz8b7xLNhxHp2aqvLn26HWD\nJBsmyrKxhv5UYIW3UF3mRMLhhvYhm8rIF8CkWIXfegIW76WW1czEaw78bUi4\nr5VzDgzXT7TKwy1ZII6jirzXj62Eo3KasB/oPIWeBCNyOLx0WwrFvQHIEoEK\nktgohiZqBz9RhPU9BLmrY5l5SC3WoJVDcQGyXEwfnwRnXRrVL2ODFleHlxY9\nFxV6T0Ckff5GH6kLIzNM0NDyPhszf/Jsi8/jZCwu6q2P5uX27UbTfpTmu8Mj\nlgIIGiqaYvEvB2wGYPoZ5LqSunI2R8zlCugQi+jlMdApDZgxzqCZtUuUwEuJ\ngJvYJhAqU++xGdYxcIAMuVMRS9OrjrNI/VIU/G0mIhxZr4H8OsT9q0cbfju3\n4ca6wB/xesPInXMkotTLWY3mk0tSirmYzfgX2BmflEpqloMnhCgJml+HG306\n/8UK\r\n=p30X\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    }
+  },
+  "modified": "2020-11-09T22:04:41.864Z"
+}

--- a/test/fixtures/registry-mocks/content/builtin-status-codes.json
+++ b/test/fixtures/registry-mocks/content/builtin-status-codes.json
@@ -1,0 +1,256 @@
+{
+  "_id": "builtin-status-codes",
+  "_rev": "4-c78dedd13b89086005906c39f6ee1092",
+  "name": "builtin-status-codes",
+  "description": "The map of HTTP status codes from the builtin http module",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "builtin-status-codes",
+      "main": "index.js",
+      "browser": "browser.js",
+      "version": "1.0.0",
+      "description": "The map of HTTP status codes from the builtin http module",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/bendrucker/builtin-status-codes"
+      },
+      "author": {
+        "name": "Ben Drucker",
+        "email": "bvdrucker@gmail.com",
+        "url": "bendrucker.me"
+      },
+      "scripts": {
+        "test": "standard && tape test.js",
+        "build": "node build.js"
+      },
+      "keywords": [
+        "http",
+        "status",
+        "codes",
+        "builtin",
+        "map"
+      ],
+      "devDependencies": {
+        "tape": "^4.0.0",
+        "standard": "^4.0.0"
+      },
+      "files": [
+        "index.js",
+        "browser.js",
+        "build.js"
+      ],
+      "standard": {
+        "ignore": [
+          "browser.js"
+        ]
+      },
+      "gitHead": "50e6cac771eb0737e7af3015eed2345b323aa311",
+      "bugs": {
+        "url": "https://github.com/bendrucker/builtin-status-codes/issues"
+      },
+      "homepage": "https://github.com/bendrucker/builtin-status-codes",
+      "_id": "builtin-status-codes@1.0.0",
+      "_shasum": "30637ee262978ac07174e16d7f82f0ad06e085ad",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "bendrucker",
+        "email": "bvdrucker@gmail.com"
+      },
+      "dist": {
+        "shasum": "30637ee262978ac07174e16d7f82f0ad06e085ad",
+        "tarball": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "bendrucker",
+          "email": "bvdrucker@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "builtin-status-codes",
+      "main": "index.js",
+      "browser": "browser.js",
+      "version": "2.0.0",
+      "description": "The map of HTTP status codes from the builtin http module",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bendrucker/builtin-status-codes.git"
+      },
+      "author": {
+        "name": "Ben Drucker",
+        "email": "bvdrucker@gmail.com",
+        "url": "bendrucker.me"
+      },
+      "scripts": {
+        "test": "standard && tape test.js",
+        "build": "node build.js"
+      },
+      "keywords": [
+        "http",
+        "status",
+        "codes",
+        "builtin",
+        "map"
+      ],
+      "devDependencies": {
+        "tape": "^4.0.0",
+        "standard": "^4.0.0"
+      },
+      "files": [
+        "index.js",
+        "browser.js",
+        "build.js"
+      ],
+      "standard": {
+        "ignore": [
+          "browser.js"
+        ]
+      },
+      "gitHead": "30cae0c6b3464cfe75109999e42f055e00016338",
+      "bugs": {
+        "url": "https://github.com/bendrucker/builtin-status-codes/issues"
+      },
+      "homepage": "https://github.com/bendrucker/builtin-status-codes#readme",
+      "_id": "builtin-status-codes@2.0.0",
+      "_shasum": "6f22003baacf003ccd287afe6872151fddc58579",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "bendrucker",
+        "email": "bvdrucker@gmail.com"
+      },
+      "dist": {
+        "shasum": "6f22003baacf003ccd287afe6872151fddc58579",
+        "tarball": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "bendrucker",
+          "email": "bvdrucker@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "builtin-status-codes",
+      "main": "index.js",
+      "browser": "browser.js",
+      "version": "3.0.0",
+      "description": "The map of HTTP status codes from the builtin http module",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bendrucker/builtin-status-codes.git"
+      },
+      "author": {
+        "name": "Ben Drucker",
+        "email": "bvdrucker@gmail.com",
+        "url": "bendrucker.me"
+      },
+      "scripts": {
+        "test": "standard && tape test.js",
+        "build": "node build.js"
+      },
+      "keywords": [
+        "http",
+        "status",
+        "codes",
+        "builtin",
+        "map"
+      ],
+      "devDependencies": {
+        "tape": "^4.0.0",
+        "standard": "^4.0.0"
+      },
+      "files": [
+        "index.js",
+        "browser.js",
+        "build.js"
+      ],
+      "standard": {
+        "ignore": [
+          "browser.js"
+        ]
+      },
+      "gitHead": "da83219db6bfdacc252e3d1559b22a04757fe59d",
+      "bugs": {
+        "url": "https://github.com/bendrucker/builtin-status-codes/issues"
+      },
+      "homepage": "https://github.com/bendrucker/builtin-status-codes#readme",
+      "_id": "builtin-status-codes@3.0.0",
+      "_shasum": "85982878e21b98e1c66425e03d0174788f569ee8",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "bendrucker",
+        "email": "bvdrucker@gmail.com"
+      },
+      "dist": {
+        "shasum": "85982878e21b98e1c66425e03d0174788f569ee8",
+        "tarball": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "bendrucker",
+          "email": "bvdrucker@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/builtin-status-codes-3.0.0.tgz_1467230247404_0.560280139092356"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# builtin-status-codes [![Build Status](https://travis-ci.org/bendrucker/builtin-status-codes.svg?branch=master)](https://travis-ci.org/bendrucker/builtin-status-codes)\n\n> The map of HTTP status codes from the builtin http module. Exposes the latest directly from `http` in Node, with a zero-dependencies version for the browser.\n\n\n## Install\n\n```\n$ npm install --save builtin-status-codes\n```\n\n\n## Usage\n\n```js\nvar codes = require('builtin-status-codes')\ncodes[100]\n//=> Continue\n```\n\n## Build\n\nTo create a new browser build:\n\n```sh\n$ npm run build\n```\n\n## License\n\nMIT © [Ben Drucker](http://bendrucker.me)\n",
+  "maintainers": [
+    {
+      "name": "bendrucker",
+      "email": "bvdrucker@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-11-28T00:30:53.130Z",
+    "created": "2015-07-03T13:12:34.450Z",
+    "1.0.0": "2015-07-03T13:12:34.450Z",
+    "2.0.0": "2015-11-17T22:24:17.064Z",
+    "3.0.0": "2016-06-29T19:57:30.192Z"
+  },
+  "homepage": "https://github.com/bendrucker/builtin-status-codes#readme",
+  "keywords": [
+    "http",
+    "status",
+    "codes",
+    "builtin",
+    "map"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bendrucker/builtin-status-codes.git"
+  },
+  "author": {
+    "name": "Ben Drucker",
+    "email": "bvdrucker@gmail.com",
+    "url": "bendrucker.me"
+  },
+  "bugs": {
+    "url": "https://github.com/bendrucker/builtin-status-codes/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "snowdream": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/builtin-status-codes.min.json
+++ b/test/fixtures/registry-mocks/content/builtin-status-codes.min.json
@@ -1,0 +1,45 @@
+{
+  "name": "builtin-status-codes",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "builtin-status-codes",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "^4.0.0",
+        "standard": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "30637ee262978ac07174e16d7f82f0ad06e085ad",
+        "tarball": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "builtin-status-codes",
+      "version": "2.0.0",
+      "devDependencies": {
+        "tape": "^4.0.0",
+        "standard": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "6f22003baacf003ccd287afe6872151fddc58579",
+        "tarball": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "builtin-status-codes",
+      "version": "3.0.0",
+      "devDependencies": {
+        "tape": "^4.0.0",
+        "standard": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "85982878e21b98e1c66425e03d0174788f569ee8",
+        "tarball": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
+      }
+    }
+  },
+  "modified": "2017-11-28T00:30:53.130Z"
+}

--- a/test/fixtures/registry-mocks/content/bytes.json
+++ b/test/fixtures/registry-mocks/content/bytes.json
@@ -1,0 +1,1183 @@
+{
+  "_id": "bytes",
+  "_rev": "61-0f3b6358b5552b519a0b72c47a77828d",
+  "name": "bytes",
+  "description": "Utility to parse a string bytes to bytes and vice-versa",
+  "dist-tags": {
+    "latest": "3.1.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "bytes",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "byte string parser (5mb etc)",
+      "version": "0.0.1",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "bytes@0.0.1",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.24",
+      "_nodeVersion": "v0.6.19",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "2a76c866ba90e6fd2641ab5c9fdb6c4e8b4015f7",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "bytes",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "byte size string parser / serializer",
+      "version": "0.1.0",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "bytes": "index.js"
+        }
+      },
+      "_id": "bytes@0.1.0",
+      "dist": {
+        "shasum": "c574812228126d6369d1576925a8579db3f8e5a2",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "bytes",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "byte size string parser / serializer",
+      "version": "0.2.0",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "_id": "bytes@0.2.0",
+      "dist": {
+        "shasum": "aad33ec14e3dc2ca74e8e7d451f9ba053ad4f7a0",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz"
+      },
+      "_npmVersion": "1.1.64",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "bytes",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "byte size string parser / serializer",
+      "version": "0.2.1",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "_id": "bytes@0.2.1",
+      "dist": {
+        "shasum": "555b08abcb063f8975905302523e4cd4ffdfdf31",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "bytes",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "byte size string parser / serializer",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/bytes.js.git"
+      },
+      "version": "0.3.0",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js",
+      "_id": "bytes@0.3.0",
+      "dist": {
+        "shasum": "78e2e0e28c7f9c7b988ea8aee0db4d5fa9941935",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "bytes",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "byte size string parser / serializer",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/bytes.js.git"
+      },
+      "version": "1.0.0",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js",
+      "_id": "bytes@1.0.0",
+      "dist": {
+        "shasum": "3569ede8ba34315fab99c3e92cb04c7220de1fa8",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "bytes",
+      "version": "2.0.0",
+      "description": "Utility to parse a string bytes (ex: `1TB`) to bytes (`1099511627776`) and vice-versa.",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/bytes.js.git"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "main": "index.js",
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "scripts": {
+        "test": "node_modules/mocha/bin/mocha --check-leaks"
+      },
+      "dependencies": {
+        "node.extend": "*"
+      },
+      "devDependencies": {
+        "chai": "*",
+        "mocha": "*"
+      },
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "michaelsanford",
+          "url": "https://medium.com/@msanford"
+        },
+        {
+          "name": "vladikoff",
+          "email": "github@vf.io",
+          "url": "http://vf.io"
+        },
+        {
+          "name": "justindeguzman",
+          "url": "http://justindeguzman.net"
+        },
+        {
+          "name": "mixu",
+          "url": "http://mixu.net"
+        },
+        {
+          "name": "theofidry",
+          "email": "theo.fidry@gmail.com",
+          "url": "https://github.com/theofidry"
+        }
+      ],
+      "license": "MIT",
+      "gitHead": "6b0e590f1aa83a43b20b4678441cba883f06d6fd",
+      "homepage": "https://github.com/visionmedia/bytes.js",
+      "_id": "bytes@2.0.0",
+      "_shasum": "37feb25b3478674e7b78a16720826b033459a6ff",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "0.11.16",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "37feb25b3478674e7b78a16720826b033459a6ff",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "bytes",
+      "version": "2.0.1",
+      "description": "Utility to parse a string bytes (ex: `1TB`) to bytes (`1099511627776`) and vice-versa.",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/bytes.js.git"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "main": "index.js",
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec"
+      },
+      "devDependencies": {
+        "chai": "*",
+        "mocha": "*"
+      },
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "michaelsanford",
+          "url": "https://medium.com/@msanford"
+        },
+        {
+          "name": "vladikoff",
+          "email": "github@vf.io",
+          "url": "http://vf.io"
+        },
+        {
+          "name": "justindeguzman",
+          "url": "http://justindeguzman.net"
+        },
+        {
+          "name": "mixu",
+          "url": "http://mixu.net"
+        },
+        {
+          "name": "theofidry",
+          "email": "theo.fidry@gmail.com",
+          "url": "https://github.com/theofidry"
+        }
+      ],
+      "files": [
+        "lib/",
+        "History.md",
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "license": "MIT",
+      "gitHead": "8c00b7361081cbd9bbefdeaac387cfa3483ee584",
+      "homepage": "https://github.com/visionmedia/bytes.js",
+      "_id": "bytes@2.0.1",
+      "_shasum": "673743059be43d929f9c225dd7363ee0f8b15d97",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "673743059be43d929f9c225dd7363ee0f8b15d97",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "bytes",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "version": "2.0.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Jed Watson",
+          "email": "jed.watson@me.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/bytes.js"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "files": [
+        "lib/",
+        "History.md",
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec"
+      },
+      "gitHead": "613ebfa44c8e42ae107833e1a587f6a3349f6a64",
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js",
+      "_id": "bytes@2.0.2",
+      "_shasum": "580fea1111c2df039f2644ff917ce4010501184e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "580fea1111c2df039f2644ff917ce4010501184e",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "bytes",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "version": "2.1.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Jed Watson",
+          "email": "jed.watson@me.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/bytes.js"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec"
+      },
+      "gitHead": "86e4520cc369b34866154a53344ca50b2bb5ddcd",
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js",
+      "_id": "bytes@2.1.0",
+      "_shasum": "ac93c410e2ffc9cc7cf4b464b38289067f5e47b4",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ac93c410e2ffc9cc7cf4b464b38289067f5e47b4",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "bytes",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "version": "2.2.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Jed Watson",
+          "email": "jed.watson@me.com"
+        },
+        {
+          "name": "Théo FIDRY",
+          "email": "theo.fidry@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/bytes.js"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "devDependencies": {
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec"
+      },
+      "gitHead": "509a01a5472b9163ae5a7db41e2d6bd986fdf595",
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js",
+      "_id": "bytes@2.2.0",
+      "_shasum": "fd35464a403f6f9117c2de3609ecff9cae000588",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fd35464a403f6f9117c2de3609ecff9cae000588",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "bytes",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "version": "2.3.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Jed Watson",
+          "email": "jed.watson@me.com"
+        },
+        {
+          "name": "Théo FIDRY",
+          "email": "theo.fidry@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/visionmedia/bytes.js.git"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "devDependencies": {
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec"
+      },
+      "gitHead": "c8be41b24b04e04992d5918356d5a4dd35fbf805",
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js#readme",
+      "_id": "bytes@2.3.0",
+      "_shasum": "d5b680a165b6201739acb611542aabc2d8ceb070",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d5b680a165b6201739acb611542aabc2d8ceb070",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/bytes-2.3.0.tgz_1455595208428_0.5990735022351146"
+      },
+      "directories": {}
+    },
+    "2.4.0": {
+      "name": "bytes",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "version": "2.4.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Jed Watson",
+          "email": "jed.watson@me.com"
+        },
+        {
+          "name": "Théo FIDRY",
+          "email": "theo.fidry@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/bytes.js"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "devDependencies": {
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec"
+      },
+      "gitHead": "2a598442bdfa796df8d01a96cc54495cda550e70",
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js",
+      "_id": "bytes@2.4.0",
+      "_shasum": "7d97196f9d5baf7f6935e25985549edd2a6c2339",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "7d97196f9d5baf7f6935e25985549edd2a6c2339",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/bytes-2.4.0.tgz_1464812473023_0.6271433881483972"
+      },
+      "directories": {}
+    },
+    "2.5.0": {
+      "name": "bytes",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "version": "2.5.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Jed Watson",
+          "email": "jed.watson@me.com"
+        },
+        {
+          "name": "Théo FIDRY",
+          "email": "theo.fidry@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/visionmedia/bytes.js.git"
+      },
+      "component": {
+        "scripts": {
+          "bytes/index.js": "index.js"
+        }
+      },
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "nyc": "10.1.2"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec",
+        "test-ci": "nyc --reporter=text npm test",
+        "test-cov": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "a4b9af2bf289175f12b3538eb172f2489844b1ec",
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js#readme",
+      "_id": "bytes@2.5.0",
+      "_shasum": "4c9423ea2d252c270c41b2bdefeff9bb6b62c06a",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "4c9423ea2d252c270c41b2bdefeff9bb6b62c06a",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/bytes-2.5.0.tgz_1490416399283_0.2922299497295171"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "bytes",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "version": "3.0.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Jed Watson",
+          "email": "jed.watson@me.com"
+        },
+        {
+          "name": "Théo FIDRY",
+          "email": "theo.fidry@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/visionmedia/bytes.js.git"
+      },
+      "devDependencies": {
+        "mocha": "2.5.3",
+        "nyc": "10.3.2"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec",
+        "test-ci": "nyc --reporter=text npm test",
+        "test-cov": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "25d4cb488aea3b637448a85fa297d9e65b4b4e04",
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js#readme",
+      "_id": "bytes@3.0.0",
+      "_shasum": "d32815404d689699f85a4ea4fa8755dd13a96048",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d32815404d689699f85a4ea4fa8755dd13a96048",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bytes-3.0.0.tgz_1504216364188_0.5158762519713491"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "bytes",
+      "description": "Utility to parse a string bytes to bytes and vice-versa",
+      "version": "3.1.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Jed Watson",
+          "email": "jed.watson@me.com"
+        },
+        {
+          "name": "Théo FIDRY",
+          "email": "theo.fidry@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "byte",
+        "bytes",
+        "utility",
+        "parse",
+        "parser",
+        "convert",
+        "converter"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/visionmedia/bytes.js.git"
+      },
+      "devDependencies": {
+        "eslint": "5.12.1",
+        "mocha": "5.2.0",
+        "nyc": "13.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --check-leaks --reporter spec",
+        "test-ci": "nyc --reporter=text npm test",
+        "test-cov": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "49ac709cb210af60e35957c069bb2cd07f335cfd",
+      "bugs": {
+        "url": "https://github.com/visionmedia/bytes.js/issues"
+      },
+      "homepage": "https://github.com/visionmedia/bytes.js#readme",
+      "_id": "bytes@3.1.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+        "shasum": "f6cf7933a360e0588fa9fde85651cdc7f805d1f6",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10997,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcR/D3CRA9TVsSAnZWagAAKxQP/jm6fmIJFjJzEpnOmOQu\n4tOWELz5luZxpItaWETqZxSAqm0cU4PiqWdkzVV7KJPgKROz6IgtqW4gvya1\nUcI1LlVSQ8zNlu0UiDLOL8yz/MKjeOEdDppglxHN7Dim+tvUVu0hF/4uhuOc\nhAG1ybdaijfeGN6uBM9P6TiqQUpT2AFuS4BUfZoAW4Gfq8fYUG5RW0KsicZB\nJ0IVRreG3KXu9BOoFa+PiGXX+LIG45yE7vMNXbWULyE5vnkBdJJK8L45lFPJ\nSHGKqYK/WIyFEnDBEQgXK9pDsbz9UvPRJFqRfrHyAkfifpTekhpKTNvaj+bC\nvuokTgppKHo8h3l3wFpXKO/Zb/UQFYH1N0dKFO+NSv4gR47Bez6O2Q0Y1ZdE\nHJmZRrFCRzr/m1VT3fZmDwDPJxjZ5kyATliI1lttyOInGlVJg+VR0XFrn0d4\nYOSKxgqTS5jIOPBNZgvt7lYGdBt9TnGk7VYMEdwHm9jfx4Hdj2aEhj3x5mss\nxlVX6q1+5Qg0Am5EWgRMYnODh9Q0oLH4Zaxi4lJr+hSp/6Ln+0IXPNcgT0lj\n+77CxeAxOQG6Aj5G6H5e45x2CGCavny5rsR133vCGBnHGuRcNOSvgZ3BmUvH\n2JB4YSQCAxX/Ku6phJepP0Ktv8gKMWohF+AM2b4oHlUnW4Ny6B7w7PMJoscM\nlFdb\r\n=oAEj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/bytes_3.1.0_1548218614714_0.7781245590502732"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Bytes utility\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nUtility to parse a string bytes (ex: `1TB`) to bytes (`1099511627776`) and vice-versa.\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```bash\n$ npm install bytes\n```\n\n## Usage\n\n```js\nvar bytes = require('bytes');\n```\n\n#### bytes.format(number value, [options]): string｜null\n\nFormat the given value in bytes into a string. If the value is negative, it is kept as such. If it is a float, it is\n rounded.\n\n**Arguments**\n\n| Name    | Type     | Description        |\n|---------|----------|--------------------|\n| value   | `number` | Value in bytes     |\n| options | `Object` | Conversion options |\n\n**Options**\n\n| Property          | Type   | Description                                                                             |\n|-------------------|--------|-----------------------------------------------------------------------------------------|\n| decimalPlaces | `number`｜`null` | Maximum number of decimal places to include in output. Default value to `2`. |\n| fixedDecimals | `boolean`｜`null` | Whether to always display the maximum number of decimal places. Default value to `false` |\n| thousandsSeparator | `string`｜`null` | Example of values: `' '`, `','` and `.`... Default value to `''`. |\n| unit | `string`｜`null` | The unit in which the result will be returned (B/KB/MB/GB/TB). Default value to `''` (which means auto detect). |\n| unitSeparator | `string`｜`null` | Separator to use between number and unit. Default value to `''`. |\n\n**Returns**\n\n| Name    | Type             | Description                                     |\n|---------|------------------|-------------------------------------------------|\n| results | `string`｜`null` | Return null upon error. String value otherwise. |\n\n**Example**\n\n```js\nbytes(1024);\n// output: '1KB'\n\nbytes(1000);\n// output: '1000B'\n\nbytes(1000, {thousandsSeparator: ' '});\n// output: '1 000B'\n\nbytes(1024 * 1.7, {decimalPlaces: 0});\n// output: '2KB'\n\nbytes(1024, {unitSeparator: ' '});\n// output: '1 KB'\n\n```\n\n#### bytes.parse(string｜number value): number｜null\n\nParse the string value into an integer in bytes. If no unit is given, or `value`\nis a number, it is assumed the value is in bytes.\n\nSupported units and abbreviations are as follows and are case-insensitive:\n\n  * `b` for bytes\n  * `kb` for kilobytes\n  * `mb` for megabytes\n  * `gb` for gigabytes\n  * `tb` for terabytes\n  * `pb` for petabytes\n\nThe units are in powers of two, not ten. This means 1kb = 1024b according to this parser.\n\n**Arguments**\n\n| Name          | Type   | Description        |\n|---------------|--------|--------------------|\n| value   | `string`｜`number` | String to parse, or number in bytes.   |\n\n**Returns**\n\n| Name    | Type        | Description             |\n|---------|-------------|-------------------------|\n| results | `number`｜`null` | Return null upon error. Value in bytes otherwise. |\n\n**Example**\n\n```js\nbytes('1KB');\n// output: 1024\n\nbytes('1024');\n// output: 1024\n\nbytes(1024);\n// output: 1KB\n```\n\n## License \n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/visionmedia/bytes.js/master\n[coveralls-url]: https://coveralls.io/r/visionmedia/bytes.js?branch=master\n[downloads-image]: https://badgen.net/npm/dm/bytes\n[downloads-url]: https://npmjs.org/package/bytes\n[npm-image]: https://badgen.net/npm/node/bytes\n[npm-url]: https://npmjs.org/package/bytes\n[travis-image]: https://badgen.net/travis/visionmedia/bytes.js/master\n[travis-url]: https://travis-ci.org/visionmedia/bytes.js\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "tjholowaychuk",
+      "email": "tj@vision-media.ca"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-23T04:43:37.353Z",
+    "created": "2012-06-11T15:44:32.849Z",
+    "0.0.1": "2012-06-11T15:44:34.095Z",
+    "0.1.0": "2012-08-17T19:26:03.899Z",
+    "0.2.0": "2012-10-28T07:40:18.125Z",
+    "0.2.1": "2013-04-01T18:48:09.764Z",
+    "0.3.0": "2014-03-20T01:08:49.952Z",
+    "1.0.0": "2014-05-05T23:52:20.318Z",
+    "2.0.0": "2015-04-12T21:04:54.307Z",
+    "2.0.1": "2015-05-08T04:43:03.189Z",
+    "2.0.2": "2015-05-21T03:19:26.235Z",
+    "2.1.0": "2015-05-22T02:55:58.116Z",
+    "2.2.0": "2015-11-14T01:44:07.135Z",
+    "2.3.0": "2016-02-16T04:00:12.239Z",
+    "2.4.0": "2016-06-01T20:21:14.269Z",
+    "2.5.0": "2017-03-25T04:33:21.150Z",
+    "3.0.0": "2017-08-31T21:52:45.175Z",
+    "3.1.0": "2019-01-23T04:43:34.815Z"
+  },
+  "author": {
+    "name": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "url": "http://tjholowaychuk.com"
+  },
+  "users": {
+    "m42am": true,
+    "purywp": true,
+    "cshao": true,
+    "qqqppp9998": true,
+    "honzajde": true,
+    "fotooo": true,
+    "moimikey": true,
+    "dpanthula": true,
+    "x4devs": true,
+    "snowdream": true,
+    "puranjayjain": true,
+    "ta2edchimp": true,
+    "wgerven": true,
+    "seangenabe": true,
+    "shaomingquan": true,
+    "domjtalbot": true,
+    "heartnett": true,
+    "ahmed-dinar": true,
+    "mlm": true,
+    "shuoshubao": true,
+    "yinfxs": true,
+    "edwardxyt": true,
+    "ccastelli": true,
+    "luiscauro": true,
+    "zhenguo.zhao": true
+  },
+  "readmeFilename": "Readme.md",
+  "homepage": "https://github.com/visionmedia/bytes.js#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/visionmedia/bytes.js.git"
+  },
+  "bugs": {
+    "url": "https://github.com/visionmedia/bytes.js/issues"
+  },
+  "keywords": [
+    "byte",
+    "bytes",
+    "utility",
+    "parse",
+    "parser",
+    "convert",
+    "converter"
+  ],
+  "contributors": [
+    {
+      "name": "Jed Watson",
+      "email": "jed.watson@me.com"
+    },
+    {
+      "name": "Théo FIDRY",
+      "email": "theo.fidry@gmail.com"
+    }
+  ],
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/bytes.min.json
+++ b/test/fixtures/registry-mocks/content/bytes.min.json
@@ -1,0 +1,216 @@
+{
+  "name": "bytes",
+  "dist-tags": {
+    "latest": "3.1.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "bytes",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "2a76c866ba90e6fd2641ab5c9fdb6c4e8b4015f7",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "bytes",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "c574812228126d6369d1576925a8579db3f8e5a2",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "bytes",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "aad33ec14e3dc2ca74e8e7d451f9ba053ad4f7a0",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "bytes",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "555b08abcb063f8975905302523e4cd4ffdfdf31",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.2.1.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "bytes",
+      "version": "0.3.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "78e2e0e28c7f9c7b988ea8aee0db4d5fa9941935",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-0.3.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "bytes",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "3569ede8ba34315fab99c3e92cb04c7220de1fa8",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "bytes",
+      "version": "2.0.0",
+      "dependencies": {
+        "node.extend": "*"
+      },
+      "devDependencies": {
+        "chai": "*",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "37feb25b3478674e7b78a16720826b033459a6ff",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "bytes",
+      "version": "2.0.1",
+      "devDependencies": {
+        "chai": "*",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "673743059be43d929f9c225dd7363ee0f8b15d97",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "bytes",
+      "version": "2.0.2",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "580fea1111c2df039f2644ff917ce4010501184e",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.0.2.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "bytes",
+      "version": "2.1.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "ac93c410e2ffc9cc7cf4b464b38289067f5e47b4",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.1.0.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "bytes",
+      "version": "2.2.0",
+      "devDependencies": {
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "fd35464a403f6f9117c2de3609ecff9cae000588",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz"
+      }
+    },
+    "2.3.0": {
+      "name": "bytes",
+      "version": "2.3.0",
+      "devDependencies": {
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "d5b680a165b6201739acb611542aabc2d8ceb070",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz"
+      }
+    },
+    "2.4.0": {
+      "name": "bytes",
+      "version": "2.4.0",
+      "devDependencies": {
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "7d97196f9d5baf7f6935e25985549edd2a6c2339",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+      }
+    },
+    "2.5.0": {
+      "name": "bytes",
+      "version": "2.5.0",
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "nyc": "10.1.2"
+      },
+      "dist": {
+        "shasum": "4c9423ea2d252c270c41b2bdefeff9bb6b62c06a",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "3.0.0": {
+      "name": "bytes",
+      "version": "3.0.0",
+      "devDependencies": {
+        "mocha": "2.5.3",
+        "nyc": "10.3.2"
+      },
+      "dist": {
+        "shasum": "d32815404d689699f85a4ea4fa8755dd13a96048",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "3.1.0": {
+      "name": "bytes",
+      "version": "3.1.0",
+      "devDependencies": {
+        "eslint": "5.12.1",
+        "mocha": "5.2.0",
+        "nyc": "13.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+        "shasum": "f6cf7933a360e0588fa9fde85651cdc7f805d1f6",
+        "tarball": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10997,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcR/D3CRA9TVsSAnZWagAAKxQP/jm6fmIJFjJzEpnOmOQu\n4tOWELz5luZxpItaWETqZxSAqm0cU4PiqWdkzVV7KJPgKROz6IgtqW4gvya1\nUcI1LlVSQ8zNlu0UiDLOL8yz/MKjeOEdDppglxHN7Dim+tvUVu0hF/4uhuOc\nhAG1ybdaijfeGN6uBM9P6TiqQUpT2AFuS4BUfZoAW4Gfq8fYUG5RW0KsicZB\nJ0IVRreG3KXu9BOoFa+PiGXX+LIG45yE7vMNXbWULyE5vnkBdJJK8L45lFPJ\nSHGKqYK/WIyFEnDBEQgXK9pDsbz9UvPRJFqRfrHyAkfifpTekhpKTNvaj+bC\nvuokTgppKHo8h3l3wFpXKO/Zb/UQFYH1N0dKFO+NSv4gR47Bez6O2Q0Y1ZdE\nHJmZRrFCRzr/m1VT3fZmDwDPJxjZ5kyATliI1lttyOInGlVJg+VR0XFrn0d4\nYOSKxgqTS5jIOPBNZgvt7lYGdBt9TnGk7VYMEdwHm9jfx4Hdj2aEhj3x5mss\nxlVX6q1+5Qg0Am5EWgRMYnODh9Q0oLH4Zaxi4lJr+hSp/6Ln+0IXPNcgT0lj\n+77CxeAxOQG6Aj5G6H5e45x2CGCavny5rsR133vCGBnHGuRcNOSvgZ3BmUvH\n2JB4YSQCAxX/Ku6phJepP0Ktv8gKMWohF+AM2b4oHlUnW4Ny6B7w7PMJoscM\nlFdb\r\n=oAEj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-01-23T04:43:37.353Z"
+}

--- a/test/fixtures/registry-mocks/content/cacache.json
+++ b/test/fixtures/registry-mocks/content/cacache.json
@@ -1,0 +1,8583 @@
+{
+  "_id": "cacache",
+  "_rev": "103-fca2a899e56d930e65f44275129703ad",
+  "name": "cacache",
+  "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+  "dist-tags": {
+    "latest": "15.0.5",
+    "legacy": "12.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "cacache",
+      "version": "1.0.0",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "dezalgo": "^1.0.3",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "mv": "^2.1.1",
+        "pumpify": "^1.3.5",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "through2": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^8.5.0",
+        "tap": "^8.0.1"
+      },
+      "gitHead": "2d834abbcc4c60ad3364d9721c9bb2ff793aafe9",
+      "_id": "cacache@1.0.0",
+      "_shasum": "91c256942eaaf0f013683c1462d30f16a450c408",
+      "_from": ".",
+      "_npmVersion": "4.0.2",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "91c256942eaaf0f013683c1462d30f16a450c408",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-1.0.0.tgz_1479463297949_0.2984021082520485"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "cacache",
+      "version": "2.0.0",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "test": "nyc -- tap test/*.js"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "from2": "^2.3.0",
+        "fs-extra": "^1.0.0",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "mv": "^2.1.1",
+        "pumpify": "^1.3.5",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0",
+        "tar-fs": "^1.14.0",
+        "through2": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^9.0.1",
+        "standard": "^8.5.0",
+        "tacks": "^1.2.2",
+        "tap": "^8.0.1"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "0fa8f9764a137d50ec7e6574c0bf44219f21b570",
+      "_id": "cacache@2.0.0",
+      "_shasum": "d05c1db1398b1ba77f6ab18c950098995d4bc8a7",
+      "_from": ".",
+      "_npmVersion": "4.0.3",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "d05c1db1398b1ba77f6ab18c950098995d4bc8a7",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-2.0.0.tgz_1479646030946_0.24932323582470417"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "cacache",
+      "version": "3.0.0",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^8.0.1"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "d97f56e2e9e4d5e26bb7c30345ddaedee4e92b0b",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@3.0.0",
+      "_shasum": "eb3d5aec86b698c336cfc2233a67687241541761",
+      "_from": ".",
+      "_npmVersion": "4.0.3",
+      "_nodeVersion": "7.2.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "eb3d5aec86b698c336cfc2233a67687241541761",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-3.0.0.tgz_1480797089574_0.8002452596556395"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "cacache",
+      "version": "3.0.1",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^8.0.1"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "ad9d97270fee0dfd9e036f07c190c33eb8c9b110",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@3.0.1",
+      "_shasum": "f2bbc3ea4603da1888c9577a288dbad3aa649cbb",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.2.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "f2bbc3ea4603da1888c9577a288dbad3aa649cbb",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-3.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-3.0.1.tgz_1480835211471_0.4059302939567715"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "cacache",
+      "version": "4.0.0",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^9.0.3"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "bfcb818546929601c21aacdf53907e8578dea0d6",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@4.0.0",
+      "_shasum": "acfe5f4dfb2265900ba51783d67a30868b652029",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "acfe5f4dfb2265900ba51783d67a30868b652029",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-4.0.0.tgz_1485563494205_0.06228936044499278"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "cacache",
+      "version": "5.0.0",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^9.0.3"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "9c2e370d1f9ec6bc7918d249f56f96ab493c3b8f",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@5.0.0",
+      "_shasum": "66eda54c377fe1afc485a6d76226c98e17ab7e73",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "66eda54c377fe1afc485a6d76226c98e17ab7e73",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-5.0.0.tgz_1486087189180_0.456214397912845"
+      },
+      "directories": {}
+    },
+    "5.0.1": {
+      "name": "cacache",
+      "version": "5.0.1",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap -j8 test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.0.2"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "8fefee50d0f97171a3a40f5aaef264d45c4a7d2a",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@5.0.1",
+      "_shasum": "253cb8cb059205110c5efe1b974dce6f31c0ddf1",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "charlotteis",
+        "email": "charlottelaspencer@gmail.com"
+      },
+      "dist": {
+        "shasum": "253cb8cb059205110c5efe1b974dce6f31c0ddf1",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-5.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-5.0.1.tgz_1487404076153_0.38444646121934056"
+      },
+      "directories": {}
+    },
+    "5.0.2": {
+      "name": "cacache",
+      "version": "5.0.2",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap -j8 test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.0.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.7"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "30030ed0eca42668e3e0ac628ec9ca4b752b5093",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@5.0.2",
+      "_shasum": "5c1659e49fd83a3fd56010e5cdaad23f563302b5",
+      "_from": ".",
+      "_npmVersion": "4.3.0",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "5c1659e49fd83a3fd56010e5cdaad23f563302b5",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-5.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-5.0.2.tgz_1487563944795_0.8896687692031264"
+      },
+      "directories": {}
+    },
+    "5.0.3": {
+      "name": "cacache",
+      "version": "5.0.3",
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap -j8 test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.0.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.7"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "bd1b71f323658dbed44b1bb8be68cff2a81421ae",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@5.0.3",
+      "_shasum": "f8c651e6613865dda88ddfd87bc514d9cd34a65f",
+      "_from": ".",
+      "_npmVersion": "4.3.0",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "f8c651e6613865dda88ddfd87bc514d9cd34a65f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-5.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-5.0.3.tgz_1487580656016_0.7145839324221015"
+      },
+      "directories": {}
+    },
+    "6.0.0": {
+      "name": "cacache",
+      "version": "6.0.0",
+      "cache-version": {
+        "content": "1",
+        "index": "1"
+      },
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "slide": "^1.1.6",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^9.0.0",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "1aef3e527e3a1e73b9e2faee482939e9ce958006",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@6.0.0",
+      "_shasum": "994ab2c3ec9c2233c1e55ea69dd54ba34539432d",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "994ab2c3ec9c2233c1e55ea69dd54ba34539432d",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-6.0.0.tgz_1488698454431_0.8984206928871572"
+      },
+      "directories": {}
+    },
+    "6.0.1": {
+      "name": "cacache",
+      "version": "6.0.1",
+      "cache-version": {
+        "content": "1",
+        "index": "1"
+      },
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "slide": "^1.1.6",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^9.0.0",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "b2014641ecff503b8bf8506de5bcb7a5af49b42b",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@6.0.1",
+      "_shasum": "cae27481c35ae7264d6bbccad7e520876302b77d",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "cae27481c35ae7264d6bbccad7e520876302b77d",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-6.0.1.tgz_1488703539820_0.8354658233001828"
+      },
+      "directories": {}
+    },
+    "6.0.2": {
+      "name": "cacache",
+      "version": "6.0.2",
+      "cache-version": {
+        "content": "2",
+        "index": "2"
+      },
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^9.0.0",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "00a64756a4adf445b5b870a20d417195ba037267",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@6.0.2",
+      "_shasum": "abda997519d86232b2bf11a901e01caf03d66a93",
+      "_from": ".",
+      "_npmVersion": "4.4.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "abda997519d86232b2bf11a901e01caf03d66a93",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-6.0.2.tgz_1489191123557_0.18352518323808908"
+      },
+      "directories": {}
+    },
+    "6.1.0": {
+      "name": "cacache",
+      "version": "6.1.0",
+      "cache-version": {
+        "content": "2",
+        "index": "2"
+      },
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "cac5f9cb23e08093eccb4573370f6ea87bd54e84",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@6.1.0",
+      "_shasum": "7c86652a413e797680f1ef3e759b3c8f4a5fc599",
+      "_from": ".",
+      "_npmVersion": "4.4.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "7c86652a413e797680f1ef3e759b3c8f4a5fc599",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-6.1.0.tgz_1489297959380_0.3542158380150795"
+      },
+      "directories": {}
+    },
+    "6.1.1": {
+      "name": "cacache",
+      "version": "6.1.1",
+      "cache-version": {
+        "content": "2",
+        "index": "2"
+      },
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "2318a8f9b79b6efa15c19285046a2be1469dfa77",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@6.1.1",
+      "_shasum": "ad4405780016a33b608bf55a760aa18af0ada309",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "ad4405780016a33b608bf55a760aa18af0ada309",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-6.1.1.tgz_1489400152392_0.13603505678474903"
+      },
+      "directories": {}
+    },
+    "6.1.2": {
+      "name": "cacache",
+      "version": "6.1.2",
+      "cache-version": {
+        "content": "2",
+        "index": "2"
+      },
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "956687682e7690680059daaf455d621ce2ceb126",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@6.1.2",
+      "_shasum": "fba9b76f1e2a0fe6073000d9034108ca28d7b577",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "fba9b76f1e2a0fe6073000d9034108ca28d7b577",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-6.1.2.tgz_1489400728495_0.06708851829171181"
+      },
+      "directories": {}
+    },
+    "6.2.0": {
+      "name": "cacache",
+      "version": "6.2.0",
+      "cache-version": {
+        "content": "2",
+        "index": "3"
+      },
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "00f773eada2f3af160bf08b3b0df0afa6c0eb20f",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@6.2.0",
+      "_shasum": "ed3001398eacbb3750241cc57375202bb81ae5d1",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "ed3001398eacbb3750241cc57375202bb81ae5d1",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-6.2.0.tgz_1489542166404_0.23625470255501568"
+      },
+      "directories": {}
+    },
+    "6.3.0": {
+      "name": "cacache",
+      "version": "6.3.0",
+      "cache-version": {
+        "content": "2",
+        "index": "3"
+      },
+      "description": "General content-addressable cache system that maintains a filesystem registry of file data.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "content-addressable cache",
+        "file store"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "move-concurrently": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "82a977ead70a17f60926d54c38cd140ec79a6f30",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@6.3.0",
+      "_shasum": "ecc428901b79aabbd0b0492bca62b88cda0d4773",
+      "_from": ".",
+      "_npmVersion": "4.5.0",
+      "_nodeVersion": "4.8.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "ecc428901b79aabbd0b0492bca62b88cda0d4773",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-6.3.0.tgz_1491029412988_0.4537326372228563"
+      },
+      "directories": {}
+    },
+    "7.0.0": {
+      "name": "cacache",
+      "version": "7.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "4"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^3.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "99769f69bf8900c8039815ade6b6c44c792a28c7",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@7.0.0",
+      "_shasum": "7e59224ff4f1ebafe5f42ff68f472d179a5c204c",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "7e59224ff4f1ebafe5f42ff68f472d179a5c204c",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-7.0.0.tgz_1491207188752_0.21650386229157448"
+      },
+      "directories": {}
+    },
+    "7.0.1": {
+      "name": "cacache",
+      "version": "7.0.1",
+      "cache-version": {
+        "content": "2",
+        "index": "4"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^3.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "5e7341ce0e6e718cf3b9dd27cccfa794c4246b18",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@7.0.1",
+      "_shasum": "7f66ca4f725b121d8037067e1979b0019727b4f4",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "7f66ca4f725b121d8037067e1979b0019727b4f4",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-7.0.1.tgz_1491207359331_0.7451633384916931"
+      },
+      "directories": {}
+    },
+    "7.0.2": {
+      "name": "cacache",
+      "version": "7.0.2",
+      "cache-version": {
+        "content": "2",
+        "index": "4"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "422a86dae8269ab3f56bc7e952280c34b58ddfb6",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@7.0.2",
+      "_shasum": "5b7f7155675b0559ad98a1961f9d0a4c1260532d",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "5b7f7155675b0559ad98a1961f9d0a4c1260532d",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-7.0.2.tgz_1491216099682_0.127382418140769"
+      },
+      "directories": {}
+    },
+    "7.0.3": {
+      "name": "cacache",
+      "version": "7.0.3",
+      "cache-version": {
+        "content": "2",
+        "index": "4"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "b677f6def269b2a6968ca3e7c65261dcf1878e47",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@7.0.3",
+      "_shasum": "62e876694cf2c094d319f257b83769ea752278ab",
+      "_from": ".",
+      "_npmVersion": "4.5.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "62e876694cf2c094d319f257b83769ea752278ab",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-7.0.3.tgz_1491373492663_0.1923560865689069"
+      },
+      "directories": {}
+    },
+    "7.0.4": {
+      "name": "cacache",
+      "version": "7.0.4",
+      "cache-version": {
+        "content": "2",
+        "index": "4"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "a6b344891adeecca6e2b02d9e5b9f3340e91de68",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@7.0.4",
+      "_npmVersion": "4.5.0",
+      "_nodeVersion": "6.10.2",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "59eb6a4dca1aa3dc2a6450c097679afba37bc990",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-7.0.4.tgz_1492285095516_0.7461334373801947"
+      },
+      "directories": {}
+    },
+    "7.0.5": {
+      "name": "cacache",
+      "version": "7.0.5",
+      "cache-version": {
+        "content": "2",
+        "index": "4"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "0be449e5deb99a54c3efcdd2054c52ecfe4834c6",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@7.0.5",
+      "_npmVersion": "5.0.0-beta.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "31b23a28b2b1e4083e60a42df9ddd2e5dbd3b4ce",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-7.0.5.tgz_1492509873056_0.9271866513881832"
+      },
+      "directories": {}
+    },
+    "7.1.0": {
+      "name": "cacache",
+      "version": "7.1.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "0a0c54336994409c4e86e56f2cc3f8cd32adc12a",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@7.1.0",
+      "_npmVersion": "5.0.0-beta.4",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "f73777163e437e4ec45e21a2be298edeb584e36f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-7.1.0.tgz_1492683249221_0.14916861057281494"
+      },
+      "directories": {}
+    },
+    "8.0.0": {
+      "name": "cacache",
+      "version": "8.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "358443a2f0547664ba04cc533f0b2d8f944c20a2",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@8.0.0",
+      "_shasum": "2c3899c16941aeb0e7378845df8aff03bb0eb81a",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "2c3899c16941aeb0e7378845df8aff03bb0eb81a",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-8.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-8.0.0.tgz_1492892421119_0.964167490368709"
+      },
+      "directories": {}
+    },
+    "9.0.0": {
+      "name": "cacache",
+      "version": "9.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "c2d6b436c99f4cd4715af59547fd3eb528d537a6",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.0.0",
+      "_shasum": "edcf620030b0fbf3708193f0718136eedb2170a4",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "edcf620030b0fbf3708193f0718136eedb2170a4",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/cacache-9.0.0.tgz_1493340297200_0.2679894659668207"
+      },
+      "directories": {}
+    },
+    "9.1.0": {
+      "name": "cacache",
+      "version": "9.1.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "28a3efa033824d40d5db54ee4fba7370f1a7b003",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.1.0",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-pNQeGpcAptdM0JFJA3kQfKoMrg43vuQBgxdoqbPRNMcAjO1oXONAvN4T3RJsZsmgmvNY/bQmotne4nmsEyFn4g==",
+        "shasum": "7972de4fa9f2a81a4b737011a2cf1f0e0d7ab213",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-9.1.0.tgz_1494746134130_0.6239770308602601"
+      },
+      "directories": {}
+    },
+    "9.2.0": {
+      "name": "cacache",
+      "version": "9.2.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "8f6906ed49d5554a18eb712db15f5dc0ec8e2232",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.0",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-6p5OrZdfA2f/JX2y2u70FsG40h8bib83wBVaFnKqDLaWeii4yvkR4jCC4P9tADyee3Y9sgYnWPvv0XCZMUfPBA==",
+        "shasum": "5e14e78842ea7c8df0c35fc4b315452724c27b79",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-9.2.0.tgz_1494796168879_0.19379548192955554"
+      },
+      "directories": {}
+    },
+    "9.2.1": {
+      "name": "cacache",
+      "version": "9.2.1",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "b91d2479e75159983dbcd6101229ecbeb9468d97",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.1",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-wknnaRGoo1yzuXMdXXbT/+i/78PWdjZGyNC2LY9t73zARhV0DRrOrJI+eSebosIvtiDZXHK7DiAgl94gGWdtyA==",
+        "shasum": "5baf6875a3ef3dca4fdf33efb9b0e3ac23a983a3",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-9.2.1.tgz_1494802832163_0.25340488692745566"
+      },
+      "directories": {}
+    },
+    "9.2.2": {
+      "name": "cacache",
+      "version": "9.2.2",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "950b19a4fba8c5eb0b117114bf7462a939b12cc6",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.2",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-KchIh0VVk0zpYKtztqFQDYc2ZnQAqwOO3Z5bsuxYfTJuNGvUgEVEBlEVmb/Rf3t3CKgd/8U7x2RC+lgJe0kz2Q==",
+        "shasum": "cb67e5c3497d474f6b6d889a90ebfc969f2d83fa",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cacache-9.2.2.tgz_1494805618593_0.29162677587009966"
+      },
+      "directories": {}
+    },
+    "9.2.3": {
+      "name": "cacache",
+      "version": "9.2.3",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "1e469adcc80ba94b6afbb3ae50259a2876cc18f7",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.3",
+      "_npmVersion": "5.0.0-beta.61",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-Xvz0paVT+igGRdGPDfMy2UgAFnbc77hp6/XruCiJQzcBtKzb+jkP1NG0kAHS8RKp3h560Fc09WnonXyT/oXMxA==",
+        "shasum": "22edd762e8f91a2d89dc9a2f6f7f28a6b11bf71e",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-9.2.3.tgz_1495618087947_0.260176362702623"
+      },
+      "directories": {}
+    },
+    "9.2.4": {
+      "name": "cacache",
+      "version": "9.2.4",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.3.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "fc46a7b78e424c61f6a5a06e00c49795d14291b7",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.4",
+      "_npmVersion": "5.0.0-beta.61",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-DkEucrb5TwM6yCLgDfyHWMH3QECt9g0pMGNtuGBrALo/B0FcQSnt8B+DyyuPFqOvSOwSPZgqYD4TK9IKJBUoKg==",
+        "shasum": "f222f569e6d3e1415ad1ae66969c69ca0fc25955",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-9.2.4.tgz_1495618360254_0.6785227581858635"
+      },
+      "directories": {}
+    },
+    "9.2.5": {
+      "name": "cacache",
+      "version": "9.2.5",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.3",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.3.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "babf105e227d07ec95c8fd8045ea750a8b1c8c3e",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.5",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-mURsTvkjbCSFRTdkuPhHUp9sbEHn3AVrvM4mveg/bhlKKYolfRm23TsFUVAssC9p622lwmh7pgpb+H5mSVpYcA==",
+        "shasum": "cb401d0e59858532062de1f104097cb40c71c3bf",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-9.2.5.tgz_1495675401383_0.041375950910151005"
+      },
+      "directories": {}
+    },
+    "9.2.6": {
+      "name": "cacache",
+      "version": "9.2.6",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.3.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "5e04eb7ec441ce556d611c4edf141a481e107280",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.6",
+      "_npmVersion": "5.0.0",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-YK0Z5Np5t755edPL6gfdCeGxtU0rcW/DBhYhYVDckT+7AFkCCtedf2zru5NRbBLFk6e7Agi/RaqTOAfiaipUfg==",
+        "shasum": "ea5c7f2b6b514710a22a58a27f857fd972fdfa51",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-9.2.6.tgz_1496209410635_0.7262062451336533"
+      },
+      "directories": {}
+    },
+    "9.2.7": {
+      "name": "cacache",
+      "version": "9.2.7",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^11.0.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.1.0",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "c4f2f6c95833024d758de1564655a6be4ea27dc8",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.7",
+      "_npmVersion": "5.0.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-SWRnkRNV5h61SeTfPvVYotM2yqW5KXtG835CebVV7G5EYHQu+dgQbNkasSIcN7LWeoaViLpgaxVlt01TFpqOKw==",
+        "shasum": "67d71835fed94f6989bde522cf2956df862e3ca5",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-9.2.7.tgz_1496673430525_0.7083461554720998"
+      },
+      "directories": {}
+    },
+    "9.2.8": {
+      "name": "cacache",
+      "version": "9.2.8",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.5",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^11.0.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.1.0",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "9fd57d24d89ae780389aa8d22e8d2c98f72897d9",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.8",
+      "_npmVersion": "5.0.2-canary.9",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-nA3gmaDPEsFWqI5eYAe35IfvW54yGJ3ns2wDopWf4iDA3fkhBNsdvnYp4NrL+L7ysMt0/isM84Mwi+b4l8/pMQ==",
+        "shasum": "2e38b51161a3904e3b9fb35c0869b751f7d0bcf4",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-9.2.8.tgz_1496697511971_0.9950958741828799"
+      },
+      "directories": {}
+    },
+    "9.2.9": {
+      "name": "cacache",
+      "version": "9.2.9",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.6",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.0.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.1.0",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.4",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "296f37667a7b3ab4144b52d08365cd4b76bd73b7",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.2.9",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
+        "shasum": "f9d7ffe039851ec94c28290662afa4dd4bb9e8dd",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-9.2.9.tgz_1497732123721_0.6806205452885479"
+      },
+      "directories": {}
+    },
+    "9.3.0": {
+      "name": "cacache",
+      "version": "9.3.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.6",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "8c9ef3ea922c2590c0ac4abc0be21a6ace50f388",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@9.3.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
+        "shasum": "9cd58f2dd0b8c8cacf685b7067b416d6d3cf9db1",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-9.3.0.tgz_1507418688161_0.054106614319607615"
+      },
+      "directories": {}
+    },
+    "10.0.0": {
+      "name": "cacache",
+      "version": "10.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "ae31cd670555b39336490eeccb51a8cef2927a8e",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@10.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-s9h6I9NY3KcBjfuS28K6XNmrv/HNFSzlpVD6eYMXugZg3Y8jjI1lUzTeUMa0oKByCDtHfsIy5Ec7KgWRnC5gtg==",
+        "shasum": "3bba88bf62b0773fd9a691605f60c9d3c595e853",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-10.0.0.tgz_1508783137726_0.09417407028377056"
+      },
+      "directories": {}
+    },
+    "10.0.1": {
+      "name": "cacache",
+      "version": "10.0.1",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "32dc59ad340ede670668485299b2dad8e4db0427",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@10.0.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
+        "shasum": "3e05f6e616117d9b54665b1b20c8aeb93ea5d36f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-10.0.1.tgz_1510785251234_0.04544048057869077"
+      },
+      "directories": {}
+    },
+    "10.0.2": {
+      "name": "cacache",
+      "version": "10.0.2",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "81b8d1afdee1c275caa00e4907967b46a0feebe6",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@10.0.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
+        "shasum": "105a93a162bbedf3a25da42e1939ed99ffb145f8",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache-10.0.2.tgz_1515296450961_0.34615294821560383"
+      },
+      "directories": {}
+    },
+    "10.0.3": {
+      "name": "cacache",
+      "version": "10.0.3",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "c15350e1c0629a054f497679e652edbed4972e28",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@10.0.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-fhy5oPxjgI/pfsSPhlqCFtvuM/lvRnD0T7/fCFoXNmR6/1IKMXsjk2UlNbrOkACbm3e9Xb2TfuDZ4d6lyqHXSQ==",
+        "shasum": "3d7cac2f179ae5523e777f74c4e956ce6686f31f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.3.tgz",
+        "fileCount": 29,
+        "unpackedSize": 101928
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_10.0.3_1518811245878_0.5010480970477138"
+      },
+      "_hasShrinkwrap": false
+    },
+    "10.0.4": {
+      "name": "cacache",
+      "version": "10.0.4",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true nyc --all -- tap -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.2.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.1",
+        "cross-env": "^5.1.3",
+        "nyc": "^11.4.1",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tacks": "^1.2.2",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "555114e87a79f5c6115b5fde8e74b3fb62bc4a33",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@10.0.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+        "shasum": "6452367999eff9d4188aefd9a14e9d7c6a263460",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+        "fileCount": 29,
+        "unpackedSize": 102024
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_10.0.4_1518821654618_0.08192369229055396"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.0.0": {
+      "name": "cacache",
+      "version": "11.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.3.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tacks": "^1.2.2",
+        "tap": "^11.1.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "aa59d8256aa45d3043ad081fe65a8a443df562d5",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.0.0",
+      "_npmVersion": "6.0.0-next.0",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-pWhgsZ8GL5Boz69gJ4RPM1xiyIfB5gbB1V0P1WCYjIUDeww1zSIaM63x8R7YlRV95MxvXfxB+QVeY1YdneVaiQ==",
+        "shasum": "6b7ddb262c764cf482495ab086c69ff084385821",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.0.0.tgz",
+        "fileCount": 29,
+        "unpackedSize": 103377
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.0.0_1523234286252_0.6432170196203006"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.0.1": {
+      "name": "cacache",
+      "version": "11.0.1",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tacks": "^1.2.2",
+        "tap": "^11.1.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "41e12c1bba2fd9e296ad98f1e26567f76d3e9e01",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.0.1",
+      "_npmVersion": "6.0.0-next.0",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-s5YA8Lva1PF76kHDquIPW1N0YJXNFiItwrrDXAn8vvunOv/VNXOR1LtQYgPBRpaweIX2xSaBpqIXCYeOTZfHSQ==",
+        "shasum": "63cde88b51aa5f50741e34833c9d0048a138d1dd",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.0.1.tgz",
+        "fileCount": 29,
+        "unpackedSize": 103486
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.0.1_1523385908811_0.4553085564595629"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.0.2": {
+      "name": "cacache",
+      "version": "11.0.2",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tacks": "^1.2.2",
+        "tap": "^11.1.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "dfceb7d59980d48918bbff75f230ef3313cb7630",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.0.2",
+      "_npmVersion": "6.0.0-canary.3",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-hMiz7LN4w8sdfmKsvNs80ao/vf2JCGWWdpu95JyY90AJZRbZJmgE71dCefRiNf8OCqiZQDcUBfYiLlUNu4/j5A==",
+        "shasum": "ff30541a05302200108a759e660e30786f788764",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.0.2.tgz",
+        "fileCount": 29,
+        "unpackedSize": 103864,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa8KCeCRA9TVsSAnZWagAARwIP/iLX3k/nIgihaXX1urCX\nq+kBkZ5pjhGAAH22PhKfhJcMmLStLEzhxQMnFDf+9HowhMHM8vccMZuZbWVW\n6j6xtdalp2L+n9TjJZIGZk5BRLF3Tc3n93G+f8cpbxVvhHnYvs80dJpUMN32\npPNFFa8C3knDGaE9UtQLhsA651OzgFSHykf9lLVJ8hvgne4VpD6wTbKNLd8D\n7UxDtj3Ue+7OTZZBZMdVTgBDrUKqDJX6zUP2dZe/Gtjnc1CtbEmBxh4wRbSx\nRJSJJxVVpwZjxVvdmHXEnwqnxXJseQQP6klSxtjJglGmc5izGFrQvL4CVQeZ\nxSSWyEn/2zmNAvbTvVhM5xsr81hWLWyEc7MbOxss1HjiDe/FJgsCRTt/FE8R\nO7aaT2r9sABBfT2YLr9b1VAcqoiL8H0ATLwe/1RMFJbLtuWkBLBpOe1Cuz5F\nDBL9JwG8rSmCfUMjlFwFXK9YFwEfV/PHz2dtGc7QN0qwyXfmPbl7jmFMJgzh\npa6Z4i72r/LGh1gI4VPQSjcYjTbRWsH9nPPjt7iY6WOF2ZEEXMQqOHvG79Mt\nFaNzzaUiPlfhTpI1iHqAS8at117kpmadxO3058jln68NnJ9CdDZZ8+V3HX8K\ntyjXxV3DrwLvCcd111kPmbE5+KSe9nfXAEL6OpTStkK6q7W9LsW/94QX9vhq\n82+u\r\n=RUWS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.0.2_1525719196036_0.5875191634477166"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.0.3": {
+      "name": "cacache",
+      "version": "11.0.3",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "8a94928a0463f05348e8084fb0a3a037b2c275b8",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.0.3",
+      "_npmVersion": "6.3.0-next.0",
+      "_nodeVersion": "10.5.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-PKg49kjNaPFvzwcIo4mo46av7uKDnECAeyNDp3R+WTohi+BeQjPC7zcKxx7P1lyMySNBY5FeGD8Ys38VtBGcTg==",
+        "shasum": "632afc1c48c17cf4f37fb0044f8da184b475426d",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.0.3.tgz",
+        "fileCount": 29,
+        "unpackedSize": 104392,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbYhgPCRA9TVsSAnZWagAAdY0P/38vCfVgefLo504o/7Sf\njknTMGrBZcxqaV6+jCdky8jz5Nje9URKhrlUyYme7ZE2rzc14N1kFvul3df1\n8NedG4rNcNiJxMpc4k7PN6Iv0sC8+uoZ38TAQpYH2brSuOEAkILDVFpAKXAA\nmoNuPs/bZSJKzNIe7gzVpIbTZaZLFLjK+QsXIa+g8/YgEDOM4BqI01A70nzG\n39gieFaqYv3EiBcSq8qFdkz547wtheGSY359XI4kYhnByE95EJ5PWOtOqxcY\nXZHycgWJEBWzh+zRXzISq3ED3cONWwmbneB9pMb4qW9kwxzsYuJ8EH7GxLyb\nvRxCKtE4qBY4CTJg/vVsfMzF/nKquRHDJKXMtsISoLi9Nm2QUsnrzJuCOT8f\nqxc0jRTEth/k5hFvbj4KXQNPokVT/IoZvvo+oaTfts+39Eum3pfs45Yfa+IN\nl/w8I3dWYPdDi0r4PIl3nqVKh5Og1lJsbc5NNnmZyBDMM4XguaTGyXpUbGL+\nRE5s0jK5QIbQUk8nSqNLlB4xTu0IUGpLBejy04drmBl6aHfmQNxPPZb3Fquh\nyG4jnx5lGPamsSonjtlH8odWZkhiTto8zlsG6WqvyE7RCMyEOZ6YYbU/eine\n7jlvSMoA/Jk04ycXJ1iOjM4rULA9ed6Ssv0yW+BwqwUg7ikYMFnAxHvjevmB\ntrNZ\r\n=m+e7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.0.3_1533155343050_0.8426501612589756"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.1.0": {
+      "name": "cacache",
+      "version": "11.1.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "4b28ae3dfd21477f67cf63ae288f0a471fe78970",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.1.0",
+      "_npmVersion": "6.3.0-next.0",
+      "_nodeVersion": "10.5.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-wFLexxfPdlvoUlpHIaU4y4Vm+Im/otOPCg1ov5g9/HRfUhVA8GpDdQL66SWBgRpgNC+5ebMT1Vr1RyPaFrJVqw==",
+        "shasum": "3d76dbc2e9da413acaad2557051960a4dad3e1a4",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.1.0.tgz",
+        "fileCount": 29,
+        "unpackedSize": 105687,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbYi/bCRA9TVsSAnZWagAA3BkP/Rjumg5NF0KdlOtimiEu\nDy5v3o8DZMvpQKi/ULuvK3qY0TCCR9GJc3HKk3FCrGWUp53AwJSeBcEFM3W6\nc15/X+97adBqNv+MgkcmK1bs7V56buBfEAoIYGNfhjJu5WuYt4nHR9USdwrD\nSrBl2nR6S8iRgrlOMtSH29c5bwjxvx43omHloxUG3+WSnQnyDZ45r99izi/a\nkxouEmWMAWYPSIEsEoDtlc/VegbED1OcHyJ6EG8GRBZt0PK4coOJMnpaZiUj\npjbdTM/35jyRoKUNK22LHDe6FPFp8iD8eZTORwnMinOIcjUPcE4qo9hxOLSO\n1ucjaFWyAN4xOXoVGoijq/2heGbDMf9SGGFpeBfltiMLhZmA8NakjtrU0wbc\nlcKkTOcKtowhGlkE2bCzs6kZCbhG5NyLwJZWBd4zFN2kk4ttd6u9tK8W99LC\nCmg26BWsDhic/aleju7UIwNq8+c9uBqBBpVxJTeYU7gGrfOdZAoCsx5RjmzX\nDWXyA2h42NdLSl2t6IeFIQV4Xq1ZMB1b3/vGtA5AquFubIYe9lnxlEUjAqF5\n7L4Y6bqVB05bT7qfpq0//yesXQTeod8Zpmjy/1JYTT1U4Vxqtk6j0fjqKTmK\ngjgpHqMLzXML88eRkeyNw4BNmom97GLhpeeuo3bFJ7QqI/rTWF+85y1Tpqsa\n7dRn\r\n=yCMw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.1.0_1533161434574_0.4302741097099263"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.2.0": {
+      "name": "cacache",
+      "version": "11.2.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib",
+        "locales"
+      ],
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "93b08939e622275afc3f912e885257a93cb56e53",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.2.0",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.5.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
+        "shasum": "617bdc0b02844af56310e411c0878941d5739965",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
+        "fileCount": 29,
+        "unpackedSize": 106685,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaj3sCRA9TVsSAnZWagAAwHsP/j64ncfiQL/IKCQb45Zx\nYRD43mMsd2BDc0k+qCrOlIw2x3jA+eTh9BHjvMBE0BuMuWAjwV4wXKXjBIpu\nwBhzYxwoCEsQbksV7oTAMS1PnQiOQfuZEs2zLfRIxQ8RbeGuynbE6HIKQSL8\nedyjMvsT3rMdY2rFvClYdLxx7qwZJYdL/6GXi8K0+F4Lxe04sMkKqNvwD2UF\nL2dPeZ3OcflO+piFJTZ4/8Yrb8fwR22D0zSiknQEI9T/ojYc7WJWetIPTija\n1IS4cAww4b29oWDY7SUS3yx1+09vPPydioZSvtboIfHqjo6Ahc0QQg3e97+d\nxcS5YJdpANFA6SQHK8gnlkfWZ+AX7eVowzWG17qYqq9XEgo9RcUoKvXS3AtO\nA7HHAkr6ylzkg8JF3xLT/gtyAltAwpIYis9wRb4Vij/clML5vVHjxNb2Vmab\n3TN7JubsSDxrPsdZ8RwBW5VuwqZS5nNo/WTLrUOYQHjSP0zjek8lmq9xAP07\npHgMEAcGKZnMzGkBwBSzEsrCWKLGo2WkkogubRJClL1VAeofLcTT/VpiNLFR\n6fs8oliVIA3KmOV45PPW0LJHt/Cyj0F9jO1BlMZIAn4XSIWUF7IyDjtRqVYA\nh5Ia8Lksurz9SC2b7c8JfOPCHt7gP+RRJyzVJmpbVNO6LGi6UosvT+6SabZh\nGb91\r\n=GisX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.2.0_1533689324598_0.6219370503557153"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.3.0": {
+      "name": "cacache",
+      "version": "11.3.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "4c38261d756a4133cec220d7ac8be3bd142a9dd5",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.3.0",
+      "_nodeVersion": "10.6.0",
+      "_npmVersion": "6.4.1",
+      "dist": {
+        "integrity": "sha512-6Af/h56f+GXGAuxfutTZGxOofff+PfaZ3K0XlXjMAzS8HHijzNYySP8zHrJ0vniSzd4wrMgwOHegWh695pHSRA==",
+        "shasum": "c37d4c12e3114064becf8904adba039a5befd4fd",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.3.0.tgz",
+        "fileCount": 29,
+        "unpackedSize": 110919,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb38VpCRA9TVsSAnZWagAAwjgP/1hBBUmdSNN1Z7uLlb2K\nDxWWZvH9oPsaNrU++q7PF52VgvszUNpau6lj8E33Wi4O71skDVakfEBZG5WV\nCo7Hm97nWZubL5VD/3Eb/jMe+T4PAyI7lBSefG4sDkMgvbztk7gS5BvAf6ix\nsBZAQb/PIS2f+2tQHiDrxHf1+/ut19EyYX01hOo0IZ70rhZmtVqXQhjtBpSx\nK5Ir++WREaNTRMiRVoAdqVpMl6783NKBErtFziuUm6GFA+JhOjmPm69Yhj9z\nNI3umXFqiLLfA/GdlIJIYEurcCnDqGAxcUDv5aItgXyWVK/prT4V2gPmJkOM\nuzGpXA5Kfh/KO+fjOKh0vMkNlqZROc1h4K6EYKZKeq0xlSL1JadBfTaZOIMS\n2WRhMzFjlZNy43iAtDljJIU41qtbU/fUgnGRA0f784iXAY4XDsYveKyNqOMn\nBE5fXDSuPTEg1NyvOaOYomnwfjTPa4J1kA2bM1BokrnZ5O6XfVbR6/4DvZ36\nJ5peve0oaJ5lJTC/BK5HM301/AFETOQ3H8zmUFTROModACV6l25elIyODFON\n8zMNocTqh5ClN73L4MwvxOkFFl+zmKKJ5iZFs2Eo3cukgwL3ZTOWglk3WsU9\niVGjDmd9LGjwg+vPaY/D8UxXgb4dVKajpOwepiBPhl129uXtFusaHlsiIcSs\nzYQ3\r\n=E2jl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.3.0_1541391717699_0.7941223170061609"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.3.1": {
+      "name": "cacache",
+      "version": "11.3.1",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "4c94e2cff7985739adb504745324c5052f7ad95e",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.3.1",
+      "_nodeVersion": "10.6.0",
+      "_npmVersion": "6.4.1",
+      "dist": {
+        "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
+        "shasum": "d09d25f6c4aca7a6d305d141ae332613aa1d515f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
+        "fileCount": 29,
+        "unpackedSize": 111301,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4LNYCRA9TVsSAnZWagAAKwQP/1WNsqOngJOmHit1rRAc\ngDtvOXzeEn42MtKAQFoZOJT7zt8xNBIg83PMmRXZRtWGGkQvo07pfB4qanoE\nEvze/fDFHi/jvcToD/brYsBJZ/IMXWZs8ukx7vMj/ZdqIH6TGk0dvbOi2TP4\n1kvK9FLcp4esdRQ1so/SAvuOA//fZWaNv+JX6KvMRlLM1tPjujHV+DIRCihQ\nE1BhSYP7c0vmn2telUTfzAPBGR9CFT0h3vk5KMmZs3KvFsRRFs1+MCA+XHku\nw4KnM5zhAgPS6N83DQm01aNMDYp7f+yVmG6oj75Q7tJ+XHMotAbmz7CwwWAm\nEcUvYcLOo71e6oQESuy+VxHff5X6Rk2K3LrOi551cBqOC1u1VEna4g947imD\nhtcEURJZtkLhRARiUkyMiKaRPPOgYiOfvq289WbjroWMR3XdajOwclyn9Cpc\nLwPPp877gN/s60pkQqar5K0mcFjeUF7aLoiV7NRt2Gc/PepFg0VThQ6eitjG\nAQU+pk+a+/W3DVCqzFu98YMUoQvOMz2vViZ1irDiSC8dooH5GK8hitOQ+nHY\nKz2Xjs5uQOFZbCDHQf5pYTVX9WL4/2T4Am1Knz9uscyZGgQsgVqeX3wECkN9\nqLT5bu1KV+CoDRy6VcRTp/8ar6LE6FCR3uJZ3K2Ix0y5oxoTCPzdrY6jvyhW\nK8e5\r\n=1Wit\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.3.1_1541452631258_0.9082455476227975"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.3.2": {
+      "name": "cacache",
+      "version": "11.3.2",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.3",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.1.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "e2f7cfa65b00d49ad40e6934378221f79159b34f",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.3.2",
+      "_nodeVersion": "10.14.1",
+      "_npmVersion": "6.6.0-next.0",
+      "dist": {
+        "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+        "shasum": "2d81e308e3d258ca38125b676b98b2ac9ce69bfa",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+        "fileCount": 29,
+        "unpackedSize": 111544,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcHTf1CRA9TVsSAnZWagAAMtEQAJTVEcbY8QkjMVhIBBNe\nV7nbRouS62lNStW78eyOqVaakJRH/1w5oe0jzgTm27ItNM1hQae1MJyihDkg\ngs1SE0A9bsUA5IRUyGSmISa0LA/NSMLIYBO3XvLKpY+gLQ7D5enXLHWKbDJ3\nF6x3wpresZZCdynvYtiDz234ofrotdvU/xaIxrxv0laoaJElzPhuRgUShLNe\nYIQxxzF9cNYIYh3he/tiuj90NKYtbOsnHfStrxFneRqx3ynD77l/vdk9tEeM\n4THtgv538k6yN3Nd7ZqSNNTEPEvmIl/ibp5Hb96kiMKctUAsNs907k8LPW/5\nf4c/Jh+SeiIiYR/AjkatC4zWcfhk8Glxac/lNUr3ehwXi3FMTAIp0J0JHpXz\noGUhC1LNDw25Ojjm1EUthBOxLS3HQXMWG/E2Ec4I4QJXE3tYWZs5cch+SvdJ\nLadUCtsewwzMfJocPfGVyh7ujJbKeJ6MT1Lc11TQ9BBpCtjPF4skMK8btWRY\nYLspAHyDEzi7Awu3symh/t9+/4P4fjFchJ2ahGeT64QtoPomezxh8mFhKhnr\niUufymVJWs4O0STKTSpVhBk5Rb/9RVR+RLlss/xuGnBlRuTb7kVCfWCzSQU8\nZKPMIqeC6ZoPCIZ8y09XUrf/RQmMZSwws/PWBSktnLTnMozKyQv4biIvfBNl\nGPMM\r\n=/TH5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.3.2_1545418741005_0.06216671094411241"
+      },
+      "_hasShrinkwrap": false
+    },
+    "11.3.3": {
+      "name": "cacache",
+      "version": "11.3.3",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "886b40f394d5b0879a2aa1bee06326a4265459ee",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@11.3.3",
+      "_nodeVersion": "10.15.3",
+      "_npmVersion": "6.9.1-next.0",
+      "dist": {
+        "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+        "shasum": "8bd29df8c6a718a6ebd2d010da4d7972ae3bbadc",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+        "fileCount": 29,
+        "unpackedSize": 112357,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdB7xwCRA9TVsSAnZWagAALpIP/0hXZCajeHjjzLrBUEV7\n7EUQTQEZym84XZx0B9mgjcr+Ga/udYJjFX2s+omXnxn47sEDh3aN0AHW5n17\nBVon5YDJo8DJRR2QGBPUE/Dr/nDCPZT6Crgk3z59W/iH4BgnlIOCM4N1xZrI\neiQmlyoFw/bDCDMPNw2a3nvYHLBpYMGOrJrGz0ZxklB3WWJbh5eFsO7QNdJN\npTECf/2TU7AtwnJuo7bcD2nyKPW9z04ijV5JnCZKW3GU6yM7KnfvSb4rghep\nL2K1hhmkqt1YlztHXC/jXo6fNiZid37vcQDPVa7muKZXWOEDQexl4DO0WP1x\nAzo3VdObNRInfQp2mmDTnEfKScfEI81zcWMtfq4izWLKLOMl3QkUKGDDCpq9\nl0Gip5INniQ0cbf3Mu5XuBfzQ+f8n16vgIhkwEQj1+vUXhM6wus8td2wyCDo\nk0in7zPMhpNZmy5EI14rZtJuFQ3m9nSJN8SVi/XDcKYqXZT4/FmQZ+2m/WQ4\nzjJxN4Fh/rJFK+3Mf+itcQApjwTQlBshTkcltEeeAXsRKIGNlWApxZaGOkqm\nvxUmctFA3R7avdsmXIIj/AtwHRbGQSpJZBDR8HmuiHFkRu/JK5mmI7ohMewZ\nNkszQFCfcwYGou3dEw8tJVv0/PMUBhWCBiUQJYqdK/+t6jFKhP6dJFd5M7jH\nofMB\r\n=MkeU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "charlotteis",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_11.3.3_1560788079893_0.464903352864831"
+      },
+      "_hasShrinkwrap": false
+    },
+    "12.0.0": {
+      "name": "cacache",
+      "version": "12.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "5e961324fa1c6a39c5889c5d31114886a84586f7",
+      "bugs": {
+        "url": "https://github.com/zkat/cacache/issues"
+      },
+      "homepage": "https://github.com/zkat/cacache#readme",
+      "_id": "cacache@12.0.0",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.10.1",
+      "dist": {
+        "integrity": "sha512-0baf1FhCp16LhN+xDJsOrSiaPDCTD3JegZptVmLDoEbFcT5aT+BeFGt3wcDU3olCP5tpTCXU5sv0+TsKWT9WGQ==",
+        "shasum": "1ed91cc306312a53ad688b1563ce4c416faec564",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.0.tgz",
+        "fileCount": 31,
+        "unpackedSize": 133904,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdLQxECRA9TVsSAnZWagAAnlAP/3tLeWfkXm2trXO+9nFC\nCKLz1Yum8RFhj9BlBNjC/JOWiwb0+s95R+FENdfg8mbuiyBc5SY/HV78C+Dc\ngYvrkg1piAYOna9TK+DdiQ+WafhWQohyq3X6QxatyUvsMaE3yQzo3vYBQmsA\nuZ6U7A3qPZuRaf8A9ryCaSk//EQx8P6eJqY1RmJoSC3axi3CMo6DlxzWa2mA\nEWQXxdMKD1+elGwtjkuO6XFiV6VYX/q1VneXAe5ONpcEtz1N3k77hs0a+YXi\nFCxJ6putj1Z/cIaaRxkVE7woXhTkeB2DqFCPa3DRuDTBrofHlQuH57cXcdAJ\nTwUPMnxwDjn3F8oiRcJuN/bQrrqK4Uuu0nP7SCpmdDudiUhRbTbMO9rjl5b9\nqH0PlECVEO4b6VR4jKQhqQncBRmru4eMaqpCvN9u+aSBEAEZBvQIHoNcR8GJ\nZ2MD+gocXjYctRkKqMTS8V7CuCy64hifepAO64gn/tEpy6y0YOA0I2md/Ig0\nhCs5LaQKKQ5Yit7gQBk8MUZrbm30Jk8k4PdcAzOq7zBwrK6a/Rr+pbnA8sKJ\nAKq1Q9NVbAW6zVHBOcD/2efSwkVgoFD3R/sg17TLEM+JKw9wCNj7GpxrIVMd\nkMhhPkXxfWrItB232gEzo6m7KJDHiUu9lFfpvqTbXf3sw9mnrPUACMZnqdnC\nl28U\r\n=Z5zo\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_12.0.0_1563233347682_0.7510440409614905"
+      },
+      "_hasShrinkwrap": false
+    },
+    "12.0.1": {
+      "name": "cacache",
+      "version": "12.0.1",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/infer-owner": "^1.0.1",
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "1d2cd974154fc98d29c427435d56dc09e293501f",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@12.0.1",
+      "_nodeVersion": "12.6.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-tJtxCdrtecQEmAkTCt8qKZQWANckuD6T7d0EhVUxh9lbggCedG/UoGCEyo5+/vgbpwhEQJ/FHgREsgoObex8Pg==",
+        "shasum": "527af5682b34bebdcde549ff267a4a46f2944857",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.1.tgz",
+        "fileCount": 29,
+        "unpackedSize": 115180,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMkWDCRA9TVsSAnZWagAAUNAQAJ24oeKldNsQiWWNhQqq\n3e2TfwG6w3Xd0g3J4RuU68mPTxXONa8wm6bbmtIropKpSqPVYaNSjm31LNsM\nvm4rnHfbN2iLSys8qBgtrSoDg4qWiC9s9oMhm3HHpuH83nE2eYBy4yfOgVO9\nxKwPfSOE6AJvXvDP1CgETSCIw1Yr5lwu0S+KVZ9SAhK1RbExaOaGXgYtruUE\ncigDd/Nz8Yz+NL+T5EXr8bwhMOfAUetvy7y2a+ikeeUDVaXhuznAloukMyM4\nlAS7QtDA0sFME0LVhvdu1nnWB5q3+yzgTlD/2NAdyVbkP0tLt+T2/1XTe6aS\njCn/AdjRXJPXW7PuTPwr+J1xwwM/MbMW3D9TQ+WEZ+zpzbFMKGyvDLqrszVT\n+TUCh66DXZmnIzl+Gwc8i7wFdpP/zZC6ONvarjyjtDGljpOaytGxc8LUppES\n3zSrFdsPxav+HpOVt2RbesAZ2mhFcNffjSznu24D5pGyIvDDRJLOGsd9dJ7b\nZFNPACU0Jg5LXHigMYe62NIiQBBHqAd61FYU3A6GzAFIWHJKU8GLg9t/I1un\nwWgW9++lfev0R/Ed10V1W8MZZTkxtje3EUgQqjU/Iq/pyhjDsDbg/Je1q9ye\neEJAnMogGD3/N/2XLPqv/w6OIgsImQe4xdBzjyaJ9Ynbjxozm482jg7cZIgg\nSf/q\r\n=QeUk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_12.0.1_1563575682876_0.9849059790812396"
+      },
+      "_hasShrinkwrap": false
+    },
+    "12.0.2": {
+      "name": "cacache",
+      "version": "12.0.2",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "568d7eb5e7429d540a670daf2a9ccde5e9be793e",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@12.0.2",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==",
+        "shasum": "8db03205e36089a3df6954c66ce92541441ac46c",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
+        "fileCount": 29,
+        "unpackedSize": 115251,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMk4MCRA9TVsSAnZWagAARK8QAJADGsGGVtuD7catXO/a\nlqb285/vpwd9ZsHGUepNeMq6p53Hbek47jukUwlMR+e99dbroWfiJ3R/tnLb\nrRcUXzovB7mmmac3Br9JtVBDHKt6G6W/HexkPGdCXDE3lWk+xKax8QUgif4g\nQBc5u6IYnCDEEZRSMMVgLbUr0Cj5bzSvXewk2W9eAoAfjSkQL4HVKwmRUIKd\nKdlt2xQ3QbOYKVsd6jO3tqRzeNyVDwx9W/e6y+SPDYZzeqy2HGsLOguqAr+1\n8BhKDEtqh7hJlMDqY2EMSNokAz0r2Jz7L0N1mf40hfQZibx2dWonmiP8xPFC\nm5j2Zo4tQJlthB+S/UCcLQlgKbIHg7Ww92ZEhZYJFCNo64Pc5vUF0TLJZ6XE\nmtRzT6Ze/vO/08o9RmIyadEUfDOmY/i9larInPNDBkgwdc6UMKlevW975MI1\nLRbogcEWVVJ8NseOLpi0Nzg3IyXva7H+J6v03LvU/u+gcvzjUtSWuEdFxln9\nC2MpQ6BAktlMdz0UA2kljL1E9cvykFBBzEznAChUpmWSqUtBvAtTLWoJpBE/\nERcjOynd7v70SMyUmQ8OsflydFO6dEEHR5U2A4QMlWVaaYGarm5ViABJSo7K\nibCpB7Ef9DhFPGgqzKe/WveSaDxX7WEltT3euzKaVOrjPFrWElRWodSnziuN\nvq/X\r\n=WzUQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_12.0.2_1563577867745_0.7249907864571483"
+      },
+      "_hasShrinkwrap": false
+    },
+    "12.0.3": {
+      "name": "cacache",
+      "version": "12.0.3",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "0cb1aaa333eb4d9e3afca20af143c9f7c9fb3d49",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@12.0.3",
+      "_nodeVersion": "12.6.0",
+      "_npmVersion": "6.10.3",
+      "dist": {
+        "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+        "shasum": "be99abba4e1bf5df461cd5a2c1071fc432573390",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+        "fileCount": 29,
+        "unpackedSize": 115547,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdWvksCRA9TVsSAnZWagAACsEQAJnoOZHbECu0/AKMvHME\nZspR+OhjsI8UyJa0+4bp4419RLpW/J8S5A5AgdnLXZc5+1TRXdd6oVXgqeAW\n7vswR/5SPUeljQYI8DjJELTO2dqbQRxXbeM7LaaJbQBtLMTNpzdhqNnW88/i\nDJVgUUX7hPKHVS2rRa2WbGmR5Qi92be6Q73pCdD+t1nZBc2baaPMEQzzOylk\niXM4CO96ZHLOggn95U1f2AL1RQy1pzWC/9muMpG8Yu0YIJ5JBlF60vjGTkwO\nhdrWFcy3ARZ3tjWIEIQkh2Tet/3yW1dKzk/8DnKwoJ6C+8RhUj43+fOvrOFD\nHvfk4BFZ0Dz3EW2Je83Bj0kjdvNtxZlvwH+BA6Nkq7/uNwiWP+os0A0knE0Q\njlE+Wp5LgJHAvMW95mEyMR0dtzsZ9RFM2oYDPkpLxl2LUAQ2wFQ+mqS9phIl\n3CBWb62xjgrRbh+CbqnUa44y/sU4kXFEzJs2nFj8EAZo1avF4OAsmue1Zr07\n8QKKX2JIyy9KGEhZ/rnQ5dWMJRpPjD5JzY4ejypxnxZgW9QP7h3BXnpkK/zr\nHStpZ2DH4AB8F7/Gf8cm8EcHi6c0MdlIZazJXEUgIURYkr2T0JFUlCp9b6at\nZBLn17XqPSvdewCedGvqGVOuwttsDIKz2F6iwRPXsJpx+5+zZjOQS2zKPSLu\nT60S\r\n=qek1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "anne@npmjs.com",
+          "name": "annekimsey"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_12.0.3_1566243114847_0.27856964581226906"
+      },
+      "_hasShrinkwrap": false
+    },
+    "13.0.0": {
+      "name": "cacache",
+      "version": "13.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "fs-minipass": "^1.2.7",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^2.6.5",
+        "minipass-collect": "^1.0.1",
+        "minipass-flush": "^1.0.3",
+        "minipass-pipeline": "^1.1.2",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^7.0.0",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.2.1",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.6.4",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "nyc": {
+        "branches": 70,
+        "lines": 80,
+        "functions": 80,
+        "statements": 80,
+        "exclude": [
+          "node_modules/**",
+          "coverage/**",
+          "test/**"
+        ]
+      },
+      "gitHead": "63ef08d2c6e537b8e71e2b1bfa7ea5fd6837c644",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@13.0.0",
+      "_nodeVersion": "12.10.0",
+      "_npmVersion": "6.11.3",
+      "_npmUser": {
+        "name": "ruyadorno",
+        "email": "ruyadorno@hotmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-hc9ozSyxintw3TulgdYl5q3ZMjugHYI8lE5hd1S6E1/7OwLf0vNlBdCaROlzHxE5x0lUpFx+B3iMjWmcHDRxiQ==",
+        "shasum": "1797c957bcddf7bc697520920e3a284e64fc21cc",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-13.0.0.tgz",
+        "fileCount": 22,
+        "unpackedSize": 98894,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdi7oJCRA9TVsSAnZWagAAFOwP/RQ3pTGWJG1yIPEKsQRs\nRkJfdtfM71vfEFkbcVXnPZGUTh73Q2LiQVxnaKjTcdkSIVl/wnhkcMCAuElK\n/yGOey19J+JJXVwU2dmT0wV8ZkV2bh/rqALk05pSVN5M8Vo0+lPheTxZn7an\nJhJhDQaYVzi9K0Jl/cUWd5PgrxVbFHOUCiwPUZrMAvTv4uaMeqDVjiOwbGYn\nozsUslwOHlBTtoB8BWcb7em7S0K35iq/FlD129zgFfsUWOnc7tPP24ShukaO\nTGfl+8ay7dxQ7C0JncowStCrNDivBC+Zzj5tHRg9VPTV5cwSDfJfcm5VFKfo\nVBYr1Wn319tnXuOwsNZdrUH6D7Kg8nlk49lrV5Eq5vleZgzgF+7BPQX8z9Y4\nuz0dayrINZcK3eG3n0PJmlPTthPJU8nlVUMp5fGmuJSV/WhUkx9OTNEl3eMz\nALVLAF0CGdbuXtGrlygLXxX3cpl4eX/l++g8EDMztjrjezHCa7Ot+CFunPpw\nr3c4oFrVlPVpO1eW7KrKEI41rlYJVg3q3UfPI6Or12EbXQZu1lRkv9WamIEV\n2Ggr+jCplkfoBOZ6zduwJ5RqSOmkXrv8MqZREWecPhO2rOgUE7Kf3sufehwJ\niK/F+hrecwbTNSEMSmRI0giM72YQ6ymr7OJjaC+R7iC4AC6j9iVQSYRm+x05\nSs35\r\n=si4Q\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "anne@npmjs.com",
+          "name": "annekimsey"
+        },
+        {
+          "email": "billatnpm@gmail.com",
+          "name": "billatnpm"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "mike@mikecorp.ca",
+          "name": "mikemimik"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_13.0.0_1569438216725_0.6681915916397869"
+      },
+      "_hasShrinkwrap": false
+    },
+    "13.0.1": {
+      "name": "cacache",
+      "version": "13.0.1",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^7.0.0",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.2.1",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.6.9",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      },
+      "gitHead": "a931c99a1063c93946104e976b37e8faa824d957",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@13.0.1",
+      "_nodeVersion": "12.8.1",
+      "_npmVersion": "6.12.0-next.0",
+      "dist": {
+        "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+        "shasum": "a8000c21697089082f85287a1aec6e382024a71c",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
+        "fileCount": 22,
+        "unpackedSize": 99047,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdkm1eCRA9TVsSAnZWagAASTUP/jEBg8ZJhAowxxM44jkE\nHyrFqRUlvQaF463jFtK9zqHpCdPXxwmT6lgnPOg1OKwawt9ZYWyF1rVvV4bd\nIzR7GVqI3THIDI1g7JjlRbdItTN0412o8B0Jz+8wjMGwyaVk7uP5Lz9GWOAB\nPnMUhDcUUCK5hsEqh8JHbAJrfs8mZkrQX7HYNTYnWQEWnB7OQ8xZp/CNEioa\n7BJQ+NyEvjxbPL4UGtpROtGJ/WO2pU3hG6gdxKQ2X2DhEv2n5aRr4qMGY7//\nfTgAZfYHyfbHNQCEzMv6+dPAi0SI7e0wYTqY/eZM8Hm5BCOah63muml6+/1o\nySBrJv+j2ZOXBQLCdFGcEgYt7CQWBtwRZ39MFtOB8iK6RXkUTNmlmV3DMgLs\nyHYkxtIjc2WkrnjjcKsGFuzhug3tBpDQ26F8w9K1d0Vba9h0ULGUKDh2Lu6p\nyih3S6Hh4xB+SUgeKyeAJ08kTT6xLwGM2Ufv+Ry9hZgPXqQG3xcWCW6QFmVR\n2LolngiVqK4IeCCXATOjx45qARE4foj+1ZBksX/x6Vk4WiSA1N7dV6TxrmZ+\n3oFJM99uJ1xwfkduuTImvl1NbFAcR+KX5boaLJXgW0MfbMfFGu8A7/sN/QSo\nRb3qq48G7bE+PNNf1yxQCcxSlD9M0tf0JApNItZsjnh2tKJQ/sKWw3/jF1/X\nl3qb\r\n=0KSH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "anne@npmjs.com",
+          "name": "annekimsey"
+        },
+        {
+          "email": "billatnpm@gmail.com",
+          "name": "billatnpm"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "mike@mikecorp.ca",
+          "name": "mikemimik"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_13.0.1_1569877341577_0.9708965806445355"
+      },
+      "_hasShrinkwrap": false
+    },
+    "14.0.0": {
+      "name": "cacache",
+      "version": "14.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^7.0.0",
+        "tar": "^6.0.0",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.2.1",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.6.9",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "tap": {
+        "100": true
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "gitHead": "9ab38aae2b1bde96c5bccfaf071046fc5f49d393",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@14.0.0",
+      "_nodeVersion": "13.4.0",
+      "_npmVersion": "6.13.6",
+      "dist": {
+        "integrity": "sha512-+Nr/BnA/tjAUXza9gH8F+FSP+1HvWqCKt4c95dQr4EDVJVafbzmPZpLKCkLYexs6vSd2B/1TOXrAoNnqVPfvRA==",
+        "shasum": "97c10fc87c4c7ee41d45e32631c26761c2687caa",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-14.0.0.tgz",
+        "fileCount": 22,
+        "unpackedSize": 99805,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeL5PGCRA9TVsSAnZWagAA8nMP/iK0X+XlNwoBSzN/WdZX\nfec0Nm8KGGqVTRU6JCwgLu6KWcxkrEUKhaakRm1EpIH2buhemPAKl+M6/uIP\nLF+YXtKr4LvkNk5PS8jZmBvC6OG151ng73c5I2BqHf9HSmpl5iknADbtoII3\nXQEujXetENEr3UYWdkRrnI+kkI+sIl26sFaICVPWc1GYIIJN3JQRJW/tGLu8\no0d7fvx5WTZZ21NFWmJdqJjhowmONjIJ9rorahB581r1guMTjbt9Mpv+556X\nkMoX+uC37npY4ilz74AAOkzn26X0Wo9TZcXooIc2R28yPHjOLhugGKrrMpfh\nK7pbz8w6EzZ5QtSCuR2goiW1MJ4NGweuiYYPlH5zWUzrfLNgZPcDSL+3C7To\nH7shSK+vXbwoqeC33l5KGCwK0PqgzDBsGCRAcy2li33KTVxnbwGE9Z5i4piB\nJ2jy5hNiD8cYOjsk24cB/7LOQVtszGJOU42T7yhthnjAt8SBYVaVENIXjKEE\nWE5yAcpNTg6phmc1JVl8C6rEW09amaB46KeepUUfu1lRY8ecWdKR7JhjGJV9\n6aSoWvzatfwh0KBGmpUuXgB3JkbZI5dVe4ADwWNrJmRXGuOmgeu6ECmjWgEJ\nLkghjo0s7DLah1XdIAptbXp2vBFNqEsVP/BWihy4MUA6Q99VpCcfmXx/Xr1O\nhbDA\r\n=+lX4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "mike@mikecorp.ca",
+          "name": "mikemimik"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_14.0.0_1580176326012_0.7801106723175186"
+      },
+      "_hasShrinkwrap": false
+    },
+    "15.0.0": {
+      "name": "cacache",
+      "version": "15.0.0",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "lint": "standard",
+        "postrelease": "npm publish",
+        "posttest": "npm run lint",
+        "prepublishOnly": "git push --follow-tags",
+        "prerelease": "npm t",
+        "release": "standard-version -s",
+        "test": "tap",
+        "coverage": "tap",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^1.1.2",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.1",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "tap": {
+        "100": true,
+        "test-regex": "test/[^/]*.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "gitHead": "f9c677b8b37989a6466372277fb312dc8d48e01f",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@15.0.0",
+      "_nodeVersion": "13.7.0",
+      "_npmVersion": "6.13.6",
+      "dist": {
+        "integrity": "sha512-L0JpXHhplbJSiDGzyJJnJCTL7er7NzbBgxzVqLswEb4bO91Zbv17OUMuUeu/q0ZwKn3V+1HM4wb9tO4eVE/K8g==",
+        "shasum": "133b59edbd2a37ea8ef2d54964c6f247e47e5059",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.0.tgz",
+        "fileCount": 23,
+        "unpackedSize": 120578,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeSz78CRA9TVsSAnZWagAArukP/jRhV5YGJdPCbGIvTj1j\nQyYUmmnISqQXuw+0Q9TOWGMOTaV+sQzRq0vZted8xaDiK4micGHFHlW+/ZPY\niFlz/l9vtv09+5TkhakTCR1X+URAcylN+tfTkKDVMptVhTvVuhosKRD80HjM\nHxdr5P2SlaOKaGlfsFeqFzMKIo/8LQTgLyrC/Yd5NiluoOihps0xi5Jy9PX4\nLTIkmWNe7SyT9Ygg8jtgAVtnh3jOupj0yMenuojd+EcwLtjsK1dbJHUHrvy8\nZfYLcGybJnl4eG/52cJoTRQcxZkNquDEghSY6KhFOXdAS+e9LeJiNK8T+8zd\nHQdLmXrDhv1/2yyrH1SsbdL8xBOc2ipOvVmVan9zL8Wh0lMSt3ipMme2hzIJ\nNmjqlIdh1dK/uJF3QcOMsyDlsa3Ra6jCtBTC2fgZWM2VG8AxdgV8CBoNX79S\nNa/wXUfY+AveixvvXHo0nD4XJo/WVIVYFqhM0Q4BSH9DeYHLbrPVBf3AGs10\nSiyzqzZ7YKQ2a7QCfvrLBtUro/YBgu0TWFFsAwqc0UH2GuW06Cu7b5uoKyc9\n4+rlNfXvBD0FJVw0w/3OB4RjT/Y/StY9tldvGuPcEj80WlzbXMO6RQNwpEli\nS/wPceAF/hDAdW3SCdYRhSI08lfToY/C+H4RUVExwsgzxW/shuUvDIrE8uD1\nJZsc\r\n=w3RA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "mike@mikecorp.ca",
+          "name": "mikemimik"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_15.0.0_1581989628316_0.35215341493957464"
+      },
+      "_hasShrinkwrap": false
+    },
+    "12.0.4": {
+      "name": "cacache",
+      "publishConfig": {
+        "tag": "legacy"
+      },
+      "version": "12.0.4",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "cross-env CACACHE_UPDATE_LOCALE_FILES=true tap --coverage --nyc-arg=--all -J test/*.js",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "readme": "# cacache [![npm version](https://img.shields.io/npm/v/cacache.svg)](https://npm.im/cacache) [![license](https://img.shields.io/npm/l/cacache.svg)](https://npm.im/cacache) [![Travis](https://img.shields.io/travis/zkat/cacache.svg)](https://travis-ci.org/zkat/cacache) [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/zkat/cacache?svg=true)](https://ci.appveyor.com/project/zkat/cacache) [![Coverage Status](https://coveralls.io/repos/github/zkat/cacache/badge.svg?branch=latest)](https://coveralls.io/github/zkat/cacache?branch=latest)\n\n[`cacache`](https://github.com/zkat/cacache) es una librería de Node.js para\nmanejar caches locales en disco, con acceso tanto con claves únicas como\ndirecciones de contenido (hashes/hacheos). Es súper rápida, excelente con el\nacceso concurrente, y jamás te dará datos incorrectos, aún si se corrompen o\nmanipulan directamente los ficheros del cache.\n\nEl propósito original era reemplazar el caché local de\n[npm](https://npm.im/npm), pero se puede usar por su propia cuenta.\n\n_Traducciones: [English](README.md)_\n\n## Instalación\n\n`$ npm install --save cacache`\n\n## Índice\n\n* [Ejemplo](#ejemplo)\n* [Características](#características)\n* [Cómo Contribuir](#cómo-contribuir)\n* [API](#api)\n  * [Usando el API en español](#localized-api)\n  * Leer\n    * [`ls`](#ls)\n    * [`ls.flujo`](#ls-stream)\n    * [`saca`](#get-data)\n    * [`saca.flujo`](#get-stream)\n    * [`saca.info`](#get-info)\n    * [`saca.tieneDatos`](#get-hasContent)\n  * Escribir\n    * [`mete`](#put-data)\n    * [`mete.flujo`](#put-stream)\n    * [opciones para `mete*`](#put-options)\n    * [`rm.todo`](#rm-all)\n    * [`rm.entrada`](#rm-entry)\n    * [`rm.datos`](#rm-content)\n  * Utilidades\n    * [`ponLenguaje`](#set-locale)\n    * [`limpiaMemoizado`](#clear-memoized)\n    * [`tmp.hazdir`](#tmp-mkdir)\n    * [`tmp.conTmp`](#with-tmp)\n  * Integridad\n    * [Subresource Integrity](#integrity)\n    * [`verifica`](#verify)\n    * [`verifica.ultimaVez`](#verify-last-run)\n\n### Ejemplo\n\n```javascript\nconst cacache = require('cacache/es')\nconst fs = require('fs')\n\nconst tarbol = '/ruta/a/mi-tar.tgz'\nconst rutaCache = '/tmp/my-toy-cache'\nconst clave = 'mi-clave-única-1234'\n\n// ¡Añádelo al caché! Usa `rutaCache` como raíz del caché.\ncacache.mete(rutaCache, clave, '10293801983029384').then(integrity => {\n  console.log(`Saved content to ${rutaCache}.`)\n})\n\nconst destino = '/tmp/mytar.tgz'\n\n// Copia el contenido del caché a otro fichero, pero esta vez con flujos.\ncacache.saca.flujo(\n  rutaCache, clave\n).pipe(\n  fs.createWriteStream(destino)\n).on('finish', () => {\n  console.log('extracción completada')\n})\n\n// La misma cosa, pero accesando el contenido directamente, sin tocar el índice.\ncacache.saca.porHacheo(rutaCache, integridad).then(datos => {\n  fs.writeFile(destino, datos, err => {\n    console.log('datos del tarbol sacados basado en su sha512, y escrito a otro fichero')\n  })\n})\n```\n\n### Características\n\n* Extracción por clave o por dirección de contenido (shasum, etc)\n* Usa el estándard de web, [Subresource Integrity](#integrity)\n* Compatible con multiples algoritmos - usa sha1, sha512, etc, en el mismo caché sin problema\n* Entradas con contenido idéntico comparten ficheros\n* Tolerancia de fallas (inmune a corrupción, ficheros parciales, carreras de proceso, etc)\n* Verificación completa de datos cuando (escribiendo y leyendo)\n* Concurrencia rápida, segura y \"lockless\"\n* Compatible con `stream`s (flujos)\n* Compatible con `Promise`s (promesas)\n* Bastante rápida -- acceso, incluyendo verificación, en microsegundos\n* Almacenaje de metadatos arbitrarios\n* Colección de basura y verificación adicional fuera de banda\n* Cobertura rigurosa de pruebas\n* Probablente hay un \"Bloom filter\" por ahí en algún lado. Eso le mola a la gente, ¿Verdad? 🤔\n\n### Cómo Contribuir\n\nEl equipo de cacache felizmente acepta contribuciones de código y otras maneras de participación. ¡Hay muchas formas diferentes de contribuir! La [Guía de Colaboradores](CONTRIBUTING.md) (en inglés) tiene toda la información que necesitas para cualquier tipo de contribución: todo desde cómo reportar errores hasta cómo someter parches con nuevas características. Con todo y eso, no se preocupe por si lo que haces está exáctamente correcto: no hay ningún problema en hacer preguntas si algo no está claro, o no lo encuentras.\n\nEl equipo de cacache tiene miembros hispanohablantes: es completamente aceptable crear `issues` y `pull requests` en español/castellano.\n\nTodos los participantes en este proyecto deben obedecer el [Código de Conducta](CODE_OF_CONDUCT.md) (en inglés), y en general actuar de forma amable y respetuosa mientras participan en esta comunidad.\n\nPor favor refiérase al [Historial de Cambios](CHANGELOG.md) (en inglés) para detalles sobre cambios importantes incluídos en cada versión.\n\nFinalmente, cacache tiene un sistema de localización de lenguaje. Si te interesa añadir lenguajes o mejorar los que existen, mira en el directorio `./locales` para comenzar.\n\nHappy hacking!\n\n### API\n\n#### <a name=\"localized-api\"></a> Usando el API en español\n\ncacache incluye una traducción completa de su API al castellano, con las mismas\ncaracterísticas. Para usar el API como está documentado en este documento, usa\n`require('cacache/es')`\n\ncacache también tiene otros lenguajes: encuéntralos bajo `./locales`, y podrás\nusar el API en ese lenguaje con `require('cacache/<lenguaje>')`\n\n#### <a name=\"ls\"></a> `> cacache.ls(cache) -> Promise<Object>`\n\nEnumera todas las entradas en el caché, dentro de un solo objeto. Cada entrada\nen el objeto tendrá como clave la clave única usada para el índice, el valor\nsiendo un objeto de [`saca.info`](#get-info).\n\n##### Ejemplo\n\n```javascript\ncacache.ls(rutaCache).then(console.log)\n// Salida\n{\n  'my-thing': {\n    key: 'my-thing',\n    integrity: 'sha512-BaSe64/EnCoDED+HAsh=='\n    path: '.testcache/content/deadbeef', // unido con `rutaCache`\n    time: 12345698490,\n    size: 4023948,\n    metadata: {\n      name: 'blah',\n      version: '1.2.3',\n      description: 'this was once a package but now it is my-thing'\n    }\n  },\n  'other-thing': {\n    key: 'other-thing',\n    integrity: 'sha1-ANothER+hasH=',\n    path: '.testcache/content/bada55',\n    time: 11992309289,\n    size: 111112\n  }\n}\n```\n\n#### <a name=\"ls-stream\"></a> `> cacache.ls.flujo(cache) -> Readable`\n\nEnumera todas las entradas en el caché, emitiendo un objeto de\n[`saca.info`](#get-info) por cada evento de `data` en el flujo.\n\n##### Ejemplo\n\n```javascript\ncacache.ls.flujo(rutaCache).on('data', console.log)\n// Salida\n{\n  key: 'my-thing',\n  integrity: 'sha512-BaSe64HaSh',\n  path: '.testcache/content/deadbeef', // unido con `rutaCache`\n  time: 12345698490,\n  size: 13423,\n  metadata: {\n    name: 'blah',\n    version: '1.2.3',\n    description: 'this was once a package but now it is my-thing'\n  }\n}\n\n{\n  key: 'other-thing',\n  integrity: 'whirlpool-WoWSoMuchSupport',\n  path: '.testcache/content/bada55',\n  time: 11992309289,\n  size: 498023984029\n}\n\n{\n  ...\n}\n```\n\n#### <a name=\"get-data\"></a> `> cacache.saca(cache, clave, [ops]) -> Promise({data, metadata, integrity})`\n\nDevuelve un objeto con los datos, hacheo de integridad y metadatos identificados\npor la `clave`. La propiedad `data` de este objeto será una instancia de\n`Buffer` con los datos almacenados en el caché. to do with it! cacache just\nwon't care.\n\n`integrity` es un `string` de [Subresource Integrity](#integrity). Dígase, un\n`string` que puede ser usado para verificar a la `data`, que tiene como formato\n`<algoritmo>-<hacheo-integridad-base64>`.\n\nSo no existe ninguna entrada identificada por `clave`, o se los datos\nalmacenados localmente fallan verificación, el `Promise` fallará.\n\nUna sub-función, `saca.porHacheo`, tiene casi el mismo comportamiento, excepto\nque busca entradas usando el hacheo de integridad, sin tocar el índice general.\nEsta versión *sólo* devuelve `data`, sin ningún objeto conteniéndola.\n\n##### Nota\n\nEsta función lee la entrada completa a la memoria antes de devolverla. Si estás\nalmacenando datos Muy Grandes, es posible que [`saca.flujo`](#get-stream) sea\nuna mejor solución.\n\n##### Ejemplo\n\n```javascript\n// Busca por clave\ncache.saca(rutaCache, 'my-thing').then(console.log)\n// Salida:\n{\n  metadata: {\n    thingName: 'my'\n  },\n  integrity: 'sha512-BaSe64HaSh',\n  data: Buffer#<deadbeef>,\n  size: 9320\n}\n\n// Busca por hacheo\ncache.saca.porHacheo(rutaCache, 'sha512-BaSe64HaSh').then(console.log)\n// Salida:\nBuffer#<deadbeef>\n```\n\n#### <a name=\"get-stream\"></a> `> cacache.saca.flujo(cache, clave, [ops]) -> Readable`\n\nDevuelve un [Readable\nStream](https://nodejs.org/api/stream.html#stream_readable_streams) de los datos\nalmacenados bajo `clave`.\n\nSo no existe ninguna entrada identificada por `clave`, o se los datos\nalmacenados localmente fallan verificación, el `Promise` fallará.\n\n`metadata` y `integrity` serán emitidos como eventos antes de que el flujo\ncierre.\n\nUna sub-función, `saca.flujo.porHacheo`, tiene casi el mismo comportamiento,\nexcepto que busca entradas usando el hacheo de integridad, sin tocar el índice\ngeneral. Esta versión no emite eventos de `metadata` o `integrity`.\n\n##### Ejemplo\n\n```javascript\n// Busca por clave\ncache.saca.flujo(\n  rutaCache, 'my-thing'\n).on('metadata', metadata => {\n  console.log('metadata:', metadata)\n}).on('integrity', integrity => {\n  console.log('integrity:', integrity)\n}).pipe(\n  fs.createWriteStream('./x.tgz')\n)\n// Salidas:\nmetadata: { ... }\nintegrity: 'sha512-SoMeDIGest+64=='\n\n// Busca por hacheo\ncache.saca.flujo.porHacheo(\n  rutaCache, 'sha512-SoMeDIGest+64=='\n).pipe(\n  fs.createWriteStream('./x.tgz')\n)\n```\n\n#### <a name=\"get-info\"></a> `> cacache.saca.info(cache, clave) -> Promise`\n\nBusca la `clave` en el índice del caché, devolviendo información sobre la\nentrada si existe.\n\n##### Campos\n\n* `key` - Clave de la entrada. Igual al argumento `clave`.\n* `integrity` - [hacheo de Subresource Integrity](#integrity) del contenido al que se refiere esta entrada.\n* `path` - Dirección del fichero de datos almacenados, unida al argumento `cache`.\n* `time` - Hora de creación de la entrada\n* `metadata` - Metadatos asignados a esta entrada por el usuario\n\n##### Ejemplo\n\n```javascript\ncacache.saca.info(rutaCache, 'my-thing').then(console.log)\n\n// Salida\n{\n  key: 'my-thing',\n  integrity: 'sha256-MUSTVERIFY+ALL/THINGS=='\n  path: '.testcache/content/deadbeef',\n  time: 12345698490,\n  size: 849234,\n  metadata: {\n    name: 'blah',\n    version: '1.2.3',\n    description: 'this was once a package but now it is my-thing'\n  }\n}\n```\n\n#### <a name=\"get-hasContent\"></a> `> cacache.saca.tieneDatos(cache, integrity) -> Promise`\n\nBusca un [hacheo Subresource Integrity](#integrity) en el caché. Si existe el\ncontenido asociado con `integrity`, devuelve un objeto con dos campos: el hacheo\n_específico_ que se usó para la búsqueda, `sri`, y el tamaño total del\ncontenido, `size`. Si no existe ningún contenido asociado con `integrity`,\ndevuelve `false`.\n\n##### Ejemplo\n\n```javascript\ncacache.saca.tieneDatos(rutaCache, 'sha256-MUSTVERIFY+ALL/THINGS==').then(console.log)\n\n// Salida\n{\n  sri: {\n    source: 'sha256-MUSTVERIFY+ALL/THINGS==',\n    algorithm: 'sha256',\n    digest: 'MUSTVERIFY+ALL/THINGS==',\n    options: []\n  },\n  size: 9001\n}\n\ncacache.saca.tieneDatos(rutaCache, 'sha521-NOT+IN/CACHE==').then(console.log)\n\n// Salida\nfalse\n```\n\n#### <a name=\"put-data\"></a> `> cacache.mete(cache, clave, datos, [ops]) -> Promise`\n\nInserta `datos` en el caché. El `Promise` devuelto se resuelve con un hacheo\n(generado conforme a [`ops.algorithms`](#optsalgorithms)) después que la entrada\nhaya sido escrita en completo.\n\n##### Ejemplo\n\n```javascript\nfetch(\n  'https://registry.npmjs.org/cacache/-/cacache-1.0.0.tgz'\n).then(datos => {\n  return cacache.mete(rutaCache, 'registry.npmjs.org|cacache@1.0.0', datos)\n}).then(integridad => {\n  console.log('el hacheo de integridad es', integridad)\n})\n```\n\n#### <a name=\"put-stream\"></a> `> cacache.mete.flujo(cache, clave, [ops]) -> Writable`\n\nDevuelve un [Writable\nStream](https://nodejs.org/api/stream.html#stream_writable_streams) que inserta\nal caché los datos escritos a él. Emite un evento `integrity` con el hacheo del\ncontenido escrito, cuando completa.\n\n##### Ejemplo\n\n```javascript\nrequest.get(\n  'https://registry.npmjs.org/cacache/-/cacache-1.0.0.tgz'\n).pipe(\n  cacache.mete.flujo(\n    rutaCache, 'registry.npmjs.org|cacache@1.0.0'\n  ).on('integrity', d => console.log(`integrity digest is ${d}`))\n)\n```\n\n#### <a name=\"put-options\"></a> `> opciones para cacache.mete`\n\nLa funciones `cacache.mete` tienen un número de opciones en común.\n\n##### `ops.metadata`\n\nMetadatos del usuario que se almacenarán con la entrada.\n\n##### `ops.size`\n\nEl tamaño declarado de los datos que se van a insertar. Si es proveído, cacache\nverificará que los datos escritos sean de ese tamaño, o si no, fallará con un\nerror con código `EBADSIZE`.\n\n##### `ops.integrity`\n\nEl hacheo de integridad de los datos siendo escritos.\n\nSi es proveído, y los datos escritos no le corresponden, la operación fallará\ncon un error con código `EINTEGRITY`.\n\n`ops.algorithms` no tiene ningún efecto si esta opción está presente.\n\n##### `ops.algorithms`\n\nPor Defecto: `['sha512']`\n\nAlgoritmos que se deben usar cuando se calcule el hacheo de [subresource\nintegrity](#integrity) para los datos insertados. Puede usar cualquier algoritmo\nenumerado en `crypto.getHashes()`.\n\nPor el momento, sólo se acepta un algoritmo (dígase, un array con exáctamente un\nvalor). No tiene ningún efecto si `ops.integrity` también ha sido proveido.\n\n##### `ops.uid`/`ops.gid`\n\nSi están presentes, cacache hará todo lo posible para asegurarse que todos los\nficheros creados en el proceso de sus operaciones en el caché usen esta\ncombinación en particular.\n\n##### `ops.memoize`\n\nPor Defecto: `null`\n\nSi es verdad, cacache tratará de memoizar los datos de la entrada en memoria. La\npróxima vez que el proceso corriente trate de accesar los datos o entrada,\ncacache buscará en memoria antes de buscar en disco.\n\nSi `ops.memoize` es un objeto regular o un objeto como `Map` (es decir, un\nobjeto con métodos `get()` y `set()`), este objeto en sí sera usado en vez del\ncaché de memoria global. Esto permite tener lógica específica a tu aplicación\nencuanto al almacenaje en memoria de tus datos.\n\nSi quieres asegurarte que los datos se lean del disco en vez de memoria, usa\n`memoize: false` cuando uses funciones de `cacache.saca`.\n\n#### <a name=\"rm-all\"></a> `> cacache.rm.todo(cache) -> Promise`\n\nBorra el caché completo, incluyendo ficheros temporeros, ficheros de datos, y el\níndice del caché.\n\n##### Ejemplo\n\n```javascript\ncacache.rm.todo(rutaCache).then(() => {\n  console.log('THE APOCALYPSE IS UPON US 😱')\n})\n```\n\n#### <a name=\"rm-entry\"></a> `> cacache.rm.entrada(cache, clave) -> Promise`\n\nAlias: `cacache.rm`\n\nBorra la entrada `clave` del índuce. El contenido asociado con esta entrada\nseguirá siendo accesible por hacheo usando\n[`saca.flujo.porHacheo`](#get-stream).\n\nPara borrar el contenido en sí, usa [`rm.datos`](#rm-content). Si quieres hacer\nesto de manera más segura (pues ficheros de contenido pueden ser usados por\nmultiples entradas), usa [`verifica`](#verify) para borrar huérfanos.\n\n##### Ejemplo\n\n```javascript\ncacache.rm.entrada(rutaCache, 'my-thing').then(() => {\n  console.log('I did not like it anyway')\n})\n```\n\n#### <a name=\"rm-content\"></a> `> cacache.rm.datos(cache, integrity) -> Promise`\n\nBorra el contenido identificado por `integrity`. Cualquier entrada que se\nrefiera a este contenido quedarán huérfanas y se invalidarán si se tratan de\naccesar, al menos que contenido idéntico sea añadido bajo `integrity`.\n\n##### Ejemplo\n\n```javascript\ncacache.rm.datos(rutaCache, 'sha512-SoMeDIGest/IN+BaSE64==').then(() => {\n  console.log('los datos para `mi-cosa` se borraron')\n})\n```\n\n#### <a name=\"set-locale\"></a> `> cacache.ponLenguaje(locale)`\n\nConfigura el lenguaje usado para mensajes y errores de cacache. La lista de\nlenguajes disponibles está en el directorio `./locales` del proyecto.\n\n_Te interesa añadir más lenguajes? [Somete un PR](CONTRIBUTING.md)!_\n\n#### <a name=\"clear-memoized\"></a> `> cacache.limpiaMemoizado()`\n\nCompletamente reinicializa el caché de memoria interno. Si estás usando tu\npropio objecto con `ops.memoize`, debes hacer esto de manera específica a él.\n\n#### <a name=\"tmp-mkdir\"></a> `> tmp.hazdir(cache, ops) -> Promise<Path>`\n\nAlias: `tmp.mkdir`\n\nDevuelve un directorio único dentro del directorio `tmp` del caché.\n\nUna vez tengas el directorio, es responsabilidad tuya asegurarte que todos los\nficheros escrito a él sean creados usando los permisos y `uid`/`gid` concordante\ncon el caché. Si no, puedes pedirle a cacache que lo haga llamando a\n[`cacache.tmp.fix()`](#tmp-fix). Esta función arreglará todos los permisos en el\ndirectorio tmp.\n\nSi quieres que cacache limpie el directorio automáticamente cuando termines, usa\n[`cacache.tmp.conTmp()`](#with-tpm).\n\n##### Ejemplo\n\n```javascript\ncacache.tmp.mkdir(cache).then(dir => {\n  fs.writeFile(path.join(dir, 'blablabla'), Buffer#<1234>, ...)\n})\n```\n\n#### <a name=\"with-tmp\"></a> `> tmp.conTmp(cache, ops, cb) -> Promise`\n\nCrea un directorio temporero con [`tmp.mkdir()`](#tmp-mkdir) y ejecuta `cb` con\nél como primer argumento. El directorio creado será removido automáticamente\ncuando el valor devolvido por `cb()` se resuelva.\n\nLas mismas advertencias aplican en cuanto a manejando permisos para los ficheros\ndentro del directorio.\n\n##### Ejemplo\n\n```javascript\ncacache.tmp.conTmp(cache, dir => {\n  return fs.writeFileAsync(path.join(dir, 'blablabla'), Buffer#<1234>, ...)\n}).then(() => {\n  // `dir` no longer exists\n})\n```\n\n#### <a name=\"integrity\"></a> Hacheos de Subresource Integrity\n\ncacache usa strings que siguen la especificación de [Subresource Integrity\nspec](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).\n\nEs decir, donde quiera cacache espera un argumento o opción `integrity`, ese\nstring debería usar el formato `<algoritmo>-<hacheo-base64>`.\n\nUna variación importante sobre los hacheos que cacache acepta es que acepta el\nnombre de cualquier algoritmo aceptado por el proceso de Node.js donde se usa.\nPuedes usar `crypto.getHashes()` para ver cuales están disponibles.\n\n##### Generando tus propios hacheos\n\nSi tienes un `shasum`, en general va a estar en formato de string hexadecimal\n(es decir, un `sha1` se vería como algo así:\n`5f5513f8822fdbe5145af33b64d8d970dcf95c6e`).\n\nPara ser compatible con cacache, necesitas convertir esto a su equivalente en\nsubresource integrity. Por ejemplo, el hacheo correspondiente al ejemplo\nanterior sería: `sha1-X1UT+IIv2+UUWvM7ZNjZcNz5XG4=`.\n\nPuedes usar código así para generarlo por tu cuenta:\n\n```javascript\nconst crypto = require('crypto')\nconst algoritmo = 'sha512'\nconst datos = 'foobarbaz'\n\nconst integrity = (\n  algorithm +\n  '-' +\n  crypto.createHash(algoritmo).update(datos).digest('base64')\n)\n```\n\nTambién puedes usar [`ssri`](https://npm.im/ssri) para deferir el trabajo a otra\nlibrería que garantiza que todo esté correcto, pues maneja probablemente todas\nlas operaciones que tendrías que hacer con SRIs, incluyendo convirtiendo entre\nhexadecimal y el formato SRI.\n\n#### <a name=\"verify\"></a> `> cacache.verifica(cache, ops) -> Promise`\n\nExamina y arregla tu caché:\n\n* Limpia entradas inválidas, huérfanas y corrompidas\n* Te deja filtrar cuales entradas retener, con tu propio filtro\n* Reclama cualquier ficheros de contenido sin referencias en el índice\n* Verifica integridad de todos los ficheros de contenido y remueve los malos\n* Arregla permisos del caché\n* Remieve el directorio `tmp` en el caché, y todo su contenido.\n\nCuando termine, devuelve un objeto con varias estadísticas sobre el proceso de\nverificación, por ejemplo la cantidad de espacio de disco reclamado, el número\nde entradas válidas, número de entradas removidas, etc.\n\n##### Opciones\n\n* `ops.uid` - uid para asignarle al caché y su contenido\n* `ops.gid` - gid para asignarle al caché y su contenido\n* `ops.filter` - recibe una entrada como argumento. Devuelve falso para removerla. Nota: es posible que esta función sea invocada con la misma entrada más de una vez.\n\n##### Example\n\n```sh\necho somegarbage >> $RUTACACHE/content/deadbeef\n```\n\n```javascript\ncacache.verifica(rutaCache).then(stats => {\n  // deadbeef collected, because of invalid checksum.\n  console.log('cache is much nicer now! stats:', stats)\n})\n```\n\n#### <a name=\"verify-last-run\"></a> `> cacache.verifica.ultimaVez(cache) -> Promise`\n\nAlias: `últimaVez`\n\nDevuelve un `Date` que representa la última vez que `cacache.verifica` fue\nejecutada en `cache`.\n\n##### Example\n\n```javascript\ncacache.verifica(rutaCache).then(() => {\n  cacache.verifica.ultimaVez(rutaCache).then(última => {\n    console.log('La última vez que se usó cacache.verifica() fue ' + última)\n  })\n})\n```\n",
+      "readmeFilename": "README.es.md",
+      "gitHead": "3379fe8b3bafe91de3afb4f138c4ed3bc24a9edd",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@12.0.4",
+      "_nodeVersion": "13.10.1",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+        "shasum": "668bcbd105aeb5f1d92fe25570ec9525c8faa40c",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+        "fileCount": 29,
+        "unpackedSize": 115357,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeeVLTCRA9TVsSAnZWagAAvqkP+QGEXsbyzFeaxv8Qv+TB\n8AAXsonmPOk9S+nphs2l4VZJdtEF/EpFXdiaLghALtZ4aWIYacjGklZj47oi\n+MwQSSpPpst7Wla0nCt2fq7Ejm1lVtaVYedk9WwEZKg4hdOTXoy23aKOtnYg\nlHnm/0p1F4/GNNearPtNI/T7drvNyOLYSkkEaRaH5+EVau5fkGF+o9CKVYJj\nCl9gYu+3/S2drDAf+9gYHEOOirN7Hwbx/S18j3M0E8yByrTbtYzUT3G++4ww\nqnsUwcYseQMTbqpn2ogJjNpBmzePJ17K+3Gd49NWk3nTqA+1sILTRcV4Bmfm\n2OImnazGU8KRUz/o/2yhYn1spdWrqzlD5NSuuYIu4lb/kTGN6ZhUYKsYbnx7\nbPM0J6CaagmL2GR97JLELGeMFl4qYYhWR5dn1S4lXHECnZuzhpndqNdE+BAn\nwsBjUvj7xVrzYFhQC18C/t/2tAqNevOF4yhtNQLNS3WCog0vC15F40h4N3wx\n1l7PsYNhe5zSQjWEF7jypi19HqdVfqD1EWESntGPcAedEUdB7+7YHW0ciCob\nwphqxKj7Yeo0AITk20MF24SNDmeAWf8yyYW0uEH8bYcAnRIBGHuuQWOzP5jj\nbnJvUh9MCSKQyqpwH2KzVAGLLfejoFUuI3s5tk++ZWFb6e4NVjuyq8+jCtVG\nEASj\r\n=PNlN\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_12.0.4_1585009363459_0.1674006323773336"
+      },
+      "_hasShrinkwrap": false
+    },
+    "15.0.1": {
+      "name": "cacache",
+      "version": "15.0.1",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "lint": "standard",
+        "postrelease": "npm publish",
+        "posttest": "npm run lint",
+        "prepublishOnly": "git push --follow-tags",
+        "prerelease": "npm t",
+        "release": "standard-version -s",
+        "test": "tap",
+        "coverage": "tap",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "move-file": "^2.0.0",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tacks": "^1.3.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tap": "^14.10.6"
+      },
+      "tap": {
+        "100": true,
+        "test-regex": "test/[^/]*.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "gitHead": "14567c3047588938a54f77add7fb6f94214c7fa8",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@15.0.1",
+      "_nodeVersion": "13.10.1",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-k427rNJGgXeXmnYiRgKoRKOsF+HAysd4NSi3fwMlSWVoIgGt6Snp8oTNKRH6kjRkrM64aQyOVl5B9hxxV+vtrg==",
+        "shasum": "a200a2505aced2154aac9a2150111e6954a5926a",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.1.tgz",
+        "fileCount": 24,
+        "unpackedSize": 128823,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJep3SpCRA9TVsSAnZWagAA+wAP/1JO1xZfz6ZgCNLKpU+s\nW59tvXNvXqHSatX6MlWK7rsxGEq2OqwtDCwn1O2MH+rIdPK8jVH+1eU60PQ9\nU8Hrw39HG+2s1ib1+57x9D9H+vcHgSdvjSqFudI7nPWKUtkjAjwEVBpTTIqC\nVXRKitT4fEoXO0bizfFrHPTeuNl4hxO7SqLSAt2lkpnZbE/GgfBW60RQFc1S\n5roMdnszH1Wog5JFCK0hNXmkdUwgYOSGjUYRpR9tcWsc2Kn8msB9ThlmLq5K\n5y+OFOA2170Su5puPbJNMQzqVCj4wZDz+BH0zwX7leNEnLuE6667Uxr/El44\n1EYrwKn1Da76/hs6sjcNN7jeErvrSMi5dKIJlru9qyAkXT5EpSszBuvGzfEG\ntrNxT5fnOpJXovJoLE/1F60YPDh0tT9+nwBcXqnRu7GbNx14MVxUUQXN9+Yj\n+tAkNE0PytCKRaa//SJAZNvIOLuCL9z9Bm4Fs81n6kf6n5N+3dEI/uc2K6Se\n5LPRYIz4cFrUTpLggN+82GzWaKN5wXsk00SFHUB2pIBEqoxK4n5mxzjgiJQh\nbRPz7AhrjG3E85zsuYsPt4HGguG+++ZLIoH8wHus1O8jZe71jY5mwW4MPDF0\nN08L7zteDEoJT7dxyJDNcpYp/9cWN7HaHBWPDuvbR/RdK/XQ3/s0AIMx/tej\nNrLD\r\n=v9aM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_15.0.1_1588032680878_0.9783494568336131"
+      },
+      "_hasShrinkwrap": false
+    },
+    "15.0.2": {
+      "name": "cacache",
+      "version": "15.0.2",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "lint": "standard",
+        "postrelease": "npm publish",
+        "posttest": "npm run lint",
+        "prepublishOnly": "git push --follow-tags",
+        "prerelease": "npm t",
+        "release": "standard-version -s",
+        "test": "tap",
+        "coverage": "tap",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "move-file": "^2.0.0",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "tap": {
+        "100": true,
+        "test-regex": "test/[^/]*.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "gitHead": "b954f2b1672cdd8f1a05883669f9a8e5e5891563",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@15.0.2",
+      "_nodeVersion": "13.10.1",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-XVCLiqTL5KaVnNKIUyZ1rTwmPSFgC8LAeV+ZsQqulmFdDkcUF/4y7duJ+tz1TJv0ZRUOdHZtVew4Ztz6LtvijA==",
+        "shasum": "e25391962f0477f9ba16acd68a8f301d2e84d2ab",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.2.tgz",
+        "fileCount": 24,
+        "unpackedSize": 129289,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJep3YNCRA9TVsSAnZWagAA/CYP/3TT0joYz9+vkRD6afX3\n4pmG7ftuSg6eBMvboATE9MfKMPX0fFP5nFmo3+QPwFjZsDNF7WC3LB+W8cZY\n1xbvK8wMatcUL4QKiqeF79+XNBvgRBKdl/C3TXxXIL+axXRWYPx/AG3kKmbK\nsk+1cZW99rPrLvN8elWdxaTrfkt3xfoZ0ViKOb6cITziPlwFK1MMzmmvYh21\n97q5E1wCeySY13iLgpY53LMpPoH3vO89/Uz5T55miOJPw8aDueQ3e2WjF27n\nQ4rp4pl7jjxtOcbz9w3bW8iVTq1zeGboy8+zH/6K5ht9Lqh++LxQ84YLZWdt\ne+7lOuotPkSWPhR+5fxz+581MWYcq8BrDmq1lcDBoB/G8G36qJBldT+MFYnB\nJ2NoWNm69uAbhXWLyvJxXkycW9OnFAOVHWP6YJfMTd8E7/JVD4TXEy6NpM6/\nn5Fk67GLY6XztJuC5SgL4tI+LPJKpNjH8pJeIp5kPOI0R4w4IDSQZkW6aVV8\nYHggkqUIwbjpia9dYFQ9h2SkDVQv0I/1PHykdAwLtrVMe/GoCsoLH4FL+QWe\n0J3HAUCA2fL4ZoBHQCioqduC1d39b+DwaIxjqT6TEGIz48h00Zp+cL8lKPwh\nI0IHmeJZb9+QzhaatUjQUVPdXOVOilFzb1KMCJRB4FrL3LSFVaQAKSkzpZ3i\nSBc7\r\n=EqCW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_15.0.2_1588033037328_0.9525403729782369"
+      },
+      "_hasShrinkwrap": false
+    },
+    "15.0.3": {
+      "name": "cacache",
+      "version": "15.0.3",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "lint": "standard",
+        "postrelease": "npm publish",
+        "posttest": "npm run lint",
+        "prepublishOnly": "git push --follow-tags",
+        "prerelease": "npm t",
+        "release": "standard-version -s",
+        "test": "tap",
+        "coverage": "tap",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-file": "^2.0.0",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "tap": {
+        "100": true,
+        "test-regex": "test/[^/]*.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "gitHead": "5ce07a7b194b94de273cfda63a9fcfba08517d8f",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@15.0.3",
+      "_nodeVersion": "13.10.1",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-bc3jKYjqv7k4pWh7I/ixIjfcjPul4V4jme/WbjvwGS5LzoPL/GzXr4C5EgPNLO/QEZl9Oi61iGitYEdwcrwLCQ==",
+        "shasum": "2225c2d1dd8e872339950d6a39c051e0e9334392",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.3.tgz",
+        "fileCount": 24,
+        "unpackedSize": 129488,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJep3aLCRA9TVsSAnZWagAApJAP/1Vx0j7hc7C8TL/NIJzr\nhFa7N+S/1iexWVrRtPQpuf9Kj6oxKmTj9VnMO/iJCjYMBWC1D2WQIyGvc7U3\nRkt3B6s++UVmxbM1JX/8OIN4dhK6PwzrYZQF2nUvYd7YJrN76obtysyfC5Pb\nPMB41ARNFIS0Z37rPSkH/kB8wAn4hF+xLUO9tzP+zb40uMMY7gf/l5iGDzSG\nZs8U92yYwB5cSkTqHiv8oPD6N8/2mpmUAXDEUa0JqDvHGtQFeUDtxCiWjWGW\nWgY32EL0Aer2Kiba2jMAbUtXrDcBvuCEiQKHaNyFfqCqhQ08vWlKdzfCqrNb\nEzqn2R5xM1peYkjrrwuy/cYwrehAMtGjW8/ySRssM++/cB/Jt+MMsQmcUL+w\nRaIkusNTNy5iZpDPnqB/3Iow0dnPhAiGubodMQq6bq+R7jNTxpHqt9C2cVso\nAvxrFvYs/PEjEBPhzEViBAgXpx3hBGq90MzAaCl9qODbAB5Jt7063GLJos37\nYMzpBxa4vH9+J1W7ZtjtJiXSqIFpNjqF7drIiVlfoFfzuv7tWThsw3kidSBS\niBlN3XY/Y1at/UMftZtDHvAcDmyV0gYVTmOOAUrFpeXhVg+aC/Ni8NPw1UBb\nnYVUDlmoCEj0FxtPqS4853Uc16QggSa1oPnb1V/Sa78q012/KlfrJZd9j2R6\nGdJa\r\n=tBCz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_15.0.3_1588033163189_0.6261166999737149"
+      },
+      "_hasShrinkwrap": false
+    },
+    "15.0.4": {
+      "name": "cacache",
+      "version": "15.0.4",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "lint": "standard",
+        "postrelease": "npm publish",
+        "posttest": "npm run lint",
+        "prepublishOnly": "git push --follow-tags",
+        "prerelease": "npm t",
+        "release": "standard-version -s",
+        "test": "tap",
+        "coverage": "tap",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "tap": {
+        "100": true,
+        "test-regex": "test/[^/]*.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "gitHead": "cb07554c1fe4fe2509a417f89890845747dbe47d",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@15.0.4",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-YlnKQqTbD/6iyoJvEY3KJftjrdBYroCbxxYXzhOzsFLWlp6KX4BOlEf4mTx0cMUfVaTS3ENL2QtDWeRYoGLkkw==",
+        "shasum": "b2c23cf4ac4f5ead004fb15a0efb0a20340741f1",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.4.tgz",
+        "fileCount": 22,
+        "unpackedSize": 101129,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe1uhgCRA9TVsSAnZWagAARdsP/3cDCbZiJUoFT8OjL9ME\nbg/6A4JeHMmchM0YNLjey2FhM96SjvMgCcLaBywDtKn87ItuZD4wP+3Env5b\n+NWHSXZrdfFkK4mNnNTNUn499YfZmV/dRbb5alUibDm1LbdjGMqyRghl+veE\neFIXzR/+Am3F902D0S8z0Ig08Rbrt/3NvuAxqfPDWZbO0X7Iy/F1YL7e48Oq\nwvXC2WNXHQ20JpsPgge5CDGZEZOm9+X5kDhCmDIXxKzgTanMaYnBz7GS4nFd\nGhy/5zmhwaW2g/xUTpOENaGjaZSqyWayRcvRYv3DsRFMnGJjlMKx6Kh8bWJc\npWGmc58z/uXCTD4AQi4vgBf5wNiT0zEUpVfWhXWGFcEI5ahJ6ZBhx+RDHDlV\nYTJ6SGB1Dt0v49opaytX9ptAAPL2kWXfYuq6eLDDTHLM10hofBsybGjEwzIF\nX0NUnRXQFUB+aF22rM7nKd+CAjp0GCw4hVv3nm+eXVIgI8QW7imTkNpJt1vt\nzmrAXfRQOOlrB+IxwLmcD3CCjL99BdsRsAqhpAZ3q8thL/Vkyvwyeg6y81cC\nZ/m/3t8AGWUHjA+G2MUyTb4uiQPbVhsV6UNara9Ka2SRirgo+WGPLNxPjAlr\nvV/CHikm29BNP2c2gGyHXntZrv8w5BMJ7Ex3ldDPnWLC8bE7/BlCcQ/pEBLh\n5Sti\r\n=l2vx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_15.0.4_1591142495512_0.0986317365863143"
+      },
+      "_hasShrinkwrap": false
+    },
+    "15.0.5": {
+      "name": "cacache",
+      "version": "15.0.5",
+      "cache-version": {
+        "content": "2",
+        "index": "5"
+      },
+      "description": "Fast, fault-tolerant, cross-platform, disk-based, data-agnostic, content-addressable cache.",
+      "main": "index.js",
+      "scripts": {
+        "benchmarks": "node test/benchmarks",
+        "lint": "standard",
+        "postrelease": "npm publish",
+        "posttest": "npm run lint",
+        "prepublishOnly": "git push --follow-tags",
+        "prerelease": "npm t",
+        "release": "standard-version -s",
+        "test": "tap",
+        "coverage": "tap",
+        "test-docker": "docker run -it --rm --name pacotest -v \"$PWD\":/tmp -w /tmp node:latest npm test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/cacache.git"
+      },
+      "keywords": [
+        "cache",
+        "caching",
+        "content-addressable",
+        "sri",
+        "sri hash",
+        "subresource integrity",
+        "cache",
+        "storage",
+        "store",
+        "file store",
+        "filesystem",
+        "disk cache",
+        "disk storage"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "contributors": [
+        {
+          "name": "Charlotte Spencer",
+          "email": "charlottelaspencer@gmail.com"
+        },
+        {
+          "name": "Rebecca Turner",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "tap": {
+        "100": true,
+        "test-regex": "test/[^/]*.js"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "gitHead": "1e5d25448f39194f1217047e08613fd726766911",
+      "bugs": {
+        "url": "https://github.com/npm/cacache/issues"
+      },
+      "homepage": "https://github.com/npm/cacache#readme",
+      "_id": "cacache@15.0.5",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+        "shasum": "69162833da29170d6732334643c60e005f5f17d0",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+        "fileCount": 22,
+        "unpackedSize": 101214,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfCRDiCRA9TVsSAnZWagAA3OEP/2xU8xoGxnBmzg7xkslx\nhwlrEXdYkjmoDmAG21tnIRiJD4wlg97cXS/dCVtuy+zP1MHAl/2AgW78O1KG\n0aATiEaB5p+TurkBdM47kuRnKTF5Eq06hXE4PBRuXSKLyMT5t3pSza910JVu\nND3cx54o81GdoOC71XPIrlZIPe5fzn/msvbv+Cjn0O6m6FPIQ8UxPDv2Yl13\nPODTmXYRfVfbaXZy6AoWcusxli7oK6aPe5VN3gvh4gZZo6vlbWKnVFeAAEp5\nrJbU/nSa3TrQ8w4DpvmvU2pq9tp32CBAF1+3+8RgqQ1yCMco+xHJKdHNuBw8\nnvz15togFKmiF3LiWEKTryEaRG6b1YaAsE/UvCFdQHQO98ThZQHvwaVVQ65W\nYGxQTJQX2l9uzYIhYUsEOqkrIOGeycXWvpwEpUkWzJSQwC2cxa4EG1i8irbc\nkF+axrkeWsBOYeiCegZUvcPV0M7R274iYbdGPv6ROgWRj5itCWrf6mMlYKBF\nO/QuKHtuxyQBfxaM5JozrO6oyaE1sVk+0y856b9oYbo0G0QiWEvUS7M3dU7a\nRYp6bZRKNvtHo3F2C3nW2W3ENOrfy0esFyXJz0Y8fZr/DaL4JGE5Hh7kSPrl\nZx4qJeTkaiqJZ3bBXwXyZs6ly5aisQHziam04wZM1aVs0y1MYOcs19LBaUBA\nSv2B\r\n=i2T6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cacache_15.0.5_1594429665586_0.7582732826078691"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# cacache [![npm version](https://img.shields.io/npm/v/cacache.svg)](https://npm.im/cacache) [![license](https://img.shields.io/npm/l/cacache.svg)](https://npm.im/cacache) [![Travis](https://img.shields.io/travis/npm/cacache.svg)](https://travis-ci.org/npm/cacache) [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/npm/cacache?svg=true)](https://ci.appveyor.com/project/npm/cacache) [![Coverage Status](https://coveralls.io/repos/github/npm/cacache/badge.svg?branch=latest)](https://coveralls.io/github/npm/cacache?branch=latest)\n\n[`cacache`](https://github.com/npm/cacache) is a Node.js library for managing\nlocal key and content address caches. It's really fast, really good at\nconcurrency, and it will never give you corrupted data, even if cache files\nget corrupted or manipulated.\n\nOn systems that support user and group settings on files, cacache will\nmatch the `uid` and `gid` values to the folder where the cache lives, even\nwhen running as `root`.\n\nIt was written to be used as [npm](https://npm.im)'s local cache, but can\njust as easily be used on its own.\n\n## Install\n\n`$ npm install --save cacache`\n\n## Table of Contents\n\n* [Example](#example)\n* [Features](#features)\n* [Contributing](#contributing)\n* [API](#api)\n  * [Using localized APIs](#localized-api)\n  * Reading\n    * [`ls`](#ls)\n    * [`ls.stream`](#ls-stream)\n    * [`get`](#get-data)\n    * [`get.stream`](#get-stream)\n    * [`get.info`](#get-info)\n    * [`get.hasContent`](#get-hasContent)\n  * Writing\n    * [`put`](#put-data)\n    * [`put.stream`](#put-stream)\n    * [`rm.all`](#rm-all)\n    * [`rm.entry`](#rm-entry)\n    * [`rm.content`](#rm-content)\n  * Utilities\n    * [`clearMemoized`](#clear-memoized)\n    * [`tmp.mkdir`](#tmp-mkdir)\n    * [`tmp.withTmp`](#with-tmp)\n  * Integrity\n    * [Subresource Integrity](#integrity)\n    * [`verify`](#verify)\n    * [`verify.lastRun`](#verify-last-run)\n\n### Example\n\n```javascript\nconst cacache = require('cacache')\nconst fs = require('fs')\n\nconst tarball = '/path/to/mytar.tgz'\nconst cachePath = '/tmp/my-toy-cache'\nconst key = 'my-unique-key-1234'\n\n// Cache it! Use `cachePath` as the root of the content cache\ncacache.put(cachePath, key, '10293801983029384').then(integrity => {\n  console.log(`Saved content to ${cachePath}.`)\n})\n\nconst destination = '/tmp/mytar.tgz'\n\n// Copy the contents out of the cache and into their destination!\n// But this time, use stream instead!\ncacache.get.stream(\n  cachePath, key\n).pipe(\n  fs.createWriteStream(destination)\n).on('finish', () => {\n  console.log('done extracting!')\n})\n\n// The same thing, but skip the key index.\ncacache.get.byDigest(cachePath, integrityHash).then(data => {\n  fs.writeFile(destination, data, err => {\n    console.log('tarball data fetched based on its sha512sum and written out!')\n  })\n})\n```\n\n### Features\n\n* Extraction by key or by content address (shasum, etc)\n* [Subresource Integrity](#integrity) web standard support\n* Multi-hash support - safely host sha1, sha512, etc, in a single cache\n* Automatic content deduplication\n* Fault tolerance (immune to corruption, partial writes, process races, etc)\n* Consistency guarantees on read and write (full data verification)\n* Lockless, high-concurrency cache access\n* Streaming support\n* Promise support\n* Fast -- sub-millisecond reads and writes including verification\n* Arbitrary metadata storage\n* Garbage collection and additional offline verification\n* Thorough test coverage\n* There's probably a bloom filter in there somewhere. Those are cool, right? 🤔\n\n### Contributing\n\nThe cacache team enthusiastically welcomes contributions and project participation! There's a bunch of things you can do if you want to contribute! The [Contributor Guide](CONTRIBUTING.md) has all the information you need for everything from reporting bugs to contributing entire new features. Please don't hesitate to jump in if you'd like to, or even ask us questions if something isn't clear.\n\nAll participants and maintainers in this project are expected to follow [Code of Conduct](CODE_OF_CONDUCT.md), and just generally be excellent to each other.\n\nPlease refer to the [Changelog](CHANGELOG.md) for project history details, too.\n\nHappy hacking!\n\n### API\n\n#### <a name=\"ls\"></a> `> cacache.ls(cache) -> Promise<Object>`\n\nLists info for all entries currently in the cache as a single large object. Each\nentry in the object will be keyed by the unique index key, with corresponding\n[`get.info`](#get-info) objects as the values.\n\n##### Example\n\n```javascript\ncacache.ls(cachePath).then(console.log)\n// Output\n{\n  'my-thing': {\n    key: 'my-thing',\n    integrity: 'sha512-BaSe64/EnCoDED+HAsh=='\n    path: '.testcache/content/deadbeef', // joined with `cachePath`\n    time: 12345698490,\n    size: 4023948,\n    metadata: {\n      name: 'blah',\n      version: '1.2.3',\n      description: 'this was once a package but now it is my-thing'\n    }\n  },\n  'other-thing': {\n    key: 'other-thing',\n    integrity: 'sha1-ANothER+hasH=',\n    path: '.testcache/content/bada55',\n    time: 11992309289,\n    size: 111112\n  }\n}\n```\n\n#### <a name=\"ls-stream\"></a> `> cacache.ls.stream(cache) -> Readable`\n\nLists info for all entries currently in the cache as a single large object.\n\nThis works just like [`ls`](#ls), except [`get.info`](#get-info) entries are\nreturned as `'data'` events on the returned stream.\n\n##### Example\n\n```javascript\ncacache.ls.stream(cachePath).on('data', console.log)\n// Output\n{\n  key: 'my-thing',\n  integrity: 'sha512-BaSe64HaSh',\n  path: '.testcache/content/deadbeef', // joined with `cachePath`\n  time: 12345698490,\n  size: 13423,\n  metadata: {\n    name: 'blah',\n    version: '1.2.3',\n    description: 'this was once a package but now it is my-thing'\n  }\n}\n\n{\n  key: 'other-thing',\n  integrity: 'whirlpool-WoWSoMuchSupport',\n  path: '.testcache/content/bada55',\n  time: 11992309289,\n  size: 498023984029\n}\n\n{\n  ...\n}\n```\n\n#### <a name=\"get-data\"></a> `> cacache.get(cache, key, [opts]) -> Promise({data, metadata, integrity})`\n\nReturns an object with the cached data, digest, and metadata identified by\n`key`. The `data` property of this object will be a `Buffer` instance that\npresumably holds some data that means something to you. I'm sure you know what\nto do with it! cacache just won't care.\n\n`integrity` is a [Subresource\nIntegrity](#integrity)\nstring. That is, a string that can be used to verify `data`, which looks like\n`<hash-algorithm>-<base64-integrity-hash>`.\n\nIf there is no content identified by `key`, or if the locally-stored data does\nnot pass the validity checksum, the promise will be rejected.\n\nA sub-function, `get.byDigest` may be used for identical behavior, except lookup\nwill happen by integrity hash, bypassing the index entirely. This version of the\nfunction *only* returns `data` itself, without any wrapper.\n\nSee: [options](#get-options)\n\n##### Note\n\nThis function loads the entire cache entry into memory before returning it. If\nyou're dealing with Very Large data, consider using [`get.stream`](#get-stream)\ninstead.\n\n##### Example\n\n```javascript\n// Look up by key\ncache.get(cachePath, 'my-thing').then(console.log)\n// Output:\n{\n  metadata: {\n    thingName: 'my'\n  },\n  integrity: 'sha512-BaSe64HaSh',\n  data: Buffer#<deadbeef>,\n  size: 9320\n}\n\n// Look up by digest\ncache.get.byDigest(cachePath, 'sha512-BaSe64HaSh').then(console.log)\n// Output:\nBuffer#<deadbeef>\n```\n\n#### <a name=\"get-stream\"></a> `> cacache.get.stream(cache, key, [opts]) -> Readable`\n\nReturns a [Readable Stream](https://nodejs.org/api/stream.html#stream_readable_streams) of the cached data identified by `key`.\n\nIf there is no content identified by `key`, or if the locally-stored data does\nnot pass the validity checksum, an error will be emitted.\n\n`metadata` and `integrity` events will be emitted before the stream closes, if\nyou need to collect that extra data about the cached entry.\n\nA sub-function, `get.stream.byDigest` may be used for identical behavior,\nexcept lookup will happen by integrity hash, bypassing the index entirely. This\nversion does not emit the `metadata` and `integrity` events at all.\n\nSee: [options](#get-options)\n\n##### Example\n\n```javascript\n// Look up by key\ncache.get.stream(\n  cachePath, 'my-thing'\n).on('metadata', metadata => {\n  console.log('metadata:', metadata)\n}).on('integrity', integrity => {\n  console.log('integrity:', integrity)\n}).pipe(\n  fs.createWriteStream('./x.tgz')\n)\n// Outputs:\nmetadata: { ... }\nintegrity: 'sha512-SoMeDIGest+64=='\n\n// Look up by digest\ncache.get.stream.byDigest(\n  cachePath, 'sha512-SoMeDIGest+64=='\n).pipe(\n  fs.createWriteStream('./x.tgz')\n)\n```\n\n#### <a name=\"get-info\"></a> `> cacache.get.info(cache, key) -> Promise`\n\nLooks up `key` in the cache index, returning information about the entry if\none exists.\n\n##### Fields\n\n* `key` - Key the entry was looked up under. Matches the `key` argument.\n* `integrity` - [Subresource Integrity hash](#integrity) for the content this entry refers to.\n* `path` - Filesystem path where content is stored, joined with `cache` argument.\n* `time` - Timestamp the entry was first added on.\n* `metadata` - User-assigned metadata associated with the entry/content.\n\n##### Example\n\n```javascript\ncacache.get.info(cachePath, 'my-thing').then(console.log)\n\n// Output\n{\n  key: 'my-thing',\n  integrity: 'sha256-MUSTVERIFY+ALL/THINGS=='\n  path: '.testcache/content/deadbeef',\n  time: 12345698490,\n  size: 849234,\n  metadata: {\n    name: 'blah',\n    version: '1.2.3',\n    description: 'this was once a package but now it is my-thing'\n  }\n}\n```\n\n#### <a name=\"get-hasContent\"></a> `> cacache.get.hasContent(cache, integrity) -> Promise`\n\nLooks up a [Subresource Integrity hash](#integrity) in the cache. If content\nexists for this `integrity`, it will return an object, with the specific single integrity hash\nthat was found in `sri` key, and the size of the found content as `size`. If no content exists for this integrity, it will return `false`.\n\n##### Example\n\n```javascript\ncacache.get.hasContent(cachePath, 'sha256-MUSTVERIFY+ALL/THINGS==').then(console.log)\n\n// Output\n{\n  sri: {\n    source: 'sha256-MUSTVERIFY+ALL/THINGS==',\n    algorithm: 'sha256',\n    digest: 'MUSTVERIFY+ALL/THINGS==',\n    options: []\n  },\n  size: 9001\n}\n\ncacache.get.hasContent(cachePath, 'sha521-NOT+IN/CACHE==').then(console.log)\n\n// Output\nfalse\n```\n\n##### <a name=\"get-options\"></a> Options\n\n##### `opts.integrity`\nIf present, the pre-calculated digest for the inserted content. If this option\nis provided and does not match the post-insertion digest, insertion will fail\nwith an `EINTEGRITY` error.\n\n##### `opts.memoize`\n\nDefault: null\n\nIf explicitly truthy, cacache will read from memory and memoize data on bulk read. If `false`, cacache will read from disk data. Reader functions by default read from in-memory cache.\n\n##### `opts.size`\nIf provided, the data stream will be verified to check that enough data was\npassed through. If there's more or less data than expected, insertion will fail\nwith an `EBADSIZE` error.\n\n\n#### <a name=\"put-data\"></a> `> cacache.put(cache, key, data, [opts]) -> Promise`\n\nInserts data passed to it into the cache. The returned Promise resolves with a\ndigest (generated according to [`opts.algorithms`](#optsalgorithms)) after the\ncache entry has been successfully written.\n\nSee: [options](#put-options)\n\n##### Example\n\n```javascript\nfetch(\n  'https://registry.npmjs.org/cacache/-/cacache-1.0.0.tgz'\n).then(data => {\n  return cacache.put(cachePath, 'registry.npmjs.org|cacache@1.0.0', data)\n}).then(integrity => {\n  console.log('integrity hash is', integrity)\n})\n```\n\n#### <a name=\"put-stream\"></a> `> cacache.put.stream(cache, key, [opts]) -> Writable`\n\nReturns a [Writable\nStream](https://nodejs.org/api/stream.html#stream_writable_streams) that inserts\ndata written to it into the cache. Emits an `integrity` event with the digest of\nwritten contents when it succeeds.\n\nSee: [options](#put-options)\n\n##### Example\n\n```javascript\nrequest.get(\n  'https://registry.npmjs.org/cacache/-/cacache-1.0.0.tgz'\n).pipe(\n  cacache.put.stream(\n    cachePath, 'registry.npmjs.org|cacache@1.0.0'\n  ).on('integrity', d => console.log(`integrity digest is ${d}`))\n)\n```\n\n##### <a name=\"put-options\"></a> Options\n\n##### `opts.metadata`\n\nArbitrary metadata to be attached to the inserted key.\n\n##### `opts.size`\n\nIf provided, the data stream will be verified to check that enough data was\npassed through. If there's more or less data than expected, insertion will fail\nwith an `EBADSIZE` error.\n\n##### `opts.integrity`\n\nIf present, the pre-calculated digest for the inserted content. If this option\nis provided and does not match the post-insertion digest, insertion will fail\nwith an `EINTEGRITY` error.\n\n`algorithms` has no effect if this option is present.\n\n##### `opts.algorithms`\n\nDefault: ['sha512']\n\nHashing algorithms to use when calculating the [subresource integrity\ndigest](#integrity)\nfor inserted data. Can use any algorithm listed in `crypto.getHashes()` or\n`'omakase'`/`'お任せします'` to pick a random hash algorithm on each insertion. You\nmay also use any anagram of `'modnar'` to use this feature.\n\nCurrently only supports one algorithm at a time (i.e., an array length of\nexactly `1`). Has no effect if `opts.integrity` is present.\n\n##### `opts.memoize`\n\nDefault: null\n\nIf provided, cacache will memoize the given cache insertion in memory, bypassing\nany filesystem checks for that key or digest in future cache fetches. Nothing\nwill be written to the in-memory cache unless this option is explicitly truthy.\n\nIf `opts.memoize` is an object or a `Map`-like (that is, an object with `get`\nand `set` methods), it will be written to instead of the global memoization\ncache.\n\nReading from disk data can be forced by explicitly passing `memoize: false` to\nthe reader functions, but their default will be to read from memory.\n\n##### `opts.tmpPrefix`\nDefault: null\n\nPrefix to append on the temporary directory name inside the cache's tmp dir. \n\n#### <a name=\"rm-all\"></a> `> cacache.rm.all(cache) -> Promise`\n\nClears the entire cache. Mainly by blowing away the cache directory itself.\n\n##### Example\n\n```javascript\ncacache.rm.all(cachePath).then(() => {\n  console.log('THE APOCALYPSE IS UPON US 😱')\n})\n```\n\n#### <a name=\"rm-entry\"></a> `> cacache.rm.entry(cache, key) -> Promise`\n\nAlias: `cacache.rm`\n\nRemoves the index entry for `key`. Content will still be accessible if\nrequested directly by content address ([`get.stream.byDigest`](#get-stream)).\n\nTo remove the content itself (which might still be used by other entries), use\n[`rm.content`](#rm-content). Or, to safely vacuum any unused content, use\n[`verify`](#verify).\n\n##### Example\n\n```javascript\ncacache.rm.entry(cachePath, 'my-thing').then(() => {\n  console.log('I did not like it anyway')\n})\n```\n\n#### <a name=\"rm-content\"></a> `> cacache.rm.content(cache, integrity) -> Promise`\n\nRemoves the content identified by `integrity`. Any index entries referring to it\nwill not be usable again until the content is re-added to the cache with an\nidentical digest.\n\n##### Example\n\n```javascript\ncacache.rm.content(cachePath, 'sha512-SoMeDIGest/IN+BaSE64==').then(() => {\n  console.log('data for my-thing is gone!')\n})\n```\n\n#### <a name=\"clear-memoized\"></a> `> cacache.clearMemoized()`\n\nCompletely resets the in-memory entry cache.\n\n#### <a name=\"tmp-mkdir\"></a> `> tmp.mkdir(cache, opts) -> Promise<Path>`\n\nReturns a unique temporary directory inside the cache's `tmp` dir. This\ndirectory will use the same safe user assignment that all the other stuff use.\n\nOnce the directory is made, it's the user's responsibility that all files\nwithin are given the appropriate `gid`/`uid` ownership settings to match\nthe rest of the cache. If not, you can ask cacache to do it for you by\ncalling [`tmp.fix()`](#tmp-fix), which will fix all tmp directory\npermissions.\n\nIf you want automatic cleanup of this directory, use\n[`tmp.withTmp()`](#with-tpm)\n\nSee: [options](#tmp-options)\n\n##### Example\n\n```javascript\ncacache.tmp.mkdir(cache).then(dir => {\n  fs.writeFile(path.join(dir, 'blablabla'), Buffer#<1234>, ...)\n})\n```\n\n#### <a name=\"tmp-fix\"></a> `> tmp.fix(cache) -> Promise`\n\nSets the `uid` and `gid` properties on all files and folders within the tmp\nfolder to match the rest of the cache.\n\nUse this after manually writing files into [`tmp.mkdir`](#tmp-mkdir) or\n[`tmp.withTmp`](#with-tmp).\n\n##### Example\n\n```javascript\ncacache.tmp.mkdir(cache).then(dir => {\n  writeFile(path.join(dir, 'file'), someData).then(() => {\n    // make sure we didn't just put a root-owned file in the cache\n    cacache.tmp.fix().then(() => {\n      // all uids and gids match now\n    })\n  })\n})\n```\n\n#### <a name=\"with-tmp\"></a> `> tmp.withTmp(cache, opts, cb) -> Promise`\n\nCreates a temporary directory with [`tmp.mkdir()`](#tmp-mkdir) and calls `cb`\nwith it. The created temporary directory will be removed when the return value\nof `cb()` resolves, the tmp directory will be automatically deleted once that \npromise completes.\n\nThe same caveats apply when it comes to managing permissions for the tmp dir's\ncontents.\n\nSee: [options](#tmp-options)\n\n##### Example\n\n```javascript\ncacache.tmp.withTmp(cache, dir => {\n  return fs.writeFileAsync(path.join(dir, 'blablabla'), Buffer#<1234>, ...)\n}).then(() => {\n  // `dir` no longer exists\n})\n```\n\n##### <a name=\"tmp-options\"></a> Options\n\n##### `opts.tmpPrefix`\nDefault: null\n\nPrefix to append on the temporary directory name inside the cache's tmp dir. \n\n#### <a name=\"integrity\"></a> Subresource Integrity Digests\n\nFor content verification and addressing, cacache uses strings following the\n[Subresource\nIntegrity spec](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity).\nThat is, any time cacache expects an `integrity` argument or option, it\nshould be in the format `<hashAlgorithm>-<base64-hash>`.\n\nOne deviation from the current spec is that cacache will support any hash\nalgorithms supported by the underlying Node.js process. You can use\n`crypto.getHashes()` to see which ones you can use.\n\n##### Generating Digests Yourself\n\nIf you have an existing content shasum, they are generally formatted as a\nhexadecimal string (that is, a sha1 would look like:\n`5f5513f8822fdbe5145af33b64d8d970dcf95c6e`). In order to be compatible with\ncacache, you'll need to convert this to an equivalent subresource integrity\nstring. For this example, the corresponding hash would be:\n`sha1-X1UT+IIv2+UUWvM7ZNjZcNz5XG4=`.\n\nIf you want to generate an integrity string yourself for existing data, you can\nuse something like this:\n\n```javascript\nconst crypto = require('crypto')\nconst hashAlgorithm = 'sha512'\nconst data = 'foobarbaz'\n\nconst integrity = (\n  hashAlgorithm +\n  '-' +\n  crypto.createHash(hashAlgorithm).update(data).digest('base64')\n)\n```\n\nYou can also use [`ssri`](https://npm.im/ssri) to have a richer set of functionality\naround SRI strings, including generation, parsing, and translating from existing\nhex-formatted strings.\n\n#### <a name=\"verify\"></a> `> cacache.verify(cache, opts) -> Promise`\n\nChecks out and fixes up your cache:\n\n* Cleans up corrupted or invalid index entries.\n* Custom entry filtering options.\n* Garbage collects any content entries not referenced by the index.\n* Checks integrity for all content entries and removes invalid content.\n* Fixes cache ownership.\n* Removes the `tmp` directory in the cache and all its contents.\n\nWhen it's done, it'll return an object with various stats about the verification\nprocess, including amount of storage reclaimed, number of valid entries, number\nof entries removed, etc.\n\n##### <a name=\"verify-options\"></a> Options\n\n##### `opts.concurrency`\n\nDefault: 20\n\nNumber of concurrently read files in the filesystem while doing clean up.\n\n##### `opts.filter`\nReceives a formatted entry. Return false to remove it.\nNote: might be called more than once on the same entry.\n\n##### `opts.log`\nCustom logger function:\n```\n  log: { silly () {} }\n  log.silly('verify', 'verifying cache at', cache)\n```\n\n##### Example\n\n```sh\necho somegarbage >> $CACHEPATH/content/deadbeef\n```\n\n```javascript\ncacache.verify(cachePath).then(stats => {\n  // deadbeef collected, because of invalid checksum.\n  console.log('cache is much nicer now! stats:', stats)\n})\n```\n\n#### <a name=\"verify-last-run\"></a> `> cacache.verify.lastRun(cache) -> Promise`\n\nReturns a `Date` representing the last time `cacache.verify` was run on `cache`.\n\n##### Example\n\n```javascript\ncacache.verify(cachePath).then(() => {\n  cacache.verify.lastRun(cachePath).then(lastTime => {\n    console.log('cacache.verify was last called on' + lastTime)\n  })\n})\n```\n",
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-19T13:49:56.983Z",
+    "created": "2016-11-18T10:01:40.775Z",
+    "1.0.0": "2016-11-18T10:01:40.775Z",
+    "2.0.0": "2016-11-20T12:47:12.844Z",
+    "3.0.0": "2016-12-03T20:31:31.664Z",
+    "3.0.1": "2016-12-04T07:06:51.710Z",
+    "4.0.0": "2017-01-28T00:31:34.951Z",
+    "5.0.0": "2017-02-03T01:59:49.395Z",
+    "5.0.1": "2017-02-18T07:47:56.870Z",
+    "5.0.2": "2017-02-20T04:12:26.669Z",
+    "5.0.3": "2017-02-20T08:50:56.237Z",
+    "6.0.0": "2017-03-05T07:20:56.329Z",
+    "6.0.1": "2017-03-05T08:45:40.039Z",
+    "6.0.2": "2017-03-11T00:12:03.825Z",
+    "6.1.0": "2017-03-12T05:52:41.529Z",
+    "6.1.1": "2017-03-13T10:15:54.281Z",
+    "6.1.2": "2017-03-13T10:25:30.310Z",
+    "6.2.0": "2017-03-15T01:42:46.629Z",
+    "6.3.0": "2017-04-01T06:50:14.779Z",
+    "7.0.0": "2017-04-03T08:13:10.557Z",
+    "7.0.1": "2017-04-03T08:15:59.614Z",
+    "7.0.2": "2017-04-03T10:41:41.723Z",
+    "7.0.3": "2017-04-05T06:24:54.502Z",
+    "7.0.4": "2017-04-15T19:38:17.734Z",
+    "7.0.5": "2017-04-18T10:04:33.337Z",
+    "7.1.0": "2017-04-20T10:14:09.501Z",
+    "8.0.0": "2017-04-22T20:20:21.398Z",
+    "9.0.0": "2017-04-28T00:44:59.151Z",
+    "9.1.0": "2017-05-14T07:15:34.400Z",
+    "9.2.0": "2017-05-14T21:09:29.128Z",
+    "9.2.1": "2017-05-14T23:00:32.415Z",
+    "9.2.2": "2017-05-14T23:46:58.837Z",
+    "9.2.3": "2017-05-24T09:28:08.061Z",
+    "9.2.4": "2017-05-24T09:32:40.754Z",
+    "9.2.5": "2017-05-25T01:23:21.470Z",
+    "9.2.6": "2017-05-31T05:43:30.722Z",
+    "9.2.7": "2017-06-05T14:37:10.629Z",
+    "9.2.8": "2017-06-05T21:18:32.135Z",
+    "9.2.9": "2017-06-17T20:42:04.971Z",
+    "9.3.0": "2017-10-07T23:24:48.894Z",
+    "10.0.0": "2017-10-23T18:25:38.782Z",
+    "10.0.1": "2017-11-15T22:34:11.319Z",
+    "10.0.2": "2018-01-07T03:40:51.113Z",
+    "10.0.3": "2018-02-16T20:00:46.024Z",
+    "10.0.4": "2018-02-16T22:54:14.873Z",
+    "11.0.0": "2018-04-09T00:38:06.331Z",
+    "11.0.1": "2018-04-10T18:45:08.936Z",
+    "11.0.2": "2018-05-07T18:53:16.124Z",
+    "11.0.3": "2018-08-01T20:29:03.150Z",
+    "11.1.0": "2018-08-01T22:10:34.698Z",
+    "11.2.0": "2018-08-08T00:48:44.693Z",
+    "11.3.0": "2018-11-05T04:21:57.822Z",
+    "11.3.1": "2018-11-05T21:17:11.461Z",
+    "11.3.2": "2018-12-21T18:59:01.184Z",
+    "11.3.3": "2019-06-17T16:14:40.006Z",
+    "12.0.0": "2019-07-15T23:29:07.778Z",
+    "12.0.1": "2019-07-19T22:34:43.049Z",
+    "12.0.2": "2019-07-19T23:11:07.852Z",
+    "12.0.3": "2019-08-19T19:31:55.390Z",
+    "13.0.0": "2019-09-25T19:03:36.816Z",
+    "13.0.1": "2019-09-30T21:02:21.704Z",
+    "14.0.0": "2020-01-28T01:52:06.125Z",
+    "15.0.0": "2020-02-18T01:33:48.426Z",
+    "12.0.4": "2020-03-24T00:22:43.621Z",
+    "15.0.1": "2020-04-28T00:11:21.041Z",
+    "15.0.2": "2020-04-28T00:17:17.546Z",
+    "15.0.3": "2020-04-28T00:19:23.392Z",
+    "15.0.4": "2020-06-03T00:01:35.657Z",
+    "15.0.5": "2020-07-11T01:07:45.796Z"
+  },
+  "keywords": [
+    "cache",
+    "caching",
+    "content-addressable",
+    "sri",
+    "sri hash",
+    "subresource integrity",
+    "cache",
+    "storage",
+    "store",
+    "file store",
+    "filesystem",
+    "disk cache",
+    "disk storage"
+  ],
+  "author": {
+    "name": "Kat Marchán",
+    "email": "kzm@sykosomatic.org"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "charlotteis": true,
+    "ferrari": true,
+    "max_devjs": true,
+    "zazaian": true,
+    "sharper": true,
+    "daniellink": true,
+    "wangnan0610": true,
+    "losymear": true,
+    "jhq": true
+  },
+  "homepage": "https://github.com/npm/cacache#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/cacache.git"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/cacache/issues"
+  },
+  "contributors": [
+    {
+      "name": "Charlotte Spencer",
+      "email": "charlottelaspencer@gmail.com"
+    },
+    {
+      "name": "Rebecca Turner",
+      "email": "me@re-becca.org"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/cacache.min.json
+++ b/test/fixtures/registry-mocks/content/cacache.min.json
@@ -1,0 +1,2529 @@
+{
+  "name": "cacache",
+  "dist-tags": {
+    "latest": "15.0.5",
+    "legacy": "12.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "cacache",
+      "version": "1.0.0",
+      "dependencies": {
+        "dezalgo": "^1.0.3",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "mv": "^2.1.1",
+        "pumpify": "^1.3.5",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "through2": "^2.0.1"
+      },
+      "devDependencies": {
+        "standard": "^8.5.0",
+        "tap": "^8.0.1"
+      },
+      "dist": {
+        "shasum": "91c256942eaaf0f013683c1462d30f16a450c408",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "cacache",
+      "version": "2.0.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "from2": "^2.3.0",
+        "fs-extra": "^1.0.0",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mkdirp": "^0.5.1",
+        "mv": "^2.1.1",
+        "pumpify": "^1.3.5",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0",
+        "tar-fs": "^1.14.0",
+        "through2": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^9.0.1",
+        "standard": "^8.5.0",
+        "tacks": "^1.2.2",
+        "tap": "^8.0.1"
+      },
+      "dist": {
+        "shasum": "d05c1db1398b1ba77f6ab18c950098995d4bc8a7",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-2.0.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "cacache",
+      "version": "3.0.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^8.0.1"
+      },
+      "dist": {
+        "shasum": "eb3d5aec86b698c336cfc2233a67687241541761",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "cacache",
+      "version": "3.0.1",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^8.0.1"
+      },
+      "dist": {
+        "shasum": "f2bbc3ea4603da1888c9577a288dbad3aa649cbb",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-3.0.1.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "cacache",
+      "version": "4.0.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^9.0.3"
+      },
+      "dist": {
+        "shasum": "acfe5f4dfb2265900ba51783d67a30868b652029",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-4.0.0.tgz"
+      }
+    },
+    "5.0.0": {
+      "name": "cacache",
+      "version": "5.0.0",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "randomstring": "^1.1.5",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^9.0.3"
+      },
+      "dist": {
+        "shasum": "66eda54c377fe1afc485a6d76226c98e17ab7e73",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-5.0.0.tgz"
+      }
+    },
+    "5.0.1": {
+      "name": "cacache",
+      "version": "5.0.1",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.0.2"
+      },
+      "dist": {
+        "shasum": "253cb8cb059205110c5efe1b974dce6f31c0ddf1",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-5.0.1.tgz"
+      }
+    },
+    "5.0.2": {
+      "name": "cacache",
+      "version": "5.0.2",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.0.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.7"
+      },
+      "dist": {
+        "shasum": "5c1659e49fd83a3fd56010e5cdaad23f563302b5",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-5.0.2.tgz"
+      }
+    },
+    "5.0.3": {
+      "name": "cacache",
+      "version": "5.0.3",
+      "dependencies": {
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "inflight": "^1.0.6",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "rimraf": "^2.5.4",
+        "slide": "^1.1.6",
+        "split": "^1.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^8.6.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.0.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.7"
+      },
+      "dist": {
+        "shasum": "f8c651e6613865dda88ddfd87bc514d9cd34a65f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-5.0.3.tgz"
+      }
+    },
+    "6.0.0": {
+      "name": "cacache",
+      "version": "6.0.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "slide": "^1.1.6",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^9.0.0",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "994ab2c3ec9c2233c1e55ea69dd54ba34539432d",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.0.0.tgz"
+      }
+    },
+    "6.0.1": {
+      "name": "cacache",
+      "version": "6.0.1",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "slide": "^1.1.6",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^9.0.0",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "cae27481c35ae7264d6bbccad7e520876302b77d",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.0.1.tgz"
+      }
+    },
+    "6.0.2": {
+      "name": "cacache",
+      "version": "6.0.2",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "lockfile": "^1.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "standard": "^9.0.0",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "abda997519d86232b2bf11a901e01caf03d66a93",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.0.2.tgz"
+      }
+    },
+    "6.1.0": {
+      "name": "cacache",
+      "version": "6.1.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "graceful-fs": "^4.1.10",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "7c86652a413e797680f1ef3e759b3c8f4a5fc599",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.1.0.tgz"
+      }
+    },
+    "6.1.1": {
+      "name": "cacache",
+      "version": "6.1.1",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "ad4405780016a33b608bf55a760aa18af0ada309",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.1.1.tgz"
+      }
+    },
+    "6.1.2": {
+      "name": "cacache",
+      "version": "6.1.2",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "dezalgo": "^1.0.3",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "fba9b76f1e2a0fe6073000d9034108ca28d7b577",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.1.2.tgz"
+      }
+    },
+    "6.2.0": {
+      "name": "cacache",
+      "version": "6.2.0",
+      "dependencies": {
+        "@npmcorp/move": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.3",
+        "chalk": "^1.1.3",
+        "nyc": "^10.0.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "ed3001398eacbb3750241cc57375202bb81ae5d1",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.2.0.tgz"
+      }
+    },
+    "6.3.0": {
+      "name": "cacache",
+      "version": "6.3.0",
+      "dependencies": {
+        "move-concurrently": "^1.0.0",
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "ecc428901b79aabbd0b0492bca62b88cda0d4773",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-6.3.0.tgz"
+      }
+    },
+    "7.0.0": {
+      "name": "cacache",
+      "version": "7.0.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^3.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "7e59224ff4f1ebafe5f42ff68f472d179a5c204c",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.0.tgz"
+      }
+    },
+    "7.0.1": {
+      "name": "cacache",
+      "version": "7.0.1",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^3.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "7f66ca4f725b121d8037067e1979b0019727b4f4",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.1.tgz"
+      }
+    },
+    "7.0.2": {
+      "name": "cacache",
+      "version": "7.0.2",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "5b7f7155675b0559ad98a1961f9d0a4c1260532d",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.2.tgz"
+      }
+    },
+    "7.0.3": {
+      "name": "cacache",
+      "version": "7.0.3",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.0.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.1",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "62e876694cf2c094d319f257b83769ea752278ab",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.3.tgz"
+      }
+    },
+    "7.0.4": {
+      "name": "cacache",
+      "version": "7.0.4",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.0",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "59eb6a4dca1aa3dc2a6450c097679afba37bc990",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.4.tgz"
+      }
+    },
+    "7.0.5": {
+      "name": "cacache",
+      "version": "7.0.5",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.1",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "31b23a28b2b1e4083e60a42df9ddd2e5dbd3b4ce",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.0.5.tgz"
+      }
+    },
+    "7.1.0": {
+      "name": "cacache",
+      "version": "7.1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "f73777163e437e4ec45e21a2be298edeb584e36f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-7.1.0.tgz"
+      }
+    },
+    "8.0.0": {
+      "name": "cacache",
+      "version": "8.0.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "2c3899c16941aeb0e7378845df8aff03bb0eb81a",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-8.0.0.tgz"
+      }
+    },
+    "9.0.0": {
+      "name": "cacache",
+      "version": "9.0.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "edcf620030b0fbf3708193f0718136eedb2170a4",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.0.0.tgz"
+      }
+    },
+    "9.1.0": {
+      "name": "cacache",
+      "version": "9.1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-pNQeGpcAptdM0JFJA3kQfKoMrg43vuQBgxdoqbPRNMcAjO1oXONAvN4T3RJsZsmgmvNY/bQmotne4nmsEyFn4g==",
+        "shasum": "7972de4fa9f2a81a4b737011a2cf1f0e0d7ab213",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.1.0.tgz"
+      }
+    },
+    "9.2.0": {
+      "name": "cacache",
+      "version": "9.2.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-6p5OrZdfA2f/JX2y2u70FsG40h8bib83wBVaFnKqDLaWeii4yvkR4jCC4P9tADyee3Y9sgYnWPvv0XCZMUfPBA==",
+        "shasum": "5e14e78842ea7c8df0c35fc4b315452724c27b79",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.0.tgz"
+      }
+    },
+    "9.2.1": {
+      "name": "cacache",
+      "version": "9.2.1",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-wknnaRGoo1yzuXMdXXbT/+i/78PWdjZGyNC2LY9t73zARhV0DRrOrJI+eSebosIvtiDZXHK7DiAgl94gGWdtyA==",
+        "shasum": "5baf6875a3ef3dca4fdf33efb9b0e3ac23a983a3",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.1.tgz"
+      }
+    },
+    "9.2.2": {
+      "name": "cacache",
+      "version": "9.2.2",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-KchIh0VVk0zpYKtztqFQDYc2ZnQAqwOO3Z5bsuxYfTJuNGvUgEVEBlEVmb/Rf3t3CKgd/8U7x2RC+lgJe0kz2Q==",
+        "shasum": "cb67e5c3497d474f6b6d889a90ebfc969f2d83fa",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.2.tgz"
+      }
+    },
+    "9.2.3": {
+      "name": "cacache",
+      "version": "9.2.3",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.2.0",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-Xvz0paVT+igGRdGPDfMy2UgAFnbc77hp6/XruCiJQzcBtKzb+jkP1NG0kAHS8RKp3h560Fc09WnonXyT/oXMxA==",
+        "shasum": "22edd762e8f91a2d89dc9a2f6f7f28a6b11bf71e",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.3.tgz"
+      }
+    },
+    "9.2.4": {
+      "name": "cacache",
+      "version": "9.2.4",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.10",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.2",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.3.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-DkEucrb5TwM6yCLgDfyHWMH3QECt9g0pMGNtuGBrALo/B0FcQSnt8B+DyyuPFqOvSOwSPZgqYD4TK9IKJBUoKg==",
+        "shasum": "f222f569e6d3e1415ad1ae66969c69ca0fc25955",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.4.tgz"
+      }
+    },
+    "9.2.5": {
+      "name": "cacache",
+      "version": "9.2.5",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.3",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.3.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-mURsTvkjbCSFRTdkuPhHUp9sbEHn3AVrvM4mveg/bhlKKYolfRm23TsFUVAssC9p622lwmh7pgpb+H5mSVpYcA==",
+        "shasum": "cb401d0e59858532062de1f104097cb40c71c3bf",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.5.tgz"
+      }
+    },
+    "9.2.6": {
+      "name": "cacache",
+      "version": "9.2.6",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^10.3.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-YK0Z5Np5t755edPL6gfdCeGxtU0rcW/DBhYhYVDckT+7AFkCCtedf2zru5NRbBLFk6e7Agi/RaqTOAfiaipUfg==",
+        "shasum": "ea5c7f2b6b514710a22a58a27f857fd972fdfa51",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.6.tgz"
+      }
+    },
+    "9.2.7": {
+      "name": "cacache",
+      "version": "9.2.7",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^11.0.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.1.0",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-SWRnkRNV5h61SeTfPvVYotM2yqW5KXtG835CebVV7G5EYHQu+dgQbNkasSIcN7LWeoaViLpgaxVlt01TFpqOKw==",
+        "shasum": "67d71835fed94f6989bde522cf2956df862e3ca5",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.7.tgz"
+      }
+    },
+    "9.2.8": {
+      "name": "cacache",
+      "version": "9.2.8",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.0.2",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.5",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.0",
+        "nyc": "^11.0.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.1.0",
+        "standard": "^10.0.2",
+        "standard-version": "^4.0.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-nA3gmaDPEsFWqI5eYAe35IfvW54yGJ3ns2wDopWf4iDA3fkhBNsdvnYp4NrL+L7ysMt0/isM84Mwi+b4l8/pMQ==",
+        "shasum": "2e38b51161a3904e3b9fb35c0869b751f7d0bcf4",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.8.tgz"
+      }
+    },
+    "9.2.9": {
+      "name": "cacache",
+      "version": "9.2.9",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.6",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^1.1.3",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.0.2",
+        "require-inject": "^1.4.0",
+        "safe-buffer": "^5.1.0",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.3.4",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-ghg1j5OyTJ6qsrqU++dN23QiTDxb5AZCFGsF3oB+v9v/gY+F4X8L/0gdQMEjd+8Ot3D29M2etX5PKozHRn2JQw==",
+        "shasum": "f9d7ffe039851ec94c28290662afa4dd4bb9e8dd",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.2.9.tgz"
+      }
+    },
+    "9.3.0": {
+      "name": "cacache",
+      "version": "9.3.0",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^4.1.6",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-Vbi8J1XfC8v+FbQ6QkOtKXsHpPnB0i9uMeYFJoj40EbdOsEqWB3DPpNjfsnYBkqOPYA8UvrqH6FZPpBP0zdN7g==",
+        "shasum": "9cd58f2dd0b8c8cacf685b7067b416d6d3cf9db1",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-9.3.0.tgz"
+      }
+    },
+    "10.0.0": {
+      "name": "cacache",
+      "version": "10.0.0",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-s9h6I9NY3KcBjfuS28K6XNmrv/HNFSzlpVD6eYMXugZg3Y8jjI1lUzTeUMa0oKByCDtHfsIy5Ec7KgWRnC5gtg==",
+        "shasum": "3bba88bf62b0773fd9a691605f60c9d3c595e853",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.0.tgz"
+      }
+    },
+    "10.0.1": {
+      "name": "cacache",
+      "version": "10.0.1",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
+        "shasum": "3e05f6e616117d9b54665b1b20c8aeb93ea5d36f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz"
+      }
+    },
+    "10.0.2": {
+      "name": "cacache",
+      "version": "10.0.2",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-dljb7dk1jqO5ogE+dRpoR9tpHYv5xz9vPSNunh1+0wRuNdYxmzp9WmsyokgW/DUF1FDRVA/TMsmxt027R8djbQ==",
+        "shasum": "105a93a162bbedf3a25da42e1939ed99ffb145f8",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.2.tgz"
+      }
+    },
+    "10.0.3": {
+      "name": "cacache",
+      "version": "10.0.3",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.0.1",
+        "cross-env": "^5.0.1",
+        "nyc": "^11.1.0",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.2",
+        "standard-version": "^4.2.0",
+        "tacks": "^1.2.2",
+        "tap": "^10.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-fhy5oPxjgI/pfsSPhlqCFtvuM/lvRnD0T7/fCFoXNmR6/1IKMXsjk2UlNbrOkACbm3e9Xb2TfuDZ4d6lyqHXSQ==",
+        "shasum": "3d7cac2f179ae5523e777f74c4e956ce6686f31f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.3.tgz",
+        "fileCount": 29,
+        "unpackedSize": 101928
+      }
+    },
+    "10.0.4": {
+      "name": "cacache",
+      "version": "10.0.4",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.2.4",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.1",
+        "cross-env": "^5.1.3",
+        "nyc": "^11.4.1",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tacks": "^1.2.2",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+        "shasum": "6452367999eff9d4188aefd9a14e9d7c6a263460",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+        "fileCount": 29,
+        "unpackedSize": 102024
+      }
+    },
+    "11.0.0": {
+      "name": "cacache",
+      "version": "11.0.0",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^5.3.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tacks": "^1.2.2",
+        "tap": "^11.1.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-pWhgsZ8GL5Boz69gJ4RPM1xiyIfB5gbB1V0P1WCYjIUDeww1zSIaM63x8R7YlRV95MxvXfxB+QVeY1YdneVaiQ==",
+        "shasum": "6b7ddb262c764cf482495ab086c69ff084385821",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.0.0.tgz",
+        "fileCount": 29,
+        "unpackedSize": 103377
+      }
+    },
+    "11.0.1": {
+      "name": "cacache",
+      "version": "11.0.1",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tacks": "^1.2.2",
+        "tap": "^11.1.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-s5YA8Lva1PF76kHDquIPW1N0YJXNFiItwrrDXAn8vvunOv/VNXOR1LtQYgPBRpaweIX2xSaBpqIXCYeOTZfHSQ==",
+        "shasum": "63cde88b51aa5f50741e34833c9d0048a138d1dd",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.0.1.tgz",
+        "fileCount": 29,
+        "unpackedSize": 103486
+      }
+    },
+    "11.0.2": {
+      "name": "cacache",
+      "version": "11.0.2",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.2",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "safe-buffer": "^5.1.1",
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tacks": "^1.2.2",
+        "tap": "^11.1.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-hMiz7LN4w8sdfmKsvNs80ao/vf2JCGWWdpu95JyY90AJZRbZJmgE71dCefRiNf8OCqiZQDcUBfYiLlUNu4/j5A==",
+        "shasum": "ff30541a05302200108a759e660e30786f788764",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.0.2.tgz",
+        "fileCount": 29,
+        "unpackedSize": 103864,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa8KCeCRA9TVsSAnZWagAARwIP/iLX3k/nIgihaXX1urCX\nq+kBkZ5pjhGAAH22PhKfhJcMmLStLEzhxQMnFDf+9HowhMHM8vccMZuZbWVW\n6j6xtdalp2L+n9TjJZIGZk5BRLF3Tc3n93G+f8cpbxVvhHnYvs80dJpUMN32\npPNFFa8C3knDGaE9UtQLhsA651OzgFSHykf9lLVJ8hvgne4VpD6wTbKNLd8D\n7UxDtj3Ue+7OTZZBZMdVTgBDrUKqDJX6zUP2dZe/Gtjnc1CtbEmBxh4wRbSx\nRJSJJxVVpwZjxVvdmHXEnwqnxXJseQQP6klSxtjJglGmc5izGFrQvL4CVQeZ\nxSSWyEn/2zmNAvbTvVhM5xsr81hWLWyEc7MbOxss1HjiDe/FJgsCRTt/FE8R\nO7aaT2r9sABBfT2YLr9b1VAcqoiL8H0ATLwe/1RMFJbLtuWkBLBpOe1Cuz5F\nDBL9JwG8rSmCfUMjlFwFXK9YFwEfV/PHz2dtGc7QN0qwyXfmPbl7jmFMJgzh\npa6Z4i72r/LGh1gI4VPQSjcYjTbRWsH9nPPjt7iY6WOF2ZEEXMQqOHvG79Mt\nFaNzzaUiPlfhTpI1iHqAS8at117kpmadxO3058jln68NnJ9CdDZZ8+V3HX8K\ntyjXxV3DrwLvCcd111kPmbE5+KSe9nfXAEL6OpTStkK6q7W9LsW/94QX9vhq\n82+u\r\n=RUWS\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "11.0.3": {
+      "name": "cacache",
+      "version": "11.0.3",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-PKg49kjNaPFvzwcIo4mo46av7uKDnECAeyNDp3R+WTohi+BeQjPC7zcKxx7P1lyMySNBY5FeGD8Ys38VtBGcTg==",
+        "shasum": "632afc1c48c17cf4f37fb0044f8da184b475426d",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.0.3.tgz",
+        "fileCount": 29,
+        "unpackedSize": 104392,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbYhgPCRA9TVsSAnZWagAAdY0P/38vCfVgefLo504o/7Sf\njknTMGrBZcxqaV6+jCdky8jz5Nje9URKhrlUyYme7ZE2rzc14N1kFvul3df1\n8NedG4rNcNiJxMpc4k7PN6Iv0sC8+uoZ38TAQpYH2brSuOEAkILDVFpAKXAA\nmoNuPs/bZSJKzNIe7gzVpIbTZaZLFLjK+QsXIa+g8/YgEDOM4BqI01A70nzG\n39gieFaqYv3EiBcSq8qFdkz547wtheGSY359XI4kYhnByE95EJ5PWOtOqxcY\nXZHycgWJEBWzh+zRXzISq3ED3cONWwmbneB9pMb4qW9kwxzsYuJ8EH7GxLyb\nvRxCKtE4qBY4CTJg/vVsfMzF/nKquRHDJKXMtsISoLi9Nm2QUsnrzJuCOT8f\nqxc0jRTEth/k5hFvbj4KXQNPokVT/IoZvvo+oaTfts+39Eum3pfs45Yfa+IN\nl/w8I3dWYPdDi0r4PIl3nqVKh5Og1lJsbc5NNnmZyBDMM4XguaTGyXpUbGL+\nRE5s0jK5QIbQUk8nSqNLlB4xTu0IUGpLBejy04drmBl6aHfmQNxPPZb3Fquh\nyG4jnx5lGPamsSonjtlH8odWZkhiTto8zlsG6WqvyE7RCMyEOZ6YYbU/eine\n7jlvSMoA/Jk04ycXJ1iOjM4rULA9ed6Ssv0yW+BwqwUg7ikYMFnAxHvjevmB\ntrNZ\r\n=m+e7\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "11.1.0": {
+      "name": "cacache",
+      "version": "11.1.0",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-wFLexxfPdlvoUlpHIaU4y4Vm+Im/otOPCg1ov5g9/HRfUhVA8GpDdQL66SWBgRpgNC+5ebMT1Vr1RyPaFrJVqw==",
+        "shasum": "3d76dbc2e9da413acaad2557051960a4dad3e1a4",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.1.0.tgz",
+        "fileCount": 29,
+        "unpackedSize": 105687,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbYi/bCRA9TVsSAnZWagAA3BkP/Rjumg5NF0KdlOtimiEu\nDy5v3o8DZMvpQKi/ULuvK3qY0TCCR9GJc3HKk3FCrGWUp53AwJSeBcEFM3W6\nc15/X+97adBqNv+MgkcmK1bs7V56buBfEAoIYGNfhjJu5WuYt4nHR9USdwrD\nSrBl2nR6S8iRgrlOMtSH29c5bwjxvx43omHloxUG3+WSnQnyDZ45r99izi/a\nkxouEmWMAWYPSIEsEoDtlc/VegbED1OcHyJ6EG8GRBZt0PK4coOJMnpaZiUj\npjbdTM/35jyRoKUNK22LHDe6FPFp8iD8eZTORwnMinOIcjUPcE4qo9hxOLSO\n1ucjaFWyAN4xOXoVGoijq/2heGbDMf9SGGFpeBfltiMLhZmA8NakjtrU0wbc\nlcKkTOcKtowhGlkE2bCzs6kZCbhG5NyLwJZWBd4zFN2kk4ttd6u9tK8W99LC\nCmg26BWsDhic/aleju7UIwNq8+c9uBqBBpVxJTeYU7gGrfOdZAoCsx5RjmzX\nDWXyA2h42NdLSl2t6IeFIQV4Xq1ZMB1b3/vGtA5AquFubIYe9lnxlEUjAqF5\n7L4Y6bqVB05bT7qfpq0//yesXQTeod8Zpmjy/1JYTT1U4Vxqtk6j0fjqKTmK\ngjgpHqMLzXML88eRkeyNw4BNmom97GLhpeeuo3bFJ7QqI/rTWF+85y1Tpqsa\n7dRn\r\n=yCMw\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "11.2.0": {
+      "name": "cacache",
+      "version": "11.2.0",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
+        "shasum": "617bdc0b02844af56310e411c0878941d5739965",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
+        "fileCount": 29,
+        "unpackedSize": 106685,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaj3sCRA9TVsSAnZWagAAwHsP/j64ncfiQL/IKCQb45Zx\nYRD43mMsd2BDc0k+qCrOlIw2x3jA+eTh9BHjvMBE0BuMuWAjwV4wXKXjBIpu\nwBhzYxwoCEsQbksV7oTAMS1PnQiOQfuZEs2zLfRIxQ8RbeGuynbE6HIKQSL8\nedyjMvsT3rMdY2rFvClYdLxx7qwZJYdL/6GXi8K0+F4Lxe04sMkKqNvwD2UF\nL2dPeZ3OcflO+piFJTZ4/8Yrb8fwR22D0zSiknQEI9T/ojYc7WJWetIPTija\n1IS4cAww4b29oWDY7SUS3yx1+09vPPydioZSvtboIfHqjo6Ahc0QQg3e97+d\nxcS5YJdpANFA6SQHK8gnlkfWZ+AX7eVowzWG17qYqq9XEgo9RcUoKvXS3AtO\nA7HHAkr6ylzkg8JF3xLT/gtyAltAwpIYis9wRb4Vij/clML5vVHjxNb2Vmab\n3TN7JubsSDxrPsdZ8RwBW5VuwqZS5nNo/WTLrUOYQHjSP0zjek8lmq9xAP07\npHgMEAcGKZnMzGkBwBSzEsrCWKLGo2WkkogubRJClL1VAeofLcTT/VpiNLFR\n6fs8oliVIA3KmOV45PPW0LJHt/Cyj0F9jO1BlMZIAn4XSIWUF7IyDjtRqVYA\nh5Ia8Lksurz9SC2b7c8JfOPCHt7gP+RRJyzVJmpbVNO6LGi6UosvT+6SabZh\nGb91\r\n=GisX\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "11.3.0": {
+      "name": "cacache",
+      "version": "11.3.0",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-6Af/h56f+GXGAuxfutTZGxOofff+PfaZ3K0XlXjMAzS8HHijzNYySP8zHrJ0vniSzd4wrMgwOHegWh695pHSRA==",
+        "shasum": "c37d4c12e3114064becf8904adba039a5befd4fd",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.3.0.tgz",
+        "fileCount": 29,
+        "unpackedSize": 110919,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb38VpCRA9TVsSAnZWagAAwjgP/1hBBUmdSNN1Z7uLlb2K\nDxWWZvH9oPsaNrU++q7PF52VgvszUNpau6lj8E33Wi4O71skDVakfEBZG5WV\nCo7Hm97nWZubL5VD/3Eb/jMe+T4PAyI7lBSefG4sDkMgvbztk7gS5BvAf6ix\nsBZAQb/PIS2f+2tQHiDrxHf1+/ut19EyYX01hOo0IZ70rhZmtVqXQhjtBpSx\nK5Ir++WREaNTRMiRVoAdqVpMl6783NKBErtFziuUm6GFA+JhOjmPm69Yhj9z\nNI3umXFqiLLfA/GdlIJIYEurcCnDqGAxcUDv5aItgXyWVK/prT4V2gPmJkOM\nuzGpXA5Kfh/KO+fjOKh0vMkNlqZROc1h4K6EYKZKeq0xlSL1JadBfTaZOIMS\n2WRhMzFjlZNy43iAtDljJIU41qtbU/fUgnGRA0f784iXAY4XDsYveKyNqOMn\nBE5fXDSuPTEg1NyvOaOYomnwfjTPa4J1kA2bM1BokrnZ5O6XfVbR6/4DvZ36\nJ5peve0oaJ5lJTC/BK5HM301/AFETOQ3H8zmUFTROModACV6l25elIyODFON\n8zMNocTqh5ClN73L4MwvxOkFFl+zmKKJ5iZFs2Eo3cukgwL3ZTOWglk3WsU9\niVGjDmd9LGjwg+vPaY/D8UxXgb4dVKajpOwepiBPhl129uXtFusaHlsiIcSs\nzYQ3\r\n=E2jl\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "11.3.1": {
+      "name": "cacache",
+      "version": "11.3.1",
+      "dependencies": {
+        "bluebird": "^3.5.1",
+        "chownr": "^1.0.1",
+        "figgy-pudding": "^3.1.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.3",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
+        "shasum": "d09d25f6c4aca7a6d305d141ae332613aa1d515f",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
+        "fileCount": 29,
+        "unpackedSize": 111301,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4LNYCRA9TVsSAnZWagAAKwQP/1WNsqOngJOmHit1rRAc\ngDtvOXzeEn42MtKAQFoZOJT7zt8xNBIg83PMmRXZRtWGGkQvo07pfB4qanoE\nEvze/fDFHi/jvcToD/brYsBJZ/IMXWZs8ukx7vMj/ZdqIH6TGk0dvbOi2TP4\n1kvK9FLcp4esdRQ1so/SAvuOA//fZWaNv+JX6KvMRlLM1tPjujHV+DIRCihQ\nE1BhSYP7c0vmn2telUTfzAPBGR9CFT0h3vk5KMmZs3KvFsRRFs1+MCA+XHku\nw4KnM5zhAgPS6N83DQm01aNMDYp7f+yVmG6oj75Q7tJ+XHMotAbmz7CwwWAm\nEcUvYcLOo71e6oQESuy+VxHff5X6Rk2K3LrOi551cBqOC1u1VEna4g947imD\nhtcEURJZtkLhRARiUkyMiKaRPPOgYiOfvq289WbjroWMR3XdajOwclyn9Cpc\nLwPPp877gN/s60pkQqar5K0mcFjeUF7aLoiV7NRt2Gc/PepFg0VThQ6eitjG\nAQU+pk+a+/W3DVCqzFu98YMUoQvOMz2vViZ1irDiSC8dooH5GK8hitOQ+nHY\nKz2Xjs5uQOFZbCDHQf5pYTVX9WL4/2T4Am1Knz9uscyZGgQsgVqeX3wECkN9\nqLT5bu1KV+CoDRy6VcRTp/8ar6LE6FCR3uJZ3K2Ix0y5oxoTCPzdrY6jvyhW\nK8e5\r\n=1Wit\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "11.3.2": {
+      "name": "cacache",
+      "version": "11.3.2",
+      "dependencies": {
+        "bluebird": "^3.5.3",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.2",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.3.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.2",
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tacks": "^1.2.7",
+        "tap": "^12.1.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+        "shasum": "2d81e308e3d258ca38125b676b98b2ac9ce69bfa",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
+        "fileCount": 29,
+        "unpackedSize": 111544,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcHTf1CRA9TVsSAnZWagAAMtEQAJTVEcbY8QkjMVhIBBNe\nV7nbRouS62lNStW78eyOqVaakJRH/1w5oe0jzgTm27ItNM1hQae1MJyihDkg\ngs1SE0A9bsUA5IRUyGSmISa0LA/NSMLIYBO3XvLKpY+gLQ7D5enXLHWKbDJ3\nF6x3wpresZZCdynvYtiDz234ofrotdvU/xaIxrxv0laoaJElzPhuRgUShLNe\nYIQxxzF9cNYIYh3he/tiuj90NKYtbOsnHfStrxFneRqx3ynD77l/vdk9tEeM\n4THtgv538k6yN3Nd7ZqSNNTEPEvmIl/ibp5Hb96kiMKctUAsNs907k8LPW/5\nf4c/Jh+SeiIiYR/AjkatC4zWcfhk8Glxac/lNUr3ehwXi3FMTAIp0J0JHpXz\noGUhC1LNDw25Ojjm1EUthBOxLS3HQXMWG/E2Ec4I4QJXE3tYWZs5cch+SvdJ\nLadUCtsewwzMfJocPfGVyh7ujJbKeJ6MT1Lc11TQ9BBpCtjPF4skMK8btWRY\nYLspAHyDEzi7Awu3symh/t9+/4P4fjFchJ2ahGeT64QtoPomezxh8mFhKhnr\niUufymVJWs4O0STKTSpVhBk5Rb/9RVR+RLlss/xuGnBlRuTb7kVCfWCzSQU8\nZKPMIqeC6ZoPCIZ8y09XUrf/RQmMZSwws/PWBSktnLTnMozKyQv4biIvfBNl\nGPMM\r\n=/TH5\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "11.3.3": {
+      "name": "cacache",
+      "version": "11.3.3",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+        "shasum": "8bd29df8c6a718a6ebd2d010da4d7972ae3bbadc",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+        "fileCount": 29,
+        "unpackedSize": 112357,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdB7xwCRA9TVsSAnZWagAALpIP/0hXZCajeHjjzLrBUEV7\n7EUQTQEZym84XZx0B9mgjcr+Ga/udYJjFX2s+omXnxn47sEDh3aN0AHW5n17\nBVon5YDJo8DJRR2QGBPUE/Dr/nDCPZT6Crgk3z59W/iH4BgnlIOCM4N1xZrI\neiQmlyoFw/bDCDMPNw2a3nvYHLBpYMGOrJrGz0ZxklB3WWJbh5eFsO7QNdJN\npTECf/2TU7AtwnJuo7bcD2nyKPW9z04ijV5JnCZKW3GU6yM7KnfvSb4rghep\nL2K1hhmkqt1YlztHXC/jXo6fNiZid37vcQDPVa7muKZXWOEDQexl4DO0WP1x\nAzo3VdObNRInfQp2mmDTnEfKScfEI81zcWMtfq4izWLKLOMl3QkUKGDDCpq9\nl0Gip5INniQ0cbf3Mu5XuBfzQ+f8n16vgIhkwEQj1+vUXhM6wus8td2wyCDo\nk0in7zPMhpNZmy5EI14rZtJuFQ3m9nSJN8SVi/XDcKYqXZT4/FmQZ+2m/WQ4\nzjJxN4Fh/rJFK+3Mf+itcQApjwTQlBshTkcltEeeAXsRKIGNlWApxZaGOkqm\nvxUmctFA3R7avdsmXIIj/AtwHRbGQSpJZBDR8HmuiHFkRu/JK5mmI7ohMewZ\nNkszQFCfcwYGou3dEw8tJVv0/PMUBhWCBiUQJYqdK/+t6jFKhP6dJFd5M7jH\nofMB\r\n=MkeU\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "12.0.0": {
+      "name": "cacache",
+      "version": "12.0.0",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-0baf1FhCp16LhN+xDJsOrSiaPDCTD3JegZptVmLDoEbFcT5aT+BeFGt3wcDU3olCP5tpTCXU5sv0+TsKWT9WGQ==",
+        "shasum": "1ed91cc306312a53ad688b1563ce4c416faec564",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.0.tgz",
+        "fileCount": 31,
+        "unpackedSize": 133904,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdLQxECRA9TVsSAnZWagAAnlAP/3tLeWfkXm2trXO+9nFC\nCKLz1Yum8RFhj9BlBNjC/JOWiwb0+s95R+FENdfg8mbuiyBc5SY/HV78C+Dc\ngYvrkg1piAYOna9TK+DdiQ+WafhWQohyq3X6QxatyUvsMaE3yQzo3vYBQmsA\nuZ6U7A3qPZuRaf8A9ryCaSk//EQx8P6eJqY1RmJoSC3axi3CMo6DlxzWa2mA\nEWQXxdMKD1+elGwtjkuO6XFiV6VYX/q1VneXAe5ONpcEtz1N3k77hs0a+YXi\nFCxJ6putj1Z/cIaaRxkVE7woXhTkeB2DqFCPa3DRuDTBrofHlQuH57cXcdAJ\nTwUPMnxwDjn3F8oiRcJuN/bQrrqK4Uuu0nP7SCpmdDudiUhRbTbMO9rjl5b9\nqH0PlECVEO4b6VR4jKQhqQncBRmru4eMaqpCvN9u+aSBEAEZBvQIHoNcR8GJ\nZ2MD+gocXjYctRkKqMTS8V7CuCy64hifepAO64gn/tEpy6y0YOA0I2md/Ig0\nhCs5LaQKKQ5Yit7gQBk8MUZrbm30Jk8k4PdcAzOq7zBwrK6a/Rr+pbnA8sKJ\nAKq1Q9NVbAW6zVHBOcD/2efSwkVgoFD3R/sg17TLEM+JKw9wCNj7GpxrIVMd\nkMhhPkXxfWrItB232gEzo6m7KJDHiUu9lFfpvqTbXf3sw9mnrPUACMZnqdnC\nl28U\r\n=Z5zo\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "12.0.1": {
+      "name": "cacache",
+      "version": "12.0.1",
+      "dependencies": {
+        "@npmcli/infer-owner": "^1.0.1",
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-tJtxCdrtecQEmAkTCt8qKZQWANckuD6T7d0EhVUxh9lbggCedG/UoGCEyo5+/vgbpwhEQJ/FHgREsgoObex8Pg==",
+        "shasum": "527af5682b34bebdcde549ff267a4a46f2944857",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.1.tgz",
+        "fileCount": 29,
+        "unpackedSize": 115180,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMkWDCRA9TVsSAnZWagAAUNAQAJ24oeKldNsQiWWNhQqq\n3e2TfwG6w3Xd0g3J4RuU68mPTxXONa8wm6bbmtIropKpSqPVYaNSjm31LNsM\nvm4rnHfbN2iLSys8qBgtrSoDg4qWiC9s9oMhm3HHpuH83nE2eYBy4yfOgVO9\nxKwPfSOE6AJvXvDP1CgETSCIw1Yr5lwu0S+KVZ9SAhK1RbExaOaGXgYtruUE\ncigDd/Nz8Yz+NL+T5EXr8bwhMOfAUetvy7y2a+ikeeUDVaXhuznAloukMyM4\nlAS7QtDA0sFME0LVhvdu1nnWB5q3+yzgTlD/2NAdyVbkP0tLt+T2/1XTe6aS\njCn/AdjRXJPXW7PuTPwr+J1xwwM/MbMW3D9TQ+WEZ+zpzbFMKGyvDLqrszVT\n+TUCh66DXZmnIzl+Gwc8i7wFdpP/zZC6ONvarjyjtDGljpOaytGxc8LUppES\n3zSrFdsPxav+HpOVt2RbesAZ2mhFcNffjSznu24D5pGyIvDDRJLOGsd9dJ7b\nZFNPACU0Jg5LXHigMYe62NIiQBBHqAd61FYU3A6GzAFIWHJKU8GLg9t/I1un\nwWgW9++lfev0R/Ed10V1W8MZZTkxtje3EUgQqjU/Iq/pyhjDsDbg/Je1q9ye\neEJAnMogGD3/N/2XLPqv/w6OIgsImQe4xdBzjyaJ9Ynbjxozm482jg7cZIgg\nSf/q\r\n=QeUk\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "12.0.2": {
+      "name": "cacache",
+      "version": "12.0.2",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==",
+        "shasum": "8db03205e36089a3df6954c66ce92541441ac46c",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
+        "fileCount": 29,
+        "unpackedSize": 115251,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMk4MCRA9TVsSAnZWagAARK8QAJADGsGGVtuD7catXO/a\nlqb285/vpwd9ZsHGUepNeMq6p53Hbek47jukUwlMR+e99dbroWfiJ3R/tnLb\nrRcUXzovB7mmmac3Br9JtVBDHKt6G6W/HexkPGdCXDE3lWk+xKax8QUgif4g\nQBc5u6IYnCDEEZRSMMVgLbUr0Cj5bzSvXewk2W9eAoAfjSkQL4HVKwmRUIKd\nKdlt2xQ3QbOYKVsd6jO3tqRzeNyVDwx9W/e6y+SPDYZzeqy2HGsLOguqAr+1\n8BhKDEtqh7hJlMDqY2EMSNokAz0r2Jz7L0N1mf40hfQZibx2dWonmiP8xPFC\nm5j2Zo4tQJlthB+S/UCcLQlgKbIHg7Ww92ZEhZYJFCNo64Pc5vUF0TLJZ6XE\nmtRzT6Ze/vO/08o9RmIyadEUfDOmY/i9larInPNDBkgwdc6UMKlevW975MI1\nLRbogcEWVVJ8NseOLpi0Nzg3IyXva7H+J6v03LvU/u+gcvzjUtSWuEdFxln9\nC2MpQ6BAktlMdz0UA2kljL1E9cvykFBBzEznAChUpmWSqUtBvAtTLWoJpBE/\nERcjOynd7v70SMyUmQ8OsflydFO6dEEHR5U2A4QMlWVaaYGarm5ViABJSo7K\nibCpB7Ef9DhFPGgqzKe/WveSaDxX7WEltT3euzKaVOrjPFrWElRWodSnziuN\nvq/X\r\n=WzUQ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "12.0.3": {
+      "name": "cacache",
+      "version": "12.0.3",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+        "shasum": "be99abba4e1bf5df461cd5a2c1071fc432573390",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+        "fileCount": 29,
+        "unpackedSize": 115547,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdWvksCRA9TVsSAnZWagAACsEQAJnoOZHbECu0/AKMvHME\nZspR+OhjsI8UyJa0+4bp4419RLpW/J8S5A5AgdnLXZc5+1TRXdd6oVXgqeAW\n7vswR/5SPUeljQYI8DjJELTO2dqbQRxXbeM7LaaJbQBtLMTNpzdhqNnW88/i\nDJVgUUX7hPKHVS2rRa2WbGmR5Qi92be6Q73pCdD+t1nZBc2baaPMEQzzOylk\niXM4CO96ZHLOggn95U1f2AL1RQy1pzWC/9muMpG8Yu0YIJ5JBlF60vjGTkwO\nhdrWFcy3ARZ3tjWIEIQkh2Tet/3yW1dKzk/8DnKwoJ6C+8RhUj43+fOvrOFD\nHvfk4BFZ0Dz3EW2Je83Bj0kjdvNtxZlvwH+BA6Nkq7/uNwiWP+os0A0knE0Q\njlE+Wp5LgJHAvMW95mEyMR0dtzsZ9RFM2oYDPkpLxl2LUAQ2wFQ+mqS9phIl\n3CBWb62xjgrRbh+CbqnUa44y/sU4kXFEzJs2nFj8EAZo1avF4OAsmue1Zr07\n8QKKX2JIyy9KGEhZ/rnQ5dWMJRpPjD5JzY4ejypxnxZgW9QP7h3BXnpkK/zr\nHStpZ2DH4AB8F7/Gf8cm8EcHi6c0MdlIZazJXEUgIURYkr2T0JFUlCp9b6at\nZBLn17XqPSvdewCedGvqGVOuwttsDIKz2F6iwRPXsJpx+5+zZjOQS2zKPSLu\nT60S\r\n=qek1\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "13.0.0": {
+      "name": "cacache",
+      "version": "13.0.0",
+      "dependencies": {
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "fs-minipass": "^1.2.7",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^2.6.5",
+        "minipass-collect": "^1.0.1",
+        "minipass-flush": "^1.0.3",
+        "minipass-pipeline": "^1.1.2",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^7.0.0",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.2.1",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.6.4",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-hc9ozSyxintw3TulgdYl5q3ZMjugHYI8lE5hd1S6E1/7OwLf0vNlBdCaROlzHxE5x0lUpFx+B3iMjWmcHDRxiQ==",
+        "shasum": "1797c957bcddf7bc697520920e3a284e64fc21cc",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-13.0.0.tgz",
+        "fileCount": 22,
+        "unpackedSize": 98894,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdi7oJCRA9TVsSAnZWagAAFOwP/RQ3pTGWJG1yIPEKsQRs\nRkJfdtfM71vfEFkbcVXnPZGUTh73Q2LiQVxnaKjTcdkSIVl/wnhkcMCAuElK\n/yGOey19J+JJXVwU2dmT0wV8ZkV2bh/rqALk05pSVN5M8Vo0+lPheTxZn7an\nJhJhDQaYVzi9K0Jl/cUWd5PgrxVbFHOUCiwPUZrMAvTv4uaMeqDVjiOwbGYn\nozsUslwOHlBTtoB8BWcb7em7S0K35iq/FlD129zgFfsUWOnc7tPP24ShukaO\nTGfl+8ay7dxQ7C0JncowStCrNDivBC+Zzj5tHRg9VPTV5cwSDfJfcm5VFKfo\nVBYr1Wn319tnXuOwsNZdrUH6D7Kg8nlk49lrV5Eq5vleZgzgF+7BPQX8z9Y4\nuz0dayrINZcK3eG3n0PJmlPTthPJU8nlVUMp5fGmuJSV/WhUkx9OTNEl3eMz\nALVLAF0CGdbuXtGrlygLXxX3cpl4eX/l++g8EDMztjrjezHCa7Ot+CFunPpw\nr3c4oFrVlPVpO1eW7KrKEI41rlYJVg3q3UfPI6Or12EbXQZu1lRkv9WamIEV\n2Ggr+jCplkfoBOZ6zduwJ5RqSOmkXrv8MqZREWecPhO2rOgUE7Kf3sufehwJ\niK/F+hrecwbTNSEMSmRI0giM72YQ6ymr7OJjaC+R7iC4AC6j9iVQSYRm+x05\nSs35\r\n=si4Q\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "13.0.1": {
+      "name": "cacache",
+      "version": "13.0.1",
+      "dependencies": {
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^7.0.0",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.2.1",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.6.9",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==",
+        "shasum": "a8000c21697089082f85287a1aec6e382024a71c",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
+        "fileCount": 22,
+        "unpackedSize": 99047,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdkm1eCRA9TVsSAnZWagAASTUP/jEBg8ZJhAowxxM44jkE\nHyrFqRUlvQaF463jFtK9zqHpCdPXxwmT6lgnPOg1OKwawt9ZYWyF1rVvV4bd\nIzR7GVqI3THIDI1g7JjlRbdItTN0412o8B0Jz+8wjMGwyaVk7uP5Lz9GWOAB\nPnMUhDcUUCK5hsEqh8JHbAJrfs8mZkrQX7HYNTYnWQEWnB7OQ8xZp/CNEioa\n7BJQ+NyEvjxbPL4UGtpROtGJ/WO2pU3hG6gdxKQ2X2DhEv2n5aRr4qMGY7//\nfTgAZfYHyfbHNQCEzMv6+dPAi0SI7e0wYTqY/eZM8Hm5BCOah63muml6+/1o\nySBrJv+j2ZOXBQLCdFGcEgYt7CQWBtwRZ39MFtOB8iK6RXkUTNmlmV3DMgLs\nyHYkxtIjc2WkrnjjcKsGFuzhug3tBpDQ26F8w9K1d0Vba9h0ULGUKDh2Lu6p\nyih3S6Hh4xB+SUgeKyeAJ08kTT6xLwGM2Ufv+Ry9hZgPXqQG3xcWCW6QFmVR\n2LolngiVqK4IeCCXATOjx45qARE4foj+1ZBksX/x6Vk4WiSA1N7dV6TxrmZ+\n3oFJM99uJ1xwfkduuTImvl1NbFAcR+KX5boaLJXgW0MfbMfFGu8A7/sN/QSo\nRb3qq48G7bE+PNNf1yxQCcxSlD9M0tf0JApNItZsjnh2tKJQ/sKWw3/jF1/X\nl3qb\r\n=0KSH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "14.0.0": {
+      "name": "cacache",
+      "version": "14.0.0",
+      "dependencies": {
+        "chownr": "^1.1.2",
+        "figgy-pudding": "^3.5.1",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.2",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.0.0",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^7.0.0",
+        "tar": "^6.0.0",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.2.1",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.6.9",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-+Nr/BnA/tjAUXza9gH8F+FSP+1HvWqCKt4c95dQr4EDVJVafbzmPZpLKCkLYexs6vSd2B/1TOXrAoNnqVPfvRA==",
+        "shasum": "97c10fc87c4c7ee41d45e32631c26761c2687caa",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-14.0.0.tgz",
+        "fileCount": 22,
+        "unpackedSize": 99805,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeL5PGCRA9TVsSAnZWagAA8nMP/iK0X+XlNwoBSzN/WdZX\nfec0Nm8KGGqVTRU6JCwgLu6KWcxkrEUKhaakRm1EpIH2buhemPAKl+M6/uIP\nLF+YXtKr4LvkNk5PS8jZmBvC6OG151ng73c5I2BqHf9HSmpl5iknADbtoII3\nXQEujXetENEr3UYWdkRrnI+kkI+sIl26sFaICVPWc1GYIIJN3JQRJW/tGLu8\no0d7fvx5WTZZ21NFWmJdqJjhowmONjIJ9rorahB581r1guMTjbt9Mpv+556X\nkMoX+uC37npY4ilz74AAOkzn26X0Wo9TZcXooIc2R28yPHjOLhugGKrrMpfh\nK7pbz8w6EzZ5QtSCuR2goiW1MJ4NGweuiYYPlH5zWUzrfLNgZPcDSL+3C7To\nH7shSK+vXbwoqeC33l5KGCwK0PqgzDBsGCRAcy2li33KTVxnbwGE9Z5i4piB\nJ2jy5hNiD8cYOjsk24cB/7LOQVtszGJOU42T7yhthnjAt8SBYVaVENIXjKEE\nWE5yAcpNTg6phmc1JVl8C6rEW09amaB46KeepUUfu1lRY8ecWdKR7JhjGJV9\n6aSoWvzatfwh0KBGmpUuXgB3JkbZI5dVe4ADwWNrJmRXGuOmgeu6ECmjWgEJ\nLkghjo0s7DLah1XdIAptbXp2vBFNqEsVP/BWihy4MUA6Q99VpCcfmXx/Xr1O\nhbDA\r\n=+lX4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "15.0.0": {
+      "name": "cacache",
+      "version": "15.0.0",
+      "dependencies": {
+        "chownr": "^1.1.2",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "p-map": "^3.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.7.1",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.1",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-L0JpXHhplbJSiDGzyJJnJCTL7er7NzbBgxzVqLswEb4bO91Zbv17OUMuUeu/q0ZwKn3V+1HM4wb9tO4eVE/K8g==",
+        "shasum": "133b59edbd2a37ea8ef2d54964c6f247e47e5059",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.0.tgz",
+        "fileCount": 23,
+        "unpackedSize": 120578,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeSz78CRA9TVsSAnZWagAArukP/jRhV5YGJdPCbGIvTj1j\nQyYUmmnISqQXuw+0Q9TOWGMOTaV+sQzRq0vZted8xaDiK4micGHFHlW+/ZPY\niFlz/l9vtv09+5TkhakTCR1X+URAcylN+tfTkKDVMptVhTvVuhosKRD80HjM\nHxdr5P2SlaOKaGlfsFeqFzMKIo/8LQTgLyrC/Yd5NiluoOihps0xi5Jy9PX4\nLTIkmWNe7SyT9Ygg8jtgAVtnh3jOupj0yMenuojd+EcwLtjsK1dbJHUHrvy8\nZfYLcGybJnl4eG/52cJoTRQcxZkNquDEghSY6KhFOXdAS+e9LeJiNK8T+8zd\nHQdLmXrDhv1/2yyrH1SsbdL8xBOc2ipOvVmVan9zL8Wh0lMSt3ipMme2hzIJ\nNmjqlIdh1dK/uJF3QcOMsyDlsa3Ra6jCtBTC2fgZWM2VG8AxdgV8CBoNX79S\nNa/wXUfY+AveixvvXHo0nD4XJo/WVIVYFqhM0Q4BSH9DeYHLbrPVBf3AGs10\nSiyzqzZ7YKQ2a7QCfvrLBtUro/YBgu0TWFFsAwqc0UH2GuW06Cu7b5uoKyc9\n4+rlNfXvBD0FJVw0w/3OB4RjT/Y/StY9tldvGuPcEj80WlzbXMO6RQNwpEli\nS/wPceAF/hDAdW3SCdYRhSI08lfToY/C+H4RUVExwsgzxW/shuUvDIrE8uD1\nJZsc\r\n=w3RA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "12.0.4": {
+      "name": "cacache",
+      "version": "12.0.4",
+      "dependencies": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^2.4.2",
+        "cross-env": "^5.1.4",
+        "require-inject": "^1.4.4",
+        "standard": "^12.0.1",
+        "standard-version": "^6.0.1",
+        "tacks": "^1.3.0",
+        "tap": "^12.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+        "shasum": "668bcbd105aeb5f1d92fe25570ec9525c8faa40c",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+        "fileCount": 29,
+        "unpackedSize": 115357,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeeVLTCRA9TVsSAnZWagAAvqkP+QGEXsbyzFeaxv8Qv+TB\n8AAXsonmPOk9S+nphs2l4VZJdtEF/EpFXdiaLghALtZ4aWIYacjGklZj47oi\n+MwQSSpPpst7Wla0nCt2fq7Ejm1lVtaVYedk9WwEZKg4hdOTXoy23aKOtnYg\nlHnm/0p1F4/GNNearPtNI/T7drvNyOLYSkkEaRaH5+EVau5fkGF+o9CKVYJj\nCl9gYu+3/S2drDAf+9gYHEOOirN7Hwbx/S18j3M0E8yByrTbtYzUT3G++4ww\nqnsUwcYseQMTbqpn2ogJjNpBmzePJ17K+3Gd49NWk3nTqA+1sILTRcV4Bmfm\n2OImnazGU8KRUz/o/2yhYn1spdWrqzlD5NSuuYIu4lb/kTGN6ZhUYKsYbnx7\nbPM0J6CaagmL2GR97JLELGeMFl4qYYhWR5dn1S4lXHECnZuzhpndqNdE+BAn\nwsBjUvj7xVrzYFhQC18C/t/2tAqNevOF4yhtNQLNS3WCog0vC15F40h4N3wx\n1l7PsYNhe5zSQjWEF7jypi19HqdVfqD1EWESntGPcAedEUdB7+7YHW0ciCob\nwphqxKj7Yeo0AITk20MF24SNDmeAWf8yyYW0uEH8bYcAnRIBGHuuQWOzP5jj\nbnJvUh9MCSKQyqpwH2KzVAGLLfejoFUuI3s5tk++ZWFb6e4NVjuyq8+jCtVG\nEASj\r\n=PNlN\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "15.0.1": {
+      "name": "cacache",
+      "version": "15.0.1",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "move-file": "^2.0.0",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tacks": "^1.3.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-k427rNJGgXeXmnYiRgKoRKOsF+HAysd4NSi3fwMlSWVoIgGt6Snp8oTNKRH6kjRkrM64aQyOVl5B9hxxV+vtrg==",
+        "shasum": "a200a2505aced2154aac9a2150111e6954a5926a",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.1.tgz",
+        "fileCount": 24,
+        "unpackedSize": 128823,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJep3SpCRA9TVsSAnZWagAA+wAP/1JO1xZfz6ZgCNLKpU+s\nW59tvXNvXqHSatX6MlWK7rsxGEq2OqwtDCwn1O2MH+rIdPK8jVH+1eU60PQ9\nU8Hrw39HG+2s1ib1+57x9D9H+vcHgSdvjSqFudI7nPWKUtkjAjwEVBpTTIqC\nVXRKitT4fEoXO0bizfFrHPTeuNl4hxO7SqLSAt2lkpnZbE/GgfBW60RQFc1S\n5roMdnszH1Wog5JFCK0hNXmkdUwgYOSGjUYRpR9tcWsc2Kn8msB9ThlmLq5K\n5y+OFOA2170Su5puPbJNMQzqVCj4wZDz+BH0zwX7leNEnLuE6667Uxr/El44\n1EYrwKn1Da76/hs6sjcNN7jeErvrSMi5dKIJlru9qyAkXT5EpSszBuvGzfEG\ntrNxT5fnOpJXovJoLE/1F60YPDh0tT9+nwBcXqnRu7GbNx14MVxUUQXN9+Yj\n+tAkNE0PytCKRaa//SJAZNvIOLuCL9z9Bm4Fs81n6kf6n5N+3dEI/uc2K6Se\n5LPRYIz4cFrUTpLggN+82GzWaKN5wXsk00SFHUB2pIBEqoxK4n5mxzjgiJQh\nbRPz7AhrjG3E85zsuYsPt4HGguG+++ZLIoH8wHus1O8jZe71jY5mwW4MPDF0\nN08L7zteDEoJT7dxyJDNcpYp/9cWN7HaHBWPDuvbR/RdK/XQ3/s0AIMx/tej\nNrLD\r\n=v9aM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "15.0.2": {
+      "name": "cacache",
+      "version": "15.0.2",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-concurrently": "^1.0.1",
+        "move-file": "^2.0.0",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-XVCLiqTL5KaVnNKIUyZ1rTwmPSFgC8LAeV+ZsQqulmFdDkcUF/4y7duJ+tz1TJv0ZRUOdHZtVew4Ztz6LtvijA==",
+        "shasum": "e25391962f0477f9ba16acd68a8f301d2e84d2ab",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.2.tgz",
+        "fileCount": 24,
+        "unpackedSize": 129289,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJep3YNCRA9TVsSAnZWagAA/CYP/3TT0joYz9+vkRD6afX3\n4pmG7ftuSg6eBMvboATE9MfKMPX0fFP5nFmo3+QPwFjZsDNF7WC3LB+W8cZY\n1xbvK8wMatcUL4QKiqeF79+XNBvgRBKdl/C3TXxXIL+axXRWYPx/AG3kKmbK\nsk+1cZW99rPrLvN8elWdxaTrfkt3xfoZ0ViKOb6cITziPlwFK1MMzmmvYh21\n97q5E1wCeySY13iLgpY53LMpPoH3vO89/Uz5T55miOJPw8aDueQ3e2WjF27n\nQ4rp4pl7jjxtOcbz9w3bW8iVTq1zeGboy8+zH/6K5ht9Lqh++LxQ84YLZWdt\ne+7lOuotPkSWPhR+5fxz+581MWYcq8BrDmq1lcDBoB/G8G36qJBldT+MFYnB\nJ2NoWNm69uAbhXWLyvJxXkycW9OnFAOVHWP6YJfMTd8E7/JVD4TXEy6NpM6/\nn5Fk67GLY6XztJuC5SgL4tI+LPJKpNjH8pJeIp5kPOI0R4w4IDSQZkW6aVV8\nYHggkqUIwbjpia9dYFQ9h2SkDVQv0I/1PHykdAwLtrVMe/GoCsoLH4FL+QWe\n0J3HAUCA2fL4ZoBHQCioqduC1d39b+DwaIxjqT6TEGIz48h00Zp+cL8lKPwh\nI0IHmeJZb9+QzhaatUjQUVPdXOVOilFzb1KMCJRB4FrL3LSFVaQAKSkzpZ3i\nSBc7\r\n=EqCW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "15.0.3": {
+      "name": "cacache",
+      "version": "15.0.3",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "move-file": "^2.0.0",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-bc3jKYjqv7k4pWh7I/ixIjfcjPul4V4jme/WbjvwGS5LzoPL/GzXr4C5EgPNLO/QEZl9Oi61iGitYEdwcrwLCQ==",
+        "shasum": "2225c2d1dd8e872339950d6a39c051e0e9334392",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.3.tgz",
+        "fileCount": 24,
+        "unpackedSize": 129488,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJep3aLCRA9TVsSAnZWagAApJAP/1Vx0j7hc7C8TL/NIJzr\nhFa7N+S/1iexWVrRtPQpuf9Kj6oxKmTj9VnMO/iJCjYMBWC1D2WQIyGvc7U3\nRkt3B6s++UVmxbM1JX/8OIN4dhK6PwzrYZQF2nUvYd7YJrN76obtysyfC5Pb\nPMB41ARNFIS0Z37rPSkH/kB8wAn4hF+xLUO9tzP+zb40uMMY7gf/l5iGDzSG\nZs8U92yYwB5cSkTqHiv8oPD6N8/2mpmUAXDEUa0JqDvHGtQFeUDtxCiWjWGW\nWgY32EL0Aer2Kiba2jMAbUtXrDcBvuCEiQKHaNyFfqCqhQ08vWlKdzfCqrNb\nEzqn2R5xM1peYkjrrwuy/cYwrehAMtGjW8/ySRssM++/cB/Jt+MMsQmcUL+w\nRaIkusNTNy5iZpDPnqB/3Iow0dnPhAiGubodMQq6bq+R7jNTxpHqt9C2cVso\nAvxrFvYs/PEjEBPhzEViBAgXpx3hBGq90MzAaCl9qODbAB5Jt7063GLJos37\nYMzpBxa4vH9+J1W7ZtjtJiXSqIFpNjqF7drIiVlfoFfzuv7tWThsw3kidSBS\niBlN3XY/Y1at/UMftZtDHvAcDmyV0gYVTmOOAUrFpeXhVg+aC/Ni8NPw1UBb\nnYVUDlmoCEj0FxtPqS4853Uc16QggSa1oPnb1V/Sa78q012/KlfrJZd9j2R6\nGdJa\r\n=tBCz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "15.0.4": {
+      "name": "cacache",
+      "version": "15.0.4",
+      "dependencies": {
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^5.1.1",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-YlnKQqTbD/6iyoJvEY3KJftjrdBYroCbxxYXzhOzsFLWlp6KX4BOlEf4mTx0cMUfVaTS3ENL2QtDWeRYoGLkkw==",
+        "shasum": "b2c23cf4ac4f5ead004fb15a0efb0a20340741f1",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.4.tgz",
+        "fileCount": 22,
+        "unpackedSize": 101129,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe1uhgCRA9TVsSAnZWagAARdsP/3cDCbZiJUoFT8OjL9ME\nbg/6A4JeHMmchM0YNLjey2FhM96SjvMgCcLaBywDtKn87ItuZD4wP+3Env5b\n+NWHSXZrdfFkK4mNnNTNUn499YfZmV/dRbb5alUibDm1LbdjGMqyRghl+veE\neFIXzR/+Am3F902D0S8z0Ig08Rbrt/3NvuAxqfPDWZbO0X7Iy/F1YL7e48Oq\nwvXC2WNXHQ20JpsPgge5CDGZEZOm9+X5kDhCmDIXxKzgTanMaYnBz7GS4nFd\nGhy/5zmhwaW2g/xUTpOENaGjaZSqyWayRcvRYv3DsRFMnGJjlMKx6Kh8bWJc\npWGmc58z/uXCTD4AQi4vgBf5wNiT0zEUpVfWhXWGFcEI5ahJ6ZBhx+RDHDlV\nYTJ6SGB1Dt0v49opaytX9ptAAPL2kWXfYuq6eLDDTHLM10hofBsybGjEwzIF\nX0NUnRXQFUB+aF22rM7nKd+CAjp0GCw4hVv3nm+eXVIgI8QW7imTkNpJt1vt\nzmrAXfRQOOlrB+IxwLmcD3CCjL99BdsRsAqhpAZ3q8thL/Vkyvwyeg6y81cC\nZ/m/3t8AGWUHjA+G2MUyTb4uiQPbVhsV6UNara9Ka2SRirgo+WGPLNxPjAlr\nvV/CHikm29BNP2c2gGyHXntZrv8w5BMJ7Ex3ldDPnWLC8bE7/BlCcQ/pEBLh\n5Sti\r\n=l2vx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "15.0.5": {
+      "name": "cacache",
+      "version": "15.0.5",
+      "dependencies": {
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.0",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "^4.0.0",
+        "require-inject": "^1.4.4",
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tacks": "^1.3.0",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==",
+        "shasum": "69162833da29170d6732334643c60e005f5f17d0",
+        "tarball": "https://registry.npmjs.org/cacache/-/cacache-15.0.5.tgz",
+        "fileCount": 22,
+        "unpackedSize": 101214,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfCRDiCRA9TVsSAnZWagAA3OEP/2xU8xoGxnBmzg7xkslx\nhwlrEXdYkjmoDmAG21tnIRiJD4wlg97cXS/dCVtuy+zP1MHAl/2AgW78O1KG\n0aATiEaB5p+TurkBdM47kuRnKTF5Eq06hXE4PBRuXSKLyMT5t3pSza910JVu\nND3cx54o81GdoOC71XPIrlZIPe5fzn/msvbv+Cjn0O6m6FPIQ8UxPDv2Yl13\nPODTmXYRfVfbaXZy6AoWcusxli7oK6aPe5VN3gvh4gZZo6vlbWKnVFeAAEp5\nrJbU/nSa3TrQ8w4DpvmvU2pq9tp32CBAF1+3+8RgqQ1yCMco+xHJKdHNuBw8\nnvz15togFKmiF3LiWEKTryEaRG6b1YaAsE/UvCFdQHQO98ThZQHvwaVVQ65W\nYGxQTJQX2l9uzYIhYUsEOqkrIOGeycXWvpwEpUkWzJSQwC2cxa4EG1i8irbc\nkF+axrkeWsBOYeiCegZUvcPV0M7R274iYbdGPv6ROgWRj5itCWrf6mMlYKBF\nO/QuKHtuxyQBfxaM5JozrO6oyaE1sVk+0y856b9oYbo0G0QiWEvUS7M3dU7a\nRYp6bZRKNvtHo3F2C3nW2W3ENOrfy0esFyXJz0Y8fZr/DaL4JGE5Hh7kSPrl\nZx4qJeTkaiqJZ3bBXwXyZs6ly5aisQHziam04wZM1aVs0y1MYOcs19LBaUBA\nSv2B\r\n=i2T6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:49:56.983Z"
+}

--- a/test/fixtures/registry-mocks/content/chownr.json
+++ b/test/fixtures/registry-mocks/content/chownr.json
@@ -1,0 +1,613 @@
+{
+  "_id": "chownr",
+  "_rev": "16-9250fdf304ab489329b0b10a8ff780b7",
+  "name": "chownr",
+  "description": "like `chown -R`",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "0.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "tap": "0.2",
+        "mkdirp": "0.3",
+        "rimraf": ""
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "BSD",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "_id": "chownr@0.0.1",
+      "dependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.23",
+      "_nodeVersion": "v0.7.10-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "51d18189d9092d5f8afd623f3288bfd1c6bf1a62",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "0.0.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "tap": "0.2",
+        "mkdirp": "0.3",
+        "rimraf": ""
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "ISC",
+      "gitHead": "3cafeb70b2c343e893f710750406b3909ec537cb",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@0.0.2",
+      "_shasum": "2f9aebf746f90808ce00607b72ba73b41604c485",
+      "_from": ".",
+      "_npmVersion": "2.10.0",
+      "_nodeVersion": "2.0.1",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "isaacs@npmjs.com"
+      },
+      "dist": {
+        "shasum": "2f9aebf746f90808ce00607b72ba73b41604c485",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "1.0.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^1.2.0"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "ISC",
+      "gitHead": "4f72743895927db8108dbf3d5462c667db22ebce",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@1.0.0",
+      "_shasum": "02855833d20515cf2681c717d686bb8c1f3ea91a",
+      "_from": ".",
+      "_npmVersion": "3.2.2",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "isaacs@npmjs.com"
+      },
+      "dist": {
+        "shasum": "02855833d20515cf2681c717d686bb8c1f3ea91a",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "1.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "files": [
+        "chownr.js"
+      ],
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^1.2.0"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "ISC",
+      "gitHead": "c6c43844e80d7c7045e737a72b9fbb1ba0579a26",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@1.0.1",
+      "_shasum": "e2a75042a9551908bebd25b8523d5f9769d79181",
+      "_from": ".",
+      "_npmVersion": "3.2.2",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "isaacs@npmjs.com"
+      },
+      "dist": {
+        "shasum": "e2a75042a9551908bebd25b8523d5f9769d79181",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "1.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^12.0.1"
+      },
+      "scripts": {
+        "test": "tap test/*.js --cov",
+        "preversion": "npm test",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all; git push origin --tags"
+      },
+      "license": "ISC",
+      "gitHead": "76c21fad5b9e518b3dba16a1bd53bd6f5f2c2e5c",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@1.1.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.10.0",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "dist": {
+        "integrity": "sha512-BGowLy8nGWXPbtRR/8imBkaAFdArC2ES+q4HvCy8RruTpKU3MEgxVpT+AxlkAax0ykKqnoNnHAZh+Ryu0eFCIw==",
+        "shasum": "17405cadd8706bc41f017b564bb2de460381e7d1",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 3828,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbnaJ3CRA9TVsSAnZWagAA/dgP/2yH2/y8vSOL20GKVFNh\nPgKIQOFhZCbZ97iZD105qpMVjYI2S6qOXV7chayXDrYtVfudZ3VZLF6nDQW+\nq2PQ8FgvSk1zN6xegTvIlEb0fboWHi4VZ4Ca1vg8GDdIrSefnxocbq75KvNx\n170Pc/NM4Q2W1tXhMTpLCAtHcvT+fMsOUI9DDWxoNLvMwWcY2JS6ggc9FPii\nySbbsoz9RkKIkxJm2Lv28mcrAzq9eBPC9Q0f5r/P+0dc4YWAf8kNTasxXWNI\nCtLUcOXxYtDQ6OJqFimDa0wrccnEjIDo8PKP/15FuC4doFByteq1zmtE++dH\nETDXZd4+b7JrSGC9EVTJA7uSss/gXK6/bYOP+r59Ld39FHBUK+xegBYMCnCk\nWacMiZ9y/TYjKI1v4RTfDxd21+VbqRFn+V/ZSUFRTyNqtLdu91Aaxc4Xa1Ga\n7NJosnfcGN01jr6SqDEPBi2RiUQm+20by+j8H+nViBXUmHqdkGsVVxCqKYXs\nxktIKdaSovdFH+VP2oJ04Vj0o9tlhcG5HNfeURZjU0LZDufpi/JPdfN5l/7c\nompEaIvMLLyke8GLPmuSZSPlRCzbIQka7NsN9v0G1DH/7kna7+9tlaa6pkqN\nMv1/NFwC9Ake2miQjXnC8LA9Pn0jUz5v4cubX8g9u+P68noLXDcCEUbuHE2j\n68at\r\n=Q33U\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/chownr_1.1.0_1537057399049_0.3682169782824076"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.1": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "1.1.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^12.0.1"
+      },
+      "scripts": {
+        "test": "tap test/*.js --cov",
+        "preversion": "npm test",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all; git push origin --tags"
+      },
+      "license": "ISC",
+      "gitHead": "7a5c3d57c3691eebb9c66fa00fa6003d02ef9440",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@1.1.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.10.0",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "dist": {
+        "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+        "shasum": "54726b8b8fff4df053c42187e801fb4412df1494",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 3901,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbncqBCRA9TVsSAnZWagAAzhUP/1pR2jFff+rVryKPm7jF\nc+IGuZPRxl4qLEjUSNSuVmq+eSWK3zMwSm+59eyI/+ArsjZvtIEi9TUo5ddV\n9vwa64C57bjTcbsSJgHUK+N+8qWggo3nXHYUhFUyVgaVihvVt4LUYPhWFpp2\nzjDdysskuD3hIkcsRPN7123OZwvl9NXU5E/DFmZJ95Jz0tVrABhE5GptOSab\nK69de/oz7tK+3tFAcApq1xNYfzkPSEQscQum+sleV56SEaEUQJfQzJC4iccM\nK7DjBNGkdH+japMi2vD9je2Jo5949wXBgOgjcZmoSgzb2gWivB4HcGeYh/fS\n5yX2CLCy0VOFdkK6C1bxIzxHQEqALY1pnPos1HkXSJMvzWdhNnq+n62IPOh9\n8MXEf0fUOdDfKSwAyOphtWmfu7Wy9gUrYDg4rHPDTQjGDM+mvIIMxMIwmQ0k\nsOOZMdXaaKf3tXtqNUT1j96hgVBTQ7X8/HrXxPuQI9hBrh4CdR7TekZFZ0NG\nrkiNT5fEGwpEz0EeiNlMkaNPkw+hvg6nTFp+0tePyWPC1weMlNCbhm4jipHt\nKl9t8ox+bsoKH/UviCYjC3XfJSEGqBpaox7i8Pjvcp25s4p9FwNiExE0pe2I\nvbWrbGEVL8lsoCJi84uI2n5PBcOyN51srZmWI6P9EU1nYzDPF/B2Z0N8yw5K\n8ks4\r\n=wIis\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/chownr_1.1.1_1537067648822_0.8733677031057796"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.2": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "1.1.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^12.0.1"
+      },
+      "scripts": {
+        "test": "tap test/*.js --cov",
+        "preversion": "npm test",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all; git push origin --tags"
+      },
+      "license": "ISC",
+      "gitHead": "cf3b27b5723045b01f7bbe68a874423d978683f7",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@1.1.2",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.10.1-next.0",
+      "dist": {
+        "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+        "shasum": "a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4925,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdHR8GCRA9TVsSAnZWagAApbkP/R0CiSVRS8E4FwRY/hoU\nXD6FlTt1IVt3HAvHs6stXKdkUV9EWYKXLjFuEj/hpCBp4ENrIdIX4saVAVYc\n2R3XKtSWHARdmXq/GHTidzp2tU4j42TSXWl9xEU1Jh7NY7/nBOSxNjL51rPp\n2XkD7B0Jw0YCPUb1yk/Ludn8+i2MqjCIZxsq1cA7OTtlAdMcBNXBfT9eeFhZ\ndH9UKOQcwL6lzMn0ZMVVrZ//A8ly8Pml66ZwHrulkNBc9Ghbwcwhx58R+3C/\n0mCVzdQ3a414qVlwoMoSCS424VhKvxE9oxWMkZuKeBQXwGDuBmZO6XV2CuJn\nVWAl9DtVL4439qry95xnnqFCCzBqjQVvNKBhLyqFvI1y5gFYelr3veRqr8Oy\nnOs7XHsMdHeN5vQFEultyU69DGjYDtvh3FMVbp/CeRObHdMrLdWlHwGonqTH\nj6gO4Gu/kcFMmlqkX0kEgrtVfhDU6da5RtwkNoV1ZtHboYyhsU1Q/DWP+FII\nRB8h+CHVOoihZSn1kIxfQQO/E1DVTgMRgKF0UyEZIihryRJgYSqIyNTodrJh\nXrOodmBwVklhCYrBzKue4T9phn4buHLtDSRdc/9rO3i9oa2RK1X3GRchm6uZ\nC6Thf/RfUaKy09OqG2mxi4izXDi870vbPhIaBtFXzU+BMw5vRN2arsCCmXSr\nmBKR\r\n=p5u9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/chownr_1.1.2_1562189571355_0.8148922644594261"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.3": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "1.1.3",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^12.0.1"
+      },
+      "scripts": {
+        "test": "tap test/*.js --cov",
+        "preversion": "npm test",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --follow-tags"
+      },
+      "license": "ISC",
+      "gitHead": "deaa058afe2a04c6528965a218ece1226a9ee2ae",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@1.1.3",
+      "_nodeVersion": "12.8.1",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+        "shasum": "42d837d5239688d55f303003a508230fa6727142",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4945,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdiv/WCRA9TVsSAnZWagAAYqAP/2j2OpJYBCwWko0V34P/\n6YwcVdnX4OUfICGDwX3Nvoz7lByUkQ3AXlQ6WTwuMssmT6YRFmYX+sSww8XK\nXI4v7RKSLpqV1ZsQFPe9Wqc79dP6lsYJoxiOBah31jmZYX4vKknam/IMZS/+\nMsK1hUTD41v/xWGsOtmZbxuXfUHoxAyhMwo8cAzdUUOsx4mr75q2vf16rnU4\nSUWHM+66PQCw2fvj+PXk2IXRDPI/WjOZbqY6ehVM2E2i52NGPRJn5xjzoxbc\nd4vTAtWcUV5WfdWAZ6h+gM7DFHiXGtcb0AtaGPYO7o/tGKbAT3vbhUM4jieY\nyz1XR205fIRluR7CNRi/JTQ5QFMpedtag60nT3WTwWMz3vjIAoD8etNPdZUW\nnN8y0vD0KTJHKAxwQkMgN67N0bPpZk/RAQRzDNzk8ymX5PNK0Wbs1dvv6Xm0\nmDNd5F5XUKwjf+zl32d+CdusNWzzRjiSxeNW9sEpjt0LgbTagWbTWJxNtRNA\nzIwW/gyM99nZv7W9s0LdC5BgVDeAk2ecjwsdn4b37/f+tb1IPCQLQtw69kXu\niDhxbhIL+s1i4ssul7FAYhO1zZQG3faF3kQg4TB9YDq0FPTZ9bQLbSlYJ17s\nQMqsPGTL6hkxCIaRiVwI1uewfYq7GMH4stpvOBOFNpe3ntAZ5dnK3g9Jua9o\nJTDY\r\n=VIgB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/chownr_1.1.3_1569390549998_0.778423331031457"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.4": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "1.1.4",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "^2.7.1",
+        "tap": "^14.10.6"
+      },
+      "tap": {
+        "check-coverage": true
+      },
+      "scripts": {
+        "test": "tap",
+        "preversion": "npm test",
+        "postversion": "npm publish",
+        "prepublishOnly": "git push origin --follow-tags"
+      },
+      "license": "ISC",
+      "gitHead": "814f6422241dcc1bbb324fa29cd6d9f6dc2141ae",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@1.1.4",
+      "_nodeVersion": "13.7.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+        "shasum": "6fc9d7b42d32a583596337666e7d08084da2cc6b",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5709,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeQ2NeCRA9TVsSAnZWagAAgjsP/RcBpHpxPazXjd9noJxf\n8TRBu2JP/zftaLpBoBVUWlBdnlYS8rjwuZmi8SPazhXddUpl55lD3ZHyWclf\n6AFvlPP5enIwcbpb6Q54c9vIAxQYoagUD9iQ6U62w+T5908PKi9ha1DEv1+2\n+il9xSwj5P0Qq8AhZV0EY3SZ7Lb+kf5rRPrqVKz4UqIs2NbkvMk/Er/+wGSa\nYjWxti2FCSyUcwakYg95eEm0JP1SqbdCswOG4wAKT9I4zF4MDv7ogTNmY5+F\nj1v8OkW9swaSrzPmIInvPNC2dFAQy80/DK7X8S6h3tSjKE3sZcrDdi+3Rte0\nYZtZwby4NRkLfGmAILt6swlEcCDhL92uHUWuX06z5/GsZDYRAp4O4BPmPsNV\nUnflZjqx12aot820CSODekwxetT0e2IQFWNhyn9FdVeGVVJ90rEAhE5A1NbX\nXr/uHMrNl++QXdIoy+HvQxANWPq3QFqmrlZtfXQOJSFS7DPFAp65eFJvRWuo\nhFgOIGRsmxFPLPmOCgP3xp/NOJl4Upen3eabA2xBSVdEJg4yB6OyiUOel5a9\n+xrE/HIOgwFxz+M9p7t2eTqH3LajzqxEFEb2pFwgox/efUVdtKXWckFWiYfg\nWEWwa89Js62El4/6ne8mIka6k9OV6dFHbMWhxH9PE7AUufwhJw1/7JtWAUHZ\n8wXy\r\n=4vE7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/chownr_1.1.4_1581474654243_0.7221239722665642"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "name": "chownr",
+      "description": "like `chown -R`",
+      "version": "2.0.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/isaacs/chownr.git"
+      },
+      "main": "chownr.js",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "^2.7.1",
+        "tap": "^14.10.6"
+      },
+      "tap": {
+        "check-coverage": true
+      },
+      "scripts": {
+        "test": "tap",
+        "preversion": "npm test",
+        "postversion": "npm publish",
+        "prepublishOnly": "git push origin --follow-tags"
+      },
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      },
+      "gitHead": "f9f9d866bebb2f9ff8efc93b78305f9d999c6f17",
+      "bugs": {
+        "url": "https://github.com/isaacs/chownr/issues"
+      },
+      "homepage": "https://github.com/isaacs/chownr#readme",
+      "_id": "chownr@2.0.0",
+      "_nodeVersion": "13.7.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+        "shasum": "15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5748,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeQ2PkCRA9TVsSAnZWagAApeIP/2yqh1W+b3D7qaCsODPY\nG/eO4oYZvjf7XYYvExZs3oiFkHWKHLgIZH0Z1NdhfyxG/pyVnDpF6ewy03z8\nuNYo3aHX3h5bgiwbgAaNWa+ZxhNbeQ8CJWZNH9OYT37aKB9XvamCdLt7btO+\nkJbkYkdlz/3XTMP7CXxsMng0qorjHHk0IyNJZ1Bcy+NSeKPFlyq7/8E5VIK2\nsoz2Zz2pXAi0nKsrJdMzjjAwm50bKRq9eD1gZE2nUFfUjICk0A9d9PTc+2Pn\nalkGyPLMTpTxiTvaWLr+CXAhudfhBbteUVz1CFi6hXR+iVevCqcVewuzWijL\nDlFzTz/TQOR1i6/aH4FUVIdm1BS6jee+JVLCAH58zbdQR1QYQV8MukKHocpH\nWNuLPyX/YyCjU9+LlPMX0pLpikjReZgxZkpZdtIYPtN6u3c4zNhub9jNlaNz\nlcgSAk/0LpH0lSs+Zh3GxBd/O43fXfchPHoIHqILIH8oTRSXLzw6tG+5LNkt\nS/JWmOz+RXp0AzRrPz9ra09ssJIKzYhqprxBLXwvj3MnbZzev9GfDgrPoBCk\n93CA+q3eS32Wg1D18yqC0spgEfsptypdnxWhVijnFZ+egcdMFpTRb6HzKyEj\n5FYbiqMkP2aHnQD7SEIcxQmkF9izZnHfmftOjI2lzjyfeKl9+F46smiJRoeh\nhn9O\r\n=R+L8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/chownr_2.0.0_1581474787748_0.7116861792550564"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "Like `chown -R`.\n\nTakes the same arguments as `fs.chown()`\n",
+  "maintainers": [
+    {
+      "name": "isaacs",
+      "email": "i@izs.me"
+    }
+  ],
+  "time": {
+    "modified": "2020-02-12T02:33:10.215Z",
+    "created": "2012-06-04T04:01:25.807Z",
+    "0.0.1": "2012-06-04T04:01:28.039Z",
+    "0.0.2": "2015-05-20T07:04:02.130Z",
+    "1.0.0": "2015-08-09T22:22:45.361Z",
+    "1.0.1": "2015-08-09T22:24:36.640Z",
+    "1.1.0": "2018-09-16T00:23:19.205Z",
+    "1.1.1": "2018-09-16T03:14:08.990Z",
+    "1.1.2": "2019-07-03T21:32:51.511Z",
+    "1.1.3": "2019-09-25T05:49:10.172Z",
+    "1.1.4": "2020-02-12T02:30:54.444Z",
+    "2.0.0": "2020-02-12T02:33:07.865Z"
+  },
+  "author": {
+    "name": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/isaacs/chownr.git"
+  },
+  "users": {
+    "jswartwood": true,
+    "brandonpapworth": true
+  },
+  "homepage": "https://github.com/isaacs/chownr#readme",
+  "bugs": {
+    "url": "https://github.com/isaacs/chownr/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/chownr.min.json
+++ b/test/fixtures/registry-mocks/content/chownr.min.json
@@ -1,0 +1,169 @@
+{
+  "name": "chownr",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "chownr",
+      "version": "0.0.1",
+      "devDependencies": {
+        "tap": "0.2",
+        "mkdirp": "0.3",
+        "rimraf": ""
+      },
+      "dist": {
+        "shasum": "51d18189d9092d5f8afd623f3288bfd1c6bf1a62",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.2": {
+      "name": "chownr",
+      "version": "0.0.2",
+      "devDependencies": {
+        "tap": "0.2",
+        "mkdirp": "0.3",
+        "rimraf": ""
+      },
+      "dist": {
+        "shasum": "2f9aebf746f90808ce00607b72ba73b41604c485",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-0.0.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "chownr",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^1.2.0"
+      },
+      "dist": {
+        "shasum": "02855833d20515cf2681c717d686bb8c1f3ea91a",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "chownr",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^1.2.0"
+      },
+      "dist": {
+        "shasum": "e2a75042a9551908bebd25b8523d5f9769d79181",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "chownr",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^12.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-BGowLy8nGWXPbtRR/8imBkaAFdArC2ES+q4HvCy8RruTpKU3MEgxVpT+AxlkAax0ykKqnoNnHAZh+Ryu0eFCIw==",
+        "shasum": "17405cadd8706bc41f017b564bb2de460381e7d1",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 3828,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbnaJ3CRA9TVsSAnZWagAA/dgP/2yH2/y8vSOL20GKVFNh\nPgKIQOFhZCbZ97iZD105qpMVjYI2S6qOXV7chayXDrYtVfudZ3VZLF6nDQW+\nq2PQ8FgvSk1zN6xegTvIlEb0fboWHi4VZ4Ca1vg8GDdIrSefnxocbq75KvNx\n170Pc/NM4Q2W1tXhMTpLCAtHcvT+fMsOUI9DDWxoNLvMwWcY2JS6ggc9FPii\nySbbsoz9RkKIkxJm2Lv28mcrAzq9eBPC9Q0f5r/P+0dc4YWAf8kNTasxXWNI\nCtLUcOXxYtDQ6OJqFimDa0wrccnEjIDo8PKP/15FuC4doFByteq1zmtE++dH\nETDXZd4+b7JrSGC9EVTJA7uSss/gXK6/bYOP+r59Ld39FHBUK+xegBYMCnCk\nWacMiZ9y/TYjKI1v4RTfDxd21+VbqRFn+V/ZSUFRTyNqtLdu91Aaxc4Xa1Ga\n7NJosnfcGN01jr6SqDEPBi2RiUQm+20by+j8H+nViBXUmHqdkGsVVxCqKYXs\nxktIKdaSovdFH+VP2oJ04Vj0o9tlhcG5HNfeURZjU0LZDufpi/JPdfN5l/7c\nompEaIvMLLyke8GLPmuSZSPlRCzbIQka7NsN9v0G1DH/7kna7+9tlaa6pkqN\nMv1/NFwC9Ake2miQjXnC8LA9Pn0jUz5v4cubX8g9u+P68noLXDcCEUbuHE2j\n68at\r\n=Q33U\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.1": {
+      "name": "chownr",
+      "version": "1.1.1",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^12.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+        "shasum": "54726b8b8fff4df053c42187e801fb4412df1494",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 3901,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbncqBCRA9TVsSAnZWagAAzhUP/1pR2jFff+rVryKPm7jF\nc+IGuZPRxl4qLEjUSNSuVmq+eSWK3zMwSm+59eyI/+ArsjZvtIEi9TUo5ddV\n9vwa64C57bjTcbsSJgHUK+N+8qWggo3nXHYUhFUyVgaVihvVt4LUYPhWFpp2\nzjDdysskuD3hIkcsRPN7123OZwvl9NXU5E/DFmZJ95Jz0tVrABhE5GptOSab\nK69de/oz7tK+3tFAcApq1xNYfzkPSEQscQum+sleV56SEaEUQJfQzJC4iccM\nK7DjBNGkdH+japMi2vD9je2Jo5949wXBgOgjcZmoSgzb2gWivB4HcGeYh/fS\n5yX2CLCy0VOFdkK6C1bxIzxHQEqALY1pnPos1HkXSJMvzWdhNnq+n62IPOh9\n8MXEf0fUOdDfKSwAyOphtWmfu7Wy9gUrYDg4rHPDTQjGDM+mvIIMxMIwmQ0k\nsOOZMdXaaKf3tXtqNUT1j96hgVBTQ7X8/HrXxPuQI9hBrh4CdR7TekZFZ0NG\nrkiNT5fEGwpEz0EeiNlMkaNPkw+hvg6nTFp+0tePyWPC1weMlNCbhm4jipHt\nKl9t8ox+bsoKH/UviCYjC3XfJSEGqBpaox7i8Pjvcp25s4p9FwNiExE0pe2I\nvbWrbGEVL8lsoCJi84uI2n5PBcOyN51srZmWI6P9EU1nYzDPF/B2Z0N8yw5K\n8ks4\r\n=wIis\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.2": {
+      "name": "chownr",
+      "version": "1.1.2",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^12.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
+        "shasum": "a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4925,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdHR8GCRA9TVsSAnZWagAApbkP/R0CiSVRS8E4FwRY/hoU\nXD6FlTt1IVt3HAvHs6stXKdkUV9EWYKXLjFuEj/hpCBp4ENrIdIX4saVAVYc\n2R3XKtSWHARdmXq/GHTidzp2tU4j42TSXWl9xEU1Jh7NY7/nBOSxNjL51rPp\n2XkD7B0Jw0YCPUb1yk/Ludn8+i2MqjCIZxsq1cA7OTtlAdMcBNXBfT9eeFhZ\ndH9UKOQcwL6lzMn0ZMVVrZ//A8ly8Pml66ZwHrulkNBc9Ghbwcwhx58R+3C/\n0mCVzdQ3a414qVlwoMoSCS424VhKvxE9oxWMkZuKeBQXwGDuBmZO6XV2CuJn\nVWAl9DtVL4439qry95xnnqFCCzBqjQVvNKBhLyqFvI1y5gFYelr3veRqr8Oy\nnOs7XHsMdHeN5vQFEultyU69DGjYDtvh3FMVbp/CeRObHdMrLdWlHwGonqTH\nj6gO4Gu/kcFMmlqkX0kEgrtVfhDU6da5RtwkNoV1ZtHboYyhsU1Q/DWP+FII\nRB8h+CHVOoihZSn1kIxfQQO/E1DVTgMRgKF0UyEZIihryRJgYSqIyNTodrJh\nXrOodmBwVklhCYrBzKue4T9phn4buHLtDSRdc/9rO3i9oa2RK1X3GRchm6uZ\nC6Thf/RfUaKy09OqG2mxi4izXDi870vbPhIaBtFXzU+BMw5vRN2arsCCmXSr\nmBKR\r\n=p5u9\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.3": {
+      "name": "chownr",
+      "version": "1.1.3",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "",
+        "tap": "^12.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+        "shasum": "42d837d5239688d55f303003a508230fa6727142",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4945,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdiv/WCRA9TVsSAnZWagAAYqAP/2j2OpJYBCwWko0V34P/\n6YwcVdnX4OUfICGDwX3Nvoz7lByUkQ3AXlQ6WTwuMssmT6YRFmYX+sSww8XK\nXI4v7RKSLpqV1ZsQFPe9Wqc79dP6lsYJoxiOBah31jmZYX4vKknam/IMZS/+\nMsK1hUTD41v/xWGsOtmZbxuXfUHoxAyhMwo8cAzdUUOsx4mr75q2vf16rnU4\nSUWHM+66PQCw2fvj+PXk2IXRDPI/WjOZbqY6ehVM2E2i52NGPRJn5xjzoxbc\nd4vTAtWcUV5WfdWAZ6h+gM7DFHiXGtcb0AtaGPYO7o/tGKbAT3vbhUM4jieY\nyz1XR205fIRluR7CNRi/JTQ5QFMpedtag60nT3WTwWMz3vjIAoD8etNPdZUW\nnN8y0vD0KTJHKAxwQkMgN67N0bPpZk/RAQRzDNzk8ymX5PNK0Wbs1dvv6Xm0\nmDNd5F5XUKwjf+zl32d+CdusNWzzRjiSxeNW9sEpjt0LgbTagWbTWJxNtRNA\nzIwW/gyM99nZv7W9s0LdC5BgVDeAk2ecjwsdn4b37/f+tb1IPCQLQtw69kXu\niDhxbhIL+s1i4ssul7FAYhO1zZQG3faF3kQg4TB9YDq0FPTZ9bQLbSlYJ17s\nQMqsPGTL6hkxCIaRiVwI1uewfYq7GMH4stpvOBOFNpe3ntAZ5dnK3g9Jua9o\nJTDY\r\n=VIgB\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.4": {
+      "name": "chownr",
+      "version": "1.1.4",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "^2.7.1",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+        "shasum": "6fc9d7b42d32a583596337666e7d08084da2cc6b",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5709,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeQ2NeCRA9TVsSAnZWagAAgjsP/RcBpHpxPazXjd9noJxf\n8TRBu2JP/zftaLpBoBVUWlBdnlYS8rjwuZmi8SPazhXddUpl55lD3ZHyWclf\n6AFvlPP5enIwcbpb6Q54c9vIAxQYoagUD9iQ6U62w+T5908PKi9ha1DEv1+2\n+il9xSwj5P0Qq8AhZV0EY3SZ7Lb+kf5rRPrqVKz4UqIs2NbkvMk/Er/+wGSa\nYjWxti2FCSyUcwakYg95eEm0JP1SqbdCswOG4wAKT9I4zF4MDv7ogTNmY5+F\nj1v8OkW9swaSrzPmIInvPNC2dFAQy80/DK7X8S6h3tSjKE3sZcrDdi+3Rte0\nYZtZwby4NRkLfGmAILt6swlEcCDhL92uHUWuX06z5/GsZDYRAp4O4BPmPsNV\nUnflZjqx12aot820CSODekwxetT0e2IQFWNhyn9FdVeGVVJ90rEAhE5A1NbX\nXr/uHMrNl++QXdIoy+HvQxANWPq3QFqmrlZtfXQOJSFS7DPFAp65eFJvRWuo\nhFgOIGRsmxFPLPmOCgP3xp/NOJl4Upen3eabA2xBSVdEJg4yB6OyiUOel5a9\n+xrE/HIOgwFxz+M9p7t2eTqH3LajzqxEFEb2pFwgox/efUVdtKXWckFWiYfg\nWEWwa89Js62El4/6ne8mIka6k9OV6dFHbMWhxH9PE7AUufwhJw1/7JtWAUHZ\n8wXy\r\n=4vE7\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "chownr",
+      "version": "2.0.0",
+      "devDependencies": {
+        "mkdirp": "0.3",
+        "rimraf": "^2.7.1",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+        "shasum": "15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece",
+        "tarball": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5748,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeQ2PkCRA9TVsSAnZWagAApeIP/2yqh1W+b3D7qaCsODPY\nG/eO4oYZvjf7XYYvExZs3oiFkHWKHLgIZH0Z1NdhfyxG/pyVnDpF6ewy03z8\nuNYo3aHX3h5bgiwbgAaNWa+ZxhNbeQ8CJWZNH9OYT37aKB9XvamCdLt7btO+\nkJbkYkdlz/3XTMP7CXxsMng0qorjHHk0IyNJZ1Bcy+NSeKPFlyq7/8E5VIK2\nsoz2Zz2pXAi0nKsrJdMzjjAwm50bKRq9eD1gZE2nUFfUjICk0A9d9PTc+2Pn\nalkGyPLMTpTxiTvaWLr+CXAhudfhBbteUVz1CFi6hXR+iVevCqcVewuzWijL\nDlFzTz/TQOR1i6/aH4FUVIdm1BS6jee+JVLCAH58zbdQR1QYQV8MukKHocpH\nWNuLPyX/YyCjU9+LlPMX0pLpikjReZgxZkpZdtIYPtN6u3c4zNhub9jNlaNz\nlcgSAk/0LpH0lSs+Zh3GxBd/O43fXfchPHoIHqILIH8oTRSXLzw6tG+5LNkt\nS/JWmOz+RXp0AzRrPz9ra09ssJIKzYhqprxBLXwvj3MnbZzev9GfDgrPoBCk\n93CA+q3eS32Wg1D18yqC0spgEfsptypdnxWhVijnFZ+egcdMFpTRb6HzKyEj\n5FYbiqMkP2aHnQD7SEIcxQmkF9izZnHfmftOjI2lzjyfeKl9+F46smiJRoeh\nhn9O\r\n=R+L8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  },
+  "modified": "2020-02-12T02:33:10.215Z"
+}

--- a/test/fixtures/registry-mocks/content/cipher-base.json
+++ b/test/fixtures/registry-mocks/content/cipher-base.json
@@ -1,0 +1,325 @@
+{
+  "_id": "cipher-base",
+  "_rev": "5-af6d8d7be0aab60a0a9ee9a638a80f6c",
+  "name": "cipher-base",
+  "description": "abstract base class for crypto-streams",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "cipher-base",
+      "version": "1.0.0",
+      "description": "abstract base class for crypto-streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/cipher-base.git"
+      },
+      "keywords": [
+        "cipher",
+        "stream"
+      ],
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/cipher-base/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/cipher-base#readme",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "8fbd9e7654d384b578e63d12e0311ae16dc07741",
+      "_id": "cipher-base@1.0.0",
+      "_shasum": "b7aa42ea5fe8e7615926380528c4ee3a2d33444d",
+      "_from": ".",
+      "_npmVersion": "2.13.2",
+      "_nodeVersion": "2.5.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "b7aa42ea5fe8e7615926380528c4ee3a2d33444d",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "cipher-base",
+      "version": "1.0.1",
+      "description": "abstract base class for crypto-streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/cipher-base.git"
+      },
+      "keywords": [
+        "cipher",
+        "stream"
+      ],
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/cipher-base/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/cipher-base#readme",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "5f5eb4a23599806ef5f92aa25930ac0beeb35bd1",
+      "_id": "cipher-base@1.0.1",
+      "_shasum": "b714888e810519106b3b039948e4fc9e2718c563",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "b714888e810519106b3b039948e4fc9e2718c563",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "cipher-base",
+      "version": "1.0.2",
+      "description": "abstract base class for crypto-streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/cipher-base.git"
+      },
+      "keywords": [
+        "cipher",
+        "stream"
+      ],
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/cipher-base/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/cipher-base#readme",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "c295535e1eef90a587dba110c8799bfd68f75161",
+      "_id": "cipher-base@1.0.2",
+      "_shasum": "54ac1d1ebdf6a1bcd3559e6f369d72697f2cab8f",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "54ac1d1ebdf6a1bcd3559e6f369d72697f2cab8f",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "cipher-base",
+      "version": "1.0.3",
+      "description": "abstract base class for crypto-streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/cipher-base.git"
+      },
+      "keywords": [
+        "cipher",
+        "stream"
+      ],
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/cipher-base/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/cipher-base#readme",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "de2af9758ce75ef5f9a9bdaf0ba5312609a7e59a",
+      "_id": "cipher-base@1.0.3",
+      "_shasum": "eeabf194419ce900da3018c207d212f2a6df0a07",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.12.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "eeabf194419ce900da3018c207d212f2a6df0a07",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/cipher-base-1.0.3.tgz_1473767078206_0.1380389309488237"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "cipher-base",
+      "version": "1.0.4",
+      "description": "abstract base class for crypto-streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/cipher-base.git"
+      },
+      "keywords": [
+        "cipher",
+        "stream"
+      ],
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/cipher-base/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/cipher-base#readme",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^10.0.2",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "bc18dc847050c34f11f7a0472ff13a76b53fedc6",
+      "_id": "cipher-base@1.0.4",
+      "_npmVersion": "5.1.0",
+      "_nodeVersion": "8.1.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+        "shasum": "8760e4ecc272f4c363532f926d874aae2c1397de",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cipher-base-1.0.4.tgz_1499455256804_0.9936195954214782"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "cipher-base\n===\n\n[![Build Status](https://travis-ci.org/crypto-browserify/cipher-base.svg)](https://travis-ci.org/crypto-browserify/cipher-base)\n\nAbstract base class to inherit from if you want to create streams implementing\nthe same api as node crypto streams.\n\nRequires you to implement 2 methods `_final` and `_update`. `_update` takes a\nbuffer and should return a buffer, `_final` takes no arguments and should return\na buffer.\n\n\nThe constructor takes one argument and that is a string which if present switches\nit into hash mode, i.e. the object you get from crypto.createHash or\ncrypto.createSign, this switches the name of the final method to be the string\nyou passed instead of `final` and returns `this` from update.\n",
+  "maintainers": [
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-07-07T19:20:57.712Z",
+    "created": "2015-09-26T21:01:59.671Z",
+    "1.0.0": "2015-09-26T21:01:59.671Z",
+    "1.0.1": "2015-09-26T22:01:11.047Z",
+    "1.0.2": "2015-10-23T18:30:27.552Z",
+    "1.0.3": "2016-09-13T11:44:40.235Z",
+    "1.0.4": "2017-07-07T19:20:57.712Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/cipher-base#readme",
+  "keywords": [
+    "cipher",
+    "stream"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/cipher-base.git"
+  },
+  "author": {
+    "name": "Calvin Metcalf",
+    "email": "calvin.metcalf@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/cipher-base/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/cipher-base.min.json
+++ b/test/fixtures/registry-mocks/content/cipher-base.min.json
@@ -1,0 +1,87 @@
+{
+  "name": "cipher-base",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "cipher-base",
+      "version": "1.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "b7aa42ea5fe8e7615926380528c4ee3a2d33444d",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "cipher-base",
+      "version": "1.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "b714888e810519106b3b039948e4fc9e2718c563",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "cipher-base",
+      "version": "1.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "54ac1d1ebdf6a1bcd3559e6f369d72697f2cab8f",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "cipher-base",
+      "version": "1.0.3",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "eeabf194419ce900da3018c207d212f2a6df0a07",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "cipher-base",
+      "version": "1.0.4",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^10.0.2",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+        "shasum": "8760e4ecc272f4c363532f926d874aae2c1397de",
+        "tarball": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz"
+      }
+    }
+  },
+  "modified": "2017-07-07T19:20:57.712Z"
+}

--- a/test/fixtures/registry-mocks/content/class-utils.json
+++ b/test/fixtures/registry-mocks/content/class-utils.json
@@ -1,0 +1,1497 @@
+{
+  "_id": "class-utils",
+  "_rev": "15-a92daf6fd45760cb119975789d481430",
+  "name": "class-utils",
+  "description": "Utils for working with JavaScript classes and prototype methods.",
+  "dist-tags": {
+    "latest": "0.3.6"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "_id": "class-utils@0.1.0",
+      "_shasum": "cf628b4d69396ece81931a4452db44bed2561a33",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cf628b4d69396ece81931a4452db44bed2561a33",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "gitHead": "0aa09badd9d691f5d8ba18eddd77d76ce7944610",
+      "_id": "class-utils@0.1.1",
+      "_shasum": "08bb125e43114084e58c7ed1c9a30092ebaad5f5",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "08bb125e43114084e58c7ed1c9a30092ebaad5f5",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "gitHead": "5773b91bbee08dd0e0dd0893123e7fadbb9ecb60",
+      "_id": "class-utils@0.1.2",
+      "_shasum": "dfb4177384dd39e307f468d7d50d7ebcddc2083a",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dfb4177384dd39e307f468d7d50d7ebcddc2083a",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "gitHead": "18b860275605e3dab9066175e1f9e844779c04ec",
+      "_id": "class-utils@0.2.0",
+      "_shasum": "40b536996529c37638db6718baa4c3034555fc5c",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "40b536996529c37638db6718baa4c3034555fc5c",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.3"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "gitHead": "4a74ab5261a91f15be81bf8a3aecc85321417530",
+      "_id": "class-utils@0.2.1",
+      "_shasum": "23c96cdb4612252aae00403674c9341968446d08",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "23c96cdb4612252aae00403674c9341968446d08",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.2.2",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.3"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "gitHead": "4a74ab5261a91f15be81bf8a3aecc85321417530",
+      "_id": "class-utils@0.2.2",
+      "_shasum": "185c9dc21307e0fbfbb2adbeb44652c7c13b6e5d",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "185c9dc21307e0fbfbb2adbeb44652c7c13b6e5d",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.2.3",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.4"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "gitHead": "d9456f7c32923cdc7e78579737f81c04a1f35d35",
+      "_id": "class-utils@0.2.3",
+      "_shasum": "0799c47d8f6b35b39f338d56d8323b889699be95",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0799c47d8f6b35b39f338d56d8323b889699be95",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.4"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "gitHead": "7ef1a4cd2d74de1dd7e3a84d03fce96f50380b95",
+      "_id": "class-utils@0.3.0",
+      "_shasum": "4a2635be33ca3461e01351f1611e2f28348d8689",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "shasum": "4a2635be33ca3461e01351f1611e2f28348d8689",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.3.1",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.4"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        }
+      },
+      "gitHead": "00a9fa2083603e1aab9b534a983bbcba316e7a5f",
+      "_id": "class-utils@0.3.1",
+      "_shasum": "9db43650b2cd0474eb6cc7148635177864cb1ef9",
+      "_from": ".",
+      "_npmVersion": "3.5.2",
+      "_nodeVersion": "5.1.1",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "shasum": "9db43650b2cd0474eb6cc7148635177864cb1ef9",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.3.2",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "inherit",
+        "object",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "86db31b49ec9deca4c50df474e66f585fbd8b6a1",
+      "_id": "class-utils@0.3.2",
+      "_shasum": "5c282251b7a2f031abc9906e55c048f03988164a",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5c282251b7a2f031abc9906e55c048f03988164a",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/class-utils-0.3.2.tgz_1457560335014_0.4505936591885984"
+      },
+      "directories": {}
+    },
+    "0.3.3": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.3.3",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^1.0.3",
+        "static-extend": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5",
+        "should": "^8.2.2",
+        "through2": "^2.0.1"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "ctor",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "extends",
+        "inherit",
+        "inheritance",
+        "merge",
+        "method",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "prototype",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "87216cc3c6482a30c106d6d40b3ec9ddfaf73319",
+      "_id": "class-utils@0.3.3",
+      "_shasum": "59dbf4399579ffd8c400a75124c69a6b2f4e574d",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "59dbf4399579ffd8c400a75124c69a6b2f4e574d",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/class-utils-0.3.3.tgz_1457685388238_0.9255549304652959"
+      },
+      "directories": {}
+    },
+    "0.3.4": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.3.4",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^1.0.3",
+        "static-extend": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5",
+        "should": "^8.2.2",
+        "through2": "^2.0.1"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "ctor",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "extends",
+        "inherit",
+        "inheritance",
+        "merge",
+        "method",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "prototype",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "a20c8d1402573756714afa71f6e5b22ee1912d1e",
+      "_id": "class-utils@0.3.4",
+      "_shasum": "9f6c1a572ebe62670c5842cb12be3d9716581f1c",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9f6c1a572ebe62670c5842cb12be3d9716581f1c",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/class-utils-0.3.4.tgz_1459888510108_0.14073048764839768"
+      },
+      "directories": {}
+    },
+    "0.3.5": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.3.5",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "email": "wtgtybhertgeghgtwtg@gmail.com",
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        },
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "static-extend": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5",
+        "should": "^8.2.2",
+        "through2": "^2.0.1"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "ctor",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "extends",
+        "inherit",
+        "inheritance",
+        "merge",
+        "method",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "prototype",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "58e45f5116ee26365016d5d05ed97aac5e9b1a19",
+      "_id": "class-utils@0.3.5",
+      "_shasum": "17e793103750f9627b2176ea34cfd1b565903c80",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "17e793103750f9627b2176ea34cfd1b565903c80",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/class-utils-0.3.5.tgz_1488061458818_0.0674502404872328"
+      },
+      "directories": {}
+    },
+    "0.3.6": {
+      "name": "class-utils",
+      "description": "Utils for working with JavaScript classes and prototype methods.",
+      "version": "0.3.6",
+      "homepage": "https://github.com/jonschlinkert/class-utils",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/class-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/class-utils/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5",
+        "should": "^8.2.2",
+        "through2": "^2.0.1"
+      },
+      "keywords": [
+        "array",
+        "assign",
+        "class",
+        "copy",
+        "ctor",
+        "define",
+        "delegate",
+        "descriptor",
+        "extend",
+        "extends",
+        "inherit",
+        "inheritance",
+        "merge",
+        "method",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "prototype",
+        "util",
+        "utils"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "delegate-properties",
+            "is-descriptor"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "0ad9e639d6a63d6dc04043ac5931df85fb898e06",
+      "_id": "class-utils@0.3.6",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+        "shasum": "f93369ae8b9a7ce02fd41faad0ca83033190c463",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/class-utils-0.3.6.tgz_1515682163077_0.6769419175107032"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# class-utils [![NPM version](https://img.shields.io/npm/v/class-utils.svg?style=flat)](https://www.npmjs.com/package/class-utils) [![NPM monthly downloads](https://img.shields.io/npm/dm/class-utils.svg?style=flat)](https://npmjs.org/package/class-utils) [![NPM total downloads](https://img.shields.io/npm/dt/class-utils.svg?style=flat)](https://npmjs.org/package/class-utils) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/class-utils.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/class-utils)\n\n> Utils for working with JavaScript classes and prototype methods.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save class-utils\n```\n\n## Usage\n\n```js\nvar cu = require('class-utils');\n```\n\n## API\n\n### [.has](index.js#L43)\n\nReturns true if an array has any of the given elements, or an object has any of the give keys.\n\n**Params**\n\n* `obj` **{Object}**\n* `val` **{String|Array}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\ncu.has(['a', 'b', 'c'], 'c');\n//=> true\n\ncu.has(['a', 'b', 'c'], ['c', 'z']);\n//=> true\n\ncu.has({a: 'b', c: 'd'}, ['c', 'z']);\n//=> true\n```\n\n### [.hasAll](index.js#L90)\n\nReturns true if an array or object has all of the given values.\n\n**Params**\n\n* `val` **{Object|Array}**\n* `values` **{String|Array}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\ncu.hasAll(['a', 'b', 'c'], 'c');\n//=> true\n\ncu.hasAll(['a', 'b', 'c'], ['c', 'z']);\n//=> false\n\ncu.hasAll({a: 'b', c: 'd'}, ['c', 'z']);\n//=> false\n```\n\n### [.arrayify](index.js#L117)\n\nCast the given value to an array.\n\n**Params**\n\n* `val` **{String|Array}**\n* `returns` **{Array}**\n\n**Example**\n\n```js\ncu.arrayify('foo');\n//=> ['foo']\n\ncu.arrayify(['foo']);\n//=> ['foo']\n```\n\n### [.hasConstructor](index.js#L152)\n\nReturns true if a value has a `contructor`\n\n**Params**\n\n* `value` **{Object}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\ncu.hasConstructor({});\n//=> true\n\ncu.hasConstructor(Object.create(null));\n//=> false\n```\n\n### [.nativeKeys](index.js#L174)\n\nGet the native `ownPropertyNames` from the constructor of the given `object`. An empty array is returned if the object does not have a constructor.\n\n**Params**\n\n* `obj` **{Object}**: Object that has a `constructor`.\n* `returns` **{Array}**: Array of keys.\n\n**Example**\n\n```js\ncu.nativeKeys({a: 'b', b: 'c', c: 'd'})\n//=> ['a', 'b', 'c']\n\ncu.nativeKeys(function(){})\n//=> ['length', 'caller']\n```\n\n### [.getDescriptor](index.js#L208)\n\nReturns property descriptor `key` if it's an \"own\" property of the given object.\n\n**Params**\n\n* `obj` **{Object}**\n* `key` **{String}**\n* `returns` **{Object}**: Returns descriptor `key`\n\n**Example**\n\n```js\nfunction App() {}\nObject.defineProperty(App.prototype, 'count', {\n  get: function() {\n    return Object.keys(this).length;\n  }\n});\ncu.getDescriptor(App.prototype, 'count');\n// returns:\n// {\n//   get: [Function],\n//   set: undefined,\n//   enumerable: false,\n//   configurable: false\n// }\n```\n\n### [.copyDescriptor](index.js#L238)\n\nCopy a descriptor from one object to another.\n\n**Params**\n\n* `receiver` **{Object}**\n* `provider` **{Object}**\n* `name` **{String}**\n* `returns` **{Object}**\n\n**Example**\n\n```js\nfunction App() {}\nObject.defineProperty(App.prototype, 'count', {\n  get: function() {\n    return Object.keys(this).length;\n  }\n});\nvar obj = {};\ncu.copyDescriptor(obj, App.prototype, 'count');\n```\n\n### [.copy](index.js#L264)\n\nCopy static properties, prototype properties, and descriptors\nfrom one object to another.\n\n**Params**\n\n* `receiver` **{Object}**\n* `provider` **{Object}**\n* `omit` **{String|Array}**: One or more properties to omit\n* `returns` **{Object}**\n\n### [.inherit](index.js#L299)\n\nInherit the static properties, prototype properties, and descriptors\nfrom of an object.\n\n**Params**\n\n* `receiver` **{Object}**\n* `provider` **{Object}**\n* `omit` **{String|Array}**: One or more properties to omit\n* `returns` **{Object}**\n\n### [.extend](index.js#L343)\n\nReturns a function for extending the static properties, prototype properties, and descriptors from the `Parent` constructor onto `Child` constructors.\n\n**Params**\n\n* `Parent` **{Function}**: Parent ctor\n* `extend` **{Function}**: Optional extend function to handle custom extensions. Useful when updating methods that require a specific prototype.\n* `Child` **{Function}**: Child ctor\n* `proto` **{Object}**: Optionally pass additional prototype properties to inherit.\n* `returns` **{Object}**\n\n**Example**\n\n```js\nvar extend = cu.extend(Parent);\nParent.extend(Child);\n\n// optional methods\nParent.extend(Child, {\n  foo: function() {},\n  bar: function() {}\n});\n```\n\n### [.bubble](index.js#L356)\n\nBubble up events emitted from static methods on the Parent ctor.\n\n**Params**\n\n* `Parent` **{Object}**\n* `events` **{Array}**: Event names to bubble up\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [define-property](https://www.npmjs.com/package/define-property): Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty. | [homepage](https://github.com/jonschlinkert/define-property \"Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty.\")\n* [delegate-properties](https://www.npmjs.com/package/delegate-properties): Deep-clone properties from one object to another and make them non-enumerable, or make existing properties… [more](https://github.com/jonschlinkert/delegate-properties) | [homepage](https://github.com/jonschlinkert/delegate-properties \"Deep-clone properties from one object to another and make them non-enumerable, or make existing properties on an object non-enumerable.\")\n* [is-descriptor](https://www.npmjs.com/package/is-descriptor): Returns true if a value has the characteristics of a valid JavaScript descriptor. Works for… [more](https://github.com/jonschlinkert/is-descriptor) | [homepage](https://github.com/jonschlinkert/is-descriptor \"Returns true if a value has the characteristics of a valid JavaScript descriptor. Works for data descriptors and accessor descriptors.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 34 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 8 | [doowb](https://github.com/doowb) |\n| 2 | [wtgtybhertgeghgtwtg](https://github.com/wtgtybhertgeghgtwtg) |\n\n### Author\n\n**Jon Schlinkert**\n\n* [linkedin/in/jonschlinkert](https://linkedin.com/in/jonschlinkert)\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on January 11, 2018._",
+  "maintainers": [
+    {
+      "name": "doowb",
+      "email": "brian.woodward@gmail.com"
+    },
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-01-11T14:49:23.288Z",
+    "created": "2015-09-15T20:52:19.323Z",
+    "0.1.0": "2015-09-15T20:52:19.323Z",
+    "0.1.1": "2015-09-15T21:06:26.539Z",
+    "0.1.2": "2015-09-20T02:52:22.369Z",
+    "0.2.0": "2015-10-01T21:17:47.326Z",
+    "0.2.1": "2015-10-04T19:32:37.867Z",
+    "0.2.2": "2015-10-21T22:31:35.565Z",
+    "0.2.3": "2015-11-29T07:16:54.623Z",
+    "0.3.0": "2015-12-01T21:48:19.752Z",
+    "0.3.1": "2016-01-27T02:06:47.886Z",
+    "0.3.2": "2016-03-09T21:52:17.394Z",
+    "0.3.3": "2016-03-11T08:36:30.525Z",
+    "0.3.4": "2016-04-05T20:35:12.359Z",
+    "0.3.5": "2017-02-25T22:24:19.614Z",
+    "0.3.6": "2018-01-11T14:49:23.288Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/class-utils",
+  "keywords": [
+    "array",
+    "assign",
+    "class",
+    "copy",
+    "ctor",
+    "define",
+    "delegate",
+    "descriptor",
+    "extend",
+    "extends",
+    "inherit",
+    "inheritance",
+    "merge",
+    "method",
+    "object",
+    "prop",
+    "properties",
+    "property",
+    "prototype",
+    "util",
+    "utils"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/class-utils.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/class-utils/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Brian Woodward",
+      "url": "https://twitter.com/doowb"
+    },
+    {
+      "name": "Jon Schlinkert",
+      "url": "http://twitter.com/jonschlinkert"
+    },
+    {
+      "url": "https://github.com/wtgtybhertgeghgtwtg"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/class-utils.min.json
+++ b/test/fixtures/registry-mocks/content/class-utils.min.json
@@ -1,0 +1,367 @@
+{
+  "name": "class-utils",
+  "dist-tags": {
+    "latest": "0.3.6"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "class-utils",
+      "version": "0.1.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "dist": {
+        "shasum": "cf628b4d69396ece81931a4452db44bed2561a33",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "class-utils",
+      "version": "0.1.1",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "dist": {
+        "shasum": "08bb125e43114084e58c7ed1c9a30092ebaad5f5",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "class-utils",
+      "version": "0.1.2",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "dist": {
+        "shasum": "dfb4177384dd39e307f468d7d50d7ebcddc2083a",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "class-utils",
+      "version": "0.2.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "dist": {
+        "shasum": "40b536996529c37638db6718baa4c3034555fc5c",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.1": {
+      "name": "class-utils",
+      "version": "0.2.1",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.3"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "dist": {
+        "shasum": "23c96cdb4612252aae00403674c9341968446d08",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.2": {
+      "name": "class-utils",
+      "version": "0.2.2",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.3"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "^2.3.2",
+        "should": "^7.1.0"
+      },
+      "dist": {
+        "shasum": "185c9dc21307e0fbfbb2adbeb44652c7c13b6e5d",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.2.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.3": {
+      "name": "class-utils",
+      "version": "0.2.3",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.4"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "0799c47d8f6b35b39f338d56d8323b889699be95",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.2.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.0": {
+      "name": "class-utils",
+      "version": "0.3.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.4"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "4a2635be33ca3461e01351f1611e2f28348d8689",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.1": {
+      "name": "class-utils",
+      "version": "0.3.1",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^0.2.4"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "9db43650b2cd0474eb6cc7148635177864cb1ef9",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.2": {
+      "name": "class-utils",
+      "version": "0.3.2",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "5c282251b7a2f031abc9906e55c048f03988164a",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.3": {
+      "name": "class-utils",
+      "version": "0.3.3",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^1.0.3",
+        "static-extend": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5",
+        "should": "^8.2.2",
+        "through2": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "59dbf4399579ffd8c400a75124c69a6b2f4e574d",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.4": {
+      "name": "class-utils",
+      "version": "0.3.4",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^2.0.0",
+        "lazy-cache": "^1.0.3",
+        "static-extend": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5",
+        "should": "^8.2.2",
+        "through2": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "9f6c1a572ebe62670c5842cb12be3d9716581f1c",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.5": {
+      "name": "class-utils",
+      "version": "0.3.5",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "static-extend": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5",
+        "should": "^8.2.2",
+        "through2": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "17e793103750f9627b2176ea34cfd1b565903c80",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.6": {
+      "name": "class-utils",
+      "version": "0.3.6",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.7",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5",
+        "should": "^8.2.2",
+        "through2": "^2.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+        "shasum": "f93369ae8b9a7ce02fd41faad0ca83033190c463",
+        "tarball": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2018-01-11T14:49:23.288Z"
+}

--- a/test/fixtures/registry-mocks/content/collection-visit.json
+++ b/test/fixtures/registry-mocks/content/collection-visit.json
@@ -1,0 +1,640 @@
+{
+  "_id": "collection-visit",
+  "_rev": "9-54dca90000dfa029dbc426645d34d6a6",
+  "name": "collection-visit",
+  "description": "Visit a method over the items in an object, or map visit over the objects in an array.",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "collection-visit",
+      "description": "Visit a method over the items in an object, or map visit over the objects in an array.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/collection-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/collection-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/collection-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "map-visit": "^0.1.0",
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "context",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verbiage": {
+        "related": {
+          "list": [
+            "object-visit",
+            "map-visit"
+          ]
+        }
+      },
+      "gitHead": "d81c5237aa8488f65cca885a32f87a3a970a4580",
+      "_id": "collection-visit@0.1.0",
+      "_shasum": "aa62c98059c886e7305dbe9dd299ce63be1f1665",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "aa62c98059c886e7305dbe9dd299ce63be1f1665",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "collection-visit",
+      "description": "Visit a method over the items in an object, or map visit over the objects in an array.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/collection-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/collection-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/collection-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "map-visit": "^0.1.0",
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "context",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verbiage": {
+        "related": {
+          "list": [
+            "object-visit",
+            "map-visit"
+          ]
+        }
+      },
+      "gitHead": "d81c5237aa8488f65cca885a32f87a3a970a4580",
+      "_id": "collection-visit@0.1.1",
+      "_shasum": "ea6f937e340748725c28107a674554df759e070c",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ea6f937e340748725c28107a674554df759e070c",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "collection-visit",
+      "description": "Visit a method over the items in an object, or map visit over the objects in an array.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/collection-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/collection-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/collection-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "map-visit": "^0.1.1",
+        "object-visit": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "context",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verbiage": {
+        "related": {
+          "list": [
+            "object-visit",
+            "map-visit"
+          ]
+        }
+      },
+      "gitHead": "88e2cb62bbfff3949410624c4b6e26271e3d2c63",
+      "_id": "collection-visit@0.2.0",
+      "_shasum": "c1ab62a88911e8867d3a798cf10ce82d54de410c",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c1ab62a88911e8867d3a798cf10ce82d54de410c",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "collection-visit",
+      "description": "Visit a method over the items in an object, or map visit over the objects in an array.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/collection-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/collection-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/collection-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "lazy-cache": "^0.2.3",
+        "map-visit": "^0.1.3",
+        "object-visit": "^0.2.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "context",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verbiage": {
+        "related": {
+          "list": [
+            "base-methods",
+            "object-visit",
+            "map-visit"
+          ]
+        }
+      },
+      "gitHead": "f78bd0c17ec56da6477e1d42c0e605c95bf00bff",
+      "_id": "collection-visit@0.2.1",
+      "_shasum": "2441aaee1ad073e27dd8afbef361e67bd0f2d678",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2441aaee1ad073e27dd8afbef361e67bd0f2d678",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "collection-visit",
+      "description": "Visit a method over the items in an object, or map visit over the objects in an array.",
+      "version": "0.2.3",
+      "homepage": "https://github.com/jonschlinkert/collection-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/collection-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/collection-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "lazy-cache": "^2.0.1",
+        "map-visit": "^0.1.5",
+        "object-visit": "^0.3.4"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.0.0",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.0.1",
+        "should": "^10.0.0"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "context",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "base-methods",
+            "object-visit",
+            "map-visit"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "e00730979acb959313cd56b870014ebb3374c22f",
+      "_id": "collection-visit@0.2.3",
+      "_shasum": "2f62483caecc95f083b9a454a3ee9e6139ad7957",
+      "_from": ".",
+      "_npmVersion": "3.7.5",
+      "_nodeVersion": "5.1.1",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "shasum": "2f62483caecc95f083b9a454a3ee9e6139ad7957",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/collection-visit-0.2.3.tgz_1470434671880_0.7803895985707641"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "collection-visit",
+      "description": "Visit a method over the items in an object, or map visit over the objects in an array.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/collection-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/collection-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/collection-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "devDependencies": {
+        "clone-deep": "^0.2.4",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "collection",
+        "context",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "base-methods",
+            "map-visit",
+            "object-visit"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "39c229dceb7e124cb821b59668df5da1d5c81a6c",
+      "_id": "collection-visit@1.0.0",
+      "_shasum": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/collection-visit-1.0.0.tgz_1491775229437_0.10189219401217997"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# collection-visit [![NPM version](https://img.shields.io/npm/v/collection-visit.svg?style=flat)](https://www.npmjs.com/package/collection-visit) [![NPM monthly downloads](https://img.shields.io/npm/dm/collection-visit.svg?style=flat)](https://npmjs.org/package/collection-visit)  [![NPM total downloads](https://img.shields.io/npm/dt/collection-visit.svg?style=flat)](https://npmjs.org/package/collection-visit) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/collection-visit.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/collection-visit)\n\n> Visit a method over the items in an object, or map visit over the objects in an array.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save collection-visit\n```\n\n## Usage\n\n```js\nvar visit = require('collection-visit');\n\nvar ctx = {\n  data: {},\n  set: function (key, value) {\n    if (typeof key === 'object') {\n      visit(ctx, 'set', key);\n    } else {\n      ctx.data[key] = value;\n    }\n  }\n};\n\nctx.set('a', 'a');\nctx.set('b', 'b');\nctx.set('c', 'c');\nctx.set({d: {e: 'f'}});\n\nconsole.log(ctx.data);\n//=> {a: 'a', b: 'b', c: 'c', d: { e: 'f' }};\n```\n\n## About\n\n### Related projects\n\n* [base-methods](https://www.npmjs.com/package/base-methods): base-methods is the foundation for creating modular, unit testable and highly pluggable node.js applications, starting… [more](https://github.com/jonschlinkert/base-methods) | [homepage](https://github.com/jonschlinkert/base-methods \"base-methods is the foundation for creating modular, unit testable and highly pluggable node.js applications, starting with a handful of common methods, like `set`, `get`, `del` and `use`.\")\n* [map-visit](https://www.npmjs.com/package/map-visit): Map `visit` over an array of objects. | [homepage](https://github.com/jonschlinkert/map-visit \"Map `visit` over an array of objects.\")\n* [object-visit](https://www.npmjs.com/package/object-visit): Call a specified method on each value in the given object. | [homepage](https://github.com/jonschlinkert/object-visit \"Call a specified method on each value in the given object.\")\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 13 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 9 | [doowb](https://github.com/doowb) |\n\n### Building docs\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n### Running tests\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2017, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.5.0, on April 09, 2017._",
+  "maintainers": [
+    {
+      "name": "doowb",
+      "email": "brian.woodward@gmail.com"
+    },
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-04-09T22:00:31.200Z",
+    "created": "2015-07-31T21:37:58.665Z",
+    "0.1.0": "2015-07-31T21:37:58.665Z",
+    "0.1.1": "2015-08-05T09:59:50.927Z",
+    "0.2.0": "2015-08-29T23:39:18.234Z",
+    "0.2.1": "2015-10-06T13:37:34.052Z",
+    "0.2.2": "2015-11-08T19:13:43.260Z",
+    "0.2.3": "2016-08-05T22:04:33.762Z",
+    "1.0.0": "2017-04-09T22:00:31.200Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/collection-visit",
+  "keywords": [
+    "array",
+    "arrays",
+    "collection",
+    "context",
+    "function",
+    "helper",
+    "invoke",
+    "key",
+    "map",
+    "method",
+    "object",
+    "objects",
+    "value",
+    "visit",
+    "visitor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/collection-visit.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/collection-visit/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Brian Woodward",
+      "email": "brian.woodward@gmail.com",
+      "url": "https://twitter.com/doowb"
+    },
+    {
+      "name": "Jon Schlinkert",
+      "email": "jon.schlinkert@sellside.com",
+      "url": "http://twitter.com/jonschlinkert"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/collection-visit.min.json
+++ b/test/fixtures/registry-mocks/content/collection-visit.min.json
@@ -1,0 +1,140 @@
+{
+  "name": "collection-visit",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "collection-visit",
+      "version": "0.1.0",
+      "dependencies": {
+        "map-visit": "^0.1.0",
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "aa62c98059c886e7305dbe9dd299ce63be1f1665",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "collection-visit",
+      "version": "0.1.1",
+      "dependencies": {
+        "map-visit": "^0.1.0",
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "ea6f937e340748725c28107a674554df759e070c",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "collection-visit",
+      "version": "0.2.0",
+      "dependencies": {
+        "map-visit": "^0.1.1",
+        "object-visit": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "c1ab62a88911e8867d3a798cf10ce82d54de410c",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.1": {
+      "name": "collection-visit",
+      "version": "0.2.1",
+      "dependencies": {
+        "lazy-cache": "^0.2.3",
+        "map-visit": "^0.1.3",
+        "object-visit": "^0.2.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "2441aaee1ad073e27dd8afbef361e67bd0f2d678",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.3": {
+      "name": "collection-visit",
+      "version": "0.2.3",
+      "dependencies": {
+        "lazy-cache": "^2.0.1",
+        "map-visit": "^0.1.5",
+        "object-visit": "^0.3.4"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.0.0",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.0.1",
+        "should": "^10.0.0"
+      },
+      "dist": {
+        "shasum": "2f62483caecc95f083b9a454a3ee9e6139ad7957",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-0.2.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "collection-visit",
+      "version": "1.0.0",
+      "dependencies": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      },
+      "devDependencies": {
+        "clone-deep": "^0.2.4",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "4bc0373c164bc3291b4d368c829cf1a80a59dca0",
+        "tarball": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-04-09T22:00:31.200Z"
+}

--- a/test/fixtures/registry-mocks/content/component-emitter.json
+++ b/test/fixtures/registry-mocks/content/component-emitter.json
@@ -1,0 +1,902 @@
+{
+  "_id": "component-emitter",
+  "_rev": "51-66c8e77e9488b7b90b6d1793e1ae4a71",
+  "name": "component-emitter",
+  "description": "Event emitter",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "versions": {
+    "1.1.2": {
+      "name": "component-emitter",
+      "description": "Event emitter",
+      "version": "1.1.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "emitter/index.js": "index.js"
+        }
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/emitter.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bugs": {
+        "url": "https://github.com/component/emitter/issues"
+      },
+      "homepage": "https://github.com/component/emitter",
+      "_id": "component-emitter@1.1.2",
+      "dist": {
+        "shasum": "296594f2753daa63996d2af08d15a95116c9aec3",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "maintainers": [
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "component-emitter",
+      "description": "Event emitter",
+      "version": "1.1.3",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "emitter/index.js": "index.js"
+        }
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/emitter.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bugs": {
+        "url": "https://github.com/component/emitter/issues"
+      },
+      "homepage": "https://github.com/component/emitter",
+      "_id": "component-emitter@1.1.3",
+      "_shasum": "2bf887a4a9fc856eafcabcd82a43eb42a57eec6f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "juliangruber",
+        "email": "julian@juliangruber.com"
+      },
+      "maintainers": [
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2bf887a4a9fc856eafcabcd82a43eb42a57eec6f",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "component-emitter",
+      "description": "Event emitter",
+      "version": "1.2.0",
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "emitter/index.js": "index.js"
+        }
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/emitter.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "4d18307a2cdd2cec16d1fadf9e04f02351a8d62e",
+      "bugs": {
+        "url": "https://github.com/component/emitter/issues"
+      },
+      "homepage": "https://github.com/component/emitter",
+      "_id": "component-emitter@1.2.0",
+      "_shasum": "ccd113a86388d06482d03de3fc7df98526ba8efe",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "1.2.0",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ccd113a86388d06482d03de3fc7df98526ba8efe",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "component-emitter",
+      "description": "Event emitter",
+      "version": "1.2.1",
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "emitter/index.js": "index.js"
+        }
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/component/emitter.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "187492ab8028c7221b589bdfd482b715149cd868",
+      "bugs": {
+        "url": "https://github.com/component/emitter/issues"
+      },
+      "homepage": "https://github.com/component/emitter#readme",
+      "_id": "component-emitter@1.2.1",
+      "_shasum": "137918d6d78283f7df7a6b7c5a63e140e69425e6",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "nami-doc",
+        "email": "karp@hotmail.fr"
+      },
+      "maintainers": [
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "137918d6d78283f7df7a6b7c5a63e140e69425e6",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/component-emitter-1.2.1.tgz_1461005707641_0.14232611074112356"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "component-emitter",
+      "description": "Event emitter",
+      "version": "1.3.0",
+      "license": "MIT",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "component": {
+        "scripts": {
+          "emitter/index.js": "index.js"
+        }
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/component/emitter.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "gitHead": "6bd7817e8a444cb16e8abdf7dd2d7f04d5ca3dc8",
+      "bugs": {
+        "url": "https://github.com/component/emitter/issues"
+      },
+      "homepage": "https://github.com/component/emitter#readme",
+      "_id": "component-emitter@1.3.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "nami-doc",
+        "email": "vendethiel@hotmail.fr"
+      },
+      "dist": {
+        "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+        "shasum": "16e4070fba8ae29b679f2215853ee181ab2eabc0",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8001,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJctO4ICRA9TVsSAnZWagAAIwkP/2seJl5R6k04DzjI2I4D\ns/OxuiaQjcjhXseLkEuSdRNzJKdeGdL9nujc6/zYzbhWfIyUpes9FetRnsut\nGMpM2ClspSTxKGIxkHyvTFzYEM/nBHjwfxlDuiT2siCpCIoRvRV5440MyrBU\nNio6j/uAlAVSPUDzXYNUvzdsMl+2mAJUcgXmrFFvn2hI2tJbDJ8UuMdZ9++R\nk8vPm5Dm7XL7b3LmZZZ9Y5JndyZuISGeAPL2bbRYOm+0p9ozA4FGtpJysVIe\ntOTuiXZfvMSgXVYgGP0avYXbx40L6X+Kcwmm1W2P7Owz3T6r7oVmtnvk4Z8/\nZbWLeJ5Pbq61e+1udRLidmCtKz6X5oafK4bElnQ4Oa1zrjP/bwLlkmfaLPOc\n3dZiPnOZ8TwbLFmH7Fc2yL2Vx3mcYQ7p+e4wcWcxlAVJA74GXzg/7+a79GSq\nl5b62nbeU7dvU831b375PZaa5RpGs7Tbw4hsOV14kCLd2khmOLwF4u1xmMTZ\n8r45Qjb2ZO+3rGSWOM2SGdl6Biw4SGXeC1WalAY1PaY1Bd1MDjCqqqNeKGC8\nwrKD/koSSGKzcKi54OffLLi63Rwk7rLeu4/kF+RKw5EzI/eQcB/EK6gSfJOP\nm/ErUTK3436UgHhg6/XHyj1JVM6zrOJnaEHwyqVtd6xkXF/Nm0FhsvXOxyA4\n0xVL\r\n=o9Hs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "amjad.masad@gmail.com",
+          "name": "amasad"
+        },
+        {
+          "email": "antshort@gmail.com",
+          "name": "anthonyshort"
+        },
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "calvin@calv.info",
+          "name": "calvinfo"
+        },
+        {
+          "email": "clint@anotherway.co.za",
+          "name": "clintwood"
+        },
+        {
+          "email": "thecoreh@gmail.com",
+          "name": "coreh"
+        },
+        {
+          "email": "cristiandouce@gmail.com",
+          "name": "cristiandouce"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "df.creative@gmail.com",
+          "name": "dfcreative"
+        },
+        {
+          "email": "dominic@dbarnes.info",
+          "name": "dominicbarnes"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "ian@ianstormtaylor.com",
+          "name": "ianstormtaylor"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "julian@juliangruber.com",
+          "name": "juliangruber"
+        },
+        {
+          "email": "kelonyemitchel@gmail.com",
+          "name": "kelonye"
+        },
+        {
+          "email": "mattmuelle@gmail.com",
+          "name": "mattmueller"
+        },
+        {
+          "email": "vendethiel@hotmail.fr",
+          "name": "nami-doc"
+        },
+        {
+          "email": "fabian.eichenberger@gmail.com",
+          "name": "queckezz"
+        },
+        {
+          "email": "rauchg@gmail.com",
+          "name": "rauchg"
+        },
+        {
+          "email": "rdsuarez@gmail.com",
+          "name": "retrofox"
+        },
+        {
+          "email": "gstagas@gmail.com",
+          "name": "stagas"
+        },
+        {
+          "email": "me@stephenmathieson.com",
+          "name": "stephenmathieson"
+        },
+        {
+          "email": "arpad.borsos@googlemail.com",
+          "name": "swatinem"
+        },
+        {
+          "email": "dnfagnan@gmail.com",
+          "name": "thehydroimpulse"
+        },
+        {
+          "email": "timaschew@gmail.com",
+          "name": "timaschew"
+        },
+        {
+          "email": "secoif@gmail.com",
+          "name": "timoxley"
+        },
+        {
+          "email": "tj@vision-media.ca",
+          "name": "tjholowaychuk"
+        },
+        {
+          "email": "nathan@tootallnate.net",
+          "name": "tootallnate"
+        },
+        {
+          "email": "trevorgerhardt@gmail.com",
+          "name": "trevorgerhardt"
+        },
+        {
+          "email": "yields@icloud.com",
+          "name": "yields"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/component-emitter_1.3.0_1555361288195_0.12626268851479416"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Emitter [![Build Status](https://travis-ci.org/component/emitter.png)](https://travis-ci.org/component/emitter)\r\n\r\n  Event emitter component.\r\n\r\n## Installation\r\n\r\n```\r\n$ component install component/emitter\r\n```\r\n\r\n## API\r\n\r\n### Emitter(obj)\r\n\r\n  The `Emitter` may also be used as a mixin. For example\r\n  a \"plain\" object may become an emitter, or you may\r\n  extend an existing prototype.\r\n\r\n  As an `Emitter` instance:\r\n\r\n```js\r\nvar Emitter = require('emitter');\r\nvar emitter = new Emitter;\r\nemitter.emit('something');\r\n```\r\n\r\n  As a mixin:\r\n\r\n```js\r\nvar Emitter = require('emitter');\r\nvar user = { name: 'tobi' };\r\nEmitter(user);\r\n\r\nuser.emit('im a user');\r\n```\r\n\r\n  As a prototype mixin:\r\n\r\n```js\r\nvar Emitter = require('emitter');\r\nEmitter(User.prototype);\r\n```\r\n\r\n### Emitter#on(event, fn)\r\n\r\n  Register an `event` handler `fn`.\r\n\r\n### Emitter#once(event, fn)\r\n\r\n  Register a single-shot `event` handler `fn`,\r\n  removed immediately after it is invoked the\r\n  first time.\r\n\r\n### Emitter#off(event, fn)\r\n\r\n  * Pass `event` and `fn` to remove a listener.\r\n  * Pass `event` to remove all listeners on that event.\r\n  * Pass nothing to remove all listeners on all events.\r\n\r\n### Emitter#emit(event, ...)\r\n\r\n  Emit an `event` with variable option args.\r\n\r\n### Emitter#listeners(event)\r\n\r\n  Return an array of callbacks, or an empty array.\r\n\r\n### Emitter#hasListeners(event)\r\n\r\n  Check if this emitter has `event` handlers.\r\n\r\n## License\r\n\r\nMIT\r\n",
+  "maintainers": [
+    {
+      "email": "amjad.masad@gmail.com",
+      "name": "amasad"
+    },
+    {
+      "email": "antshort@gmail.com",
+      "name": "anthonyshort"
+    },
+    {
+      "email": "hello@blakeembrey.com",
+      "name": "blakeembrey"
+    },
+    {
+      "email": "calvin@calv.info",
+      "name": "calvinfo"
+    },
+    {
+      "email": "clint@anotherway.co.za",
+      "name": "clintwood"
+    },
+    {
+      "email": "thecoreh@gmail.com",
+      "name": "coreh"
+    },
+    {
+      "email": "cristiandouce@gmail.com",
+      "name": "cristiandouce"
+    },
+    {
+      "email": "shtylman@gmail.com",
+      "name": "defunctzombie"
+    },
+    {
+      "email": "df.creative@gmail.com",
+      "name": "dfcreative"
+    },
+    {
+      "email": "dominic@dbarnes.info",
+      "name": "dominicbarnes"
+    },
+    {
+      "email": "forbes@lindesay.co.uk",
+      "name": "forbeslindesay"
+    },
+    {
+      "email": "hughskennedy@gmail.com",
+      "name": "hughsk"
+    },
+    {
+      "email": "ian@ianstormtaylor.com",
+      "name": "ianstormtaylor"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jonathanong"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    },
+    {
+      "email": "julian@juliangruber.com",
+      "name": "juliangruber"
+    },
+    {
+      "email": "kelonyemitchel@gmail.com",
+      "name": "kelonye"
+    },
+    {
+      "email": "mattmuelle@gmail.com",
+      "name": "mattmueller"
+    },
+    {
+      "email": "vendethiel@hotmail.fr",
+      "name": "nami-doc"
+    },
+    {
+      "email": "fabian.eichenberger@gmail.com",
+      "name": "queckezz"
+    },
+    {
+      "email": "rauchg@gmail.com",
+      "name": "rauchg"
+    },
+    {
+      "email": "rdsuarez@gmail.com",
+      "name": "retrofox"
+    },
+    {
+      "email": "gstagas@gmail.com",
+      "name": "stagas"
+    },
+    {
+      "email": "me@stephenmathieson.com",
+      "name": "stephenmathieson"
+    },
+    {
+      "email": "arpad.borsos@googlemail.com",
+      "name": "swatinem"
+    },
+    {
+      "email": "dnfagnan@gmail.com",
+      "name": "thehydroimpulse"
+    },
+    {
+      "email": "timaschew@gmail.com",
+      "name": "timaschew"
+    },
+    {
+      "email": "secoif@gmail.com",
+      "name": "timoxley"
+    },
+    {
+      "email": "tj@vision-media.ca",
+      "name": "tjholowaychuk"
+    },
+    {
+      "email": "nathan@tootallnate.net",
+      "name": "tootallnate"
+    },
+    {
+      "email": "trevorgerhardt@gmail.com",
+      "name": "trevorgerhardt"
+    },
+    {
+      "email": "yields@icloud.com",
+      "name": "yields"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-15T20:48:14.119Z",
+    "created": "2014-02-11T02:15:29.076Z",
+    "1.1.2": "2014-02-11T02:15:29.076Z",
+    "1.1.3": "2014-06-20T06:24:49.737Z",
+    "1.2.0": "2015-02-12T18:37:13.945Z",
+    "1.2.1": "2016-04-18T18:55:09.978Z",
+    "1.3.0": "2019-04-15T20:48:08.367Z"
+  },
+  "readmeFilename": "Readme.md",
+  "homepage": "https://github.com/component/emitter#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/component/emitter.git"
+  },
+  "bugs": {
+    "url": "https://github.com/component/emitter/issues"
+  },
+  "users": {
+    "h02e56": true,
+    "kontrax": true,
+    "tommyzzm": true,
+    "monjer": true,
+    "alexsasharegan": true,
+    "dwqs": true,
+    "heartnett": true
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/component-emitter.min.json
+++ b/test/fixtures/registry-mocks/content/component-emitter.min.json
@@ -1,0 +1,73 @@
+{
+  "name": "component-emitter",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "versions": {
+    "1.1.2": {
+      "name": "component-emitter",
+      "version": "1.1.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "296594f2753daa63996d2af08d15a95116c9aec3",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "component-emitter",
+      "version": "1.1.3",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "2bf887a4a9fc856eafcabcd82a43eb42a57eec6f",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.3.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "component-emitter",
+      "version": "1.2.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "ccd113a86388d06482d03de3fc7df98526ba8efe",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "component-emitter",
+      "version": "1.2.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "137918d6d78283f7df7a6b7c5a63e140e69425e6",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "component-emitter",
+      "version": "1.3.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+        "shasum": "16e4070fba8ae29b679f2215853ee181ab2eabc0",
+        "tarball": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8001,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJctO4ICRA9TVsSAnZWagAAIwkP/2seJl5R6k04DzjI2I4D\ns/OxuiaQjcjhXseLkEuSdRNzJKdeGdL9nujc6/zYzbhWfIyUpes9FetRnsut\nGMpM2ClspSTxKGIxkHyvTFzYEM/nBHjwfxlDuiT2siCpCIoRvRV5440MyrBU\nNio6j/uAlAVSPUDzXYNUvzdsMl+2mAJUcgXmrFFvn2hI2tJbDJ8UuMdZ9++R\nk8vPm5Dm7XL7b3LmZZZ9Y5JndyZuISGeAPL2bbRYOm+0p9ozA4FGtpJysVIe\ntOTuiXZfvMSgXVYgGP0avYXbx40L6X+Kcwmm1W2P7Owz3T6r7oVmtnvk4Z8/\nZbWLeJ5Pbq61e+1udRLidmCtKz6X5oafK4bElnQ4Oa1zrjP/bwLlkmfaLPOc\n3dZiPnOZ8TwbLFmH7Fc2yL2Vx3mcYQ7p+e4wcWcxlAVJA74GXzg/7+a79GSq\nl5b62nbeU7dvU831b375PZaa5RpGs7Tbw4hsOV14kCLd2khmOLwF4u1xmMTZ\n8r45Qjb2ZO+3rGSWOM2SGdl6Biw4SGXeC1WalAY1PaY1Bd1MDjCqqqNeKGC8\nwrKD/koSSGKzcKi54OffLLi63Rwk7rLeu4/kF+RKw5EzI/eQcB/EK6gSfJOP\nm/ErUTK3436UgHhg6/XHyj1JVM6zrOJnaEHwyqVtd6xkXF/Nm0FhsvXOxyA4\n0xVL\r\n=o9Hs\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-04-15T20:48:14.119Z"
+}

--- a/test/fixtures/registry-mocks/content/compressible.json
+++ b/test/fixtures/registry-mocks/content/compressible.json
@@ -1,0 +1,2432 @@
+{
+  "_id": "compressible",
+  "_rev": "55-bc6068b24785960f1e136449c9613e6b",
+  "name": "compressible",
+  "description": "Compressible Content-Type / mime checking",
+  "dist-tags": {
+    "latest": "2.0.18"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "compressible",
+      "description": "Compressible mime types",
+      "version": "0.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compressible.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compressible/issues"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "homepage": "https://github.com/expressjs/compressible",
+      "_id": "compressible@0.1.0",
+      "dist": {
+        "shasum": "87c187cb37ef9f028f7486ef9b0fc3ef02f3eb85",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "compressible",
+      "description": "Compressible mime types",
+      "version": "0.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": {
+        "name": "Jeremiah Senkpiel",
+        "email": "fishrock123@rocketmail.com",
+        "url": "https://searchbeam.jit.su",
+        "twitter": "https://twitter.com/fishrock123"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compressible.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compressible/issues"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "homepage": "https://github.com/expressjs/compressible",
+      "_id": "compressible@0.1.1",
+      "dist": {
+        "shasum": "8e0003ef366d1d52a0300ab351f79df79e574b9f",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.18",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "0.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": {
+        "name": "Jeremiah Senkpiel",
+        "email": "fishrock123@rocketmail.com",
+        "url": "https://searchbeam.jit.su",
+        "twitter": "https://twitter.com/fishrock123"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compressible.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compressible/issues"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "_id": "compressible@0.2.0",
+      "dist": {
+        "shasum": "1c03ada271f3f4a6cd6306490b0ce3efe47997b5",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "fishrock123",
+        "email": "fishrock123@rocketmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": {
+        "name": "Jeremiah Senkpiel",
+        "email": "fishrock123@rocketmail.com",
+        "url": "https://searchbeam.jit.su",
+        "twitter": "https://twitter.com/fishrock123"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compressible.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compressible/issues"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "beautify-benchmark": "~0.2.4",
+        "mime": "*"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "posttest": "mocha --reporter spec bench.js"
+      },
+      "homepage": "https://github.com/expressjs/compressible",
+      "_id": "compressible@1.0.0",
+      "dist": {
+        "shasum": "f83e49c1cb61421753545125a8011d68b492427d",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.22",
+      "_npmUser": {
+        "name": "fishrock123",
+        "email": "fishrock123@rocketmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compressible.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compressible/issues"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "beautify-benchmark": "~0.2.4",
+        "mime": "*"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/compressible.js",
+        "posttest": "mocha --reporter spec test/benchmarks.js"
+      },
+      "homepage": "https://github.com/expressjs/compressible",
+      "_id": "compressible@1.0.1",
+      "dist": {
+        "shasum": "8ed8224822c60c3c8dabcad34e913ed2952ad170",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "fishrock123",
+        "email": "fishrock123@rocketmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compressible.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compressible/issues"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "devDependencies": {
+        "mocha": "~1.20.1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/"
+      },
+      "homepage": "https://github.com/expressjs/compressible",
+      "_id": "compressible@1.1.0",
+      "_shasum": "124d8a7bba18a05a410a2f25bad413b1b94aff67",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "fishrock123",
+        "email": "fishrock123@rocketmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "dist": {
+        "shasum": "124d8a7bba18a05a410a2f25bad413b1b94aff67",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compressible.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compressible/issues"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "devDependencies": {
+        "mocha": "~1.20.1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/"
+      },
+      "gitHead": "b19369eb9ff35a696a97d14d5fa409521b115a45",
+      "homepage": "https://github.com/expressjs/compressible",
+      "_id": "compressible@1.1.1",
+      "_shasum": "23b71ea90ea6c6a66289701a918182c24d0729ef",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "dist": {
+        "shasum": "23b71ea90ea6c6a66289701a918182c24d0729ef",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.0",
+      "contributors": [
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": "~1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "~1.20.1"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "files": [
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot -check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.0",
+      "_shasum": "90086ce57102e9e2427ee945a5fb2a98dd51dfb4",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "fishrock123",
+        "email": "fishrock123@rocketmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "dist": {
+        "shasum": "90086ce57102e9e2427ee945a5fb2a98dd51dfb4",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.1",
+      "contributors": [
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": "1.x"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "~1.20.1"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "files": [
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot -check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.1",
+      "_shasum": "3550115793eb3435f7eb16775afe05df1a333ebc",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "fishrock123",
+        "email": "fishrock123@rocketmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "dist": {
+        "shasum": "3550115793eb3435f7eb16775afe05df1a333ebc",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.2",
+      "contributors": [
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.1.2 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "files": [
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot -check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "06e9d6810e86e70dfc17c9805eeecf8b2fa995b5",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.2",
+      "_shasum": "d0474a6ba6590a43d39c2ce9a6cfbb6479be76a5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "dist": {
+        "shasum": "d0474a6ba6590a43d39c2ce9a6cfbb6479be76a5",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.3",
+      "contributors": [
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.13.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "9205c624b9bb54b16a5692fe7002e58d29f40911",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.3",
+      "_shasum": "046fe398c1c32ae5af1f4a601cf9ae4632bf2b78",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "046fe398c1c32ae5af1f4a601cf9ae4632bf2b78",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.4",
+      "contributors": [
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.14.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "cc2e4730900c4da07190c9bf6b44391baeeb9ea7",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.4",
+      "_shasum": "4d8099e88afd0ffbf7c78fd16991d9ac060a94f6",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4d8099e88afd0ffbf7c78fd16991d9ac060a94f6",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.5": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.5",
+      "contributors": [
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.16.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "4604137fbf5a038cb4bd21898f9fe342809d84f1",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.5",
+      "_shasum": "c7dd0514a7a90c02a3ec9ee0ce14d8650bde9b6f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c7dd0514a7a90c02a3ec9ee0ce14d8650bde9b6f",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.6": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.6",
+      "contributors": [
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.19.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "74899bfd08b273950fa0a942ae1d1d64e2716bd4",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.6",
+      "_shasum": "9e4aa9321ffcf9cc4d81954f7aafa9f35767d5ea",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9e4aa9321ffcf9cc4d81954f7aafa9f35767d5ea",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.7": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.7",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.21.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "c12994fff506aa15af676c59a4117c0e09c0ae65",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.7",
+      "_shasum": "2058c52722fd3f1538a4f22ab14d0635904d19ae",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2058c52722fd3f1538a4f22ab14d0635904d19ae",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.8": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.8",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.23.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "2.9.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "b696fa801bf93ffff41a3854cedd6f2ce86b0124",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.8",
+      "_shasum": "7162e6c46d3b9d200ffb45cb4e4a0f7832732503",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "7162e6c46d3b9d200ffb45cb4e4a0f7832732503",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.8.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/compressible-2.0.8.tgz_1463066991355_0.24597734049893916"
+      },
+      "directories": {}
+    },
+    "2.0.9": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.9",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/compressible"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.24.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.9.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.3.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "9e750e00d459f01b9a16df504f87ad829bf2a518",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible",
+      "_id": "compressible@2.0.9",
+      "_shasum": "6daab4e2b599c2770dd9e21e7a891b1c5a755425",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "6daab4e2b599c2770dd9e21e7a891b1c5a755425",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/compressible-2.0.9.tgz_1477956262136_0.9366124230436981"
+      },
+      "directories": {}
+    },
+    "2.0.10": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.10",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.27.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.18.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --check-leaks"
+      },
+      "gitHead": "235bc74b36aa7fe854df88ce2c68242c0a4ca938",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.10",
+      "_shasum": "feda1c7f7617912732b29bf8cf26252a20b9eecd",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "feda1c7f7617912732b29bf8cf26252a20b9eecd",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/compressible-2.0.10.tgz_1490330888540_0.3248714415822178"
+      },
+      "directories": {}
+    },
+    "2.0.11": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.11",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.29.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "~1.21.5",
+        "nyc": "11.0.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "9d52686b8de6d5c64db7ac447bd43d8fe26d7d8b",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.11",
+      "_shasum": "16718a75de283ed8e604041625a2064586797d8a",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "16718a75de283ed8e604041625a2064586797d8a",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compressible-2.0.11.tgz_1501207319365_0.11534262751229107"
+      },
+      "directories": {}
+    },
+    "2.0.12": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.12",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.30.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "~1.21.5",
+        "nyc": "11.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "07919d9b158879909404d3f942b777dbf47d2788",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.12",
+      "_shasum": "c59a5c99db76767e9876500e271ef63b3493bd66",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "c59a5c99db76767e9876500e271ef63b3493bd66",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compressible-2.0.12.tgz_1508543757843_0.14214342553168535"
+      },
+      "directories": {}
+    },
+    "2.0.13": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.13",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.33.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "~1.21.5",
+        "nyc": "11.3.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "c1818de6f01950c9e74f08e321cb50335a18be03",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.13",
+      "_shasum": "0d1020ab924b2fdb4d6279875c7d6daba6baa7a9",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "0d1020ab924b2fdb4d6279875c7d6daba6baa7a9",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6804
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compressible_2.0.13_1518929614998_0.372341918795023"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.14": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.14",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.34.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.12.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.8.0",
+        "eslint-plugin-standard": "3.1.0",
+        "mocha": "~1.21.5",
+        "nyc": "11.9.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "7863941f7a7aed199ed86d2d512e505f27584082",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.14",
+      "_shasum": "326c5f507fbb055f54116782b969a81b67a29da7",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.14.2",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "326c5f507fbb055f54116782b969a81b67a29da7",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6930,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbFsybCRA9TVsSAnZWagAAQWIP/ixIs4z3dX20ZVCcl7C1\niXgJsGVTZ6X4JHJpwAhdPav6Aqdo2rPM45Rbbah8MnGteMc7UUIJMySa8B8r\nyBnBOqjVE76TNY7AM6CXrY2Gci6S9vLe0exKeEbbSfy927hdmXxHwczAcPB9\nzJ9WfJgSLZorlfqSWv66Fafc4VKcfwnKpNAso70IG1wNDcj5RYgcHgPQU2uA\nEaPBwbv4b3/Tnq8m0NUKdYNDo9+7dqklgAFB0H5rCMegUDQmHfqiGy5CtN7B\nFBex3vpDq6OkJyd9Sr64c7PlI1kR8UdKtoIUqXAG1U5ewbYNtisYb662C3xA\nYmBK0/9UfHGlsFIJMDdHLAIRArwaQtevKABZ4QdQJeWhfeC//giQejoYeUjV\nnC6nGyP6TCXS+WlM201gKncvbA0WKQ41V9dNGWFMpH4N5bEXgn+au9ulRiCN\nTyWDRUTzJtx/AGk8es0Nz5N9HnQmSDq8g/pT7RyU3XZr7qNIPHzOSYXy8Ce4\naUnbYZVW1qYBfWv1IMrkYPbOQpW8KtMipc6DxxTbtn3l5iEVSAvku5+aHNnF\nyxedqQKFGAVFpEx89R/L0pdBPSASmaeTmgz+iJz6BSGfOKUKZjdoba09oIAn\nobUZD82I5bruxoHQvrcKAoR4OHDjY1USZFG7X/0c/uXRxSWdIAZw5ixO0SBa\nB8qj\r\n=rPuR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compressible_2.0.14_1528220827129_0.2663089354097006"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.15": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.15",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.36.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "5.5.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "5.2.0",
+        "nyc": "13.1.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "ce6e0ab553745d62de42ce5c07e749c85b3cebf1",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.15",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.12.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+        "shasum": "857a9ab0a7e5a07d8d837ed43fe2defff64fe212",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7003,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbn7wsCRA9TVsSAnZWagAA3BkP/12uh13r/9IQ/9Fbp73u\nWZepalH9mXEabZWsGu54MNyauzR4H3HqosgUbfATwG3zpDvxPXZ0F7EBaYMS\n6jJQboQxf/rnSywh3Ut3QRkjfT5VmkPYifA1IxLxocSnN00IK8b/VLzwTmHl\nQsZ9EgZsWRp2vul0wb/Nxixl535V2RTGbS7LwyMZN+KvAYoEJmagTIDX46Wh\nrKmfFSvjJ7HaJU4X6euMQ9AQERo0NUFOTUXGJg4/npE5m/wwAqihTu0vot3Q\n98aEdb0xXPMnehGR/UMJ32DyaiHZ7GLBs+nJU4OYj2T6tpwDBTUwvz841l9T\nllrOnXxoH7QfQiqyUTRjejPbZtDQLruYOnPBUBlQSxOVEhz0itBxJuZ8hKle\nukjRlD6gKFTKA+AjIAG3nCGR25pQuJP/ZAOVI3shhvNmWhbWKPY0qALvexNd\n0zBRwYC7RjKrm4/wAKCeBS3VsydtxK/Yh31z5zHJTGrqDX515+MRCcpYWlHE\nA1R62HqrGfYCDczmBgsLJh3KXV1k4ebWFy/aeivovuCnT72c1DROPBrGSQC5\n663Ax7OjmPH9bufpV/ONuUhrxrgjb5HuLbQg+fM22WUOchQnqPS9i+pTFgDC\nru9FY+k/+CG6X9l9xjwlFBSaLuIXvZ6Ee4TtkzfC501rKOA8tYOc1JsVirwF\nAfPF\r\n=6Sz4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compressible_2.0.15_1537195052419_0.38702542610355484"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.16": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.16",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.38.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "5.14.1",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "5.2.0",
+        "nyc": "13.3.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "fcca904d8cefee3f0a84bc9e42264c97fde44708",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.16",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
+        "shasum": "a49bf9858f3821b64ce1be0296afc7380466a77f",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7116,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcav9vCRA9TVsSAnZWagAAqWIP/2PS0cVG2KMSYi8NnART\nSDCsVF+LNer2Z4/2ILPI/sTmAmiUFvTeo0G2PkAp6TTunWYlAdy23sI4qys6\nWSNPNBobOv2Kj6iDFk3Yv+OxIplzVaxDUw5tyikFw02SJPvXxueo32w7VX9s\nx9o3Q9zhiAfNdp2Az+rFFdHnEu8w5kK0ruvMf7kKyZt6gwrqBVd4JSiKwwKo\nMAEOVR0uEJXA9rlI7EyPwogtqyZTX8Yy4uH7PAOrfbzk+ZaVxilnOvmEtQmL\nkfQkW/ZD/ZIdgeu2s60oJVKPdQEeJ7s6noe9L/8mXewpRihCAwZ1NE0kYVxO\nyAMfMwt7nopz8fuJ0haD0dS5+uybkXpwfeetPY991uHKMIk1WxyPpy74edMF\nnXHzuJO4o8nWnBmW471BB6A4IEIvZJSNio49aLx3douHrd9dZuvhKj+uj3Al\nyrqGG/P4So0CbBODLVhTwHLECy4q/emuRbvExnrjg9cZ82e0Qe3D1fUIfnCn\nm0p3x5qfGO9wzUths/Xnn8ZFK3PZFLDSEIBHt3hJE32z8Bq5t4HCm+zDvkS+\nXO5obVlrR9Ixr6RWA+SuPNyfe/FtT7t6/2z2JJ1aIztfAOhxDNg4aHy7DBso\n3SqOZyjgEzpdUbBrszpNRVm0n9vlQ7rVvPGa0fJ4+4PdNj7Q0VKD95+jyh7U\n2urj\r\n=t9LW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compressible_2.0.16_1550516079234_0.7456236838477543"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.17": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.17",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.40.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "5.15.2",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "57985690741c2670fb5c171bdefb07114ce1a63f",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.17",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+        "shasum": "6e8c108a16ad58384a977f3a482ca20bff2f38c1",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7192,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwOKwCRA9TVsSAnZWagAAL78P/2lEciMjw1wyutzAX3dx\nxblDJFTALdONTTC8GslxhL5AGEy5MwqiJnU7isb5e0L9st6ixwtnR+LYCVcX\nURWwM8AQqQl+uR9yXfQw/ctyije2uAs4205TpY0aSKW9mZ0tRVL3IiPz0el9\nGKhBfYrw8TPVaX5L06L1IBR4OzU0KI0+1AAucC+miX27BXlORKX1jvAuky4h\n1w5y4sB2DQvQ00Bzn/aKZj+VlmFZaCEAxbcpdzO/4wJmZUnAh6XSBNaGGoi7\npRRh7IFMhWancon/XC9LcbcfZhuApqPCXBE9wn4vqFQTkNcPwdUSd+5PTRYm\n9+sQQXRiuDtGszrdYz01YI9W+jlQT7Ibi+Qe2HeS9bXSxdre9Y9JZ4urDKGV\n994vVI0EtZEBMQhoH0AN4YyuAOxSC/2VkCFXijZDGeJ4LR/WJQS+2AwTkp6L\nI+a7+ySb0i8CAiq9YcUB51XjIcaj//MkuZWOwmYG1qjnIAKyCUOR+HdopIlI\nX1WkAVFsTfxXIM9Ep35173umIUmY3ijdHBJrVQxndNRKf4hTBB2FCHj1EFqv\n3BtQjL0ghP2pSSror3gbf1rL/UshhMqqzRUGAF9nqv+BRUKpAM9QfCW1rXZD\n2QHul4xqvGtLojV2Kq6yNAfd89KCunxe2r9ISWyrIPtot8JwzP5hzDzWT8lI\n2QsC\r\n=XUus\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compressible_2.0.17_1556144816176_0.3226185429681636"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.18": {
+      "name": "compressible",
+      "description": "Compressible Content-Type / mime checking",
+      "version": "2.0.18",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "Jeremiah Senkpiel",
+          "email": "fishrock123@rocketmail.com",
+          "url": "https://searchbeam.jit.su"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/compressible.git"
+      },
+      "keywords": [
+        "compress",
+        "gzip",
+        "mime",
+        "content-type"
+      ],
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "6.8.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-plugin-import": "2.19.1",
+        "eslint-plugin-markdown": "1.0.1",
+        "eslint-plugin-node": "11.0.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.1",
+        "mocha": "7.0.0",
+        "nyc": "15.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "f4b72172c155b692c8407730e1bc41d2ca81e000",
+      "bugs": {
+        "url": "https://github.com/jshttp/compressible/issues"
+      },
+      "homepage": "https://github.com/jshttp/compressible#readme",
+      "_id": "compressible@2.0.18",
+      "_nodeVersion": "12.12.0",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+        "shasum": "af53cca6b070d4c3c0750fbd77286a6d7cc46fba",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7355,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeEryBCRA9TVsSAnZWagAAJ+oQAKCAszvCKZ9xyxyd5R9j\nMwZYPmN071vz6z3MXQxmFaFvYsE/U1HW9JU8dvgfuOdT/0mXVuRN+l94HcxJ\nbInW6GgsvwTZ+owcWQhG88jbEegcwaTh3wi4Us+aJTOb781ITaedr7spEll7\nakccNmpOS9Mk+oy52A0EC7N8/+xy9WEBTdWii3MsbyDWmsD+0qWl/SeKYboQ\n4/0JX9YHg3wDoiIlRJHXp4VXBRyp6Wscl38xWkZn5DRHhPLSzkDdYtvZkwcv\n9VD9UNma+OxDAEZdmFavvL964QrhPPrjiI77fIOP/S7LFdepDWlIgpSduhdZ\nN2KhBJtRWNZywCKzFGBSRJuAa/ZTUqIv9cSBWTidqNOHucVJf+00dQBqYFuY\nkbqVPks/LC54An6loFaqkj4U+C0a/PFHVgdH4C2eBldz3W6bwFEQ0kLmICCi\ns53uKWv5+4ULBXiOIpGa0LtH6fM6GfHKS02BScI7cMpengBNM4bTvAkz8s6g\ntu8wG0b+mxuu7rCGzdUaLHLvBjuuQsQRa96NH+L3omSMSmDeZhGWVuK9ObiA\nXcGJnVWsGQ1vuuRht8Npx/aq4YOZ05jh5MvYCh9hgDbLQOnvUCxpB7i9UjSY\nPl1liyYKzmxyQ91ZGXkIQC6qCGWPgmz1XhvAUkLgPmFLOCbwBIEfrcwcBSqj\n/v94\r\n=4fyH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compressible_2.0.18_1578286208836_0.5819187129766967"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# compressible\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nCompressible `Content-Type` / `mime` checking.\n\n## Installation\n\n```sh\n$ npm install compressible\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar compressible = require('compressible')\n```\n\n### compressible(type)\n\nChecks if the given `Content-Type` is compressible. The `type` argument is expected\nto be a value MIME type or `Content-Type` string, though no validation is performed.\n\nThe MIME is looked up in the [`mime-db`](https://www.npmjs.com/package/mime-db) and\nif there is compressible information in the database entry, that is returned. Otherwise,\nthis module will fallback to `true` for the following types:\n\n  * `text/*`\n  * `*/*+json`\n  * `*/*+text`\n  * `*/*+xml`\n\nIf this module is not sure if a type is specifically compressible or specifically\nuncompressible, `undefined` is returned.\n\n<!-- eslint-disable no-undef -->\n\n```js\ncompressible('text/html') // => true\ncompressible('image/png') // => false\n```\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/compressible/master\n[coveralls-url]: https://coveralls.io/r/jshttp/compressible?branch=master\n[node-version-image]: https://badgen.net/npm/node/compressible\n[node-version-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/compressible\n[npm-url]: https://npmjs.org/package/compressible\n[npm-version-image]: https://badgen.net/npm/v/compressible\n[travis-image]: https://badgen.net/travis/jshttp/compressible/master\n[travis-url]: https://travis-ci.org/jshttp/compressible\n",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "fishrock123@rocketmail.com",
+      "name": "fishrock123"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    }
+  ],
+  "time": {
+    "modified": "2020-01-06T04:50:11.898Z",
+    "created": "2013-12-19T00:48:45.488Z",
+    "0.1.0": "2013-12-19T00:48:45.488Z",
+    "0.1.1": "2013-12-19T03:23:42.219Z",
+    "0.2.0": "2013-12-23T18:06:22.278Z",
+    "1.0.0": "2014-01-01T17:33:03.131Z",
+    "1.0.1": "2014-03-21T21:08:07.838Z",
+    "1.1.0": "2014-06-04T15:01:31.603Z",
+    "1.1.1": "2014-08-06T03:48:29.898Z",
+    "2.0.0": "2014-09-02T17:54:09.232Z",
+    "2.0.1": "2014-10-04T17:33:56.762Z",
+    "2.0.2": "2015-02-01T06:59:18.255Z",
+    "2.0.3": "2015-06-08T20:45:51.957Z",
+    "2.0.4": "2015-07-02T00:37:02.596Z",
+    "2.0.5": "2015-07-31T01:42:33.086Z",
+    "2.0.6": "2015-09-30T01:58:52.816Z",
+    "2.0.7": "2016-01-19T00:16:42.883Z",
+    "2.0.8": "2016-05-12T15:29:53.063Z",
+    "2.0.9": "2016-10-31T23:24:22.675Z",
+    "2.0.10": "2017-03-24T04:48:10.529Z",
+    "2.0.11": "2017-07-28T02:02:00.282Z",
+    "2.0.12": "2017-10-20T23:55:58.696Z",
+    "2.0.13": "2018-02-18T04:53:35.100Z",
+    "2.0.14": "2018-06-05T17:47:07.191Z",
+    "2.0.15": "2018-09-17T14:37:32.514Z",
+    "2.0.16": "2019-02-18T18:54:39.356Z",
+    "2.0.17": "2019-04-24T22:26:56.351Z",
+    "2.0.18": "2020-01-06T04:50:09.027Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/compressible.git"
+  },
+  "users": {
+    "fishrock123": true,
+    "crazyjingling": true,
+    "jetthiago": true,
+    "mikestaub": true,
+    "snowdream": true,
+    "enhezzz": true
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jshttp/compressible#readme",
+  "keywords": [
+    "compress",
+    "gzip",
+    "mime",
+    "content-type"
+  ],
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    },
+    {
+      "name": "Jeremiah Senkpiel",
+      "email": "fishrock123@rocketmail.com",
+      "url": "https://searchbeam.jit.su"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/jshttp/compressible/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/compressible.min.json
+++ b/test/fixtures/registry-mocks/content/compressible.min.json
@@ -1,0 +1,524 @@
+{
+  "name": "compressible",
+  "dist-tags": {
+    "latest": "2.0.18"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "compressible",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "87c187cb37ef9f028f7486ef9b0fc3ef02f3eb85",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "compressible",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "8e0003ef366d1d52a0300ab351f79df79e574b9f",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-0.1.1.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "compressible",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "1c03ada271f3f4a6cd6306490b0ce3efe47997b5",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-0.2.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "compressible",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "beautify-benchmark": "~0.2.4",
+        "mime": "*"
+      },
+      "dist": {
+        "shasum": "f83e49c1cb61421753545125a8011d68b492427d",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "compressible",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "beautify-benchmark": "~0.2.4",
+        "mime": "*"
+      },
+      "dist": {
+        "shasum": "8ed8224822c60c3c8dabcad34e913ed2952ad170",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "compressible",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "~1.20.1"
+      },
+      "dist": {
+        "shasum": "124d8a7bba18a05a410a2f25bad413b1b94aff67",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "compressible",
+      "version": "1.1.1",
+      "devDependencies": {
+        "mocha": "~1.20.1"
+      },
+      "dist": {
+        "shasum": "23b71ea90ea6c6a66289701a918182c24d0729ef",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-1.1.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "compressible",
+      "version": "2.0.0",
+      "dependencies": {
+        "mime-db": "~1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "~1.20.1"
+      },
+      "dist": {
+        "shasum": "90086ce57102e9e2427ee945a5fb2a98dd51dfb4",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "2.0.1": {
+      "name": "compressible",
+      "version": "2.0.1",
+      "dependencies": {
+        "mime-db": "1.x"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "~1.20.1"
+      },
+      "dist": {
+        "shasum": "3550115793eb3435f7eb16775afe05df1a333ebc",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "2.0.2": {
+      "name": "compressible",
+      "version": "2.0.2",
+      "dependencies": {
+        "mime-db": ">= 1.1.2 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "d0474a6ba6590a43d39c2ce9a6cfbb6479be76a5",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "2.0.3": {
+      "name": "compressible",
+      "version": "2.0.3",
+      "dependencies": {
+        "mime-db": ">= 1.13.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "046fe398c1c32ae5af1f4a601cf9ae4632bf2b78",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.4": {
+      "name": "compressible",
+      "version": "2.0.4",
+      "dependencies": {
+        "mime-db": ">= 1.14.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "4d8099e88afd0ffbf7c78fd16991d9ac060a94f6",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.5": {
+      "name": "compressible",
+      "version": "2.0.5",
+      "dependencies": {
+        "mime-db": ">= 1.16.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "c7dd0514a7a90c02a3ec9ee0ce14d8650bde9b6f",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.6": {
+      "name": "compressible",
+      "version": "2.0.6",
+      "dependencies": {
+        "mime-db": ">= 1.19.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "9e4aa9321ffcf9cc4d81954f7aafa9f35767d5ea",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.7": {
+      "name": "compressible",
+      "version": "2.0.7",
+      "dependencies": {
+        "mime-db": ">= 1.21.0 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "2058c52722fd3f1538a4f22ab14d0635904d19ae",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.8": {
+      "name": "compressible",
+      "version": "2.0.8",
+      "dependencies": {
+        "mime-db": ">= 1.23.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "2.9.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "7162e6c46d3b9d200ffb45cb4e4a0f7832732503",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.9": {
+      "name": "compressible",
+      "version": "2.0.9",
+      "dependencies": {
+        "mime-db": ">= 1.24.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.9.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.3.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "6daab4e2b599c2770dd9e21e7a891b1c5a755425",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.10": {
+      "name": "compressible",
+      "version": "2.0.10",
+      "dependencies": {
+        "mime-db": ">= 1.27.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.18.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "feda1c7f7617912732b29bf8cf26252a20b9eecd",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.11": {
+      "name": "compressible",
+      "version": "2.0.11",
+      "dependencies": {
+        "mime-db": ">= 1.29.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "~1.21.5",
+        "nyc": "11.0.3"
+      },
+      "dist": {
+        "shasum": "16718a75de283ed8e604041625a2064586797d8a",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.12": {
+      "name": "compressible",
+      "version": "2.0.12",
+      "dependencies": {
+        "mime-db": ">= 1.30.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "~1.21.5",
+        "nyc": "11.2.1"
+      },
+      "dist": {
+        "shasum": "c59a5c99db76767e9876500e271ef63b3493bd66",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.13": {
+      "name": "compressible",
+      "version": "2.0.13",
+      "dependencies": {
+        "mime-db": ">= 1.33.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "~1.21.5",
+        "nyc": "11.3.0"
+      },
+      "dist": {
+        "shasum": "0d1020ab924b2fdb4d6279875c7d6daba6baa7a9",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.13.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6804
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.14": {
+      "name": "compressible",
+      "version": "2.0.14",
+      "dependencies": {
+        "mime-db": ">= 1.34.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.12.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.8.0",
+        "eslint-plugin-standard": "3.1.0",
+        "mocha": "~1.21.5",
+        "nyc": "11.9.0"
+      },
+      "dist": {
+        "shasum": "326c5f507fbb055f54116782b969a81b67a29da7",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6930,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbFsybCRA9TVsSAnZWagAAQWIP/ixIs4z3dX20ZVCcl7C1\niXgJsGVTZ6X4JHJpwAhdPav6Aqdo2rPM45Rbbah8MnGteMc7UUIJMySa8B8r\nyBnBOqjVE76TNY7AM6CXrY2Gci6S9vLe0exKeEbbSfy927hdmXxHwczAcPB9\nzJ9WfJgSLZorlfqSWv66Fafc4VKcfwnKpNAso70IG1wNDcj5RYgcHgPQU2uA\nEaPBwbv4b3/Tnq8m0NUKdYNDo9+7dqklgAFB0H5rCMegUDQmHfqiGy5CtN7B\nFBex3vpDq6OkJyd9Sr64c7PlI1kR8UdKtoIUqXAG1U5ewbYNtisYb662C3xA\nYmBK0/9UfHGlsFIJMDdHLAIRArwaQtevKABZ4QdQJeWhfeC//giQejoYeUjV\nnC6nGyP6TCXS+WlM201gKncvbA0WKQ41V9dNGWFMpH4N5bEXgn+au9ulRiCN\nTyWDRUTzJtx/AGk8es0Nz5N9HnQmSDq8g/pT7RyU3XZr7qNIPHzOSYXy8Ce4\naUnbYZVW1qYBfWv1IMrkYPbOQpW8KtMipc6DxxTbtn3l5iEVSAvku5+aHNnF\nyxedqQKFGAVFpEx89R/L0pdBPSASmaeTmgz+iJz6BSGfOKUKZjdoba09oIAn\nobUZD82I5bruxoHQvrcKAoR4OHDjY1USZFG7X/0c/uXRxSWdIAZw5ixO0SBa\nB8qj\r\n=rPuR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.15": {
+      "name": "compressible",
+      "version": "2.0.15",
+      "dependencies": {
+        "mime-db": ">= 1.36.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "5.5.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "5.2.0",
+        "nyc": "13.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-4aE67DL33dSW9gw4CI2H/yTxqHLNcxp0yS6jB+4h+wr3e43+1z7vm0HU9qXOH8j+qjKuL8+UtkOxYQSMq60Ylw==",
+        "shasum": "857a9ab0a7e5a07d8d837ed43fe2defff64fe212",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.15.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7003,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbn7wsCRA9TVsSAnZWagAA3BkP/12uh13r/9IQ/9Fbp73u\nWZepalH9mXEabZWsGu54MNyauzR4H3HqosgUbfATwG3zpDvxPXZ0F7EBaYMS\n6jJQboQxf/rnSywh3Ut3QRkjfT5VmkPYifA1IxLxocSnN00IK8b/VLzwTmHl\nQsZ9EgZsWRp2vul0wb/Nxixl535V2RTGbS7LwyMZN+KvAYoEJmagTIDX46Wh\nrKmfFSvjJ7HaJU4X6euMQ9AQERo0NUFOTUXGJg4/npE5m/wwAqihTu0vot3Q\n98aEdb0xXPMnehGR/UMJ32DyaiHZ7GLBs+nJU4OYj2T6tpwDBTUwvz841l9T\nllrOnXxoH7QfQiqyUTRjejPbZtDQLruYOnPBUBlQSxOVEhz0itBxJuZ8hKle\nukjRlD6gKFTKA+AjIAG3nCGR25pQuJP/ZAOVI3shhvNmWhbWKPY0qALvexNd\n0zBRwYC7RjKrm4/wAKCeBS3VsydtxK/Yh31z5zHJTGrqDX515+MRCcpYWlHE\nA1R62HqrGfYCDczmBgsLJh3KXV1k4ebWFy/aeivovuCnT72c1DROPBrGSQC5\n663Ax7OjmPH9bufpV/ONuUhrxrgjb5HuLbQg+fM22WUOchQnqPS9i+pTFgDC\nru9FY+k/+CG6X9l9xjwlFBSaLuIXvZ6Ee4TtkzfC501rKOA8tYOc1JsVirwF\nAfPF\r\n=6Sz4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.16": {
+      "name": "compressible",
+      "version": "2.0.16",
+      "dependencies": {
+        "mime-db": ">= 1.38.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "5.14.1",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "5.2.0",
+        "nyc": "13.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-JQfEOdnI7dASwCuSPWIeVYwc/zMsu/+tRhoUvEfXz2gxOA2DNjmG5vhtFdBlhWPPGo+RdT9S3tgc/uH5qgDiiA==",
+        "shasum": "a49bf9858f3821b64ce1be0296afc7380466a77f",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.16.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7116,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcav9vCRA9TVsSAnZWagAAqWIP/2PS0cVG2KMSYi8NnART\nSDCsVF+LNer2Z4/2ILPI/sTmAmiUFvTeo0G2PkAp6TTunWYlAdy23sI4qys6\nWSNPNBobOv2Kj6iDFk3Yv+OxIplzVaxDUw5tyikFw02SJPvXxueo32w7VX9s\nx9o3Q9zhiAfNdp2Az+rFFdHnEu8w5kK0ruvMf7kKyZt6gwrqBVd4JSiKwwKo\nMAEOVR0uEJXA9rlI7EyPwogtqyZTX8Yy4uH7PAOrfbzk+ZaVxilnOvmEtQmL\nkfQkW/ZD/ZIdgeu2s60oJVKPdQEeJ7s6noe9L/8mXewpRihCAwZ1NE0kYVxO\nyAMfMwt7nopz8fuJ0haD0dS5+uybkXpwfeetPY991uHKMIk1WxyPpy74edMF\nnXHzuJO4o8nWnBmW471BB6A4IEIvZJSNio49aLx3douHrd9dZuvhKj+uj3Al\nyrqGG/P4So0CbBODLVhTwHLECy4q/emuRbvExnrjg9cZ82e0Qe3D1fUIfnCn\nm0p3x5qfGO9wzUths/Xnn8ZFK3PZFLDSEIBHt3hJE32z8Bq5t4HCm+zDvkS+\nXO5obVlrR9Ixr6RWA+SuPNyfe/FtT7t6/2z2JJ1aIztfAOhxDNg4aHy7DBso\n3SqOZyjgEzpdUbBrszpNRVm0n9vlQ7rVvPGa0fJ4+4PdNj7Q0VKD95+jyh7U\n2urj\r\n=t9LW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.17": {
+      "name": "compressible",
+      "version": "2.0.17",
+      "dependencies": {
+        "mime-db": ">= 1.40.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "5.15.2",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+        "shasum": "6e8c108a16ad58384a977f3a482ca20bff2f38c1",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7192,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwOKwCRA9TVsSAnZWagAAL78P/2lEciMjw1wyutzAX3dx\nxblDJFTALdONTTC8GslxhL5AGEy5MwqiJnU7isb5e0L9st6ixwtnR+LYCVcX\nURWwM8AQqQl+uR9yXfQw/ctyije2uAs4205TpY0aSKW9mZ0tRVL3IiPz0el9\nGKhBfYrw8TPVaX5L06L1IBR4OzU0KI0+1AAucC+miX27BXlORKX1jvAuky4h\n1w5y4sB2DQvQ00Bzn/aKZj+VlmFZaCEAxbcpdzO/4wJmZUnAh6XSBNaGGoi7\npRRh7IFMhWancon/XC9LcbcfZhuApqPCXBE9wn4vqFQTkNcPwdUSd+5PTRYm\n9+sQQXRiuDtGszrdYz01YI9W+jlQT7Ibi+Qe2HeS9bXSxdre9Y9JZ4urDKGV\n994vVI0EtZEBMQhoH0AN4YyuAOxSC/2VkCFXijZDGeJ4LR/WJQS+2AwTkp6L\nI+a7+ySb0i8CAiq9YcUB51XjIcaj//MkuZWOwmYG1qjnIAKyCUOR+HdopIlI\nX1WkAVFsTfxXIM9Ep35173umIUmY3ijdHBJrVQxndNRKf4hTBB2FCHj1EFqv\n3BtQjL0ghP2pSSror3gbf1rL/UshhMqqzRUGAF9nqv+BRUKpAM9QfCW1rXZD\n2QHul4xqvGtLojV2Kq6yNAfd89KCunxe2r9ISWyrIPtot8JwzP5hzDzWT8lI\n2QsC\r\n=XUus\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.18": {
+      "name": "compressible",
+      "version": "2.0.18",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "6.8.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-plugin-import": "2.19.1",
+        "eslint-plugin-markdown": "1.0.1",
+        "eslint-plugin-node": "11.0.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.1",
+        "mocha": "7.0.0",
+        "nyc": "15.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+        "shasum": "af53cca6b070d4c3c0750fbd77286a6d7cc46fba",
+        "tarball": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7355,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeEryBCRA9TVsSAnZWagAAJ+oQAKCAszvCKZ9xyxyd5R9j\nMwZYPmN071vz6z3MXQxmFaFvYsE/U1HW9JU8dvgfuOdT/0mXVuRN+l94HcxJ\nbInW6GgsvwTZ+owcWQhG88jbEegcwaTh3wi4Us+aJTOb781ITaedr7spEll7\nakccNmpOS9Mk+oy52A0EC7N8/+xy9WEBTdWii3MsbyDWmsD+0qWl/SeKYboQ\n4/0JX9YHg3wDoiIlRJHXp4VXBRyp6Wscl38xWkZn5DRHhPLSzkDdYtvZkwcv\n9VD9UNma+OxDAEZdmFavvL964QrhPPrjiI77fIOP/S7LFdepDWlIgpSduhdZ\nN2KhBJtRWNZywCKzFGBSRJuAa/ZTUqIv9cSBWTidqNOHucVJf+00dQBqYFuY\nkbqVPks/LC54An6loFaqkj4U+C0a/PFHVgdH4C2eBldz3W6bwFEQ0kLmICCi\ns53uKWv5+4ULBXiOIpGa0LtH6fM6GfHKS02BScI7cMpengBNM4bTvAkz8s6g\ntu8wG0b+mxuu7rCGzdUaLHLvBjuuQsQRa96NH+L3omSMSmDeZhGWVuK9ObiA\nXcGJnVWsGQ1vuuRht8Npx/aq4YOZ05jh5MvYCh9hgDbLQOnvUCxpB7i9UjSY\nPl1liyYKzmxyQ91ZGXkIQC6qCGWPgmz1XhvAUkLgPmFLOCbwBIEfrcwcBSqj\n/v94\r\n=4fyH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2020-01-06T04:50:11.898Z"
+}

--- a/test/fixtures/registry-mocks/content/compression.json
+++ b/test/fixtures/registry-mocks/content/compression.json
@@ -1,0 +1,3508 @@
+{
+  "_id": "compression",
+  "_rev": "296-9e18156f0db6c14bf9bd83ae73dbe0e8",
+  "name": "compression",
+  "description": "Node.js compression middleware",
+  "dist-tags": {
+    "latest": "1.7.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "dependencies": {
+        "bytes": "0.2.1",
+        "negotiator": "0.3.0",
+        "compressible": "1.0.0"
+      },
+      "devDependencies": {
+        "supertest": "*",
+        "connect": "*",
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.0",
+      "dist": {
+        "shasum": "8aeb85d48db5145d38bc8b181b6352d8eab26020",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.22",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "dependencies": {
+        "bytes": "0.2.1",
+        "negotiator": "0.4.2",
+        "compressible": "1.0.0"
+      },
+      "devDependencies": {
+        "supertest": "*",
+        "connect": "*",
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.1",
+      "dist": {
+        "shasum": "e42b3e31040778ff66b4f4cb6a43bdbc6cd7d88b",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "dependencies": {
+        "bytes": "0.3.0",
+        "negotiator": "0.4.3",
+        "compressible": "1.0.1"
+      },
+      "devDependencies": {
+        "supertest": "*",
+        "connect": "*",
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.2",
+      "dist": {
+        "shasum": "90ea20033ee689473678b2ee32226183d7030893",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "dependencies": {
+        "accepts": "1.0.2",
+        "bytes": "1.0.0",
+        "compressible": "1.0.1",
+        "on-headers": "0.0.0"
+      },
+      "devDependencies": {
+        "connect": "2",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "supertest": "~0.13.0",
+        "should": "~4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.3",
+      "dist": {
+        "shasum": "4370058053d29402f2ff6312296d9e74463e9901",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "dependencies": {
+        "accepts": "1.0.2",
+        "bytes": "1.0.0",
+        "compressible": "1.0.1",
+        "on-headers": "0.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "supertest": "~0.13.0",
+        "should": "~4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.4",
+      "dist": {
+        "shasum": "b9fbfbc11ce6436eb71b9c944006f31b134cfef8",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.5",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "dependencies": {
+        "accepts": "1.0.2",
+        "bytes": "1.0.0",
+        "compressible": "1.0.1",
+        "on-headers": "0.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "supertest": "~0.13.0",
+        "should": "~4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.5",
+      "_shasum": "fbf10806b74d96300a18917795e3d6c040532bbc",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fbf10806b74d96300a18917795e3d6c040532bbc",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.6",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "dependencies": {
+        "accepts": "1.0.2",
+        "bytes": "1.0.0",
+        "compressible": "1.0.1",
+        "on-headers": "0.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "supertest": "~0.13.0",
+        "should": "~4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.6",
+      "_shasum": "efbc5c5870980e9d7e5a9d6e6d7437cccf6a9a8a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "efbc5c5870980e9d7e5a9d6e6d7437cccf6a9a8a",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.7": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.7",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "1.0.3",
+        "bytes": "1.0.0",
+        "compressible": "1.1.0",
+        "on-headers": "0.0.0",
+        "vary": "0.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "ebbad0bde5277f883d5b26b9a1bfd37f68aa5a07",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.7",
+      "_shasum": "fc4bff261df4e37a130006f2db2a99a34896f55a",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fc4bff261df4e37a130006f2db2a99a34896f55a",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.8": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.8",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.0.5",
+        "bytes": "1.0.0",
+        "compressible": "1.1.0",
+        "on-headers": "0.0.0",
+        "vary": "0.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.8",
+      "dist": {
+        "shasum": "803ecc67183e71e42b1efcc6a29f6144fdd9afad",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.9": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.9",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "bytes": "1.0.0",
+        "compressible": "1.1.0",
+        "debug": "1.0.4",
+        "on-headers": "0.0.0",
+        "vary": "0.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.9",
+      "dist": {
+        "shasum": "edbe08829cc2b49d601773c814a3851c135d0931",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.10": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.10",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "bytes": "1.0.0",
+        "compressible": "~1.1.1",
+        "debug": "1.0.4",
+        "on-headers": "0.0.0",
+        "vary": "0.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.3",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "7610208dc92268c4fc7ba4ae9714b25f8c9f28d0",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.10",
+      "_shasum": "4e5ba4b317dbca8bab486e5ba60b09fcb6e22e44",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4e5ba4b317dbca8bab486e5ba60b09fcb6e22e44",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.10.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.11": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.0.11",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "bytes": "1.0.0",
+        "compressible": "~1.1.1",
+        "debug": "1.0.4",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.3",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "65d707c924a3d84d6228a7d8b8a8315354ee876b",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.0.11",
+      "_shasum": "69700cf1ee8963454356ac192a6e5e91e232bffb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "69700cf1ee8963454356ac192a6e5e91e232bffb",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.11.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.0",
+        "debug": "~2.0.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.3",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "3b2473dfc4d81116de2dfe84061b6a5962a96062",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.1.0",
+      "_shasum": "58243eded272fc531d7c744d8e8daa7cc0b99215",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "58243eded272fc531d7c744d8e8daa7cc0b99215",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.0.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.3",
+        "supertest": "~0.14.0",
+        "should": "~4.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "80b9c5b78f29b187fc91bdc9644c828567727b7f",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.1.1",
+      "_shasum": "5dd7d78ab9c9bafb0d33eb92831b18bf6f9ad75f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5dd7d78ab9c9bafb0d33eb92831b18bf6f9ad75f",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.1.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.0.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "supertest": "~0.14.0",
+        "should": "~4.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "b4e98249dfbc3058e3dff8021349dd0c59cb72d9",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.1.2",
+      "_shasum": "f93fb7fcdb3573ec4c7d5398984caae230e2a8d7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f93fb7fcdb3573ec4c7d5398984caae230e2a8d7",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.1.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "supertest": "~0.14.0",
+        "should": "~4.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "f0b18f7563b1f0c1f62970086d3b266d4f8f4c42",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.2.0",
+      "_shasum": "c6951ca9ad90588ada7617da693c6bbbe8736866",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c6951ca9ad90588ada7617da693c6bbbe8736866",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.2.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.1.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "c45fae318f6853667bc588386cc78692eaf1f7ac",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.2.1",
+      "_shasum": "12ebaac04d308ca6103618a9716ce5634b939e9c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "12ebaac04d308ca6103618a9716ce5634b939e9c",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.2.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.1.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.4",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "8c6f50c13c297c136e7ff66839df533e8eb9c12c",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.2.2",
+      "_shasum": "637604c25ed659c0d5c9fac1038fc2f2d5494dbf",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "637604c25ed659c0d5c9fac1038fc2f2d5494dbf",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "compression",
+      "description": "Compression middleware for connect and node.js",
+      "version": "1.3.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.2",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.1.1",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "0f530f1acccac39806ed05207309a930c9394b79",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.3.0",
+      "_shasum": "03289a1d45e1dbbf8bd509dba50d036657b7bac8",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "03289a1d45e1dbbf8bd509dba50d036657b7bac8",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.3.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.3",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.1",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "2637bb8251d7a3d85bebfbae047348a8d1673399",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.3.1",
+      "_shasum": "30986b2f519ba90e57759896301de4955ce00945",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "30986b2f519ba90e57759896301de4955ce00945",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.4.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.3",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.1",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "622ef84321b69dbc5318075c5a32a25a04af753d",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.4.0",
+      "_shasum": "e78287443ef7b4fa0c6a437bc8e5ad31919040bb",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e78287443ef7b4fa0c6a437bc8e5ad31919040bb",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.4.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.1",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "680793a316c852e50dbd00af9611b64fb26d30f2",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.4.1",
+      "_shasum": "c6f707ac2659e13c7f3e8834321b02cd09338d78",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c6f707ac2659e13c7f3e8834321b02cd09338d78",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.2": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.4.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.2",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "93b2c6290af8a2b617c2d4f433bb1f7d185b2d01",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.4.2",
+      "_shasum": "59213b7f4b55f12d6852030946facd1d01e578d7",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "59213b7f4b55f12d6852030946facd1d01e578d7",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.3": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.4.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.5",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.3",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "7cabc570cc8dde90d337c575ce6d7814b680a68a",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.4.3",
+      "_shasum": "7161bc0441df629273e5c31dd631b8e41e886b4d",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7161bc0441df629273e5c31dd631b8e41e886b4d",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.4": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.4.4",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.7",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "2086d1139c839ccfcf404282306bd78ca6f7a58a",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.4.4",
+      "_shasum": "2f9994ca476e4d9ba5fdc67ac929942837d0b6a4",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2f9994ca476e4d9ba5fdc67ac929942837d0b6a4",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.5.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.9",
+        "bytes": "2.1.0",
+        "compressible": "~2.0.3",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.15",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "6b5d417fc626b76ecf87221044e9da27e87becf2",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.5.0",
+      "_shasum": "ccc1a54788da1b3ad7729c49f6a00b3ac9adf47f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ccc1a54788da1b3ad7729c49f6a00b3ac9adf47f",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.5.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.10",
+        "bytes": "2.1.0",
+        "compressible": "~2.0.4",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "cd350fb3bdff6d4d3edbb589babeb680433ba61b",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.5.1",
+      "_shasum": "ed8d42fc86cbe09b1d775b0c0c1b48dbec8239ba",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ed8d42fc86cbe09b1d775b0c0c1b48dbec8239ba",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.5.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "bytes": "2.1.0",
+        "compressible": "~2.0.5",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "c2af8bd8d5cec3577b40d61859ca3a0467052ded",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.5.2",
+      "_shasum": "b03b8d86e6f8ad29683cba8df91ddc6ffc77b395",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b03b8d86e6f8ad29683cba8df91ddc6ffc77b395",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.6.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.3.0",
+        "bytes": "2.1.0",
+        "compressible": "~2.0.6",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.1",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "2.3.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "2b4549abaea461161ed6e8531da9ef8f1e80acab",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.6.0",
+      "_shasum": "886465ffa4a19f9b73b41682db77d28179b30920",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "886465ffa4a19f9b73b41682db77d28179b30920",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.6.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/compression"
+      },
+      "dependencies": {
+        "accepts": "~1.3.1",
+        "bytes": "2.2.0",
+        "compressible": "~2.0.7",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.1",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "3333505901afc9508e026320feffa92d41e7c552",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression",
+      "_id": "compression@1.6.1",
+      "_shasum": "1bf4f96fd72019a3fd11513b4fc4dcd3bd16db55",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1bf4f96fd72019a3fd11513b4fc4dcd3bd16db55",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.6.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/compression.git"
+      },
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "bytes": "2.3.0",
+        "compressible": "~2.0.8",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.1",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "eslint": "2.9.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "b9c63ced82b9f719cd5d9fd250c8432b00752d89",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression#readme",
+      "_id": "compression@1.6.2",
+      "_shasum": "cceb121ecc9d09c52d7ad0c3350ea93ddd402bc3",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "cceb121ecc9d09c52d7ad0c3350ea93ddd402bc3",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/compression-1.6.2.tgz_1463095977791_0.03453603922389448"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.7.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/compression.git"
+      },
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "bytes": "2.5.0",
+        "compressible": "~2.0.10",
+        "debug": "2.6.8",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "8c3f7eabba0be7dfb7fec86297cb28458efc3c58",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression#readme",
+      "_id": "compression@1.7.0",
+      "_shasum": "030c9f198f1643a057d776a738e922da4373012d",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "030c9f198f1643a057d776a738e922da4373012d",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compression-1.7.0.tgz_1499753654730_0.6516832136549056"
+      },
+      "directories": {}
+    },
+    "1.7.1": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.7.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/compression.git"
+      },
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.11",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "93586e75a0a1c5bbfd353c4cec1cfcee2e52adde",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression#readme",
+      "_id": "compression@1.7.1",
+      "_shasum": "eff2603efc2e22cf86f35d2eb93589f9875373db",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "eff2603efc2e22cf86f35d2eb93589f9875373db",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compression-1.7.1.tgz_1506489019778_0.34800254576839507"
+      },
+      "directories": {}
+    },
+    "1.7.2": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.7.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/compression.git"
+      },
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.13",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "eslint": "4.18.0",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "20efa155bed9ecfb1d94fae3c2a8d338c61a3084",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression#readme",
+      "_id": "compression@1.7.2",
+      "_shasum": "aaffbcd6aaf854b44ebb280353d5ad1651f59a69",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "aaffbcd6aaf854b44ebb280353d5ad1651f59a69",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22623
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compression_1.7.2_1519015854354_0.28362862485921836"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.3": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.7.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/compression.git"
+      },
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.14",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.13.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.8.0",
+        "eslint-plugin-standard": "3.1.0",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "becc1c0afb04e0fca5fd12a764b9c9ac8f17a378",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression#readme",
+      "_id": "compression@1.7.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+        "shasum": "27e0e176aaf260f7f2c2813c3e440adb9f1993db",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22876,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbS76XCRA9TVsSAnZWagAADrMP/Rhf/BBJXT0AaaJ/qePc\nRwq3Rj7dE9Fjlc1c0Ib4S1Kl5ug0b9l18L0TtRuFXYzKpul2uxzHTQtv9wyY\nyveW4+zk/bM+BN0ZpHbND2pWQLwSCwQ0jnm6PMO8jsDCQRiafDOQqh8wwr0k\n2K9prCysA+369kWCOiCuF9Ra1F+rZjlGuXbjOmorsZIDu1ZT+opv8VNTvm3D\nsWU7/xWFoKdJVH27m+PKsAZAcYNJEirYY84JUFDONFZq84ItOONQaKX6Rm8/\n5nAalJh3wuor0Mv3u55U8iHrtf7izi0j78c6MuequWEPAwtR1R2/jeherA4L\nMGkfzHK/JaR5SNtQ+ryjHSuSDVKO+obJKs/x74cdh8aFI++Gl1MkQSgDWt6l\n9DYF51HvOo8QKDWQf1A7lyYfrdp/lHK1BKZ1YdyvnsbQ9bszAfkgKwWkbZ9K\nUziNChH65rP4tkPUAJ5qgQlFY2yFcXuzxZwwkufff47wkYAza0eWQ+gGRoWl\nl6dQ96CC4n4v/7xut2mJW2evGk/RYfnfJLw73x/fqwXF1JnKbtP6u6OSn6CS\nPZJJAFF8gY3boaZPm8m+iVUKEl0Cxy+ZgXFb7S9Qn/CX544V1ZA6BlIyTAq0\nlieaRKSBCDjXigw2F69/nRyZeOkE0Ms7Lb0Abz7Qaut0y6+32J4xkUi5GNku\nyu8/\r\n=lzg0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compression_1.7.3_1531690647387_0.876294486083377"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.4": {
+      "name": "compression",
+      "description": "Node.js compression middleware",
+      "version": "1.7.4",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/compression.git"
+      },
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "5.15.1",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.0.2",
+        "supertest": "4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "dd5055dc92fdeacad706972c4fcf3a7ff10066ef",
+      "bugs": {
+        "url": "https://github.com/expressjs/compression/issues"
+      },
+      "homepage": "https://github.com/expressjs/compression#readme",
+      "_id": "compression@1.7.4",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+        "shasum": "95523eff170ca57c29a0ca41e6fe131f41e5bb8f",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23306,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcj66MCRA9TVsSAnZWagAA5VcP/R4JRuhO78tvsnnBepBz\nzSdSm0onNd0iQp8ajRSpcrd3D1r0eYcQDe8qYraO9tTdzISngweiOZnrp3v/\nitiqTfINI0cFgffUe0LD6ZHP4hnerj04z6NQ3k1Ayr0yEywjLErjznuy+f4U\nznor4SRG8fb5fjel4VJXSVSpq5A7pisGJbb7tw5Bh8n/GQUm3i9bGBL7QRb3\nf++/H1YxTjQoMxMupbvZ6bDvBVVFKl6OLebi4lfVRSoLxKd0+F2KeZ0D1VzH\niZIPgjo5ojAzgmBlDD62dHcg7vwNSFT1UV8U0A6yDSx90hqDUqBK8f2oOL+C\n7mObbeSLqsgspXmM/evEIpkIcF0VeSDf44ClH2u5lAkNb07kf5CevOnRWs/o\nTneqN8c6hMEIriNY7xun9tX6837VRXn9/F98NdcSTiT3lidEMC4y5tXWikSE\n6FAXlJmutIiRNi8LOR50UqPGiWeFNCSVIgPGKBk1jHN78WbkXgvfSFvrRoB8\nj2eY/cK+9RmeXJrzG1oUdEDGHqTpHC0TkKmL0aZyOUEftby8bgEMP9wWa1z+\nGJTueAVQzeu3BCQEkMDiQoxVRoM1E9n8oZDm6CE1sTTmPtCk3rMQMmovpJWs\nrL10koK/Asp7oB3JctY5De2icreXAi08Mytf9pHh+Wibo0XIpxh23Y/BD6TR\nwaMv\r\n=n7iJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/compression_1.7.4_1552920204067_0.8065650793323169"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# compression\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nNode.js compression middleware.\n\nThe following compression codings are supported:\n\n  - deflate\n  - gzip\n\n## Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```bash\n$ npm install compression\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar compression = require('compression')\n```\n\n### compression([options])\n\nReturns the compression middleware using the given `options`. The middleware\nwill attempt to compress response bodies for all request that traverse through\nthe middleware, based on the given `options`.\n\nThis middleware will never compress responses that include a `Cache-Control`\nheader with the [`no-transform` directive](https://tools.ietf.org/html/rfc7234#section-5.2.2.4),\nas compressing will transform the body.\n\n#### Options\n\n`compression()` accepts these properties in the options object. In addition to\nthose listed below, [zlib](http://nodejs.org/api/zlib.html) options may be\npassed in to the options object.\n\n##### chunkSize\n\nThe default value is `zlib.Z_DEFAULT_CHUNK`, or `16384`.\n\nSee [Node.js documentation](http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning)\nregarding the usage.\n\n##### filter\n\nA function to decide if the response should be considered for compression.\nThis function is called as `filter(req, res)` and is expected to return\n`true` to consider the response for compression, or `false` to not compress\nthe response.\n\nThe default filter function uses the [compressible](https://www.npmjs.com/package/compressible)\nmodule to determine if `res.getHeader('Content-Type')` is compressible.\n\n##### level\n\nThe level of zlib compression to apply to responses. A higher level will result\nin better compression, but will take longer to complete. A lower level will\nresult in less compression, but will be much faster.\n\nThis is an integer in the range of `0` (no compression) to `9` (maximum\ncompression). The special value `-1` can be used to mean the \"default\ncompression level\", which is a default compromise between speed and\ncompression (currently equivalent to level 6).\n\n  - `-1` Default compression level (also `zlib.Z_DEFAULT_COMPRESSION`).\n  - `0` No compression (also `zlib.Z_NO_COMPRESSION`).\n  - `1` Fastest compression (also `zlib.Z_BEST_SPEED`).\n  - `2`\n  - `3`\n  - `4`\n  - `5`\n  - `6` (currently what `zlib.Z_DEFAULT_COMPRESSION` points to).\n  - `7`\n  - `8`\n  - `9` Best compression (also `zlib.Z_BEST_COMPRESSION`).\n\nThe default value is `zlib.Z_DEFAULT_COMPRESSION`, or `-1`.\n\n**Note** in the list above, `zlib` is from `zlib = require('zlib')`.\n\n##### memLevel\n\nThis specifies how much memory should be allocated for the internal compression\nstate and is an integer in the range of `1` (minimum level) and `9` (maximum\nlevel).\n\nThe default value is `zlib.Z_DEFAULT_MEMLEVEL`, or `8`.\n\nSee [Node.js documentation](http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning)\nregarding the usage.\n\n##### strategy\n\nThis is used to tune the compression algorithm. This value only affects the\ncompression ratio, not the correctness of the compressed output, even if it\nis not set appropriately.\n\n  - `zlib.Z_DEFAULT_STRATEGY` Use for normal data.\n  - `zlib.Z_FILTERED` Use for data produced by a filter (or predictor).\n    Filtered data consists mostly of small values with a somewhat random\n    distribution. In this case, the compression algorithm is tuned to\n    compress them better. The effect is to force more Huffman coding and less\n    string matching; it is somewhat intermediate between `zlib.Z_DEFAULT_STRATEGY`\n    and `zlib.Z_HUFFMAN_ONLY`.\n  - `zlib.Z_FIXED` Use to prevent the use of dynamic Huffman codes, allowing\n    for a simpler decoder for special applications.\n  - `zlib.Z_HUFFMAN_ONLY` Use to force Huffman encoding only (no string match).\n  - `zlib.Z_RLE` Use to limit match distances to one (run-length encoding).\n    This is designed to be almost as fast as `zlib.Z_HUFFMAN_ONLY`, but give\n    better compression for PNG image data.\n\n**Note** in the list above, `zlib` is from `zlib = require('zlib')`.\n\n##### threshold\n\nThe byte threshold for the response body size before compression is considered\nfor the response, defaults to `1kb`. This is a number of bytes or any string\naccepted by the [bytes](https://www.npmjs.com/package/bytes) module.\n\n**Note** this is only an advisory setting; if the response size cannot be determined\nat the time the response headers are written, then it is assumed the response is\n_over_ the threshold. To guarantee the response size can be determined, be sure\nset a `Content-Length` response header.\n\n##### windowBits\n\nThe default value is `zlib.Z_DEFAULT_WINDOWBITS`, or `15`.\n\nSee [Node.js documentation](http://nodejs.org/api/zlib.html#zlib_memory_usage_tuning)\nregarding the usage.\n\n#### .filter\n\nThe default `filter` function. This is used to construct a custom filter\nfunction that is an extension of the default function.\n\n```js\nvar compression = require('compression')\nvar express = require('express')\n\nvar app = express()\napp.use(compression({ filter: shouldCompress }))\n\nfunction shouldCompress (req, res) {\n  if (req.headers['x-no-compression']) {\n    // don't compress responses with this request header\n    return false\n  }\n\n  // fallback to standard filter function\n  return compression.filter(req, res)\n}\n```\n\n### res.flush\n\nThis module adds a `res.flush()` method to force the partially-compressed\nresponse to be flushed to the client.\n\n## Examples\n\n### express/connect\n\nWhen using this module with express or connect, simply `app.use` the module as\nhigh as you like. Requests that pass through the middleware will be compressed.\n\n```js\nvar compression = require('compression')\nvar express = require('express')\n\nvar app = express()\n\n// compress all responses\napp.use(compression())\n\n// add all routes\n```\n\n### Server-Sent Events\n\nBecause of the nature of compression this module does not work out of the box\nwith server-sent events. To compress content, a window of the output needs to\nbe buffered up in order to get good compression. Typically when using server-sent\nevents, there are certain block of data that need to reach the client.\n\nYou can achieve this by calling `res.flush()` when you need the data written to\nactually make it to the client.\n\n```js\nvar compression = require('compression')\nvar express = require('express')\n\nvar app = express()\n\n// compress responses\napp.use(compression())\n\n// server-sent event stream\napp.get('/events', function (req, res) {\n  res.setHeader('Content-Type', 'text/event-stream')\n  res.setHeader('Cache-Control', 'no-cache')\n\n  // send a ping approx every 2 seconds\n  var timer = setInterval(function () {\n    res.write('data: ping\\n\\n')\n\n    // !!! this is the important part\n    res.flush()\n  }, 2000)\n\n  res.on('close', function () {\n    clearInterval(timer)\n  })\n})\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/compression.svg\n[npm-url]: https://npmjs.org/package/compression\n[travis-image]: https://img.shields.io/travis/expressjs/compression/master.svg\n[travis-url]: https://travis-ci.org/expressjs/compression\n[coveralls-image]: https://img.shields.io/coveralls/expressjs/compression/master.svg\n[coveralls-url]: https://coveralls.io/r/expressjs/compression?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/compression.svg\n[downloads-url]: https://npmjs.org/package/compression\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-09-21T18:45:07.031Z",
+    "created": "2014-01-01T23:38:49.435Z",
+    "1.0.0": "2014-01-01T23:38:49.435Z",
+    "1.0.1": "2014-03-08T21:06:27.250Z",
+    "1.0.2": "2014-04-29T05:04:53.976Z",
+    "1.0.3": "2014-05-30T00:17:20.830Z",
+    "1.0.4": "2014-06-03T20:11:20.873Z",
+    "1.0.5": "2014-06-04T01:09:30.227Z",
+    "1.0.6": "2014-06-04T01:24:28.264Z",
+    "1.0.7": "2014-06-12T02:38:37.237Z",
+    "1.0.8": "2014-06-20T18:12:29.411Z",
+    "1.0.9": "2014-07-21T03:41:37.065Z",
+    "1.0.10": "2014-08-06T03:59:27.545Z",
+    "1.0.11": "2014-08-11T01:17:29.659Z",
+    "1.1.0": "2014-09-08T03:21:47.844Z",
+    "1.1.1": "2014-10-13T04:54:09.301Z",
+    "1.1.2": "2014-10-16T03:06:43.813Z",
+    "1.2.0": "2014-10-17T01:58:41.203Z",
+    "1.2.1": "2014-11-23T19:18:10.022Z",
+    "1.2.2": "2014-12-10T21:00:50.807Z",
+    "1.3.0": "2014-12-31T05:08:31.761Z",
+    "1.3.1": "2015-02-01T07:25:53.741Z",
+    "1.4.0": "2015-02-01T22:25:07.534Z",
+    "1.4.1": "2015-02-15T20:22:36.902Z",
+    "1.4.2": "2015-03-12T04:08:38.559Z",
+    "1.4.3": "2015-03-15T03:35:49.718Z",
+    "1.4.4": "2015-05-12T05:20:15.984Z",
+    "1.5.0": "2015-06-10T03:35:56.802Z",
+    "1.5.1": "2015-07-06T02:43:34.298Z",
+    "1.5.2": "2015-07-31T03:29:49.884Z",
+    "1.6.0": "2015-09-30T05:09:57.880Z",
+    "1.6.1": "2016-01-20T04:55:08.544Z",
+    "1.6.2": "2016-05-12T23:33:00.326Z",
+    "1.7.0": "2017-07-11T06:14:15.834Z",
+    "1.7.1": "2017-09-27T05:10:20.820Z",
+    "1.7.2": "2018-02-19T04:50:54.459Z",
+    "1.7.3": "2018-07-15T21:37:27.495Z",
+    "1.7.4": "2019-03-18T14:43:24.201Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/expressjs/compression#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/expressjs/compression.git"
+  },
+  "bugs": {
+    "url": "https://github.com/expressjs/compression/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "tcskrovseth": true,
+    "mswanson1524": true,
+    "dofy": true,
+    "subfuzion": true,
+    "magemagic": true,
+    "tunderdomb": true,
+    "esessoms": true,
+    "lucasmciruzzi": true,
+    "dlpowless": true,
+    "moe.duffdude": true,
+    "robermac": true,
+    "theodor.lindekaer": true,
+    "docksteaderluke": true,
+    "vboctor": true,
+    "jamescostian": true,
+    "jhabdas": true,
+    "akiva": true,
+    "dongxu": true,
+    "flyslow": true,
+    "wangnan0610": true,
+    "markthethomas": true,
+    "godion": true,
+    "sua": true,
+    "richfoxton": true,
+    "m.lautenbach": true,
+    "craneleeon": true,
+    "luuhoangnam": true,
+    "blitzprog": true,
+    "sergiodxa": true,
+    "zhangyaochun": true,
+    "freshlogic": true,
+    "karthickt": true,
+    "montyanderson": true,
+    "m412c0": true,
+    "clong365": true,
+    "jessaustin": true,
+    "karlbateman": true,
+    "sixertoy": true,
+    "vbv": true,
+    "stephn_r": true,
+    "solodu": true,
+    "raiseandfall": true,
+    "johnny.young": true,
+    "jonatasnona": true,
+    "hema": true,
+    "karlbright": true,
+    "esundahl": true,
+    "mjurincic": true,
+    "0x4c3p": true,
+    "lherediawoodward": true,
+    "ruyadorno": true,
+    "bpatel": true,
+    "nmccready": true,
+    "jerkovicl": true,
+    "ral.amgstromg": true,
+    "panlw": true,
+    "cspotcode": true,
+    "kparkov": true,
+    "hckhanh": true,
+    "phajej": true,
+    "ramzesucr": true,
+    "crazyjingling": true,
+    "igor.gudymenko": true,
+    "yash3492": true,
+    "almccann": true,
+    "program247365": true,
+    "ajduke": true,
+    "js3692": true,
+    "mastayoda": true,
+    "ffi": true,
+    "monkeymonk": true,
+    "vladimirkazan": true,
+    "richardcfelix": true,
+    "redmonkeydf": true,
+    "potnox": true,
+    "evan2x": true,
+    "jbob": true,
+    "animustechnology": true,
+    "justinliao": true,
+    "djamseed": true,
+    "itonyyo": true,
+    "crusaderltd": true,
+    "tobiasnickel": true,
+    "psmorrow": true,
+    "rusintez": true,
+    "peckzeg": true,
+    "craql": true,
+    "sqrtthree": true,
+    "nickeltobias": true,
+    "pruettti": true,
+    "shujianbu": true,
+    "igorissen": true,
+    "jmorris": true,
+    "palelion": true,
+    "yanndinendal": true,
+    "snowdream": true,
+    "sylvain261": true,
+    "mauriciolauffer": true,
+    "nagra": true,
+    "glebec": true,
+    "obouchari": true,
+    "mrbgit": true,
+    "akod3vs": true,
+    "alin.alexa": true,
+    "kikna": true,
+    "scotchulous": true,
+    "joshuadavidson": true,
+    "jmsherry": true,
+    "anhurtado": true,
+    "tims": true,
+    "robba.jt": true,
+    "imappbox": true,
+    "vipergtsrz": true,
+    "abuelwafa": true,
+    "tmurngon": true,
+    "kistoryg": true,
+    "knoja4": true,
+    "mobeicaoyuan": true,
+    "ognjen.jevremovic": true,
+    "ahvonenj": true,
+    "langri-sha": true,
+    "lfilipowicz": true,
+    "sam16": true,
+    "jamiechoi": true,
+    "isaacvitor": true,
+    "danielrhayes": true,
+    "largepuma": true,
+    "hibrahimsafak": true,
+    "13lank.null": true,
+    "dbogda": true,
+    "wujr5": true,
+    "ramoslin02": true,
+    "adeelp": true,
+    "joaquin.briceno": true,
+    "sgvinci": true,
+    "giussa_dan": true,
+    "satoru": true,
+    "isa424": true,
+    "carlosvillademor": true,
+    "donvercety": true,
+    "chinawolf_wyp": true,
+    "serge-nikitin": true,
+    "rocket0191": true,
+    "jirqoadai": true,
+    "leonzhao": true,
+    "rokeyzki": true,
+    "merkjs": true,
+    "sadmansamee": true,
+    "cognivator": true,
+    "milan322": true,
+    "superchenney": true,
+    "tpkn": true,
+    "rbelow": true,
+    "pddivine": true,
+    "fabioper": true,
+    "nbuchanan": true,
+    "vjudge": true,
+    "heartnett": true,
+    "kenanchristian": true,
+    "bianlongting": true,
+    "jamesbedont": true,
+    "kkho595": true,
+    "ungurys": true,
+    "asd123cqp": true,
+    "3ddario": true,
+    "lukvonstrom": true,
+    "seanr": true,
+    "kerwyn": true,
+    "goulash1971": true,
+    "sayansaha": true,
+    "itcorp": true,
+    "yeming": true,
+    "rahulraghavankklm": true,
+    "iamninad": true,
+    "kodekracker": true,
+    "astraloverflow": true,
+    "joey.dossche": true,
+    "luffy84217": true,
+    "daniel-lewis-bsc-hons": true,
+    "adrtho4": true,
+    "keybouh": true,
+    "danday74": true,
+    "hanhq": true,
+    "donecharlton": true,
+    "netoperatorwibby": true,
+    "enhezzz": true,
+    "nuwaio": true,
+    "diegorbaquero": true,
+    "vivek.vikhere": true,
+    "cr8tiv": true,
+    "nguyenvanhoang26041994": true,
+    "shivayl": true,
+    "mdedirudianto": true,
+    "imaginegenesis": true,
+    "jasonwang1888": true,
+    "bytescrafter": true,
+    "noste": true,
+    "washingtonhua": true,
+    "karnavpargi": true,
+    "fadihania": true,
+    "horrorandtropics": true,
+    "ghostcode521": true,
+    "endsoul": true,
+    "aime": true,
+    "edmondnow": true,
+    "pablo384": true,
+    "mohsinnadeem": true,
+    "zuojiang": true,
+    "rapomon": true
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/compression.min.json
+++ b/test/fixtures/registry-mocks/content/compression.min.json
@@ -1,0 +1,921 @@
+{
+  "name": "compression",
+  "dist-tags": {
+    "latest": "1.7.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "compression",
+      "version": "1.0.0",
+      "dependencies": {
+        "bytes": "0.2.1",
+        "negotiator": "0.3.0",
+        "compressible": "1.0.0"
+      },
+      "devDependencies": {
+        "supertest": "*",
+        "connect": "*",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "8aeb85d48db5145d38bc8b181b6352d8eab26020",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "compression",
+      "version": "1.0.1",
+      "dependencies": {
+        "bytes": "0.2.1",
+        "negotiator": "0.4.2",
+        "compressible": "1.0.0"
+      },
+      "devDependencies": {
+        "supertest": "*",
+        "connect": "*",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "e42b3e31040778ff66b4f4cb6a43bdbc6cd7d88b",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "compression",
+      "version": "1.0.2",
+      "dependencies": {
+        "bytes": "0.3.0",
+        "negotiator": "0.4.3",
+        "compressible": "1.0.1"
+      },
+      "devDependencies": {
+        "supertest": "*",
+        "connect": "*",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "90ea20033ee689473678b2ee32226183d7030893",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.3": {
+      "name": "compression",
+      "version": "1.0.3",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "bytes": "1.0.0",
+        "compressible": "1.0.1",
+        "on-headers": "0.0.0"
+      },
+      "devDependencies": {
+        "connect": "2",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "supertest": "~0.13.0",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "4370058053d29402f2ff6312296d9e74463e9901",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.4": {
+      "name": "compression",
+      "version": "1.0.4",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "bytes": "1.0.0",
+        "compressible": "1.0.1",
+        "on-headers": "0.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "supertest": "~0.13.0",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "b9fbfbc11ce6436eb71b9c944006f31b134cfef8",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.5": {
+      "name": "compression",
+      "version": "1.0.5",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "bytes": "1.0.0",
+        "compressible": "1.0.1",
+        "on-headers": "0.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "supertest": "~0.13.0",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "fbf10806b74d96300a18917795e3d6c040532bbc",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.6": {
+      "name": "compression",
+      "version": "1.0.6",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "bytes": "1.0.0",
+        "compressible": "1.0.1",
+        "on-headers": "0.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "supertest": "~0.13.0",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "efbc5c5870980e9d7e5a9d6e6d7437cccf6a9a8a",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.7": {
+      "name": "compression",
+      "version": "1.0.7",
+      "dependencies": {
+        "accepts": "1.0.3",
+        "bytes": "1.0.0",
+        "compressible": "1.1.0",
+        "on-headers": "0.0.0",
+        "vary": "0.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "fc4bff261df4e37a130006f2db2a99a34896f55a",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.8": {
+      "name": "compression",
+      "version": "1.0.8",
+      "dependencies": {
+        "accepts": "~1.0.5",
+        "bytes": "1.0.0",
+        "compressible": "1.1.0",
+        "on-headers": "0.0.0",
+        "vary": "0.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "803ecc67183e71e42b1efcc6a29f6144fdd9afad",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.9": {
+      "name": "compression",
+      "version": "1.0.9",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "bytes": "1.0.0",
+        "compressible": "1.1.0",
+        "debug": "1.0.4",
+        "on-headers": "0.0.0",
+        "vary": "0.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "edbe08829cc2b49d601773c814a3851c135d0931",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.10": {
+      "name": "compression",
+      "version": "1.0.10",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "bytes": "1.0.0",
+        "compressible": "~1.1.1",
+        "debug": "1.0.4",
+        "on-headers": "0.0.0",
+        "vary": "0.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.3",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "4e5ba4b317dbca8bab486e5ba60b09fcb6e22e44",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.11": {
+      "name": "compression",
+      "version": "1.0.11",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "bytes": "1.0.0",
+        "compressible": "~1.1.1",
+        "debug": "1.0.4",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.3",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "69700cf1ee8963454356ac192a6e5e91e232bffb",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.0.11.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.0": {
+      "name": "compression",
+      "version": "1.1.0",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.0",
+        "debug": "~2.0.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.3",
+        "supertest": "~0.13.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "58243eded272fc531d7c744d8e8daa7cc0b99215",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.1": {
+      "name": "compression",
+      "version": "1.1.1",
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.0.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.3",
+        "supertest": "~0.14.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "5dd7d78ab9c9bafb0d33eb92831b18bf6f9ad75f",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.2": {
+      "name": "compression",
+      "version": "1.1.2",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.0.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "supertest": "~0.14.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "f93fb7fcdb3573ec4c7d5398984caae230e2a8d7",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.0": {
+      "name": "compression",
+      "version": "1.2.0",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.1.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "supertest": "~0.14.0",
+        "should": "~4.0.1"
+      },
+      "dist": {
+        "shasum": "c6951ca9ad90588ada7617da693c6bbbe8736866",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.1": {
+      "name": "compression",
+      "version": "1.2.1",
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.1.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "12ebaac04d308ca6103618a9716ce5634b939e9c",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.2": {
+      "name": "compression",
+      "version": "1.2.2",
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.1.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.4",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "637604c25ed659c0d5c9fac1038fc2f2d5494dbf",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.0": {
+      "name": "compression",
+      "version": "1.3.0",
+      "dependencies": {
+        "accepts": "~1.2.2",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.1",
+        "debug": "~2.1.1",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "03289a1d45e1dbbf8bd509dba50d036657b7bac8",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.1": {
+      "name": "compression",
+      "version": "1.3.1",
+      "dependencies": {
+        "accepts": "~1.2.3",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.1",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "30986b2f519ba90e57759896301de4955ce00945",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.0": {
+      "name": "compression",
+      "version": "1.4.0",
+      "dependencies": {
+        "accepts": "~1.2.3",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.1",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "e78287443ef7b4fa0c6a437bc8e5ad31919040bb",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.1": {
+      "name": "compression",
+      "version": "1.4.1",
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.1",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "c6f707ac2659e13c7f3e8834321b02cd09338d78",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.2": {
+      "name": "compression",
+      "version": "1.4.2",
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.2",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "59213b7f4b55f12d6852030946facd1d01e578d7",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.3": {
+      "name": "compression",
+      "version": "1.4.3",
+      "dependencies": {
+        "accepts": "~1.2.5",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.1.3",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "7161bc0441df629273e5c31dd631b8e41e886b4d",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.4": {
+      "name": "compression",
+      "version": "1.4.4",
+      "dependencies": {
+        "accepts": "~1.2.7",
+        "bytes": "1.0.0",
+        "compressible": "~2.0.2",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "2f9994ca476e4d9ba5fdc67ac929942837d0b6a4",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.4.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.0": {
+      "name": "compression",
+      "version": "1.5.0",
+      "dependencies": {
+        "accepts": "~1.2.9",
+        "bytes": "2.1.0",
+        "compressible": "~2.0.3",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.15",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "ccc1a54788da1b3ad7729c49f6a00b3ac9adf47f",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.1": {
+      "name": "compression",
+      "version": "1.5.1",
+      "dependencies": {
+        "accepts": "~1.2.10",
+        "bytes": "2.1.0",
+        "compressible": "~2.0.4",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "ed8d42fc86cbe09b1d775b0c0c1b48dbec8239ba",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.2": {
+      "name": "compression",
+      "version": "1.5.2",
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "bytes": "2.1.0",
+        "compressible": "~2.0.5",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "b03b8d86e6f8ad29683cba8df91ddc6ffc77b395",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.0": {
+      "name": "compression",
+      "version": "1.6.0",
+      "dependencies": {
+        "accepts": "~1.3.0",
+        "bytes": "2.1.0",
+        "compressible": "~2.0.6",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.1",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "2.3.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "886465ffa4a19f9b73b41682db77d28179b30920",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.1": {
+      "name": "compression",
+      "version": "1.6.1",
+      "dependencies": {
+        "accepts": "~1.3.1",
+        "bytes": "2.2.0",
+        "compressible": "~2.0.7",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.1",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "1bf4f96fd72019a3fd11513b4fc4dcd3bd16db55",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.2": {
+      "name": "compression",
+      "version": "1.6.2",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "bytes": "2.3.0",
+        "compressible": "~2.0.8",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.1",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "eslint": "2.9.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "cceb121ecc9d09c52d7ad0c3350ea93ddd402bc3",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.0": {
+      "name": "compression",
+      "version": "1.7.0",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "bytes": "2.5.0",
+        "compressible": "~2.0.10",
+        "debug": "2.6.8",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "030c9f198f1643a057d776a738e922da4373012d",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.1": {
+      "name": "compression",
+      "version": "1.7.1",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.11",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "eff2603efc2e22cf86f35d2eb93589f9875373db",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.2": {
+      "name": "compression",
+      "version": "1.7.2",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.13",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "eslint": "4.18.0",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "aaffbcd6aaf854b44ebb280353d5ad1651f59a69",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22623
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.3": {
+      "name": "compression",
+      "version": "1.7.3",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.14",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.1",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.13.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.8.0",
+        "eslint-plugin-standard": "3.1.0",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+        "shasum": "27e0e176aaf260f7f2c2813c3e440adb9f1993db",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22876,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbS76XCRA9TVsSAnZWagAADrMP/Rhf/BBJXT0AaaJ/qePc\nRwq3Rj7dE9Fjlc1c0Ib4S1Kl5ug0b9l18L0TtRuFXYzKpul2uxzHTQtv9wyY\nyveW4+zk/bM+BN0ZpHbND2pWQLwSCwQ0jnm6PMO8jsDCQRiafDOQqh8wwr0k\n2K9prCysA+369kWCOiCuF9Ra1F+rZjlGuXbjOmorsZIDu1ZT+opv8VNTvm3D\nsWU7/xWFoKdJVH27m+PKsAZAcYNJEirYY84JUFDONFZq84ItOONQaKX6Rm8/\n5nAalJh3wuor0Mv3u55U8iHrtf7izi0j78c6MuequWEPAwtR1R2/jeherA4L\nMGkfzHK/JaR5SNtQ+ryjHSuSDVKO+obJKs/x74cdh8aFI++Gl1MkQSgDWt6l\n9DYF51HvOo8QKDWQf1A7lyYfrdp/lHK1BKZ1YdyvnsbQ9bszAfkgKwWkbZ9K\nUziNChH65rP4tkPUAJ5qgQlFY2yFcXuzxZwwkufff47wkYAza0eWQ+gGRoWl\nl6dQ96CC4n4v/7xut2mJW2evGk/RYfnfJLw73x/fqwXF1JnKbtP6u6OSn6CS\nPZJJAFF8gY3boaZPm8m+iVUKEl0Cxy+ZgXFb7S9Qn/CX544V1ZA6BlIyTAq0\nlieaRKSBCDjXigw2F69/nRyZeOkE0Ms7Lb0Abz7Qaut0y6+32J4xkUi5GNku\nyu8/\r\n=lzg0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.4": {
+      "name": "compression",
+      "version": "1.7.4",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "5.15.1",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.0.2",
+        "supertest": "4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+        "shasum": "95523eff170ca57c29a0ca41e6fe131f41e5bb8f",
+        "tarball": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23306,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcj66MCRA9TVsSAnZWagAA5VcP/R4JRuhO78tvsnnBepBz\nzSdSm0onNd0iQp8ajRSpcrd3D1r0eYcQDe8qYraO9tTdzISngweiOZnrp3v/\nitiqTfINI0cFgffUe0LD6ZHP4hnerj04z6NQ3k1Ayr0yEywjLErjznuy+f4U\nznor4SRG8fb5fjel4VJXSVSpq5A7pisGJbb7tw5Bh8n/GQUm3i9bGBL7QRb3\nf++/H1YxTjQoMxMupbvZ6bDvBVVFKl6OLebi4lfVRSoLxKd0+F2KeZ0D1VzH\niZIPgjo5ojAzgmBlDD62dHcg7vwNSFT1UV8U0A6yDSx90hqDUqBK8f2oOL+C\n7mObbeSLqsgspXmM/evEIpkIcF0VeSDf44ClH2u5lAkNb07kf5CevOnRWs/o\nTneqN8c6hMEIriNY7xun9tX6837VRXn9/F98NdcSTiT3lidEMC4y5tXWikSE\n6FAXlJmutIiRNi8LOR50UqPGiWeFNCSVIgPGKBk1jHN78WbkXgvfSFvrRoB8\nj2eY/cK+9RmeXJrzG1oUdEDGHqTpHC0TkKmL0aZyOUEftby8bgEMP9wWa1z+\nGJTueAVQzeu3BCQEkMDiQoxVRoM1E9n8oZDm6CE1sTTmPtCk3rMQMmovpJWs\nrL10koK/Asp7oB3JctY5De2icreXAi08Mytf9pHh+Wibo0XIpxh23Y/BD6TR\nwaMv\r\n=n7iJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    }
+  },
+  "modified": "2019-09-21T18:45:07.031Z"
+}

--- a/test/fixtures/registry-mocks/content/connect-history-api-fallback.json
+++ b/test/fixtures/registry-mocks/content/connect-history-api-fallback.json
@@ -1,0 +1,828 @@
+{
+  "_id": "connect-history-api-fallback",
+  "_rev": "38-71524b03f8618c7b5c6e4dff32c235c8",
+  "name": "connect-history-api-fallback",
+  "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+  "dist-tags": {
+    "latest": "1.6.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.1",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "grunt"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "_id": "connect-history-api-fallback@0.0.1",
+      "dist": {
+        "shasum": "deb051601f0ebd13727c76b165d73fef52f65975",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.2",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "grunt"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "_id": "connect-history-api-fallback@0.0.2",
+      "dist": {
+        "shasum": "674832149d54813039ed57919ebd89337ebedb9c",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.3",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "grunt"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "_id": "connect-history-api-fallback@0.0.3",
+      "dist": {
+        "shasum": "946b96eb735defe203c20dfe37c28874ea758a91",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.4",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "grunt"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "_id": "connect-history-api-fallback@0.0.4",
+      "dist": {
+        "shasum": "b430713e14b52df4a97de72bd17d38cbddbe14d3",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.5",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "grunt"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "bugs": {
+        "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+      },
+      "homepage": "https://github.com/bripkens/connect-history-api-fallback",
+      "_id": "connect-history-api-fallback@0.0.5",
+      "dist": {
+        "shasum": "ef0509d0040bfbc486eab5f7f500bb1769cf354a",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.0.0",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "eslint lib/index.js test/index_test.js && nodeunit test/index_test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "contributors": [
+        {
+          "name": "Craig Myles",
+          "email": "cr@igmyles.com",
+          "url": "http://www.craigmyles.com"
+        }
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "gitHead": "7c4738211539505d1e8c2da9a3abbf03feaacc73",
+      "bugs": {
+        "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+      },
+      "homepage": "https://github.com/bripkens/connect-history-api-fallback",
+      "_id": "connect-history-api-fallback@1.0.0",
+      "_shasum": "a3bdae0c97a0f15b861674725ef4cca6b084d8f6",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.37",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a3bdae0c97a0f15b861674725ef4cca6b084d8f6",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.1.0",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "eslint lib/index.js test/index_test.js && nodeunit test/index_test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "contributors": [
+        {
+          "name": "Craig Myles",
+          "email": "cr@igmyles.com",
+          "url": "http://www.craigmyles.com"
+        }
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "gitHead": "c4411c155c00c84f0a9fd26e17d810dc6480171b",
+      "bugs": {
+        "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+      },
+      "homepage": "https://github.com/bripkens/connect-history-api-fallback",
+      "_id": "connect-history-api-fallback@1.1.0",
+      "_shasum": "5a6dee82d9a648cb29131d3f9dd400ffa4593742",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.37",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5a6dee82d9a648cb29131d3f9dd400ffa4593742",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.2.0",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "eslint lib/index.js test/index_test.js && nodeunit test/index_test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "contributors": [
+        {
+          "name": "Craig Myles",
+          "email": "cr@igmyles.com",
+          "url": "http://www.craigmyles.com"
+        }
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "gitHead": "e5bc77c5b1e3c9d07647764675971d262e773ac9",
+      "bugs": {
+        "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+      },
+      "homepage": "https://github.com/bripkens/connect-history-api-fallback#readme",
+      "_id": "connect-history-api-fallback@1.2.0",
+      "_shasum": "df4a8b05e40362f5b598a1c0a6aa012f21471d40",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.8.0",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "df4a8b05e40362f5b598a1c0a6aa012f21471d40",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/connect-history-api-fallback-1.2.0.tgz_1458587541331_0.6849686577916145"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.3.0",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "eslint lib/index.js test/index_test.js && nodeunit test/index_test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "contributors": [
+        {
+          "name": "Craig Myles",
+          "email": "cr@igmyles.com",
+          "url": "http://www.craigmyles.com"
+        }
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "gitHead": "709252d1b7afbf4b29748ec9a881684603d01f97",
+      "bugs": {
+        "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+      },
+      "homepage": "https://github.com/bripkens/connect-history-api-fallback#readme",
+      "_id": "connect-history-api-fallback@1.3.0",
+      "_shasum": "e51d17f8f0ef0db90a64fdb47de3051556e9f169",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e51d17f8f0ef0db90a64fdb47de3051556e9f169",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/connect-history-api-fallback-1.3.0.tgz_1470552836120_0.7486736204009503"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.4.0",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "eslint lib/index.js test/index_test.js && nodeunit test/index_test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "contributors": [
+        {
+          "name": "Craig Myles",
+          "email": "cr@igmyles.com",
+          "url": "http://www.craigmyles.com"
+        }
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "gitHead": "7d953fee45b7d2f4e26cb252199ebdd18617f5d6",
+      "bugs": {
+        "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+      },
+      "homepage": "https://github.com/bripkens/connect-history-api-fallback#readme",
+      "_id": "connect-history-api-fallback@1.4.0",
+      "_shasum": "3db24f973f4b923b0e82f619ce0df02411ca623d",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3db24f973f4b923b0e82f619ce0df02411ca623d",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/connect-history-api-fallback-1.4.0.tgz_1507871134046_0.01949539640918374"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.5.0",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "eslint lib/index.js test/index_test.js && nodeunit test/index_test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "contributors": [
+        {
+          "name": "Craig Myles",
+          "email": "cr@igmyles.com",
+          "url": "http://www.craigmyles.com"
+        }
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "gitHead": "9748349e62006ef101c7800d6be8ec37f74fc70c",
+      "bugs": {
+        "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+      },
+      "homepage": "https://github.com/bripkens/connect-history-api-fallback#readme",
+      "_id": "connect-history-api-fallback@1.5.0",
+      "_shasum": "b06873934bc5e344fef611a196a6faae0aee015a",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.5",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b06873934bc5e344fef611a196a6faae0aee015a",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/connect-history-api-fallback-1.5.0.tgz_1510246125020_0.02864476339891553"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.6.0",
+      "description": "Provides a fallback for non-existing directories so that the HTML 5 history API can be used.",
+      "keyswords": [
+        "connect",
+        "html5",
+        "history api",
+        "fallback",
+        "spa"
+      ],
+      "engines": {
+        "node": ">=0.8"
+      },
+      "main": "lib/index.js",
+      "scripts": {
+        "test": "eslint lib/index.js test/index_test.js && nodeunit test/index_test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/bripkens/connect-history-api-fallback.git"
+      },
+      "author": {
+        "name": "Ben Ripkens",
+        "email": "bripkens.dev@gmail.com",
+        "url": "http://bripkens.de"
+      },
+      "contributors": [
+        {
+          "name": "Craig Myles",
+          "email": "cr@igmyles.com",
+          "url": "http://www.craigmyles.com"
+        }
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.11.3",
+        "sinon": "^1.14.1"
+      },
+      "gitHead": "5d3a83e22f7d8994106b50ff19242b7739938525",
+      "bugs": {
+        "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+      },
+      "homepage": "https://github.com/bripkens/connect-history-api-fallback#readme",
+      "_id": "connect-history-api-fallback@1.6.0",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "bripkens",
+        "email": "bripkens.dev@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+        "shasum": "8b32089359308d111115d81cad3fceab888f97bc",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 11523,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcNGA8CRA9TVsSAnZWagAAz7EQAJJKxgDIse2UDKLjTFVq\niMD+V5XHO0KDlr+VmT7ayhr05u9ID1cgfWaWBr07JD3IWGmtUNdCjYIu2p+Y\nFilsPW94ta/mEUgVUUHx2RDLFlNz/sDQBiCKcgcSqGosqZaYeEXSVm9LoUD0\nPc2PHb/AJa4LS8h3B4UyNcBa2sk+X3FQ9AlDs8c6o729KI386SpNYVyVhs8h\nZzIcyPI9j2jY/4KpWWgkSKQ7naWebpoGhm5a9r6USiB6PwPD0hEWvgSzAmra\nd42HowhHElHnnnjq9cyrmOo4knCXdeoxXnxNqy8JVYVrAAb7TDyIv4/E4hJg\nZOFiKmxp4SAViZLmZhFVBYE1TtvdoVhKCHLTjIG8mc0Gq3xL1bATmNqdZyWv\nC5z10F7+nmduh89tC/n7cI1NoY6vy7u/3jv/crcPgBlev1wACBkfmWigx1+6\n8mFBudDPS/2tRk9LCDgcyi2RMbiuaUz1RUVSC1t8Gxwjo6PHH5ViZYRHtXWl\nqNavg7Bmsc5FhFQ/s700h27nAAtuhtxni73Nk1GfJsOW3g9rro/zXgFpujv+\nO9OhSJSyZKu4oOfP16OD1KbUiKjvmVm1I2NG2GC0oI+8juFh/8oRCF6hkwCD\nQwLGCMnJ9QpPYmfjUb8ZF5nDiaI4cdiNL44ld32MVXrmiLOyJQm6K+joyTEO\nhKnS\r\n=9k/a\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bripkens",
+          "email": "bripkens.dev@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/connect-history-api-fallback_1.6.0_1546936380183_0.5015516416248609"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "<h1 align=\"center\">connect-history-api-fallback</h1>\n<p align=\"center\">Middleware to proxy requests through a specified index page, useful for Single Page Applications that utilise the HTML5 History API.</p>\n\n[![Build Status](https://travis-ci.org/bripkens/connect-history-api-fallback.svg?branch=master)](https://travis-ci.org/bripkens/connect-history-api-fallback)\n[![Dependency Status](https://david-dm.org/bripkens/connect-history-api-fallback/master.svg)](https://david-dm.org/bripkens/connect-history-api-fallback/master)\n\n[![NPM](https://nodei.co/npm/connect-history-api-fallback.png?downloads=true&downloadRank=true)](https://nodei.co/npm/connect-history-api-fallback/)\n\n\n<h2>Table of Contents</h2>\n\n<!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->\n\n- [Introduction](#introduction)\n- [Usage](#usage)\n- [Options](#options)\n\t- [index](#index)\n\t- [rewrites](#rewrites)\n\t- [verbose](#verbose)\n\t- [htmlAcceptHeaders](#htmlacceptheaders)\n\t- [disableDotRule](#disabledotrule)\n\n<!-- /TOC -->\n\n## Introduction\n\nSingle Page Applications (SPA) typically only utilise one index file that is\naccessible by web browsers: usually `index.html`. Navigation in the application\nis then commonly handled using JavaScript with the help of the\n[HTML5 History API](http://www.w3.org/html/wg/drafts/html/master/single-page.html#the-history-interface).\nThis results in issues when the user hits the refresh button or is directly\naccessing a page other than the landing page, e.g. `/help` or `/help/online`\nas the web server bypasses the index file to locate the file at this location.\nAs your application is a SPA, the web server will fail trying to retrieve the file and return a *404 - Not Found*\nmessage to the user.\n\nThis tiny middleware addresses some of the issues. Specifically, it will change\nthe requested location to the index you specify (default being `/index.html`)\nwhenever there is a request which fulfills the following criteria:\n\n 1. The request is a GET request\n 2. which accepts `text/html`,\n 3. is not a direct file request, i.e. the requested path does not contain a\n    `.` (DOT) character and\n 4. does not match a pattern provided in options.rewrites (see options below)\n\n## Usage\n\nThe middleware is available through NPM and can easily be added.\n\n```\nnpm install --save connect-history-api-fallback\n```\n\nImport the library\n\n```javascript\nvar history = require('connect-history-api-fallback');\n```\n\nNow you only need to add the middleware to your application like so\n\n```javascript\nvar connect = require('connect');\n\nvar app = connect()\n  .use(history())\n  .listen(3000);\n```\n\nOf course you can also use this piece of middleware with express:\n\n```javascript\nvar express = require('express');\n\nvar app = express();\napp.use(history());\n```\n\n## Options\nYou can optionally pass options to the library when obtaining the middleware\n\n```javascript\nvar middleware = history({});\n```\n\n### index\nOverride the index (default `/index.html`)\n\n```javascript\nhistory({\n  index: '/default.html'\n});\n```\n\n### rewrites\nOverride the index when the request url matches a regex pattern. You can either rewrite to a static string or use a function to transform the incoming request.\n\nThe following will rewrite a request that matches the `/\\/soccer/` pattern to `/soccer.html`.\n```javascript\nhistory({\n  rewrites: [\n    { from: /\\/soccer/, to: '/soccer.html'}\n  ]\n});\n```\n\nAlternatively functions can be used to have more control over the rewrite process. For instance, the following listing shows how requests to `/libs/jquery/jquery.1.12.0.min.js` and the like can be routed to `./bower_components/libs/jquery/jquery.1.12.0.min.js`. You can also make use of this if you have an API version in the URL path.\n```javascript\nhistory({\n  rewrites: [\n    {\n      from: /^\\/libs\\/.*$/,\n      to: function(context) {\n        return '/bower_components' + context.parsedUrl.pathname;\n      }\n    }\n  ]\n});\n```\n\nThe function will always be called with a context object that has the following properties:\n\n - **parsedUrl**: Information about the URL as provided by the [URL module's](https://nodejs.org/api/url.html#url_url_parse_urlstr_parsequerystring_slashesdenotehost) `url.parse`.\n - **match**: An Array of matched results as provided by `String.match(...)`.\n - **request**: The HTTP request object.\n\n\n### verbose\nThis middleware does not log any information by default. If you wish to activate logging, then you can do so via the `verbose` option or by specifying a logger function.\n\n```javascript\nhistory({\n  verbose: true\n});\n```\n\nAlternatively use your own logger\n\n```javascript\nhistory({\n  logger: console.log.bind(console)\n});\n```\n\n### htmlAcceptHeaders\nOverride the default `Accepts:` headers that are queried when matching HTML content requests (Default: `['text/html', '*/*']`).\n\n```javascript\nhistory({\n  htmlAcceptHeaders: ['text/html', 'application/xhtml+xml']\n})\n```\n\n### disableDotRule\nDisables the dot rule mentioned above:\n\n> […] is not a direct file request, i.e. the requested path does not contain a `.` (DOT) character […]\n\n```javascript\nhistory({\n  disableDotRule: true\n})\n```\n",
+  "maintainers": [
+    {
+      "name": "bripkens",
+      "email": "bripkens.dev@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-08T08:33:02.843Z",
+    "created": "2013-05-18T13:47:54.775Z",
+    "0.0.1": "2013-05-18T13:47:58.244Z",
+    "0.0.2": "2013-07-15T20:04:56.899Z",
+    "0.0.3": "2013-07-16T20:02:55.758Z",
+    "0.0.4": "2013-07-16T20:13:33.457Z",
+    "0.0.5": "2014-10-01T16:54:01.659Z",
+    "1.0.0": "2015-04-11T06:06:30.740Z",
+    "1.1.0": "2015-04-16T06:38:05.983Z",
+    "1.2.0": "2016-03-21T19:12:23.525Z",
+    "1.3.0": "2016-08-07T06:53:57.855Z",
+    "1.4.0": "2017-10-13T05:05:34.920Z",
+    "1.5.0": "2017-11-09T16:48:45.095Z",
+    "1.6.0": "2019-01-08T08:33:00.369Z"
+  },
+  "author": {
+    "name": "Ben Ripkens",
+    "email": "bripkens.dev@gmail.com",
+    "url": "http://bripkens.de"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/bripkens/connect-history-api-fallback.git"
+  },
+  "homepage": "https://github.com/bripkens/connect-history-api-fallback#readme",
+  "bugs": {
+    "url": "https://github.com/bripkens/connect-history-api-fallback/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Craig Myles",
+      "email": "cr@igmyles.com",
+      "url": "http://www.craigmyles.com"
+    }
+  ],
+  "users": {
+    "jabbrwcky": true,
+    "sabrina.luo": true,
+    "travm": true,
+    "staydan": true,
+    "panlw": true,
+    "lore-w": true,
+    "largepuma": true,
+    "ldq-first": true,
+    "yeming": true,
+    "serge-nikitin": true,
+    "tardis103": true,
+    "fakefarm": true,
+    "muzi131313": true,
+    "hewenxuan": true,
+    "ptspzy": true,
+    "edwardxyt": true,
+    "losymear": true,
+    "he313572052": true,
+    "xbilek18": true,
+    "yangteng": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/connect-history-api-fallback.min.json
+++ b/test/fixtures/registry-mocks/content/connect-history-api-fallback.min.json
@@ -1,0 +1,200 @@
+{
+  "name": "connect-history-api-fallback",
+  "dist-tags": {
+    "latest": "1.6.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.1",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "dist": {
+        "shasum": "deb051601f0ebd13727c76b165d73fef52f65975",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "0.0.2": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.2",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "dist": {
+        "shasum": "674832149d54813039ed57919ebd89337ebedb9c",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "0.0.3": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.3",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "dist": {
+        "shasum": "946b96eb735defe203c20dfe37c28874ea758a91",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "0.0.4": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.4",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "dist": {
+        "shasum": "b430713e14b52df4a97de72bd17d38cbddbe14d3",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "0.0.5": {
+      "name": "connect-history-api-fallback",
+      "version": "0.0.5",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-contrib-nodeunit": "~0.1.2"
+      },
+      "dist": {
+        "shasum": "ef0509d0040bfbc486eab5f7f500bb1769cf354a",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "1.0.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.0.0",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "dist": {
+        "shasum": "a3bdae0c97a0f15b861674725ef4cca6b084d8f6",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "1.1.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.1.0",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "dist": {
+        "shasum": "5a6dee82d9a648cb29131d3f9dd400ffa4593742",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "1.2.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.2.0",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "dist": {
+        "shasum": "df4a8b05e40362f5b598a1c0a6aa012f21471d40",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "1.3.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.3.0",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "dist": {
+        "shasum": "e51d17f8f0ef0db90a64fdb47de3051556e9f169",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "1.4.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.4.0",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "dist": {
+        "shasum": "3db24f973f4b923b0e82f619ce0df02411ca623d",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "1.5.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.5.0",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.9.1",
+        "sinon": "^1.14.1"
+      },
+      "dist": {
+        "shasum": "b06873934bc5e344fef611a196a6faae0aee015a",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "1.6.0": {
+      "name": "connect-history-api-fallback",
+      "version": "1.6.0",
+      "devDependencies": {
+        "eslint": "^0.18.0",
+        "nodeunit": "^0.11.3",
+        "sinon": "^1.14.1"
+      },
+      "dist": {
+        "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+        "shasum": "8b32089359308d111115d81cad3fceab888f97bc",
+        "tarball": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 11523,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcNGA8CRA9TVsSAnZWagAAz7EQAJJKxgDIse2UDKLjTFVq\niMD+V5XHO0KDlr+VmT7ayhr05u9ID1cgfWaWBr07JD3IWGmtUNdCjYIu2p+Y\nFilsPW94ta/mEUgVUUHx2RDLFlNz/sDQBiCKcgcSqGosqZaYeEXSVm9LoUD0\nPc2PHb/AJa4LS8h3B4UyNcBa2sk+X3FQ9AlDs8c6o729KI386SpNYVyVhs8h\nZzIcyPI9j2jY/4KpWWgkSKQ7naWebpoGhm5a9r6USiB6PwPD0hEWvgSzAmra\nd42HowhHElHnnnjq9cyrmOo4knCXdeoxXnxNqy8JVYVrAAb7TDyIv4/E4hJg\nZOFiKmxp4SAViZLmZhFVBYE1TtvdoVhKCHLTjIG8mc0Gq3xL1bATmNqdZyWv\nC5z10F7+nmduh89tC/n7cI1NoY6vy7u/3jv/crcPgBlev1wACBkfmWigx1+6\n8mFBudDPS/2tRk9LCDgcyi2RMbiuaUz1RUVSC1t8Gxwjo6PHH5ViZYRHtXWl\nqNavg7Bmsc5FhFQ/s700h27nAAtuhtxni73Nk1GfJsOW3g9rro/zXgFpujv+\nO9OhSJSyZKu4oOfP16OD1KbUiKjvmVm1I2NG2GC0oI+8juFh/8oRCF6hkwCD\nQwLGCMnJ9QpPYmfjUb8ZF5nDiaI4cdiNL44ld32MVXrmiLOyJQm6K+joyTEO\nhKnS\r\n=9k/a\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    }
+  },
+  "modified": "2019-01-08T08:33:02.843Z"
+}

--- a/test/fixtures/registry-mocks/content/console-browserify.json
+++ b/test/fixtures/registry-mocks/content/console-browserify.json
@@ -1,0 +1,1463 @@
+{
+  "_id": "console-browserify",
+  "_rev": "34-e46f950bca8f9b15b2309e43fcc47d4a",
+  "name": "console-browserify",
+  "description": "Emulate console for all the browsers",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "console-browserify",
+      "version": "0.1.0",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {
+        "date-now": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem",
+        "postinstall": "npm dedup"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@0.1.0",
+      "dist": {
+        "shasum": "8b268ddd05d6d6162f6bbd9f7a7316042fc63c42",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.0.tgz"
+      },
+      "_npmVersion": "1.1.71",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "console-browserify",
+      "version": "0.1.1",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {
+        "date-now": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem",
+        "postinstall": "npm dedup"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@0.1.1",
+      "dist": {
+        "shasum": "1f7b530e8a94e28e8d7579bc21a18c076ed38874",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.1.tgz"
+      },
+      "_npmVersion": "1.1.71",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "console-browserify",
+      "version": "0.1.2",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {
+        "date-now": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem",
+        "postinstall": "npm dedup"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@0.1.2",
+      "dist": {
+        "shasum": "9e8d6a7cdada01b60d178f57b1aa7c7b2dba1551",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.2.tgz"
+      },
+      "_npmVersion": "1.1.71",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "console-browserify",
+      "version": "0.1.3",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {
+        "date-now": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem",
+        "postinstall": "npm dedup"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@0.1.3",
+      "dist": {
+        "shasum": "0d5b48bddb6ab922f968fd55e29e018996a462d9",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.3.tgz"
+      },
+      "_npmVersion": "1.1.71",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "console-browserify",
+      "version": "0.1.4",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {
+        "date-now": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@0.1.4",
+      "dist": {
+        "shasum": "42efecda651fe1896311221e964ada4ad1b45f81",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.4.tgz"
+      },
+      "_npmVersion": "1.1.71",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "console-browserify",
+      "version": "0.1.5",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@0.1.5",
+      "dist": {
+        "shasum": "3e4c5360d4b7214d9dccbd581b9f7e1ff0b2a8db",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.6": {
+      "name": "console-browserify",
+      "version": "0.1.6",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@0.1.6",
+      "dist": {
+        "shasum": "d128a3c0bb88350eb5626c6e7c71a6f0fd48983c",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "console-browserify",
+      "version": "1.0.1",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@1.0.1",
+      "dist": {
+        "shasum": "86d35db62438704ebfa4285232f307b85d5376df",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "console-browserify",
+      "version": "1.0.2",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@1.0.2",
+      "dist": {
+        "shasum": "def1cea1e03f5436332323a2bed8112337f94475",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "console-browserify",
+      "version": "1.0.3",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": {
+          "ie": [
+            "6",
+            "7",
+            "8",
+            "9",
+            "10"
+          ],
+          "firefox": [
+            "16",
+            "17",
+            "nightly"
+          ],
+          "chrome": [
+            "22",
+            "23",
+            "canary"
+          ],
+          "opera": [
+            "12",
+            "next"
+          ],
+          "safari": [
+            "5.1"
+          ]
+        }
+      },
+      "_id": "console-browserify@1.0.3",
+      "dist": {
+        "shasum": "d3898d2c3a93102f364197f8874b4f92b5286a8e",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "console-browserify",
+      "version": "1.1.0",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Raynos/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/Raynos/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/Raynos/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "dependencies": {
+        "date-now": "^0.1.4"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "jsonify": "0.0.0",
+        "tap-spec": "^0.1.8",
+        "run-browser": "^1.3.0",
+        "tap-dot": "^0.2.1"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/Raynos/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test/index.js | tap-spec",
+        "dot": "node ./test/index.js | tap-dot",
+        "start": "node ./index.js",
+        "cover": "istanbul cover --report none --print detail ./test/index.js",
+        "view-cover": "istanbul report html && google-chrome ./coverage/index.html",
+        "browser": "run-browser test/index.js",
+        "phantom": "run-browser test/index.js -b | tap-spec",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/16..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "_id": "console-browserify@1.1.0",
+      "dist": {
+        "shasum": "f0241c45730a9fc6323b206dbf38edc741d0bb10",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "console-browserify",
+      "version": "1.2.0",
+      "description": "Emulate console for all the browsers",
+      "keywords": [],
+      "author": {
+        "name": "Raynos",
+        "email": "raynos2@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/console-browserify.git"
+      },
+      "main": "index",
+      "homepage": "https://github.com/browserify/console-browserify",
+      "contributors": [
+        {
+          "name": "Raynos"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/browserify/console-browserify/issues",
+        "email": "raynos2@gmail.com"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "jsonify": "0.0.0",
+        "tap-spec": "^0.1.8",
+        "run-browser": "^1.3.0",
+        "tap-dot": "^0.2.1"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/browserify/console-browserify/raw/master/LICENSE"
+        }
+      ],
+      "scripts": {
+        "test": "node ./test/index.js | tap-spec",
+        "dot": "node ./test/index.js | tap-dot",
+        "start": "node ./index.js",
+        "cover": "istanbul cover --report none --print detail ./test/index.js",
+        "view-cover": "istanbul report html && google-chrome ./coverage/index.html",
+        "browser": "run-browser test/index.js",
+        "phantom": "run-browser test/index.js -b | tap-spec",
+        "build": "browserify test/index.js -o test/static/bundle.js",
+        "testem": "testem"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/16..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "ee8033921697e97f52e3a4ecc641faf649a03ac3",
+      "_id": "console-browserify@1.2.0",
+      "_nodeVersion": "12.13.0",
+      "_npmVersion": "6.12.0",
+      "dist": {
+        "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+        "shasum": "67063cef57ceb6cf4993a2ab3a55840ae8c49336",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 10275,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdtqplCRA9TVsSAnZWagAAF6cP/1Kx1sQ8vaSWWu2ozb8k\nXs1npZM3BjXVFPI60LBFrHzOSRvKaleYb0LuXAFs4WdS4z8xTphfZWTxmeYU\nXF7EWJ0JmF5fgUxIp1tnfMuOLJeWe5xzO7mAvQtBxgKjP0aivmUeQrW2I7Dg\nsr9RBz16A7xmL2bBBKovvrnEYmK/CP1FGxM+GQPEZyUN/5qOoc0r3o2y+/08\nH6XjJBHYlMCwZYKmRI4CEmgd7FT1Z0EPBOpXdoeWOPZTcFZzP6Guij/AfKwP\nHBQxDFcYPOX+E4tI/9k8eq7bw7a02SfE67N1Q57IDslykwKY2uNoMdLqTBfz\nbeJaOsha+SpScjzlfuYgvEyaUbfrXfeo8cga/Ebq7OlgEQginGio2cYponat\nLNryKWGGXGnLPnjY8zS2qLqbHzS1wEu38Atuq7uvZamGgvX8KIvFBO82n373\nSotFzdAjb3s6gEoSIBu6bmCIXGG1LoFAGXOMs2UapF02eV0BClTE1IMitQpk\nRx+sRmkbFbaWzkB+BmODAT59oogC6yjGEx7wpGE9ca3HGXjV7O76PnvOj8NX\nvSpFqaDbehb/B5o9b+MR1WWG2anj8n1TFuEJOUfDaZEu6Tgubk7lYFUblhLV\n0JQCQFXuL5Gj8ybPi57CTkEcLmrI9n9CWJI2/5BWWCOiOMVRHiBnLooha/0h\nMn45\r\n=Ksg7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "raynos2@gmail.com",
+          "name": "raynos"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/console-browserify_1.2.0_1572252260673_0.6432941903463654"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# console-browserify [![Build Status](https://travis-ci.org/browserify/console-browserify.png?branch=master)](https://travis-ci.org/browserify/console-browserify)\n\nEmulate console for all the browsers\n\n## Install\n\nYou usually do not have to install `console-browserify` yourself! If your code runs in Node.js, `console` is built in. If your code runs in the browser, bundlers like [browserify](https://github.com/browserify/browserify) or [webpack](https://github.com/webpack/webpack) also include the `console-browserify` module when you do `require('console')`.\n\nBut if none of those apply, with npm do:\n\n```\nnpm install console-browserify\n```\n\n## Usage\n\n```js\nvar console = require(\"console\")\n// Or when manually using console-browserify directly:\n// var console = require(\"console-browserify\")\n\nconsole.log(\"hello world!\")\n```\n\n## API\n\nSee the [Node.js Console docs](https://nodejs.org/api/console.html). `console-browserify` does not support creating new `Console` instances and does not support the Inspector-only methods.\n\n## Contributing\n\nPRs are very welcome! The main way to contribute to `console-browserify` is by porting features, bugfixes and tests from Node.js. Ideally, code contributions to this module are copy-pasted from Node.js and transpiled to ES5, rather than reimplemented from scratch. Matching the Node.js code as closely as possible makes maintenance simpler when new changes land in Node.js.\nThis module intends to provide exactly the same API as Node.js, so features that are not available in the core `console` module will not be accepted. Feature requests should instead be directed at [nodejs/node](https://github.com/nodejs/node) and will be added to this module once they are implemented in Node.js.\n\nIf there is a difference in behaviour between Node.js's `console` module and this module, please open an issue!\n\n## Contributors\n\n - Raynos\n\n## License\n\n[MIT](./LICENSE)\n",
+  "maintainers": [
+    {
+      "email": "lukechilds123@gmail.com",
+      "name": "lukechilds"
+    },
+    {
+      "email": "shtylman@gmail.com",
+      "name": "defunctzombie"
+    },
+    {
+      "email": "substack@gmail.com",
+      "name": "substack"
+    },
+    {
+      "email": "feross@feross.org",
+      "name": "feross"
+    },
+    {
+      "email": "me@gkatsev.com",
+      "name": "gkatsev"
+    },
+    {
+      "email": "zertosh@gmail.com",
+      "name": "zertosh"
+    },
+    {
+      "email": "mathiasbuus@gmail.com",
+      "name": "mafintosh"
+    },
+    {
+      "email": "max@maxogden.com",
+      "name": "maxogden"
+    },
+    {
+      "email": "dominic.tarr@gmail.com",
+      "name": "dominictarr"
+    },
+    {
+      "email": "thlorenz@gmx.de",
+      "name": "thlorenz"
+    },
+    {
+      "email": "terinjokes@gmail.com",
+      "name": "terinjokes"
+    },
+    {
+      "email": "npm-public@jessemccarthy.net",
+      "name": "jmm"
+    },
+    {
+      "email": "palmermebane@gmail.com",
+      "name": "mellowmelon"
+    },
+    {
+      "email": "darawk@gmail.com",
+      "name": "ashaffer88"
+    },
+    {
+      "email": "b@lupton.cc",
+      "name": "balupton"
+    },
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jryans@gmail.com",
+      "name": "jryans"
+    },
+    {
+      "email": "sethvincent@gmail.com",
+      "name": "sethvincent"
+    },
+    {
+      "email": "yoshuawuyts@gmail.com",
+      "name": "yoshuawuyts"
+    },
+    {
+      "email": "ungoldman@gmail.com",
+      "name": "ungoldman"
+    },
+    {
+      "email": "michael.williams@enspiral.com",
+      "name": "ahdinosaur"
+    },
+    {
+      "email": "contact@elnounch.net",
+      "name": "elnounch"
+    },
+    {
+      "email": "parshap+npm@gmail.com",
+      "name": "parshap"
+    },
+    {
+      "email": "yerko.palma@usach.cl",
+      "name": "yerkopalma"
+    },
+    {
+      "email": "forbes@lindesay.co.uk",
+      "name": "forbeslindesay"
+    },
+    {
+      "email": "martin.heidegger@gmail.com",
+      "name": "leichtgewicht"
+    },
+    {
+      "email": "garann@gmail.com",
+      "name": "garann"
+    },
+    {
+      "email": "bcomnes@gmail.com",
+      "name": "bret"
+    },
+    {
+      "email": "vestibule@anandthakker.net",
+      "name": "anandthakker"
+    },
+    {
+      "email": "dave.des@gmail.com",
+      "name": "mattdesl"
+    },
+    {
+      "email": "hughskennedy@gmail.com",
+      "name": "hughsk"
+    },
+    {
+      "email": "pereira.filype@gmail.com",
+      "name": "fpereira1"
+    },
+    {
+      "email": "renee@kooi.me",
+      "name": "goto-bus-stop"
+    },
+    {
+      "email": "post.ben.here@gmail.com",
+      "name": "bpostlethwaite"
+    },
+    {
+      "email": "github@tixz.dk",
+      "name": "emilbayes"
+    },
+    {
+      "email": "maochenyan@gmail.com",
+      "name": "stevemao"
+    },
+    {
+      "email": "peteris.krumins@gmail.com",
+      "name": "pkrumins"
+    },
+    {
+      "email": "me@JoshDuff.com",
+      "name": "tehshrike"
+    },
+    {
+      "email": "raynos2@gmail.com",
+      "name": "raynos"
+    }
+  ],
+  "time": {
+    "modified": "2020-02-01T21:46:24.953Z",
+    "created": "2013-01-27T05:05:36.936Z",
+    "0.1.0": "2013-01-27T05:05:37.892Z",
+    "0.1.1": "2013-01-27T05:15:25.967Z",
+    "0.1.2": "2013-01-27T05:20:25.376Z",
+    "0.1.3": "2013-01-27T05:42:25.110Z",
+    "0.1.4": "2013-01-29T22:33:05.762Z",
+    "0.1.5": "2013-01-30T02:59:39.845Z",
+    "0.1.6": "2013-02-05T04:59:35.082Z",
+    "1.0.1": "2013-09-23T18:45:29.638Z",
+    "1.0.2": "2013-12-13T18:33:49.234Z",
+    "1.0.3": "2013-12-13T18:39:56.650Z",
+    "1.1.0": "2014-04-08T20:30:24.778Z",
+    "1.2.0": "2019-10-28T08:44:20.862Z"
+  },
+  "author": {
+    "name": "Raynos",
+    "email": "raynos2@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/browserify/console-browserify.git"
+  },
+  "homepage": "https://github.com/browserify/console-browserify",
+  "keywords": [],
+  "contributors": [
+    {
+      "name": "Raynos"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/browserify/console-browserify/issues",
+    "email": "raynos2@gmail.com"
+  },
+  "readmeFilename": "README.md",
+  "users": {
+    "binnng": true,
+    "simplyianm": true,
+    "erikvold": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/console-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/console-browserify.min.json
@@ -1,0 +1,201 @@
+{
+  "name": "console-browserify",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "console-browserify",
+      "version": "0.1.0",
+      "dependencies": {
+        "date-now": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55"
+      },
+      "dist": {
+        "shasum": "8b268ddd05d6d6162f6bbd9f7a7316042fc63c42",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.0.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.1.1": {
+      "name": "console-browserify",
+      "version": "0.1.1",
+      "dependencies": {
+        "date-now": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55"
+      },
+      "dist": {
+        "shasum": "1f7b530e8a94e28e8d7579bc21a18c076ed38874",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.1.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.1.2": {
+      "name": "console-browserify",
+      "version": "0.1.2",
+      "dependencies": {
+        "date-now": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55"
+      },
+      "dist": {
+        "shasum": "9e8d6a7cdada01b60d178f57b1aa7c7b2dba1551",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.2.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.1.3": {
+      "name": "console-browserify",
+      "version": "0.1.3",
+      "dependencies": {
+        "date-now": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55"
+      },
+      "dist": {
+        "shasum": "0d5b48bddb6ab922f968fd55e29e018996a462d9",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.3.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.1.4": {
+      "name": "console-browserify",
+      "version": "0.1.4",
+      "dependencies": {
+        "date-now": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "dist": {
+        "shasum": "42efecda651fe1896311221e964ada4ad1b45f81",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "console-browserify",
+      "version": "0.1.5",
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "dist": {
+        "shasum": "3e4c5360d4b7214d9dccbd581b9f7e1ff0b2a8db",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.5.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "console-browserify",
+      "version": "0.1.6",
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "dist": {
+        "shasum": "d128a3c0bb88350eb5626c6e7c71a6f0fd48983c",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-0.1.6.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "console-browserify",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "dist": {
+        "shasum": "86d35db62438704ebfa4285232f307b85d5376df",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "console-browserify",
+      "version": "1.0.2",
+      "devDependencies": {
+        "tape": "~0.2.2",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "dist": {
+        "shasum": "def1cea1e03f5436332323a2bed8112337f94475",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "console-browserify",
+      "version": "1.0.3",
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "browserify": "https://github.com/raynos/node-browserify/tarball/master",
+        "testem": "~0.2.55",
+        "jsonify": "0.0.0"
+      },
+      "dist": {
+        "shasum": "d3898d2c3a93102f364197f8874b4f92b5286a8e",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.3.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "console-browserify",
+      "version": "1.1.0",
+      "dependencies": {
+        "date-now": "^0.1.4"
+      },
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "jsonify": "0.0.0",
+        "tap-spec": "^0.1.8",
+        "run-browser": "^1.3.0",
+        "tap-dot": "^0.2.1"
+      },
+      "dist": {
+        "shasum": "f0241c45730a9fc6323b206dbf38edc741d0bb10",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "console-browserify",
+      "version": "1.2.0",
+      "devDependencies": {
+        "tape": "^2.12.3",
+        "jsonify": "0.0.0",
+        "tap-spec": "^0.1.8",
+        "run-browser": "^1.3.0",
+        "tap-dot": "^0.2.1"
+      },
+      "dist": {
+        "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+        "shasum": "67063cef57ceb6cf4993a2ab3a55840ae8c49336",
+        "tarball": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 10275,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdtqplCRA9TVsSAnZWagAAF6cP/1Kx1sQ8vaSWWu2ozb8k\nXs1npZM3BjXVFPI60LBFrHzOSRvKaleYb0LuXAFs4WdS4z8xTphfZWTxmeYU\nXF7EWJ0JmF5fgUxIp1tnfMuOLJeWe5xzO7mAvQtBxgKjP0aivmUeQrW2I7Dg\nsr9RBz16A7xmL2bBBKovvrnEYmK/CP1FGxM+GQPEZyUN/5qOoc0r3o2y+/08\nH6XjJBHYlMCwZYKmRI4CEmgd7FT1Z0EPBOpXdoeWOPZTcFZzP6Guij/AfKwP\nHBQxDFcYPOX+E4tI/9k8eq7bw7a02SfE67N1Q57IDslykwKY2uNoMdLqTBfz\nbeJaOsha+SpScjzlfuYgvEyaUbfrXfeo8cga/Ebq7OlgEQginGio2cYponat\nLNryKWGGXGnLPnjY8zS2qLqbHzS1wEu38Atuq7uvZamGgvX8KIvFBO82n373\nSotFzdAjb3s6gEoSIBu6bmCIXGG1LoFAGXOMs2UapF02eV0BClTE1IMitQpk\nRx+sRmkbFbaWzkB+BmODAT59oogC6yjGEx7wpGE9ca3HGXjV7O76PnvOj8NX\nvSpFqaDbehb/B5o9b+MR1WWG2anj8n1TFuEJOUfDaZEu6Tgubk7lYFUblhLV\n0JQCQFXuL5Gj8ybPi57CTkEcLmrI9n9CWJI2/5BWWCOiOMVRHiBnLooha/0h\nMn45\r\n=Ksg7\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-02-01T21:46:24.953Z"
+}

--- a/test/fixtures/registry-mocks/content/constants-browserify.json
+++ b/test/fixtures/registry-mocks/content/constants-browserify.json
@@ -1,0 +1,206 @@
+{
+  "_id": "constants-browserify",
+  "_rev": "8-1ae917d0940dcd2281ecdd6527ca205e",
+  "name": "constants-browserify",
+  "description": "node's constants module for the browser",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "constants-browserify",
+      "description": "node's constants module for the browser",
+      "version": "0.0.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/juliangruber/constants-browserify.git"
+      },
+      "homepage": "https://github.com/juliangruber/constants-browserify",
+      "main": "index.js",
+      "dependencies": {},
+      "keywords": [
+        "constants",
+        "node",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "Julian Gruber",
+        "email": "mail@juliangruber.com",
+        "url": "http://juliangruber.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/juliangruber/constants-browserify/issues"
+      },
+      "_id": "constants-browserify@0.0.0",
+      "dist": {
+        "shasum": "4de3072df4c582fda906a8e5f627c76d0a9a1dce",
+        "tarball": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "juliangruber",
+        "email": "julian@juliangruber.com"
+      },
+      "maintainers": [
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "constants-browserify",
+      "description": "node's constants module for the browser",
+      "version": "0.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/juliangruber/constants-browserify.git"
+      },
+      "homepage": "https://github.com/juliangruber/constants-browserify",
+      "main": "constants.json",
+      "dependencies": {},
+      "keywords": [
+        "constants",
+        "node",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "Julian Gruber",
+        "email": "julian@juliangruber.com",
+        "url": "http://juliangruber.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/juliangruber/constants-browserify/issues"
+      },
+      "_id": "constants-browserify@0.0.1",
+      "dist": {
+        "shasum": "92577db527ba6c4cf0a4568d84bc031f441e21f2",
+        "tarball": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "juliangruber",
+        "email": "julian@juliangruber.com"
+      },
+      "maintainers": [
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "constants-browserify",
+      "description": "node's constants module for the browser",
+      "version": "1.0.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/juliangruber/constants-browserify.git"
+      },
+      "homepage": "https://github.com/juliangruber/constants-browserify",
+      "main": "constants.json",
+      "dependencies": {},
+      "keywords": [
+        "constants",
+        "node",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "Julian Gruber",
+        "email": "julian@juliangruber.com",
+        "url": "http://juliangruber.com"
+      },
+      "scripts": {
+        "test": "node test.js"
+      },
+      "contributors": [
+        {
+          "name": "James J. Womack",
+          "email": "james@womack.io",
+          "url": "http://netflix.com"
+        }
+      ],
+      "license": "MIT",
+      "gitHead": "e0ee990c75f3a0b3275e6bb2e3ff4d5d169d1b9d",
+      "bugs": {
+        "url": "https://github.com/juliangruber/constants-browserify/issues"
+      },
+      "_id": "constants-browserify@1.0.0",
+      "_shasum": "c20b96d8c617748aaf1c16021760cd27fcb8cb75",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "juliangruber",
+        "email": "julian@juliangruber.com"
+      },
+      "maintainers": [
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c20b96d8c617748aaf1c16021760cd27fcb8cb75",
+        "tarball": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "\n# constants-browserify\n\nNode's `constants` module for the browser.\n\n[![downloads](https://img.shields.io/npm/dm/constants-browserify.svg)](https://www.npmjs.org/package/constants-browserify)\n\n## Usage\n\nTo use with browserify cli:\n\n```bash\n$ browserify -r constants:constants-browserify script.js\n```\n\nTo use with browserify api:\n\n```js\nbrowserify()\n  .require('constants-browserify', { expose: 'constants' })\n  .add(__dirname + '/script.js')\n  .bundle()\n  // ...\n```\n\n## Installation\n\nWith [npm](http://npmjs.org) do\n\n```bash\n$ npm install constants-browserify\n```\n\n## License\n\nCopyright (c) 2013 Julian Gruber &lt;julian@juliangruber.com&gt;\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "juliangruber",
+      "email": "julian@juliangruber.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-06-30T15:55:55.569Z",
+    "created": "2013-07-10T15:38:41.881Z",
+    "0.0.0": "2013-07-10T15:38:44.928Z",
+    "0.0.1": "2013-07-20T17:35:00.887Z",
+    "1.0.0": "2015-07-13T18:16:42.306Z"
+  },
+  "author": {
+    "name": "Julian Gruber",
+    "email": "julian@juliangruber.com",
+    "url": "http://juliangruber.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/juliangruber/constants-browserify.git"
+  },
+  "users": {
+    "simplyianm": true,
+    "erikvold": true
+  },
+  "homepage": "https://github.com/juliangruber/constants-browserify",
+  "keywords": [
+    "constants",
+    "node",
+    "browser",
+    "browserify"
+  ],
+  "bugs": {
+    "url": "https://github.com/juliangruber/constants-browserify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "James J. Womack",
+      "email": "james@womack.io",
+      "url": "http://netflix.com"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/constants-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/constants-browserify.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "constants-browserify",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "constants-browserify",
+      "version": "0.0.0",
+      "dist": {
+        "shasum": "4de3072df4c582fda906a8e5f627c76d0a9a1dce",
+        "tarball": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "constants-browserify",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "92577db527ba6c4cf0a4568d84bc031f441e21f2",
+        "tarball": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "constants-browserify",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "c20b96d8c617748aaf1c16021760cd27fcb8cb75",
+        "tarball": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
+      }
+    }
+  },
+  "modified": "2017-06-30T15:55:55.569Z"
+}

--- a/test/fixtures/registry-mocks/content/content-disposition.json
+++ b/test/fixtures/registry-mocks/content/content-disposition.json
@@ -1,0 +1,791 @@
+{
+  "_id": "content-disposition",
+  "_rev": "34-a5ca17912ddb4f9477b0ff4574f3d890",
+  "name": "content-disposition",
+  "description": "Create and parse Content-Disposition header",
+  "dist-tags": {
+    "latest": "0.5.3"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "content-disposition",
+      "description": "Create an attachment Content-Disposition header",
+      "version": "0.0.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "5ab443630137b8adfa5b030d9375d00ae5fcf286",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.0.0",
+      "_shasum": "836890c43058eb815cf16b9e8c190ec6221330a2",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "836890c43058eb815cf16b9e8c190ec6221330a2",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "content-disposition",
+      "description": "Create an attachment Content-Disposition header",
+      "version": "0.1.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "66b641f4a42ae66d762ec4995ebad6d75db86e7d",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.1.0",
+      "_shasum": "66658a81614f35b209fab5562feeeb4acf25105c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "66658a81614f35b209fab5562feeeb4acf25105c",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "content-disposition",
+      "description": "Create an attachment Content-Disposition header",
+      "version": "0.1.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ef54df731e18d33ba33562479c8e51e618817b81",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.1.1",
+      "_shasum": "73affd67d9f2795cbc1a28869c6c5b5c469b6e45",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "73affd67d9f2795cbc1a28869c6c5b5c469b6e45",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "content-disposition",
+      "description": "Create an attachment Content-Disposition header",
+      "version": "0.2.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "5769394c412b559cc3c11d50e4ee52939cb06248",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.2.0",
+      "_shasum": "74cd6d87997f23fa4d72e3dab5cc0bf2be1fe0ce",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "74cd6d87997f23fa4d72e3dab5cc0bf2be1fe0ce",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "content-disposition",
+      "description": "Create an attachment Content-Disposition header",
+      "version": "0.1.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "775f752ec49d564eacd0ea6b508e3658f7c0d9b6",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.1.2",
+      "_shasum": "df995b34be2a2c0c205ea5887d25eb598403e7bf",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "df995b34be2a2c0c205ea5887d25eb598403e7bf",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "content-disposition",
+      "description": "Create an attachment Content-Disposition header",
+      "version": "0.3.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f347389f873d79ea7b529bf05857f1ef8ddf98d6",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.3.0",
+      "_shasum": "c416865f3637ccfdfe954604b8dce158ea6ec075",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c416865f3637ccfdfe954604b8dce158ea6ec075",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "content-disposition",
+      "description": "Create an attachment Content-Disposition header",
+      "version": "0.4.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f09cb955eb1ed0db2d0ed2708a5c95e6f119ad50",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.4.0",
+      "_shasum": "e91e43f22fd1d58b44dfe0cf089502fa9ffec2bb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e91e43f22fd1d58b44dfe0cf089502fa9ffec2bb",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "content-disposition",
+      "description": "Create and parse Content-Disposition header",
+      "version": "0.5.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f3c915f0c9d9f5ec79713dba24c8c6181b73305d",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.5.0",
+      "_shasum": "4284fe6ae0630874639e44e80a418c2934135e9e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4284fe6ae0630874639e44e80a418c2934135e9e",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "content-disposition",
+      "description": "Create and parse Content-Disposition header",
+      "version": "0.5.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-disposition"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "7b391db3af5629d4c698f1de21802940bb9f22a5",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition",
+      "_id": "content-disposition@0.5.1",
+      "_shasum": "87476c6a67c8daa87e32e87616df883ba7fb071b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "87476c6a67c8daa87e32e87616df883ba7fb071b",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "content-disposition",
+      "description": "Create and parse Content-Disposition header",
+      "version": "0.5.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/content-disposition.git"
+      },
+      "devDependencies": {
+        "eslint": "3.11.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.3.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "2a08417377cf55678c9f870b305f3c6c088920f3",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition#readme",
+      "_id": "content-disposition@0.5.2",
+      "_shasum": "0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/content-disposition-0.5.2.tgz_1481246224565_0.35659545403905213"
+      },
+      "directories": {}
+    },
+    "0.5.3": {
+      "name": "content-disposition",
+      "description": "Create and parse Content-Disposition header",
+      "version": "0.5.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "content-disposition",
+        "http",
+        "rfc6266",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/content-disposition.git"
+      },
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "devDependencies": {
+        "deep-equal": "1.0.1",
+        "eslint": "5.10.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-rc.1",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "5.2.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f6d7cba7ea09dfea1492d5ffe438fe2f2e3cc3bb",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-disposition/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-disposition#readme",
+      "_id": "content-disposition@0.5.3",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.14.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+        "shasum": "e130caf7e7279087c5616c2007d0485698984fbd",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19115,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcGAStCRA9TVsSAnZWagAAvYUP/1EacAGPVQ+v81km3r0i\n9KorME5iKSDmfrmTmwPqebr9nzY/KupheRlT5dHnxcrSaLVbWRPdxWIG1YbP\nMel73EUEea8hE+CW5X1ThiEAG/UwaNGH5LI0J/K9WG+AHlPRd7soSrPtZ2gV\nnWWKx9g5tjE4j3qH8fhMb+cmrZOAR5xq19st5w5YC1gchmxJftw+VjuyWneW\nOMylWGW3aBAD1lL3uRgdG+FddffUydUsjshi1U0Dq4Pd4JP/skJBJpnF2DmM\nFtbKJd2X+Ff1632wakl2htvnhpDoRwnY60Xkzuz8GeQqi31j8Ll5rvneEMcA\nl5ZJSW3VHJJYJQ0xCay/snWqCo4M40fwFheunTpsXcvjwNxH8qktRTR/8MxU\nHFWQHOUZrK3iNNOOLV4lo8BaQc+8vvqjkBShxOEs0U9ZVNU1lHD3ieBKjGVB\nM29v2L4RTA0URwNP+5a9GCwFz1BJoOLiZcdMu7VsA7cG4cE4eFfbHW3dl3Tx\nekcfYc0dVI2XQZA02RzHNHrgy+gUrpZtp+takxq5buU7fSMX327eJLyOhGzM\n63bThVu5bH7CpOzRvbZNkupDbWgHfue16RKouL0Hr4+lrYdc4TuU8HLCYs+K\n5SP+gtxAvbs6FDp5IOf8OptfYYQsi26GOnW5AzcyeHUyPWFLkT5sLb4Ihi7s\nwfu6\r\n=iuNE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/content-disposition_0.5.3_1545077932478_0.35856888210069715"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# content-disposition\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nCreate and parse HTTP `Content-Disposition` header\n\n## Installation\n\n```sh\n$ npm install content-disposition\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar contentDisposition = require('content-disposition')\n```\n\n### contentDisposition(filename, options)\n\nCreate an attachment `Content-Disposition` header value using the given file name,\nif supplied. The `filename` is optional and if no file name is desired, but you\nwant to specify `options`, set `filename` to `undefined`.\n\n<!-- eslint-disable no-undef -->\n\n```js\nres.setHeader('Content-Disposition', contentDisposition('∫ maths.pdf'))\n```\n\n**note** HTTP headers are of the ISO-8859-1 character set. If you are writing this\nheader through a means different from `setHeader` in Node.js, you'll want to specify\nthe `'binary'` encoding in Node.js.\n\n#### Options\n\n`contentDisposition` accepts these properties in the options object.\n\n##### fallback\n\nIf the `filename` option is outside ISO-8859-1, then the file name is actually\nstored in a supplemental field for clients that support Unicode file names and\na ISO-8859-1 version of the file name is automatically generated.\n\nThis specifies the ISO-8859-1 file name to override the automatic generation or\ndisables the generation all together, defaults to `true`.\n\n  - A string will specify the ISO-8859-1 file name to use in place of automatic\n    generation.\n  - `false` will disable including a ISO-8859-1 file name and only include the\n    Unicode version (unless the file name is already ISO-8859-1).\n  - `true` will enable automatic generation if the file name is outside ISO-8859-1.\n\nIf the `filename` option is ISO-8859-1 and this option is specified and has a\ndifferent value, then the `filename` option is encoded in the extended field\nand this set as the fallback field, even though they are both ISO-8859-1.\n\n##### type\n\nSpecifies the disposition type, defaults to `\"attachment\"`. This can also be\n`\"inline\"`, or any other value (all values except inline are treated like\n`attachment`, but can convey additional information if both parties agree to\nit). The type is normalized to lower-case.\n\n### contentDisposition.parse(string)\n\n<!-- eslint-disable no-undef, no-unused-vars -->\n\n```js\nvar disposition = contentDisposition.parse('attachment; filename=\"EURO rates.txt\"; filename*=UTF-8\\'\\'%e2%82%ac%20rates.txt')\n```\n\nParse a `Content-Disposition` header string. This automatically handles extended\n(\"Unicode\") parameters by decoding them and providing them under the standard\nparameter name. This will return an object with the following properties (examples\nare shown for the string `'attachment; filename=\"EURO rates.txt\"; filename*=UTF-8\\'\\'%e2%82%ac%20rates.txt'`):\n\n - `type`: The disposition type (always lower case). Example: `'attachment'`\n\n - `parameters`: An object of the parameters in the disposition (name of parameter\n   always lower case and extended versions replace non-extended versions). Example:\n   `{filename: \"€ rates.txt\"}`\n\n## Examples\n\n### Send a file for download\n\n```js\nvar contentDisposition = require('content-disposition')\nvar destroy = require('destroy')\nvar fs = require('fs')\nvar http = require('http')\nvar onFinished = require('on-finished')\n\nvar filePath = '/path/to/public/plans.pdf'\n\nhttp.createServer(function onRequest (req, res) {\n  // set headers\n  res.setHeader('Content-Type', 'application/pdf')\n  res.setHeader('Content-Disposition', contentDisposition(filePath))\n\n  // send file\n  var stream = fs.createReadStream(filePath)\n  stream.pipe(res)\n  onFinished(res, function () {\n    destroy(stream)\n  })\n})\n```\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## References\n\n- [RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1][rfc-2616]\n- [RFC 5987: Character Set and Language Encoding for Hypertext Transfer Protocol (HTTP) Header Field Parameters][rfc-5987]\n- [RFC 6266: Use of the Content-Disposition Header Field in the Hypertext Transfer Protocol (HTTP)][rfc-6266]\n- [Test Cases for HTTP Content-Disposition header field (RFC 6266) and the Encodings defined in RFCs 2047, 2231 and 5987][tc-2231]\n\n[rfc-2616]: https://tools.ietf.org/html/rfc2616\n[rfc-5987]: https://tools.ietf.org/html/rfc5987\n[rfc-6266]: https://tools.ietf.org/html/rfc6266\n[tc-2231]: http://greenbytes.de/tech/tc2231/\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/content-disposition.svg\n[npm-url]: https://npmjs.org/package/content-disposition\n[node-version-image]: https://img.shields.io/node/v/content-disposition.svg\n[node-version-url]: https://nodejs.org/en/download\n[travis-image]: https://img.shields.io/travis/jshttp/content-disposition.svg\n[travis-url]: https://travis-ci.org/jshttp/content-disposition\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/content-disposition.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/content-disposition?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/content-disposition.svg\n[downloads-url]: https://npmjs.org/package/content-disposition\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-11T07:25:20.805Z",
+    "created": "2014-09-19T05:02:12.936Z",
+    "0.0.0": "2014-09-19T05:02:12.936Z",
+    "0.1.0": "2014-09-19T05:39:30.525Z",
+    "0.1.1": "2014-09-19T15:11:29.395Z",
+    "0.2.0": "2014-09-20T07:26:06.901Z",
+    "0.1.2": "2014-09-20T07:27:06.106Z",
+    "0.3.0": "2014-09-21T00:36:24.194Z",
+    "0.4.0": "2014-10-11T22:03:04.039Z",
+    "0.5.0": "2014-10-11T22:06:03.045Z",
+    "0.5.1": "2016-01-17T21:02:33.711Z",
+    "0.5.2": "2016-12-09T01:17:05.156Z",
+    "0.5.3": "2018-12-17T20:18:52.643Z"
+  },
+  "homepage": "https://github.com/jshttp/content-disposition#readme",
+  "keywords": [
+    "content-disposition",
+    "http",
+    "rfc6266",
+    "res"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/content-disposition.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/content-disposition/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "superjoe": true,
+    "goodseller": true,
+    "simplyianm": true,
+    "vwal": true,
+    "jovaage": true,
+    "xieranmaya": true,
+    "wangnan0610": true,
+    "kistoryg": true,
+    "chaoliu": true,
+    "zuojiang": true
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  }
+}

--- a/test/fixtures/registry-mocks/content/content-disposition.min.json
+++ b/test/fixtures/registry-mocks/content/content-disposition.min.json
@@ -1,0 +1,193 @@
+{
+  "name": "content-disposition",
+  "dist-tags": {
+    "latest": "0.5.3"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "content-disposition",
+      "version": "0.0.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "836890c43058eb815cf16b9e8c190ec6221330a2",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.1.0": {
+      "name": "content-disposition",
+      "version": "0.1.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "66658a81614f35b209fab5562feeeb4acf25105c",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.1.1": {
+      "name": "content-disposition",
+      "version": "0.1.1",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "73affd67d9f2795cbc1a28869c6c5b5c469b6e45",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.2.0": {
+      "name": "content-disposition",
+      "version": "0.2.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "74cd6d87997f23fa4d72e3dab5cc0bf2be1fe0ce",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.1.2": {
+      "name": "content-disposition",
+      "version": "0.1.2",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "df995b34be2a2c0c205ea5887d25eb598403e7bf",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.3.0": {
+      "name": "content-disposition",
+      "version": "0.3.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "c416865f3637ccfdfe954604b8dce158ea6ec075",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.4.0": {
+      "name": "content-disposition",
+      "version": "0.4.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "e91e43f22fd1d58b44dfe0cf089502fa9ffec2bb",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.0": {
+      "name": "content-disposition",
+      "version": "0.5.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "4284fe6ae0630874639e44e80a418c2934135e9e",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.1": {
+      "name": "content-disposition",
+      "version": "0.5.1",
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "87476c6a67c8daa87e32e87616df883ba7fb071b",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.2": {
+      "name": "content-disposition",
+      "version": "0.5.2",
+      "devDependencies": {
+        "eslint": "3.11.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.3.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.3": {
+      "name": "content-disposition",
+      "version": "0.5.3",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "devDependencies": {
+        "deep-equal": "1.0.1",
+        "eslint": "5.10.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-rc.1",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "5.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+        "shasum": "e130caf7e7279087c5616c2007d0485698984fbd",
+        "tarball": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19115,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcGAStCRA9TVsSAnZWagAAvYUP/1EacAGPVQ+v81km3r0i\n9KorME5iKSDmfrmTmwPqebr9nzY/KupheRlT5dHnxcrSaLVbWRPdxWIG1YbP\nMel73EUEea8hE+CW5X1ThiEAG/UwaNGH5LI0J/K9WG+AHlPRd7soSrPtZ2gV\nnWWKx9g5tjE4j3qH8fhMb+cmrZOAR5xq19st5w5YC1gchmxJftw+VjuyWneW\nOMylWGW3aBAD1lL3uRgdG+FddffUydUsjshi1U0Dq4Pd4JP/skJBJpnF2DmM\nFtbKJd2X+Ff1632wakl2htvnhpDoRwnY60Xkzuz8GeQqi31j8Ll5rvneEMcA\nl5ZJSW3VHJJYJQ0xCay/snWqCo4M40fwFheunTpsXcvjwNxH8qktRTR/8MxU\nHFWQHOUZrK3iNNOOLV4lo8BaQc+8vvqjkBShxOEs0U9ZVNU1lHD3ieBKjGVB\nM29v2L4RTA0URwNP+5a9GCwFz1BJoOLiZcdMu7VsA7cG4cE4eFfbHW3dl3Tx\nekcfYc0dVI2XQZA02RzHNHrgy+gUrpZtp+takxq5buU7fSMX327eJLyOhGzM\n63bThVu5bH7CpOzRvbZNkupDbWgHfue16RKouL0Hr4+lrYdc4TuU8HLCYs+K\n5SP+gtxAvbs6FDp5IOf8OptfYYQsi26GOnW5AzcyeHUyPWFLkT5sLb4Ihi7s\nwfu6\r\n=iuNE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2019-01-11T07:25:20.805Z"
+}

--- a/test/fixtures/registry-mocks/content/content-type.json
+++ b/test/fixtures/registry-mocks/content/content-type.json
@@ -1,0 +1,456 @@
+{
+  "_id": "content-type",
+  "_rev": "27-a5da291185c434a3ceb739269653d485",
+  "name": "content-type",
+  "description": "Create and parse HTTP Content-Type header",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "content-type",
+      "version": "0.0.1",
+      "description": "Javascript/ECMAScript library for parsing Content-Type and Media/MIME type strings",
+      "main": "content-type.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/deoxxa/content-type.git"
+      },
+      "keywords": [
+        "content-type",
+        "parse",
+        "http",
+        "header"
+      ],
+      "author": {
+        "name": "Austin Wright",
+        "email": "https://github.com/Acubed"
+      },
+      "license": "Unlicense <http://unlicense.org/>",
+      "bugs": {
+        "url": "https://github.com/deoxxa/content-type/issues"
+      },
+      "_id": "content-type@0.0.1",
+      "dist": {
+        "shasum": "b8dd2786f814b2c8d0985fdbea8a3d361366ea80",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "deoxxa",
+        "email": "deoxxa@fknsrs.biz"
+      },
+      "maintainers": [
+        {
+          "name": "deoxxa",
+          "email": "deoxxa@fknsrs.biz"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "content-type",
+      "description": "Create and parse HTTP Content-Type header",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "content-type",
+        "http",
+        "req",
+        "res",
+        "rfc7231"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-type"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "31266966b656ace33556e8dfd432b0790df82870",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-type/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-type",
+      "_id": "content-type@1.0.0",
+      "_shasum": "2b66ca456422371bd04e63fdda92501210f40be4",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "deoxxa",
+          "email": "deoxxa@fknsrs.biz"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2b66ca456422371bd04e63fdda92501210f40be4",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "content-type",
+      "description": "Create and parse HTTP Content-Type header",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "content-type",
+        "http",
+        "req",
+        "res",
+        "rfc7231"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/content-type"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "3aa58f9c5a358a3634b8601602177888b4a477d8",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-type/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-type",
+      "_id": "content-type@1.0.1",
+      "_shasum": "a19d2247327dc038050ce622b7a154ec59c5e600",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a19d2247327dc038050ce622b7a154ec59c5e600",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "content-type",
+      "description": "Create and parse HTTP Content-Type header",
+      "version": "1.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "content-type",
+        "http",
+        "req",
+        "res",
+        "rfc7231"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/content-type.git"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "8118763adfbbac80cf1254191889330aec8b8be7",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-type/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-type#readme",
+      "_id": "content-type@1.0.2",
+      "_shasum": "b7d113aee7a8dd27bd21133c4dc2529df1721eed",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "b7d113aee7a8dd27bd21133c4dc2529df1721eed",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/content-type-1.0.2.tgz_1462852785748_0.5491233412176371"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "content-type",
+      "description": "Create and parse HTTP Content-Type header",
+      "version": "1.0.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "content-type",
+        "http",
+        "req",
+        "res",
+        "rfc7231"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/content-type.git"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "255c440e81ffe0f3eaa4b4644360d2f352aeff48",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-type/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-type#readme",
+      "_id": "content-type@1.0.3",
+      "_shasum": "da18ef2fb64ca6acc905cc72017d3f38185b91d1",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "da18ef2fb64ca6acc905cc72017d3f38185b91d1",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/content-type-1.0.3.tgz_1505105047769_0.7591841116081923"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "content-type",
+      "description": "Create and parse HTTP Content-Type header",
+      "version": "1.0.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "content-type",
+        "http",
+        "req",
+        "res",
+        "rfc7231"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/content-type.git"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "d22f8ac6c407789c906bd6fed137efde8f772b09",
+      "bugs": {
+        "url": "https://github.com/jshttp/content-type/issues"
+      },
+      "homepage": "https://github.com/jshttp/content-type#readme",
+      "_id": "content-type@1.0.4",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+        "shasum": "e138cc75e040c727b1966fe5e5f8c9aee256fe3b",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/content-type-1.0.4.tgz_1505166155546_0.06956395204178989"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# content-type\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nCreate and parse HTTP Content-Type header according to RFC 7231\n\n## Installation\n\n```sh\n$ npm install content-type\n```\n\n## API\n\n```js\nvar contentType = require('content-type')\n```\n\n### contentType.parse(string)\n\n```js\nvar obj = contentType.parse('image/svg+xml; charset=utf-8')\n```\n\nParse a content type string. This will return an object with the following\nproperties (examples are shown for the string `'image/svg+xml; charset=utf-8'`):\n\n - `type`: The media type (the type and subtype, always lower case).\n   Example: `'image/svg+xml'`\n\n - `parameters`: An object of the parameters in the media type (name of parameter\n   always lower case). Example: `{charset: 'utf-8'}`\n\nThrows a `TypeError` if the string is missing or invalid.\n\n### contentType.parse(req)\n\n```js\nvar obj = contentType.parse(req)\n```\n\nParse the `content-type` header from the given `req`. Short-cut for\n`contentType.parse(req.headers['content-type'])`.\n\nThrows a `TypeError` if the `Content-Type` header is missing or invalid.\n\n### contentType.parse(res)\n\n```js\nvar obj = contentType.parse(res)\n```\n\nParse the `content-type` header set on the given `res`. Short-cut for\n`contentType.parse(res.getHeader('content-type'))`.\n\nThrows a `TypeError` if the `Content-Type` header is missing or invalid.\n\n### contentType.format(obj)\n\n```js\nvar str = contentType.format({type: 'image/svg+xml'})\n```\n\nFormat an object into a content type string. This will return a string of the\ncontent type for the given object with the following properties (examples are\nshown that produce the string `'image/svg+xml; charset=utf-8'`):\n\n - `type`: The media type (will be lower-cased). Example: `'image/svg+xml'`\n\n - `parameters`: An object of the parameters in the media type (name of the\n   parameter will be lower-cased). Example: `{charset: 'utf-8'}`\n\nThrows a `TypeError` if the object contains an invalid type or parameter names.\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/content-type.svg\n[npm-url]: https://npmjs.org/package/content-type\n[node-version-image]: https://img.shields.io/node/v/content-type.svg\n[node-version-url]: http://nodejs.org/download/\n[travis-image]: https://img.shields.io/travis/jshttp/content-type/master.svg\n[travis-url]: https://travis-ci.org/jshttp/content-type\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/content-type/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/content-type\n[downloads-image]: https://img.shields.io/npm/dm/content-type.svg\n[downloads-url]: https://npmjs.org/package/content-type\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-09T05:25:31.129Z",
+    "created": "2013-10-08T07:37:45.765Z",
+    "0.0.1": "2013-10-08T07:37:54.398Z",
+    "1.0.0": "2015-02-02T07:31:29.037Z",
+    "1.0.1": "2015-02-14T00:37:57.925Z",
+    "1.0.2": "2016-05-10T03:59:48.395Z",
+    "1.0.3": "2017-09-11T04:44:08.721Z",
+    "1.0.4": "2017-09-11T21:42:36.476Z"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/content-type.git"
+  },
+  "keywords": [
+    "content-type",
+    "http",
+    "req",
+    "res",
+    "rfc7231"
+  ],
+  "bugs": {
+    "url": "https://github.com/jshttp/content-type/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jshttp/content-type#readme",
+  "users": {
+    "goodseller": true,
+    "simplyianm": true,
+    "qqqppp9998": true,
+    "rocket0191": true,
+    "snowdream": true,
+    "rbecheras": true,
+    "huhgawz": true,
+    "shanewholloway": true,
+    "eyson": true,
+    "zuojiang": true,
+    "semir2": true,
+    "zhenguo.zhao": true,
+    "hualei": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/content-type.min.json
+++ b/test/fixtures/registry-mocks/content/content-type.min.json
@@ -1,0 +1,105 @@
+{
+  "name": "content-type",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "content-type",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "b8dd2786f814b2c8d0985fdbea8a3d361366ea80",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-0.0.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "content-type",
+      "version": "1.0.0",
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "2b66ca456422371bd04e63fdda92501210f40be4",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.1": {
+      "name": "content-type",
+      "version": "1.0.1",
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "a19d2247327dc038050ce622b7a154ec59c5e600",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.2": {
+      "name": "content-type",
+      "version": "1.0.2",
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "b7d113aee7a8dd27bd21133c4dc2529df1721eed",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.3": {
+      "name": "content-type",
+      "version": "1.0.3",
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "da18ef2fb64ca6acc905cc72017d3f38185b91d1",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.4": {
+      "name": "content-type",
+      "version": "1.0.4",
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+        "shasum": "e138cc75e040c727b1966fe5e5f8c9aee256fe3b",
+        "tarball": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2019-01-09T05:25:31.129Z"
+}

--- a/test/fixtures/registry-mocks/content/cookie-signature.json
+++ b/test/fixtures/registry-mocks/content/cookie-signature.json
@@ -1,0 +1,493 @@
+{
+  "_id": "cookie-signature",
+  "_rev": "35-8b4b33597408fd99277233447971a296",
+  "name": "cookie-signature",
+  "description": "Sign and unsign cookies",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "cookie-signature",
+      "version": "0.0.1",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "cookie-signature@0.0.1",
+      "dist": {
+        "shasum": "13d3603b5cf63befbf85a8801e37aa900db46985",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "cookie-signature",
+      "version": "1.0.0",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "cookie-signature@1.0.0",
+      "dist": {
+        "shasum": "0044f332ac623df851c914e88eacc57f0c9704fe",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "cookie-signature",
+      "version": "1.0.1",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "_id": "cookie-signature@1.0.1",
+      "dist": {
+        "shasum": "44e072148af01e6e8e24afbf12690d68ae698ecb",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "cookie-signature",
+      "version": "1.0.2",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-cookie-signature.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-cookie-signature/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-cookie-signature",
+      "_id": "cookie-signature@1.0.2",
+      "dist": {
+        "shasum": "3d8ed55a70e4bcd474f699af0d03b5b652fe85ba",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "cookie-signature",
+      "version": "1.0.3",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-cookie-signature.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-cookie-signature/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-cookie-signature",
+      "_id": "cookie-signature@1.0.3",
+      "dist": {
+        "shasum": "91cd997cc51fb641595738c69cda020328f50ff9",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "cookie-signature",
+      "version": "1.0.4",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-cookie-signature.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-cookie-signature/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-cookie-signature",
+      "_id": "cookie-signature@1.0.4",
+      "dist": {
+        "shasum": "0edd22286e3a111b9a2a70db363e925e867f6aca",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "natevw",
+        "email": "natevw@yahoo.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "natevw",
+          "email": "natevw@yahoo.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "cookie-signature",
+      "version": "1.0.5",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-cookie-signature.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "main": "index",
+      "gitHead": "73ed69b511b3ef47555d71b4ed1deea9e5ed6e1f",
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-cookie-signature/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-cookie-signature",
+      "_id": "cookie-signature@1.0.5",
+      "scripts": {},
+      "_shasum": "a122e3f1503eca0f5355795b0711bb2368d450f9",
+      "_from": ".",
+      "_npmVersion": "1.4.20",
+      "_npmUser": {
+        "name": "natevw",
+        "email": "natevw@yahoo.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "natevw",
+          "email": "natevw@yahoo.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a122e3f1503eca0f5355795b0711bb2368d450f9",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "cookie-signature",
+      "version": "1.0.6",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-cookie-signature.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec"
+      },
+      "main": "index",
+      "gitHead": "391b56cf44d88c493491b7e3fc53208cfb976d2a",
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-cookie-signature/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-cookie-signature",
+      "_id": "cookie-signature@1.0.6",
+      "_shasum": "e303a882b342cc3ee8ca513a79999734dab3ae2c",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "natevw",
+        "email": "natevw@yahoo.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "natevw",
+          "email": "natevw@yahoo.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e303a882b342cc3ee8ca513a79999734dab3ae2c",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "cookie-signature",
+      "version": "1.1.0",
+      "description": "Sign and unsign cookies",
+      "keywords": [
+        "cookie",
+        "sign",
+        "unsign"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@learnboost.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/visionmedia/node-cookie-signature.git"
+      },
+      "dependencies": {},
+      "engines": {
+        "node": ">=6.6.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec"
+      },
+      "main": "index",
+      "gitHead": "1e5f40d6c1f631a7fa43992e82918c1d78dbdb89",
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-cookie-signature/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-cookie-signature#readme",
+      "_id": "cookie-signature@1.1.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "natevw",
+        "email": "natevw@yahoo.com"
+      },
+      "dist": {
+        "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==",
+        "shasum": "cc94974f91fb9a9c1bb485e95fc2b7f4b120aff2",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "natevw",
+          "email": "natevw@yahoo.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cookie-signature-1.1.0.tgz_1516336355373_0.5579380588606"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "\n# cookie-signature\n\n  Sign and unsign cookies.\n\n## Example\n\n```js\nvar cookie = require('cookie-signature');\n\nvar val = cookie.sign('hello', 'tobiiscool');\nval.should.equal('hello.DGDUkGlIkCzPz+C0B064FNgHdEjox7ch8tOBGslZ5QI');\n\nvar val = cookie.sign('hello', 'tobiiscool');\ncookie.unsign(val, 'tobiiscool').should.equal('hello');\ncookie.unsign(val, 'luna').should.be.false;\n```\n\n## License \n\n(The MIT License)\n\nCopyright (c) 2012 LearnBoost &lt;tj@learnboost.com&gt;\n\nPermission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n'Software'), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
+  "maintainers": [
+    {
+      "name": "tjholowaychuk",
+      "email": "tj@vision-media.ca"
+    },
+    {
+      "name": "natevw",
+      "email": "natevw@yahoo.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-08-03T00:40:07.759Z",
+    "created": "2012-10-15T15:53:32.007Z",
+    "0.0.1": "2012-10-15T15:53:33.933Z",
+    "1.0.0": "2013-04-12T19:07:28.737Z",
+    "1.0.1": "2013-04-15T19:29:17.362Z",
+    "1.0.2": "2014-01-29T00:00:59.981Z",
+    "1.0.3": "2014-01-29T01:15:41.790Z",
+    "1.0.4": "2014-06-25T22:14:18.119Z",
+    "1.0.5": "2014-09-05T23:22:06.935Z",
+    "1.0.6": "2015-02-03T22:23:15.095Z",
+    "1.1.0": "2018-01-19T04:32:35.808Z"
+  },
+  "author": {
+    "name": "TJ Holowaychuk",
+    "email": "tj@learnboost.com"
+  },
+  "users": {
+    "285858315": true,
+    "haiyang5210": true,
+    "dgarlitt": true,
+    "simplyianm": true,
+    "ivansky": true,
+    "awangxh": true,
+    "panlw": true,
+    "qbylucky": true,
+    "milfromoz": true,
+    "nickeltobias": true,
+    "giussa_dan": true,
+    "yong_a": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/visionmedia/node-cookie-signature.git"
+  },
+  "readmeFilename": "Readme.md",
+  "homepage": "https://github.com/visionmedia/node-cookie-signature#readme",
+  "keywords": [
+    "cookie",
+    "sign",
+    "unsign"
+  ],
+  "bugs": {
+    "url": "https://github.com/visionmedia/node-cookie-signature/issues"
+  },
+  "license": "MIT",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/cookie-signature.min.json
+++ b/test/fixtures/registry-mocks/content/cookie-signature.min.json
@@ -1,0 +1,121 @@
+{
+  "name": "cookie-signature",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "cookie-signature",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "13d3603b5cf63befbf85a8801e37aa900db46985",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-0.0.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "cookie-signature",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "0044f332ac623df851c914e88eacc57f0c9704fe",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "cookie-signature",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "44e072148af01e6e8e24afbf12690d68ae698ecb",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "cookie-signature",
+      "version": "1.0.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "3d8ed55a70e4bcd474f699af0d03b5b652fe85ba",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "cookie-signature",
+      "version": "1.0.3",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "91cd997cc51fb641595738c69cda020328f50ff9",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "cookie-signature",
+      "version": "1.0.4",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "0edd22286e3a111b9a2a70db363e925e867f6aca",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "cookie-signature",
+      "version": "1.0.5",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "a122e3f1503eca0f5355795b0711bb2368d450f9",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+      }
+    },
+    "1.0.6": {
+      "name": "cookie-signature",
+      "version": "1.0.6",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "e303a882b342cc3ee8ca513a79999734dab3ae2c",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "cookie-signature",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==",
+        "shasum": "cc94974f91fb9a9c1bb485e95fc2b7f4b120aff2",
+        "tarball": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    }
+  },
+  "modified": "2018-08-03T00:40:07.759Z"
+}

--- a/test/fixtures/registry-mocks/content/cookie.json
+++ b/test/fixtures/registry-mocks/content/cookie.json
@@ -1,0 +1,1488 @@
+{
+  "_id": "cookie",
+  "_rev": "124-13988ff040c44fb2aeb7c07178147dfd",
+  "name": "cookie",
+  "description": "HTTP server cookie parsing and serialization",
+  "dist-tags": {
+    "latest": "0.4.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.0.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "_id": "cookie@0.0.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.12",
+      "_nodeVersion": "v0.6.14",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "a134b9c981df85c8a67b1620be5a36c0db1bdc63",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "_id": "cookie@0.0.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.12",
+      "_nodeVersion": "v0.6.14",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "3162dd34ea833740e2e0d6e7129f2dcd55dcf7ed",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.0.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "_id": "cookie@0.0.2",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.12",
+      "_nodeVersion": "v0.6.14",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "17aedf62bc6af53745fecb55c45c3f097c2e858b",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.0.3",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "_id": "cookie@0.0.3",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.21",
+      "_nodeVersion": "v0.7.10-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "732b0e64cb77186954f5e36b0b6bcfd062a12e91",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.0.4",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "_id": "cookie@0.0.4",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.24",
+      "_nodeVersion": "v0.6.20-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "5456bd47aee2666eac976ea80a6105940483fe98",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.0.5",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_id": "cookie@0.0.5",
+      "dist": {
+        "shasum": "f9acf9db57eb7568c9fcc596256b7bb22e307c81",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.6": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.0.6",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_id": "cookie@0.0.6",
+      "dist": {
+        "shasum": "7bc6bb50205dcb98cf13ad09d6c60bc523f6fcb7",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_id": "cookie@0.1.0",
+      "dist": {
+        "shasum": "90eb469ddce905c866de687efc43131d8801f9d0",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.1.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/shtylman/node-cookie/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-cookie",
+      "_id": "cookie@0.1.1",
+      "dist": {
+        "shasum": "cbd4b537aa65f800b6c66ead2520ba8d6afbdf54",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.1.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-cookie.git"
+      },
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/shtylman/node-cookie/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-cookie",
+      "_id": "cookie@0.1.2",
+      "dist": {
+        "shasum": "72fec3d24e48a3432073d90c12642005061004b1",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.1.3",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "1.x.x"
+      },
+      "files": [
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "f46097723c16f920a7b9759e154c34792e1d1a3b",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.1.3",
+      "_shasum": "e734a5c1417fce472d5aef82c381cabb64d1a435",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e734a5c1417fce472d5aef82c381cabb64d1a435",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.2.0",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "e0d36be803099855dfa323de092eed97bec155bd",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.2.0",
+      "_shasum": "9708beeaa361857de7d16516fea779572625caad",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9708beeaa361857de7d16516fea779572625caad",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.1.4",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "337c0f1be395c1b62b8cae4306a745012c62a989",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.1.4",
+      "_shasum": "4955c0bd32fffa83b7433586185875876ea04e4b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4955c0bd32fffa83b7433586185875876ea04e4b",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.2.1",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "f3b5262b23b8eb64c9cbebc6f6271894889b14b1",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.2.1",
+      "_shasum": "e1bc7c07d1985c17ad7347502bac1a0eb072ac9a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e1bc7c07d1985c17ad7347502bac1a0eb072ac9a",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.1.5",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "0dfc4876575cef2609cdc1082fccf832743822c2",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.1.5",
+      "_shasum": "6ab9948a4b1ae21952cd2588530a4722d4044d7c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6ab9948a4b1ae21952cd2588530a4722d4044d7c",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.2.2",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "9b481be547730c5f487364b720ab298d097541d5",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.2.2",
+      "_shasum": "579ef8bc9b2d6f7e975a16bf4164d572e752e540",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "579ef8bc9b2d6f7e975a16bf4164d572e752e540",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.2.3",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.22",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "35326af88e9665bb8ea1be280cb827523e9360a7",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.2.3",
+      "_shasum": "1a59536af68537a21178a01346f87cb059d2ae5c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1a59536af68537a21178a01346f87cb059d2ae5c",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.4": {
+      "name": "cookie",
+      "description": "cookie parsing and serialization",
+      "version": "0.2.4",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "0c6fe48e2976d66ed73c03817bb5cb10180b50ee",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.2.4",
+      "_shasum": "a8c155aa7b9b2cf2c4d32ebc7b9a0aa288ccc6bd",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a8c155aa7b9b2cf2c4d32ebc7b9a0aa288ccc6bd",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/cookie-0.2.4.tgz_1463790764235_0.7945549874566495"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "cookie",
+      "description": "HTTP server cookie parsing and serialization",
+      "version": "0.3.0",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "91b733fbe29ae6fcfa305f8e8ff31a1c2e651feb",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.3.0",
+      "_shasum": "a4bdd609d86748a5ce6c64d7ede6f4840ba434d8",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a4bdd609d86748a5ce6c64d7ede6f4840ba434d8",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.3.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cookie-0.3.0.tgz_1464310839393_0.722841773647815"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "cookie",
+      "description": "HTTP server cookie parsing and serialization",
+      "version": "0.3.1",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/cookie"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "e3c77d497d66c8b8d4b677b8954c1b192a09f0b3",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie",
+      "_id": "cookie@0.3.1",
+      "_shasum": "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/cookie-0.3.1.tgz_1464323556714_0.6435900838114321"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "cookie",
+      "description": "HTTP server cookie parsing and serialization",
+      "version": "0.4.0",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/cookie.git"
+      },
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "5.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "aec1177c7da67e3b3273df96cf476824dbc9ae09",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie#readme",
+      "_id": "cookie@0.4.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+        "shasum": "beb437e7022b3b6d49019d088665303ebe9c14ba",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17858,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3NhPCRA9TVsSAnZWagAADA4P/0Y8HkoR7zm45iuEtjAd\nEfcXA4oFAC9rTJtAWNcmDGwTW1HxfIX3M9ci8WSjlwbEqWsvE6XJYq4yjhZq\ncwj7IRftR1aGaGusZPrBQTXnwqMvRKTFG4ZMwH/IeeoEtmBq9hJJZX8yXjNL\nZbaAq84JTiGriMb9kjS+sizB6dHMUrCN4SDTP6EUEAVuF6lIVrikG3G6i7am\nqXeFIVXJQFn31/MRV/258l6eOefuPTlgWqpiBBLSScxSOSsyLhW2+FTpZ1Ga\n8wqAhQVf0JATKrElCH5x2u2slNxOI8FltAwxfMFHzN/5Q2XlOFznqFqoO1l6\nEYF0NgJQZXBQuKWIAVIyqwBZ5fQ9+lhjKtVqCGbcw9I2U+TRK0eHMNDgI+pR\nebdSwAhVWGTp0o2ahqhQBW/CB+tPgIjgy0lPRg5ioPs9noBb6AZZ5H9I0Ffm\niWO1FsneQYbFL+2IM/P3rIQefwFTParMXRuq70XxuVcU+cTXNi4X8lzH8KiJ\ncnq3Pit6czof7+OvNBWQAIq++d6z1tMq+ELOqp7L0QogZl7OGI/nFtZQrTbn\n2VtTg4su5j/zkE350pwTXirnRkS/9AiignuLco2H9PspMxEadPnmmakwErZJ\n+KXAFLAHZhgxfa7meSbFFoYDarbpuizUzDDULbUM0murTVR2dAYZUnCByEoi\nvmIe\r\n=Oa0u\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cookie_0.4.0_1557977167056_0.23732140409492142"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.4.1": {
+      "name": "cookie",
+      "description": "HTTP server cookie parsing and serialization",
+      "version": "0.4.1",
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "cookie",
+        "cookies"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/cookie.git"
+      },
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "6.8.0",
+        "eslint-plugin-markdown": "1.0.2",
+        "mocha": "7.1.1",
+        "nyc": "15.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks --ui qunit test/",
+        "test-ci": "nyc --reporter=text npm test",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "b22458dd9f7ca94705fd7ee25780836601b913aa",
+      "bugs": {
+        "url": "https://github.com/jshttp/cookie/issues"
+      },
+      "homepage": "https://github.com/jshttp/cookie#readme",
+      "_id": "cookie@0.4.1",
+      "_nodeVersion": "13.12.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+        "shasum": "afd713fe26ebd21ba95ceb61f9a8116e50a537d1",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18123,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJen7jNCRA9TVsSAnZWagAAX/wP/j8Mcw3MQyifqWMFSZTL\nwpTBVC0/hRHh581NsIKtfF1fzWvRHKu+VPlGhMg1vqXoZweebf1H5Mwhlz7z\nDEiUiPQgCi6hXgdsUMxc+iDOFy2fQoPOKtY4LnfDA/vZMCok8QFLVWArl3CC\nLmA5Amh/Zfud0WkGzDGrjRQKWHRRAUVrQBZ6ziTM5KplDWy1PBSE59M3WYMY\nUFOdCEqk4xGEvW8YjkAkRSiY5Z8r8wcES4GkxaLsVFfpLJbI0cbRCen6b1uK\n4ZTGjwpnQKHPaywefIX1UTV8Em6D0QGweyc4CgTicMz+lPD9uZT8jmZr+Apy\nkcfen3enN1sKrn0e4p6AXOu1Ku38KeK0nLyU3ueo7/KzbAf8XVkbbsWdZ1Yr\nteOjmHDqv5k7B7616PSjyQJRmXhfB2FgR84MmyUbeEtOSStBaNPI7BxzA0Mj\nKvSfVDGxxO0dTb3Uu6QRF4tl8T2AFKarNzpik5VNvJpYsueISnGVG4J480YI\nz8L/Ayn3+BmW7GLtVU5nfXaMZBjGNryRRQFhju7tS0JOzbRgmUCRLK77NGUX\n+warQVVAXDJJgAVexSen90OLR+SSNq84HIBT9/UP70OLFxwndxB91XuDTuMO\nNot9PtZFUNZnv9ArYN/HGCRKDkJm98Gn0Pu5eJ4ITNA3iCE/urbSnVLzigSA\n11mU\r\n=IPIC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/cookie_0.4.1_1587525837181_0.04343373246138138"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# cookie\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nBasic HTTP cookie parser and serializer for HTTP servers.\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install cookie\n```\n\n## API\n\n```js\nvar cookie = require('cookie');\n```\n\n### cookie.parse(str, options)\n\nParse an HTTP `Cookie` header string and returning an object of all cookie name-value pairs.\nThe `str` argument is the string representing a `Cookie` header value and `options` is an\noptional object containing additional parsing options.\n\n```js\nvar cookies = cookie.parse('foo=bar; equation=E%3Dmc%5E2');\n// { foo: 'bar', equation: 'E=mc^2' }\n```\n\n#### Options\n\n`cookie.parse` accepts these properties in the options object.\n\n##### decode\n\nSpecifies a function that will be used to decode a cookie's value. Since the value of a cookie\nhas a limited character set (and must be a simple string), this function can be used to decode\na previously-encoded cookie value into a JavaScript string or other object.\n\nThe default function is the global `decodeURIComponent`, which will decode any URL-encoded\nsequences into their byte representations.\n\n**note** if an error is thrown from this function, the original, non-decoded cookie value will\nbe returned as the cookie's value.\n\n### cookie.serialize(name, value, options)\n\nSerialize a cookie name-value pair into a `Set-Cookie` header string. The `name` argument is the\nname for the cookie, the `value` argument is the value to set the cookie to, and the `options`\nargument is an optional object containing additional serialization options.\n\n```js\nvar setCookie = cookie.serialize('foo', 'bar');\n// foo=bar\n```\n\n#### Options\n\n`cookie.serialize` accepts these properties in the options object.\n\n##### domain\n\nSpecifies the value for the [`Domain` `Set-Cookie` attribute][rfc-6265-5.2.3]. By default, no\ndomain is set, and most clients will consider the cookie to apply to only the current domain.\n\n##### encode\n\nSpecifies a function that will be used to encode a cookie's value. Since value of a cookie\nhas a limited character set (and must be a simple string), this function can be used to encode\na value into a string suited for a cookie's value.\n\nThe default function is the global `encodeURIComponent`, which will encode a JavaScript string\ninto UTF-8 byte sequences and then URL-encode any that fall outside of the cookie range.\n\n##### expires\n\nSpecifies the `Date` object to be the value for the [`Expires` `Set-Cookie` attribute][rfc-6265-5.2.1].\nBy default, no expiration is set, and most clients will consider this a \"non-persistent cookie\" and\nwill delete it on a condition like exiting a web browser application.\n\n**note** the [cookie storage model specification][rfc-6265-5.3] states that if both `expires` and\n`maxAge` are set, then `maxAge` takes precedence, but it is possible not all clients by obey this,\nso if both are set, they should point to the same date and time.\n\n##### httpOnly\n\nSpecifies the `boolean` value for the [`HttpOnly` `Set-Cookie` attribute][rfc-6265-5.2.6]. When truthy,\nthe `HttpOnly` attribute is set, otherwise it is not. By default, the `HttpOnly` attribute is not set.\n\n**note** be careful when setting this to `true`, as compliant clients will not allow client-side\nJavaScript to see the cookie in `document.cookie`.\n\n##### maxAge\n\nSpecifies the `number` (in seconds) to be the value for the [`Max-Age` `Set-Cookie` attribute][rfc-6265-5.2.2].\nThe given number will be converted to an integer by rounding down. By default, no maximum age is set.\n\n**note** the [cookie storage model specification][rfc-6265-5.3] states that if both `expires` and\n`maxAge` are set, then `maxAge` takes precedence, but it is possible not all clients by obey this,\nso if both are set, they should point to the same date and time.\n\n##### path\n\nSpecifies the value for the [`Path` `Set-Cookie` attribute][rfc-6265-5.2.4]. By default, the path\nis considered the [\"default path\"][rfc-6265-5.1.4].\n\n##### sameSite\n\nSpecifies the `boolean` or `string` to be the value for the [`SameSite` `Set-Cookie` attribute][rfc-6265bis-03-4.1.2.7].\n\n  - `true` will set the `SameSite` attribute to `Strict` for strict same site enforcement.\n  - `false` will not set the `SameSite` attribute.\n  - `'lax'` will set the `SameSite` attribute to `Lax` for lax same site enforcement.\n  - `'none'` will set the `SameSite` attribute to `None` for an explicit cross-site cookie.\n  - `'strict'` will set the `SameSite` attribute to `Strict` for strict same site enforcement.\n\nMore information about the different enforcement levels can be found in\n[the specification][rfc-6265bis-03-4.1.2.7].\n\n**note** This is an attribute that has not yet been fully standardized, and may change in the future.\nThis also means many clients may ignore this attribute until they understand it.\n\n##### secure\n\nSpecifies the `boolean` value for the [`Secure` `Set-Cookie` attribute][rfc-6265-5.2.5]. When truthy,\nthe `Secure` attribute is set, otherwise it is not. By default, the `Secure` attribute is not set.\n\n**note** be careful when setting this to `true`, as compliant clients will not send the cookie back to\nthe server in the future if the browser does not have an HTTPS connection.\n\n## Example\n\nThe following example uses this module in conjunction with the Node.js core HTTP server\nto prompt a user for their name and display it back on future visits.\n\n```js\nvar cookie = require('cookie');\nvar escapeHtml = require('escape-html');\nvar http = require('http');\nvar url = require('url');\n\nfunction onRequest(req, res) {\n  // Parse the query string\n  var query = url.parse(req.url, true, true).query;\n\n  if (query && query.name) {\n    // Set a new cookie with the name\n    res.setHeader('Set-Cookie', cookie.serialize('name', String(query.name), {\n      httpOnly: true,\n      maxAge: 60 * 60 * 24 * 7 // 1 week\n    }));\n\n    // Redirect back after setting cookie\n    res.statusCode = 302;\n    res.setHeader('Location', req.headers.referer || '/');\n    res.end();\n    return;\n  }\n\n  // Parse the cookies on the request\n  var cookies = cookie.parse(req.headers.cookie || '');\n\n  // Get the visitor name set in the cookie\n  var name = cookies.name;\n\n  res.setHeader('Content-Type', 'text/html; charset=UTF-8');\n\n  if (name) {\n    res.write('<p>Welcome back, <b>' + escapeHtml(name) + '</b>!</p>');\n  } else {\n    res.write('<p>Hello, new visitor!</p>');\n  }\n\n  res.write('<form method=\"GET\">');\n  res.write('<input placeholder=\"enter your name\" name=\"name\"> <input type=\"submit\" value=\"Set Name\">');\n  res.end('</form>');\n}\n\nhttp.createServer(onRequest).listen(3000);\n```\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## Benchmark\n\n```\n$ npm run bench\n\n> cookie@0.3.1 bench cookie\n> node benchmark/index.js\n\n  http_parser@2.8.0\n  node@6.14.2\n  v8@5.1.281.111\n  uv@1.16.1\n  zlib@1.2.11\n  ares@1.10.1-DEV\n  icu@58.2\n  modules@48\n  napi@3\n  openssl@1.0.2o\n\n> node benchmark/parse.js\n\n  cookie.parse\n\n  6 tests completed.\n\n  simple      x 1,200,691 ops/sec ±1.12% (189 runs sampled)\n  decode      x 1,012,994 ops/sec ±0.97% (186 runs sampled)\n  unquote     x 1,074,174 ops/sec ±2.43% (186 runs sampled)\n  duplicates  x   438,424 ops/sec ±2.17% (184 runs sampled)\n  10 cookies  x   147,154 ops/sec ±1.01% (186 runs sampled)\n  100 cookies x    14,274 ops/sec ±1.07% (187 runs sampled)\n```\n\n## References\n\n- [RFC 6265: HTTP State Management Mechanism][rfc-6265]\n- [Same-site Cookies][rfc-6265bis-03-4.1.2.7]\n\n[rfc-6265bis-03-4.1.2.7]: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7\n[rfc-6265]: https://tools.ietf.org/html/rfc6265\n[rfc-6265-5.1.4]: https://tools.ietf.org/html/rfc6265#section-5.1.4\n[rfc-6265-5.2.1]: https://tools.ietf.org/html/rfc6265#section-5.2.1\n[rfc-6265-5.2.2]: https://tools.ietf.org/html/rfc6265#section-5.2.2\n[rfc-6265-5.2.3]: https://tools.ietf.org/html/rfc6265#section-5.2.3\n[rfc-6265-5.2.4]: https://tools.ietf.org/html/rfc6265#section-5.2.4\n[rfc-6265-5.2.5]: https://tools.ietf.org/html/rfc6265#section-5.2.5\n[rfc-6265-5.2.6]: https://tools.ietf.org/html/rfc6265#section-5.2.6\n[rfc-6265-5.3]: https://tools.ietf.org/html/rfc6265#section-5.3\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/cookie/master\n[coveralls-url]: https://coveralls.io/r/jshttp/cookie?branch=master\n[node-version-image]: https://badgen.net/npm/node/cookie\n[node-version-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/cookie\n[npm-url]: https://npmjs.org/package/cookie\n[npm-version-image]: https://badgen.net/npm/v/cookie\n[travis-image]: https://badgen.net/travis/jshttp/cookie/master\n[travis-url]: https://travis-ci.org/jshttp/cookie\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-04-22T03:23:59.666Z",
+    "created": "2012-05-28T23:56:11.938Z",
+    "0.0.0": "2012-05-28T23:56:12.299Z",
+    "0.0.1": "2012-05-29T02:15:56.897Z",
+    "0.0.2": "2012-06-01T17:57:58.161Z",
+    "0.0.3": "2012-06-06T18:50:00.041Z",
+    "0.0.4": "2012-06-21T16:27:06.621Z",
+    "0.0.5": "2012-10-29T17:26:30.049Z",
+    "0.0.6": "2013-04-09T05:59:56.056Z",
+    "0.1.0": "2013-05-01T19:18:22.075Z",
+    "0.1.1": "2014-02-23T15:56:33.086Z",
+    "0.1.2": "2014-04-16T23:00:21.566Z",
+    "0.1.3": "2015-05-20T01:22:20.719Z",
+    "0.2.0": "2015-08-14T05:15:35.455Z",
+    "0.1.4": "2015-09-17T17:03:42.289Z",
+    "0.2.1": "2015-09-17T17:08:41.911Z",
+    "0.1.5": "2015-09-17T18:52:10.481Z",
+    "0.2.2": "2015-09-17T20:40:15.826Z",
+    "0.2.3": "2015-10-26T01:02:06.233Z",
+    "0.2.4": "2016-05-21T00:32:45.246Z",
+    "0.3.0": "2016-05-27T01:00:41.646Z",
+    "0.3.1": "2016-05-27T04:32:39.156Z",
+    "0.4.0": "2019-05-16T03:26:07.333Z",
+    "0.4.1": "2020-04-22T03:23:57.297Z"
+  },
+  "author": {
+    "name": "Roman Shtylman",
+    "email": "shtylman@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/cookie.git"
+  },
+  "users": {
+    "285858315": true,
+    "fgribreau": true,
+    "m42am": true,
+    "rhedenk": true,
+    "substack": true,
+    "grncdr": true,
+    "masanorinyo": true,
+    "qiuzuhui": true,
+    "shen-weizhong": true,
+    "dexteryy": true,
+    "dofy": true,
+    "dgarlitt": true,
+    "priyaranjan": true,
+    "roryrjb": true,
+    "x_soth": true,
+    "vboctor": true,
+    "koulmomo": true,
+    "goodseller": true,
+    "simplyianm": true,
+    "trotyl": true,
+    "akiva": true,
+    "dac2205": true,
+    "flyslow": true,
+    "markthethomas": true,
+    "nickeljew": true,
+    "ovuncozturk": true,
+    "kungkk": true,
+    "awzm": true,
+    "antanst": true,
+    "intuitivcloud": true,
+    "panlw": true,
+    "wut": true,
+    "justinliao": true,
+    "qbylucky": true,
+    "milfromoz": true,
+    "demod": true,
+    "oikewll": true,
+    "qinyifeng": true,
+    "princetoad": true,
+    "danielsunami": true,
+    "wkaifang": true,
+    "antixrist": true,
+    "hongbo-miao": true,
+    "abuelwafa": true,
+    "wenbing": true,
+    "tedyhy": true,
+    "mhaidarh": true,
+    "zuizuihao": true,
+    "monjer": true,
+    "zoluzo": true,
+    "giussa_dan": true,
+    "ilex.h": true,
+    "waidd": true,
+    "xiaoqiang.yang": true,
+    "bphanikumar": true,
+    "wayn": true,
+    "vjudge": true,
+    "frankl83": true,
+    "infernocloud": true,
+    "shanyy": true,
+    "hbkapps": true,
+    "grin_zhou": true,
+    "shuoshubao": true,
+    "vcordero07": true,
+    "bumsuk": true,
+    "alexchao": true,
+    "dennisli87": true,
+    "imaginegenesis": true,
+    "mfessenden": true,
+    "rparris": true,
+    "zuojiang": true
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jshttp/cookie#readme",
+  "keywords": [
+    "cookie",
+    "cookies"
+  ],
+  "bugs": {
+    "url": "https://github.com/jshttp/cookie/issues"
+  },
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/cookie.min.json
+++ b/test/fixtures/registry-mocks/content/cookie.min.json
@@ -1,0 +1,345 @@
+{
+  "name": "cookie",
+  "dist-tags": {
+    "latest": "0.4.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "cookie",
+      "version": "0.0.0",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "a134b9c981df85c8a67b1620be5a36c0db1bdc63",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.1": {
+      "name": "cookie",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "3162dd34ea833740e2e0d6e7129f2dcd55dcf7ed",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.2": {
+      "name": "cookie",
+      "version": "0.0.2",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "17aedf62bc6af53745fecb55c45c3f097c2e858b",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.3": {
+      "name": "cookie",
+      "version": "0.0.3",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "732b0e64cb77186954f5e36b0b6bcfd062a12e91",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.4": {
+      "name": "cookie",
+      "version": "0.0.4",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "5456bd47aee2666eac976ea80a6105940483fe98",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.5": {
+      "name": "cookie",
+      "version": "0.0.5",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "f9acf9db57eb7568c9fcc596256b7bb22e307c81",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.6": {
+      "name": "cookie",
+      "version": "0.0.6",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "7bc6bb50205dcb98cf13ad09d6c60bc523f6fcb7",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.0.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "cookie",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "90eb469ddce905c866de687efc43131d8801f9d0",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.1": {
+      "name": "cookie",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "cbd4b537aa65f800b6c66ead2520ba8d6afbdf54",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.2": {
+      "name": "cookie",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "72fec3d24e48a3432073d90c12642005061004b1",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.3": {
+      "name": "cookie",
+      "version": "0.1.3",
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "1.x.x"
+      },
+      "dist": {
+        "shasum": "e734a5c1417fce472d5aef82c381cabb64d1a435",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.0": {
+      "name": "cookie",
+      "version": "0.2.0",
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "9708beeaa361857de7d16516fea779572625caad",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.1.4": {
+      "name": "cookie",
+      "version": "0.1.4",
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "4955c0bd32fffa83b7433586185875876ea04e4b",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.2.1": {
+      "name": "cookie",
+      "version": "0.2.1",
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "e1bc7c07d1985c17ad7347502bac1a0eb072ac9a",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.1.5": {
+      "name": "cookie",
+      "version": "0.1.5",
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "6ab9948a4b1ae21952cd2588530a4722d4044d7c",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.2.2": {
+      "name": "cookie",
+      "version": "0.2.2",
+      "devDependencies": {
+        "istanbul": "0.3.20",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "579ef8bc9b2d6f7e975a16bf4164d572e752e540",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.2.3": {
+      "name": "cookie",
+      "version": "0.2.3",
+      "devDependencies": {
+        "istanbul": "0.3.22",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "1a59536af68537a21178a01346f87cb059d2ae5c",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.2.4": {
+      "name": "cookie",
+      "version": "0.2.4",
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "a8c155aa7b9b2cf2c4d32ebc7b9a0aa288ccc6bd",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.2.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.3.0": {
+      "name": "cookie",
+      "version": "0.3.0",
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "a4bdd609d86748a5ce6c64d7ede6f4840ba434d8",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.3.1": {
+      "name": "cookie",
+      "version": "0.3.1",
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.4.0": {
+      "name": "cookie",
+      "version": "0.4.0",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "5.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4"
+      },
+      "dist": {
+        "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+        "shasum": "beb437e7022b3b6d49019d088665303ebe9c14ba",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17858,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3NhPCRA9TVsSAnZWagAADA4P/0Y8HkoR7zm45iuEtjAd\nEfcXA4oFAC9rTJtAWNcmDGwTW1HxfIX3M9ci8WSjlwbEqWsvE6XJYq4yjhZq\ncwj7IRftR1aGaGusZPrBQTXnwqMvRKTFG4ZMwH/IeeoEtmBq9hJJZX8yXjNL\nZbaAq84JTiGriMb9kjS+sizB6dHMUrCN4SDTP6EUEAVuF6lIVrikG3G6i7am\nqXeFIVXJQFn31/MRV/258l6eOefuPTlgWqpiBBLSScxSOSsyLhW2+FTpZ1Ga\n8wqAhQVf0JATKrElCH5x2u2slNxOI8FltAwxfMFHzN/5Q2XlOFznqFqoO1l6\nEYF0NgJQZXBQuKWIAVIyqwBZ5fQ9+lhjKtVqCGbcw9I2U+TRK0eHMNDgI+pR\nebdSwAhVWGTp0o2ahqhQBW/CB+tPgIjgy0lPRg5ioPs9noBb6AZZ5H9I0Ffm\niWO1FsneQYbFL+2IM/P3rIQefwFTParMXRuq70XxuVcU+cTXNi4X8lzH8KiJ\ncnq3Pit6czof7+OvNBWQAIq++d6z1tMq+ELOqp7L0QogZl7OGI/nFtZQrTbn\n2VtTg4su5j/zkE350pwTXirnRkS/9AiignuLco2H9PspMxEadPnmmakwErZJ\n+KXAFLAHZhgxfa7meSbFFoYDarbpuizUzDDULbUM0murTVR2dAYZUnCByEoi\nvmIe\r\n=Oa0u\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.4.1": {
+      "name": "cookie",
+      "version": "0.4.1",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "6.8.0",
+        "eslint-plugin-markdown": "1.0.2",
+        "mocha": "7.1.1",
+        "nyc": "15.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+        "shasum": "afd713fe26ebd21ba95ceb61f9a8116e50a537d1",
+        "tarball": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18123,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJen7jNCRA9TVsSAnZWagAAX/wP/j8Mcw3MQyifqWMFSZTL\nwpTBVC0/hRHh581NsIKtfF1fzWvRHKu+VPlGhMg1vqXoZweebf1H5Mwhlz7z\nDEiUiPQgCi6hXgdsUMxc+iDOFy2fQoPOKtY4LnfDA/vZMCok8QFLVWArl3CC\nLmA5Amh/Zfud0WkGzDGrjRQKWHRRAUVrQBZ6ziTM5KplDWy1PBSE59M3WYMY\nUFOdCEqk4xGEvW8YjkAkRSiY5Z8r8wcES4GkxaLsVFfpLJbI0cbRCen6b1uK\n4ZTGjwpnQKHPaywefIX1UTV8Em6D0QGweyc4CgTicMz+lPD9uZT8jmZr+Apy\nkcfen3enN1sKrn0e4p6AXOu1Ku38KeK0nLyU3ueo7/KzbAf8XVkbbsWdZ1Yr\nteOjmHDqv5k7B7616PSjyQJRmXhfB2FgR84MmyUbeEtOSStBaNPI7BxzA0Mj\nKvSfVDGxxO0dTb3Uu6QRF4tl8T2AFKarNzpik5VNvJpYsueISnGVG4J480YI\nz8L/Ayn3+BmW7GLtVU5nfXaMZBjGNryRRQFhju7tS0JOzbRgmUCRLK77NGUX\n+warQVVAXDJJgAVexSen90OLR+SSNq84HIBT9/UP70OLFxwndxB91XuDTuMO\nNot9PtZFUNZnv9ArYN/HGCRKDkJm98Gn0Pu5eJ4ITNA3iCE/urbSnVLzigSA\n11mU\r\n=IPIC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2020-04-22T03:23:59.666Z"
+}

--- a/test/fixtures/registry-mocks/content/copy-concurrently.json
+++ b/test/fixtures/registry-mocks/content/copy-concurrently.json
@@ -1,0 +1,484 @@
+{
+  "_id": "copy-concurrently",
+  "_rev": "21-15b9d9072eb5bd648b9e2073e5faa00b",
+  "name": "copy-concurrently",
+  "description": "Promises of copies of files, directories and symlinks, with concurrency controls and win32 junction fallback.",
+  "dist-tags": {
+    "latest": "1.0.5"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "copy-concurrently",
+      "version": "1.0.0",
+      "description": "Copy files, directories and links, preserving ownership and perms, with configurable concurrency.",
+      "main": "copy.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "files": [
+        "copy.js",
+        "is-windows.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/copy-concurrently.git"
+      },
+      "bugs": {
+        "url": "https://github.com/npm/copy-concurrently/issues"
+      },
+      "homepage": "https://www.npmjs.com/package/copy-concurrently",
+      "gitHead": "ce8bd33eb3e118227084adc4cf423e3ecb8af5ac",
+      "_id": "copy-concurrently@1.0.0",
+      "_shasum": "178caaffa3ae5e2a0dbcb63429b6787e39b03068",
+      "_from": ".",
+      "_npmVersion": "4.4.3",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "178caaffa3ae5e2a0dbcb63429b6787e39b03068",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/copy-concurrently-1.0.0.tgz_1489704187810_0.059374428587034345"
+      }
+    },
+    "1.0.1": {
+      "name": "copy-concurrently",
+      "version": "1.0.1",
+      "description": "Promises of copies of files, directories and symlinks, with concurrency controls and win32 junction fallback.",
+      "main": "copy.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [
+        "copy",
+        "cpr"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "files": [
+        "copy.js",
+        "is-windows.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/copy-concurrently.git"
+      },
+      "bugs": {
+        "url": "https://github.com/npm/copy-concurrently/issues"
+      },
+      "homepage": "https://www.npmjs.com/package/copy-concurrently",
+      "gitHead": "c27b675d0a1a8426ed8bdf94a369af0a7b279f5a",
+      "_id": "copy-concurrently@1.0.1",
+      "_shasum": "aa42d41dccd4d08ca71e825c9471ed91e67d7b13",
+      "_from": ".",
+      "_npmVersion": "4.4.3",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "aa42d41dccd4d08ca71e825c9471ed91e67d7b13",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/copy-concurrently-1.0.1.tgz_1489704604928_0.8405833058059216"
+      }
+    },
+    "1.0.2": {
+      "name": "copy-concurrently",
+      "version": "1.0.2",
+      "description": "Promises of copies of files, directories and symlinks, with concurrency controls and win32 junction fallback.",
+      "main": "copy.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [
+        "copy",
+        "cpr"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "files": [
+        "copy.js",
+        "is-windows.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/copy-concurrently.git"
+      },
+      "bugs": {
+        "url": "https://github.com/npm/copy-concurrently/issues"
+      },
+      "homepage": "https://www.npmjs.com/package/copy-concurrently",
+      "gitHead": "b6b2172b0be5493b848f0fdb130e9e16f6c54ce1",
+      "_id": "copy-concurrently@1.0.2",
+      "_shasum": "9cd371780d1203783d20bc78e2578fb942785106",
+      "_from": ".",
+      "_npmVersion": "4.4.3",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "9cd371780d1203783d20bc78e2578fb942785106",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/copy-concurrently-1.0.2.tgz_1489706165061_0.44832303188741207"
+      }
+    },
+    "1.0.3": {
+      "name": "copy-concurrently",
+      "version": "1.0.3",
+      "description": "Promises of copies of files, directories and symlinks, with concurrency controls and win32 junction fallback.",
+      "main": "copy.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [
+        "copy",
+        "cpr"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "files": [
+        "copy.js",
+        "is-windows.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/copy-concurrently.git"
+      },
+      "bugs": {
+        "url": "https://github.com/npm/copy-concurrently/issues"
+      },
+      "homepage": "https://www.npmjs.com/package/copy-concurrently",
+      "gitHead": "1b4b93b19c0cb2f6676c8a73dc86a1333d373230",
+      "_id": "copy-concurrently@1.0.3",
+      "_shasum": "45fb7866249a1ca889aa5708e6cbd273e75bb250",
+      "_from": ".",
+      "_npmVersion": "4.4.3",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "45fb7866249a1ca889aa5708e6cbd273e75bb250",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/copy-concurrently-1.0.3.tgz_1489706523710_0.4328302445355803"
+      }
+    },
+    "1.0.4": {
+      "name": "copy-concurrently",
+      "version": "1.0.4",
+      "description": "Promises of copies of files, directories and symlinks, with concurrency controls and win32 junction fallback.",
+      "main": "copy.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [
+        "copy",
+        "cpr"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "files": [
+        "copy.js",
+        "is-windows.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/copy-concurrently.git"
+      },
+      "bugs": {
+        "url": "https://github.com/npm/copy-concurrently/issues"
+      },
+      "homepage": "https://www.npmjs.com/package/copy-concurrently",
+      "gitHead": "e26fb43c77e8fdc0e95216dd14d1a711867c85ff",
+      "_id": "copy-concurrently@1.0.4",
+      "_npmVersion": "5.4.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-XXS0XxjvGYHNdCQe3VFiRfXqom2Uf8r+MmHEnuLEqln47OZW7yxIkjS0oaxsL9Q2fCl1sdrYlXdqsaBLofMyuQ==",
+        "shasum": "333c5c0450d234e6498fd17f2d4c28200233aa6e",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/copy-concurrently-1.0.4.tgz_1503701571485_0.4761425491888076"
+      }
+    },
+    "1.0.5": {
+      "name": "copy-concurrently",
+      "version": "1.0.5",
+      "description": "Promises of copies of files, directories and symlinks, with concurrency controls and win32 junction fallback.",
+      "main": "copy.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [
+        "copy",
+        "cpr"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "files": [
+        "copy.js",
+        "is-windows.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/copy-concurrently.git"
+      },
+      "bugs": {
+        "url": "https://github.com/npm/copy-concurrently/issues"
+      },
+      "homepage": "https://www.npmjs.com/package/copy-concurrently",
+      "gitHead": "3381d20cdafa55a7aa42ab7b79a2b34f971a44c4",
+      "_id": "copy-concurrently@1.0.5",
+      "_npmVersion": "5.4.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+        "shasum": "92297398cae34937fcafd6ec8139c18051f0b5e0",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/copy-concurrently-1.0.5.tgz_1503701787867_0.12750811083242297"
+      }
+    }
+  },
+  "readme": "# copy-concurrently\n\nCopy files, directories and symlinks\n\n```\nconst copy = require('copy-concurrently')\ncopy('/path/to/thing', '/new/path/thing').then(() => {\n  // this is now copied\n}).catch(err => {\n  // oh noooo\n})\n```\n\nCopies files, directories and symlinks.  Ownership is maintained when\nrunning as root, permissions are always maintained.  On Windows, if symlinks\nare unavailable then junctions will be used.\n\n## PUBLIC INTERFACE\n\n### copy(from, to, [options]) → Promise\n\nRecursively copies `from` to `to` and resolves its promise when finished. \nIf `to` already exists then the promise will be rejected with an `EEXIST`\nerror.\n\nOptions are:\n\n* maxConcurrency – (Default: `1`) The maximum number of concurrent copies to do at once.\n* recurseWith - (Default: `copy.item`) The function to call on each file after recursing into a directory.\n* isWindows - (Default: `process.platform === 'win32'`) If true enables Windows symlink semantics. This requires\n  an extra `stat` to determine if the destination of a symlink is a file or directory. If symlinking a directory\n  fails then we'll try making a junction instead.\n\nOptions can also include dependency injection:\n\n* Promise - (Default: `global.Promise`) The promise implementation to use, defaults to Node's.\n* fs - (Default: `require('fs')`) The filesystem module to use.  Can be used\n  to use `graceful-fs` or to inject a mock.\n* writeStreamAtomic - (Default: `require('fs-write-stream-atomic')`) The\n  implementation of `writeStreamAtomic` to use.  Used to inject a mock.\n* getuid - (Default: `process.getuid`) A function that returns the current UID. Used to inject a mock.\n\n## EXTENSION INTERFACE\n\nOrdinarily you'd only call `copy` above.  But it's possible to use it's\ncomponent functions directly.  This is useful if, say, you're writing\n[move-concurently](https://npmjs.com/package/move-concurrently).\n\n### copy.file(from, to, options) → Promise\n\nCopies an ordinary file `from` to destination `to`.  Uses\n`fs-write-stream-atomic` to ensure that the file is either entirely copied\nor not at all.\n\nOptions are:\n\n* uid, gid - (Optional) If `getuid()` is `0` then this and gid will be used to\n  set the user and group of `to`.  If uid is present then gid must be too.\n* mode - (Optional) If set then `to` will have its perms set to `mode`.\n* fs - (Default: `require('fs')`) The filesystem module to use.  Can be used\n  to use `graceful-fs` or to inject a mock.\n* Promise - (Default: `global.Promise`) The promise implementation to use, defaults to Node's.\n* writeStreamAtomic - (Default `require('fs-write-stream-atomic')`) The\n  implementation of `writeStreamAtomic` to use.  Used to inject a mock.\n\n### copy.symlink(from, to, options) → Promise\n\nCopies a symlink `from` to destination `to`.  If you're using Windows and\nsymlinking fails and what you're linking is a directory then junctions will\nbe tried instead.\n\nOptions are:\n\n* top - The top level the copy is being run from.  This is used to determine\n  if the symlink destination is within the set of files we're copying or\n  outside it.\n* fs - (Default: `require('fs')`) The filesystem module to use.  Can be used\n  to use `graceful-fs` or to inject a mock.\n* Promise - (Default: `global.Promise`) The promise implementation to use, defaults to Node's.\n* isWindows - (Default: `process.platform === 'win32'`) If true enables Windows symlink semantics. This requires\n  an extra `stat` to determine if the destination of a symlink is a file or directory. If symlinking a directory\n  fails then we'll try making a junction instead.\n\n### copy.recurse(from, to, options) → Promise\n\nReads all of the files in directory `from` and adds them to the `queue`\nusing `recurseWith` (by default `copy.item`).\n\nOptions are:\n\n* queue - A [`run-queue`](https://npmjs.com/package/run-queue) object to add files found inside `from` to.\n* recurseWith - (Default: `copy.item`) The function to call on each file after recursing into a directory.\n* uid, gid - (Optional) If `getuid()` is `0` then this and gid will be used to\n  set the user and group of `to`.  If uid is present then gid must be too.\n* mode - (Optional) If set then `to` will have its perms set to `mode`.\n* fs - (Default: `require('fs')`) The filesystem module to use.  Can be used\n  to use `graceful-fs` or to inject a mock.\n* getuid - (Default: `process.getuid`) A function that returns the current UID. Used to inject a mock.\n\n### copy.item(from, to, options) → Promise\n\nCopies some kind of `from` to destination `to`.  This looks at the filetype\nand calls `copy.file`, `copy.symlink` or `copy.recurse` as appropriate.\n\nSymlink copies are queued with a priority such that they happen after all\nfile and directory copies as you can't create a junction on windows to a\nfile that doesn't exist yet.\n\nOptions are:\n\n* top - The top level the copy is being run from.  This is used to determine\n  if the symlink destination is within the set of files we're copying or\n  outside it.\n* queue - The [`run-queue`](https://npmjs.com/package/run-queue) object to\n  pass to `copy.recurse` if `from` is a directory.\n* recurseWith - (Default: `copy.item`) The function to call on each file after recursing into a directory.\n* uid, gid - (Optional) If `getuid()` is `0` then this and gid will be used to\n  set the user and group of `to`.  If uid is present then gid must be too.\n* mode - (Optional) If set then `to` will have its perms set to `mode`.\n* fs - (Default: `require('fs')`) The filesystem module to use.  Can be used\n  to use `graceful-fs` or to inject a mock.\n* getuid - (Default: `process.getuid`) A function that returns the current UID. Used to inject a mock.\n* isWindows - (Default: `process.platform === 'win32'`) If true enables Windows symlink semantics. This requires\n  an extra `stat` to determine if the destination of a symlink is a file or directory. If symlinking a directory\n  fails then we'll try making a junction instead.\n* Promise - (Default: `global.Promise`) The promise implementation to use, defaults to Node's.\n* writeStreamAtomic - (Default `require('fs-write-stream-atomic')`) The\n  implementation of `writeStreamAtomic` to use.  Used to inject a mock.\n",
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-19T13:49:37.518Z",
+    "created": "2017-03-16T22:43:08.066Z",
+    "1.0.0": "2017-03-16T22:43:08.066Z",
+    "1.0.1": "2017-03-16T22:50:06.793Z",
+    "1.0.2": "2017-03-16T23:16:05.281Z",
+    "1.0.3": "2017-03-16T23:22:03.959Z",
+    "1.0.4": "2017-08-25T22:52:51.625Z",
+    "1.0.5": "2017-08-25T22:56:27.943Z"
+  },
+  "homepage": "https://www.npmjs.com/package/copy-concurrently",
+  "keywords": [
+    "copy",
+    "cpr"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/copy-concurrently.git"
+  },
+  "author": {
+    "name": "Rebecca Turner",
+    "email": "me@re-becca.org",
+    "url": "http://re-becca.org/"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/copy-concurrently/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "iarna": true,
+    "youcp": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/copy-concurrently.min.json
+++ b/test/fixtures/registry-mocks/content/copy-concurrently.min.json
@@ -1,0 +1,155 @@
+{
+  "name": "copy-concurrently",
+  "dist-tags": {
+    "latest": "1.0.5"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "copy-concurrently",
+      "version": "1.0.0",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "178caaffa3ae5e2a0dbcb63429b6787e39b03068",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "copy-concurrently",
+      "version": "1.0.1",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "aa42d41dccd4d08ca71e825c9471ed91e67d7b13",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "copy-concurrently",
+      "version": "1.0.2",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "9cd371780d1203783d20bc78e2578fb942785106",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "copy-concurrently",
+      "version": "1.0.3",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "45fb7866249a1ca889aa5708e6cbd273e75bb250",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "copy-concurrently",
+      "version": "1.0.4",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-XXS0XxjvGYHNdCQe3VFiRfXqom2Uf8r+MmHEnuLEqln47OZW7yxIkjS0oaxsL9Q2fCl1sdrYlXdqsaBLofMyuQ==",
+        "shasum": "333c5c0450d234e6498fd17f2d4c28200233aa6e",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "copy-concurrently",
+      "version": "1.0.5",
+      "dependencies": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
+        "shasum": "92297398cae34937fcafd6ec8139c18051f0b5e0",
+        "tarball": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:49:37.518Z"
+}

--- a/test/fixtures/registry-mocks/content/copy-descriptor.json
+++ b/test/fixtures/registry-mocks/content/copy-descriptor.json
@@ -1,0 +1,202 @@
+{
+  "_id": "copy-descriptor",
+  "_rev": "2-503acfee57f93a8cf946ed478a39472d",
+  "name": "copy-descriptor",
+  "description": "Copy a descriptor from object A to object B",
+  "dist-tags": {
+    "latest": "0.1.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "copy-descriptor",
+      "description": "Copy a descriptor from object A to object B",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/copy-descriptor",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/copy-descriptor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/copy-descriptor/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.4",
+        "mocha": "*"
+      },
+      "keywords": [
+        "copy",
+        "descriptor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "is-accessor-descriptor",
+            "is-data-descriptor",
+            "is-descriptor",
+            "is-plain-object",
+            "isobject"
+          ]
+        },
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "layout": "default"
+      },
+      "gitHead": "b229b64ef949a9b2c7bc812015891521da32659c",
+      "_id": "copy-descriptor@0.1.0",
+      "_shasum": "85b03cf2870a42c34feabb2da433874d279130bb",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "85b03cf2870a42c34feabb2da433874d279130bb",
+        "tarball": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "copy-descriptor",
+      "description": "Copy a descriptor from object A to object B",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/copy-descriptor",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/copy-descriptor.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/copy-descriptor/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.9",
+        "mocha": "^2.5.3"
+      },
+      "keywords": [
+        "copy",
+        "descriptor"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "is-accessor-descriptor",
+            "is-data-descriptor",
+            "is-descriptor",
+            "is-plain-object",
+            "isobject"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "verb-readme-generator",
+          "verb"
+        ]
+      },
+      "gitHead": "572c31416d4538b7ba5f52e2bb0765ac237f79e2",
+      "_id": "copy-descriptor@0.1.1",
+      "_shasum": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+        "tarball": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/copy-descriptor-0.1.1.tgz_1465497122701_0.666076025692746"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# copy-descriptor [![NPM version](https://img.shields.io/npm/v/copy-descriptor.svg?style=flat)](https://www.npmjs.com/package/copy-descriptor) [![NPM downloads](https://img.shields.io/npm/dm/copy-descriptor.svg?style=flat)](https://npmjs.org/package/copy-descriptor) [![Build Status](https://img.shields.io/travis/jonschlinkert/copy-descriptor.svg?style=flat)](https://travis-ci.org/jonschlinkert/copy-descriptor)\n\nCopy a descriptor from object A to object B\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install copy-descriptor --save\n```\n\n## Usage\n\n```js\nvar copy = require('copy-descriptor');\n```\n\n## API\n\n### [copy](index.js#L50)\n\nCopy a descriptor from one object to another.\n\n**Params**\n\n* `receiver` **{Object}**: The target object\n* `provider` **{Object}**: The provider object\n* `from` **{String}**: The key to copy on provider.\n* `to` **{String}**: Optionally specify a new key name to use.\n* `returns` **{Object}**\n\n**Example**\n\n```js\nfunction App() {\n  this.cache = {};\n}\nApp.prototype.set = function(key, val) {\n  this.cache[key] = val;\n  return this;\n};\nObject.defineProperty(App.prototype, 'count', {\n  get: function() {\n    return Object.keys(this.cache).length;\n  }\n});\n\ncopy(App.prototype, 'count', 'len');\n\n// create an instance\nvar app = new App();\n\napp.set('a', true);\napp.set('b', true);\napp.set('c', true);\n\nconsole.log(app.count);\n//=> 3\nconsole.log(app.len);\n//=> 3\n```\n\n## Related projects\n\nYou might also be interested in these projects:\n\n* [is-accessor-descriptor](https://www.npmjs.com/package/is-accessor-descriptor): Returns true if a value has the characteristics of a valid JavaScript accessor descriptor. | [homepage](https://github.com/jonschlinkert/is-accessor-descriptor \"Returns true if a value has the characteristics of a valid JavaScript accessor descriptor.\")\n* [is-data-descriptor](https://www.npmjs.com/package/is-data-descriptor): Returns true if a value has the characteristics of a valid JavaScript data descriptor. | [homepage](https://github.com/jonschlinkert/is-data-descriptor \"Returns true if a value has the characteristics of a valid JavaScript data descriptor.\")\n* [is-descriptor](https://www.npmjs.com/package/is-descriptor): Returns true if a value has the characteristics of a valid JavaScript descriptor. Works for… [more](https://github.com/jonschlinkert/is-descriptor) | [homepage](https://github.com/jonschlinkert/is-descriptor \"Returns true if a value has the characteristics of a valid JavaScript descriptor. Works for data descriptors and accessor descriptors.\")\n* [is-plain-object](https://www.npmjs.com/package/is-plain-object): Returns true if an object was created by the `Object` constructor. | [homepage](https://github.com/jonschlinkert/is-plain-object \"Returns true if an object was created by the `Object` constructor.\")\n* [isobject](https://www.npmjs.com/package/isobject): Returns true if the value is an object and not an array or null. | [homepage](https://github.com/jonschlinkert/isobject \"Returns true if the value is an object and not an array or null.\")\n\n## Contributing\n\nThis document was generated by [verb-readme-generator](https://github.com/verbose/verb-readme-generator) (a [verb](https://github.com/verbose/verb) generator), please don't edit directly. Any changes to the readme must be made in [.verb.md](.verb.md). See [Building Docs](#building-docs).\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new). Or visit the [verb-readme-generator](https://github.com/verbose/verb-readme-generator) project to submit bug reports or pull requests for the readme layout template.\n\n## Building docs\n\nGenerate readme and API documentation with [verb](https://github.com/verbose/verb):\n\n```sh\n$ npm install -g verb verb-readme-generator && verb\n```\n\n## Running tests\n\nInstall dev dependencies:\n\n```sh\n$ npm install -d && npm test\n```\n\n## Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](http://twitter.com/jonschlinkert)\n\n## License\n\nCopyright © 2016, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT license](https://github.com/jonschlinkert/copy-descriptor/blob/master/LICENSE).\n\n***\n\n_This file was generated by [verb](https://github.com/verbose/verb), v0.9.0, on June 09, 2016._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2016-06-09T18:32:05.080Z",
+    "created": "2015-12-28T10:28:49.609Z",
+    "0.1.0": "2015-12-28T10:28:49.609Z",
+    "0.1.1": "2016-06-09T18:32:05.080Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/copy-descriptor",
+  "keywords": [
+    "copy",
+    "descriptor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/copy-descriptor.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/copy-descriptor/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/copy-descriptor.min.json
+++ b/test/fixtures/registry-mocks/content/copy-descriptor.min.json
@@ -1,0 +1,39 @@
+{
+  "name": "copy-descriptor",
+  "dist-tags": {
+    "latest": "0.1.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "copy-descriptor",
+      "version": "0.1.0",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.4",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "85b03cf2870a42c34feabb2da433874d279130bb",
+        "tarball": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "copy-descriptor",
+      "version": "0.1.1",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.9",
+        "mocha": "^2.5.3"
+      },
+      "dist": {
+        "shasum": "676f6eb3c39997c2ee1ac3a924fd6124748f578d",
+        "tarball": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2016-06-09T18:32:05.080Z"
+}

--- a/test/fixtures/registry-mocks/content/create-ecdh.json
+++ b/test/fixtures/registry-mocks/content/create-ecdh.json
@@ -1,0 +1,967 @@
+{
+  "_id": "create-ecdh",
+  "_rev": "27-8f092712854b730c04732ecc7e6d4fa5",
+  "name": "create-ecdh",
+  "description": "createECDH but browserifiable",
+  "dist-tags": {
+    "latest": "4.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "create-ecdh",
+      "version": "1.0.0",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/createECDH/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/createECDH",
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "elliptic": "^0.15.14"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "_id": "create-ecdh@1.0.0",
+      "dist": {
+        "shasum": "7016bf4c68b1000d71d9ccb0112e7105789d4b1a",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "create-ecdh",
+      "version": "1.0.1",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/createECDH/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/createECDH",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "elliptic": "^0.15.14"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "c244bfaaacdd885ab3cdbdc0fbcaa5f8e087b406",
+      "_id": "create-ecdh@1.0.1",
+      "_shasum": "5969175126df97878dd3780f1d53b91982d26588",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5969175126df97878dd3780f1d53b91982d26588",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "create-ecdh",
+      "version": "1.0.2",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/createECDH/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/createECDH",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "elliptic": "^0.15.14"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "ea6732fd0f681a45aac259c8bed0152c5c6d002b",
+      "_id": "create-ecdh@1.0.2",
+      "_shasum": "9cc3ec6daff4fe9b4ab1b9a0ceb2caae8fa876f9",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9cc3ec6daff4fe9b4ab1b9a0ceb2caae8fa876f9",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "create-ecdh",
+      "version": "1.0.3",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/createECDH/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/createECDH",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "elliptic": "^1.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "eeb5fe401529834dc36202aa2b20f0354a063112",
+      "_id": "create-ecdh@1.0.3",
+      "_shasum": "ff6fce0d36747adf3a87918b97b93e302541a157",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ff6fce0d36747adf3a87918b97b93e302541a157",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "create-ecdh",
+      "version": "2.0.0",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "elliptic": "^1.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "8f2d7e13c6621ba66bd79121ab4b8a67968f6476",
+      "_id": "create-ecdh@2.0.0",
+      "_shasum": "59a11dbd3af8de5acbc8d005b624ccf7136f2a78",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "1.2.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "59a11dbd3af8de5acbc8d005b624ccf7136f2a78",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "create-ecdh",
+      "version": "2.0.1",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "elliptic": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "7968658674ae3b4501c3a4489623cada6b196785",
+      "_id": "create-ecdh@2.0.1",
+      "_shasum": "94ba1ae3a96a0e522d143633f556a1adbad98f56",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "94ba1ae3a96a0e522d143633f556a1adbad98f56",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "create-ecdh",
+      "version": "2.0.2",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "elliptic": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "a0dc2b85e0868e85e3c7d284c4ed75a2077fe7d7",
+      "_id": "create-ecdh@2.0.2",
+      "_shasum": "5b0dc9e1241944a29973f8cd2ecf1ba0cadb6255",
+      "_from": ".",
+      "_npmVersion": "3.3.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "5b0dc9e1241944a29973f8cd2ecf1ba0cadb6255",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "create-ecdh",
+      "version": "3.0.0",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^3.0.0",
+        "elliptic": "^5.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "bbf7cc97a628de988fb51d4d60011f3d1e82e0ba",
+      "_id": "create-ecdh@3.0.0",
+      "_shasum": "11f7fc7a70eaac77c87d6502b45872e5d7b5fe34",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "3.3.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "11f7fc7a70eaac77c87d6502b45872e5d7b5fe34",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "create-ecdh",
+      "version": "4.0.0",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "115f7b6bad56934285b9015575e1b43f23148a8a",
+      "_id": "create-ecdh@4.0.0",
+      "_shasum": "888c723596cdf7612f6498233eebd7a35301737d",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "888c723596cdf7612f6498233eebd7a35301737d",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.1": {
+      "name": "create-ecdh",
+      "version": "4.0.1",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "66dc7a2de4165bb3705f5b738538e765a64a6420",
+      "_id": "create-ecdh@4.0.1",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+        "shasum": "44223dfed533193ba5ba54e0df5709b89acf1f82",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5232
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/create-ecdh_4.0.1_1523448707686_0.9044979378150946"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.2": {
+      "name": "create-ecdh",
+      "version": "4.0.2",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0",
+        "standard": "^5.4.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "438b256af2674d21a23b076106c794c77d2bad86",
+      "_id": "create-ecdh@4.0.2",
+      "_npmVersion": "6.0.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-SRDAmYjvUEhe59Uzm8g5Jazqxc316iXDYpLWdBACy3DnAL0i7MSfxEhM6hWebCdP53k6OQVVwvSvwovMsm2h2w==",
+        "shasum": "e1098e6917ec1871ffcd83454a4da0e44bc48d05",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5402,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa8FJpCRA9TVsSAnZWagAAVusQAInpWqxpFS1VHiZfYl+D\nxPuq6++l/++ZivDBJkYH22mxkPH6OiTc38b9nxNUJg/a0i9Mfe/o+GPY59AT\n3V8wWyPzg2hhvVJYE0kUYi394b4AEHKHbg9fW/xZFHWt94vD/qBUGeq40QbF\nUHAIdYc6u9OIeHOmLgk94de5eA6qyNtO4lpCDwGKacz45pp71hPfFFasNDvP\nMsJs1yirDxPDu82dsPu3WqurwhC/HRiXtAwkL+Kk7JUOtiGTewCZFWfZWRv6\njIJunEqyvnBmWMR9bPRYZE2uRhBr+KRWhr16wIyR+48px4dazg05Z3ndxKXT\nIzzoCsfMZwJ2S9aSeFKp0G5GloHbbPEerAs+/EMeukHvDuKt0hGgItP5FFGy\nDxpGmW/zU14yzaSy1TjzWbqi89oCUn4eqWGoO9UwmTUlA22Ai7ynKHT5qkI+\nzUEvZB6Gu2cZcau0DBNItxWTx/pqpxcU5LRPDA8zZYzuOArvq6wafeBMFt+A\nH9AOzo9XVRY/ZhtXIZS/yiMNHtW657c2tsgrmhIt6tq11YrUTkJoR2ZuvSFE\n8HP8HxnKJKPDNreO7sRQAQCr45V5+VhE6ZIZT91FbM1i6FoMzcT3XTc2ljHD\nrS87nXWqwjNS5qIO7NidI1bby9GSdHrpG+9AHyGU4oAv/1bwTIlqOOpGBppM\nPre5\r\n=+hK4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/create-ecdh_4.0.2_1525699177256_0.09929469869088381"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.3": {
+      "name": "create-ecdh",
+      "version": "4.0.3",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1",
+        "standard": "^5.4.1"
+      },
+      "gitHead": "3e7d3d301bfa4c332e6124db609743718cf1ffae",
+      "_id": "create-ecdh@4.0.3",
+      "_npmVersion": "6.0.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+        "shasum": "c9111b6f33045c4697f144787f9254cdc77c45ff",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5402,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa8GGxCRA9TVsSAnZWagAAH+QQAKDA87unr1N/Md0VZu/V\nS6EfsjbkYwQo7RINaQ2cuXRHWrftr7F05hj1vUiwqdjcxoeKzwwr31m5DpPx\nR5G73LWFuJe/fZpkVC6JAA4pq/jFtb+dGb37+B6vQ87qOrPJjjiwJXMyBPj1\n3dEZZQfQ+gUWyktPd52Sen1Pamo1yCZP9bXptp/WKqQ63GVVq3jckx7VCdPs\nYYwoDh1gGowJv2YUofAffisexGylmztv4Is+RnBnCHKl/Zgi95wZyMRkHESQ\nIw10aCYgbCLYs08MvZFOWqoBybtHs3kYMwWqw4onpsAu15S1gRsblr3i2gWd\nsIqTKusCjoNsi4wJQWMlJe4eHV2WE3dFFDBZeuAKYXwlx5IGo0przsp8zubJ\neepq10XFnl6Ypl595KtZ4VDAi/2OKlP6DpKOFbKerAlHczbmlwr8KTVgtfCr\nesRbJOVERvD8inawscIqaMtb17hrQYoE5ccgsvQUFQpEt4BvxG/XvPDHBV2x\noJEMRvb21DNtSRuJNHIERLGMI+4YEc5lXkUQClRlOWEyrufzs0IJtt97yGH/\nLcyK4QHonAw1X54ZQuSWV8LBt+DpkRjtiWnmW2aLmM7DHOhMCakMNTRzAxDX\nGl7QWSbTEcUkx7NaCYt+aBGvUF7vc+7EyrmqHTbehOLY5qzgvxhqcBnu4a+S\n+5fd\r\n=DonG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/create-ecdh_4.0.3_1525703089210_0.010752726417076364"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.4": {
+      "name": "create-ecdh",
+      "version": "4.0.4",
+      "description": "createECDH but browserifiable",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createECDH.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "ECDH"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createECDH/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createECDH",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1",
+        "standard": "^5.4.1"
+      },
+      "gitHead": "51b8c81594beb156f2f531e4662c8e8497a05dad",
+      "_id": "create-ecdh@4.0.4",
+      "_nodeVersion": "12.16.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+        "shasum": "d6e7f4bffa66736085a0762fd3a632684dabcc4e",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5402,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKYhMCRA9TVsSAnZWagAAdkYP/3LX0DJzBamaFVAHeNjN\ntWh9rGUTJRnG9/GNSO/FLU/zFyQUnRDqk5dVNswyWrFWrEBFiq4kdHgeheQU\nW0ic81BpDEHB11mQ4DS4xK9mHr/hzU/TBWYmw2271WwHp6E0YMU/261f5Lkw\n6/WjKdir95PK4CGZSiFU6zx6s35nmiFQm1PvCIbQUB1EEPm2r5MWmM7IONeK\nN2uRkTSnL9+tMAKESdpYUcg7rsxVFtvw+KAwbxsZz39J5GytDIZueQ2OSc7e\nhr3Ck8Lcnw2WeylE+KxGb3Mldkp6cGG09sPuNfdSuGUatxYjCYALLv8ySAqE\n3qRZZLr9Gmj3lX5MEkfvBqGneWxOVApfQVir2k48SR5s95YBj3w32YdUQamv\nbt8y6qfIsCeQFHfpGkIG+zIj43searw8RYKDj9qsS/uJr5gJnGlp5gkoA6QD\nG093RA7jr43PcCj5yz3q7AJh0y9vgSTyVmmeXQawEVUt1x7v3PSecqys0lAZ\nzjsmuvMOV2U0Se8gRTCOjQf053O+kumwIIZ0MGRo1lHw1iM+TJ/XpX9Q1sLr\nvMZGtF+A6XLPGPT48iwA/v58mg8ww+q0b3qA+MdDKqe30UqvCKNzdNAA9T//\nJ6MNn7+J5ytd1gxjVeHxPpeMV24OW6Gg7ezpDxTL0XwSQrKWITQH4UhDYt9E\nh+dm\r\n=bvD4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/create-ecdh_4.0.4_1596557388470_0.9452730268590201"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "createECDH [![Build Status](https://travis-ci.org/crypto-browserify/createECDH.svg)](https://travis-ci.org/crypto-browserify/createECDH)\n====\n\nIn io.js or node >= 0.11 this module is just a shortcut to crypto.createECDH.  In node <= 0.11 or the browser this is a pure JavaScript implimentation, more specifically a wrapper around [elliptic](https://github.com/indutny/elliptic), to give it the same API as node. `secp256k1`, `secp224r1` (aka p224), `prime256v1` (aka p256, secp256r1), `prime192v1` (aka p192, secp192r1), `secp384r1` (aka p384), `secp521r1` (aka p521)  curves all work in both this library and node (though only the highlighted name will work in node).\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-04T16:09:50.853Z",
+    "created": "2014-11-06T18:13:43.230Z",
+    "1.0.0": "2014-11-06T18:13:43.230Z",
+    "1.0.1": "2015-01-03T13:50:03.667Z",
+    "1.0.2": "2015-01-06T13:00:32.560Z",
+    "1.0.3": "2015-01-06T13:03:00.533Z",
+    "2.0.0": "2015-02-12T13:32:36.317Z",
+    "2.0.1": "2015-05-21T02:55:08.373Z",
+    "2.0.2": "2015-10-04T21:19:26.524Z",
+    "3.0.0": "2015-10-27T01:28:54.668Z",
+    "4.0.0": "2015-10-29T13:07:51.788Z",
+    "4.0.1": "2018-04-11T12:11:47.845Z",
+    "4.0.2": "2018-05-07T13:19:37.433Z",
+    "4.0.3": "2018-05-07T14:24:49.272Z",
+    "4.0.4": "2020-08-04T16:09:48.587Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/createECDH",
+  "keywords": [
+    "diffie",
+    "hellman",
+    "diffiehellman",
+    "ECDH"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/createECDH.git"
+  },
+  "author": {
+    "name": "Calvin Metcalf"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/createECDH/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md"
+}

--- a/test/fixtures/registry-mocks/content/create-ecdh.min.json
+++ b/test/fixtures/registry-mocks/content/create-ecdh.min.json
@@ -1,0 +1,235 @@
+{
+  "name": "create-ecdh",
+  "dist-tags": {
+    "latest": "4.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "create-ecdh",
+      "version": "1.0.0",
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "elliptic": "^0.15.14"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "7016bf4c68b1000d71d9ccb0112e7105789d4b1a",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "create-ecdh",
+      "version": "1.0.1",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "elliptic": "^0.15.14"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "5969175126df97878dd3780f1d53b91982d26588",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "create-ecdh",
+      "version": "1.0.2",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "elliptic": "^0.15.14"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "9cc3ec6daff4fe9b4ab1b9a0ceb2caae8fa876f9",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "create-ecdh",
+      "version": "1.0.3",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "elliptic": "^1.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "ff6fce0d36747adf3a87918b97b93e302541a157",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-1.0.3.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "create-ecdh",
+      "version": "2.0.0",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "elliptic": "^1.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "59a11dbd3af8de5acbc8d005b624ccf7136f2a78",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "create-ecdh",
+      "version": "2.0.1",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "elliptic": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "94ba1ae3a96a0e522d143633f556a1adbad98f56",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "create-ecdh",
+      "version": "2.0.2",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "elliptic": "^3.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "5b0dc9e1241944a29973f8cd2ecf1ba0cadb6255",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-2.0.2.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "create-ecdh",
+      "version": "3.0.0",
+      "dependencies": {
+        "bn.js": "^3.0.0",
+        "elliptic": "^5.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "11f7fc7a70eaac77c87d6502b45872e5d7b5fe34",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-3.0.0.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "create-ecdh",
+      "version": "4.0.0",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "888c723596cdf7612f6498233eebd7a35301737d",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
+      }
+    },
+    "4.0.1": {
+      "name": "create-ecdh",
+      "version": "4.0.1",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+        "shasum": "44223dfed533193ba5ba54e0df5709b89acf1f82",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5232
+      }
+    },
+    "4.0.2": {
+      "name": "create-ecdh",
+      "version": "4.0.2",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0",
+        "standard": "^5.4.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-SRDAmYjvUEhe59Uzm8g5Jazqxc316iXDYpLWdBACy3DnAL0i7MSfxEhM6hWebCdP53k6OQVVwvSvwovMsm2h2w==",
+        "shasum": "e1098e6917ec1871ffcd83454a4da0e44bc48d05",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5402,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa8FJpCRA9TVsSAnZWagAAVusQAInpWqxpFS1VHiZfYl+D\nxPuq6++l/++ZivDBJkYH22mxkPH6OiTc38b9nxNUJg/a0i9Mfe/o+GPY59AT\n3V8wWyPzg2hhvVJYE0kUYi394b4AEHKHbg9fW/xZFHWt94vD/qBUGeq40QbF\nUHAIdYc6u9OIeHOmLgk94de5eA6qyNtO4lpCDwGKacz45pp71hPfFFasNDvP\nMsJs1yirDxPDu82dsPu3WqurwhC/HRiXtAwkL+Kk7JUOtiGTewCZFWfZWRv6\njIJunEqyvnBmWMR9bPRYZE2uRhBr+KRWhr16wIyR+48px4dazg05Z3ndxKXT\nIzzoCsfMZwJ2S9aSeFKp0G5GloHbbPEerAs+/EMeukHvDuKt0hGgItP5FFGy\nDxpGmW/zU14yzaSy1TjzWbqi89oCUn4eqWGoO9UwmTUlA22Ai7ynKHT5qkI+\nzUEvZB6Gu2cZcau0DBNItxWTx/pqpxcU5LRPDA8zZYzuOArvq6wafeBMFt+A\nH9AOzo9XVRY/ZhtXIZS/yiMNHtW657c2tsgrmhIt6tq11YrUTkJoR2ZuvSFE\n8HP8HxnKJKPDNreO7sRQAQCr45V5+VhE6ZIZT91FbM1i6FoMzcT3XTc2ljHD\nrS87nXWqwjNS5qIO7NidI1bby9GSdHrpG+9AHyGU4oAv/1bwTIlqOOpGBppM\nPre5\r\n=+hK4\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.3": {
+      "name": "create-ecdh",
+      "version": "4.0.3",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1",
+        "standard": "^5.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+        "shasum": "c9111b6f33045c4697f144787f9254cdc77c45ff",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5402,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa8GGxCRA9TVsSAnZWagAAH+QQAKDA87unr1N/Md0VZu/V\nS6EfsjbkYwQo7RINaQ2cuXRHWrftr7F05hj1vUiwqdjcxoeKzwwr31m5DpPx\nR5G73LWFuJe/fZpkVC6JAA4pq/jFtb+dGb37+B6vQ87qOrPJjjiwJXMyBPj1\n3dEZZQfQ+gUWyktPd52Sen1Pamo1yCZP9bXptp/WKqQ63GVVq3jckx7VCdPs\nYYwoDh1gGowJv2YUofAffisexGylmztv4Is+RnBnCHKl/Zgi95wZyMRkHESQ\nIw10aCYgbCLYs08MvZFOWqoBybtHs3kYMwWqw4onpsAu15S1gRsblr3i2gWd\nsIqTKusCjoNsi4wJQWMlJe4eHV2WE3dFFDBZeuAKYXwlx5IGo0przsp8zubJ\neepq10XFnl6Ypl595KtZ4VDAi/2OKlP6DpKOFbKerAlHczbmlwr8KTVgtfCr\nesRbJOVERvD8inawscIqaMtb17hrQYoE5ccgsvQUFQpEt4BvxG/XvPDHBV2x\noJEMRvb21DNtSRuJNHIERLGMI+4YEc5lXkUQClRlOWEyrufzs0IJtt97yGH/\nLcyK4QHonAw1X54ZQuSWV8LBt+DpkRjtiWnmW2aLmM7DHOhMCakMNTRzAxDX\nGl7QWSbTEcUkx7NaCYt+aBGvUF7vc+7EyrmqHTbehOLY5qzgvxhqcBnu4a+S\n+5fd\r\n=DonG\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.4": {
+      "name": "create-ecdh",
+      "version": "4.0.4",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1",
+        "standard": "^5.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+        "shasum": "d6e7f4bffa66736085a0762fd3a632684dabcc4e",
+        "tarball": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5402,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKYhMCRA9TVsSAnZWagAAdkYP/3LX0DJzBamaFVAHeNjN\ntWh9rGUTJRnG9/GNSO/FLU/zFyQUnRDqk5dVNswyWrFWrEBFiq4kdHgeheQU\nW0ic81BpDEHB11mQ4DS4xK9mHr/hzU/TBWYmw2271WwHp6E0YMU/261f5Lkw\n6/WjKdir95PK4CGZSiFU6zx6s35nmiFQm1PvCIbQUB1EEPm2r5MWmM7IONeK\nN2uRkTSnL9+tMAKESdpYUcg7rsxVFtvw+KAwbxsZz39J5GytDIZueQ2OSc7e\nhr3Ck8Lcnw2WeylE+KxGb3Mldkp6cGG09sPuNfdSuGUatxYjCYALLv8ySAqE\n3qRZZLr9Gmj3lX5MEkfvBqGneWxOVApfQVir2k48SR5s95YBj3w32YdUQamv\nbt8y6qfIsCeQFHfpGkIG+zIj43searw8RYKDj9qsS/uJr5gJnGlp5gkoA6QD\nG093RA7jr43PcCj5yz3q7AJh0y9vgSTyVmmeXQawEVUt1x7v3PSecqys0lAZ\nzjsmuvMOV2U0Se8gRTCOjQf053O+kumwIIZ0MGRo1lHw1iM+TJ/XpX9Q1sLr\nvMZGtF+A6XLPGPT48iwA/v58mg8ww+q0b3qA+MdDKqe30UqvCKNzdNAA9T//\nJ6MNn7+J5ytd1gxjVeHxPpeMV24OW6Gg7ezpDxTL0XwSQrKWITQH4UhDYt9E\nh+dm\r\n=bvD4\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-08-04T16:09:50.853Z"
+}

--- a/test/fixtures/registry-mocks/content/create-hash.json
+++ b/test/fixtures/registry-mocks/content/create-hash.json
@@ -1,0 +1,586 @@
+{
+  "_id": "create-hash",
+  "_rev": "24-04a1cdd07224ad75c01d73a11d231c62",
+  "name": "create-hash",
+  "description": "create hashes for browserify",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "create-hash",
+      "version": "1.0.0",
+      "description": "create hashes for browserify",
+      "main": "create-hash.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:crypto-browserify/crypto-createHash.git"
+      },
+      "keywords": [
+        "crypto"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-createHash/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/crypto-createHash",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^0.2.1",
+        "sha.js": "^2.3.6"
+      },
+      "gitHead": "2cc3ae81f75634e1263e1fb643c734392edb7bf0",
+      "_id": "create-hash@1.0.0",
+      "_shasum": "4a8e85fb9d1cdef2fb31cae6871a5a8ef6cbe37c",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4a8e85fb9d1cdef2fb31cae6871a5a8ef6cbe37c",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "create-hash",
+      "version": "1.0.1",
+      "description": "create hashes for browserify",
+      "main": "create-hash.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:crypto-browserify/crypto-createHash.git"
+      },
+      "keywords": [
+        "crypto"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-createHash/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/crypto-createHash",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "gitHead": "c5a7283804d4231d0f721f703cd60220ff7becd1",
+      "_id": "create-hash@1.0.1",
+      "_shasum": "e8204cf689b05c74c984b380f62a57de0e99a09a",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e8204cf689b05c74c984b380f62a57de0e99a09a",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "create-hash",
+      "version": "1.0.2",
+      "description": "create hashes for browserify",
+      "browser": "create-hash.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:crypto-browserify/crypto-createHash.git"
+      },
+      "keywords": [
+        "crypto"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-createHash/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/crypto-createHash",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "gitHead": "541763f999b2b4ffad9b23327a1df81579ba3fa8",
+      "_id": "create-hash@1.0.2",
+      "_shasum": "3cff6282a2bf1fa528b9ca8f7c1049535170776a",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3cff6282a2bf1fa528b9ca8f7c1049535170776a",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "create-hash",
+      "version": "1.1.0",
+      "description": "create hashes for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:crypto-browserify/createHash.git"
+      },
+      "keywords": [
+        "crypto"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHash/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHash",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "gitHead": "08badfc3bee31ac9c7b9310d9bb8f64f17218d90",
+      "_id": "create-hash@1.1.0",
+      "_shasum": "c2ab96b5d4ece5f22df2ef4306803d14da6931e7",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c2ab96b5d4ece5f22df2ef4306803d14da6931e7",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "create-hash",
+      "version": "1.1.1",
+      "description": "create hashes for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:crypto-browserify/createHash.git"
+      },
+      "keywords": [
+        "crypto"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHash/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHash",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "gitHead": "dcc25f9e0b66d07fbf76d13e2616ea4c34cbcc90",
+      "_id": "create-hash@1.1.1",
+      "_shasum": "a55424f97b5369bfb2a97e53bd9b7a1aa6dd3a17",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a55424f97b5369bfb2a97e53bd9b7a1aa6dd3a17",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "create-hash",
+      "version": "1.1.2",
+      "description": "create hashes for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/createHash.git"
+      },
+      "keywords": [
+        "crypto"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHash/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHash",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "gitHead": "426cefe8cae9feddda5af336d34e1d83bed13579",
+      "_id": "create-hash@1.1.2",
+      "_shasum": "51210062d7bb7479f6c65bb41a92208b1d61abad",
+      "_from": ".",
+      "_npmVersion": "3.3.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "51210062d7bb7479f6c65bb41a92208b1d61abad",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "create-hash",
+      "version": "1.1.3",
+      "description": "create hashes for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script standard && npm run-script unit",
+        "unit": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/createHash.git"
+      },
+      "keywords": [
+        "crypto"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHash/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHash",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^5.3.1",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
+      },
+      "gitHead": "d78f61ebe25078d0020cd4b7088a9e745078db30",
+      "_id": "create-hash@1.1.3",
+      "_shasum": "606042ac8b9262750f483caddab0f5819172d8fd",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "606042ac8b9262750f483caddab0f5819172d8fd",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/create-hash-1.1.3.tgz_1494508195809_0.8463289202190936"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "create-hash",
+      "version": "1.2.0",
+      "description": "create hashes for browserify",
+      "browser": "browser.js",
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script standard && npm run-script unit",
+        "unit": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/createHash.git"
+      },
+      "keywords": [
+        "crypto"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHash/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHash",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3"
+      },
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      },
+      "gitHead": "6514b6ce14b5c097f1411b1a4bce095cbb115a56",
+      "_id": "create-hash@1.2.0",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+        "shasum": "889078af11a63756bcfb59bd221996be3a9ef196",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 5214
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/create-hash_1.2.0_1523451264591_0.41127376643860547"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# create-hash\n\n[![Build Status](https://travis-ci.org/crypto-browserify/createHash.svg)](https://travis-ci.org/crypto-browserify/createHash)\n\nNode style hashes for use in the browser, with native hash functions in node.\n\nAPI is the same as hashes in node:\n```js\nvar createHash = require('create-hash')\nvar hash = createHash('sha224')\nhash.update('synchronous write') // optional encoding parameter\nhash.digest() // synchronously get result with optional encoding parameter\n\nhash.write('write to it as a stream')\nhash.end() // remember it's a stream\nhash.read() // only if you ended it as a stream though\n```\n\nTo get the JavaScript version even in node do `require('create-hash/browser')`\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-01T16:56:54.352Z",
+    "created": "2015-01-14T13:04:23.530Z",
+    "1.0.0": "2015-01-14T13:04:23.530Z",
+    "1.0.1": "2015-01-14T13:17:46.336Z",
+    "1.0.2": "2015-01-14T15:20:25.599Z",
+    "1.1.0": "2015-01-16T12:44:28.344Z",
+    "1.1.1": "2015-03-18T08:34:45.526Z",
+    "1.1.2": "2015-09-27T23:01:28.933Z",
+    "1.1.3": "2017-05-11T13:10:18.358Z",
+    "1.2.0": "2018-04-11T12:54:24.678Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/createHash",
+  "keywords": [
+    "crypto"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/crypto-browserify/createHash.git"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/createHash/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "larrychen": true,
+    "mohamadou": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/create-hash.min.json
+++ b/test/fixtures/registry-mocks/content/create-hash.min.json
@@ -1,0 +1,163 @@
+{
+  "name": "create-hash",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "create-hash",
+      "version": "1.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^0.2.1",
+        "sha.js": "^2.3.6"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "4a8e85fb9d1cdef2fb31cae6871a5a8ef6cbe37c",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "create-hash",
+      "version": "1.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "e8204cf689b05c74c984b380f62a57de0e99a09a",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "create-hash",
+      "version": "1.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "3cff6282a2bf1fa528b9ca8f7c1049535170776a",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "create-hash",
+      "version": "1.1.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "c2ab96b5d4ece5f22df2ef4306803d14da6931e7",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "create-hash",
+      "version": "1.1.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "a55424f97b5369bfb2a97e53bd9b7a1aa6dd3a17",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "create-hash",
+      "version": "1.1.2",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^1.0.0",
+        "sha.js": "^2.3.6"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "51210062d7bb7479f6c65bb41a92208b1d61abad",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "create-hash",
+      "version": "1.1.3",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^5.3.1",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "606042ac8b9262750f483caddab0f5819172d8fd",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "create-hash",
+      "version": "1.2.0",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "safe-buffer": "^5.0.1",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3"
+      },
+      "dist": {
+        "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+        "shasum": "889078af11a63756bcfb59bd221996be3a9ef196",
+        "tarball": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 5214
+      }
+    }
+  },
+  "modified": "2019-01-01T16:56:54.352Z"
+}

--- a/test/fixtures/registry-mocks/content/create-hmac.json
+++ b/test/fixtures/registry-mocks/content/create-hmac.json
@@ -1,0 +1,822 @@
+{
+  "_id": "create-hmac",
+  "_rev": "27-5be87d5ce98d20183d1062e608308c26",
+  "name": "create-hmac",
+  "description": "node style hmacs in the browser",
+  "dist-tags": {
+    "latest": "1.1.7"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "create-hmac",
+      "version": "1.0.0",
+      "description": "node style hmacs in the browser",
+      "main": "create-hmac.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.0.0"
+      },
+      "gitHead": "2275bd55bb52f1b3dd3075fb075910c47acd9c57",
+      "_id": "create-hmac@1.0.0",
+      "_shasum": "1d7710b82a6e577dc23e4e05c4e3f5cde9a226ab",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1d7710b82a6e577dc23e4e05c4e3f5cde9a226ab",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "create-hmac",
+      "version": "1.0.1",
+      "description": "node style hmacs in the browser",
+      "main": "create-hmac.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "b4e96baae9c9dd72641abc182a2bb28fdf65209c",
+      "_id": "create-hmac@1.0.1",
+      "_shasum": "63eb04ac4782182d9b3a0dd08d18b24e42856f5c",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "63eb04ac4782182d9b3a0dd08d18b24e42856f5c",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "create-hmac",
+      "version": "1.0.2",
+      "description": "node style hmacs in the browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "browser": "./create-hmac.js",
+      "gitHead": "e90b28cf8b65720b6c9d7d0da2104273ce57cd4a",
+      "_id": "create-hmac@1.0.2",
+      "_shasum": "fabced999a6fcdacd7763191f986551daceb21c1",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fabced999a6fcdacd7763191f986551daceb21c1",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "create-hmac",
+      "version": "1.1.0",
+      "description": "node style hmacs in the browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "browser": "./browser.js",
+      "gitHead": "5a14266329ccfb0761185429b3330ec556b38688",
+      "_id": "create-hmac@1.1.0",
+      "_shasum": "92f8b6378471f4bc67eefc9dee6622df6b8754be",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "92f8b6378471f4bc67eefc9dee6622df6b8754be",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "create-hmac",
+      "version": "1.1.1",
+      "description": "node style hmacs in the browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "browser": "./browser.js",
+      "gitHead": "ea7c2efdd0f59749e339efcb7fbd4309b590850c",
+      "_id": "create-hmac@1.1.1",
+      "_shasum": "78d6005f72c98572f8d5bd12d32658bebecb669e",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.15",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "78d6005f72c98572f8d5bd12d32658bebecb669e",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "create-hmac",
+      "version": "1.1.2",
+      "description": "node style hmacs in the browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "browser": "./browser.js",
+      "gitHead": "5044e84cd98237c7739b28f2418771dc67658394",
+      "_id": "create-hmac@1.1.2",
+      "_shasum": "1149b6f5309277b65e6a8e0082f0f4e615b926a8",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1149b6f5309277b65e6a8e0082f0f4e615b926a8",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "create-hmac",
+      "version": "1.1.3",
+      "description": "node style hmacs in the browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "browser": "./browser.js",
+      "gitHead": "0db078774769487d9ede6951a56c4cffe3de1c14",
+      "_id": "create-hmac@1.1.3",
+      "_shasum": "29843e9c191ba412ab001bc55ac8b8b9ae54b670",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "29843e9c191ba412ab001bc55ac8b8b9ae54b670",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "create-hmac",
+      "version": "1.1.4",
+      "description": "node style hmacs in the browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "browser": "./browser.js",
+      "gitHead": "3c7dd3047b5ab3e3be44d802241d224f0c9e2325",
+      "_id": "create-hmac@1.1.4",
+      "_shasum": "d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170",
+      "_from": ".",
+      "_npmVersion": "3.3.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "create-hmac",
+      "version": "1.1.5",
+      "description": "node style hmacs in the browser",
+      "files": [
+        "browser.js",
+        "index.js"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script standard && npm run-script unit",
+        "unit": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^5.3.1",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "browser": "./browser.js",
+      "gitHead": "d7bfc99d838e4aad836f13b422eeccae0a50df27",
+      "_id": "create-hmac@1.1.5",
+      "_shasum": "b2c145f2e697d2b538fc686fd80a136aa6dadcad",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "b2c145f2e697d2b538fc686fd80a136aa6dadcad",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/create-hmac-1.1.5.tgz_1494508187426_0.9113117505330592"
+      },
+      "directories": {}
+    },
+    "1.1.6": {
+      "name": "create-hmac",
+      "version": "1.1.6",
+      "description": "node style hmacs in the browser",
+      "files": [
+        "browser.js",
+        "index.js",
+        "legacy.js"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script standard && npm run-script unit",
+        "unit": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^5.3.1",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "browser": "./browser.js",
+      "gitHead": "f46295a4b49383f35812ce5bc87c4d158efc3e19",
+      "_id": "create-hmac@1.1.6",
+      "_shasum": "acb9e221a4e17bdb076e90657c42b93e3726cf06",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "acb9e221a4e17bdb076e90657c42b93e3726cf06",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/create-hmac-1.1.6.tgz_1494513770834_0.9636347822379321"
+      },
+      "directories": {}
+    },
+    "1.1.7": {
+      "name": "create-hmac",
+      "version": "1.1.7",
+      "description": "node style hmacs in the browser",
+      "files": [
+        "browser.js",
+        "index.js",
+        "legacy.js"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run-script standard && npm run-script unit",
+        "unit": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/createHmac.git"
+      },
+      "keywords": [
+        "crypto",
+        "hmac"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/createHmac/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/createHmac",
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^5.3.1",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "browser": "./browser.js",
+      "gitHead": "fa6c90b5b0d33b805ec3d65a7a370b88dd1994f3",
+      "_id": "create-hmac@1.1.7",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+        "shasum": "69170c78b3ab957147b2b8b04572e47ead2243ff",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5809
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/create-hmac_1.1.7_1523449880084_0.9803481561229792"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# create-hmac\n\n[![NPM Package](https://img.shields.io/npm/v/create-hmac.svg?style=flat-square)](https://www.npmjs.org/package/create-hmac)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/createHmac.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/createHmac)\n[![Dependency status](https://img.shields.io/david/crypto-browserify/createHmac.svg?style=flat-square)](https://david-dm.org/crypto-browserify/createHmac#info=dependencies)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nNode style HMACs for use in the browser, with native HMAC functions in node. API is the same as HMACs in node:\n\n```js\nvar createHmac = require('create-hmac')\nvar hmac = createHmac('sha224', Buffer.from('secret key'))\nhmac.update('synchronous write') //optional encoding parameter\nhmac.digest() // synchronously get result with optional encoding parameter\n\nhmac.write('write to it as a stream')\nhmac.end() //remember it's a stream\nhmac.read() //only if you ended it as a stream though\n```\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-01T16:56:56.678Z",
+    "created": "2015-01-14T13:15:35.764Z",
+    "1.0.0": "2015-01-14T13:15:35.764Z",
+    "1.0.1": "2015-01-14T15:05:19.884Z",
+    "1.0.2": "2015-01-14T15:18:05.180Z",
+    "1.1.0": "2015-01-16T16:17:17.726Z",
+    "1.1.1": "2015-01-27T00:21:30.427Z",
+    "1.1.2": "2015-01-28T12:08:57.131Z",
+    "1.1.3": "2015-01-30T00:22:21.831Z",
+    "1.1.4": "2015-09-27T23:15:50.769Z",
+    "1.1.5": "2017-05-11T13:09:49.930Z",
+    "1.1.6": "2017-05-11T14:42:51.717Z",
+    "1.1.7": "2018-04-11T12:31:20.190Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/createHmac",
+  "keywords": [
+    "crypto",
+    "hmac"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/createHmac.git"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/createHmac/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/create-hmac.min.json
+++ b/test/fixtures/registry-mocks/content/create-hmac.min.json
@@ -1,0 +1,213 @@
+{
+  "name": "create-hmac",
+  "dist-tags": {
+    "latest": "1.1.7"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "create-hmac",
+      "version": "1.0.0",
+      "dependencies": {
+        "create-hash": "^1.0.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "1d7710b82a6e577dc23e4e05c4e3f5cde9a226ab",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "create-hmac",
+      "version": "1.0.1",
+      "dependencies": {
+        "create-hash": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "63eb04ac4782182d9b3a0dd08d18b24e42856f5c",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "create-hmac",
+      "version": "1.0.2",
+      "dependencies": {
+        "create-hash": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "fabced999a6fcdacd7763191f986551daceb21c1",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "create-hmac",
+      "version": "1.1.0",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "92f8b6378471f4bc67eefc9dee6622df6b8754be",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "create-hmac",
+      "version": "1.1.1",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "78d6005f72c98572f8d5bd12d32658bebecb669e",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "create-hmac",
+      "version": "1.1.2",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "1149b6f5309277b65e6a8e0082f0f4e615b926a8",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "create-hmac",
+      "version": "1.1.3",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "29843e9c191ba412ab001bc55ac8b8b9ae54b670",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.3.tgz"
+      }
+    },
+    "1.1.4": {
+      "name": "create-hmac",
+      "version": "1.1.4",
+      "dependencies": {
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "d3fb4ba253eb8b3f56e39ea2fbcb8af747bd3170",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+      }
+    },
+    "1.1.5": {
+      "name": "create-hmac",
+      "version": "1.1.5",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^5.3.1",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "b2c145f2e697d2b538fc686fd80a136aa6dadcad",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.5.tgz"
+      }
+    },
+    "1.1.6": {
+      "name": "create-hmac",
+      "version": "1.1.6",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^5.3.1",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "acb9e221a4e17bdb076e90657c42b93e3726cf06",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz"
+      }
+    },
+    "1.1.7": {
+      "name": "create-hmac",
+      "version": "1.1.7",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^5.3.1",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+        "shasum": "69170c78b3ab957147b2b8b04572e47ead2243ff",
+        "tarball": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+        "fileCount": 6,
+        "unpackedSize": 5809
+      }
+    }
+  },
+  "modified": "2019-01-01T16:56:56.678Z"
+}

--- a/test/fixtures/registry-mocks/content/crypto-browserify.json
+++ b/test/fixtures/registry-mocks/content/crypto-browserify.json
@@ -1,0 +1,5137 @@
+{
+  "_id": "crypto-browserify",
+  "_rev": "175-d9af4dc02f084c740ffe3574ce25a352",
+  "name": "crypto-browserify",
+  "description": "implementation of crypto for the browser",
+  "dist-tags": {
+    "latest": "3.12.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.0.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "url": ""
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "_id": "crypto-browserify@0.0.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "eb70a764fc7dc0f4e77c6ec34ce14b0f5242c967",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.0.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "url": ""
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "_id": "crypto-browserify@0.0.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e87209b392fd759eeb5a84494be47095fbcccc7f",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.1.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "url": ""
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "_id": "crypto-browserify@0.1.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.23",
+      "_nodeVersion": "v0.6.18",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f36094c2c4208c9c86bc730b166d86184faac8ff",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.1.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "url": ""
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_id": "crypto-browserify@0.1.1",
+      "dist": {
+        "shasum": "34343b512041a9c32ae7ec6a7f8ab4d06b418a0b",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.1.2",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_id": "crypto-browserify@0.1.2",
+      "dist": {
+        "shasum": "7c6ce24c0ac1640dcd9701f47645ef1950d01765",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.1.2.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.2.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "optionalDependencies": {},
+      "_id": "crypto-browserify@0.2.0",
+      "dist": {
+        "shasum": "e4f80da2cac3735b7544a69749f264e00b78a217",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.0.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.2.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "optionalDependencies": {},
+      "_id": "crypto-browserify@0.2.1",
+      "dist": {
+        "shasum": "303ed9046f8604a3d7c35ec4a6d46d2268712078",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.1.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.2.2",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            8,
+            9
+          ],
+          "firefox": [
+            13
+          ],
+          "chrome": [
+            20
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "optionalDependencies": {},
+      "_id": "crypto-browserify@0.2.2",
+      "dist": {
+        "shasum": "0f1c8499ba0edaa5b087176924e3b2f088582c2d",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.3": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.2.3",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            8,
+            9
+          ],
+          "firefox": [
+            13
+          ],
+          "chrome": [
+            20
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "optionalDependencies": {},
+      "_id": "crypto-browserify@0.2.3",
+      "dist": {
+        "shasum": "c98141505d90e31a1e456cb97343dc3b0f4a1a2a",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.3.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            8,
+            9
+          ],
+          "firefox": [
+            13
+          ],
+          "chrome": [
+            20
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "optionalDependencies": {},
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@0.3.0",
+      "dist": {
+        "shasum": "0c0991f19be6da34415e12bc58a56bf71a950587",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "0.4.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            8,
+            9
+          ],
+          "firefox": [
+            13
+          ],
+          "chrome": [
+            20
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "optionalDependencies": {},
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@0.4.0",
+      "dist": {
+        "shasum": "246f6a337b884c99ffe8bfb085a184aee60c33f3",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/simple.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.0",
+      "dist": {
+        "shasum": "d5d8bd9fe60c53e8f8b7aa39ab6561dcf7fea64f",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.1",
+      "dist": {
+        "shasum": "09db81b972418eaa0caff05d85d0d8af3b31aed1",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.2",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.2",
+      "dist": {
+        "shasum": "55b9d57a98b6ec0e94c3e477cecfe7871a98d38e",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.3",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.3",
+      "dist": {
+        "shasum": "834063a48147eefd5d96580826c385a10535c7f5",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.4": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.4",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.4",
+      "dist": {
+        "shasum": "f1f23dfde1730fee5884585cc4f2ae019a394a78",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.5": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.5",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.5",
+      "dist": {
+        "shasum": "40273430e62f30adf412aeb761675672b81ace63",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.6": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.6",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.6",
+      "dist": {
+        "shasum": "55470f73639581dc59e6529a890f64c0b04d08d4",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.7": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.7",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "browserify": {
+        "transform": [
+          "brfs"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.7",
+      "dist": {
+        "shasum": "12dbfc84c39ff6e7222765b42ea5913e719423c5",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.8": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.8",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "brfs": "~0.0.8",
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.8",
+      "dist": {
+        "shasum": "07f9d01e3c79bd248512fdfb1e5f75110dbbcf6d",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.9": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "1.0.9",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "node test/node.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "brfs": "~0.0.8",
+        "tape": "~1.0.4"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@1.0.9",
+      "dist": {
+        "shasum": "cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.0.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "sha.js": "1.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.0.0",
+      "dist": {
+        "shasum": "4aa6e3bac6686fe94ddc1f41850550039897b9c7",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "sha.js": "1.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "testling": {
+        "files": "test/browser.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.0",
+      "dist": {
+        "shasum": "5c5880bb3b6d350f8580d8eb666ed8fa0902cce0",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "sha.js": "2.1.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "testling": {
+        "files": "test/{create-hash,create-hmac,simple}.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.1",
+      "dist": {
+        "shasum": "7dc55b1b40c2c07ec997aad3b089b18f5969b11f",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.2": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.2",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "sha.js": "2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "testling": {
+        "files": "test/{create-hash,create-hmac,simple}.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.2",
+      "dist": {
+        "shasum": "fb5fe9ad367e936f17e44bebd7e0373d38a97a37",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.3": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.3",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "sha.js": "2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "testling": {
+        "files": "test/{create-hash,create-hmac,simple}.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.3",
+      "dist": {
+        "shasum": "4542421c55abd3831db3ebbd79f73942d44221bb",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.4": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.4",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "sha.js": "2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "testling": {
+        "files": "test/{create-hash,create-hmac,simple}.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.4",
+      "dist": {
+        "shasum": "74c7a75d07d0edd1d553efcfe33ffba5f872584b",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.5": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.5",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "sha.js": "2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "testling": {
+        "files": "test/{create-hash,create-hmac,simple}.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.5",
+      "dist": {
+        "shasum": "8a1ed33d0f0168a11e803d10f90d559ae62993ed",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.6": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.6",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "sha.js": "2.1.3"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "testling": {
+        "files": "test/{create-hash,create-hmac,simple}.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.6",
+      "dist": {
+        "shasum": "40495449c5ab3c5786b3ac8ad8ee41e1ba96a421",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.7": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.7",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.3"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.7",
+      "_shasum": "8543d09a74437afd7fcdb6b87139ae56708f35d5",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8543d09a74437afd7fcdb6b87139ae56708f35d5",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.7.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.8": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.8",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.3"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/20..latest",
+          "firefox/10..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.8",
+      "_shasum": "3ef8ccd7da5a4debdd379e7d64a2ae128b9d977a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3ef8ccd7da5a4debdd379e7d64a2ae128b9d977a",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.8.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.10": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "2.1.10",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@2.1.10",
+      "_shasum": "4f2ca6311843cf087cdf008e43a4f3686ef6e6bb",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4f2ca6311843cf087cdf008e43a4f3686ef6e6bb",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.10.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.0.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.0.0",
+      "_shasum": "5d42e013137c658bcc74de792d2d96268aeaa883",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5d42e013137c658bcc74de792d2d96268aeaa883",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.0.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.7"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.0.1",
+      "_shasum": "770fd68e8422f9b1e53d6812f1c2ce2ea7ab917c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "770fd68e8422f9b1e53d6812f1c2ce2ea7ab917c",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.0.2",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.8"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "gitHead": "a460a9c96697b1eb6a7a9db425029fd32b05019b",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.0.2",
+      "_shasum": "43218365d9d086e8c1b88f968fb7134f13505c84",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43218365d9d086e8c1b88f968fb7134f13505c84",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.1.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "gitHead": "d58beeb646224807f5c0c2a585c4b5139f6b640a",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.1.0",
+      "_shasum": "25e9591408054fae17326003c4bf1e15bf27a1a4",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "25e9591408054fae17326003c4bf1e15bf27a1a4",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.2.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "gitHead": "a5cf35baecd8e661333c78b614ed13379ec70043",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.2.0",
+      "_shasum": "424b5f9ab3d1afa4ba20faff5c90992eeb9cd705",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "424b5f9ab3d1afa4ba20faff5c90992eeb9cd705",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.2.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "pbkdf2-compat": "2.0.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "gitHead": "080b93070b9060e0a91671077cf4706f5658815c",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.2.1",
+      "_shasum": "be21a5b291b4b896facb145505252c6d8820b9d2",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "be21a5b291b4b896facb145505252c6d8820b9d2",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.2": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.2.2",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "pbkdf2-compat": "2.0.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "gitHead": "ce9bf42a00c323fd3f84e33c1ca60e0271dde1e9",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.2.2",
+      "_shasum": "e5ec42700ff964f1e5ca472d943c5c27db75e36a",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e5ec42700ff964f1e5ca472d943c5c27db75e36a",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.4": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.2.4",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js-",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "gitHead": "c31b9d711d3e2603c6587cb00d1f64c9a559d4d4",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.2.4",
+      "_shasum": "0d704f787b38e952c65211bcf28e4c3fca9167d0",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0d704f787b38e952c65211bcf28e4c3fca9167d0",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.5": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.2.5",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "gitHead": "57407fc5d42864e4b112e5d1686a2a618691250c",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.2.5",
+      "_shasum": "26c92bba20c8bfa7c50aa71ca95972b353ebbec2",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "26c92bba20c8bfa7c50aa71ca95972b353ebbec2",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.5.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.6": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.2.6",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "license": "MIT",
+      "gitHead": "4997928aec9cb52b0dd49688b96fbdb96399e172",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.2.6",
+      "_shasum": "e65a44893ad85138dbf0eaf515675adfd917cdb4",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e65a44893ad85138dbf0eaf515675adfd917cdb4",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.6.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.7": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.2.7",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "ceed76c0a9270469fbea4916327f3e2750537225",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.2.7",
+      "_shasum": "b2aea649d58136caa02710f9fe1af4ab762d14d5",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b2aea649d58136caa02710f9fe1af4ab762d14d5",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.7.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.8": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.2.8",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "bbf4bce8d6f9ec644f8b158111793be72aa123af",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.2.8",
+      "_shasum": "b9b11dbe6d9651dd882a01e6cc467df718ecf189",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b9b11dbe6d9651dd882a01e6cc467df718ecf189",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
+      },
+      "directories": {}
+    },
+    "3.3.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.3.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6",
+        "browserify-aes": "0.4.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "0f1821f6233548f632de2b5658c895fa7a8e3d3d",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.3.0",
+      "_shasum": "b9fc75bb4a0ed61dcf1cd5dae96eb30c9c3e506c",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b9fc75bb4a0ed61dcf1cd5dae96eb30c9c3e506c",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.4.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.4.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.4.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "a4ed53349155cdd9ffaa683756d4ef6790102eee",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.4.0",
+      "_shasum": "0081fea45550de8689f032ef08a2a78ea73b3295",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0081fea45550de8689f032ef08a2a78ea73b3295",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.4.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.4.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.4.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0",
+        "sha.js": "~2.2.7"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "78ccc68d28bcb4ef505e3159bbe9de395e1cccc1",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.4.1",
+      "_shasum": "b058aa8b935861e38f19b80220fe447145e2b5cb",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b058aa8b935861e38f19b80220fe447145e2b5cb",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.4.3": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.4.3",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.4.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0",
+        "sha.js": "~2.2.7"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "347471d85c797ebe239b3604e57e05e01de0e7a0",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.4.3",
+      "_shasum": "7bff7ea481ed679a159fd8bf0f4e56a1d8b50e00",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7bff7ea481ed679a159fd8bf0f4e56a1d8b50e00",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.5.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.5.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.4.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "230b3ca29b4cdf3819ae378586430ebb772988a1",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.5.0",
+      "_shasum": "e0f6039b83c375431b8989637d9b3883fd226177",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e0f6039b83c375431b8989637d9b3883fd226177",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.5.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.5.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.6.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "fb1d36ba4efbc6a75d6ab04e6695f2137f515456",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.5.1",
+      "_shasum": "eab25427de15f80d15f296466fbfb3a8a86ee500",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "eab25427de15f80d15f296466fbfb3a8a86ee500",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.6.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.6.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.6.0",
+        "browserify-sign": "2.4.0",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "6602891ba0e28b6e0979443e85a73dba8c010bb8",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.6.0",
+      "_shasum": "6f74a6d30cf0bd11ef5168410bbdc7a65f6d01cb",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6f74a6d30cf0bd11ef5168410bbdc7a65f6d01cb",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.7.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.7.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.6.1",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "browserify-sign": "2.6.0",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "7e2fe95bcb063b581ad457096e8f1b00d278e11a",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.7.0",
+      "_shasum": "5b9de9b65b04f22a087cb0339db5232f536323cc",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5b9de9b65b04f22a087cb0339db5232f536323cc",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.7.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.7.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.6.1",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "browserify-sign": "2.6.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "9f6c244e4baed7dba68f5aca2de2e375ab5e508d",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.7.1",
+      "_shasum": "ed9788686ece390183217aeb56e908bdd33d83f3",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ed9788686ece390183217aeb56e908bdd33d83f3",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.7.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.7.2": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.7.2",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.6.1",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "browserify-sign": "2.7.0",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "4c4bb09da9f93d87fd4c7e1cefdd60d7a33c5135",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.7.2",
+      "_shasum": "17456add9fce4648a39645d2aa2d0096fdd90b80",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "17456add9fce4648a39645d2aa2d0096fdd90b80",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.7.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.8.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.8.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.7.2",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "browserify-sign": "2.7.0",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "44ad3caff87f1db1bf2f4e267ef217d4e9c8edd9",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.8.0",
+      "_shasum": "fd564ae7cc34f266f024003e189f1bf476c7eb19",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fd564ae7cc34f266f024003e189f1bf476c7eb19",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.8.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.8.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.7.2",
+        "create-ecdh": "1.0.1",
+        "diffie-hellman": "2.2.2",
+        "browserify-sign": "2.7.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "be7c55239558c65db5d1bcf01bfb75882b3ed070",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.8.1",
+      "_shasum": "dcae2d68c57994d53eb349cffc77893408a87635",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dcae2d68c57994d53eb349cffc77893408a87635",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.8.3": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "partial implementation of crypto for the browser",
+      "version": "3.8.3",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.0",
+        "create-ecdh": "1.0.1",
+        "diffie-hellman": "2.2.2",
+        "browserify-sign": "2.7.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/latest",
+          "chrome/latest",
+          "firefox/latest",
+          "safari/latest",
+          "opera/latest"
+        ]
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "75bd305d4e917684c456e54b329af08da5f3e56b",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.8.3",
+      "_shasum": "a7f91d3204c92bc6593d134b6af70be0dc1aad32",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a7f91d3204c92bc6593d134b6af70be0dc1aad32",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.8.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.0",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.1",
+        "diffie-hellman": "2.2.2",
+        "browserify-sign": "2.7.2",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "df0180c7dc6213e8158ef84a84b5c1208dda0b8a",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.0",
+      "_shasum": "04faa9abee7d972a44b474f7e91b196baf2a2d0b",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "04faa9abee7d972a44b474f7e91b196baf2a2d0b",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.1",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.7.5",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "c38b4927bf491a08c3176ac979da5c0dc1c9d5e6",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.1",
+      "_shasum": "020319381171e3895c5d30480b281f417d583359",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "020319381171e3895c5d30480b281f417d583359",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.2": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.2",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.7.5",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "17a43770bb7b34c4bb76b8c1746c51c6a9675826",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.2",
+      "_shasum": "4e295140c8eef2b720184323087c30f4cbb82fa9",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4e295140c8eef2b720184323087c30f4cbb82fa9",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.3": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.3",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.7.5",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.4"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "d95c99bd948180b750bd0dd980736372332bedd0",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.3",
+      "_shasum": "fced960abd47e55c130a802663c70081cddf9245",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fced960abd47e55c130a802663c70081cddf9245",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.4": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.4",
+      "homepage": "https://github.com/dominictarr/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.8.0",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.4"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "db1ac5ed9a4f445652ada8943c8dbb429d586fbc",
+      "bugs": {
+        "url": "https://github.com/dominictarr/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.4",
+      "_shasum": "1bda647421800616e4332be0196ac4045a5c51a3",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1bda647421800616e4332be0196ac4045a5c51a3",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.4.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.6": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.6",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.8.0",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "a060b2b41b840a8ae50ec6041302fe58f9b580e8",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.6",
+      "_shasum": "5e0f9494e9720dd99ef2f23dce7ec6d5be098615",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5e0f9494e9720dd99ef2f23dce7ec6d5be098615",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.6.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.7": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.7",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "2.2.3",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "c08a8ea93a6175da0889a50d20f9e32c61664ff8",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.7",
+      "_shasum": "f737a62c13fa11b1e0cdd64b6ed86897e5d5e0e8",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f737a62c13fa11b1e0cdd64b6ed86897e5d5e0e8",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.7.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.8": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.8",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "2.2.3",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "8796866647b48b1f3c40c1ff507f3cc75d3ba64f",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.8",
+      "_shasum": "b107059e9b5bf9a4e7d094bf28fb63ab49639697",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b107059e9b5bf9a4e7d094bf28fb63ab49639697",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.8.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.9": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.9",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "2.2.3",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "b2a8bb9e55ef724b5196c9e26f772ba96a0ea9e0",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.9",
+      "_shasum": "1296ad1fb0168fb621b44af68dcc7939df0d4af6",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1296ad1fb0168fb621b44af68dcc7939df0d4af6",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.9.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.10": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.10",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "2.2.3",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "a96c30c3ec14aafdb70887f068a1d55a3c28c182",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.10",
+      "_shasum": "3b8bfa3876dd9a466d6720abf1f74dbbea934a75",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.15",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3b8bfa3876dd9a466d6720abf1f74dbbea934a75",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.10.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.11": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.11",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "dbd16c6148f8313e43e46fe8071e20827a74efc0",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.11",
+      "_shasum": "2cd8539bd4577f4c2dd7616905112fd982ddd277",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2cd8539bd4577f4c2dd7616905112fd982ddd277",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.11.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.12": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.12",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "^3.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "e896146a4e99b8efffe1119fe6b28f5d34f48341",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.12",
+      "_shasum": "3ddbfa01bb3e4c6501b3871787916744b3c97175",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "1.0.4",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3ddbfa01bb3e4c6501b3871787916744b3c97175",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.12.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.13": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.13",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "^3.0.1",
+        "public-encrypt": "^2.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "b3e9dcaa517b58b942e40335896421ffa658b68b",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.13",
+      "_shasum": "07b829716685101dcd73f0bbcc95d16aa73fedf1",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "07b829716685101dcd73f0bbcc95d16aa73fedf1",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.14": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.9.14",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/node/*.js test/*.js; do node $t; done",
+        "prepublish": "npm ls && npm test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "^3.0.1",
+        "create-ecdh": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^2.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "7ac9b42974526f0b7fe1714c1dac970eb7c0ef3c",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.9.14",
+      "_shasum": "d69925252c845392714aed1460c54b56605314ab",
+      "_from": ".",
+      "_npmVersion": "2.7.0",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d69925252c845392714aed1460c54b56605314ab",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz"
+      },
+      "directories": {}
+    },
+    "3.10.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.10.0",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit",
+        "unit": "set -e; for t in test/node/*.js test/*.js; do node $t; done"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^3.0.1",
+        "create-ecdh": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^2.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "~1.3.2",
+        "standard": "^5.0.2",
+        "tape": "~2.3.2"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "0d36370d453d663552f5d4a522aec3c27cc0557f",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.10.0",
+      "_shasum": "bfe70d7987b4abb8e551ea964307767c3b5d56bf",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "bfe70d7987b4abb8e551ea964307767c3b5d56bf",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.10.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.11.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.11.0",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run standard && npm run unit",
+        "unit": "node test/",
+        "browser": "zuul --browser-version $BROWSER_VERSION --browser-name $BROWSER_NAME -- test/index.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "~1.3.2",
+        "pseudorandombytes": "^2.0.0",
+        "standard": "^5.0.2",
+        "tape": "~2.3.2",
+        "zuul": "^3.6.0"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "9fabcbd78209a99c7c624d1509d389b00e8d733f",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.11.0",
+      "_shasum": "3652a0906ab9b2a7e0c3ce66a408e957a2485522",
+      "_from": ".",
+      "_npmVersion": "3.3.10",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "3652a0906ab9b2a7e0c3ce66a408e957a2485522",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.11.1": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.11.1",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run standard && npm run unit",
+        "unit": "node test/",
+        "browser": "zuul --browser-version $BROWSER_VERSION --browser-name $BROWSER_NAME -- test/index.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "~1.3.2",
+        "pseudorandombytes": "^2.0.0",
+        "standard": "^5.0.2",
+        "tape": "~2.3.2",
+        "zuul": "^3.6.0"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "acd878919d8be5b6d3f7678f1708a7afafa2319d",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.11.1",
+      "_npmVersion": "5.1.0",
+      "_nodeVersion": "8.1.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+        "shasum": "948945efc6757a400d6e5e5af47194d10064279f",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/crypto-browserify-3.11.1.tgz_1499783159169_0.4202242400497198"
+      },
+      "directories": {}
+    },
+    "3.12.0": {
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "name": "crypto-browserify",
+      "description": "implementation of crypto for the browser",
+      "version": "3.12.0",
+      "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+      },
+      "scripts": {
+        "standard": "standard",
+        "test": "npm run standard && npm run unit",
+        "unit": "node test/",
+        "browser": "zuul --browser-version $BROWSER_VERSION --browser-name $BROWSER_NAME -- test/index.js"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "~1.3.2",
+        "pseudorandombytes": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "standard": "^5.0.2",
+        "tape": "~2.3.2",
+        "zuul": "^3.6.0"
+      },
+      "optionalDependencies": {},
+      "browser": {
+        "crypto": false
+      },
+      "license": "MIT",
+      "gitHead": "5ffcb3c1c8c0715cb0d75ce012103e70cc625e8c",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+      },
+      "_id": "crypto-browserify@3.12.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+        "shasum": "396cf9f3137f03e4b8e532c58f698254e00f80ec",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/crypto-browserify-3.12.0.tgz_1509711759261_0.0643247205298394"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# crypto-browserify\n\nA port of node's `crypto` module to the browser.\n\n[![Build Status](https://travis-ci.org/crypto-browserify/crypto-browserify.svg?branch=master)](https://travis-ci.org/crypto-browserify/crypto-browserify)\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n[![Sauce Test Status](https://saucelabs.com/browser-matrix/crypto-browserify.svg)](https://saucelabs.com/u/crypto-browserify)\n\nThe goal of this module is to reimplement node's crypto module,\nin pure javascript so that it can run in the browser.\n\nHere is the subset that is currently implemented:\n\n* createHash (sha1, sha224, sha256, sha384, sha512, md5, rmd160)\n* createHmac (sha1, sha224, sha256, sha384, sha512, md5, rmd160)\n* pbkdf2\n* pbkdf2Sync\n* randomBytes\n* pseudoRandomBytes\n* createCipher (aes)\n* createDecipher (aes)\n* createDiffieHellman\n* createSign (rsa, ecdsa)\n* createVerify (rsa, ecdsa)\n* createECDH (secp256k1)\n* publicEncrypt/privateDecrypt (rsa)\n* privateEncrypt/publicDecrypt (rsa)\n\n## todo\n\nthese features from node's `crypto` are still unimplemented.\n\n* createCredentials\n\n## contributions\n\nIf you are interested in writing a feature, please implement as a new module,\nwhich will be incorporated into crypto-browserify as a dependency.\n\nAll deps must be compatible with node's crypto\n(generate example inputs and outputs with node,\nand save base64 strings inside JSON, so that tests can run in the browser.\nsee [sha.js](https://github.com/dominictarr/sha.js)\n\nCrypto is _extra serious_ so please do not hesitate to review the code,\nand post comments if you do.\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2019-03-20T09:22:42.666Z",
+    "created": "2012-04-23T05:52:35.813Z",
+    "0.0.0": "2012-04-23T05:52:40.032Z",
+    "0.0.1": "2012-04-23T06:35:32.555Z",
+    "0.1.0": "2012-06-20T07:26:29.527Z",
+    "0.1.1": "2012-07-20T06:09:09.391Z",
+    "0.1.2": "2012-12-19T23:15:21.364Z",
+    "0.2.0": "2012-12-22T18:48:35.490Z",
+    "0.2.1": "2012-12-22T20:41:44.264Z",
+    "0.2.2": "2013-05-04T12:45:13.724Z",
+    "0.2.3": "2013-05-12T17:57:36.103Z",
+    "0.3.0": "2013-07-30T10:02:08.223Z",
+    "0.4.0": "2013-07-31T14:24:07.777Z",
+    "1.0.0": "2013-08-05T22:06:16.297Z",
+    "1.0.1": "2013-08-06T04:33:14.376Z",
+    "1.0.2": "2013-08-07T08:53:41.670Z",
+    "1.0.3": "2013-09-20T22:10:27.013Z",
+    "1.0.4": "2013-10-12T10:36:20.916Z",
+    "1.0.5": "2013-10-12T11:19:33.359Z",
+    "1.0.6": "2013-11-04T06:13:23.018Z",
+    "1.0.7": "2013-11-19T16:53:09.308Z",
+    "1.0.8": "2013-11-27T04:03:55.699Z",
+    "1.0.9": "2013-11-27T05:16:02.386Z",
+    "2.0.0": "2014-01-06T10:17:10.517Z",
+    "2.1.0": "2014-01-16T18:48:48.934Z",
+    "2.1.1": "2014-04-04T00:00:50.011Z",
+    "2.1.2": "2014-04-04T06:45:43.581Z",
+    "2.1.3": "2014-04-23T04:32:15.794Z",
+    "2.1.4": "2014-04-23T05:02:26.885Z",
+    "2.1.5": "2014-04-23T05:41:55.893Z",
+    "2.1.6": "2014-04-27T17:24:54.140Z",
+    "2.1.7": "2014-05-11T14:23:22.595Z",
+    "2.1.8": "2014-05-11T14:27:12.900Z",
+    "2.1.10": "2014-07-19T18:16:38.660Z",
+    "3.0.0": "2014-07-22T21:42:29.480Z",
+    "3.0.1": "2014-07-28T07:01:41.532Z",
+    "3.0.2": "2014-08-31T16:57:09.388Z",
+    "3.1.0": "2014-09-18T09:40:07.853Z",
+    "3.2.0": "2014-09-22T08:09:31.291Z",
+    "3.2.1": "2014-09-24T09:25:12.143Z",
+    "3.2.2": "2014-09-24T10:42:59.551Z",
+    "3.2.3": "2014-09-24T19:20:48.876Z",
+    "3.2.4": "2014-09-25T00:29:24.731Z",
+    "3.2.5": "2014-09-25T21:27:03.876Z",
+    "3.2.6": "2014-10-03T15:11:24.330Z",
+    "3.2.7": "2014-10-09T12:20:26.611Z",
+    "3.2.8": "2014-10-20T12:20:42.148Z",
+    "3.3.0": "2014-11-01T15:55:38.347Z",
+    "3.4.0": "2014-11-17T16:15:10.869Z",
+    "3.4.1": "2014-11-17T20:38:06.900Z",
+    "3.4.3": "2014-11-17T20:56:58.728Z",
+    "3.5.0": "2014-11-26T10:35:51.505Z",
+    "3.5.1": "2014-11-26T10:46:45.263Z",
+    "3.6.0": "2014-11-26T10:53:18.009Z",
+    "3.7.0": "2014-12-19T00:25:46.994Z",
+    "3.7.1": "2014-12-22T20:57:00.031Z",
+    "3.7.2": "2014-12-23T03:45:35.715Z",
+    "3.8.0": "2015-01-03T13:44:04.753Z",
+    "3.8.1": "2015-01-04T13:17:18.118Z",
+    "3.8.3": "2015-01-05T01:22:10.406Z",
+    "3.9.0": "2015-01-06T00:05:08.495Z",
+    "3.9.1": "2015-01-10T00:48:04.953Z",
+    "3.9.2": "2015-01-11T16:35:27.299Z",
+    "3.9.3": "2015-01-12T20:56:18.521Z",
+    "3.9.4": "2015-01-12T23:38:41.950Z",
+    "3.9.6": "2015-01-14T08:57:55.771Z",
+    "3.9.7": "2015-01-19T13:25:26.736Z",
+    "3.9.8": "2015-01-20T12:58:05.034Z",
+    "3.9.9": "2015-01-21T11:08:20.003Z",
+    "3.9.10": "2015-01-26T14:34:42.344Z",
+    "3.9.11": "2015-01-29T14:03:40.978Z",
+    "3.9.12": "2015-02-02T13:16:02.436Z",
+    "3.9.13": "2015-02-23T21:18:37.771Z",
+    "3.9.14": "2015-04-16T12:53:34.184Z",
+    "3.10.0": "2015-09-27T23:57:08.152Z",
+    "3.11.0": "2015-11-03T18:00:42.791Z",
+    "3.11.1": "2017-07-11T14:26:00.207Z",
+    "3.12.0": "2017-11-03T12:22:40.198Z"
+  },
+  "author": {
+    "name": "Dominic Tarr",
+    "email": "dominic.tarr@gmail.com",
+    "url": "dominictarr.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/crypto-browserify/crypto-browserify.git"
+  },
+  "users": {
+    "wenbing": true,
+    "stanzhai": true,
+    "ryanj": true,
+    "tangiblej": true,
+    "arnold-almeida": true,
+    "simplyianm": true,
+    "pcooney10": true,
+    "ersineser": true,
+    "alexbuczynsky": true,
+    "zwwggg": true,
+    "quafoo": true,
+    "yuxy": true
+  },
+  "homepage": "https://github.com/crypto-browserify/crypto-browserify",
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/crypto-browserify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/crypto-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/crypto-browserify.min.json
@@ -1,0 +1,1515 @@
+{
+  "name": "crypto-browserify",
+  "dist-tags": {
+    "latest": "3.12.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "crypto-browserify",
+      "version": "0.0.0",
+      "dist": {
+        "shasum": "eb70a764fc7dc0f4e77c6ec34ce14b0f5242c967",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.1": {
+      "name": "crypto-browserify",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "e87209b392fd759eeb5a84494be47095fbcccc7f",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "crypto-browserify",
+      "version": "0.1.0",
+      "dist": {
+        "shasum": "f36094c2c4208c9c86bc730b166d86184faac8ff",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.1": {
+      "name": "crypto-browserify",
+      "version": "0.1.1",
+      "dist": {
+        "shasum": "34343b512041a9c32ae7ec6a7f8ab4d06b418a0b",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.2": {
+      "name": "crypto-browserify",
+      "version": "0.1.2",
+      "dist": {
+        "shasum": "7c6ce24c0ac1640dcd9701f47645ef1950d01765",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.0": {
+      "name": "crypto-browserify",
+      "version": "0.2.0",
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "e4f80da2cac3735b7544a69749f264e00b78a217",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.1": {
+      "name": "crypto-browserify",
+      "version": "0.2.1",
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "303ed9046f8604a3d7c35ec4a6d46d2268712078",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.2": {
+      "name": "crypto-browserify",
+      "version": "0.2.2",
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "0f1c8499ba0edaa5b087176924e3b2f088582c2d",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.3": {
+      "name": "crypto-browserify",
+      "version": "0.2.3",
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "c98141505d90e31a1e456cb97343dc3b0f4a1a2a",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.2.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.3.0": {
+      "name": "crypto-browserify",
+      "version": "0.3.0",
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "0c0991f19be6da34415e12bc58a56bf71a950587",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.3.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.0": {
+      "name": "crypto-browserify",
+      "version": "0.4.0",
+      "devDependencies": {
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "246f6a337b884c99ffe8bfb085a184aee60c33f3",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-0.4.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.0": {
+      "name": "crypto-browserify",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "d5d8bd9fe60c53e8f8b7aa39ab6561dcf7fea64f",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.1": {
+      "name": "crypto-browserify",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "09db81b972418eaa0caff05d85d0d8af3b31aed1",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.2": {
+      "name": "crypto-browserify",
+      "version": "1.0.2",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "55b9d57a98b6ec0e94c3e477cecfe7871a98d38e",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.3": {
+      "name": "crypto-browserify",
+      "version": "1.0.3",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "834063a48147eefd5d96580826c385a10535c7f5",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.4": {
+      "name": "crypto-browserify",
+      "version": "1.0.4",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "f1f23dfde1730fee5884585cc4f2ae019a394a78",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.5": {
+      "name": "crypto-browserify",
+      "version": "1.0.5",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "40273430e62f30adf412aeb761675672b81ace63",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.6": {
+      "name": "crypto-browserify",
+      "version": "1.0.6",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "55470f73639581dc59e6529a890f64c0b04d08d4",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.7": {
+      "name": "crypto-browserify",
+      "version": "1.0.7",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "12dbfc84c39ff6e7222765b42ea5913e719423c5",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.8": {
+      "name": "crypto-browserify",
+      "version": "1.0.8",
+      "devDependencies": {
+        "brfs": "~0.0.8",
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "07f9d01e3c79bd248512fdfb1e5f75110dbbcf6d",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.9": {
+      "name": "crypto-browserify",
+      "version": "1.0.9",
+      "devDependencies": {
+        "brfs": "~0.0.8",
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "cc5449685dfb85eb11c9828acc7cb87ab5bbfcc0",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.0.0": {
+      "name": "crypto-browserify",
+      "version": "2.0.0",
+      "dependencies": {
+        "sha.js": "1.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "4aa6e3bac6686fe94ddc1f41850550039897b9c7",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.0": {
+      "name": "crypto-browserify",
+      "version": "2.1.0",
+      "dependencies": {
+        "sha.js": "1.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "5c5880bb3b6d350f8580d8eb666ed8fa0902cce0",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.1": {
+      "name": "crypto-browserify",
+      "version": "2.1.1",
+      "dependencies": {
+        "sha.js": "2.1.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "7dc55b1b40c2c07ec997aad3b089b18f5969b11f",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.2": {
+      "name": "crypto-browserify",
+      "version": "2.1.2",
+      "dependencies": {
+        "sha.js": "2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "fb5fe9ad367e936f17e44bebd7e0373d38a97a37",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.3": {
+      "name": "crypto-browserify",
+      "version": "2.1.3",
+      "dependencies": {
+        "sha.js": "2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "4542421c55abd3831db3ebbd79f73942d44221bb",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.4": {
+      "name": "crypto-browserify",
+      "version": "2.1.4",
+      "dependencies": {
+        "sha.js": "2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "74c7a75d07d0edd1d553efcfe33ffba5f872584b",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.5": {
+      "name": "crypto-browserify",
+      "version": "2.1.5",
+      "dependencies": {
+        "sha.js": "2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "8a1ed33d0f0168a11e803d10f90d559ae62993ed",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.6": {
+      "name": "crypto-browserify",
+      "version": "2.1.6",
+      "dependencies": {
+        "sha.js": "2.1.3"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "40495449c5ab3c5786b3ac8ad8ee41e1ba96a421",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.7": {
+      "name": "crypto-browserify",
+      "version": "2.1.7",
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.3"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "8543d09a74437afd7fcdb6b87139ae56708f35d5",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.8": {
+      "name": "crypto-browserify",
+      "version": "2.1.8",
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.3"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "3ef8ccd7da5a4debdd379e7d64a2ae128b9d977a",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "2.1.10": {
+      "name": "crypto-browserify",
+      "version": "2.1.10",
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "4f2ca6311843cf087cdf008e43a4f3686ef6e6bb",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-2.1.10.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0": {
+      "name": "crypto-browserify",
+      "version": "3.0.0",
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "5d42e013137c658bcc74de792d2d96268aeaa883",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.1": {
+      "name": "crypto-browserify",
+      "version": "3.0.1",
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.7"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "770fd68e8422f9b1e53d6812f1c2ce2ea7ab917c",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.2": {
+      "name": "crypto-browserify",
+      "version": "3.0.2",
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.1.8"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "43218365d9d086e8c1b88f968fb7134f13505c84",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.1.0": {
+      "name": "crypto-browserify",
+      "version": "3.1.0",
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "25e9591408054fae17326003c4bf1e15bf27a1a4",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.0": {
+      "name": "crypto-browserify",
+      "version": "3.2.0",
+      "dependencies": {
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "424b5f9ab3d1afa4ba20faff5c90992eeb9cd705",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.1": {
+      "name": "crypto-browserify",
+      "version": "3.2.1",
+      "dependencies": {
+        "pbkdf2-compat": "2.0.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "be21a5b291b4b896facb145505252c6d8820b9d2",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.2": {
+      "name": "crypto-browserify",
+      "version": "3.2.2",
+      "dependencies": {
+        "pbkdf2-compat": "2.0.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "e5ec42700ff964f1e5ca472d943c5c27db75e36a",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.4": {
+      "name": "crypto-browserify",
+      "version": "3.2.4",
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "0d704f787b38e952c65211bcf28e4c3fca9167d0",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.5": {
+      "name": "crypto-browserify",
+      "version": "3.2.5",
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "26c92bba20c8bfa7c50aa71ca95972b353ebbec2",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.6": {
+      "name": "crypto-browserify",
+      "version": "3.2.6",
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "e65a44893ad85138dbf0eaf515675adfd917cdb4",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.7": {
+      "name": "crypto-browserify",
+      "version": "3.2.7",
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "b2aea649d58136caa02710f9fe1af4ab762d14d5",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.8": {
+      "name": "crypto-browserify",
+      "version": "3.2.8",
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "b9b11dbe6d9651dd882a01e6cc467df718ecf189",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.0": {
+      "name": "crypto-browserify",
+      "version": "3.3.0",
+      "dependencies": {
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.2.6",
+        "browserify-aes": "0.4.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "b9fc75bb4a0ed61dcf1cd5dae96eb30c9c3e506c",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.0": {
+      "name": "crypto-browserify",
+      "version": "3.4.0",
+      "dependencies": {
+        "browserify-aes": "0.4.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "0081fea45550de8689f032ef08a2a78ea73b3295",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.4.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.1": {
+      "name": "crypto-browserify",
+      "version": "3.4.1",
+      "dependencies": {
+        "browserify-aes": "0.4.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0",
+        "sha.js": "~2.2.7"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "b058aa8b935861e38f19b80220fe447145e2b5cb",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.4.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.3": {
+      "name": "crypto-browserify",
+      "version": "3.4.3",
+      "dependencies": {
+        "browserify-aes": "0.4.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0",
+        "sha.js": "~2.2.7"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "7bff7ea481ed679a159fd8bf0f4e56a1d8b50e00",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.4.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.5.0": {
+      "name": "crypto-browserify",
+      "version": "3.5.0",
+      "dependencies": {
+        "browserify-aes": "0.4.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "e0f6039b83c375431b8989637d9b3883fd226177",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.5.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.5.1": {
+      "name": "crypto-browserify",
+      "version": "3.5.1",
+      "dependencies": {
+        "browserify-aes": "0.6.0",
+        "browserify-sign": "2.4.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "diffie-hellman": "2.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "eab25427de15f80d15f296466fbfb3a8a86ee500",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.5.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.6.0": {
+      "name": "crypto-browserify",
+      "version": "3.6.0",
+      "dependencies": {
+        "browserify-aes": "0.6.0",
+        "browserify-sign": "2.4.0",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "pbkdf2-compat": "2.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "6f74a6d30cf0bd11ef5168410bbdc7a65f6d01cb",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.6.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.7.0": {
+      "name": "crypto-browserify",
+      "version": "3.7.0",
+      "dependencies": {
+        "browserify-aes": "0.6.1",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "browserify-sign": "2.6.0",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "5b9de9b65b04f22a087cb0339db5232f536323cc",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.7.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.7.1": {
+      "name": "crypto-browserify",
+      "version": "3.7.1",
+      "dependencies": {
+        "browserify-aes": "0.6.1",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "browserify-sign": "2.6.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.0.1",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "ed9788686ece390183217aeb56e908bdd33d83f3",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.7.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.7.2": {
+      "name": "crypto-browserify",
+      "version": "3.7.2",
+      "dependencies": {
+        "browserify-aes": "0.6.1",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "browserify-sign": "2.7.0",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "17456add9fce4648a39645d2aa2d0096fdd90b80",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.7.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.8.0": {
+      "name": "crypto-browserify",
+      "version": "3.8.0",
+      "dependencies": {
+        "browserify-aes": "0.7.2",
+        "create-ecdh": "1.0.0",
+        "diffie-hellman": "2.2.0",
+        "browserify-sign": "2.7.0",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "fd564ae7cc34f266f024003e189f1bf476c7eb19",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.8.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.8.1": {
+      "name": "crypto-browserify",
+      "version": "3.8.1",
+      "dependencies": {
+        "browserify-aes": "0.7.2",
+        "create-ecdh": "1.0.1",
+        "diffie-hellman": "2.2.2",
+        "browserify-sign": "2.7.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "dcae2d68c57994d53eb349cffc77893408a87635",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.8.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.8.3": {
+      "name": "crypto-browserify",
+      "version": "3.8.3",
+      "dependencies": {
+        "browserify-aes": "0.8.0",
+        "create-ecdh": "1.0.1",
+        "diffie-hellman": "2.2.2",
+        "browserify-sign": "2.7.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "a7f91d3204c92bc6593d134b6af70be0dc1aad32",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.8.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.0": {
+      "name": "crypto-browserify",
+      "version": "3.9.0",
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.1",
+        "diffie-hellman": "2.2.2",
+        "browserify-sign": "2.7.2",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.0",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "04faa9abee7d972a44b474f7e91b196baf2a2d0b",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.1": {
+      "name": "crypto-browserify",
+      "version": "3.9.1",
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.7.5",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "020319381171e3895c5d30480b281f417d583359",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.2": {
+      "name": "crypto-browserify",
+      "version": "3.9.2",
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.7.5",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "4e295140c8eef2b720184323087c30f4cbb82fa9",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.3": {
+      "name": "crypto-browserify",
+      "version": "3.9.3",
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.7.5",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.4"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "fced960abd47e55c130a802663c70081cddf9245",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.4": {
+      "name": "crypto-browserify",
+      "version": "3.9.4",
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.8.0",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.4"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.0"
+      },
+      "dist": {
+        "shasum": "1bda647421800616e4332be0196ac4045a5c51a3",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.6": {
+      "name": "crypto-browserify",
+      "version": "3.9.6",
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "create-ecdh": "1.0.3",
+        "diffie-hellman": "2.2.3",
+        "browserify-sign": "2.8.0",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "ripemd160": "0.2.0",
+        "sha.js": "2.3.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "5e0f9494e9720dd99ef2f23dce7ec6d5be098615",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.7": {
+      "name": "crypto-browserify",
+      "version": "3.9.7",
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "2.2.3",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "f737a62c13fa11b1e0cdd64b6ed86897e5d5e0e8",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.8": {
+      "name": "crypto-browserify",
+      "version": "3.9.8",
+      "dependencies": {
+        "browserify-aes": "0.8.1",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "2.2.3",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "b107059e9b5bf9a4e7d094bf28fb63ab49639697",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.9": {
+      "name": "crypto-browserify",
+      "version": "3.9.9",
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "2.2.3",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "1296ad1fb0168fb621b44af68dcc7939df0d4af6",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.9.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.10": {
+      "name": "crypto-browserify",
+      "version": "3.9.10",
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "2.2.3",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "3b8bfa3876dd9a466d6720abf1f74dbbea934a75",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.10.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.11": {
+      "name": "crypto-browserify",
+      "version": "3.9.11",
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "2.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "2cd8539bd4577f4c2dd7616905112fd982ddd277",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.11.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.12": {
+      "name": "crypto-browserify",
+      "version": "3.9.12",
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "1.0.3",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "^3.0.1",
+        "public-encrypt": "1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "3ddbfa01bb3e4c6501b3871787916744b3c97175",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.12.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.13": {
+      "name": "crypto-browserify",
+      "version": "3.9.13",
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "2.8.0",
+        "create-ecdh": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2-compat": "^3.0.1",
+        "public-encrypt": "^2.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "07b829716685101dcd73f0bbcc95d16aa73fedf1",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.9.14": {
+      "name": "crypto-browserify",
+      "version": "3.9.14",
+      "dependencies": {
+        "browserify-aes": "^1.0.0",
+        "browserify-sign": "^3.0.1",
+        "create-ecdh": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^2.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2",
+        "hash-test-vectors": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "d69925252c845392714aed1460c54b56605314ab",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.9.14.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.10.0": {
+      "name": "crypto-browserify",
+      "version": "3.10.0",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^3.0.1",
+        "create-ecdh": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^3.0.1",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^2.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "~1.3.2",
+        "standard": "^5.0.2",
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "bfe70d7987b4abb8e551ea964307767c3b5d56bf",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.10.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.11.0": {
+      "name": "crypto-browserify",
+      "version": "3.11.0",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "~1.3.2",
+        "pseudorandombytes": "^2.0.0",
+        "standard": "^5.0.2",
+        "tape": "~2.3.2",
+        "zuul": "^3.6.0"
+      },
+      "dist": {
+        "shasum": "3652a0906ab9b2a7e0c3ce66a408e957a2485522",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.11.1": {
+      "name": "crypto-browserify",
+      "version": "3.11.1",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "~1.3.2",
+        "pseudorandombytes": "^2.0.0",
+        "standard": "^5.0.2",
+        "tape": "~2.3.2",
+        "zuul": "^3.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+        "shasum": "948945efc6757a400d6e5e5af47194d10064279f",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.12.0": {
+      "name": "crypto-browserify",
+      "version": "3.12.0",
+      "dependencies": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "~1.3.2",
+        "pseudorandombytes": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "standard": "^5.0.2",
+        "tape": "~2.3.2",
+        "zuul": "^3.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+        "shasum": "396cf9f3137f03e4b8e532c58f698254e00f80ec",
+        "tarball": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    }
+  },
+  "modified": "2019-03-20T09:22:42.666Z"
+}

--- a/test/fixtures/registry-mocks/content/cyclist.json
+++ b/test/fixtures/registry-mocks/content/cyclist.json
@@ -1,0 +1,371 @@
+{
+  "_id": "cyclist",
+  "_rev": "13-bd33eb53de31bf4eb0651f923b4ace1a",
+  "name": "cyclist",
+  "description": "Cyclist is an efficient cyclic list implemention.",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "cyclist",
+      "version": "0.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/cyclist"
+      },
+      "description": "Cyclist is an efficient cyclic list implemention.",
+      "dependencies": {},
+      "keywords": [
+        "circular",
+        "buffer",
+        "ring",
+        "cyclic",
+        "data"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/cyclist/issues"
+      },
+      "_id": "cyclist@0.1.0",
+      "dist": {
+        "shasum": "71f5250dd4e9ea89e4b2874a294f4e9b98b451f2",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "cyclist",
+      "version": "0.1.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/cyclist"
+      },
+      "description": "Cyclist is an efficient cyclic list implemention.",
+      "dependencies": {},
+      "keywords": [
+        "circular",
+        "buffer",
+        "ring",
+        "cyclic",
+        "data"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/cyclist/issues"
+      },
+      "_id": "cyclist@0.1.1",
+      "dist": {
+        "shasum": "1bcfa56b081448cdb5e12bfc1bfad34b47fba8f3",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "cyclist",
+      "version": "0.2.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/cyclist"
+      },
+      "description": "Cyclist is an efficient cyclic list implemention.",
+      "dependencies": {},
+      "keywords": [
+        "circular",
+        "buffer",
+        "ring",
+        "cyclic",
+        "data"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/cyclist/issues"
+      },
+      "_id": "cyclist@0.2.0",
+      "dist": {
+        "shasum": "2d211e34d73037c809f70a28ddd072b0854c30e2",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "cyclist",
+      "version": "0.2.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/cyclist"
+      },
+      "description": "Cyclist is an efficient cyclic list implemention.",
+      "dependencies": {},
+      "keywords": [
+        "circular",
+        "buffer",
+        "ring",
+        "cyclic",
+        "data"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/cyclist/issues"
+      },
+      "_id": "cyclist@0.2.1",
+      "dist": {
+        "shasum": "87d906a82d9d1e73662ebac012c0d1583a0e45eb",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "cyclist",
+      "version": "0.2.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/cyclist"
+      },
+      "description": "Cyclist is an efficient cyclic list implemention.",
+      "dependencies": {},
+      "keywords": [
+        "circular",
+        "buffer",
+        "ring",
+        "cyclic",
+        "data"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/cyclist/issues"
+      },
+      "_id": "cyclist@0.2.2",
+      "dist": {
+        "shasum": "1b33792e11e914a2fd6d6ed6447464444e5fa640",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "cyclist",
+      "version": "1.0.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/cyclist"
+      },
+      "description": "Cyclist is an efficient cyclic list implemention.",
+      "dependencies": {},
+      "keywords": [
+        "circular",
+        "buffer",
+        "ring",
+        "cyclic",
+        "data"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "devDependencies": {
+        "standard": "^3.8.0",
+        "tape": "^4.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/cyclist/issues"
+      },
+      "homepage": "https://github.com/mafintosh/cyclist",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "license": "MIT",
+      "gitHead": "dcc75e12064841fa8cfa1b75b797192898a147d5",
+      "_id": "cyclist@1.0.0",
+      "_shasum": "56941d812de95866d1b33b986717e6e662c3d2fa",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "56941d812de95866d1b33b986717e6e662c3d2fa",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "cyclist",
+      "version": "1.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/cyclist"
+      },
+      "description": "Cyclist is an efficient cyclic list implemention.",
+      "dependencies": {},
+      "keywords": [
+        "circular",
+        "buffer",
+        "ring",
+        "cyclic",
+        "data"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "devDependencies": {
+        "standard": "^3.8.0",
+        "tape": "^4.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/cyclist/issues"
+      },
+      "homepage": "https://github.com/mafintosh/cyclist",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "license": "MIT",
+      "gitHead": "c7be6d79b57c19b046cf05fc23fabf43d50f060d",
+      "_id": "cyclist@1.0.1",
+      "_shasum": "596e9698fd0c80e12038c2b82d6eb1b35b6224d9",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "596e9698fd0c80e12038c2b82d6eb1b35b6224d9",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# Cyclist\n\nCyclist is an efficient [cyclic list](http://en.wikipedia.org/wiki/Circular_buffer) implemention for Javascript.\nIt is available through npm\n\n```\nnpm install cyclist\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/cyclist.svg?style=flat)](http://travis-ci.org/mafintosh/cyclist)\n\n## What?\n\nCyclist allows you to create a list of fixed size that is cyclic.\nIn a cyclist list the element following the last one is the first one.\nThis property can be really useful when for example trying to order data\npackets that can arrive out of order over a network stream.\n\n## Usage\n\n``` js\nvar cyclist = require('cyclist')\nvar list = cyclist(4)\n\nlist.put(42, 'hello 42') // store something and index 42\nlist.put(43, 'hello 43') // store something and index 43\n\nconsole.log(list.get(42)) // prints hello 42\nconsole.log(list.get(46)) // prints hello 42 again since 46 - 42 == list.size\n```\n\n## API\n\n* `cyclist(size)` creates a new buffer\n* `cyclist#get(index)` get an object stored in the buffer\n* `cyclist#put(index,value)` insert an object into the buffer\n* `cyclist#del(index)` delete an object from an index\n* `cyclist#size` property containing current size of buffer\n\n## License\n\nMIT\n\n",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2015-05-13T16:50:43.329Z",
+    "created": "2013-06-12T22:20:11.877Z",
+    "0.1.0": "2013-06-12T22:20:16.306Z",
+    "0.1.1": "2013-06-12T22:55:40.255Z",
+    "0.2.0": "2013-06-19T21:37:00.223Z",
+    "0.2.1": "2013-07-30T19:20:49.032Z",
+    "0.2.2": "2013-07-30T20:09:15.472Z",
+    "1.0.0": "2015-05-13T16:25:25.577Z",
+    "1.0.1": "2015-05-13T16:50:43.329Z"
+  },
+  "author": {
+    "name": "Mathias Buus Madsen",
+    "email": "mathiasbuus@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mafintosh/cyclist"
+  },
+  "homepage": "https://github.com/mafintosh/cyclist",
+  "keywords": [
+    "circular",
+    "buffer",
+    "ring",
+    "cyclic",
+    "data"
+  ],
+  "bugs": {
+    "url": "https://github.com/mafintosh/cyclist/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/cyclist.min.json
+++ b/test/fixtures/registry-mocks/content/cyclist.min.json
@@ -1,0 +1,73 @@
+{
+  "name": "cyclist",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "cyclist",
+      "version": "0.1.0",
+      "dist": {
+        "shasum": "71f5250dd4e9ea89e4b2874a294f4e9b98b451f2",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "cyclist",
+      "version": "0.1.1",
+      "dist": {
+        "shasum": "1bcfa56b081448cdb5e12bfc1bfad34b47fba8f3",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.1.1.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "cyclist",
+      "version": "0.2.0",
+      "dist": {
+        "shasum": "2d211e34d73037c809f70a28ddd072b0854c30e2",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "cyclist",
+      "version": "0.2.1",
+      "dist": {
+        "shasum": "87d906a82d9d1e73662ebac012c0d1583a0e45eb",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "cyclist",
+      "version": "0.2.2",
+      "dist": {
+        "shasum": "1b33792e11e914a2fd6d6ed6447464444e5fa640",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "cyclist",
+      "version": "1.0.0",
+      "devDependencies": {
+        "standard": "^3.8.0",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "56941d812de95866d1b33b986717e6e662c3d2fa",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "cyclist",
+      "version": "1.0.1",
+      "devDependencies": {
+        "standard": "^3.8.0",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "596e9698fd0c80e12038c2b82d6eb1b35b6224d9",
+        "tarball": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2015-05-13T16:50:43.329Z"
+}

--- a/test/fixtures/registry-mocks/content/decode-uri-component.json
+++ b/test/fixtures/registry-mocks/content/decode-uri-component.json
@@ -1,0 +1,187 @@
+{
+  "_id": "decode-uri-component",
+  "_rev": "2-98d50a51a9681c8c1dbd92574c6022e5",
+  "name": "decode-uri-component",
+  "description": "A better decodeURIComponent",
+  "dist-tags": {
+    "latest": "0.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "decode-uri-component",
+      "version": "0.1.0",
+      "description": "A better decodeURIComponent",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/samverschueren/decode-uri-component.git"
+      },
+      "author": {
+        "name": "Sam Verschueren",
+        "email": "sam.verschueren@gmail.com",
+        "url": "github.com/SamVerschueren"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && nyc ava",
+        "coveralls": "nyc report --reporter=text-lcov | coveralls"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "decode",
+        "uri",
+        "component",
+        "decodeuricomponent",
+        "components",
+        "decoder",
+        "url"
+      ],
+      "devDependencies": {
+        "ava": "*",
+        "coveralls": "^2.13.1",
+        "nyc": "^10.3.2",
+        "xo": "*"
+      },
+      "gitHead": "43d5a895a5dbcac13faf19d3235a155635f5feda",
+      "bugs": {
+        "url": "https://github.com/samverschueren/decode-uri-component/issues"
+      },
+      "homepage": "https://github.com/samverschueren/decode-uri-component#readme",
+      "_id": "decode-uri-component@0.1.0",
+      "_shasum": "6eb2ac05e5cf288590b4a8b60d774c027e3fd5ab",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "samverschueren",
+        "email": "sam.verschueren@gmail.com"
+      },
+      "dist": {
+        "shasum": "6eb2ac05e5cf288590b4a8b60d774c027e3fd5ab",
+        "tarball": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "samverschueren",
+          "email": "sam.verschueren@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/decode-uri-component-0.1.0.tgz_1495226477010_0.7113540396094322"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "decode-uri-component",
+      "version": "0.2.0",
+      "description": "A better decodeURIComponent",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/samverschueren/decode-uri-component.git"
+      },
+      "author": {
+        "name": "Sam Verschueren",
+        "email": "sam.verschueren@gmail.com",
+        "url": "github.com/SamVerschueren"
+      },
+      "engines": {
+        "node": ">=0.10"
+      },
+      "scripts": {
+        "test": "xo && nyc ava",
+        "coveralls": "nyc report --reporter=text-lcov | coveralls"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "decode",
+        "uri",
+        "component",
+        "decodeuricomponent",
+        "components",
+        "decoder",
+        "url"
+      ],
+      "devDependencies": {
+        "ava": "^0.17.0",
+        "coveralls": "^2.13.1",
+        "nyc": "^10.3.2",
+        "xo": "^0.16.0"
+      },
+      "gitHead": "52782a347527a6a05fed02434ffcf8f2ba1b19a3",
+      "bugs": {
+        "url": "https://github.com/samverschueren/decode-uri-component/issues"
+      },
+      "homepage": "https://github.com/samverschueren/decode-uri-component#readme",
+      "_id": "decode-uri-component@0.2.0",
+      "_shasum": "eb3913333458775cb84cd1a1fae062106bb87545",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "samverschueren",
+        "email": "sam.verschueren@gmail.com"
+      },
+      "dist": {
+        "shasum": "eb3913333458775cb84cd1a1fae062106bb87545",
+        "tarball": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "samverschueren",
+          "email": "sam.verschueren@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/decode-uri-component-0.2.0.tgz_1498673766342_0.38562501198612154"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# decode-uri-component\n\n[![Build Status](https://travis-ci.org/SamVerschueren/decode-uri-component.svg?branch=master)](https://travis-ci.org/SamVerschueren/decode-uri-component) [![Coverage Status](https://coveralls.io/repos/SamVerschueren/decode-uri-component/badge.svg?branch=master&service=github)](https://coveralls.io/github/SamVerschueren/decode-uri-component?branch=master)\n\n> A better [decodeURIComponent](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent)\n\n\n## Why?\n\n- Decodes `+` to a space.\n- Converts the [BOM](https://en.wikipedia.org/wiki/Byte_order_mark) to a [replacement character](https://en.wikipedia.org/wiki/Specials_(Unicode_block)#Replacement_character) `�`.\n- Does not throw with invalid encoded input.\n- Decodes as much of the string as possible.\n\n\n## Install\n\n```\n$ npm install --save decode-uri-component\n```\n\n\n## Usage\n\n```js\nconst decodeUriComponent = require('decode-uri-component');\n\ndecodeUriComponent('%25');\n//=> '%'\n\ndecodeUriComponent('%');\n//=> '%'\n\ndecodeUriComponent('st%C3%A5le');\n//=> 'ståle'\n\ndecodeUriComponent('%st%C3%A5le%');\n//=> '%ståle%'\n\ndecodeUriComponent('%%7Bst%C3%A5le%7D%');\n//=> '%{ståle}%'\n\ndecodeUriComponent('%7B%ab%%7C%de%%7D');\n//=> '{%ab%|%de%}'\n\ndecodeUriComponent('%FE%FF');\n//=> '\\uFFFD\\uFFFD'\n\ndecodeUriComponent('%C2');\n//=> '\\uFFFD'\n\ndecodeUriComponent('%C2%B5');\n//=> 'µ'\n```\n\n\n## API\n\n### decodeUriComponent(encodedURI)\n\n#### encodedURI\n\nType: `string`\n\nAn encoded component of a Uniform Resource Identifier.\n\n\n## License\n\nMIT © [Sam Verschueren](https://github.com/SamVerschueren)\n",
+  "maintainers": [
+    {
+      "name": "samverschueren",
+      "email": "sam.verschueren@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-06-28T18:16:07.372Z",
+    "created": "2017-05-19T20:41:18.502Z",
+    "0.1.0": "2017-05-19T20:41:18.502Z",
+    "0.2.0": "2017-06-28T18:16:07.372Z"
+  },
+  "homepage": "https://github.com/samverschueren/decode-uri-component#readme",
+  "keywords": [
+    "decode",
+    "uri",
+    "component",
+    "decodeuricomponent",
+    "components",
+    "decoder",
+    "url"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/samverschueren/decode-uri-component.git"
+  },
+  "author": {
+    "name": "Sam Verschueren",
+    "email": "sam.verschueren@gmail.com",
+    "url": "github.com/SamVerschueren"
+  },
+  "bugs": {
+    "url": "https://github.com/samverschueren/decode-uri-component/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/decode-uri-component.min.json
+++ b/test/fixtures/registry-mocks/content/decode-uri-component.min.json
@@ -1,0 +1,43 @@
+{
+  "name": "decode-uri-component",
+  "dist-tags": {
+    "latest": "0.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "decode-uri-component",
+      "version": "0.1.0",
+      "devDependencies": {
+        "ava": "*",
+        "coveralls": "^2.13.1",
+        "nyc": "^10.3.2",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "6eb2ac05e5cf288590b4a8b60d774c027e3fd5ab",
+        "tarball": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "0.2.0": {
+      "name": "decode-uri-component",
+      "version": "0.2.0",
+      "devDependencies": {
+        "ava": "^0.17.0",
+        "coveralls": "^2.13.1",
+        "nyc": "^10.3.2",
+        "xo": "^0.16.0"
+      },
+      "dist": {
+        "shasum": "eb3913333458775cb84cd1a1fae062106bb87545",
+        "tarball": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    }
+  },
+  "modified": "2017-06-28T18:16:07.372Z"
+}

--- a/test/fixtures/registry-mocks/content/deep-equal.json
+++ b/test/fixtures/registry-mocks/content/deep-equal.json
@@ -1,0 +1,1695 @@
+{
+  "_id": "deep-equal",
+  "_rev": "63-c777f75c25faf7bac2110b7b5d0408db",
+  "name": "deep-equal",
+  "description": "node's assert.deepEqual algorithm",
+  "dist-tags": {
+    "latest": "2.0.4",
+    "next": "2.0.3"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "deep-equal",
+      "version": "0.0.0",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "devDependencies": {
+        "tap": "0.0.x"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT/X11",
+      "engine": {
+        "node": ">=0.4"
+      },
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "_id": "deep-equal@0.0.0",
+      "dependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "99679d3bbd047156fcd450d3d01eeb9068691e83",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "0.1.0": {
+      "name": "deep-equal",
+      "version": "0.1.0",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "devDependencies": {
+        "tap": "~0.3.0",
+        "tape": "~0.0.5"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "_id": "deep-equal@0.1.0",
+      "dist": {
+        "shasum": "81fcefc84551d9d67cccdd80e1fced7f355e146f",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.7",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "0.1.1": {
+      "name": "deep-equal",
+      "version": "0.1.1",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "devDependencies": {
+        "tap": "~0.3.0",
+        "tape": "~0.0.5"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal",
+      "_id": "deep-equal@0.1.1",
+      "dist": {
+        "shasum": "8a55b7eddb6ea545a55231fe0a405ebf05077e62",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "0.1.2": {
+      "name": "deep-equal",
+      "version": "0.1.2",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal",
+      "_id": "deep-equal@0.1.2",
+      "dist": {
+        "shasum": "b246c2b80a570a47c11be1d9bd1070ec878b87ce",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "0.2.0": {
+      "name": "deep-equal",
+      "version": "0.2.0",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal",
+      "_id": "deep-equal@0.2.0",
+      "dist": {
+        "shasum": "81994cd7332efcf72a373e7f2ba490b2763159b5",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "0.2.1": {
+      "name": "deep-equal",
+      "version": "0.2.1",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal",
+      "_id": "deep-equal@0.2.1",
+      "dist": {
+        "shasum": "fad7a793224cbf0c3c7786f92ef780e4fc8cc878",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "0.2.2": {
+      "name": "deep-equal",
+      "version": "0.2.2",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "gitHead": "05cd26a25f0d7babf0c2758827b4dafec9d0582e",
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal",
+      "_id": "deep-equal@0.2.2",
+      "_shasum": "84b745896f34c684e98f2ce0e42abaf43bba017d",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dist": {
+        "shasum": "84b745896f34c684e98f2ce0e42abaf43bba017d",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "deep-equal",
+      "version": "1.0.0",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "gitHead": "39c740ebdafed9443912a4ef1493b18693934daf",
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal",
+      "_id": "deep-equal@1.0.0",
+      "_shasum": "d4564f07d2f0ab3e46110bec16592abd7dc2e326",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dist": {
+        "shasum": "d4564f07d2f0ab3e46110bec16592abd7dc2e326",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "deep-equal",
+      "version": "1.0.1",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "gitHead": "59c511f5aeae19e3dd1de054077a789d7302be34",
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal#readme",
+      "_id": "deep-equal@1.0.1",
+      "_shasum": "f5d260292b660e084eff4cdbc9f08ad3247448b5",
+      "_from": ".",
+      "_npmVersion": "3.2.2",
+      "_nodeVersion": "2.4.0",
+      "_npmUser": {
+        "name": "substack",
+        "email": "substack@gmail.com"
+      },
+      "dist": {
+        "shasum": "f5d260292b660e084eff4cdbc9f08ad3247448b5",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "1.1.0": {
+      "name": "deep-equal",
+      "version": "1.1.0",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "pretest": "npm run lint",
+        "lint": "eslint .",
+        "tests-only": "tape test/*",
+        "test": "npm run tests-only"
+      },
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^13.1.1",
+        "eslint": "^5.16.0",
+        "tape": "^4.11.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "gitHead": "6099799587240963f9ebef6f2a819fcf28add15b",
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal#readme",
+      "_id": "deep-equal@1.1.0",
+      "_nodeVersion": "12.9.1",
+      "_npmVersion": "6.10.2",
+      "dist": {
+        "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+        "shasum": "3103cdf8ab6d32cf4a8df7865458f2b8d33f3745",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 25392,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZhQ9CRA9TVsSAnZWagAA8ukP/R/S/Xq8/fH3oZVEKfEn\nJKtrK/5ZrJw4jLl5ASI8s8trOgXArGRgyu8qdWH4lZk9/g2eiogrMZeujkzN\n6S6PVs9xNE9PYU7oOfOcY0aHF5cwDhOC453QSYTZGbj9VkCmS0Ez1WpIldwf\nDdPnxXFejBzesOOa/zYkRRRHtdBq/jauHz0K+KOXEgXODMJa2vRoLn9HJD1P\ngnwtsW6judAX8Q9qakDRX0Y28u+Ax8dMjnE9Dz5NeBcGR0nJ1ALgiUG9wyjN\nqaCl4cyoEwmVk+exCbIZHn6VgDWodo/JzQmTJbV5Wjn0ctzJa/NK7Tce9JHJ\nLh7x4TPZliRSDosbLMW994K/HgI0Xbz1fiilRGNdNkG5/ZV99tzTmfm8fhYP\nGZrr6jTo5Vzwu0YS55YHt95c5vxlKKuMFeyM0AvpKgggYQbGvXn+lCR+P31l\nZv6sg6UaTG9AeaeiG65JXPMwAWkeoLezgOc0YlqWF3tSWnR43r9qJILuyp+L\nhacNC7nQhapImJ35K2yrx0NndJ+V27DIY+3uXyKmpvBMnpVCEXBObGB+rklu\n9BNtq+uZF6MIYoLk/GrQ8wizQA2b0neerRktqkaWW5gWeSl3u4ey4GvfSi80\nJWyWHHn4nbkJkDcjNmVgytbvCQqGGlR4CQeBj5m0MUoSFLFABVRn/GZszVCa\nKkh8\r\n=Piz6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/deep-equal_1.1.0_1566970940528_0.38605092487709936"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.1": {
+      "name": "deep-equal",
+      "version": "1.1.1",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "lint": "eslint .",
+        "tests-only": "tape test/*",
+        "test": "npm run tests-only",
+        "posttest": "npx aud",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^15.0.1",
+        "auto-changelog": "^1.16.2",
+        "eslint": "^6.6.0",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^4.11.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/substack/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false
+      },
+      "gitHead": "7f21ce5ca6ac3d62f183071a12f58b9fd010bd34",
+      "bugs": {
+        "url": "https://github.com/substack/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/substack/node-deep-equal#readme",
+      "_id": "deep-equal@1.1.1",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+        "shasum": "b5c98c942ceffaf7cb051e24e1434a25a2e6076a",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+        "fileCount": 12,
+        "unpackedSize": 26384,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyxQ4CRA9TVsSAnZWagAAv+AP+weArKrZAaxlVcIgMlsi\n7WKBt2xzQrp+vei93GwLnBlutPEN1kuJ4UWTsV1mfS/s8MAHRhi5XuXOXS/l\nMswzTaAd63FUrBEpVFmUv4d4gFlV4qAKozEt/fE6A//LDpr6/RoeUVsWdtlu\nOiEn7dTsothIb8yf/FxCwivk7Vu+QA/JxKLYuAiX44xbG6b20fBVi+8wXzbJ\nWF2PILj0wrOFf5wn4ybsmC7QtFjehGti0EruiPzA6luoe6UeqND/ZDfxxrzw\nBz4v1jXY63BeDWyQYTecfAszkXu+kznruS4C31OxG9I5g93h2m552zZBWHjn\n4+2UNoh9xMkGgVqAo94pOF2xa3TZSZlJAeMc+hLEt65y5aZZ8eil3ynBqyJb\nidzz30j++zDN5v54ZuoVTlAhh30i+Pib2sGFrpgiuysscA20Sc4ch+6leoiJ\n9gR/+6OvLoMKzf+2T8E97lFfIe8Iwyi7SHIB6u5SwrMd1CCiN1VmPzH0jq+F\n5YS5oZSU3gbHfYQ/sEseGWUQNqnK9c0JuXwVhmuIWBAxg8U87RrFOjG4M5Mc\nPOdyZzlSCOGCmgVQ+HBvxH7jZGdM/4g3I2Hyu7+ybJ4ATdCLxi5NHUq7KzxI\nEjx06NOARGAIH7MUtkPrqDb3+XyS0e0UXQbPGHhRk52EdtLOlSEJ26e+fqij\nedwu\r\n=avCO\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/deep-equal_1.1.1_1573590072165_0.7652971980130199"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "deep-equal",
+      "version": "2.0.1",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "exports": {
+        ".": [
+          {
+            "default": "./index.js"
+          },
+          "./index.js"
+        ],
+        "./package": "./package.json",
+        "./package.json": "./package"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "lint": "eslint .",
+        "tests-only": "tape test/*",
+        "test": "npm run tests-only",
+        "posttest": "npx aud",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "dependencies": {
+        "es-abstract": "^1.16.3",
+        "es-get-iterator": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "isarray": "^2.0.5",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0",
+        "side-channel": "^1.0.1",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.0"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^15.0.2",
+        "auto-changelog": "^1.16.2",
+        "eslint": "^6.7.2",
+        "has-symbols": "^1.0.1",
+        "has-typed-arrays": "^1.0.0",
+        "object.assign": "^4.1.0",
+        "object.getownpropertydescriptors": "^2.0.3",
+        "safe-publish-latest": "^1.1.4",
+        "semver": "^6.3.0",
+        "tape": "^4.11.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/inspect-js/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "contributors": [
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net",
+          "url": "https://substack.net"
+        },
+        {
+          "name": "Jordan Harband",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false
+      },
+      "browser": {
+        "assert.js": false
+      },
+      "readme": "# deep-equal\n\nNode's `assert.deepEqual() algorithm` as a standalone module.\n\nThis module is around [46 times faster](https://gist.github.com/substack/2790507#gistcomment-3099862) than wrapping `assert.deepEqual()` in a `try/catch`.\n\n[![build status](https://secure.travis-ci.com/inspect-js/node-deep-equal.png)](https://travis-ci.org/inspect-js/node-deep-equal)\n\n# example\n\n``` js\nvar equal = require('deep-equal');\nconsole.dir([\n    equal(\n        { a : [ 2, 3 ], b : [ 4 ] },\n        { a : [ 2, 3 ], b : [ 4 ] }\n    ),\n    equal(\n        { x : 5, y : [6] },\n        { x : 5, y : 6 }\n    )\n]);\n```\n\n# methods\n\n``` js\nvar deepEqual = require('deep-equal')\n```\n\n## deepEqual(a, b, opts)\n\nCompare objects `a` and `b`, returning whether they are equal according to a\nrecursive equality algorithm.\n\nIf `opts.strict` is `true`, use strict equality (`===`) to compare leaf nodes.\nThe default is to use coercive equality (`==`) because that's how\n`assert.deepEqual()` works by default.\n\n# install\n\nWith [npm](https://npmjs.org) do:\n\n```\nnpm install deep-equal\n```\n\n# test\n\nWith [npm](https://npmjs.org) do:\n\n```\nnpm test\n```\n",
+      "readmeFilename": "readme.markdown",
+      "gitHead": "8ba8dbceb1a836f26a61a54b597c8bb3eac8cb8d",
+      "bugs": {
+        "url": "https://github.com/inspect-js/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/inspect-js/node-deep-equal#readme",
+      "_id": "deep-equal@2.0.1",
+      "_nodeVersion": "13.3.0",
+      "_npmVersion": "6.13.1",
+      "dist": {
+        "integrity": "sha512-7Et6r6XfNW61CPPCIYfm1YPGSmh6+CliYeL4km7GWJcpX5LTAflGF8drLLR+MZX+2P3NZfAfSduutBbSWqER4g==",
+        "shasum": "fc12bbd6850e93212f21344748682ccc5a8813cf",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 53653,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd7eghCRA9TVsSAnZWagAAiwIP/3zHahQJBXVU9ZJVNIay\n/ARzUiVgqRlWJFhIJfob4VvXwjIFSJOjcWZBlNgNnEJoYupBfFJwJZyY97n9\nrqi7YtVrl/l1KW6d8LmI3Mc0dKv6fKHaYg90jNhyjKfAb3s70CJJ3s/Bx1fB\nNVxieoCyn9NWciX56OYlIvhNWfgDV/DQNf2HvJngo4ugCCELxcaYXmaJ4Ex3\nM80DJVOiS1/KO8LCUmhQTtzyOLlLtwyrGfyxWUxQRMZotMbws/ZEFe828NWr\nknyjMH/TK8QRtQ4YXJJRFCJjR9xOdTxgIJrtThtOG93d3h6Cmxrh9oKGwqvh\n6Nc2s0nFtJxUthgkelaOfM78T3x7lK8VdAWqdyWGmvLv90NMViUgBq1/ORKa\ns7fAXRAGxtj9T9BDGpPGfSg9EkkYssZRU5HHmkUPD/9he/HOnRcrPujMaoo4\nHwpK0x5Z1MQY/9zUGTCZuq/p9xb8mNriQw0GvtattVNuXkoSS99WMv0hEnPU\njDidZJzg3DfClYx1Rrv04s6nexhwxBbaeHDWuW4dM4fgc+fON8M+ZvvefqJW\n06/KQiw6YA6RiPPEd4u0lEJadRDQKwQH53Cz9ATybQFKH39vuYSlbxPKte6Z\nNPdsO0P5J5Xppfe5QwOpWmt+bvVBmuO9JYkA7jEyICY1EMJGSfsiqUkbwMUL\nIwC/\r\n=m/Yb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/deep-equal_2.0.1_1575872545025_0.7778746444985405"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.2": {
+      "name": "deep-equal",
+      "version": "2.0.2",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "exports": {
+        ".": [
+          {
+            "default": "./index.js"
+          },
+          "./index.js"
+        ],
+        "./package": "./package.json",
+        "./package.json": "./package"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "lint": "eslint .",
+        "tests-only": "nyc tape test/*",
+        "test": "npm run tests-only",
+        "posttest": "npx aud --production",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "dependencies": {
+        "es-abstract": "^1.17.5",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.0.5",
+        "isarray": "^2.0.5",
+        "object-is": "^1.0.2",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.1"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^16.0.0",
+        "auto-changelog": "^1.16.3",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "has-typed-arrays": "^1.0.0",
+        "nyc": "^10.3.2",
+        "object.assign": "^4.1.0",
+        "object.getownpropertydescriptors": "^2.1.0",
+        "safe-publish-latest": "^1.1.4",
+        "semver": "^6.3.0",
+        "tape": "^5.0.0-next.5"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/inspect-js/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "contributors": [
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net",
+          "url": "https://substack.net"
+        },
+        {
+          "name": "Jordan Harband",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false
+      },
+      "greenkeeper": {
+        "ignore": [
+          "semver"
+        ]
+      },
+      "browser": {
+        "assert.js": false
+      },
+      "gitHead": "7eedb2dd9d1d41e5f462460ae19e54c276ae4c4d",
+      "bugs": {
+        "url": "https://github.com/inspect-js/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/inspect-js/node-deep-equal#readme",
+      "_id": "deep-equal@2.0.2",
+      "_nodeVersion": "13.12.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-kX0bjV7tdMuhrhzKPEnVwqfQCuf+IEfN+4Xqv4eKd75xGRyn8yzdQ9ujPY6a221rgJKyQC4KBu1PibDTpa6m9w==",
+        "shasum": "e68291e245493ae908ca7190c1deea57a01ed82b",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.2.tgz",
+        "fileCount": 14,
+        "unpackedSize": 64958,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJehEA2CRA9TVsSAnZWagAAROkQAIHdo41ek37IWIXMcbQI\n6/lMcSK4m18G7hB1ryOhzu40XoXfL7FiYDCtUcvdkQleaTcfTqKQXkFAp+TZ\nushTrItJ/a7+ccorrTuOrc56soKbcxcEQNv+CWi2Ny7PfvHFtRVmRRP+1CKk\n8Ril0i6QiZ9aU4maYpGwVWJu/7+Bbp/pLcheeN47dOD3Mqj8DPw5VeWfReT5\nU8G3BY5G0rKTASyngi2arwFAto0fWG7XNwHwkVwvnDNI1CyuZuo1l2uRT67J\nhXVArKLH/gNSu8EPg02ssJaMtEJaIfTYMN62tCfUphoQC8PfcwkTrVbOUQQR\nWbh0jpqGi6P11so9Tg8hi3l25u+edYznHxMGqWExY1nNuZ0j00LLXouGIci0\nZ8ezEfMsNDXx2KW7efU88aFDFxXo4STvV3S5rJy3Bc/6GGio6m7Knnw3FxA4\nosLWoDM6/L81PwKBLFtAy4B683tc/u7mh8Ag4GaiGvZSdZPitxF1er6Z4Y/X\nEhuau0jbrfGzI/rZj2LvhZMMUeVhQvjFmCTR+QdYL8K/sXsAQaqhkCuNIjyK\njEJMYCEJ/7il0HdO+AFGgA7R1hRpDnWjZGpGnPRbMyQplyQKtG+1kYEZS0qy\n5Zk1Vq0raB82R5ySzpvjHsRm6puqviUdb7IgKjt2T4xcT9wIorL97hcLlp4c\nhHCE\r\n=rtlE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/deep-equal_2.0.2_1585725494188_0.11829287453491855"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.3": {
+      "name": "deep-equal",
+      "version": "2.0.3",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "exports": {
+        ".": [
+          {
+            "default": "./index.js"
+          },
+          "./index.js"
+        ],
+        "./package": "./package.json",
+        "./package.json": "./package"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "lint": "eslint .",
+        "tests-only": "nyc tape test/*",
+        "test": "npm run tests-only",
+        "posttest": "npx aud --production",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "dependencies": {
+        "es-abstract": "^1.17.5",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.0.5",
+        "isarray": "^2.0.5",
+        "object.assign": "^4.1.0",
+        "object-is": "^1.1.2",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^16.0.0",
+        "aud": "^1.1.1",
+        "auto-changelog": "^2.0.0",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "has-typed-arrays": "^1.0.0",
+        "nyc": "^10.3.2",
+        "object.getownpropertydescriptors": "^2.1.0",
+        "safe-publish-latest": "^1.1.4",
+        "semver": "^6.3.0",
+        "tape": "^5.0.0-next.5"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/inspect-js/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "contributors": [
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net",
+          "url": "https://substack.net"
+        },
+        {
+          "name": "Jordan Harband",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false
+      },
+      "greenkeeper": {
+        "ignore": [
+          "nyc",
+          "semver"
+        ]
+      },
+      "browser": {
+        "assert.js": false
+      },
+      "gitHead": "ab21672f28a4bf4edc73ad5399c912b8bd383824",
+      "bugs": {
+        "url": "https://github.com/inspect-js/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/inspect-js/node-deep-equal#readme",
+      "_id": "deep-equal@2.0.3",
+      "_nodeVersion": "14.0.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==",
+        "shasum": "cad1c15277ad78a5c01c49c2dee0f54de8a6a7b0",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz",
+        "fileCount": 16,
+        "unpackedSize": 65915,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeooMbCRA9TVsSAnZWagAA0s0P/1Tgz89/yVZQNNIfemrq\n71X4LVBQnxoqQzGLOL++thOeG060B0c0oVCklMl1cg5W3zkE8nrmr+aZ/J/t\nhL9uCktnHeDAJGqhwQ9TtQbJ/FbN7Z+Iz9qEe6ZVwyIZi9l7lt6qxu5Ym8IY\nAzeg7Uf9Rg3BQzD5Y8kF6nHlicFxWAcRntNDVY5tNmYi9ebVLXY+o1VuQn6X\nG710yCoBsfD9LjTJUKQiphcsgmWgWZy9Nk+RnWOQld/dfq1qvfkuF5AQ0UJ8\nTiD9N0Zvv2GvROlRZUcbpEZaXfuI7zih8hn5bRleE/z2pIRTrWeUM0wjNNa7\nbZl8DIqU9mU2fHXbcdCZeaO3Tm4fV/WoDZ4LZJ2rb+PDBf/xbPuid60fMexv\n2+4n50ivDu03xxAyOSkuW4oyrKuUK/v8cwvHlqRLm4loWeQBlDYSuhGbV1GC\nzdno47krxdsJeMrmbPjaVwg+joBTwDyou/OzwHe2Ibp09HnHmBOJEZ7MQB8C\nK7zEdOQT8ssgnhMTe8ZK4J9Lha+WfFvgDl5E8L4fV8lEteUcrJzbRx0IqFGJ\nsIAfXyuPG39MTFZel2hcLEEZqeRDdFnNdZhq8p8ajOBZlWhqmyBPNxyhXBvK\nuKaMbRXzj0qadJkuNT4fuQmjCdJKsoKe6n61Mxd0TS9j8hP/no/mcT5eG1II\na+q9\r\n=M6gZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/deep-equal_2.0.3_1587708698645_0.7178129698926239"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.4": {
+      "name": "deep-equal",
+      "version": "2.0.4",
+      "description": "node's assert.deepEqual algorithm",
+      "main": "index.js",
+      "exports": {
+        ".": [
+          {
+            "default": "./index.js"
+          },
+          "./index.js"
+        ],
+        "./package": "./package.json",
+        "./package.json": "./package.json"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "lint": "eslint .",
+        "tests-only": "nyc tape test/*",
+        "test": "npm run tests-only",
+        "posttest": "npx aud --production",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "dependencies": {
+        "es-abstract": "^1.18.0-next.1",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^17.2.0",
+        "aud": "^1.1.2",
+        "auto-changelog": "^2.2.1",
+        "eslint": "^7.10.0",
+        "has-symbols": "^1.0.1",
+        "has-typed-arrays": "^1.0.0",
+        "nyc": "^10.3.2",
+        "object.getownpropertydescriptors": "^2.1.0",
+        "safe-publish-latest": "^1.1.4",
+        "semver": "^6.3.0",
+        "tape": "^5.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/inspect-js/node-deep-equal.git"
+      },
+      "keywords": [
+        "equality",
+        "equal",
+        "compare"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "contributors": [
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net",
+          "url": "https://substack.net"
+        },
+        {
+          "name": "Jordan Harband",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": {
+          "ie": [
+            6,
+            7,
+            8,
+            9
+          ],
+          "ff": [
+            3.5,
+            10,
+            15
+          ],
+          "chrome": [
+            10,
+            22
+          ],
+          "safari": [
+            5.1
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false,
+        "hideCredit": true
+      },
+      "greenkeeper": {
+        "ignore": [
+          "nyc",
+          "semver"
+        ]
+      },
+      "browser": {
+        "assert.js": false
+      },
+      "gitHead": "db63ef87deaab3bb8ca464b69522d2eb980660e2",
+      "bugs": {
+        "url": "https://github.com/inspect-js/node-deep-equal/issues"
+      },
+      "homepage": "https://github.com/inspect-js/node-deep-equal#readme",
+      "_id": "deep-equal@2.0.4",
+      "_nodeVersion": "14.12.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-BUfaXrVoCfgkOQY/b09QdO9L3XNoF2XH0A3aY9IQwQL/ZjLOe8FQgCNVl1wiolhsFo8kFdO9zdPViCPbmaJA5w==",
+        "shasum": "6b0b407a074666033169df3acaf128e1c6f3eab6",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.4.tgz",
+        "fileCount": 14,
+        "unpackedSize": 67599,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfdqsNCRA9TVsSAnZWagAA+zIP/0iFSlvF2VapBrzoBzXb\nrBjENpN/rUaqyR4QEzOzMH0fjxoRP7/nRTjISZe7wNMb9FQuHCTV+cJVNhrv\nhQzRIT9WdcUEAF70mZdcNTNU+nHGRQ7gSronKfmklk2KZCiMUOxsX+VnRnhf\nnLa19wZ4xGvkD25KIATuMKYJ3bWYZE0+03ofVKcXxpgYTUd/cCBN8ebebFvT\nb9TBW0tLiP8NJpRO7yKp0HblKjjo8LMwCtJWa42VCuahCjNQ5JY6mFtlOf2X\nG7+VjTGoQN1ch89jN+4pVd6iTPbf9YnXYgjcpoXxZALUXExosmY/4RwqVzws\n79mggSFKtyjfW6ycXeCplBWFOYU/QrhmIDjMQu0iuVPevwyih6e7L1Tby5Pz\nBCmuoaKnoed7aaKaXn9m+tqPQa4yId6c0s6Yp6YcDO3oZ5zNQEmtbp3rD7j6\n7XE0azs9QymEoWIipGoCoXwVKs4CleIgvByu7HHKtXrMVFa536sN0P2m/UhY\nqsXr3b8PdAnGzsK3FvP/aHHXG5VEevzgM3mOC4DXdO/493OmT79juJZbc+Ir\nmLTIrKaCn1Z0L44zLsjkiLDFU0tG4gZW2X/H+MOWoNh0kavH+Fp7PUD0LI1G\n8XswYdrxIcfFakSqjDaMH7I6hwUTA+1PShqK/OKTkiw8SFOkDGCaRJ8Ck9q8\nDbKf\r\n=F1Lw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        },
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/deep-equal_2.0.4_1601612556755_0.6157641233458735"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# deep-equal\n\nNode's `assert.deepEqual() algorithm` as a standalone module.\n\nThis module is around [46 times faster](https://gist.github.com/substack/2790507#gistcomment-3099862) than wrapping `assert.deepEqual()` in a `try/catch`.\n\n[![build status](https://secure.travis-ci.com/inspect-js/node-deep-equal.png)](https://travis-ci.org/inspect-js/node-deep-equal)\n\n# example\n\n``` js\nvar equal = require('deep-equal');\nconsole.dir([\n    equal(\n        { a : [ 2, 3 ], b : [ 4 ] },\n        { a : [ 2, 3 ], b : [ 4 ] }\n    ),\n    equal(\n        { x : 5, y : [6] },\n        { x : 5, y : 6 }\n    )\n]);\n```\n\n# methods\n\n``` js\nvar deepEqual = require('deep-equal')\n```\n\n## deepEqual(a, b, opts)\n\nCompare objects `a` and `b`, returning whether they are equal according to a\nrecursive equality algorithm.\n\nIf `opts.strict` is `true`, use strict equality (`===`) to compare leaf nodes.\nThe default is to use coercive equality (`==`) because that's how\n`assert.deepEqual()` works by default.\n\n# install\n\nWith [npm](https://npmjs.org) do:\n\n```\nnpm install deep-equal\n```\n\n# test\n\nWith [npm](https://npmjs.org) do:\n\n```\nnpm test\n```\n",
+  "maintainers": [
+    {
+      "name": "substack",
+      "email": "substack@gmail.com"
+    },
+    {
+      "name": "ljharb",
+      "email": "ljharb@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-02T04:22:40.453Z",
+    "created": "2012-02-11T05:42:13.188Z",
+    "0.0.0": "2012-02-11T05:42:14.579Z",
+    "0.1.0": "2013-10-14T14:52:24.917Z",
+    "0.1.1": "2013-12-20T20:40:18.118Z",
+    "0.1.2": "2013-12-21T03:05:03.548Z",
+    "0.2.0": "2014-01-29T22:04:03.965Z",
+    "0.2.1": "2014-01-29T22:05:28.806Z",
+    "0.2.2": "2015-02-07T18:27:09.674Z",
+    "1.0.0": "2015-02-07T18:27:38.585Z",
+    "1.0.1": "2015-08-29T21:02:28.562Z",
+    "1.1.0": "2019-08-28T05:42:20.711Z",
+    "1.1.1": "2019-11-12T20:21:12.351Z",
+    "2.0.0": "2019-12-03T23:33:03.946Z",
+    "2.0.1": "2019-12-09T06:22:25.201Z",
+    "2.0.2": "2020-04-01T07:18:14.359Z",
+    "2.0.3": "2020-04-24T06:11:38.843Z",
+    "2.0.4": "2020-10-02T04:22:36.888Z"
+  },
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/inspect-js/node-deep-equal.git"
+  },
+  "users": {
+    "freethenation": true,
+    "dam": true,
+    "pana": true,
+    "popomore": true,
+    "zerodi": true,
+    "amirmehmood": true,
+    "simplyianm": true,
+    "joris-van-der-wel": true,
+    "fwoelffel": true,
+    "mightyiam": true,
+    "koulmomo": true,
+    "agat": true,
+    "mkamakura": true,
+    "leodutra": true,
+    "klyngbaek": true,
+    "yatsu": true,
+    "j.su": true,
+    "ackhub": true,
+    "rtivital": true,
+    "jovinbm": true,
+    "akarem": true,
+    "shanewholloway": true,
+    "brainpoint": true,
+    "jacob-beltran": true,
+    "tzq1011": true,
+    "qujian": true,
+    "theaklair": true,
+    "erikvold": true,
+    "dm7": true,
+    "rfortune": true,
+    "n0f3": true,
+    "gleb_cher": true,
+    "nickeljew": true,
+    "tedyhy": true,
+    "leafac": true
+  },
+  "readmeFilename": "readme.markdown",
+  "homepage": "https://github.com/inspect-js/node-deep-equal#readme",
+  "keywords": [
+    "equality",
+    "equal",
+    "compare"
+  ],
+  "bugs": {
+    "url": "https://github.com/inspect-js/node-deep-equal/issues"
+  },
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "James Halliday",
+      "email": "mail@substack.net",
+      "url": "https://substack.net"
+    },
+    {
+      "name": "Jordan Harband",
+      "email": "ljharb@gmail.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/deep-equal.min.json
+++ b/test/fixtures/registry-mocks/content/deep-equal.min.json
@@ -1,0 +1,416 @@
+{
+  "name": "deep-equal",
+  "dist-tags": {
+    "latest": "2.0.4",
+    "next": "2.0.3"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "deep-equal",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tap": "0.0.x"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "99679d3bbd047156fcd450d3d01eeb9068691e83",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "deep-equal",
+      "version": "0.1.0",
+      "devDependencies": {
+        "tap": "~0.3.0",
+        "tape": "~0.0.5"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "81fcefc84551d9d67cccdd80e1fced7f355e146f",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "deep-equal",
+      "version": "0.1.1",
+      "devDependencies": {
+        "tap": "~0.3.0",
+        "tape": "~0.0.5"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "8a55b7eddb6ea545a55231fe0a405ebf05077e62",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "deep-equal",
+      "version": "0.1.2",
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "b246c2b80a570a47c11be1d9bd1070ec878b87ce",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "deep-equal",
+      "version": "0.2.0",
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "81994cd7332efcf72a373e7f2ba490b2763159b5",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "deep-equal",
+      "version": "0.2.1",
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "fad7a793224cbf0c3c7786f92ef780e4fc8cc878",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "deep-equal",
+      "version": "0.2.2",
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "84b745896f34c684e98f2ce0e42abaf43bba017d",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "deep-equal",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "d4564f07d2f0ab3e46110bec16592abd7dc2e326",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "deep-equal",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "f5d260292b660e084eff4cdbc9f08ad3247448b5",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "deep-equal",
+      "version": "1.1.0",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^13.1.1",
+        "eslint": "^5.16.0",
+        "tape": "^4.11.0"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+        "shasum": "3103cdf8ab6d32cf4a8df7865458f2b8d33f3745",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 25392,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZhQ9CRA9TVsSAnZWagAA8ukP/R/S/Xq8/fH3oZVEKfEn\nJKtrK/5ZrJw4jLl5ASI8s8trOgXArGRgyu8qdWH4lZk9/g2eiogrMZeujkzN\n6S6PVs9xNE9PYU7oOfOcY0aHF5cwDhOC453QSYTZGbj9VkCmS0Ez1WpIldwf\nDdPnxXFejBzesOOa/zYkRRRHtdBq/jauHz0K+KOXEgXODMJa2vRoLn9HJD1P\ngnwtsW6judAX8Q9qakDRX0Y28u+Ax8dMjnE9Dz5NeBcGR0nJ1ALgiUG9wyjN\nqaCl4cyoEwmVk+exCbIZHn6VgDWodo/JzQmTJbV5Wjn0ctzJa/NK7Tce9JHJ\nLh7x4TPZliRSDosbLMW994K/HgI0Xbz1fiilRGNdNkG5/ZV99tzTmfm8fhYP\nGZrr6jTo5Vzwu0YS55YHt95c5vxlKKuMFeyM0AvpKgggYQbGvXn+lCR+P31l\nZv6sg6UaTG9AeaeiG65JXPMwAWkeoLezgOc0YlqWF3tSWnR43r9qJILuyp+L\nhacNC7nQhapImJ35K2yrx0NndJ+V27DIY+3uXyKmpvBMnpVCEXBObGB+rklu\n9BNtq+uZF6MIYoLk/GrQ8wizQA2b0neerRktqkaWW5gWeSl3u4ey4GvfSi80\nJWyWHHn4nbkJkDcjNmVgytbvCQqGGlR4CQeBj5m0MUoSFLFABVRn/GZszVCa\nKkh8\r\n=Piz6\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.1": {
+      "name": "deep-equal",
+      "version": "1.1.1",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^15.0.1",
+        "auto-changelog": "^1.16.2",
+        "eslint": "^6.6.0",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^4.11.0"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+        "shasum": "b5c98c942ceffaf7cb051e24e1434a25a2e6076a",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+        "fileCount": 12,
+        "unpackedSize": 26384,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyxQ4CRA9TVsSAnZWagAAv+AP+weArKrZAaxlVcIgMlsi\n7WKBt2xzQrp+vei93GwLnBlutPEN1kuJ4UWTsV1mfS/s8MAHRhi5XuXOXS/l\nMswzTaAd63FUrBEpVFmUv4d4gFlV4qAKozEt/fE6A//LDpr6/RoeUVsWdtlu\nOiEn7dTsothIb8yf/FxCwivk7Vu+QA/JxKLYuAiX44xbG6b20fBVi+8wXzbJ\nWF2PILj0wrOFf5wn4ybsmC7QtFjehGti0EruiPzA6luoe6UeqND/ZDfxxrzw\nBz4v1jXY63BeDWyQYTecfAszkXu+kznruS4C31OxG9I5g93h2m552zZBWHjn\n4+2UNoh9xMkGgVqAo94pOF2xa3TZSZlJAeMc+hLEt65y5aZZ8eil3ynBqyJb\nidzz30j++zDN5v54ZuoVTlAhh30i+Pib2sGFrpgiuysscA20Sc4ch+6leoiJ\n9gR/+6OvLoMKzf+2T8E97lFfIe8Iwyi7SHIB6u5SwrMd1CCiN1VmPzH0jq+F\n5YS5oZSU3gbHfYQ/sEseGWUQNqnK9c0JuXwVhmuIWBAxg8U87RrFOjG4M5Mc\nPOdyZzlSCOGCmgVQ+HBvxH7jZGdM/4g3I2Hyu7+ybJ4ATdCLxi5NHUq7KzxI\nEjx06NOARGAIH7MUtkPrqDb3+XyS0e0UXQbPGHhRk52EdtLOlSEJ26e+fqij\nedwu\r\n=avCO\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "2.0.1": {
+      "name": "deep-equal",
+      "version": "2.0.1",
+      "dependencies": {
+        "es-abstract": "^1.16.3",
+        "es-get-iterator": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "isarray": "^2.0.5",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0",
+        "side-channel": "^1.0.1",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.0"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^15.0.2",
+        "auto-changelog": "^1.16.2",
+        "eslint": "^6.7.2",
+        "has-symbols": "^1.0.1",
+        "has-typed-arrays": "^1.0.0",
+        "object.assign": "^4.1.0",
+        "object.getownpropertydescriptors": "^2.0.3",
+        "safe-publish-latest": "^1.1.4",
+        "semver": "^6.3.0",
+        "tape": "^4.11.0"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-7Et6r6XfNW61CPPCIYfm1YPGSmh6+CliYeL4km7GWJcpX5LTAflGF8drLLR+MZX+2P3NZfAfSduutBbSWqER4g==",
+        "shasum": "fc12bbd6850e93212f21344748682ccc5a8813cf",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 53653,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd7eghCRA9TVsSAnZWagAAiwIP/3zHahQJBXVU9ZJVNIay\n/ARzUiVgqRlWJFhIJfob4VvXwjIFSJOjcWZBlNgNnEJoYupBfFJwJZyY97n9\nrqi7YtVrl/l1KW6d8LmI3Mc0dKv6fKHaYg90jNhyjKfAb3s70CJJ3s/Bx1fB\nNVxieoCyn9NWciX56OYlIvhNWfgDV/DQNf2HvJngo4ugCCELxcaYXmaJ4Ex3\nM80DJVOiS1/KO8LCUmhQTtzyOLlLtwyrGfyxWUxQRMZotMbws/ZEFe828NWr\nknyjMH/TK8QRtQ4YXJJRFCJjR9xOdTxgIJrtThtOG93d3h6Cmxrh9oKGwqvh\n6Nc2s0nFtJxUthgkelaOfM78T3x7lK8VdAWqdyWGmvLv90NMViUgBq1/ORKa\ns7fAXRAGxtj9T9BDGpPGfSg9EkkYssZRU5HHmkUPD/9he/HOnRcrPujMaoo4\nHwpK0x5Z1MQY/9zUGTCZuq/p9xb8mNriQw0GvtattVNuXkoSS99WMv0hEnPU\njDidZJzg3DfClYx1Rrv04s6nexhwxBbaeHDWuW4dM4fgc+fON8M+ZvvefqJW\n06/KQiw6YA6RiPPEd4u0lEJadRDQKwQH53Cz9ATybQFKH39vuYSlbxPKte6Z\nNPdsO0P5J5Xppfe5QwOpWmt+bvVBmuO9JYkA7jEyICY1EMJGSfsiqUkbwMUL\nIwC/\r\n=m/Yb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "2.0.2": {
+      "name": "deep-equal",
+      "version": "2.0.2",
+      "dependencies": {
+        "es-abstract": "^1.17.5",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.0.5",
+        "isarray": "^2.0.5",
+        "object-is": "^1.0.2",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.1"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^16.0.0",
+        "auto-changelog": "^1.16.3",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "has-typed-arrays": "^1.0.0",
+        "nyc": "^10.3.2",
+        "object.assign": "^4.1.0",
+        "object.getownpropertydescriptors": "^2.1.0",
+        "safe-publish-latest": "^1.1.4",
+        "semver": "^6.3.0",
+        "tape": "^5.0.0-next.5"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-kX0bjV7tdMuhrhzKPEnVwqfQCuf+IEfN+4Xqv4eKd75xGRyn8yzdQ9ujPY6a221rgJKyQC4KBu1PibDTpa6m9w==",
+        "shasum": "e68291e245493ae908ca7190c1deea57a01ed82b",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.2.tgz",
+        "fileCount": 14,
+        "unpackedSize": 64958,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJehEA2CRA9TVsSAnZWagAAROkQAIHdo41ek37IWIXMcbQI\n6/lMcSK4m18G7hB1ryOhzu40XoXfL7FiYDCtUcvdkQleaTcfTqKQXkFAp+TZ\nushTrItJ/a7+ccorrTuOrc56soKbcxcEQNv+CWi2Ny7PfvHFtRVmRRP+1CKk\n8Ril0i6QiZ9aU4maYpGwVWJu/7+Bbp/pLcheeN47dOD3Mqj8DPw5VeWfReT5\nU8G3BY5G0rKTASyngi2arwFAto0fWG7XNwHwkVwvnDNI1CyuZuo1l2uRT67J\nhXVArKLH/gNSu8EPg02ssJaMtEJaIfTYMN62tCfUphoQC8PfcwkTrVbOUQQR\nWbh0jpqGi6P11so9Tg8hi3l25u+edYznHxMGqWExY1nNuZ0j00LLXouGIci0\nZ8ezEfMsNDXx2KW7efU88aFDFxXo4STvV3S5rJy3Bc/6GGio6m7Knnw3FxA4\nosLWoDM6/L81PwKBLFtAy4B683tc/u7mh8Ag4GaiGvZSdZPitxF1er6Z4Y/X\nEhuau0jbrfGzI/rZj2LvhZMMUeVhQvjFmCTR+QdYL8K/sXsAQaqhkCuNIjyK\njEJMYCEJ/7il0HdO+AFGgA7R1hRpDnWjZGpGnPRbMyQplyQKtG+1kYEZS0qy\n5Zk1Vq0raB82R5ySzpvjHsRm6puqviUdb7IgKjt2T4xcT9wIorL97hcLlp4c\nhHCE\r\n=rtlE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "2.0.3": {
+      "name": "deep-equal",
+      "version": "2.0.3",
+      "dependencies": {
+        "es-abstract": "^1.17.5",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.0.5",
+        "isarray": "^2.0.5",
+        "object.assign": "^4.1.0",
+        "object-is": "^1.1.2",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^16.0.0",
+        "aud": "^1.1.1",
+        "auto-changelog": "^2.0.0",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "has-typed-arrays": "^1.0.0",
+        "nyc": "^10.3.2",
+        "object.getownpropertydescriptors": "^2.1.0",
+        "safe-publish-latest": "^1.1.4",
+        "semver": "^6.3.0",
+        "tape": "^5.0.0-next.5"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==",
+        "shasum": "cad1c15277ad78a5c01c49c2dee0f54de8a6a7b0",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz",
+        "fileCount": 16,
+        "unpackedSize": 65915,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeooMbCRA9TVsSAnZWagAA0s0P/1Tgz89/yVZQNNIfemrq\n71X4LVBQnxoqQzGLOL++thOeG060B0c0oVCklMl1cg5W3zkE8nrmr+aZ/J/t\nhL9uCktnHeDAJGqhwQ9TtQbJ/FbN7Z+Iz9qEe6ZVwyIZi9l7lt6qxu5Ym8IY\nAzeg7Uf9Rg3BQzD5Y8kF6nHlicFxWAcRntNDVY5tNmYi9ebVLXY+o1VuQn6X\nG710yCoBsfD9LjTJUKQiphcsgmWgWZy9Nk+RnWOQld/dfq1qvfkuF5AQ0UJ8\nTiD9N0Zvv2GvROlRZUcbpEZaXfuI7zih8hn5bRleE/z2pIRTrWeUM0wjNNa7\nbZl8DIqU9mU2fHXbcdCZeaO3Tm4fV/WoDZ4LZJ2rb+PDBf/xbPuid60fMexv\n2+4n50ivDu03xxAyOSkuW4oyrKuUK/v8cwvHlqRLm4loWeQBlDYSuhGbV1GC\nzdno47krxdsJeMrmbPjaVwg+joBTwDyou/OzwHe2Ibp09HnHmBOJEZ7MQB8C\nK7zEdOQT8ssgnhMTe8ZK4J9Lha+WfFvgDl5E8L4fV8lEteUcrJzbRx0IqFGJ\nsIAfXyuPG39MTFZel2hcLEEZqeRDdFnNdZhq8p8ajOBZlWhqmyBPNxyhXBvK\nuKaMbRXzj0qadJkuNT4fuQmjCdJKsoKe6n61Mxd0TS9j8hP/no/mcT5eG1II\na+q9\r\n=M6gZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "2.0.4": {
+      "name": "deep-equal",
+      "version": "2.0.4",
+      "dependencies": {
+        "es-abstract": "^1.18.0-next.1",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.3",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "devDependencies": {
+        "@ljharb/eslint-config": "^17.2.0",
+        "aud": "^1.1.2",
+        "auto-changelog": "^2.2.1",
+        "eslint": "^7.10.0",
+        "has-symbols": "^1.0.1",
+        "has-typed-arrays": "^1.0.0",
+        "nyc": "^10.3.2",
+        "object.getownpropertydescriptors": "^2.1.0",
+        "safe-publish-latest": "^1.1.4",
+        "semver": "^6.3.0",
+        "tape": "^5.0.1"
+      },
+      "directories": {
+        "lib": ".",
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-BUfaXrVoCfgkOQY/b09QdO9L3XNoF2XH0A3aY9IQwQL/ZjLOe8FQgCNVl1wiolhsFo8kFdO9zdPViCPbmaJA5w==",
+        "shasum": "6b0b407a074666033169df3acaf128e1c6f3eab6",
+        "tarball": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.4.tgz",
+        "fileCount": 14,
+        "unpackedSize": 67599,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfdqsNCRA9TVsSAnZWagAA+zIP/0iFSlvF2VapBrzoBzXb\nrBjENpN/rUaqyR4QEzOzMH0fjxoRP7/nRTjISZe7wNMb9FQuHCTV+cJVNhrv\nhQzRIT9WdcUEAF70mZdcNTNU+nHGRQ7gSronKfmklk2KZCiMUOxsX+VnRnhf\nnLa19wZ4xGvkD25KIATuMKYJ3bWYZE0+03ofVKcXxpgYTUd/cCBN8ebebFvT\nb9TBW0tLiP8NJpRO7yKp0HblKjjo8LMwCtJWa42VCuahCjNQ5JY6mFtlOf2X\nG7+VjTGoQN1ch89jN+4pVd6iTPbf9YnXYgjcpoXxZALUXExosmY/4RwqVzws\n79mggSFKtyjfW6ycXeCplBWFOYU/QrhmIDjMQu0iuVPevwyih6e7L1Tby5Pz\nBCmuoaKnoed7aaKaXn9m+tqPQa4yId6c0s6Yp6YcDO3oZ5zNQEmtbp3rD7j6\n7XE0azs9QymEoWIipGoCoXwVKs4CleIgvByu7HHKtXrMVFa536sN0P2m/UhY\nqsXr3b8PdAnGzsK3FvP/aHHXG5VEevzgM3mOC4DXdO/493OmT79juJZbc+Ir\nmLTIrKaCn1Z0L44zLsjkiLDFU0tG4gZW2X/H+MOWoNh0kavH+Fp7PUD0LI1G\n8XswYdrxIcfFakSqjDaMH7I6hwUTA+1PShqK/OKTkiw8SFOkDGCaRJ8Ck9q8\nDbKf\r\n=F1Lw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  },
+  "modified": "2020-10-02T04:22:40.453Z"
+}

--- a/test/fixtures/registry-mocks/content/default-gateway.json
+++ b/test/fixtures/registry-mocks/content/default-gateway.json
@@ -1,0 +1,3697 @@
+{
+  "_id": "default-gateway",
+  "_rev": "48-2e885dee10586b7e425432cea2c5f94c",
+  "name": "default-gateway",
+  "description": "Get the default network gateway, cross-platform.",
+  "dist-tags": {
+    "latest": "6.0.2"
+  },
+  "versions": {
+    "0.8.0": {
+      "name": "default-gateway",
+      "version": "0.8.0",
+      "description": "A Node.js module to get default gateway and default interface.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "keywords": [
+        "win32",
+        "darwin",
+        "linux",
+        "net",
+        "network",
+        "gateway",
+        "child_process",
+        "wmi",
+        "route"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "4e2fee22ccb368ad5da213d4465e6d94b3ccdb75",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@0.8.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-TN2rrft9flAS4nSk4CmFhg+DjeZWTzR0OCo9pQkZbpwCXZNmBc6v85IcNlwZOMW0b+mn9/VIHecm9tl9M/jRaA==",
+        "shasum": "45d0f1821d704f732786822e64cde2732436a121",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-0.8.0.tgz_1496923780454_0.31991476542316377"
+      },
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "default-gateway",
+      "version": "0.8.1",
+      "description": "A Node.js module to get default gateway and default interface.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "win32",
+        "darwin",
+        "linux",
+        "net",
+        "network",
+        "gateway",
+        "child_process",
+        "wmi",
+        "route"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "61cefd319c02d93d11435cd3f422d9335b4d09ec",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@0.8.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-qt0daeSPs7IVSPzYRuwwaFHIVe9q2PsqxNLAn6+WbRdGUTOlkX4E9foQ4dGttv5OuzMODGwJrQi66jvrsAACpA==",
+        "shasum": "66b3b0155c6d6e9d4d2c384f356fd1b84c43e9c5",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-0.8.1.tgz_1496923890789_0.4744621030986309"
+      },
+      "directories": {}
+    },
+    "0.8.2": {
+      "name": "default-gateway",
+      "version": "0.8.2",
+      "description": "A Node.js module to get default gateway and default interface.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "win32",
+        "darwin",
+        "linux",
+        "net",
+        "network",
+        "gateway",
+        "child_process",
+        "wmi",
+        "route"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "5fcdb30d478250af480295d79c111d0983dab9d7",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@0.8.2",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-i+6E4/e4oI/C1H/hIJTKI4a2qBo7kRc3ufHDa9ZNNKoUt5nx/CvX1LPQF4YQzlUmobGhdHax96tFMryiOwdojg==",
+        "shasum": "f05e7c191683482cea3efb9e8aa1ad4d74d85a5b",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-0.8.2.tgz_1496924380946_0.64958740118891"
+      },
+      "directories": {}
+    },
+    "0.8.3": {
+      "name": "default-gateway",
+      "version": "0.8.3",
+      "description": "A Node.js module to get default gateway and default interface.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "win32",
+        "darwin",
+        "linux",
+        "net",
+        "network",
+        "gateway",
+        "child_process",
+        "wmi",
+        "route"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "bc300e1c83e7920ecc3ae639878f8632160154bd",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@0.8.3",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-wgMuKgQTtMIb9w1Ia9lJfC4Eb1wMbkm+JAOIY86tdBQq2khK+/g280Bos0j7RETJvqZZG+sA7Ng9Zd1Y29aNUg==",
+        "shasum": "8c6d13e487086c5931507c12cd8cdf70058753c0",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-0.8.3.tgz_1496924672269_0.9910516447853297"
+      },
+      "directories": {}
+    },
+    "0.8.4": {
+      "name": "default-gateway",
+      "version": "0.8.4",
+      "description": "A Node.js module to get default gateway and default interface.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "win32",
+        "darwin",
+        "linux",
+        "net",
+        "network",
+        "gateway",
+        "child_process",
+        "wmi",
+        "route"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "d2ff304cf53f70e5ad9b4e713eb42348eeaa0c0d",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@0.8.4",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-RJmcjXuuLPulX1aqMFAa6Ll5JrRhtS/DdLJxrAhe8/kTPnTiGZ/2gxudCYmDtc9FQjyzbW4QYhQ82s5N2EZoYw==",
+        "shasum": "fadd45f58d8860e99f5b51b0214d337174e97d09",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-0.8.4.tgz_1496927018925_0.5459006540477276"
+      },
+      "directories": {}
+    },
+    "0.8.5": {
+      "name": "default-gateway",
+      "version": "0.8.5",
+      "description": "A Node.js module to get default gateway and default interface.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "win32",
+        "darwin",
+        "linux",
+        "net",
+        "network",
+        "gateway",
+        "child_process",
+        "wmi",
+        "route"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "6ca3c066e832e20353dcd3b26fd8b6695e360ba5",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@0.8.5",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-Zom3W6sMGkMPEo+7NuT43a8l+HFwtERGh3Ef5xCProv2zSRHzcBOY2ZeODZW2mbGrQvtYAdfcQg3+tq1+MMsGA==",
+        "shasum": "f94b1d364e41a7949ac13214f98dcfe98cacdd99",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-0.8.5.tgz_1496927364096_0.730536978924647"
+      },
+      "directories": {}
+    },
+    "0.8.6": {
+      "name": "default-gateway",
+      "version": "0.8.6",
+      "description": "A Node.js module to get default gateway and default interface.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "win32",
+        "darwin",
+        "linux",
+        "net",
+        "network",
+        "gateway",
+        "child_process",
+        "wmi",
+        "route"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "174518afe27c3ded514459f5c6c2b1c0bff5db27",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@0.8.6",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-EfplbT4tahQJH4124/7ERGYwtREsHs6A/SEdMARDyvTdceu23AO7vmuzX4oenFrPRL81Ye7Pr3oYgbJrWVSkTQ==",
+        "shasum": "136e647efb3a7e2899ac542dab2ea7a7e19a0e13",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-0.8.6.tgz_1496927501138_0.1886161311995238"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "default-gateway",
+      "version": "1.0.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "unix.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "3e5a6b9c0eb44f379671507c169273a84121073a",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@1.0.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-+sOq+4pXTCE/3KemFLYjNMJ4KU2S0cSmcegSohOsiFLPeeflQzVMuCz+3PfZXX4THjooOsH8iDh7a4JSlRQT7g==",
+        "shasum": "28aa456bfbb14a369f17f45cb05046ffe5fb2095",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-1.0.0.tgz_1498337405564_0.2740026218816638"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "default-gateway",
+      "version": "1.0.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "unix.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "24bfd95e14bb9fd4064cfec955ac4ed5032f09db",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@1.0.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-x/3CJWb8o0rDL+JyW4lrSKfamIEtMlaPcmbG2t+xOlRrZE+MLCJ3j0oKm/yPS7SnPuUmks+qoOSctZZlP4uRAg==",
+        "shasum": "90986880233702eda02776105c1aba701c65d190",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-1.0.1.tgz_1498393015606_0.6717980781104416"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "default-gateway",
+      "version": "1.0.2",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "784661491900a1fdeddb60c9e08ee9122019d386",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@1.0.2",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-OMQVYHF13JVrgNjSmLUeI0xMWVL0OEMUInxLhB72cqPevoKVZkyeBrgPoQdaVLo/79UQ1RHNJdE++I3WWo2wug==",
+        "shasum": "9f59056ce6ece51df8c3af591b417576fff4ce61",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-1.0.2.tgz_1498399252603_0.3600925493519753"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "default-gateway",
+      "version": "1.0.3",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "edb3b0ac6b30286afdadaf51567087d8a64a3143",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@1.0.3",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-l2kEaj1sgIUBSduAM/hBB857KrCf1rbzFrYTBs+NyKjNJGUbbJ0nsFibt4RKyzk9K0e81zX/m9Pk2q+6mAC2LA==",
+        "shasum": "8d9f18085b2b59c64ae342629a0bdaf97d889b5e",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-1.0.3.tgz_1498403191535_0.8774592285044491"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "default-gateway",
+      "version": "1.0.4",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "0e7eecec53e88bae93482d388575fcb4ca57c840",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@1.0.4",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-+ft8TFOj6l49ffU2byALasEGqE5n01ejLiaypv6zRDAQ7R5cP1FTuQXUox46fpEMKWykfxpEpJoJVij/JzjdDA==",
+        "shasum": "3d18c33a96aecb7f164d8d199023332bea57e3cc",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-1.0.4.tgz_1498403596963_0.3993046246469021"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "default-gateway",
+      "version": "2.0.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "25c7eee97d5ac53cf0d35e06c5648c8f2cc00c21",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.0.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-vsk8e4vJMNt5saEhSdaT1ZMidWEjJZ3Bos/FmEVeXXM8omSl1TZejX5zU19zyl7lXIX2EBDAU9pAM7fSdzS+sw==",
+        "shasum": "337be7babb07b704d04d5a423dec8ff41995935a",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.0.0.tgz_1498404910004_0.23805554118007421"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "default-gateway",
+      "version": "2.0.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "files": [
+        "index.js",
+        "darwin.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "a9ffd55d75630cdc8f055957f01caa3ce527097b",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.0.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-r4BwxZVSeDX8orijcVJIDly/0Ruun7BI67yJjtiCiBsh+Am3jsGYqVRxv/rjQ0x3B6EPKdXb63CVgh4K8ViKnw==",
+        "shasum": "875a07f5aa3f0237824c5dc32bec16ae5adbe064",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.0.1.tgz_1499101713531_0.672102287877351"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "default-gateway",
+      "version": "2.0.2",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "files": [
+        "darwin.js",
+        "index.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "24ed6891a635b0adb723523f5bc961c1be4c55e3",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.0.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-lvDPOoSVibdJqnZNS9OF7SzDrvr5PYVgynPNNqt89lcJWDRnLP3bpzkgFc/5t759YcuNjz9VEpFe5I6NLLrSiQ==",
+        "shasum": "e365db05c50a4643cc1990c6178228c540a0b910",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.0.2.tgz_1501271637938_0.6506575881503522"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "default-gateway",
+      "version": "2.0.3",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "android"
+      ],
+      "files": [
+        "darwin.js",
+        "index.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "6748b72326f12a228a353bb7e5e59779a3d1286a",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.0.3",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-aUOYoVzqpMZQRcqbvH97M6n3e4qBXug3ZTt+4kvC5BWv5bXtKHxGDNPxY+EGVmmOGggcfxkHk8fxg24/cIrpuA==",
+        "shasum": "afc4b30b8be731987bf1f74e9092149dc303a64a",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.0.3.tgz_1505560925488_0.5008111130446196"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "default-gateway",
+      "version": "2.1.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "android"
+      ],
+      "files": [
+        "darwin.js",
+        "index.js",
+        "linux.js",
+        "win32.js",
+        "android.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "5a724e2283fff9ed47f50c6b8122f2927e76928d",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.1.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-H0TLuBOdOhoWXKtLFDFECMP5JEbVEGT/xZ3zbE3BI9M64dRQ/Bp/iYcxmwWiHBXrPE94zmWKebxn2oe3fM1zjA==",
+        "shasum": "b7d094d09827cc7029dc66466787b65483656302",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.1.0.tgz_1505561029910_0.17285275226458907"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "default-gateway",
+      "version": "2.2.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "b14a68d083b849c3cb8d02708ee9555feb0fa46e",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.2.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-Xa7rGyRmzPEQVauuuDPhLsAuF1hiwCpPXTfsbD2kQhpKfcbb9zSq1KwshMU9noy1E6sxn5ldQuRO2Pbz8IkuQg==",
+        "shasum": "6830474b33e9a8d5d394e57fc9c5fed03ca104e2",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.2.0.tgz_1505580718545_0.5057501748669893"
+      },
+      "directories": {}
+    },
+    "2.2.1": {
+      "name": "default-gateway",
+      "version": "2.2.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "7649dd4c9d2b67022256d8e192061c4b480c4554",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.2.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-DNwdRIvWi37hZYtwCWUBOUYz9e/4NIjTiqAcTOSW+TUoDyoCfZAfhMjzrPbKRKXmVNTSPyJlkX+5GlD18a7LWA==",
+        "shasum": "405866846f2537b34511ccce3c5c76ceab9e43e9",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.2.1.tgz_1505581089537_0.4823363956529647"
+      },
+      "directories": {}
+    },
+    "2.2.2": {
+      "name": "default-gateway",
+      "version": "2.2.2",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "c4bd7a2c85bc471f5a06e9b3ae2d1e4f793f428c",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.2.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-eLw1G6hAmE7yZeRfFOEdvIBBlo89HB6iO6aDafnMHmD9VI8P0QNSVP+ifXoNNamVCArehVv6vb2X7MQZMcQxPg==",
+        "shasum": "797de0e09a476ca1c756efc576e5d6103f7ca7db",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.2.2.tgz_1505581876199_0.3456222431268543"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "default-gateway",
+      "version": "2.3.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "d3c532920c189c4ed1c9b3e2eadf0d6e52312d08",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.3.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-11LpAjQf4dRlsyI/Z1Q5QxC8Po62EOi6sNCi7Etq7ngJL5lGwyBymVcWHptEvmQe6kkmh6nKFw5aKGAav99jsw==",
+        "shasum": "07e7d018e8ba0abfa1e109cf59963ac5f0cdfb5e",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.3.0.tgz_1505583827745_0.39865965279750526"
+      },
+      "directories": {}
+    },
+    "2.3.1": {
+      "name": "default-gateway",
+      "version": "2.3.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "8be027ddaca5a6af825bd85e848aecc0d6a484b6",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.3.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-giiboq/CTPhoXQSEMuFqObD+vGdDWb2Rg+L7gJi9hF4g+7ekW/fsSIanbpw6rKLmRFLU7u1CReF1j+wCo3Qljg==",
+        "shasum": "52de54201428c22e60306f14069656d5f6622f58",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.3.1.tgz_1505584029491_0.5973357588518411"
+      },
+      "directories": {}
+    },
+    "2.4.0": {
+      "name": "default-gateway",
+      "version": "2.4.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "4171e9dcfb8e18b4c7a84773f72851f0af3ad7ca",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.4.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-jtdtfL2MWLLHMASg/XlDBHnVPVX+s5IEHRxyNvy/AaWyyf9XZr+ClAAPITevY7k8IdOYZvx1BcrjSyeU6e5W8w==",
+        "shasum": "65dc9a39bc78ac5cba8d4ef9e8de008ffb00e116",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.4.0.tgz_1505639950894_0.02266146265901625"
+      },
+      "directories": {}
+    },
+    "2.5.0": {
+      "name": "default-gateway",
+      "version": "2.5.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "f2fc002d09ca6c75d55831185adb9172b9c02e2f",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.5.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-Mb+xi1aktPE+Uz5RmS3vU6Kr1fDqRvlMX3M5eneBai7LkldzM+WPjaUpz396taZgOgSw4s+CJGvd6VJJ/9W0dQ==",
+        "shasum": "78e24dbd2e1df7490c2b8050515b8e816bfa7da5",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.5.0.tgz_1505665765226_0.0630882503464818"
+      },
+      "directories": {}
+    },
+    "2.6.0": {
+      "name": "default-gateway",
+      "version": "2.6.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.8.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.7.2"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "9cd877dad9aa7a28bfb7703347b09a3dd82fa337",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.6.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-aWZNwWr5ciCAAbnqOuaWDqLlUXvQw+LWvswsJuDqJBJME8Q46ulWyqr9kxCcAYZhdf8rsBfy6EloxapkXxW5lw==",
+        "shasum": "acf02d181caef4c464b6c37fe25daacd6189b903",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.6.0.tgz_1506627031300_0.7929089618846774"
+      },
+      "directories": {}
+    },
+    "2.6.1": {
+      "name": "default-gateway",
+      "version": "2.6.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.8.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.8.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "ad224db2b81b1a6a64e07fd480db175059139b02",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.6.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-03hfY1Db+URp5NIrhlQPZrKlsr4jJbJAK1jnNSCvmNwzD0pPlvg2uqOwQpXQsDIGbUaBtkG2o7AKfBOLILzGXQ==",
+        "shasum": "d337764dbd40c327532606c858f9a3c05cc456df",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.6.1.tgz_1507137090309_0.6480592666193843"
+      },
+      "directories": {}
+    },
+    "2.6.2": {
+      "name": "default-gateway",
+      "version": "2.6.2",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.8.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.12.1",
+        "updates": "^1.2.6"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "5982eb3cdd67877bc28b68bc4575ab96fd2b3562",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.6.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-64q7pVqNK+B3rKM61z7357tGUusIbM8GCzfjhtyDydSGgtQMzoeds9N7h+wcUwtDhZRQ+taU964GFZufSVHP7w==",
+        "shasum": "c53bce5f464a0fd770abdec095d0aca87406170a",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.6.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.6.2.tgz_1512841889464_0.4984933875966817"
+      },
+      "directories": {}
+    },
+    "2.6.3": {
+      "name": "default-gateway",
+      "version": "2.6.3",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.9.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.16.0",
+        "updates": "^2.1.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "9e4c1f88504b58a874edefa105045bb2517a1510",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.6.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-WuRtzZCifSO7asGg05UifgnuYU4UMzKneg+I5PEG2rxLqDB2B53Em86W/62eskOFUZeVeDC0bQRy7ZV8zqGG8g==",
+        "shasum": "fd8d2aeddb3d2a5d93526f2a75e88c13056f7968",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.6.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.6.3.tgz_1516745891326_0.7305471743457019"
+      },
+      "directories": {}
+    },
+    "2.7.0": {
+      "name": "default-gateway",
+      "version": "2.7.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.9.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.17.0",
+        "updates": "^2.2.1"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "b9005d70b3322afc09be143be36ad8d8a91d915b",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.7.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-bDPiro+T7ZBbt6HlObvUVHv+VHw1WGvF/UI3D+ZN2mqPTPgx5JM5YDgTj06zkr/tq2N5pCgGFMetNrSBi+IjLw==",
+        "shasum": "eac4456f4074b57ae2db4275cea881dcb37dd5b8",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway-2.7.0.tgz_1517938195244_0.8840121619869024"
+      },
+      "directories": {}
+    },
+    "2.7.1": {
+      "name": "default-gateway",
+      "version": "2.7.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.10.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "updates": "^2.4.1"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "beaf4a2a216c695f4154e339cff9d4ed93299bec",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.7.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.9.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-3UOsgF6oWP0js8hoDp1tcrYYndTznfl8aWr+ziU1z/p9Uv+a2UztSegX/3wwdxaM4SpPgGe3G//tJJeNEog9Zg==",
+        "shasum": "1fb2b25fdb938394b8cbca89029894f8fa068399",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13554
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_2.7.1_1522164960386_0.7998576648775979"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.7.2": {
+      "name": "default-gateway",
+      "version": "2.7.2",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "dependencies": {
+        "execa": "^0.10.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-config-silverwind": "^1.0.42",
+        "updates": "^3.0.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "88aff60b776268698f7ee7fc3aeb7a8dcd4af84d",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@2.7.2",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.3.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+        "shasum": "b7ef339e5e024b045467af403d50348db4642d0f",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13590,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbEDWICRA9TVsSAnZWagAAuBAP/ipX8v5P8O2FWRP2F+c8\nymGna1avXx6+lif04wzkZQAsoSxLLWN1xP4zXFVi1CQfjSJZjViuetgDiriP\nl72ttaoIPjTttZ/7jakDa4ZjR0y1nFiNGW4fe3ynGA28ULmdyUZznjiNisV9\n6AIPzSryWep8Hx2+sOlkA9pqS5qzK6P0YOKyW4E6upr+YUAws8O4uXRY4IKj\nZpyRljEX8Os4hQfhCiEbjugvnZnl4WLxkQuknBJ//EEGNlXuBI916yT26uQC\n9BNQTdA4sgVFdIrIqseoGPSNiywQ8t33guypb9KzSNppvhSmyDEomAGs1Vsh\n9Se0ZmPyTdpSpKk7Wg0IbvTr6IKlq+ClJ/lS2JKVPzdprE1qFEZfWiuvQTps\nrvlYeoRS7h2DSK+uztlUz8j/WQq8k0FIsASNdCL2KMKA/AJpn4EJHx6SGLHg\nK1qQSfi/XbZlLQljJyTxP7sGrzPKc9t99d8FVrZmVrrP+1UTJfOLejySgMVy\nih8JGomfOC7vuak0YMDSv4fb+DfVQR0Ac5pRFU+Hw2vR0M/efPbDUv2MChjA\n6rgV4VmHIxNj9qiVr5AieLJ6qEvvFV5eLLZsyyM8MIh65W0UCczpKhxxhbSZ\nDhueQR6itCutlxAwa8tjBnZ/DB/7wE9j4s3u1rg//vK/0dS0+rdzMSBy9DEs\nNHom\r\n=ZMZG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_2.7.2_1527788936027_0.586713733378692"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "default-gateway",
+      "version": "3.0.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^0.11.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.4.0",
+        "eslint-config-silverwind": "^2.0.7",
+        "updates": "^4.1.3"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "files": [
+        "index.js",
+        "android.js",
+        "darwin.js",
+        "freebsd.js",
+        "linux.js",
+        "openbsd.js",
+        "sunos.js",
+        "win32.js"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "1884837a6c51dff10d823a3c8c674d7e8f0be40e",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@3.0.0",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.7.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-LfNe1m2BCWt0f+fZZouHzW61OTPARdc1UUANvO3GPTybNyPqBmpwrR69vGKxjQrJmsITXY5Haa4Q8IJzHZUtBQ==",
+        "shasum": "fb180fdd08384a7a871176762458a953b859eb64",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-3.0.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13525,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbft+YCRA9TVsSAnZWagAA+QcP/idK+eE3YcwC2zrc2Urh\n/mmN8Ks3I4KxL93TEnie+lII/2fczSnXnwHIewbFclWyFrjfL/OhgNTXUzy2\nBY5lEHwFBQ+jaAgOk8KwD0l7tpf6GCODWUnBapKYgVmNGZRGJU0odRNJLn43\n/Drw+PB5hwZghzjvxuNufvDIACk04T4ym3VF6O5NN8mYxuSpZIAI4bnEYe0x\n2nvg6ZBQTB+e21Y813bhtRbqwYwfyrUSDZhH0kFsYJpxSZOkDH9A+MIpDrz1\neTCnlFmfl87axdVbbZyw6EHYsNdlMOrEcZ9TsBknRAepZ79pw0AB7c6cIaw/\nseBdM2U8HvUw7W+NOzCwyXRT1RJI912XM24aD0O9N03Ha+AqcaRw+/Ohoqoj\nw0egB5gIFiglY/lksjfZuwXN7377sjIfzYMrE5gZGUppTRioSdcaLFFvyplE\nQVuWCd/Y2Zb6R0XDlKb3SgyxWNI1+3bCMrtbvCG5XsJdbfTX2sleVrQBuEeP\np51zNRcWPJz8i4b5s55OXHou4k4qPzhrUg35skOwok7gVjDqpkd38OtKYtwH\n8U0sZv1a07d9DNiNffdVb5lZthdbt1Pk/Ccsg4cT5pUY2i8zaGsZ4jPuVbN5\noCjpKyJXFQD6CVTsZmBOpA7Tyn9afwpyLXTUURSx+AkyyqSxBz5obl9udfv1\noghy\r\n=B+gd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_3.0.0_1535041432094_0.9574511515949071"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1": {
+      "name": "default-gateway",
+      "version": "3.0.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "9d3c3a5dd46bbc09f93bce68f35cace7a7f06593",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@3.0.1",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.7.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-rdXB8nV5bCAT1p+K3PGuujpayV27yTWbTpk7brPhDq2xz3qkdkdJipLYzD+bZtwLSsfoQSpnPFFkvxzE0mlMHA==",
+        "shasum": "a5bb7d4e6b86e1a18aa59865b9c364219361f3b5",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-3.0.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13544,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbkCn/CRA9TVsSAnZWagAA6wMP/jRshUlmRJrDcd1w7cHT\nxQ8XqEALCxgsPvkLzLta+M79OqWPd5efyrrj1ejCN8KQ1SvhSOIPIBJKUt84\nzIErLoeEKQ/S1AlmsH0cwJTa5LrAubTggpjfVxpKRCcSCzNkh8i4cPqSjxXf\n+QK8U63EMTF1bKP2ACOTGFB8e/bz7emxs9+kYQNzg005js26epx6cFUk1GdQ\ntx2W7YGzsFVy2veHdDg8kBVDly/XTbHhQ0x3qCX89M+hGYQljtcoapcy5aJd\nUADp+VI/l4xVbTiwU7deqdWf1ID7ter915CwUdqPta7cyGUhs4KTDAiyrRMu\n1TVgyymcDpm67fLsY7u6u6dbG+P6C6SdeACl5dTuM+V8Q9z8pTDv2AU7WZZD\nkSPRXuefO6FSZd7RXqR2JYvA0y26Lkm2rvEHYWCiAp0zc4D/Mt44dW5n9LeN\nw250mLAc4/XPsMp/UqsqJTKpPmO+Dpfny0m+UX3vn05NuARiTa7xwAC8/CrU\nEsZLHR1NvQ4jJb0NDCRvOG499LpGFOiDgu85Nf+QpoAUjB6wKDGYLRbDnhe3\n8ILeh/rtVos3k2AqFR13Rto8hC/zSnONQlesAU5xBl5B5o3xYpydvlUWMIbM\ndAY4O+2GktN4g82v52JV+MT3EMJFg+9rBjFI6MPNiCX6kWHtT1ngw0Fzz7T3\nzTwy\r\n=IkdG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_3.0.1_1536174591110_0.2730814011118521"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "default-gateway",
+      "version": "3.1.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0",
+        "idb-connector": "^1.1.8"
+      },
+      "optionalDependencies": {
+        "idb-connector": "^1.1.8"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32",
+        "aix"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "c45118413937b790215c9c19477e64850a741c69",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@3.1.0",
+      "_nodeVersion": "11.7.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-MRhxv1cqdpKZh93zMFBkXcZfr2QFasrDlxjGa+M22Hv9EBmdWCccFe03KqSnkPLpYXlFhrR152kDX99S//3/Xw==",
+        "shasum": "85248c9b2b28336ab852be2f08c19a52e187ec4f",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-3.1.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 15748,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcZx2DCRA9TVsSAnZWagAAFGIP/1FPdUVmaATwTI1ourgW\nBegNnfe2GLVrAboRFnjVaPuPYS/UT3rHzP34/Qxl7a+6qsusKn1JDS3eZoVE\nDW1A8EoUbOFPozKkw1ZK+YYHR71FJxYPmn8lNPp950ydPUuP91QDT0HSICwq\nEU9NTLQAumO+i+QyJb59dw0Uc7OJQn7dakvt8h+WWWzWF34EqVJ1z0aKEc5L\nPvnVTFoYFBiWtndlhTE7GF24fCYwTMq7bri9UwOGrEy6WD47D+iy3P1X39kZ\nDVn+UMtSGehrgdItOxk/h3qTBGyDozfgksOOozd7b7ZUnN/dDbqo4SN94sde\nOLj2rcSTUMrJZ05jmBinAjjIg7ZH0k0k9VOkoTJ8QhRyQDCaSUksrsLhiWsq\nXb5Mw7Ejmn4xMHBrMtHUyaqJn1JhGt0S24+weehdzyeQYXV6EDtWQ9V8dh8x\naW9jpp/IfGwvlN/kqTwiIfAyi1YomQnP50fr60CAPQrf0YeBOsPXGqW7kZrJ\nTn/lF63kQi2KzkeKMF4SQA9mVFJEU/xZD3eljRNhnDlk8YsE6pGAjFLkOqe6\nScjePiWmc0TeAMN2phqsx0eXaRQSyiZkk9iWkaYd/O1E4dSqp5UI9oXyGQF4\nqIycZWPGu9UhPfg1zGP2i2pcvEStQN1FRyYHD1scQJHyNdxnGCJOHhoOPwdx\nSB6f\r\n=29W0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_3.1.0_1550261634592_0.8059259303255291"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "default-gateway",
+      "version": "4.0.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "b7b8b476db468ff5bd2e450ab2c178e1b1b2db67",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@4.0.0",
+      "_nodeVersion": "11.10.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-DV89pF1bja+CSvl3rY1Fo6K+eYuv1g29hv2vFlEVf1fSGsyR8gRq5qfpXDyX/+1dd/jlZ1sUT7tAXbvX9tJS9g==",
+        "shasum": "4a79c102d1c98ee29d90343aa3c406cca40fb40e",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.0.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13642,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJccBJoCRA9TVsSAnZWagAAWyAQAI3oi5gpO68ExisFachC\n92S16UzxLzuDkGiMJaHFDzH3UUArdHtjLvIjuDqQHULR7dYlWnEgyhHMjYQc\neVI79I4jIAR+JxzzgTjx1CXgAHH/cy7U0kcumHbJ6BuNEev9i22ll1kf1X8d\n4FAX5+3ZFE19RDbvMe9CjwM8T0sLW7BnYBNDl92YUxyhnEESERMeVyMqfVzY\n2Aud1PGiGHUhCMvDyOqZKeKKdAWb25kq+FTWZK+o9EqkV8b4FgZIYJKPdNd9\nz/dVhsIv9tUwG0V0y+GK7/cQCgsIMu2miiy44CP1zzW/4srFcJFGfHlkbCI0\nAa/eI4fx1c++ozQB+gzrubcHI8smDjPy0d3ltr6IYhfsPdkWAf+MHdDR1PFD\nzzytcfBsFH2/OWpOKyR9iQ8tfH1SY7LrdeUFCEvYY+rEJpWRfolTshY1baKE\n64T0urreZLrq+B3lz2pXgbSsahFXuI6qGXM3NtbTrufT2J29p37/eQ+WLkOd\n/sbHqT2IUNktTe7e3zOmVSiqVP1yOvAuyxttUmp1JAVn0J0LzIgldGtpH4Lh\nvNb/W3KEhqCAjuLhWKQ0/wJwRrSOYIAmlJZpDqPgMp1VrXpM5yX5B/nOhe+7\nV25j7BfRgMMtRUnEAzz7X9fjwrLZXHG/wvlr1DqCFoKjGQR8qV4yp3KoPUoS\nhp/4\r\n=eiiv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_4.0.0_1550848615561_0.41555741010345226"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.1": {
+      "name": "default-gateway",
+      "version": "4.0.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "50c51376d98584c0dc41bd42948581ad471e88b7",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@4.0.1",
+      "_nodeVersion": "11.10.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-JnSsMUgrBFy9ycs+tmOvLHN1GpILe+hNSUrIVM8mXjymfcBH9a7LJjOdoHLuUqKGuCUk6mSIPJjZ11Zszrg3oQ==",
+        "shasum": "3a7d071ca610a2831190341bd0666382b9dbc340",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.0.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13491,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJccQ66CRA9TVsSAnZWagAAF8oP/2ZFOcX0kmvYni2kt113\nbiMTt29z7zRhyJZ7IBfW5mR+zzl7/jhlSv54c6cW7p9ATnGN8OSGK1sZJPfb\n4WR7tEf01XVfgSShqyr5mk9ZTl+1nlZj9NJ0u3EI2cV87ZI05RsAjN/8YtR8\n4NocJr0k02+XMP35K4aH/Wr3in0x8aCQhe7xDls9n85FMi1+sww9msUlsEuG\nX+8mwQBfyz1QoUUsphf6n4wgnL1NKApCgUpE42oD/g+smGkNdvNhnq/CLISF\nyyd7o1pihYpRLTu5apIjSHL8DuDFkgs+HpNn1NLcNEku/ELi6ofTO9hsJJuX\nRVvGNF6LK2lSR2uFV1FPBi/wyO5AD2LJawTG2ep8SEolTqfXRH/O15UrTuiZ\nchNwuMoe763RAVwi72JzDDf3zuS5pLJV4DrDEouaeY7bLOnPEJgbr+UhFRLq\ntjvriAmsBWVQczVEHTcO5ZGu2mM5/BiIFfsmQ1RcVkA56LRHun3VaIQPU5Ng\nsz49Ru6xqpWZXFVRhxLwXM9yp+3fC1sSceb0ggDDcSTd1jy76eDdQ9OL2sD1\n6XTqZ98Ob8Sxhb94pDH0KG13vr9FDolPp0AJ+OdObVnFdvtCS3A2o96fonAY\nvCO9rOkVgfh6Gkyl6bx/6BK3T0kRNwNZURXEywftthMZMvDgrrscEIGYIr9t\nvMzQ\r\n=r8ri\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_4.0.1_1550913209682_0.49324061757062343"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.0": {
+      "name": "default-gateway",
+      "version": "4.1.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "5f4d546b04531b413f0afb365c35d1322b9101e5",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@4.1.0",
+      "_nodeVersion": "11.10.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-hCXBrb+nOcy2J1xRpClOIrK601PBhtJjjvrSVj3bZbExIqrzbBBd/x/VuYQfkEqWWCk+335FzN1qbNo5OlDIxw==",
+        "shasum": "64fce3dcabf23874ebb266326c8444a55fb960ba",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.1.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13500,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcdCpICRA9TVsSAnZWagAAQEsP/3G/x9nFqsFAeHwcxuLq\nIH7Yd7OLuEaoTdQSOeT9I17+ms3DHpl3d91dkJ6+VWURnBocLUFKqUG/V7Jj\nA9pycqKiQEDuykLcD0HVW5DzL0W6Pc4bGYGGUu0HRGZIied3u8A/0IJtKqDN\n70Z6F7HqwMMzpquECFGzQ+qf6DN1dyo3Ih3U8BQzKk0m3cpNo1y+Xc2bQoI9\nqW4JDcvYgqWHAii7coJ9ZLC2TLY0WrJE7kCrxwLfFuIXZdmsTu2hq91f/mA1\n6zazYCx8HJfr22dh3IgnmMOy0ho2oXQt/S8FB8uY1WAHuQLc1Gx01C4MkItz\n+s6U8KkzCGV+uPlvUK8C383WJasngy4JWxeM2et+5Rv4103r3q6HXoGdWGC6\nplmtVtDDrUjLbZ9qzvVeuECfYCQ5LZWnj4pAAKM1TNC3QziclR8pPi6K06Yc\nboJpk0opbSWcis+OCcxxTxGfV8LoV+8LFZBWBTp9LFfAOYZ6jiQnI2TzGNx2\nMamj1QvQ76jNd77XQr4r1xf5ZBubSJ4nNoU+MN7gxpU7BKtzwYJ9HwDwwYW4\nyiOP6ySHmr+FahSrCwAhdxwbdb+1rgy3bxgl5K4bykGUSU2hkrEUSRXNLiRY\nKseme0HbVbI/HzTtnMFtcj0YAoPJVWoI4EoKGeSb4tD6afJDe/U9EX16/X2v\nIbt+\r\n=EHxM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_4.1.0_1551116871903_0.22502390983628562"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.2": {
+      "name": "default-gateway",
+      "version": "4.1.2",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "2a7d01a720ea95a33b3ce23b50d86c764293155d",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@4.1.2",
+      "_nodeVersion": "11.10.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-xhJUAp3u02JsBGovj0V6B6uYhKCUOmiNc8xGmReUwGu77NmvcpxPVB0pCielxMFumO7CmXBG02XjM8HB97k8Hw==",
+        "shasum": "b49196b51b26609e5d1af636287517a11a9aaf42",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.1.2.tgz",
+        "fileCount": 12,
+        "unpackedSize": 14849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcdC/dCRA9TVsSAnZWagAAebEQAJJ88I1jWf2TF7lNeoOY\njQhYA/IVbjCZLwfh2YLd56dbTTa4vxxiWktU16us6NwAPmm9Pds8qW1ArRbN\nuA+oJ8xYxieQme2u0ICuvbqyiI9+XUwB9W/aVXuPWFjhm+2215jejnfhlmp8\nDt84TM6gCNg1mcDkH6oLIBkXwMbdIfuMgUmBTqs+AcYl0iYrOsLg+KlR/SjF\nFTfSht4S1U+lPf6GK16qIcnUdyJTGwgW7A7bqlkTzpQuuXTgaaVg8JUFmJB7\nFrQjpiFyk9TuORK7AQe2WwcSWk8ZpdZA7szKp6MegvdcwcydzI7UZ2++/Pnr\n4DDG7XUVmRUtfLlxTjbcb77R8qe1fK2HlnZZS8W4vELlvZp3iivrwbefdU0n\nNtT2KTCD5FAb6/jJXMib/ETFFKWRSpQDpFUI5NZfC0gHEejTYptz3zLjGFoW\nSvBJIuZOqVL4wc5xw21ODl2aQaoVbHIAJuuiIteJJfIGkRQs8jH0Y+n3iCwi\nv3CYWbyDe+pxQf7XeBlWeGRGAgxZ1O1/N2OTZ8vnJwv8MRU51Ug+9T0vF0Bk\nhP0fLpA2EvO7uKCv79h+zuei2U9uBXJPtkSjG4XwSvI17aZ1nKDa47lMsQZC\nG9r+4nb99n3UVZ1HyvYFNQ5/ZfKB3/lnRLYK6sZGTPSGutDWvnVW01YlSf/z\ncFff\r\n=+VaH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_4.1.2_1551118301217_0.2430150558278068"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.0": {
+      "name": "default-gateway",
+      "version": "4.2.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.15.1",
+        "eslint-config-silverwind": "^2.1.0",
+        "updates": "^7.2.0",
+        "ver": "4.0.1"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "b8b8fcebe3f568b1bf56bb416aeb258b78150dae",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@4.2.0",
+      "_nodeVersion": "11.10.1",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
+        "shasum": "167104c7500c2115f6dd69b0a536bb8ed720552b",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 14861,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcgCIRCRA9TVsSAnZWagAASRoP/AzTqmAmXp+VqhEii4Zz\nNLwUNLoYQAMNCUp1/9Shm0VxbxuJVeVmvu1ZwCKtenIHu8ZhqF0XWl0DpDqT\nGjUEsLMdgmKZUQLc8RQxvgfkeEcSQ5oxoMV/WH9jb3GY/MZfL+QqsnAc8JPW\nKD7e4artLCEgwrquwq7GxxXj7rR+5xijkQJyu+VUmqGtb836WwqavhWoMF7M\nBR1mCEa8UZUoo4wTfCdYY++vpVwV1ht9GInfNW5TnHeX3mySr8CKlRp1q3hK\nDNB88P1OXMtvvOhkZv+vlM40MI27Km3fQlWB3yOYa7r0yobM604P3i8e6iEC\nYumWnBZ/bfXWBmKZtHG+GNuCChOgMEgEbYnmggetgEdyWY36Vk1YibklBa7y\n2TfTWof+SkOI+MA5/YSf94z1nw9X++UJ3TMG6Vsb3e8i4bhDKK5RKtu0UsEG\nKVfzJw2y7IOucHzCHFl0Iw/aKAgJtktU5txLVk1NdhX22rLA/c0Tj0RyZC+G\nzm6QI4xXjkaqaPIlLmS4iFKNqFbxs28Q6EbS8CID+gbpvxZDuUaG9iMhcf9m\nBGblQWRjKRau8WnTvSxTvakYs/mjTOiKMnMUNBKwvXaReKfbNFPG8Dp6c97E\nN9uckLfbNdn84o/dg0uSqf5ylLVN4HlmmR87TsGZ6/2pO7/iSovU6AlYqhtS\n3/YA\r\n=3IPh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_4.2.0_1551901200580_0.29396799751046276"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.0": {
+      "name": "default-gateway",
+      "version": "5.0.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-silverwind": "^3.0.3",
+        "updates": "^8.1.0",
+        "ver": "5.0.1"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "b0734b7ea2979a2bc87a7b69ef689e3248838dc6",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@5.0.0",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-UynB4xzoJ40Uu5JV+uRjOGyl8t7YVsTUdIoYtzQbFgsL2LL2Qpn7jk1c2xCvQrRy1Fun6wrhorioiVWgCr/yKw==",
+        "shasum": "a30f61762adf00ef0e2e34f210142d173bd9233c",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 14636,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAwCuCRA9TVsSAnZWagAAmtAP/jnVNY5seZr6BGm0j6UG\nDqkICfCktJoykhd6qu/eWFKzHMFVInp5125YeyEqE/EypsYGZS+8j7qx0YEU\nO0Zmms8ZHwt8Elzwk5Idgv9kwpgMs3OKVxAyvG2SCH+vAUIjOS99iHrfR9io\nbXUnJuD8NlRACEkhMB4HQI/zFyMs58vFIUzS1NKdZYFWChVXXym7k1N0CV//\nV5rG72Yz8mFQpezmCTkTP0dHWVjNq4gmJEolnPCrR1vJK7yydXziE/m10AFx\nzsxzi6tFYATxYQaFTPxi6luiRR+A/YVUgNrMiH4Qq8g1EX2TSBSMQfJtVP28\nyDb8niQqjKPCQpuYyxEzoTcNSqYz0d4MKng1XDKi9l1Hp4L5Mmya8utiimUI\nYOC6c7MdNXFPIwtfELSa1cDCOvpC0RpX7+1ioyNbu6a/ctigGpTrci6Gclp0\nOsbcs6rSDVUnMYCRncW/CUdvZ/2tv7hns68cHcFsm544gGGZwT724uM16skQ\nuC/xMslvj5/Wz6IPW3Mo/RuUvhkfZCQcfuJkQOOakYFKc7Xf06rIbmiAXbtA\nuZeXaKzWxSfKx8XfQ27ASIvxqSf499UFnwwUzEHPEj3q2uXXlnNnO0Naz1Wt\nqVCU9YBnxJ7mFCMyb8itu5uO1dmACcBzvqpEn/ywBb3Rir3odG39Lec148Wu\nrgoB\r\n=5FCk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_5.0.0_1560477869960_0.33972598099628093"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.1": {
+      "name": "default-gateway",
+      "version": "5.0.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-silverwind": "^3.0.3",
+        "updates": "^8.1.0",
+        "ver": "5.0.1"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "14a7480c4b423d443de57a61fe6b9156f680ebc2",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@5.0.1",
+      "_nodeVersion": "11.15.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-1k5ZDMXdzx4DsBqzrqUrwONScoU3wTGIQAsrmivwQ/hnTcyCKrTBJLhJJbDilhc+4PeDz6HgCIfOPD7RKZ6/6Q==",
+        "shasum": "5e3a8d689be4d822783803bef65f35917d096b75",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.1.tgz",
+        "fileCount": 12,
+        "unpackedSize": 15166,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdA/VNCRA9TVsSAnZWagAAUkoP/jC+MvgqDPAMEBRushAm\nJly10oIdJJ4lcsnlOuHpiCNeK934vpQIQv+3qfb8MlzKN/jISCkkD7KMgkyv\n0LrsvpRgDjAHu92biB1CEkm3rmFZatzMUtCck8b4VGGw0FYs3tBQbdi8eosV\nVI/Uf8EnJU7Jc88OJ2Lg5l1LrxM9e/SqN4lXtAK5zRvTcqMcK9OHm3LsmtRO\n9LdpD27ZNxDl5RoZYfoQc4CabiojxZ3yJ7RKoUZfGdHD+lcGNhZzvQCL3nml\nNZYJ2CrNNNKRJFmQd5S5ERMDaB1jaT6EiiYylCaH6xOZhLpP/kZrdQ9tBcHg\ncjIw3BWh+tT/tSckB1Xk6DmYmeaAlbdeiASsjJ5UyR0MLG6cbksPoUaO9JWn\nHRbj4JNwggmMJdoSM84s0P9rQrkFMoCTjkUbJxz1+1tPtzkv9gXTtL7zieXa\n0UZ1zRLlR33WFhyTHOdyA0+rju3nfwApUkPuZ7bSO3+xWZaWMmzcYhxyjC6p\n1Gj2Jg9A16Vm6RN4dG8iveOU7Ateoa7PL2SuhvLzOMKiH1msp1uGCFFLEogN\naYxT3pa6v9Dsy37lhrhouvOk5+W2XMREonnHOGdTN7dPXqgoCG0R7EcLU2qb\n36eQq9pkQADPj0YEMD2JW4FOcAib1bRojLp0GXsTzI8ym719YU98QJC+V5Qm\n4V9B\r\n=ujBj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_5.0.1_1560540492447_0.1905423609291177"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.2": {
+      "name": "default-gateway",
+      "version": "5.0.2",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-silverwind": "^3.0.3",
+        "updates": "^8.1.0",
+        "ver": "5.0.1"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "b96d32aa77b14591db8d60ca294e6854b8a69ff6",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@5.0.2",
+      "_nodeVersion": "11.15.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-wXuT0q8T5vxQNecrTgz/KbU2lPUMRc98I9Y5dnH3yhFB3BGYqtADK4lhivLlG0OfjhmfKx1PGILG2jR4zjI+WA==",
+        "shasum": "d2d8a13d6fee406d9365d19ec9adccb8a60b82b3",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.2.tgz",
+        "fileCount": 12,
+        "unpackedSize": 15167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdA/YvCRA9TVsSAnZWagAA0nYP/3Cdyc9kGJGkF+ZBM8M9\ngxXDbhoUpnpzys329mu1A5BPExP5aEuCM36hjY09LYHqweYy1QwCYC26hzrN\nTFAJ7M7aZladJld76b+5Eaf0jthmjJdf/k35TBp/pltE33m8pKgc6dw1fsRi\n28hpmg4eIapIQOjdrLe8TkAskdF0wQ1YIAWRpeJgtS9lgo0ih4R6lQrzOCLe\nrTT9G/jRgswHD/IH+W4TMdJMQmk+PgW4dKF311kfgAROnG0Xu5CfxLo1k/MG\nIVrRR5SySKOo38N0NRd5CaYz3znz/x3tHl5b3kISR2ULryz2B1hto6wrq+pa\nmovIXgaqu3Bs/WTwUyBuT4FtE8I09eULovYKu5Q9AnUpjLaQFSCoJ/3nHYIp\nLDu7+nS56x+uZmbM7OCXhEPOniS2Vc7blPcIRHK2L3KpqHz1A+KGOHD5nhf3\nhlUuvfS/KsCqG/DCyzlF24eDsZV4LxqwIIHLmyDzxgl7oCbGC8qloAGVyEv1\n76uDxRcsURsV5VhOnXtw80EBs9/q+slhAQxNuhyWJR8aUKXMyonLmkBvlA3r\nKTAgrPrW9XO9o8iaZCf/580nwI9UPHDHUJjii8drRfO5YVJydzny21h3C1ek\n/w56ajSJvWz9huKyFMcTwQsoK7RUjFEjuyOzssb8r2Ldu9Zw0TZ0aGJQpV4V\n8+lk\r\n=L+tK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_5.0.2_1560540718705_0.10918250789257655"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.3": {
+      "name": "default-gateway",
+      "version": "5.0.3",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "dependencies": {
+        "execa": "^2.0.3"
+      },
+      "devDependencies": {
+        "eslint": "^6.1.0",
+        "eslint-config-silverwind": "^4.0.3",
+        "updates": "^8.5.1",
+        "ver": "5.1.2"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "54e864c6b13d688d62504ce72850d6c03b06658c",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@5.0.3",
+      "_nodeVersion": "12.8.0",
+      "_npmVersion": "6.10.3",
+      "dist": {
+        "integrity": "sha512-zW+ld9xtN0+q48wIwhitUzhfERJN7BPgvijPhuCKG6bfWqnoqtSNSnrXfvAME2ZJLpgYpz6UorpBddGfLzrJBw==",
+        "shasum": "18434c9430a18035a2861f7839bf7669b3436e6f",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.3.tgz",
+        "fileCount": 12,
+        "unpackedSize": 15976,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdU6lJCRA9TVsSAnZWagAAGAAP/RGLoKzFICiTW4P3GvcL\njgU7kZpSCUAFM4PIEOsAhsXnmEQYWyHKw9ieUdjPLjKuKMOzguepmyH/NrOy\n6ab6kyOQGlr3T4b0cPkwYBXUzBEYhpiKUfQtEKmgbsM3SRakTRRK4qiyezx6\njpKW39YvWN8Z2MWsgMjLHuCeexWcRtSVci9OZPCTWbZCfyyMy+Gv8hayIpId\nY7SmBlHzYPD66kJMOpv7xYW+0ScvDhYFXNKAR7kwXO5kk58kcHka6Wupl1oT\ngvvRkzc8yk6+c+p/EyKOMaXmTAW4FqaEqQt9vzhcXqRpo5xHk0UiNJzdKnZj\nxRd7ejse8zDKdVQWuxdLLIdZ9/DysKWHMV1wz+/jxVZUjNLNtthJVdD4U7gg\nYApDBmY6dlBpeR3BhYRVCXwIQm4gBwp8rlPxG+JYvJriY//ZRsoxqzwEuVHN\nszb0gBrEfWYDRryUnTUHpeie1utb4ZNPBC46vB1LsiNG84Km7Ln7abYWlISA\nPzcLfbK9hhjFFM7trXzdjQvgd55iIiO8Mz9e0XlWH5xNXuem8ndS00BZNYLS\nAU7duzYNbuI7TV36oJXLilYu0CM/UvDAuqcbjeZWI0ZaQLgTRPICq5tcR9No\nU257DmbYmRqXyBIQ/h0dS3RRzRNQH4nM+i9qCRGO9O2AVqOuLA0OZ1PkQnWh\n1TKb\r\n=zLUz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_5.0.3_1565763913125_0.5888241633600602"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.4": {
+      "name": "default-gateway",
+      "version": "5.0.4",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "dependencies": {
+        "execa": "^3.0.0"
+      },
+      "devDependencies": {
+        "eslint": "6.5.1",
+        "eslint-config-silverwind": "4.2.3",
+        "updates": "9.0.0",
+        "ver": "5.4.2"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "795c32e89f4e89fd839ede067b8adab7c9a13384",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@5.0.4",
+      "_nodeVersion": "12.11.1",
+      "_npmVersion": "6.12.0",
+      "dist": {
+        "integrity": "sha512-RncYZFuHZlB69pT3aAZK/YUjOpllMc3pKm/dIxHR0AyJlhRKSFbLIQbZia1WOrNoY0F1UsqadrHW9mx/lAWAgg==",
+        "shasum": "d10bf9ec1446b96acb977f88e62d59c7eefe5d01",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.4.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16185,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdpUhcCRA9TVsSAnZWagAAuk4P+wZh9Lmi14c/Z0kDT4S8\n/Kr6JObHar5KL36DSwgsTiKlpiplbeeGzOJAb2JxTZ3MKuANg+8IepLZdhd/\nR3Syptri7ZQxu04KfOCxV4GbBM8zPZ/sgZ/P0h7rPV5WDeLQm9Q0x8+/2E97\nPJv0DXb8PFaMh7OfTV2AY7ipjnFHXzBqs8H2w9rhLMRRoQljRcgrmMS1Azvu\n41ejveybe+++899ky2Q4+ESZEGkGhTB+cxdREagxdGKsO2Fg5FO2ChC9cvET\ntyA3hgrEg+gVYm7RiWbyZbi9ksJQMMQsWqG5D12D2z1n7Kkz5tOnrVEIgMH6\nAxgUE5cFGQGL2WT+cfYmRykr7QN8E9b6iL9FWuEOwRnpIRSGk1dgCDPWaL29\n93rCV1A01HUo65dKf7UpQ47KatPbyz7qkrNyCCMMnv9h3xn9cWOETceNZe8q\n2CtWx2m/+5UTDsogwpjd68r+8eRe4ntX1hdJQi3eDIXn3M5d2rTjeE84pkIe\ngoYWqLVOjqY9rXiPzwYt8pdd9pAxBlJUkk8BsLnAr2FSqPkK0vki+gg+FMOD\nPQQpQrG108uq2UKsvuPA3V55e3wLOGwDBsiPC0zslzwnSoah3z5svitqQGbe\nBBUx74z52+VqX2igmFtKazaD+XUVk/pJxNXawmkLKbQ7x+tQ/CkNkpMd3JdE\nmyc0\r\n=rgXu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_5.0.4_1571113051716_0.10124997171791494"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.5": {
+      "name": "default-gateway",
+      "version": "5.0.5",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "scripts": {
+        "test": "eslint *.js && node --pending-deprecation --trace-deprecation --throw-deprecation --trace-warnings test.js"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      },
+      "dependencies": {
+        "execa": "^3.3.0"
+      },
+      "devDependencies": {
+        "eslint": "6.6.0",
+        "eslint-config-silverwind": "5.0.0",
+        "updates": "9.0.1",
+        "ver": "6.0.2"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "02350d097ce01aaa38431c27e0c23a4c751d10b0",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@5.0.5",
+      "_nodeVersion": "12.12.0",
+      "_npmVersion": "6.13.0",
+      "dist": {
+        "integrity": "sha512-z2RnruVmj8hVMmAnEJMTIJNijhKCDiGjbLP+BHJFOT7ld3Bo5qcIBpVYDniqhbMIIf+jZDlkP2MkPXiQy/DBLA==",
+        "shasum": "4fd6bd5d2855d39b34cc5a59505486e9aafc9b10",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.5.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16327,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdzbuMCRA9TVsSAnZWagAABwIQAJW6E/Y6ZwBP4dDhjLuU\nhb1vIDVPCRhk2wP2r4DGlMN7ZC9G2TI3vx3Z6ruxdjCUsGrw3rHetiHhaMRF\n1aMV0m/9ZzaVh7N+a2fRk64hCMwib3i38quumdXmlUopRryoE5GL6S1YF7AN\nr5lNcynNF3FM4DNFEcUK1frQ8Z+klnSmfMFHDM6Gv3C+LD3+HMixh06qBykc\nGa9CDpZM/PKV23R8wuVpqkRUJA4UIuG+2N+RdTCHmGbOK5vzDGHtTUFD5Dxg\nKI9lQ1pgysUP4dl5GDl1WyrwWvOPMZpTziEBI6xQSsSkTwryAVZLnB+oloyj\nMbVrHEGT3nWvpChYNi6maC92aeaGq2KvXwkzhK308hqYliBnEHdDMY3hffhd\n7QWazfzc0ekOmQcY/smxt1tUENJhqohUsuw/mAteKmkrW+5yUB8bydR4Cud1\njdllJGxN2uUIIRd6foruebRaf+hxPJ8Wa+IT2/taDxSYzvq7TEAd56f9gFSA\n8woZ9iTY+0bJAuYsabqZSiDBauNmOmbvvlXOIiaE8+3NpAFnB7wqclRQgGBF\nRLDehrl8WvFbuJ5ulNOFiOJ0a1dY/Ja1Iux8CnI/2erWZ3abn39h8SzfsQ0g\nbbFNtjBlcUSDPaE5T5RtMXzZ6z6khEvhFDcQxk2S41z/9hJuP7Ao7ZK2tss6\nnzwE\r\n=yKbY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_5.0.5_1573763980425_0.28389837327631917"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.0": {
+      "name": "default-gateway",
+      "version": "6.0.0",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "main": "index.js",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "dependencies": {
+        "execa": "^4.0.0"
+      },
+      "devDependencies": {
+        "eslint": "6.8.0",
+        "eslint-config-silverwind": "10.0.1",
+        "jest": "25.1.0",
+        "updates": "10.2.2",
+        "versions": "8.2.4"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "6489c29df3cac8eacac5d1e821921806d170944c",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@6.0.0",
+      "_nodeVersion": "12.16.1",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-kCz5MQbiOqeImB/Ze/QSohiet/pBllgVSoYP1nL66f2NTFDhh2dh0NMTK8H8EgalGimHCEulYGNoVGjNyNePRw==",
+        "shasum": "d2ae8828ff8e49549cb52f89b114e9a94ed0047d",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16153,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeaWe2CRA9TVsSAnZWagAAYSwP/RewzrNW02pe07VYLB62\njFYsxbuIbUW85W9eETLIV/QS+QqcnaZiVktvtKqXksqztV9oL3FpWa0h3PeW\nUmMJ3wrIjez7JLFRDv/1ffiZansJEuU70z1PuNtvMMa9/ZQ3L0J3osHUyK3U\nuYQHpohZXh5YCWlBRfq+rkAHCU87GuIxtb6IRr3ZSx3ODYlHAXx8envnRNoh\nFWvcAPZOeWDfEiDwwjgrOFXdfL1RFHY95WaFbRmEc7pc/8wvScrX7JSIhaxY\nBRBRGZTyreHgwLDn+IF3oWSiHLlanH91g2UruM7zC3WDOOcu9E2tw4j8B+jY\nDsPLh0ThU3MHjySYng9Fg85cUq+BEBvtCm3m2QHtrksGc2qSP0j8U7XIOizD\n8jrnoJ0ektLbYqPLbAznBqc5dXlx3NW0GejqgwKm7v9Brt8/v4N/49JORhTT\nhnt4/TGOUrXr61Rx4uOKjDWcS0iBxOrxNZTHjw+dP6/yJY6PWbpyHLAZ9RGj\nFsX3rPvokbZF537PqztexxG3M29P0GrEWAtOMpm4ar8Ixx4v1sdL4BtDEVpg\n3Hzc/nUVp2XWXGdQH4cFP2OOI/thwkLWEVE0k2jxp+vfnn+sgUgkMV4jWMR2\nW6MMc6IMs/h1mXo3O5QhUI+rrhx/iVZPrykpTyYZqWHXeeNkgDyp/tgRPLWO\nGQsP\r\n=7WxI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_6.0.0_1583966134268_0.33564591526455034"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.1": {
+      "name": "default-gateway",
+      "version": "6.0.1",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind",
+        "email": "me@silverwind.io"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "main": "index.js",
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "dependencies": {
+        "execa": "^4.0.2"
+      },
+      "devDependencies": {
+        "eslint": "7.1.0",
+        "eslint-config-silverwind": "13.4.2",
+        "jest": "26.0.1",
+        "updates": "10.2.12",
+        "versions": "8.2.10"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "f1de81b7e04ef2327dc2a366dc37c81c79c9ca59",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@6.0.1",
+      "_nodeVersion": "14.3.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-55Zt/cfV9OkkerJR3fECxhSk4+mVv6cq/npDz7n6255faTGh0/9HbEnTpUQdMMGJXclBCxEu1Kol3h362c2cbg==",
+        "shasum": "a6b266196931bf27dfe763dec9e488573fe8c803",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.1.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16241,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJey96xCRA9TVsSAnZWagAAqw4QAILmkuH1Af31Pbg+n/f5\nyTG7qXdom+J6ZzvPbAHmgrPdceiBviFBfKnebu8FYor/hTCY67MBTbCRpgaX\nPecNC1sgLr+9ZBEJau7JRKfbzVeITXWA4ZNGThEEE8K2yaQjvRXcE5SGfHSb\nEw51YefFnYJhZ2UefOqjZlcP/z69F+Lov0GR1s6lsu00KHS2AIIHSJgBcX9c\nmdE/JuBIerr1Tep1UjeMH1tXDz+FE6kCXvW3Uvlp97eTXzGd8smfbX9dxi4/\ngaYRNs3LcJu6Ktwi1uMIZKjSK1ldQt9vMh4ijQ1efltXx40ZunsmYH257nzO\nOBvyZGiyfv1oeDduFsO+RwPueHvDlMUbKk6ZodzcO+zyyjL7jN79egb1ubSH\n0XO++5XgF2CQ88LjIjpizsDEyJ38wC/nafwsV9L8MOcGrn9QHL1EJ+O3g8vR\nJu+5xmFUwMS0sM/GA0u57O0Uk1tto4eJG8F0chMhLoWKjOKtipclRPaGihKm\nPV1My6TbTeALhpJjKKJIvn/7cxycMwrlWg184IzJsI1x/JaR42UizDwSQMrn\n7gq7FlqeTL/uruC1Kr3WAATtx1+PzHCPhsec5/LjRx2zV4J+p6NQbVIhcSEy\nzfXzQwgr76ggmSnWg9a12sMEeiJ8WXl13cLeI+SCalzZfZUyUTC279tTR1Uo\ndeM8\r\n=6srz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_6.0.1_1590419120620_0.3124669944867211"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.2": {
+      "name": "default-gateway",
+      "version": "6.0.2",
+      "description": "Get the default network gateway, cross-platform.",
+      "author": {
+        "name": "silverwind"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/silverwind/default-gateway.git"
+      },
+      "license": "BSD-2-Clause",
+      "main": "index.js",
+      "engines": {
+        "node": ">= 10"
+      },
+      "dependencies": {
+        "execa": "^4.0.3"
+      },
+      "devDependencies": {
+        "eslint": "7.7.0",
+        "eslint-config-silverwind": "18.0.5",
+        "jest": "26.4.2",
+        "updates": "10.3.5",
+        "versions": "8.4.3"
+      },
+      "keywords": [
+        "default gateway",
+        "network",
+        "default",
+        "gateway",
+        "routing",
+        "route"
+      ],
+      "gitHead": "11abd96179fe8dc3e97167c2e5fd7438c62b67ce",
+      "bugs": {
+        "url": "https://github.com/silverwind/default-gateway/issues"
+      },
+      "homepage": "https://github.com/silverwind/default-gateway#readme",
+      "_id": "default-gateway@6.0.2",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-bWrj9HZWNXJ/RUkWmBIp67JawNrPGz0il43IGWU84dazEYbNFQ52HbIiqgRQdYUHK3RyGrENrDV9QkwArt6IAQ==",
+        "shasum": "fc14f4a2ae1cbc699c2b40cedd941ab312609ea4",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.2.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16098,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfRrwSCRA9TVsSAnZWagAAKp0P/RQ5wSWraOgl18ZWTTgx\nB/Qtws+SB+FLvJvSWPOjwEyohqMuMRO3GWz7oWVxTHx1VO/pkph6GejNQ6Ji\nuXQztEqv9zAqWmO5VT96HG7nhfN/s+IM1wYSoqcmEFexB4n6sZN15Gw1EuFZ\nwhXxM7oXABuX71unWxygywNPgYrrbAdTAN8EXi8ziuNl5P6jxhhTrl19OaGZ\nvKOrtyEoEbMiOsy/ZzZb/FxQbGHrTxgKGkRQFkIXkxGsA+TbgV4zBTJeOhcK\nrkkXhTwSfwwDV0H6bdzUAs1kTr+wNfZ5Swd1Jeg2TynkyXGaE8Viy9TDj0A8\ndm1X0bhQOfTj5+sWF0R31Ash5XSCidmQcmiu2fF6VB57xpqjx3Kf/z7EqGP1\nuTpQD0ytXpHyxA2TVLcIZUhmRU6kvYItwgBEt99peRqbgJDHX+cJ3n2mV6VQ\nrNZjLFWuXOeMohe/833QseF3WdKmheFk9//StGmc93UAYbR42Y8UCU7yBTwY\nj9BeyrRzfRNOpdhtOIcnPFDLxxEY03VlTWZJ0dtfPRtMeLR1ifYtdN/G0W5G\nHyKw4Ul8NR7lN0hnNmLqMBIfMKCWKt4skhmUXsvEV3vgZts6eEn83PQ9VGqY\nQAvDEnG8a4He44GcbKXFqXedKuptisqxshXhCZCrBHqN0Xjw3llJ9KAVYrm7\nlxBV\r\n=L09C\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/default-gateway_6.0.2_1598471186393_0.7206018520030713"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# default-gateway\n[![](https://img.shields.io/npm/v/default-gateway.svg?style=flat)](https://www.npmjs.org/package/default-gateway) [![](https://img.shields.io/npm/dm/default-gateway.svg)](https://www.npmjs.org/package/default-gateway)\n\nObtains the machine's default gateway through `exec` calls to OS routing interfaces.\n\n- On Linux and Android, the `ip` command must be available (usually provided by the `iproute2` package).\n- On Windows, `wmic` must be available.\n- On IBM i, the `db2util` command must be available (provided by the `db2util` package).\n- On Unix (and macOS), the `netstat` command must be available.\n\n## Installation\n\n```\n$ npm i default-gateway\n```\n\n## Example\n\n```js\nconst defaultGateway = require('default-gateway');\n\nconst {gateway, interface} = await defaultGateway.v4();\n// gateway = '1.2.3.4', interface = 'en1'\n\nconst {gateway, interface} = await defaultGateway.v6();\n// gateway = '2001:db8::1', interface = 'en2'\n\nconst {gateway, interface} = defaultGateway.v4.sync();\n// gateway = '1.2.3.4', interface = 'en1'\n\nconst {gateway, interface} = defaultGateway.v6.sync();\n// gateway = '2001:db8::1', interface = 'en2'\n```\n\n## API\n### defaultGateway.v4()\n### defaultGateway.v6()\n### defaultGateway.v4.sync()\n### defaultGateway.v6.sync()\n\nReturns: `result` *Object*\n  - `gateway`: The IP address of the default gateway.\n  - `interface`: The name of the interface. On Windows, this is the network adapter name.\n\nThe `.v{4,6}()` methods return a Promise while the `.v{4,6}.sync()` variants will return the result synchronously.\n\nThe `gateway` property will always be defined on success, while `interface` can be `null` if it cannot be determined. All methods reject/throw on unexpected conditions.\n\n## License\n\n© [silverwind](https://github.com/silverwind), distributed under BSD licence\n",
+  "maintainers": [
+    {
+      "name": "silverwind",
+      "email": "npm@silverwind.io"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-26T19:46:31.639Z",
+    "created": "2017-06-08T12:09:41.437Z",
+    "0.8.0": "2017-06-08T12:09:41.437Z",
+    "0.8.1": "2017-06-08T12:11:31.743Z",
+    "0.8.2": "2017-06-08T12:19:41.865Z",
+    "0.8.3": "2017-06-08T12:24:33.174Z",
+    "0.8.4": "2017-06-08T13:03:39.951Z",
+    "0.8.5": "2017-06-08T13:09:24.983Z",
+    "0.8.6": "2017-06-08T13:11:42.080Z",
+    "1.0.0": "2017-06-24T20:50:06.458Z",
+    "1.0.1": "2017-06-25T12:16:56.582Z",
+    "1.0.2": "2017-06-25T14:00:53.645Z",
+    "1.0.3": "2017-06-25T15:06:32.425Z",
+    "1.0.4": "2017-06-25T15:13:17.985Z",
+    "2.0.0": "2017-06-25T15:35:10.984Z",
+    "2.0.1": "2017-07-03T17:08:34.431Z",
+    "2.0.2": "2017-07-28T19:53:58.876Z",
+    "2.0.3": "2017-09-16T11:22:06.452Z",
+    "2.1.0": "2017-09-16T11:23:50.866Z",
+    "2.2.0": "2017-09-16T16:51:59.539Z",
+    "2.2.1": "2017-09-16T16:58:10.439Z",
+    "2.2.2": "2017-09-16T17:11:17.189Z",
+    "2.3.0": "2017-09-16T17:43:48.653Z",
+    "2.3.1": "2017-09-16T17:47:10.377Z",
+    "2.4.0": "2017-09-17T09:19:12.182Z",
+    "2.5.0": "2017-09-17T16:29:26.280Z",
+    "2.6.0": "2017-09-28T19:30:32.303Z",
+    "2.6.1": "2017-10-04T17:11:31.271Z",
+    "2.6.2": "2017-12-09T17:51:30.638Z",
+    "2.6.3": "2018-01-23T22:18:11.422Z",
+    "2.7.0": "2018-02-06T17:29:56.085Z",
+    "2.7.1": "2018-03-27T15:36:00.440Z",
+    "2.7.2": "2018-05-31T17:48:56.227Z",
+    "3.0.0": "2018-08-23T16:23:52.181Z",
+    "3.0.1": "2018-09-05T19:09:51.293Z",
+    "3.1.0": "2019-02-15T20:13:54.737Z",
+    "4.0.0": "2019-02-22T15:16:55.685Z",
+    "4.0.1": "2019-02-23T09:13:29.854Z",
+    "4.1.0": "2019-02-25T17:47:52.044Z",
+    "4.1.2": "2019-02-25T18:11:41.337Z",
+    "4.2.0": "2019-03-06T19:40:00.709Z",
+    "5.0.0": "2019-06-14T02:04:30.112Z",
+    "5.0.1": "2019-06-14T19:28:12.636Z",
+    "5.0.2": "2019-06-14T19:31:59.055Z",
+    "5.0.3": "2019-08-14T06:25:13.270Z",
+    "5.0.4": "2019-10-15T04:17:31.881Z",
+    "5.0.5": "2019-11-14T20:39:40.611Z",
+    "6.0.0": "2020-03-11T22:35:34.419Z",
+    "6.0.1": "2020-05-25T15:05:20.786Z",
+    "6.0.2": "2020-08-26T19:46:26.510Z"
+  },
+  "homepage": "https://github.com/silverwind/default-gateway#readme",
+  "keywords": [
+    "default gateway",
+    "network",
+    "default",
+    "gateway",
+    "routing",
+    "route"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/silverwind/default-gateway.git"
+  },
+  "author": {
+    "name": "silverwind"
+  },
+  "bugs": {
+    "url": "https://github.com/silverwind/default-gateway/issues"
+  },
+  "license": "BSD-2-Clause",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/default-gateway.min.json
+++ b/test/fixtures/registry-mocks/content/default-gateway.min.json
@@ -1,0 +1,1230 @@
+{
+  "name": "default-gateway",
+  "dist-tags": {
+    "latest": "6.0.2"
+  },
+  "versions": {
+    "0.8.0": {
+      "name": "default-gateway",
+      "version": "0.8.0",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-TN2rrft9flAS4nSk4CmFhg+DjeZWTzR0OCo9pQkZbpwCXZNmBc6v85IcNlwZOMW0b+mn9/VIHecm9tl9M/jRaA==",
+        "shasum": "45d0f1821d704f732786822e64cde2732436a121",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "0.8.1": {
+      "name": "default-gateway",
+      "version": "0.8.1",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-qt0daeSPs7IVSPzYRuwwaFHIVe9q2PsqxNLAn6+WbRdGUTOlkX4E9foQ4dGttv5OuzMODGwJrQi66jvrsAACpA==",
+        "shasum": "66b3b0155c6d6e9d4d2c384f356fd1b84c43e9c5",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "0.8.2": {
+      "name": "default-gateway",
+      "version": "0.8.2",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-i+6E4/e4oI/C1H/hIJTKI4a2qBo7kRc3ufHDa9ZNNKoUt5nx/CvX1LPQF4YQzlUmobGhdHax96tFMryiOwdojg==",
+        "shasum": "f05e7c191683482cea3efb9e8aa1ad4d74d85a5b",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.2.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "0.8.3": {
+      "name": "default-gateway",
+      "version": "0.8.3",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-wgMuKgQTtMIb9w1Ia9lJfC4Eb1wMbkm+JAOIY86tdBQq2khK+/g280Bos0j7RETJvqZZG+sA7Ng9Zd1Y29aNUg==",
+        "shasum": "8c6d13e487086c5931507c12cd8cdf70058753c0",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.3.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "0.8.4": {
+      "name": "default-gateway",
+      "version": "0.8.4",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-RJmcjXuuLPulX1aqMFAa6Ll5JrRhtS/DdLJxrAhe8/kTPnTiGZ/2gxudCYmDtc9FQjyzbW4QYhQ82s5N2EZoYw==",
+        "shasum": "fadd45f58d8860e99f5b51b0214d337174e97d09",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.4.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "0.8.5": {
+      "name": "default-gateway",
+      "version": "0.8.5",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Zom3W6sMGkMPEo+7NuT43a8l+HFwtERGh3Ef5xCProv2zSRHzcBOY2ZeODZW2mbGrQvtYAdfcQg3+tq1+MMsGA==",
+        "shasum": "f94b1d364e41a7949ac13214f98dcfe98cacdd99",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.5.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "0.8.6": {
+      "name": "default-gateway",
+      "version": "0.8.6",
+      "dependencies": {
+        "async": "2.4.1",
+        "xml2js": "^0.4.17"
+      },
+      "devDependencies": {
+        "chai": "4.0.2",
+        "mocha": "3.4.2",
+        "mocha-clean": "1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-EfplbT4tahQJH4124/7ERGYwtREsHs6A/SEdMARDyvTdceu23AO7vmuzX4oenFrPRL81Ye7Pr3oYgbJrWVSkTQ==",
+        "shasum": "136e647efb3a7e2899ac542dab2ea7a7e19a0e13",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-0.8.6.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "1.0.0": {
+      "name": "default-gateway",
+      "version": "1.0.0",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-+sOq+4pXTCE/3KemFLYjNMJ4KU2S0cSmcegSohOsiFLPeeflQzVMuCz+3PfZXX4THjooOsH8iDh7a4JSlRQT7g==",
+        "shasum": "28aa456bfbb14a369f17f45cb05046ffe5fb2095",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "1.0.1": {
+      "name": "default-gateway",
+      "version": "1.0.1",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-x/3CJWb8o0rDL+JyW4lrSKfamIEtMlaPcmbG2t+xOlRrZE+MLCJ3j0oKm/yPS7SnPuUmks+qoOSctZZlP4uRAg==",
+        "shasum": "90986880233702eda02776105c1aba701c65d190",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "1.0.2": {
+      "name": "default-gateway",
+      "version": "1.0.2",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-OMQVYHF13JVrgNjSmLUeI0xMWVL0OEMUInxLhB72cqPevoKVZkyeBrgPoQdaVLo/79UQ1RHNJdE++I3WWo2wug==",
+        "shasum": "9f59056ce6ece51df8c3af591b417576fff4ce61",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "1.0.3": {
+      "name": "default-gateway",
+      "version": "1.0.3",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-l2kEaj1sgIUBSduAM/hBB857KrCf1rbzFrYTBs+NyKjNJGUbbJ0nsFibt4RKyzk9K0e81zX/m9Pk2q+6mAC2LA==",
+        "shasum": "8d9f18085b2b59c64ae342629a0bdaf97d889b5e",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "1.0.4": {
+      "name": "default-gateway",
+      "version": "1.0.4",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-+ft8TFOj6l49ffU2byALasEGqE5n01ejLiaypv6zRDAQ7R5cP1FTuQXUox46fpEMKWykfxpEpJoJVij/JzjdDA==",
+        "shasum": "3d18c33a96aecb7f164d8d199023332bea57e3cc",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "2.0.0": {
+      "name": "default-gateway",
+      "version": "2.0.0",
+      "dependencies": {
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-vsk8e4vJMNt5saEhSdaT1ZMidWEjJZ3Bos/FmEVeXXM8omSl1TZejX5zU19zyl7lXIX2EBDAU9pAM7fSdzS+sw==",
+        "shasum": "337be7babb07b704d04d5a423dec8ff41995935a",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "2.0.1": {
+      "name": "default-gateway",
+      "version": "2.0.1",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-r4BwxZVSeDX8orijcVJIDly/0Ruun7BI67yJjtiCiBsh+Am3jsGYqVRxv/rjQ0x3B6EPKdXb63CVgh4K8ViKnw==",
+        "shasum": "875a07f5aa3f0237824c5dc32bec16ae5adbe064",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ]
+    },
+    "2.0.2": {
+      "name": "default-gateway",
+      "version": "2.0.2",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-lvDPOoSVibdJqnZNS9OF7SzDrvr5PYVgynPNNqt89lcJWDRnLP3bpzkgFc/5t759YcuNjz9VEpFe5I6NLLrSiQ==",
+        "shasum": "e365db05c50a4643cc1990c6178228c540a0b910",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ]
+    },
+    "2.0.3": {
+      "name": "default-gateway",
+      "version": "2.0.3",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-aUOYoVzqpMZQRcqbvH97M6n3e4qBXug3ZTt+4kvC5BWv5bXtKHxGDNPxY+EGVmmOGggcfxkHk8fxg24/cIrpuA==",
+        "shasum": "afc4b30b8be731987bf1f74e9092149dc303a64a",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "android"
+      ]
+    },
+    "2.1.0": {
+      "name": "default-gateway",
+      "version": "2.1.0",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-H0TLuBOdOhoWXKtLFDFECMP5JEbVEGT/xZ3zbE3BI9M64dRQ/Bp/iYcxmwWiHBXrPE94zmWKebxn2oe3fM1zjA==",
+        "shasum": "b7d094d09827cc7029dc66466787b65483656302",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "darwin",
+        "linux",
+        "win32",
+        "android"
+      ]
+    },
+    "2.2.0": {
+      "name": "default-gateway",
+      "version": "2.2.0",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-Xa7rGyRmzPEQVauuuDPhLsAuF1hiwCpPXTfsbD2kQhpKfcbb9zSq1KwshMU9noy1E6sxn5ldQuRO2Pbz8IkuQg==",
+        "shasum": "6830474b33e9a8d5d394e57fc9c5fed03ca104e2",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ]
+    },
+    "2.2.1": {
+      "name": "default-gateway",
+      "version": "2.2.1",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-DNwdRIvWi37hZYtwCWUBOUYz9e/4NIjTiqAcTOSW+TUoDyoCfZAfhMjzrPbKRKXmVNTSPyJlkX+5GlD18a7LWA==",
+        "shasum": "405866846f2537b34511ccce3c5c76ceab9e43e9",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ]
+    },
+    "2.2.2": {
+      "name": "default-gateway",
+      "version": "2.2.2",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-eLw1G6hAmE7yZeRfFOEdvIBBlo89HB6iO6aDafnMHmD9VI8P0QNSVP+ifXoNNamVCArehVv6vb2X7MQZMcQxPg==",
+        "shasum": "797de0e09a476ca1c756efc576e5d6103f7ca7db",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.2.2.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ]
+    },
+    "2.3.0": {
+      "name": "default-gateway",
+      "version": "2.3.0",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-11LpAjQf4dRlsyI/Z1Q5QxC8Po62EOi6sNCi7Etq7ngJL5lGwyBymVcWHptEvmQe6kkmh6nKFw5aKGAav99jsw==",
+        "shasum": "07e7d018e8ba0abfa1e109cf59963ac5f0cdfb5e",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ]
+    },
+    "2.3.1": {
+      "name": "default-gateway",
+      "version": "2.3.1",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-giiboq/CTPhoXQSEMuFqObD+vGdDWb2Rg+L7gJi9hF4g+7ekW/fsSIanbpw6rKLmRFLU7u1CReF1j+wCo3Qljg==",
+        "shasum": "52de54201428c22e60306f14069656d5f6622f58",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "win32"
+      ]
+    },
+    "2.4.0": {
+      "name": "default-gateway",
+      "version": "2.4.0",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-jtdtfL2MWLLHMASg/XlDBHnVPVX+s5IEHRxyNvy/AaWyyf9XZr+ClAAPITevY7k8IdOYZvx1BcrjSyeU6e5W8w==",
+        "shasum": "65dc9a39bc78ac5cba8d4ef9e8de008ffb00e116",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "win32"
+      ]
+    },
+    "2.5.0": {
+      "name": "default-gateway",
+      "version": "2.5.0",
+      "dependencies": {
+        "execa": "^0.7.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-Mb+xi1aktPE+Uz5RmS3vU6Kr1fDqRvlMX3M5eneBai7LkldzM+WPjaUpz396taZgOgSw4s+CJGvd6VJJ/9W0dQ==",
+        "shasum": "78e24dbd2e1df7490c2b8050515b8e816bfa7da5",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "2.6.0": {
+      "name": "default-gateway",
+      "version": "2.6.0",
+      "dependencies": {
+        "execa": "^0.8.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-aWZNwWr5ciCAAbnqOuaWDqLlUXvQw+LWvswsJuDqJBJME8Q46ulWyqr9kxCcAYZhdf8rsBfy6EloxapkXxW5lw==",
+        "shasum": "acf02d181caef4c464b6c37fe25daacd6189b903",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "2.6.1": {
+      "name": "default-gateway",
+      "version": "2.6.1",
+      "dependencies": {
+        "execa": "^0.8.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-03hfY1Db+URp5NIrhlQPZrKlsr4jJbJAK1jnNSCvmNwzD0pPlvg2uqOwQpXQsDIGbUaBtkG2o7AKfBOLILzGXQ==",
+        "shasum": "d337764dbd40c327532606c858f9a3c05cc456df",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.6.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "2.6.2": {
+      "name": "default-gateway",
+      "version": "2.6.2",
+      "dependencies": {
+        "execa": "^0.8.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.12.1",
+        "updates": "^1.2.6"
+      },
+      "dist": {
+        "integrity": "sha512-64q7pVqNK+B3rKM61z7357tGUusIbM8GCzfjhtyDydSGgtQMzoeds9N7h+wcUwtDhZRQ+taU964GFZufSVHP7w==",
+        "shasum": "c53bce5f464a0fd770abdec095d0aca87406170a",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.6.2.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "2.6.3": {
+      "name": "default-gateway",
+      "version": "2.6.3",
+      "dependencies": {
+        "execa": "^0.9.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.16.0",
+        "updates": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-WuRtzZCifSO7asGg05UifgnuYU4UMzKneg+I5PEG2rxLqDB2B53Em86W/62eskOFUZeVeDC0bQRy7ZV8zqGG8g==",
+        "shasum": "fd8d2aeddb3d2a5d93526f2a75e88c13056f7968",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.6.3.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "2.7.0": {
+      "name": "default-gateway",
+      "version": "2.7.0",
+      "dependencies": {
+        "execa": "^0.9.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.17.0",
+        "updates": "^2.2.1"
+      },
+      "dist": {
+        "integrity": "sha512-bDPiro+T7ZBbt6HlObvUVHv+VHw1WGvF/UI3D+ZN2mqPTPgx5JM5YDgTj06zkr/tq2N5pCgGFMetNrSBi+IjLw==",
+        "shasum": "eac4456f4074b57ae2db4275cea881dcb37dd5b8",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "2.7.1": {
+      "name": "default-gateway",
+      "version": "2.7.1",
+      "dependencies": {
+        "execa": "^0.10.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "updates": "^2.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-3UOsgF6oWP0js8hoDp1tcrYYndTznfl8aWr+ziU1z/p9Uv+a2UztSegX/3wwdxaM4SpPgGe3G//tJJeNEog9Zg==",
+        "shasum": "1fb2b25fdb938394b8cbca89029894f8fa068399",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13554
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "2.7.2": {
+      "name": "default-gateway",
+      "version": "2.7.2",
+      "dependencies": {
+        "execa": "^0.10.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-config-silverwind": "^1.0.42",
+        "updates": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+        "shasum": "b7ef339e5e024b045467af403d50348db4642d0f",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13590,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbEDWICRA9TVsSAnZWagAAuBAP/ipX8v5P8O2FWRP2F+c8\nymGna1avXx6+lif04wzkZQAsoSxLLWN1xP4zXFVi1CQfjSJZjViuetgDiriP\nl72ttaoIPjTttZ/7jakDa4ZjR0y1nFiNGW4fe3ynGA28ULmdyUZznjiNisV9\n6AIPzSryWep8Hx2+sOlkA9pqS5qzK6P0YOKyW4E6upr+YUAws8O4uXRY4IKj\nZpyRljEX8Os4hQfhCiEbjugvnZnl4WLxkQuknBJ//EEGNlXuBI916yT26uQC\n9BNQTdA4sgVFdIrIqseoGPSNiywQ8t33guypb9KzSNppvhSmyDEomAGs1Vsh\n9Se0ZmPyTdpSpKk7Wg0IbvTr6IKlq+ClJ/lS2JKVPzdprE1qFEZfWiuvQTps\nrvlYeoRS7h2DSK+uztlUz8j/WQq8k0FIsASNdCL2KMKA/AJpn4EJHx6SGLHg\nK1qQSfi/XbZlLQljJyTxP7sGrzPKc9t99d8FVrZmVrrP+1UTJfOLejySgMVy\nih8JGomfOC7vuak0YMDSv4fb+DfVQR0Ac5pRFU+Hw2vR0M/efPbDUv2MChjA\n6rgV4VmHIxNj9qiVr5AieLJ6qEvvFV5eLLZsyyM8MIh65W0UCczpKhxxhbSZ\nDhueQR6itCutlxAwa8tjBnZ/DB/7wE9j4s3u1rg//vK/0dS0+rdzMSBy9DEs\nNHom\r\n=ZMZG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "3.0.0": {
+      "name": "default-gateway",
+      "version": "3.0.0",
+      "dependencies": {
+        "execa": "^0.11.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.4.0",
+        "eslint-config-silverwind": "^2.0.7",
+        "updates": "^4.1.3"
+      },
+      "dist": {
+        "integrity": "sha512-LfNe1m2BCWt0f+fZZouHzW61OTPARdc1UUANvO3GPTybNyPqBmpwrR69vGKxjQrJmsITXY5Haa4Q8IJzHZUtBQ==",
+        "shasum": "fb180fdd08384a7a871176762458a953b859eb64",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-3.0.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13525,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbft+YCRA9TVsSAnZWagAA+QcP/idK+eE3YcwC2zrc2Urh\n/mmN8Ks3I4KxL93TEnie+lII/2fczSnXnwHIewbFclWyFrjfL/OhgNTXUzy2\nBY5lEHwFBQ+jaAgOk8KwD0l7tpf6GCODWUnBapKYgVmNGZRGJU0odRNJLn43\n/Drw+PB5hwZghzjvxuNufvDIACk04T4ym3VF6O5NN8mYxuSpZIAI4bnEYe0x\n2nvg6ZBQTB+e21Y813bhtRbqwYwfyrUSDZhH0kFsYJpxSZOkDH9A+MIpDrz1\neTCnlFmfl87axdVbbZyw6EHYsNdlMOrEcZ9TsBknRAepZ79pw0AB7c6cIaw/\nseBdM2U8HvUw7W+NOzCwyXRT1RJI912XM24aD0O9N03Ha+AqcaRw+/Ohoqoj\nw0egB5gIFiglY/lksjfZuwXN7377sjIfzYMrE5gZGUppTRioSdcaLFFvyplE\nQVuWCd/Y2Zb6R0XDlKb3SgyxWNI1+3bCMrtbvCG5XsJdbfTX2sleVrQBuEeP\np51zNRcWPJz8i4b5s55OXHou4k4qPzhrUg35skOwok7gVjDqpkd38OtKYtwH\n8U0sZv1a07d9DNiNffdVb5lZthdbt1Pk/Ccsg4cT5pUY2i8zaGsZ4jPuVbN5\noCjpKyJXFQD6CVTsZmBOpA7Tyn9afwpyLXTUURSx+AkyyqSxBz5obl9udfv1\noghy\r\n=B+gd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "3.0.1": {
+      "name": "default-gateway",
+      "version": "3.0.1",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-rdXB8nV5bCAT1p+K3PGuujpayV27yTWbTpk7brPhDq2xz3qkdkdJipLYzD+bZtwLSsfoQSpnPFFkvxzE0mlMHA==",
+        "shasum": "a5bb7d4e6b86e1a18aa59865b9c364219361f3b5",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-3.0.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13544,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbkCn/CRA9TVsSAnZWagAA6wMP/jRshUlmRJrDcd1w7cHT\nxQ8XqEALCxgsPvkLzLta+M79OqWPd5efyrrj1ejCN8KQ1SvhSOIPIBJKUt84\nzIErLoeEKQ/S1AlmsH0cwJTa5LrAubTggpjfVxpKRCcSCzNkh8i4cPqSjxXf\n+QK8U63EMTF1bKP2ACOTGFB8e/bz7emxs9+kYQNzg005js26epx6cFUk1GdQ\ntx2W7YGzsFVy2veHdDg8kBVDly/XTbHhQ0x3qCX89M+hGYQljtcoapcy5aJd\nUADp+VI/l4xVbTiwU7deqdWf1ID7ter915CwUdqPta7cyGUhs4KTDAiyrRMu\n1TVgyymcDpm67fLsY7u6u6dbG+P6C6SdeACl5dTuM+V8Q9z8pTDv2AU7WZZD\nkSPRXuefO6FSZd7RXqR2JYvA0y26Lkm2rvEHYWCiAp0zc4D/Mt44dW5n9LeN\nw250mLAc4/XPsMp/UqsqJTKpPmO+Dpfny0m+UX3vn05NuARiTa7xwAC8/CrU\nEsZLHR1NvQ4jJb0NDCRvOG499LpGFOiDgu85Nf+QpoAUjB6wKDGYLRbDnhe3\n8ILeh/rtVos3k2AqFR13Rto8hC/zSnONQlesAU5xBl5B5o3xYpydvlUWMIbM\ndAY4O+2GktN4g82v52JV+MT3EMJFg+9rBjFI6MPNiCX6kWHtT1ngw0Fzz7T3\nzTwy\r\n=IkdG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "3.1.0": {
+      "name": "default-gateway",
+      "version": "3.1.0",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0",
+        "idb-connector": "^1.1.8"
+      },
+      "optionalDependencies": {
+        "idb-connector": "^1.1.8"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-MRhxv1cqdpKZh93zMFBkXcZfr2QFasrDlxjGa+M22Hv9EBmdWCccFe03KqSnkPLpYXlFhrR152kDX99S//3/Xw==",
+        "shasum": "85248c9b2b28336ab852be2f08c19a52e187ec4f",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-3.1.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 15748,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcZx2DCRA9TVsSAnZWagAAFGIP/1FPdUVmaATwTI1ourgW\nBegNnfe2GLVrAboRFnjVaPuPYS/UT3rHzP34/Qxl7a+6qsusKn1JDS3eZoVE\nDW1A8EoUbOFPozKkw1ZK+YYHR71FJxYPmn8lNPp950ydPUuP91QDT0HSICwq\nEU9NTLQAumO+i+QyJb59dw0Uc7OJQn7dakvt8h+WWWzWF34EqVJ1z0aKEc5L\nPvnVTFoYFBiWtndlhTE7GF24fCYwTMq7bri9UwOGrEy6WD47D+iy3P1X39kZ\nDVn+UMtSGehrgdItOxk/h3qTBGyDozfgksOOozd7b7ZUnN/dDbqo4SN94sde\nOLj2rcSTUMrJZ05jmBinAjjIg7ZH0k0k9VOkoTJ8QhRyQDCaSUksrsLhiWsq\nXb5Mw7Ejmn4xMHBrMtHUyaqJn1JhGt0S24+weehdzyeQYXV6EDtWQ9V8dh8x\naW9jpp/IfGwvlN/kqTwiIfAyi1YomQnP50fr60CAPQrf0YeBOsPXGqW7kZrJ\nTn/lF63kQi2KzkeKMF4SQA9mVFJEU/xZD3eljRNhnDlk8YsE6pGAjFLkOqe6\nScjePiWmc0TeAMN2phqsx0eXaRQSyiZkk9iWkaYd/O1E4dSqp5UI9oXyGQF4\nqIycZWPGu9UhPfg1zGP2i2pcvEStQN1FRyYHD1scQJHyNdxnGCJOHhoOPwdx\nSB6f\r\n=29W0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32",
+        "aix"
+      ]
+    },
+    "4.0.0": {
+      "name": "default-gateway",
+      "version": "4.0.0",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-DV89pF1bja+CSvl3rY1Fo6K+eYuv1g29hv2vFlEVf1fSGsyR8gRq5qfpXDyX/+1dd/jlZ1sUT7tAXbvX9tJS9g==",
+        "shasum": "4a79c102d1c98ee29d90343aa3c406cca40fb40e",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.0.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13642,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJccBJoCRA9TVsSAnZWagAAWyAQAI3oi5gpO68ExisFachC\n92S16UzxLzuDkGiMJaHFDzH3UUArdHtjLvIjuDqQHULR7dYlWnEgyhHMjYQc\neVI79I4jIAR+JxzzgTjx1CXgAHH/cy7U0kcumHbJ6BuNEev9i22ll1kf1X8d\n4FAX5+3ZFE19RDbvMe9CjwM8T0sLW7BnYBNDl92YUxyhnEESERMeVyMqfVzY\n2Aud1PGiGHUhCMvDyOqZKeKKdAWb25kq+FTWZK+o9EqkV8b4FgZIYJKPdNd9\nz/dVhsIv9tUwG0V0y+GK7/cQCgsIMu2miiy44CP1zzW/4srFcJFGfHlkbCI0\nAa/eI4fx1c++ozQB+gzrubcHI8smDjPy0d3ltr6IYhfsPdkWAf+MHdDR1PFD\nzzytcfBsFH2/OWpOKyR9iQ8tfH1SY7LrdeUFCEvYY+rEJpWRfolTshY1baKE\n64T0urreZLrq+B3lz2pXgbSsahFXuI6qGXM3NtbTrufT2J29p37/eQ+WLkOd\n/sbHqT2IUNktTe7e3zOmVSiqVP1yOvAuyxttUmp1JAVn0J0LzIgldGtpH4Lh\nvNb/W3KEhqCAjuLhWKQ0/wJwRrSOYIAmlJZpDqPgMp1VrXpM5yX5B/nOhe+7\nV25j7BfRgMMtRUnEAzz7X9fjwrLZXHG/wvlr1DqCFoKjGQR8qV4yp3KoPUoS\nhp/4\r\n=eiiv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "4.0.1": {
+      "name": "default-gateway",
+      "version": "4.0.1",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-JnSsMUgrBFy9ycs+tmOvLHN1GpILe+hNSUrIVM8mXjymfcBH9a7LJjOdoHLuUqKGuCUk6mSIPJjZ11Zszrg3oQ==",
+        "shasum": "3a7d071ca610a2831190341bd0666382b9dbc340",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.0.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13491,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJccQ66CRA9TVsSAnZWagAAF8oP/2ZFOcX0kmvYni2kt113\nbiMTt29z7zRhyJZ7IBfW5mR+zzl7/jhlSv54c6cW7p9ATnGN8OSGK1sZJPfb\n4WR7tEf01XVfgSShqyr5mk9ZTl+1nlZj9NJ0u3EI2cV87ZI05RsAjN/8YtR8\n4NocJr0k02+XMP35K4aH/Wr3in0x8aCQhe7xDls9n85FMi1+sww9msUlsEuG\nX+8mwQBfyz1QoUUsphf6n4wgnL1NKApCgUpE42oD/g+smGkNdvNhnq/CLISF\nyyd7o1pihYpRLTu5apIjSHL8DuDFkgs+HpNn1NLcNEku/ELi6ofTO9hsJJuX\nRVvGNF6LK2lSR2uFV1FPBi/wyO5AD2LJawTG2ep8SEolTqfXRH/O15UrTuiZ\nchNwuMoe763RAVwi72JzDDf3zuS5pLJV4DrDEouaeY7bLOnPEJgbr+UhFRLq\ntjvriAmsBWVQczVEHTcO5ZGu2mM5/BiIFfsmQ1RcVkA56LRHun3VaIQPU5Ng\nsz49Ru6xqpWZXFVRhxLwXM9yp+3fC1sSceb0ggDDcSTd1jy76eDdQ9OL2sD1\n6XTqZ98Ob8Sxhb94pDH0KG13vr9FDolPp0AJ+OdObVnFdvtCS3A2o96fonAY\nvCO9rOkVgfh6Gkyl6bx/6BK3T0kRNwNZURXEywftthMZMvDgrrscEIGYIr9t\nvMzQ\r\n=r8ri\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "4.1.0": {
+      "name": "default-gateway",
+      "version": "4.1.0",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-hCXBrb+nOcy2J1xRpClOIrK601PBhtJjjvrSVj3bZbExIqrzbBBd/x/VuYQfkEqWWCk+335FzN1qbNo5OlDIxw==",
+        "shasum": "64fce3dcabf23874ebb266326c8444a55fb960ba",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.1.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13500,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcdCpICRA9TVsSAnZWagAAQEsP/3G/x9nFqsFAeHwcxuLq\nIH7Yd7OLuEaoTdQSOeT9I17+ms3DHpl3d91dkJ6+VWURnBocLUFKqUG/V7Jj\nA9pycqKiQEDuykLcD0HVW5DzL0W6Pc4bGYGGUu0HRGZIied3u8A/0IJtKqDN\n70Z6F7HqwMMzpquECFGzQ+qf6DN1dyo3Ih3U8BQzKk0m3cpNo1y+Xc2bQoI9\nqW4JDcvYgqWHAii7coJ9ZLC2TLY0WrJE7kCrxwLfFuIXZdmsTu2hq91f/mA1\n6zazYCx8HJfr22dh3IgnmMOy0ho2oXQt/S8FB8uY1WAHuQLc1Gx01C4MkItz\n+s6U8KkzCGV+uPlvUK8C383WJasngy4JWxeM2et+5Rv4103r3q6HXoGdWGC6\nplmtVtDDrUjLbZ9qzvVeuECfYCQ5LZWnj4pAAKM1TNC3QziclR8pPi6K06Yc\nboJpk0opbSWcis+OCcxxTxGfV8LoV+8LFZBWBTp9LFfAOYZ6jiQnI2TzGNx2\nMamj1QvQ76jNd77XQr4r1xf5ZBubSJ4nNoU+MN7gxpU7BKtzwYJ9HwDwwYW4\nyiOP6ySHmr+FahSrCwAhdxwbdb+1rgy3bxgl5K4bykGUSU2hkrEUSRXNLiRY\nKseme0HbVbI/HzTtnMFtcj0YAoPJVWoI4EoKGeSb4tD6afJDe/U9EX16/X2v\nIbt+\r\n=EHxM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "4.1.2": {
+      "name": "default-gateway",
+      "version": "4.1.2",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-silverwind": "^2.0.9",
+        "updates": "^4.3.0",
+        "ver": "2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-xhJUAp3u02JsBGovj0V6B6uYhKCUOmiNc8xGmReUwGu77NmvcpxPVB0pCielxMFumO7CmXBG02XjM8HB97k8Hw==",
+        "shasum": "b49196b51b26609e5d1af636287517a11a9aaf42",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.1.2.tgz",
+        "fileCount": 12,
+        "unpackedSize": 14849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcdC/dCRA9TVsSAnZWagAAebEQAJJ88I1jWf2TF7lNeoOY\njQhYA/IVbjCZLwfh2YLd56dbTTa4vxxiWktU16us6NwAPmm9Pds8qW1ArRbN\nuA+oJ8xYxieQme2u0ICuvbqyiI9+XUwB9W/aVXuPWFjhm+2215jejnfhlmp8\nDt84TM6gCNg1mcDkH6oLIBkXwMbdIfuMgUmBTqs+AcYl0iYrOsLg+KlR/SjF\nFTfSht4S1U+lPf6GK16qIcnUdyJTGwgW7A7bqlkTzpQuuXTgaaVg8JUFmJB7\nFrQjpiFyk9TuORK7AQe2WwcSWk8ZpdZA7szKp6MegvdcwcydzI7UZ2++/Pnr\n4DDG7XUVmRUtfLlxTjbcb77R8qe1fK2HlnZZS8W4vELlvZp3iivrwbefdU0n\nNtT2KTCD5FAb6/jJXMib/ETFFKWRSpQDpFUI5NZfC0gHEejTYptz3zLjGFoW\nSvBJIuZOqVL4wc5xw21ODl2aQaoVbHIAJuuiIteJJfIGkRQs8jH0Y+n3iCwi\nv3CYWbyDe+pxQf7XeBlWeGRGAgxZ1O1/N2OTZ8vnJwv8MRU51Ug+9T0vF0Bk\nhP0fLpA2EvO7uKCv79h+zuei2U9uBXJPtkSjG4XwSvI17aZ1nKDa47lMsQZC\nG9r+4nb99n3UVZ1HyvYFNQ5/ZfKB3/lnRLYK6sZGTPSGutDWvnVW01YlSf/z\ncFff\r\n=+VaH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "4.2.0": {
+      "name": "default-gateway",
+      "version": "4.2.0",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.15.1",
+        "eslint-config-silverwind": "^2.1.0",
+        "updates": "^7.2.0",
+        "ver": "4.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
+        "shasum": "167104c7500c2115f6dd69b0a536bb8ed720552b",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 14861,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcgCIRCRA9TVsSAnZWagAASRoP/AzTqmAmXp+VqhEii4Zz\nNLwUNLoYQAMNCUp1/9Shm0VxbxuJVeVmvu1ZwCKtenIHu8ZhqF0XWl0DpDqT\nGjUEsLMdgmKZUQLc8RQxvgfkeEcSQ5oxoMV/WH9jb3GY/MZfL+QqsnAc8JPW\nKD7e4artLCEgwrquwq7GxxXj7rR+5xijkQJyu+VUmqGtb836WwqavhWoMF7M\nBR1mCEa8UZUoo4wTfCdYY++vpVwV1ht9GInfNW5TnHeX3mySr8CKlRp1q3hK\nDNB88P1OXMtvvOhkZv+vlM40MI27Km3fQlWB3yOYa7r0yobM604P3i8e6iEC\nYumWnBZ/bfXWBmKZtHG+GNuCChOgMEgEbYnmggetgEdyWY36Vk1YibklBa7y\n2TfTWof+SkOI+MA5/YSf94z1nw9X++UJ3TMG6Vsb3e8i4bhDKK5RKtu0UsEG\nKVfzJw2y7IOucHzCHFl0Iw/aKAgJtktU5txLVk1NdhX22rLA/c0Tj0RyZC+G\nzm6QI4xXjkaqaPIlLmS4iFKNqFbxs28Q6EbS8CID+gbpvxZDuUaG9iMhcf9m\nBGblQWRjKRau8WnTvSxTvakYs/mjTOiKMnMUNBKwvXaReKfbNFPG8Dp6c97E\nN9uckLfbNdn84o/dg0uSqf5ylLVN4HlmmR87TsGZ6/2pO7/iSovU6AlYqhtS\n3/YA\r\n=3IPh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.0": {
+      "name": "default-gateway",
+      "version": "5.0.0",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-silverwind": "^3.0.3",
+        "updates": "^8.1.0",
+        "ver": "5.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-UynB4xzoJ40Uu5JV+uRjOGyl8t7YVsTUdIoYtzQbFgsL2LL2Qpn7jk1c2xCvQrRy1Fun6wrhorioiVWgCr/yKw==",
+        "shasum": "a30f61762adf00ef0e2e34f210142d173bd9233c",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 14636,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAwCuCRA9TVsSAnZWagAAmtAP/jnVNY5seZr6BGm0j6UG\nDqkICfCktJoykhd6qu/eWFKzHMFVInp5125YeyEqE/EypsYGZS+8j7qx0YEU\nO0Zmms8ZHwt8Elzwk5Idgv9kwpgMs3OKVxAyvG2SCH+vAUIjOS99iHrfR9io\nbXUnJuD8NlRACEkhMB4HQI/zFyMs58vFIUzS1NKdZYFWChVXXym7k1N0CV//\nV5rG72Yz8mFQpezmCTkTP0dHWVjNq4gmJEolnPCrR1vJK7yydXziE/m10AFx\nzsxzi6tFYATxYQaFTPxi6luiRR+A/YVUgNrMiH4Qq8g1EX2TSBSMQfJtVP28\nyDb8niQqjKPCQpuYyxEzoTcNSqYz0d4MKng1XDKi9l1Hp4L5Mmya8utiimUI\nYOC6c7MdNXFPIwtfELSa1cDCOvpC0RpX7+1ioyNbu6a/ctigGpTrci6Gclp0\nOsbcs6rSDVUnMYCRncW/CUdvZ/2tv7hns68cHcFsm544gGGZwT724uM16skQ\nuC/xMslvj5/Wz6IPW3Mo/RuUvhkfZCQcfuJkQOOakYFKc7Xf06rIbmiAXbtA\nuZeXaKzWxSfKx8XfQ27ASIvxqSf499UFnwwUzEHPEj3q2uXXlnNnO0Naz1Wt\nqVCU9YBnxJ7mFCMyb8itu5uO1dmACcBzvqpEn/ywBb3Rir3odG39Lec148Wu\nrgoB\r\n=5FCk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "5.0.1": {
+      "name": "default-gateway",
+      "version": "5.0.1",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-silverwind": "^3.0.3",
+        "updates": "^8.1.0",
+        "ver": "5.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-1k5ZDMXdzx4DsBqzrqUrwONScoU3wTGIQAsrmivwQ/hnTcyCKrTBJLhJJbDilhc+4PeDz6HgCIfOPD7RKZ6/6Q==",
+        "shasum": "5e3a8d689be4d822783803bef65f35917d096b75",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.1.tgz",
+        "fileCount": 12,
+        "unpackedSize": 15166,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdA/VNCRA9TVsSAnZWagAAUkoP/jC+MvgqDPAMEBRushAm\nJly10oIdJJ4lcsnlOuHpiCNeK934vpQIQv+3qfb8MlzKN/jISCkkD7KMgkyv\n0LrsvpRgDjAHu92biB1CEkm3rmFZatzMUtCck8b4VGGw0FYs3tBQbdi8eosV\nVI/Uf8EnJU7Jc88OJ2Lg5l1LrxM9e/SqN4lXtAK5zRvTcqMcK9OHm3LsmtRO\n9LdpD27ZNxDl5RoZYfoQc4CabiojxZ3yJ7RKoUZfGdHD+lcGNhZzvQCL3nml\nNZYJ2CrNNNKRJFmQd5S5ERMDaB1jaT6EiiYylCaH6xOZhLpP/kZrdQ9tBcHg\ncjIw3BWh+tT/tSckB1Xk6DmYmeaAlbdeiASsjJ5UyR0MLG6cbksPoUaO9JWn\nHRbj4JNwggmMJdoSM84s0P9rQrkFMoCTjkUbJxz1+1tPtzkv9gXTtL7zieXa\n0UZ1zRLlR33WFhyTHOdyA0+rju3nfwApUkPuZ7bSO3+xWZaWMmzcYhxyjC6p\n1Gj2Jg9A16Vm6RN4dG8iveOU7Ateoa7PL2SuhvLzOMKiH1msp1uGCFFLEogN\naYxT3pa6v9Dsy37lhrhouvOk5+W2XMREonnHOGdTN7dPXqgoCG0R7EcLU2qb\n36eQq9pkQADPj0YEMD2JW4FOcAib1bRojLp0GXsTzI8ym719YU98QJC+V5Qm\n4V9B\r\n=ujBj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "5.0.2": {
+      "name": "default-gateway",
+      "version": "5.0.2",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "devDependencies": {
+        "eslint": "^5.16.0",
+        "eslint-config-silverwind": "^3.0.3",
+        "updates": "^8.1.0",
+        "ver": "5.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-wXuT0q8T5vxQNecrTgz/KbU2lPUMRc98I9Y5dnH3yhFB3BGYqtADK4lhivLlG0OfjhmfKx1PGILG2jR4zjI+WA==",
+        "shasum": "d2d8a13d6fee406d9365d19ec9adccb8a60b82b3",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.2.tgz",
+        "fileCount": 12,
+        "unpackedSize": 15167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdA/YvCRA9TVsSAnZWagAA0nYP/3Cdyc9kGJGkF+ZBM8M9\ngxXDbhoUpnpzys329mu1A5BPExP5aEuCM36hjY09LYHqweYy1QwCYC26hzrN\nTFAJ7M7aZladJld76b+5Eaf0jthmjJdf/k35TBp/pltE33m8pKgc6dw1fsRi\n28hpmg4eIapIQOjdrLe8TkAskdF0wQ1YIAWRpeJgtS9lgo0ih4R6lQrzOCLe\nrTT9G/jRgswHD/IH+W4TMdJMQmk+PgW4dKF311kfgAROnG0Xu5CfxLo1k/MG\nIVrRR5SySKOo38N0NRd5CaYz3znz/x3tHl5b3kISR2ULryz2B1hto6wrq+pa\nmovIXgaqu3Bs/WTwUyBuT4FtE8I09eULovYKu5Q9AnUpjLaQFSCoJ/3nHYIp\nLDu7+nS56x+uZmbM7OCXhEPOniS2Vc7blPcIRHK2L3KpqHz1A+KGOHD5nhf3\nhlUuvfS/KsCqG/DCyzlF24eDsZV4LxqwIIHLmyDzxgl7oCbGC8qloAGVyEv1\n76uDxRcsURsV5VhOnXtw80EBs9/q+slhAQxNuhyWJR8aUKXMyonLmkBvlA3r\nKTAgrPrW9XO9o8iaZCf/580nwI9UPHDHUJjii8drRfO5YVJydzny21h3C1ek\n/w56ajSJvWz9huKyFMcTwQsoK7RUjFEjuyOzssb8r2Ldu9Zw0TZ0aGJQpV4V\n8+lk\r\n=L+tK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "5.0.3": {
+      "name": "default-gateway",
+      "version": "5.0.3",
+      "dependencies": {
+        "execa": "^2.0.3"
+      },
+      "devDependencies": {
+        "eslint": "^6.1.0",
+        "eslint-config-silverwind": "^4.0.3",
+        "updates": "^8.5.1",
+        "ver": "5.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-zW+ld9xtN0+q48wIwhitUzhfERJN7BPgvijPhuCKG6bfWqnoqtSNSnrXfvAME2ZJLpgYpz6UorpBddGfLzrJBw==",
+        "shasum": "18434c9430a18035a2861f7839bf7669b3436e6f",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.3.tgz",
+        "fileCount": 12,
+        "unpackedSize": 15976,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdU6lJCRA9TVsSAnZWagAAGAAP/RGLoKzFICiTW4P3GvcL\njgU7kZpSCUAFM4PIEOsAhsXnmEQYWyHKw9ieUdjPLjKuKMOzguepmyH/NrOy\n6ab6kyOQGlr3T4b0cPkwYBXUzBEYhpiKUfQtEKmgbsM3SRakTRRK4qiyezx6\njpKW39YvWN8Z2MWsgMjLHuCeexWcRtSVci9OZPCTWbZCfyyMy+Gv8hayIpId\nY7SmBlHzYPD66kJMOpv7xYW+0ScvDhYFXNKAR7kwXO5kk58kcHka6Wupl1oT\ngvvRkzc8yk6+c+p/EyKOMaXmTAW4FqaEqQt9vzhcXqRpo5xHk0UiNJzdKnZj\nxRd7ejse8zDKdVQWuxdLLIdZ9/DysKWHMV1wz+/jxVZUjNLNtthJVdD4U7gg\nYApDBmY6dlBpeR3BhYRVCXwIQm4gBwp8rlPxG+JYvJriY//ZRsoxqzwEuVHN\nszb0gBrEfWYDRryUnTUHpeie1utb4ZNPBC46vB1LsiNG84Km7Ln7abYWlISA\nPzcLfbK9hhjFFM7trXzdjQvgd55iIiO8Mz9e0XlWH5xNXuem8ndS00BZNYLS\nAU7duzYNbuI7TV36oJXLilYu0CM/UvDAuqcbjeZWI0ZaQLgTRPICq5tcR9No\nU257DmbYmRqXyBIQ/h0dS3RRzRNQH4nM+i9qCRGO9O2AVqOuLA0OZ1PkQnWh\n1TKb\r\n=zLUz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "5.0.4": {
+      "name": "default-gateway",
+      "version": "5.0.4",
+      "dependencies": {
+        "execa": "^3.0.0"
+      },
+      "devDependencies": {
+        "eslint": "6.5.1",
+        "eslint-config-silverwind": "4.2.3",
+        "updates": "9.0.0",
+        "ver": "5.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-RncYZFuHZlB69pT3aAZK/YUjOpllMc3pKm/dIxHR0AyJlhRKSFbLIQbZia1WOrNoY0F1UsqadrHW9mx/lAWAgg==",
+        "shasum": "d10bf9ec1446b96acb977f88e62d59c7eefe5d01",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.4.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16185,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdpUhcCRA9TVsSAnZWagAAuk4P+wZh9Lmi14c/Z0kDT4S8\n/Kr6JObHar5KL36DSwgsTiKlpiplbeeGzOJAb2JxTZ3MKuANg+8IepLZdhd/\nR3Syptri7ZQxu04KfOCxV4GbBM8zPZ/sgZ/P0h7rPV5WDeLQm9Q0x8+/2E97\nPJv0DXb8PFaMh7OfTV2AY7ipjnFHXzBqs8H2w9rhLMRRoQljRcgrmMS1Azvu\n41ejveybe+++899ky2Q4+ESZEGkGhTB+cxdREagxdGKsO2Fg5FO2ChC9cvET\ntyA3hgrEg+gVYm7RiWbyZbi9ksJQMMQsWqG5D12D2z1n7Kkz5tOnrVEIgMH6\nAxgUE5cFGQGL2WT+cfYmRykr7QN8E9b6iL9FWuEOwRnpIRSGk1dgCDPWaL29\n93rCV1A01HUo65dKf7UpQ47KatPbyz7qkrNyCCMMnv9h3xn9cWOETceNZe8q\n2CtWx2m/+5UTDsogwpjd68r+8eRe4ntX1hdJQi3eDIXn3M5d2rTjeE84pkIe\ngoYWqLVOjqY9rXiPzwYt8pdd9pAxBlJUkk8BsLnAr2FSqPkK0vki+gg+FMOD\nPQQpQrG108uq2UKsvuPA3V55e3wLOGwDBsiPC0zslzwnSoah3z5svitqQGbe\nBBUx74z52+VqX2igmFtKazaD+XUVk/pJxNXawmkLKbQ7x+tQ/CkNkpMd3JdE\nmyc0\r\n=rgXu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "5.0.5": {
+      "name": "default-gateway",
+      "version": "5.0.5",
+      "dependencies": {
+        "execa": "^3.3.0"
+      },
+      "devDependencies": {
+        "eslint": "6.6.0",
+        "eslint-config-silverwind": "5.0.0",
+        "updates": "9.0.1",
+        "ver": "6.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-z2RnruVmj8hVMmAnEJMTIJNijhKCDiGjbLP+BHJFOT7ld3Bo5qcIBpVYDniqhbMIIf+jZDlkP2MkPXiQy/DBLA==",
+        "shasum": "4fd6bd5d2855d39b34cc5a59505486e9aafc9b10",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-5.0.5.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16327,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdzbuMCRA9TVsSAnZWagAABwIQAJW6E/Y6ZwBP4dDhjLuU\nhb1vIDVPCRhk2wP2r4DGlMN7ZC9G2TI3vx3Z6ruxdjCUsGrw3rHetiHhaMRF\n1aMV0m/9ZzaVh7N+a2fRk64hCMwib3i38quumdXmlUopRryoE5GL6S1YF7AN\nr5lNcynNF3FM4DNFEcUK1frQ8Z+klnSmfMFHDM6Gv3C+LD3+HMixh06qBykc\nGa9CDpZM/PKV23R8wuVpqkRUJA4UIuG+2N+RdTCHmGbOK5vzDGHtTUFD5Dxg\nKI9lQ1pgysUP4dl5GDl1WyrwWvOPMZpTziEBI6xQSsSkTwryAVZLnB+oloyj\nMbVrHEGT3nWvpChYNi6maC92aeaGq2KvXwkzhK308hqYliBnEHdDMY3hffhd\n7QWazfzc0ekOmQcY/smxt1tUENJhqohUsuw/mAteKmkrW+5yUB8bydR4Cud1\njdllJGxN2uUIIRd6foruebRaf+hxPJ8Wa+IT2/taDxSYzvq7TEAd56f9gFSA\n8woZ9iTY+0bJAuYsabqZSiDBauNmOmbvvlXOIiaE8+3NpAFnB7wqclRQgGBF\nRLDehrl8WvFbuJ5ulNOFiOJ0a1dY/Ja1Iux8CnI/2erWZ3abn39h8SzfsQ0g\nbbFNtjBlcUSDPaE5T5RtMXzZ6z6khEvhFDcQxk2S41z/9hJuP7Ao7ZK2tss6\nnzwE\r\n=yKbY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "^8.12.0 || >=9.7.0"
+      }
+    },
+    "6.0.0": {
+      "name": "default-gateway",
+      "version": "6.0.0",
+      "dependencies": {
+        "execa": "^4.0.0"
+      },
+      "devDependencies": {
+        "eslint": "6.8.0",
+        "eslint-config-silverwind": "10.0.1",
+        "jest": "25.1.0",
+        "updates": "10.2.2",
+        "versions": "8.2.4"
+      },
+      "dist": {
+        "integrity": "sha512-kCz5MQbiOqeImB/Ze/QSohiet/pBllgVSoYP1nL66f2NTFDhh2dh0NMTK8H8EgalGimHCEulYGNoVGjNyNePRw==",
+        "shasum": "d2ae8828ff8e49549cb52f89b114e9a94ed0047d",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16153,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeaWe2CRA9TVsSAnZWagAAYSwP/RewzrNW02pe07VYLB62\njFYsxbuIbUW85W9eETLIV/QS+QqcnaZiVktvtKqXksqztV9oL3FpWa0h3PeW\nUmMJ3wrIjez7JLFRDv/1ffiZansJEuU70z1PuNtvMMa9/ZQ3L0J3osHUyK3U\nuYQHpohZXh5YCWlBRfq+rkAHCU87GuIxtb6IRr3ZSx3ODYlHAXx8envnRNoh\nFWvcAPZOeWDfEiDwwjgrOFXdfL1RFHY95WaFbRmEc7pc/8wvScrX7JSIhaxY\nBRBRGZTyreHgwLDn+IF3oWSiHLlanH91g2UruM7zC3WDOOcu9E2tw4j8B+jY\nDsPLh0ThU3MHjySYng9Fg85cUq+BEBvtCm3m2QHtrksGc2qSP0j8U7XIOizD\n8jrnoJ0ektLbYqPLbAznBqc5dXlx3NW0GejqgwKm7v9Brt8/v4N/49JORhTT\nhnt4/TGOUrXr61Rx4uOKjDWcS0iBxOrxNZTHjw+dP6/yJY6PWbpyHLAZ9RGj\nFsX3rPvokbZF537PqztexxG3M29P0GrEWAtOMpm4ar8Ixx4v1sdL4BtDEVpg\n3Hzc/nUVp2XWXGdQH4cFP2OOI/thwkLWEVE0k2jxp+vfnn+sgUgkMV4jWMR2\nW6MMc6IMs/h1mXo3O5QhUI+rrhx/iVZPrykpTyYZqWHXeeNkgDyp/tgRPLWO\nGQsP\r\n=7WxI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "6.0.1": {
+      "name": "default-gateway",
+      "version": "6.0.1",
+      "dependencies": {
+        "execa": "^4.0.2"
+      },
+      "devDependencies": {
+        "eslint": "7.1.0",
+        "eslint-config-silverwind": "13.4.2",
+        "jest": "26.0.1",
+        "updates": "10.2.12",
+        "versions": "8.2.10"
+      },
+      "dist": {
+        "integrity": "sha512-55Zt/cfV9OkkerJR3fECxhSk4+mVv6cq/npDz7n6255faTGh0/9HbEnTpUQdMMGJXclBCxEu1Kol3h362c2cbg==",
+        "shasum": "a6b266196931bf27dfe763dec9e488573fe8c803",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.1.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16241,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJey96xCRA9TVsSAnZWagAAqw4QAILmkuH1Af31Pbg+n/f5\nyTG7qXdom+J6ZzvPbAHmgrPdceiBviFBfKnebu8FYor/hTCY67MBTbCRpgaX\nPecNC1sgLr+9ZBEJau7JRKfbzVeITXWA4ZNGThEEE8K2yaQjvRXcE5SGfHSb\nEw51YefFnYJhZ2UefOqjZlcP/z69F+Lov0GR1s6lsu00KHS2AIIHSJgBcX9c\nmdE/JuBIerr1Tep1UjeMH1tXDz+FE6kCXvW3Uvlp97eTXzGd8smfbX9dxi4/\ngaYRNs3LcJu6Ktwi1uMIZKjSK1ldQt9vMh4ijQ1efltXx40ZunsmYH257nzO\nOBvyZGiyfv1oeDduFsO+RwPueHvDlMUbKk6ZodzcO+zyyjL7jN79egb1ubSH\n0XO++5XgF2CQ88LjIjpizsDEyJ38wC/nafwsV9L8MOcGrn9QHL1EJ+O3g8vR\nJu+5xmFUwMS0sM/GA0u57O0Uk1tto4eJG8F0chMhLoWKjOKtipclRPaGihKm\nPV1My6TbTeALhpJjKKJIvn/7cxycMwrlWg184IzJsI1x/JaR42UizDwSQMrn\n7gq7FlqeTL/uruC1Kr3WAATtx1+PzHCPhsec5/LjRx2zV4J+p6NQbVIhcSEy\nzfXzQwgr76ggmSnWg9a12sMEeiJ8WXl13cLeI+SCalzZfZUyUTC279tTR1Uo\ndeM8\r\n=6srz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "6.0.2": {
+      "name": "default-gateway",
+      "version": "6.0.2",
+      "dependencies": {
+        "execa": "^4.0.3"
+      },
+      "devDependencies": {
+        "eslint": "7.7.0",
+        "eslint-config-silverwind": "18.0.5",
+        "jest": "26.4.2",
+        "updates": "10.3.5",
+        "versions": "8.4.3"
+      },
+      "dist": {
+        "integrity": "sha512-bWrj9HZWNXJ/RUkWmBIp67JawNrPGz0il43IGWU84dazEYbNFQ52HbIiqgRQdYUHK3RyGrENrDV9QkwArt6IAQ==",
+        "shasum": "fc14f4a2ae1cbc699c2b40cedd941ab312609ea4",
+        "tarball": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.2.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16098,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfRrwSCRA9TVsSAnZWagAAKp0P/RQ5wSWraOgl18ZWTTgx\nB/Qtws+SB+FLvJvSWPOjwEyohqMuMRO3GWz7oWVxTHx1VO/pkph6GejNQ6Ji\nuXQztEqv9zAqWmO5VT96HG7nhfN/s+IM1wYSoqcmEFexB4n6sZN15Gw1EuFZ\nwhXxM7oXABuX71unWxygywNPgYrrbAdTAN8EXi8ziuNl5P6jxhhTrl19OaGZ\nvKOrtyEoEbMiOsy/ZzZb/FxQbGHrTxgKGkRQFkIXkxGsA+TbgV4zBTJeOhcK\nrkkXhTwSfwwDV0H6bdzUAs1kTr+wNfZ5Swd1Jeg2TynkyXGaE8Viy9TDj0A8\ndm1X0bhQOfTj5+sWF0R31Ash5XSCidmQcmiu2fF6VB57xpqjx3Kf/z7EqGP1\nuTpQD0ytXpHyxA2TVLcIZUhmRU6kvYItwgBEt99peRqbgJDHX+cJ3n2mV6VQ\nrNZjLFWuXOeMohe/833QseF3WdKmheFk9//StGmc93UAYbR42Y8UCU7yBTwY\nj9BeyrRzfRNOpdhtOIcnPFDLxxEY03VlTWZJ0dtfPRtMeLR1ifYtdN/G0W5G\nHyKw4Ul8NR7lN0hnNmLqMBIfMKCWKt4skhmUXsvEV3vgZts6eEn83PQ9VGqY\nQAvDEnG8a4He44GcbKXFqXedKuptisqxshXhCZCrBHqN0Xjw3llJ9KAVYrm7\nlxBV\r\n=L09C\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  },
+  "modified": "2020-08-26T19:46:31.639Z"
+}

--- a/test/fixtures/registry-mocks/content/define-property.json
+++ b/test/fixtures/registry-mocks/content/define-property.json
@@ -1,0 +1,1080 @@
+{
+  "_id": "define-property",
+  "_rev": "13-4d76a46d1585cdf915fe4eaae819e4bb",
+  "name": "define-property",
+  "description": "Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty.",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "define-property",
+      "description": "Convenience for defining a non-enumberable property on an object.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "mixin-deep",
+            "mixin-object",
+            "delegate-object",
+            "forward-object"
+          ]
+        }
+      },
+      "_id": "define-property@0.1.0",
+      "_shasum": "8031b2af5e2a3e5a2d502e1a474066f3948de46a",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8031b2af5e2a3e5a2d502e1a474066f3948de46a",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object.",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "browser.js",
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "prepublish": "browserify -o browser.js -e index.js -s index --bare"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "mixin-deep",
+            "mixin-object",
+            "delegate-object",
+            "forward-object"
+          ]
+        }
+      },
+      "gitHead": "c5277006040196c1813b64cd1a55d41effd3cc5e",
+      "_id": "define-property@0.1.2",
+      "_shasum": "8e1235d85012d2d7f791ecb1d3bdd0e53560c4d5",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8e1235d85012d2d7f791ecb1d3bdd0e53560c4d5",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object.",
+      "version": "0.1.3",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "browser.js",
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "prepublish": "browserify -o browser.js -e index.js -s index --bare"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "mixin-deep",
+            "mixin-object",
+            "delegate-object",
+            "forward-object"
+          ]
+        }
+      },
+      "gitHead": "4482dd35229c08ff1a525d6cb1732c807f4decf1",
+      "_id": "define-property@0.1.3",
+      "_shasum": "15a437708bfb88e4af4508e46d8ef1273735a07b",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "15a437708bfb88e4af4508e46d8ef1273735a07b",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "mixin-deep",
+            "mixin-object",
+            "delegate-object",
+            "forward-object"
+          ]
+        }
+      },
+      "gitHead": "b4fc4209a43b939b5e12b3586bb2d188c238d5d9",
+      "_id": "define-property@0.2.0",
+      "_shasum": "7c527ab0d8b97355c3d1a98b5a5d31f41a840d3c",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7c527ab0d8b97355c3d1a98b5a5d31f41a840d3c",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "mixin-deep",
+            "mixin-object",
+            "delegate-object",
+            "forward-object"
+          ]
+        }
+      },
+      "gitHead": "4cd59415d61c76c72ad474fadab657610263140e",
+      "_id": "define-property@0.2.1",
+      "_shasum": "8d3052c4f7382a65be2aeda030c4e15b9f69446f",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8d3052c4f7382a65be2aeda030c4e15b9f69446f",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object.",
+      "version": "0.2.2",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "mixin-deep",
+            "mixin-object",
+            "delegate-object",
+            "forward-object"
+          ]
+        }
+      },
+      "gitHead": "f628e98ed4c6f63200750b389eefd0eb97487418",
+      "_id": "define-property@0.2.2",
+      "_shasum": "2db4ec1533a574a4ee93d49dcc41e4746a460778",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2db4ec1533a574a4ee93d49dcc41e4746a460778",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object.",
+      "version": "0.2.3",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "mixin-deep",
+            "mixin-object",
+            "delegate-object",
+            "forward-object"
+          ]
+        }
+      },
+      "gitHead": "acc054ed23c429580e077a6fc34d6fd3be27b9fe",
+      "_id": "define-property@0.2.3",
+      "_shasum": "66400b88f651b0ae5999af4f9d6f77c62d7f9fd4",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "66400b88f651b0ae5999af4f9d6f77c62d7f9fd4",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.5": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object.",
+      "version": "0.2.5",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "mixin-deep",
+            "mixin-object",
+            "delegate-object",
+            "forward-object"
+          ]
+        }
+      },
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "gitHead": "5bf4e5e9d8d1fdf8fba07fff4bdf13a5d6df8ae4",
+      "_id": "define-property@0.2.5",
+      "_shasum": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "extend-shallow",
+            "merge-deep",
+            "assign-deep",
+            "mixin-deep"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "4811e7c7999e82ab086265eefeb5d9cbffe10912",
+      "_id": "define-property@1.0.0",
+      "_shasum": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/define-property-1.0.0.tgz_1492669183321_0.5127195529639721"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-descriptor": "^1.0.1",
+        "kind-of": "^6.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "3.5.3"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "assign-deep",
+            "extend-shallow",
+            "merge-deep",
+            "mixin-deep"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "e5547ddcd8dc433c1d0bcd429ecbadc0365bfbb4",
+      "_id": "define-property@2.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-4/SF011K23kgjxLFt6W7xQqJ4H7An3kfCQQ+iFWk12+xyMoqkdovL+b4l+1PK1dQVO+sPNtjARF249YhYDCzwg==",
+        "shasum": "db0cd7e880bf3d2a8bc60f03ffae43a4b7015140",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/define-property-2.0.0.tgz_1511717561543_0.39900357043370605"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty.",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "assign-deep",
+            "extend-shallow",
+            "merge-deep",
+            "mixin-deep"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "63b0d9d5096ed103ca891fdadfeb9db991766728",
+      "_id": "define-property@2.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-0Bay2p3QW3TvvrmR/U6npq/ymIGVrq5Glg2uLaidbx9DmM52Y0pD9ku3aGu3p1Htaby4JQvirAxFYHf33Xs6cQ==",
+        "shasum": "b7dd7bd907a615ec119feef82af425e68f00726a",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/define-property-2.0.1.tgz_1516916222764_0.29555602883920074"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "define-property",
+      "description": "Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty.",
+      "version": "2.0.2",
+      "homepage": "https://github.com/jonschlinkert/define-property",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/define-property.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/define-property/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "define",
+        "define-property",
+        "enumerable",
+        "key",
+        "non",
+        "non-enumerable",
+        "object",
+        "prop",
+        "property",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "assign-deep",
+            "extend-shallow",
+            "merge-deep",
+            "mixin-deep"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "04717307be822f2ca2544778b92e5d2cbe300c55",
+      "_id": "define-property@2.0.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+        "shasum": "d459689e8d654ba77e02a817f8710d702cb16e9d",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "brian.woodward@gmail.com",
+          "name": "doowb"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/define-property-2.0.2.tgz_1516998261413_0.9784700081218034"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# define-property [![NPM version](https://img.shields.io/npm/v/define-property.svg?style=flat)](https://www.npmjs.com/package/define-property) [![NPM monthly downloads](https://img.shields.io/npm/dm/define-property.svg?style=flat)](https://npmjs.org/package/define-property) [![NPM total downloads](https://img.shields.io/npm/dt/define-property.svg?style=flat)](https://npmjs.org/package/define-property) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/define-property.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/define-property)\n\n> Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save define-property\n```\n\n## Release history\n\nSee [the CHANGELOG](changelog.md) for updates.\n\n## Usage\n\n**Params**\n\n* `object`: The object on which to define the property.\n* `key`: The name of the property to be defined or modified.\n* `value`: The value or descriptor of the property being defined or modified.\n\n```js\nvar define = require('define-property');\nvar obj = {};\ndefine(obj, 'foo', function(val) {\n  return val.toUpperCase();\n});\n\n// by default, defined properties are non-enumberable\nconsole.log(obj);\n//=> {}\n\nconsole.log(obj.foo('bar'));\n//=> 'BAR'\n```\n\n**defining setters/getters**\n\nPass the same properties you would if using [Object.defineProperty](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty) or [Reflect.defineProperty](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty).\n\n```js\ndefine(obj, 'foo', {\n  set: function() {},\n  get: function() {}\n});\n```\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [assign-deep](https://www.npmjs.com/package/assign-deep): Deeply assign the enumerable properties and/or es6 Symbol properies of source objects to the target… [more](https://github.com/jonschlinkert/assign-deep) | [homepage](https://github.com/jonschlinkert/assign-deep \"Deeply assign the enumerable properties and/or es6 Symbol properies of source objects to the target (first) object.\")\n* [extend-shallow](https://www.npmjs.com/package/extend-shallow): Extend an object with the properties of additional objects. node.js/javascript util. | [homepage](https://github.com/jonschlinkert/extend-shallow \"Extend an object with the properties of additional objects. node.js/javascript util.\")\n* [merge-deep](https://www.npmjs.com/package/merge-deep): Recursively merge values in a javascript object. | [homepage](https://github.com/jonschlinkert/merge-deep \"Recursively merge values in a javascript object.\")\n* [mixin-deep](https://www.npmjs.com/package/mixin-deep): Deeply mix the properties of objects into the first object. Like merge-deep, but doesn't clone. | [homepage](https://github.com/jonschlinkert/mixin-deep \"Deeply mix the properties of objects into the first object. Like merge-deep, but doesn't clone.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 28 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 1 | [doowb](https://github.com/doowb) |\n\n### Author\n\n**Jon Schlinkert**\n\n* Connect with me on [linkedin/in/jonschlinkert](https://linkedin.com/in/jonschlinkert)\n* Follow me on [github/jonschlinkert](https://github.com/jonschlinkert)\n* Follow me on [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on January 25, 2018._",
+  "maintainers": [
+    {
+      "email": "brian.woodward@gmail.com",
+      "name": "doowb"
+    },
+    {
+      "email": "github@sellside.com",
+      "name": "jonschlinkert"
+    }
+  ],
+  "time": {
+    "modified": "2018-01-26T20:24:22.283Z",
+    "created": "2015-08-13T01:46:20.557Z",
+    "0.1.0": "2015-08-13T01:46:20.557Z",
+    "0.1.2": "2015-08-13T01:56:48.653Z",
+    "0.1.3": "2015-08-13T02:02:26.205Z",
+    "0.2.0": "2015-08-27T10:16:07.004Z",
+    "0.2.1": "2015-08-27T10:43:39.413Z",
+    "0.2.2": "2015-08-28T01:52:49.347Z",
+    "0.2.3": "2015-08-29T13:15:01.908Z",
+    "0.2.5": "2015-08-31T06:31:10.166Z",
+    "1.0.0": "2017-04-20T06:19:43.879Z",
+    "2.0.0": "2017-11-26T17:32:42.453Z",
+    "2.0.1": "2018-01-25T21:37:02.821Z",
+    "2.0.2": "2018-01-26T20:24:22.283Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/define-property",
+  "keywords": [
+    "define",
+    "define-property",
+    "enumerable",
+    "key",
+    "non",
+    "non-enumerable",
+    "object",
+    "prop",
+    "property",
+    "value"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/define-property.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/define-property/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Brian Woodward",
+      "url": "https://twitter.com/doowb"
+    },
+    {
+      "name": "Jon Schlinkert",
+      "url": "http://twitter.com/jonschlinkert"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/define-property.min.json
+++ b/test/fixtures/registry-mocks/content/define-property.min.json
@@ -1,0 +1,210 @@
+{
+  "name": "define-property",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "define-property",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "8031b2af5e2a3e5a2d502e1a474066f3948de46a",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "define-property",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "8e1235d85012d2d7f791ecb1d3bdd0e53560c4d5",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.3": {
+      "name": "define-property",
+      "version": "0.1.3",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "15a437708bfb88e4af4508e46d8ef1273735a07b",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.1.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "define-property",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "7c527ab0d8b97355c3d1a98b5a5d31f41a840d3c",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.1": {
+      "name": "define-property",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "8d3052c4f7382a65be2aeda030c4e15b9f69446f",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.2": {
+      "name": "define-property",
+      "version": "0.2.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "2db4ec1533a574a4ee93d49dcc41e4746a460778",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.3": {
+      "name": "define-property",
+      "version": "0.2.3",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "66400b88f651b0ae5999af4f9d6f77c62d7f9fd4",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.5": {
+      "name": "define-property",
+      "version": "0.2.5",
+      "dependencies": {
+        "is-descriptor": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^7.0.4"
+      },
+      "dist": {
+        "shasum": "c35b1ef918ec3c990f9a5bc57be04aacec5c8116",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "define-property",
+      "version": "1.0.0",
+      "dependencies": {
+        "is-descriptor": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "define-property",
+      "version": "2.0.0",
+      "dependencies": {
+        "is-descriptor": "^1.0.1",
+        "kind-of": "^6.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-4/SF011K23kgjxLFt6W7xQqJ4H7An3kfCQQ+iFWk12+xyMoqkdovL+b4l+1PK1dQVO+sPNtjARF249YhYDCzwg==",
+        "shasum": "db0cd7e880bf3d2a8bc60f03ffae43a4b7015140",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.1": {
+      "name": "define-property",
+      "version": "2.0.1",
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-0Bay2p3QW3TvvrmR/U6npq/ymIGVrq5Glg2uLaidbx9DmM52Y0pD9ku3aGu3p1Htaby4JQvirAxFYHf33Xs6cQ==",
+        "shasum": "b7dd7bd907a615ec119feef82af425e68f00726a",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.2": {
+      "name": "define-property",
+      "version": "2.0.2",
+      "dependencies": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+        "shasum": "d459689e8d654ba77e02a817f8710d702cb16e9d",
+        "tarball": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2018-01-26T20:24:22.283Z"
+}

--- a/test/fixtures/registry-mocks/content/depd.json
+++ b/test/fixtures/registry-mocks/content/depd.json
@@ -1,0 +1,1105 @@
+{
+  "_id": "depd",
+  "_rev": "55-c70bd469592787dd4dceeb2b01403900",
+  "name": "depd",
+  "description": "Deprecate all the things",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "dependencies": {
+        "supports-color": "0.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.0.0",
+      "dist": {
+        "shasum": "f0cdb7651bf4f7cad646b01f747afab94aedad0b",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "dependencies": {
+        "supports-color": "0.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.0.1",
+      "dist": {
+        "shasum": "ff5cd1c93fa3d941539314c6f226da1b4d2ad9e2",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "dependencies": {
+        "supports-color": "0.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.1.0",
+      "dist": {
+        "shasum": "16c10b0c8b3848a5cd4e29dc3ab6b9725b46d509",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.2.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.2.0",
+      "dist": {
+        "shasum": "cdae0ed2e0ec4e10455e71532b0085e903a9b453",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.3.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.3.0",
+      "dist": {
+        "shasum": "11c9bc28e425325fbd8b38940beff69fa5326883",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.4.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.4.0",
+      "dist": {
+        "shasum": "708b0f636d3f4bf5eb593a88591da04d34858504",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.4.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.4.1",
+      "dist": {
+        "shasum": "2939465411bd56deb66be29800eb28b1a6be7491",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.4.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.4.2",
+      "dist": {
+        "shasum": "a4bc8a0e4801770a66363daa6d35138f3e3b54dd",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.3": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.4.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.4.3",
+      "dist": {
+        "shasum": "7c5118b16eb8cf123de65e98e45c8d868b44146e",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.4": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.4.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.4.4",
+      "dist": {
+        "shasum": "07091fae75f97828d89b4a02a2d4778f0e7c0662",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.5": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "0.4.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4"
+      },
+      "files": [
+        "lib/",
+        "History.md",
+        "LICENSE",
+        "index.js",
+        "Readme.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "gitHead": "e37a15044f7da76b94d8e0d46a6343feb168c82b",
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@0.4.5",
+      "_shasum": "1a664b53388b4a6573e8ae67b5f767c693ca97f1",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1a664b53388b4a6573e8ae67b5f767c693ca97f1",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4"
+      },
+      "files": [
+        "lib/",
+        "History.md",
+        "LICENSE",
+        "index.js",
+        "Readme.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "gitHead": "08b5a2182c8c1fdf7420e4ff8532bfd7e266a7b2",
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@1.0.0",
+      "_shasum": "2fda0d00e98aae2845d4991ab1bf1f2a199073d5",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2fda0d00e98aae2845d4991ab1bf1f2a199073d5",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/dougwilson/nodejs-depd"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "lib/",
+        "History.md",
+        "LICENSE",
+        "index.js",
+        "Readme.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --no-exit test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/"
+      },
+      "gitHead": "769e0f8108463c35a6937a9d634ab19fee45100a",
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@1.0.1",
+      "_shasum": "80aec64c9d6d97e65cc2a9caa93c0aa6abf73aaa",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "80aec64c9d6d97e65cc2a9caa93c0aa6abf73aaa",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "1.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/dougwilson/nodejs-depd"
+      },
+      "browser": "lib/browser/index.js",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "lib/",
+        "History.md",
+        "LICENSE",
+        "index.js",
+        "Readme.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --no-exit test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/"
+      },
+      "gitHead": "78c659de20283e3a6bee92bda455e6daff01686a",
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd",
+      "_id": "depd@1.1.0",
+      "_shasum": "e1bd82c6aab6ced965b97b88b17ed3e528ca18c3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e1bd82c6aab6ced965b97b88b17ed3e528ca18c3",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "1.1.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dougwilson/nodejs-depd.git"
+      },
+      "browser": "lib/browser/index.js",
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.7",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "lib/",
+        "History.md",
+        "LICENSE",
+        "index.js",
+        "Readme.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --no-exit test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/"
+      },
+      "gitHead": "15c5604aaab7befd413506e86670168d7481043a",
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd#readme",
+      "_id": "depd@1.1.1",
+      "_shasum": "5783b4e1c459f06fa5ca27f991f3d06e7a310359",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "5783b4e1c459f06fa5ca27f991f3d06e7a310359",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/depd-1.1.1.tgz_1501197028677_0.8715836545452476"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "1.1.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dougwilson/nodejs-depd.git"
+      },
+      "browser": "lib/browser/index.js",
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.7",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "lib/",
+        "History.md",
+        "LICENSE",
+        "index.js",
+        "Readme.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --no-exit test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/"
+      },
+      "gitHead": "9a789740084d4f07a3a611432435ae4671f722ff",
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd#readme",
+      "_id": "depd@1.1.2",
+      "_shasum": "9bcd52e14c097763e749b274c4346ed2e560b5a9",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "9bcd52e14c097763e749b274c4346ed2e560b5a9",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/depd-1.1.2.tgz_1515736023686_0.5012104702182114"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "depd",
+      "description": "Deprecate all the things",
+      "version": "2.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "deprecate",
+        "deprecated"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/dougwilson/nodejs-depd.git"
+      },
+      "browser": "lib/browser/index.js",
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "5.7.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.7",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "5.2.0",
+        "safe-buffer": "5.1.2",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail test/",
+        "test-ci": "istanbul cover --print=none node_modules/mocha/bin/_mocha -- --reporter spec test/ && istanbul report lcovonly text-summary",
+        "test-cov": "istanbul cover --print=none node_modules/mocha/bin/_mocha -- --reporter dot test/ && istanbul report lcov text-summary"
+      },
+      "gitHead": "6d59c85d093092e65ec77033576417d743079fa0",
+      "bugs": {
+        "url": "https://github.com/dougwilson/nodejs-depd/issues"
+      },
+      "homepage": "https://github.com/dougwilson/nodejs-depd#readme",
+      "_id": "depd@2.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.12.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+        "shasum": "b696163cc757560d09cf22cc8fad1571b79e76df",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 27117,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb01R4CRA9TVsSAnZWagAArWcP/jPqhJPVwB4A7UlP7Z79\nKmkIJRegTXb8sBTkFdL8t5TDikX47CViz3qWSktGdJnwY4q/GnLHeOr/+eq6\nXVvkSKLrpOdmDBYbf7DxVepxbWOLVSCAshlnw6XPXhcqOKd2smn1CPA/hgRj\n26YvwMECmyIlcE5RgubUvN4qqOyMhGF7muWjCbqRq3qcGK7hXUqEnrlHxHsY\ndKCnzRw0HbfxYX2QynmyRL1Y9ynQuq2ucTDxuhQf78ElkHAsbSYaEks9unYG\nWGhU8zH4TGOcLrmJ6GsKhZk22JvnxCg3zwgqLwks2EFiG1iojPD4EkjZgcnJ\nt8meOu2nT8JCa6fNpPMWUpYO1aUKmhoOb5KGyMhSsNX/DND+ndSu0kOP9gU1\nCetsBqRTHHH3jUK/NmyAvzMO0X8mk/FxzI+NTqKQKt8r2/Y5IW4A6oDkaRkr\nPSu1s1DpT5mw9gHBA7K0YKuVr6HwQVnd/1io+OyUmNarjXm2lMaXucpZG3+Q\ncWpj4FyrD0vf+/bV9LKTXee3qAJ9UEGNvhJAKUrGTR8vtdM6uMxLnsBe42hR\nsRM2dJ8KnMujdw+lH+sgjtqcYP/G1Gz2cRtfbVWTrc/olODQPBpu2ycIY0nc\ncejka3bMbVHzYaY7+ho/9SfbE/6x9LRlmcHSEiPzUHRSpYY3pskktQDM0bBo\nm15/\r\n=BUpb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/depd_2.0.0_1540576375784_0.14703351463172942"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# depd\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-image]][node-url]\n[![Linux Build][travis-image]][travis-url]\n[![Windows Build][appveyor-image]][appveyor-url]\n[![Coverage Status][coveralls-image]][coveralls-url]\n\nDeprecate all the things\n\n> With great modules comes great responsibility; mark things deprecated!\n\n## Install\n\nThis module is installed directly using `npm`:\n\n```sh\n$ npm install depd\n```\n\nThis module can also be bundled with systems like\n[Browserify](http://browserify.org/) or [webpack](https://webpack.github.io/),\nthough by default this module will alter it's API to no longer display or\ntrack deprecations.\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar deprecate = require('depd')('my-module')\n```\n\nThis library allows you to display deprecation messages to your users.\nThis library goes above and beyond with deprecation warnings by\nintrospection of the call stack (but only the bits that it is interested\nin).\n\nInstead of just warning on the first invocation of a deprecated\nfunction and never again, this module will warn on the first invocation\nof a deprecated function per unique call site, making it ideal to alert\nusers of all deprecated uses across the code base, rather than just\nwhatever happens to execute first.\n\nThe deprecation warnings from this module also include the file and line\ninformation for the call into the module that the deprecated function was\nin.\n\n**NOTE** this library has a similar interface to the `debug` module, and\nthis module uses the calling file to get the boundary for the call stacks,\nso you should always create a new `deprecate` object in each file and not\nwithin some central file.\n\n### depd(namespace)\n\nCreate a new deprecate function that uses the given namespace name in the\nmessages and will display the call site prior to the stack entering the\nfile this function was called from. It is highly suggested you use the\nname of your module as the namespace.\n\n### deprecate(message)\n\nCall this function from deprecated code to display a deprecation message.\nThis message will appear once per unique caller site. Caller site is the\nfirst call site in the stack in a different file from the caller of this\nfunction.\n\nIf the message is omitted, a message is generated for you based on the site\nof the `deprecate()` call and will display the name of the function called,\nsimilar to the name displayed in a stack trace.\n\n### deprecate.function(fn, message)\n\nCall this function to wrap a given function in a deprecation message on any\ncall to the function. An optional message can be supplied to provide a custom\nmessage.\n\n### deprecate.property(obj, prop, message)\n\nCall this function to wrap a given property on object in a deprecation message\non any accessing or setting of the property. An optional message can be supplied\nto provide a custom message.\n\nThe method must be called on the object where the property belongs (not\ninherited from the prototype).\n\nIf the property is a data descriptor, it will be converted to an accessor\ndescriptor in order to display the deprecation message.\n\n### process.on('deprecation', fn)\n\nThis module will allow easy capturing of deprecation errors by emitting the\nerrors as the type \"deprecation\" on the global `process`. If there are no\nlisteners for this type, the errors are written to STDERR as normal, but if\nthere are any listeners, nothing will be written to STDERR and instead only\nemitted. From there, you can write the errors in a different format or to a\nlogging source.\n\nThe error represents the deprecation and is emitted only once with the same\nrules as writing to STDERR. The error has the following properties:\n\n  - `message` - This is the message given by the library\n  - `name` - This is always `'DeprecationError'`\n  - `namespace` - This is the namespace the deprecation came from\n  - `stack` - This is the stack of the call to the deprecated thing\n\nExample `error.stack` output:\n\n```\nDeprecationError: my-cool-module deprecated oldfunction\n    at Object.<anonymous> ([eval]-wrapper:6:22)\n    at Module._compile (module.js:456:26)\n    at evalScript (node.js:532:25)\n    at startup (node.js:80:7)\n    at node.js:902:3\n```\n\n### process.env.NO_DEPRECATION\n\nAs a user of modules that are deprecated, the environment variable `NO_DEPRECATION`\nis provided as a quick solution to silencing deprecation warnings from being\noutput. The format of this is similar to that of `DEBUG`:\n\n```sh\n$ NO_DEPRECATION=my-module,othermod node app.js\n```\n\nThis will suppress deprecations from being output for \"my-module\" and \"othermod\".\nThe value is a list of comma-separated namespaces. To suppress every warning\nacross all namespaces, use the value `*` for a namespace.\n\nProviding the argument `--no-deprecation` to the `node` executable will suppress\nall deprecations (only available in Node.js 0.8 or higher).\n\n**NOTE** This will not suppress the deperecations given to any \"deprecation\"\nevent listeners, just the output to STDERR.\n\n### process.env.TRACE_DEPRECATION\n\nAs a user of modules that are deprecated, the environment variable `TRACE_DEPRECATION`\nis provided as a solution to getting more detailed location information in deprecation\nwarnings by including the entire stack trace. The format of this is the same as\n`NO_DEPRECATION`:\n\n```sh\n$ TRACE_DEPRECATION=my-module,othermod node app.js\n```\n\nThis will include stack traces for deprecations being output for \"my-module\" and\n\"othermod\". The value is a list of comma-separated namespaces. To trace every\nwarning across all namespaces, use the value `*` for a namespace.\n\nProviding the argument `--trace-deprecation` to the `node` executable will trace\nall deprecations (only available in Node.js 0.8 or higher).\n\n**NOTE** This will not trace the deperecations silenced by `NO_DEPRECATION`.\n\n## Display\n\n![message](files/message.png)\n\nWhen a user calls a function in your library that you mark deprecated, they\nwill see the following written to STDERR (in the given colors, similar colors\nand layout to the `debug` module):\n\n```\nbright cyan    bright yellow\n|              |          reset       cyan\n|              |          |           |\n▼              ▼          ▼           ▼\nmy-cool-module deprecated oldfunction [eval]-wrapper:6:22\n▲              ▲          ▲           ▲\n|              |          |           |\nnamespace      |          |           location of mycoolmod.oldfunction() call\n               |          deprecation message\n               the word \"deprecated\"\n```\n\nIf the user redirects their STDERR to a file or somewhere that does not support\ncolors, they see (similar layout to the `debug` module):\n\n```\nSun, 15 Jun 2014 05:21:37 GMT my-cool-module deprecated oldfunction at [eval]-wrapper:6:22\n▲                             ▲              ▲          ▲              ▲\n|                             |              |          |              |\ntimestamp of message          namespace      |          |             location of mycoolmod.oldfunction() call\n                                             |          deprecation message\n                                             the word \"deprecated\"\n```\n\n## Examples\n\n### Deprecating all calls to a function\n\nThis will display a deprecated message about \"oldfunction\" being deprecated\nfrom \"my-module\" on STDERR.\n\n```js\nvar deprecate = require('depd')('my-cool-module')\n\n// message automatically derived from function name\n// Object.oldfunction\nexports.oldfunction = deprecate.function(function oldfunction () {\n  // all calls to function are deprecated\n})\n\n// specific message\nexports.oldfunction = deprecate.function(function () {\n  // all calls to function are deprecated\n}, 'oldfunction')\n```\n\n### Conditionally deprecating a function call\n\nThis will display a deprecated message about \"weirdfunction\" being deprecated\nfrom \"my-module\" on STDERR when called with less than 2 arguments.\n\n```js\nvar deprecate = require('depd')('my-cool-module')\n\nexports.weirdfunction = function () {\n  if (arguments.length < 2) {\n    // calls with 0 or 1 args are deprecated\n    deprecate('weirdfunction args < 2')\n  }\n}\n```\n\nWhen calling `deprecate` as a function, the warning is counted per call site\nwithin your own module, so you can display different deprecations depending\non different situations and the users will still get all the warnings:\n\n```js\nvar deprecate = require('depd')('my-cool-module')\n\nexports.weirdfunction = function () {\n  if (arguments.length < 2) {\n    // calls with 0 or 1 args are deprecated\n    deprecate('weirdfunction args < 2')\n  } else if (typeof arguments[0] !== 'string') {\n    // calls with non-string first argument are deprecated\n    deprecate('weirdfunction non-string first arg')\n  }\n}\n```\n\n### Deprecating property access\n\nThis will display a deprecated message about \"oldprop\" being deprecated\nfrom \"my-module\" on STDERR when accessed. A deprecation will be displayed\nwhen setting the value and when getting the value.\n\n```js\nvar deprecate = require('depd')('my-cool-module')\n\nexports.oldprop = 'something'\n\n// message automatically derives from property name\ndeprecate.property(exports, 'oldprop')\n\n// explicit message\ndeprecate.property(exports, 'oldprop', 'oldprop >= 0.10')\n```\n\n## License\n\n[MIT](LICENSE)\n\n[appveyor-image]: https://badgen.net/appveyor/ci/dougwilson/nodejs-depd/master?label=windows\n[appveyor-url]: https://ci.appveyor.com/project/dougwilson/nodejs-depd\n[coveralls-image]: https://badgen.net/coveralls/c/github/dougwilson/nodejs-depd/master\n[coveralls-url]: https://coveralls.io/r/dougwilson/nodejs-depd?branch=master\n[node-image]: https://badgen.net/npm/node/depd\n[node-url]: https://nodejs.org/en/download/\n[npm-downloads-image]: https://badgen.net/npm/dm/depd\n[npm-url]: https://npmjs.org/package/depd\n[npm-version-image]: https://badgen.net/npm/v/depd\n[travis-image]: https://badgen.net/travis/dougwilson/nodejs-depd/master?label=linux\n[travis-url]: https://travis-ci.org/dougwilson/nodejs-depd\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-02T20:56:15.578Z",
+    "created": "2014-06-15T05:36:40.048Z",
+    "0.0.0": "2014-06-15T05:36:40.048Z",
+    "0.0.1": "2014-06-15T06:45:56.017Z",
+    "0.1.0": "2014-06-15T23:00:43.255Z",
+    "0.2.0": "2014-06-16T03:10:42.166Z",
+    "0.3.0": "2014-06-17T05:12:24.584Z",
+    "0.4.0": "2014-07-20T00:44:09.734Z",
+    "0.4.1": "2014-07-20T01:00:25.153Z",
+    "0.4.2": "2014-07-20T01:50:35.874Z",
+    "0.4.3": "2014-07-26T20:16:57.765Z",
+    "0.4.4": "2014-07-27T16:58:38.606Z",
+    "0.4.5": "2014-09-09T23:35:40.588Z",
+    "1.0.0": "2014-09-18T06:42:35.900Z",
+    "1.0.1": "2015-04-07T17:50:07.601Z",
+    "1.1.0": "2015-09-14T15:59:06.622Z",
+    "1.1.1": "2017-07-27T23:10:29.750Z",
+    "1.1.2": "2018-01-12T05:47:03.858Z",
+    "2.0.0": "2018-10-26T17:52:55.936Z"
+  },
+  "homepage": "https://github.com/dougwilson/nodejs-depd#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dougwilson/nodejs-depd.git"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/dougwilson/nodejs-depd/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "Readme.md",
+  "keywords": [
+    "deprecate",
+    "deprecated"
+  ],
+  "users": {
+    "306766053": true,
+    "zhangyaochun": true,
+    "forivall": true,
+    "bacra": true,
+    "cshao": true,
+    "simplyianm": true,
+    "yasinaydin": true,
+    "moimikey": true,
+    "zhanghaili": true,
+    "wangnan0610": true,
+    "lgh06": true,
+    "ahmed-dinar": true,
+    "mojaray2k": true,
+    "danielrhayes": true,
+    "leonzhao": true,
+    "programmer.severson": true,
+    "abhisekp": true,
+    "daizch": true,
+    "eyson": true,
+    "tedyhy": true,
+    "zuojiang": true,
+    "zhenguo.zhao": true,
+    "xgheaven": true,
+    "isayme": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/depd.min.json
+++ b/test/fixtures/registry-mocks/content/depd.min.json
@@ -1,0 +1,322 @@
+{
+  "name": "depd",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "depd",
+      "version": "0.0.0",
+      "dependencies": {
+        "supports-color": "0.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "f0cdb7651bf4f7cad646b01f747afab94aedad0b",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.0.1": {
+      "name": "depd",
+      "version": "0.0.1",
+      "dependencies": {
+        "supports-color": "0.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "ff5cd1c93fa3d941539314c6f226da1b4d2ad9e2",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.1.0": {
+      "name": "depd",
+      "version": "0.1.0",
+      "dependencies": {
+        "supports-color": "0.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "16c10b0c8b3848a5cd4e29dc3ab6b9725b46d509",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.2.0": {
+      "name": "depd",
+      "version": "0.2.0",
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "cdae0ed2e0ec4e10455e71532b0085e903a9b453",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.3.0": {
+      "name": "depd",
+      "version": "0.3.0",
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "11c9bc28e425325fbd8b38940beff69fa5326883",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.0": {
+      "name": "depd",
+      "version": "0.4.0",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "708b0f636d3f4bf5eb593a88591da04d34858504",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.1": {
+      "name": "depd",
+      "version": "0.4.1",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "2939465411bd56deb66be29800eb28b1a6be7491",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.2": {
+      "name": "depd",
+      "version": "0.4.2",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "a4bc8a0e4801770a66363daa6d35138f3e3b54dd",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.3": {
+      "name": "depd",
+      "version": "0.4.3",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "7c5118b16eb8cf123de65e98e45c8d868b44146e",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.4": {
+      "name": "depd",
+      "version": "0.4.4",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "07091fae75f97828d89b4a02a2d4778f0e7c0662",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.5": {
+      "name": "depd",
+      "version": "0.4.5",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "1a664b53388b4a6573e8ae67b5f767c693ca97f1",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.0": {
+      "name": "depd",
+      "version": "1.0.0",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "2fda0d00e98aae2845d4991ab1bf1f2a199073d5",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.1": {
+      "name": "depd",
+      "version": "1.0.1",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "80aec64c9d6d97e65cc2a9caa93c0aa6abf73aaa",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.0": {
+      "name": "depd",
+      "version": "1.1.0",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "e1bd82c6aab6ced965b97b88b17ed3e528ca18c3",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.1": {
+      "name": "depd",
+      "version": "1.1.1",
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.7",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "5783b4e1c459f06fa5ca27f991f3d06e7a310359",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.2": {
+      "name": "depd",
+      "version": "1.1.2",
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.7",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "9bcd52e14c097763e749b274c4346ed2e560b5a9",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.0": {
+      "name": "depd",
+      "version": "2.0.0",
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "5.7.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.7",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "5.2.0",
+        "safe-buffer": "5.1.2",
+        "uid-safe": "2.1.5"
+      },
+      "dist": {
+        "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+        "shasum": "b696163cc757560d09cf22cc8fad1571b79e76df",
+        "tarball": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 27117,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb01R4CRA9TVsSAnZWagAArWcP/jPqhJPVwB4A7UlP7Z79\nKmkIJRegTXb8sBTkFdL8t5TDikX47CViz3qWSktGdJnwY4q/GnLHeOr/+eq6\nXVvkSKLrpOdmDBYbf7DxVepxbWOLVSCAshlnw6XPXhcqOKd2smn1CPA/hgRj\n26YvwMECmyIlcE5RgubUvN4qqOyMhGF7muWjCbqRq3qcGK7hXUqEnrlHxHsY\ndKCnzRw0HbfxYX2QynmyRL1Y9ynQuq2ucTDxuhQf78ElkHAsbSYaEks9unYG\nWGhU8zH4TGOcLrmJ6GsKhZk22JvnxCg3zwgqLwks2EFiG1iojPD4EkjZgcnJ\nt8meOu2nT8JCa6fNpPMWUpYO1aUKmhoOb5KGyMhSsNX/DND+ndSu0kOP9gU1\nCetsBqRTHHH3jUK/NmyAvzMO0X8mk/FxzI+NTqKQKt8r2/Y5IW4A6oDkaRkr\nPSu1s1DpT5mw9gHBA7K0YKuVr6HwQVnd/1io+OyUmNarjXm2lMaXucpZG3+Q\ncWpj4FyrD0vf+/bV9LKTXee3qAJ9UEGNvhJAKUrGTR8vtdM6uMxLnsBe42hR\nsRM2dJ8KnMujdw+lH+sgjtqcYP/G1Gz2cRtfbVWTrc/olODQPBpu2ycIY0nc\ncejka3bMbVHzYaY7+ho/9SfbE/6x9LRlmcHSEiPzUHRSpYY3pskktQDM0bBo\nm15/\r\n=BUpb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-01-02T20:56:15.578Z"
+}

--- a/test/fixtures/registry-mocks/content/des.js.json
+++ b/test/fixtures/registry-mocks/content/des.js.json
@@ -1,0 +1,170 @@
+{
+  "_id": "des.js",
+  "_rev": "3-89143f41699fe089a67faf876f9c2190",
+  "name": "des.js",
+  "description": "DES implementation",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "des.js",
+      "version": "1.0.0",
+      "description": "DES implementation",
+      "main": "lib/des.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && jscs lib/*.js lib/**/*.js test/*.js && jshint lib/*.js lib/**/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/des.js.git"
+      },
+      "keywords": [
+        "DES",
+        "3DES",
+        "EDE",
+        "CBC"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/des.js/issues"
+      },
+      "homepage": "https://github.com/indutny/des.js#readme",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.3.0"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "6c47a16b5507a11942c293a0ded430708c206218",
+      "_id": "des.js@1.0.0",
+      "_shasum": "c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc",
+        "tarball": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "des.js",
+      "version": "1.0.1",
+      "description": "DES implementation",
+      "main": "lib/des.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && jscs lib/*.js lib/**/*.js test/*.js && jshint lib/*.js lib/**/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/des.js.git"
+      },
+      "keywords": [
+        "DES",
+        "3DES",
+        "EDE",
+        "CBC"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/des.js/issues"
+      },
+      "homepage": "https://github.com/indutny/des.js#readme",
+      "devDependencies": {
+        "jscs": "^3.0.7",
+        "jshint": "^2.8.0",
+        "mocha": "^6.2.2"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "f2050549153c67518a06e7ee8972cbe51cf7e180",
+      "_id": "des.js@1.0.1",
+      "_nodeVersion": "12.11.0",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+        "shasum": "5382142e1bdc53f85d86d53e5f4aa7deb91e0843",
+        "tarball": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+        "fileCount": 15,
+        "unpackedSize": 38611,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyvZ6CRA9TVsSAnZWagAAOSAP/108dd5fET+MfHvnYPGo\nlLcru8XAAhfP5eoQO4Ost5lIQG1o5GzTjnoFFRDHWt/xDfoa/XWhYeHQxfNJ\nXfLm7r8sVaMjraGlkDEIIcNAnmH9RPoLiw/ND/uaGErNPS/cGDw6Cq6r/v1l\ne+up49Yhn3+CfA3MkGVefQj/ceIgjKy5H371yLq2KWC+rPBopFnE3oJGyywW\ni5fn4KkTUd5OIc/YaprkPMfQspuDP6LUXOuth0pROSTKsUusj3YUoB0cV0g2\nZwRTe00rqS/kGmpgsLR1twz7D6O4rfs8Z3nBsjZqiDAinb4G/6pMxyXLE4np\nkB8jIRZf0zExiKlo5idy7O1QcFbNA6ZWQnkq51k92nzXwcUzfhdTy8IJaiwJ\n9cd5E9JTpV1/BxT98O08gWTKei9mPGb3/CZjLK/XmhFaq/JXvjiFnCIBk2w/\ntB8i+eP8ACjyXSxUh7xN8oWtrWzbwOHGxKxyqrEJ3yoy8n+QYGK0WGsn4xi/\nY3Av38VN+BZ4N8ov/w3ceYf+msCDazVnkeXsRD4RKNI5QXL9043Jo0r2Irul\nkGkbqNeZvOha5wMl79kOO8QIeXNjjryWYxQjr7yT2KZFXOYYMSVolxbY5WtL\ni2DdUSqkQ19bl3wvN8NY7rjshslta3KdoivX8NnI3lmI/Ib/31VnN/qct51P\nOLxW\r\n=OzBR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/des.js_1.0.1_1573582458086_0.04203782146589097"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# DES.js\n\n## LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2015.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-11-12T18:14:20.962Z",
+    "created": "2015-09-07T03:01:39.276Z",
+    "1.0.0": "2015-09-07T03:01:39.276Z",
+    "1.0.1": "2019-11-12T18:14:18.241Z"
+  },
+  "homepage": "https://github.com/indutny/des.js#readme",
+  "keywords": [
+    "DES",
+    "3DES",
+    "EDE",
+    "CBC"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/des.js.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/des.js/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "shuoshubao": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/des.js.min.json
+++ b/test/fixtures/registry-mocks/content/des.js.min.json
@@ -1,0 +1,47 @@
+{
+  "name": "des.js",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "des.js",
+      "version": "1.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.3.0"
+      },
+      "dist": {
+        "shasum": "c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc",
+        "tarball": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "des.js",
+      "version": "1.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^3.0.7",
+        "jshint": "^2.8.0",
+        "mocha": "^6.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+        "shasum": "5382142e1bdc53f85d86d53e5f4aa7deb91e0843",
+        "tarball": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+        "fileCount": 15,
+        "unpackedSize": 38611,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyvZ6CRA9TVsSAnZWagAAOSAP/108dd5fET+MfHvnYPGo\nlLcru8XAAhfP5eoQO4Ost5lIQG1o5GzTjnoFFRDHWt/xDfoa/XWhYeHQxfNJ\nXfLm7r8sVaMjraGlkDEIIcNAnmH9RPoLiw/ND/uaGErNPS/cGDw6Cq6r/v1l\ne+up49Yhn3+CfA3MkGVefQj/ceIgjKy5H371yLq2KWC+rPBopFnE3oJGyywW\ni5fn4KkTUd5OIc/YaprkPMfQspuDP6LUXOuth0pROSTKsUusj3YUoB0cV0g2\nZwRTe00rqS/kGmpgsLR1twz7D6O4rfs8Z3nBsjZqiDAinb4G/6pMxyXLE4np\nkB8jIRZf0zExiKlo5idy7O1QcFbNA6ZWQnkq51k92nzXwcUzfhdTy8IJaiwJ\n9cd5E9JTpV1/BxT98O08gWTKei9mPGb3/CZjLK/XmhFaq/JXvjiFnCIBk2w/\ntB8i+eP8ACjyXSxUh7xN8oWtrWzbwOHGxKxyqrEJ3yoy8n+QYGK0WGsn4xi/\nY3Av38VN+BZ4N8ov/w3ceYf+msCDazVnkeXsRD4RKNI5QXL9043Jo0r2Irul\nkGkbqNeZvOha5wMl79kOO8QIeXNjjryWYxQjr7yT2KZFXOYYMSVolxbY5WtL\ni2DdUSqkQ19bl3wvN8NY7rjshslta3KdoivX8NnI3lmI/Ib/31VnN/qct51P\nOLxW\r\n=OzBR\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-11-12T18:14:20.962Z"
+}

--- a/test/fixtures/registry-mocks/content/destroy.json
+++ b/test/fixtures/registry-mocks/content/destroy.json
@@ -1,0 +1,200 @@
+{
+  "_id": "destroy",
+  "_rev": "15-67c674574129014022d2ef18d6bf3072",
+  "name": "destroy",
+  "time": {
+    "modified": "2017-05-22T14:30:27.084Z",
+    "created": "2013-10-03T17:12:42.209Z",
+    "0.0.0": "2013-10-03T17:12:45.167Z",
+    "1.0.3": "2014-08-15T06:30:06.962Z",
+    "1.0.4": "2016-01-16T03:14:05.899Z"
+  },
+  "maintainers": [
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    },
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    }
+  ],
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "description": "destroy a stream if possible",
+  "readme": "# Destroy\n\n[![NPM version][npm-image]][npm-url]\n[![Build status][travis-image]][travis-url]\n[![Test coverage][coveralls-image]][coveralls-url]\n[![License][license-image]][license-url]\n[![Downloads][downloads-image]][downloads-url]\n[![Gittip][gittip-image]][gittip-url]\n\nDestroy a stream.\n\nThis module is meant to ensure a stream gets destroyed, handling different APIs\nand Node.js bugs.\n\n## API\n\n```js\nvar destroy = require('destroy')\n```\n\n### destroy(stream)\n\nDestroy the given stream. In most cases, this is identical to a simple\n`stream.destroy()` call. The rules are as follows for a given stream:\n\n  1. If the `stream` is an instance of `ReadStream`, then call `stream.destroy()`\n     and add a listener to the `open` event to call `stream.close()` if it is\n     fired. This is for a Node.js bug that will leak a file descriptor if\n     `.destroy()` is called before `open`.\n  2. If the `stream` is not an instance of `Stream`, then nothing happens.\n  3. If the `stream` has a `.destroy()` method, then call it.\n\nThe function returns the `stream` passed in as the argument.\n\n## Example\n\n```js\nvar destroy = require('destroy')\n\nvar fs = require('fs')\nvar stream = fs.createReadStream('package.json')\n\n// ... and later\ndestroy(stream)\n```\n\n[npm-image]: https://img.shields.io/npm/v/destroy.svg?style=flat-square\n[npm-url]: https://npmjs.org/package/destroy\n[github-tag]: http://img.shields.io/github/tag/stream-utils/destroy.svg?style=flat-square\n[github-url]: https://github.com/stream-utils/destroy/tags\n[travis-image]: https://img.shields.io/travis/stream-utils/destroy.svg?style=flat-square\n[travis-url]: https://travis-ci.org/stream-utils/destroy\n[coveralls-image]: https://img.shields.io/coveralls/stream-utils/destroy.svg?style=flat-square\n[coveralls-url]: https://coveralls.io/r/stream-utils/destroy?branch=master\n[license-image]: http://img.shields.io/npm/l/destroy.svg?style=flat-square\n[license-url]: LICENSE.md\n[downloads-image]: http://img.shields.io/npm/dm/destroy.svg?style=flat-square\n[downloads-url]: https://npmjs.org/package/destroy\n[gittip-image]: https://img.shields.io/gittip/jonathanong.svg?style=flat-square\n[gittip-url]: https://www.gittip.com/jonathanong/\n",
+  "versions": {
+    "1.0.3": {
+      "name": "destroy",
+      "description": "destroy a stream if possible",
+      "version": "1.0.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/destroy"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "stream",
+        "streams",
+        "destroy",
+        "cleanup",
+        "leak",
+        "fd"
+      ],
+      "gitHead": "50af95ece4a70202f9301bc3edc8f9fdbbad0f26",
+      "bugs": {
+        "url": "https://github.com/stream-utils/destroy/issues"
+      },
+      "homepage": "https://github.com/stream-utils/destroy",
+      "_id": "destroy@1.0.3",
+      "_shasum": "b433b4724e71fd8551d9885174851c5fc377e2c9",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b433b4724e71fd8551d9885174851c5fc377e2c9",
+        "tarball": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "destroy",
+      "description": "destroy a stream if possible",
+      "version": "1.0.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/destroy"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "keywords": [
+        "stream",
+        "streams",
+        "destroy",
+        "cleanup",
+        "leak",
+        "fd"
+      ],
+      "gitHead": "86edea01456f5fa1027f6a47250c34c713cbcc3b",
+      "bugs": {
+        "url": "https://github.com/stream-utils/destroy/issues"
+      },
+      "homepage": "https://github.com/stream-utils/destroy",
+      "_id": "destroy@1.0.4",
+      "_shasum": "978857442c44749e4206613e37946205826abd80",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "978857442c44749e4206613e37946205826abd80",
+        "tarball": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "homepage": "https://github.com/stream-utils/destroy",
+  "keywords": [
+    "stream",
+    "streams",
+    "destroy",
+    "cleanup",
+    "leak",
+    "fd"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stream-utils/destroy"
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "author": {
+    "name": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com"
+  },
+  "bugs": {
+    "url": "https://github.com/stream-utils/destroy/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "goodseller": true,
+    "kankungyip": true,
+    "mojaray2k": true,
+    "chaoliu": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/destroy.min.json
+++ b/test/fixtures/registry-mocks/content/destroy.min.json
@@ -1,0 +1,33 @@
+{
+  "name": "destroy",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "1.0.3": {
+      "name": "destroy",
+      "version": "1.0.3",
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "b433b4724e71fd8551d9885174851c5fc377e2c9",
+        "tarball": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "destroy",
+      "version": "1.0.4",
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4"
+      },
+      "dist": {
+        "shasum": "978857442c44749e4206613e37946205826abd80",
+        "tarball": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+      }
+    }
+  },
+  "modified": "2017-05-22T14:30:27.084Z"
+}

--- a/test/fixtures/registry-mocks/content/detect-node.json
+++ b/test/fixtures/registry-mocks/content/detect-node.json
@@ -1,0 +1,326 @@
+{
+  "_id": "detect-node",
+  "_rev": "14-a2d69a62996b39bd5394e0f0baf686a7",
+  "name": "detect-node",
+  "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
+  "dist-tags": {
+    "latest": "2.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "detect-node",
+      "version": "1.0.0",
+      "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/iliakan/detect-node"
+      },
+      "keywords": [
+        "detect",
+        "node"
+      ],
+      "author": {
+        "name": "Ilya Kantor"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iliakan/detect-node/issues"
+      },
+      "homepage": "https://github.com/iliakan/detect-node",
+      "_id": "detect-node@1.0.0",
+      "_shasum": "0dce710909dcb78d46a44889f8b78c983d27f1df",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "iliakan",
+        "email": "iliakan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "iliakan",
+          "email": "iliakan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0dce710909dcb78d46a44889f8b78c983d27f1df",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "detect-node",
+      "version": "2.0.0",
+      "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/iliakan/detect-node"
+      },
+      "keywords": [
+        "detect",
+        "node"
+      ],
+      "author": {
+        "name": "Ilya Kantor"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iliakan/detect-node/issues"
+      },
+      "homepage": "https://github.com/iliakan/detect-node",
+      "gitHead": "3e1d2591bdbf5e3ac1d36f4b81ddb91f37fc2280",
+      "_id": "detect-node@2.0.0",
+      "_shasum": "5ed01329818006b14a19ac8f68ec1e1a65cce725",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "iliakan",
+        "email": "iliakan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "iliakan",
+          "email": "iliakan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5ed01329818006b14a19ac8f68ec1e1a65cce725",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "detect-node",
+      "version": "2.0.1",
+      "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/iliakan/detect-node"
+      },
+      "keywords": [
+        "detect",
+        "node"
+      ],
+      "author": {
+        "name": "Ilya Kantor"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iliakan/detect-node/issues"
+      },
+      "homepage": "https://github.com/iliakan/detect-node",
+      "_id": "detect-node@2.0.1",
+      "_shasum": "d10f1b84000e46670f9f3d1456d92d07a3ac3bdf",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "iliakan",
+        "email": "iliakan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "iliakan",
+          "email": "iliakan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d10f1b84000e46670f9f3d1456d92d07a3ac3bdf",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "detect-node",
+      "version": "2.0.2",
+      "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/iliakan/detect-node"
+      },
+      "keywords": [
+        "detect",
+        "node"
+      ],
+      "author": {
+        "name": "Ilya Kantor"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iliakan/detect-node/issues"
+      },
+      "homepage": "https://github.com/iliakan/detect-node",
+      "_id": "detect-node@2.0.2",
+      "_shasum": "1d35ceac9f2b4becc5e8eae0f46a70c730e921f5",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "iliakan",
+        "email": "iliakan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "iliakan",
+          "email": "iliakan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1d35ceac9f2b4becc5e8eae0f46a70c730e921f5",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "detect-node",
+      "version": "2.0.3",
+      "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/iliakan/detect-node"
+      },
+      "keywords": [
+        "detect",
+        "node"
+      ],
+      "author": {
+        "name": "Ilya Kantor"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iliakan/detect-node/issues"
+      },
+      "homepage": "https://github.com/iliakan/detect-node",
+      "gitHead": "4837fa0620d2e8db948a718a8b5f89a8073c8ff4",
+      "_id": "detect-node@2.0.3",
+      "_shasum": "a2033c09cc8e158d37748fbde7507832bd6ce127",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "iliakan",
+        "email": "iliakan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "iliakan",
+          "email": "iliakan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a2033c09cc8e158d37748fbde7507832bd6ce127",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "detect-node",
+      "version": "2.0.4",
+      "description": "Detect Node.JS (as opposite to browser environment) (reliable)",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iliakan/detect-node.git"
+      },
+      "keywords": [
+        "detect",
+        "node"
+      ],
+      "author": {
+        "name": "Ilya Kantor"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iliakan/detect-node/issues"
+      },
+      "homepage": "https://github.com/iliakan/detect-node",
+      "gitHead": "563e0b838ec1dd9b169d843268cdb220b78ddd91",
+      "_id": "detect-node@2.0.4",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "iliakan",
+        "email": "iliakan@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+        "shasum": "014ee8f8f669c5c58023da64b8179c083a28c46c",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 2549,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbiWQ3CRA9TVsSAnZWagAAMrwQAJUWqhr3R8fUX9E2H04D\nNcoFtX6tYlFDUWz7AegYBpyj8E2c85Osf16LOM/WCAYhusmIw0kkEfd1suU2\nw7tXK+hQeDvQvhh5WGXqT88fI6UY33ryXHK4/J6QX5k1AXMO4jm74EQ8hXCs\nINjy6O+DC2CEni+CgUgxxU1CmIABcRGaB7WIwFOuwlgaHo7QRUnVnpqeZ6ZN\n7RpVE+3ucJjvCW1s5d/6pLYiRoRZIfudBMRD9OYkdvFGzQ71BKo7AhPQa4Bz\n5w8g3i0UQ6sx7RSYrWNeXRlrAD798fwvGtXsUwIkUE9QJzfT+k5jdHS/aFJT\n3cIIq4+jwV9ODJkkGxmILaWRpuBLpHI+syh3/Xmb113bB1QpcLij1BXJS8sN\ncR1xnLlD72CuFYuAeDkxsTk47D+mK0IDVWa9HgDi8D7IqBSwNOZLW1tuddql\nThwQWn6KIzzCzMKlBajt0rqyIUt5J4kLVXVS7wKvJRQhyaCrguFrdE4jbsjy\npCoqBydwvtrBnLlydr0WbNE94xoLPudJPlxjnyWrAd/MmjvI3RfhAAM+oQkE\n6s00+x2fx2cT51wjX/w+STN5CvNLGZerpTM0xgZmztwB2aWUVBybvAxdtW4F\nhaIf21JXHvTl5F8UXqKHD4dv6mB1w9X1ZcDYZ/hxetoj70xhevfvmFGZ3mVs\n6W0B\r\n=HQIg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iliakan",
+          "email": "iliakan@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/detect-node_2.0.4_1535730743130_0.9044559921683464"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "### Install\n\n```shell\nnpm install --save detect-node\n```\n\n### Usage:\n\n```js\nvar isNode = require('detect-node');\n\nif (isNode) {\n  console.log(\"Running under Node.JS\");\n} else {\n  alert(\"Hello from browser (or whatever not-a-node env)\");\n}\n```\n\nThe check is performed as:\n```js\nmodule.exports = false;\n\n// Only Node.JS has a process variable that is of [[Class]] process\ntry {\n module.exports = Object.prototype.toString.call(global.process) === '[object process]' \n} catch(e) {}\n\n```\n\nThanks to Ingvar Stepanyan for the initial idea. This check is both **the most reliable I could find** and it does not use `process` env directly, which would cause browserify to include it into the build.\n",
+  "maintainers": [
+    {
+      "name": "iliakan",
+      "email": "iliakan@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-02T21:18:08.875Z",
+    "created": "2014-07-31T10:20:21.252Z",
+    "1.0.0": "2014-07-31T10:20:21.252Z",
+    "2.0.0": "2014-07-31T10:30:55.255Z",
+    "2.0.1": "2014-07-31T10:34:58.862Z",
+    "2.0.2": "2014-07-31T10:36:39.833Z",
+    "2.0.3": "2014-08-01T16:28:40.851Z",
+    "2.0.4": "2018-08-31T15:52:23.291Z"
+  },
+  "homepage": "https://github.com/iliakan/detect-node",
+  "keywords": [
+    "detect",
+    "node"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iliakan/detect-node.git"
+  },
+  "author": {
+    "name": "Ilya Kantor"
+  },
+  "bugs": {
+    "url": "https://github.com/iliakan/detect-node/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "Readme.md",
+  "users": {
+    "xch": true,
+    "i-erokhin": true,
+    "cliff": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/detect-node.min.json
+++ b/test/fixtures/registry-mocks/content/detect-node.min.json
@@ -1,0 +1,61 @@
+{
+  "name": "detect-node",
+  "dist-tags": {
+    "latest": "2.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "detect-node",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "0dce710909dcb78d46a44889f8b78c983d27f1df",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "detect-node",
+      "version": "2.0.0",
+      "dist": {
+        "shasum": "5ed01329818006b14a19ac8f68ec1e1a65cce725",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "detect-node",
+      "version": "2.0.1",
+      "dist": {
+        "shasum": "d10f1b84000e46670f9f3d1456d92d07a3ac3bdf",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "detect-node",
+      "version": "2.0.2",
+      "dist": {
+        "shasum": "1d35ceac9f2b4becc5e8eae0f46a70c730e921f5",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "detect-node",
+      "version": "2.0.3",
+      "dist": {
+        "shasum": "a2033c09cc8e158d37748fbde7507832bd6ce127",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz"
+      }
+    },
+    "2.0.4": {
+      "name": "detect-node",
+      "version": "2.0.4",
+      "dist": {
+        "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
+        "shasum": "014ee8f8f669c5c58023da64b8179c083a28c46c",
+        "tarball": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 2549,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbiWQ3CRA9TVsSAnZWagAAMrwQAJUWqhr3R8fUX9E2H04D\nNcoFtX6tYlFDUWz7AegYBpyj8E2c85Osf16LOM/WCAYhusmIw0kkEfd1suU2\nw7tXK+hQeDvQvhh5WGXqT88fI6UY33ryXHK4/J6QX5k1AXMO4jm74EQ8hXCs\nINjy6O+DC2CEni+CgUgxxU1CmIABcRGaB7WIwFOuwlgaHo7QRUnVnpqeZ6ZN\n7RpVE+3ucJjvCW1s5d/6pLYiRoRZIfudBMRD9OYkdvFGzQ71BKo7AhPQa4Bz\n5w8g3i0UQ6sx7RSYrWNeXRlrAD798fwvGtXsUwIkUE9QJzfT+k5jdHS/aFJT\n3cIIq4+jwV9ODJkkGxmILaWRpuBLpHI+syh3/Xmb113bB1QpcLij1BXJS8sN\ncR1xnLlD72CuFYuAeDkxsTk47D+mK0IDVWa9HgDi8D7IqBSwNOZLW1tuddql\nThwQWn6KIzzCzMKlBajt0rqyIUt5J4kLVXVS7wKvJRQhyaCrguFrdE4jbsjy\npCoqBydwvtrBnLlydr0WbNE94xoLPudJPlxjnyWrAd/MmjvI3RfhAAM+oQkE\n6s00+x2fx2cT51wjX/w+STN5CvNLGZerpTM0xgZmztwB2aWUVBybvAxdtW4F\nhaIf21JXHvTl5F8UXqKHD4dv6mB1w9X1ZcDYZ/hxetoj70xhevfvmFGZ3mVs\n6W0B\r\n=HQIg\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-01-02T21:18:08.875Z"
+}

--- a/test/fixtures/registry-mocks/content/diffie-hellman.json
+++ b/test/fixtures/registry-mocks/content/diffie-hellman.json
@@ -1,0 +1,1362 @@
+{
+  "_id": "diffie-hellman",
+  "_rev": "48-c64ebbe947cfbf77a2ba28ff9358856d",
+  "name": "diffie-hellman",
+  "description": "pure js diffie-hellman",
+  "dist-tags": {
+    "latest": "5.0.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "diffie-hellman",
+      "version": "1.0.0",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "gitHead": "923fdc540603443b7da981094c8906f722ce1ef8",
+      "_id": "diffie-hellman@1.0.0",
+      "_shasum": "5322995a62db56d27da61e66243ebbe0f625bc0e",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5322995a62db56d27da61e66243ebbe0f625bc0e",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "diffie-hellman",
+      "version": "1.0.1",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "gitHead": "cb5c7cc72c2a2f76534f9b248aed13f42238347d",
+      "_id": "diffie-hellman@1.0.1",
+      "_shasum": "9fb7008b97b50d760879a4857e7ff17f1b6e34d3",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9fb7008b97b50d760879a4857e7ff17f1b6e34d3",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "diffie-hellman",
+      "version": "1.0.2",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "bea4bc80cb78848609d916ba09eb35c33b83ec9e",
+      "_id": "diffie-hellman@1.0.2",
+      "_shasum": "739d956f3eea8655bc78a06f0eecdd7732d19a3c",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "739d956f3eea8655bc78a06f0eecdd7732d19a3c",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "diffie-hellman",
+      "version": "1.0.3",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "_id": "diffie-hellman@1.0.3",
+      "dist": {
+        "shasum": "60afd81fec7cb37663291d2a7707f9bfc4e742ce",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "diffie-hellman",
+      "version": "1.1.0",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "_id": "diffie-hellman@1.1.0",
+      "dist": {
+        "shasum": "8e966bbc16c36e3b28e1e8e541b524c6135cd4e5",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "diffie-hellman",
+      "version": "1.1.1",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "0.15.2"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "_id": "diffie-hellman@1.1.1",
+      "dist": {
+        "shasum": "22fe0c522f11e3e1eba649dd33b88869dab84230",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "diffie-hellman",
+      "version": "1.1.2",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "0.15.2"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "_id": "diffie-hellman@1.1.2",
+      "dist": {
+        "shasum": "a1b3e9ca89f4e6d1e7198a05549afc6096d7c4c0",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "diffie-hellman",
+      "version": "2.0.0",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "0.15.2",
+        "miller-rabin": "^1.1.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "6b749680cd5d0228aef962069b99f0c7471b5e1b",
+      "_id": "diffie-hellman@2.0.0",
+      "_shasum": "67ea1d0cbb0a10d332b5098fb9643fa82408c5d4",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "67ea1d0cbb0a10d332b5098fb9643fa82408c5d4",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "diffie-hellman",
+      "version": "2.1.0",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "0.15.2",
+        "miller-rabin": "^1.1.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "54f928f1e69b828a0429fecb7a641c314a6231bd",
+      "_id": "diffie-hellman@2.1.0",
+      "_shasum": "2d755b0d30e38251ce3529bd7f4ba97633e2f75b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2d755b0d30e38251ce3529bd7f4ba97633e2f75b",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "diffie-hellman",
+      "version": "2.2.0",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "0.15.2",
+        "miller-rabin": "^1.1.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "cf41a506bfcf82f8578bb570a042af22004a7483",
+      "_id": "diffie-hellman@2.2.0",
+      "_shasum": "8072c466fbfb68e7898a84c56e53bc4e71a4c2e2",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8072c466fbfb68e7898a84c56e53bc4e71a4c2e2",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.1": {
+      "name": "diffie-hellman",
+      "version": "2.2.1",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "0.15.2",
+        "miller-rabin": "^1.1.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "f74fe5cba61322f9b111b0f020dc2ce5f226be00",
+      "_id": "diffie-hellman@2.2.1",
+      "_shasum": "3dbd6ccd24f02229c3a6e6798da3aec578b096c5",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3dbd6ccd24f02229c3a6e6798da3aec578b096c5",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.2": {
+      "name": "diffie-hellman",
+      "version": "2.2.2",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "miller-rabin": "^1.1.2"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "8c436ba336b29de1304fc317079e89093a1b3a42",
+      "_id": "diffie-hellman@2.2.2",
+      "_shasum": "1f79b67f0e3ecaf34bddca5af3ffd34b4cb81f43",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1f79b67f0e3ecaf34bddca5af3ffd34b4cb81f43",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.3": {
+      "name": "diffie-hellman",
+      "version": "2.2.3",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "miller-rabin": "^1.1.2"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "7d8de94705545661426506068ba83f2d393fdf36",
+      "_id": "diffie-hellman@2.2.3",
+      "_shasum": "aaf1edb9ed285d91374fba8a1d0f5204681e529a",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "aaf1edb9ed285d91374fba8a1d0f5204681e529a",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "diffie-hellman",
+      "version": "3.0.0",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "miller-rabin": "^1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "a18c751bd9a61f437f4d9920824554a4f1e8cd3f",
+      "_id": "diffie-hellman@3.0.0",
+      "_shasum": "3a261d93f55030cba398cb9d92f802a4d9574102",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3a261d93f55030cba398cb9d92f802a4d9574102",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "diffie-hellman",
+      "version": "3.0.1",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "miller-rabin": "^1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "10bb57dbcc32100acf71adc4c8dd1137bc17a1e5",
+      "_id": "diffie-hellman@3.0.1",
+      "_shasum": "13be8fc4ad657278408cd796b554a93e586ed66a",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "13be8fc4ad657278408cd796b554a93e586ed66a",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "diffie-hellman",
+      "version": "3.0.2",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "miller-rabin": "^2.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "d08366d473d086bd14fb75d8f7b12ea6de312452",
+      "_id": "diffie-hellman@3.0.2",
+      "_shasum": "2a565afb1e03589cd284c010d6ebf8077b2886d7",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2a565afb1e03589cd284c010d6ebf8077b2886d7",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "diffie-hellman",
+      "version": "4.0.0",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^3.2.0",
+        "miller-rabin": "^3.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "65776f8ccc06e2646d6009a55a6e8ff85f41145e",
+      "_id": "diffie-hellman@4.0.0",
+      "_shasum": "8e1481f15d6eec06543cdfee60d102a3dbd2d49c",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "3.3.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "8e1481f15d6eec06543cdfee60d102a3dbd2d49c",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "diffie-hellman",
+      "version": "5.0.0",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "e101e19b5e80534349595219acdea808e5ed436a",
+      "_id": "diffie-hellman@5.0.0",
+      "_shasum": "f3c957cfd5419fea048540b39a751d7e4363f031",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "f3c957cfd5419fea048540b39a751d7e4363f031",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.0.1": {
+      "name": "diffie-hellman",
+      "version": "5.0.1",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "6f9fd04569406cd822075efa4a4a2dc82236dda4",
+      "_id": "diffie-hellman@5.0.1",
+      "_shasum": "d33ea6360060e39e321b7b24125694ceda7bd29b",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "d33ea6360060e39e321b7b24125694ceda7bd29b",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.0.2": {
+      "name": "diffie-hellman",
+      "version": "5.0.2",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "6a58413e1004b48425b28fb337187db00c2d83c0",
+      "_id": "diffie-hellman@5.0.2",
+      "_shasum": "b5835739270cfe26acf632099fded2a07f209e5e",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "b5835739270cfe26acf632099fded2a07f209e5e",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.0.3": {
+      "name": "diffie-hellman",
+      "version": "5.0.3",
+      "description": "pure js diffie-hellman",
+      "main": "index.js",
+      "browser": "browser.js",
+      "scripts": {
+        "test": "node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/diffie-hellman.git"
+      },
+      "keywords": [
+        "diffie",
+        "hellman",
+        "diffiehellman",
+        "dh"
+      ],
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "gitHead": "d795c01543385196e44f6d8218ba6f9b5621d4b0",
+      "_id": "diffie-hellman@5.0.3",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+        "shasum": "40e8ee98f55a2149607146921c63e1ae5f3d2875",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+        "fileCount": 9,
+        "unpackedSize": 17297
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/diffie-hellman_5.0.3_1523448210144_0.25747828831545383"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "diffie hellman [![Build Status](https://travis-ci.org/crypto-browserify/diffie-hellman.svg)](https://travis-ci.org/crypto-browserify/diffie-hellman)\n====\n\npure js diffie-hellman, same api as node, most hard parts thanks to [bn.js](https://www.npmjs.org/package/bn.js) by [@indutny](https://github.com/indutny).  In node just returns an object with `crypto.createDiffieHellman` and `crypto.getDiffieHellman` in the browser returns a shim. To require the pure JavaScript one in node `require('diffie-hellman/browser');`;",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-02T22:10:21.673Z",
+    "created": "2014-11-02T22:53:35.595Z",
+    "1.0.0": "2014-11-02T22:53:35.595Z",
+    "1.0.1": "2014-11-02T23:00:58.769Z",
+    "1.0.2": "2014-11-03T01:05:47.090Z",
+    "1.0.3": "2014-11-04T15:24:05.885Z",
+    "1.1.0": "2014-11-05T14:37:41.895Z",
+    "1.1.1": "2014-11-07T12:54:56.929Z",
+    "1.1.2": "2014-11-07T13:31:06.367Z",
+    "2.0.0": "2014-11-16T19:46:25.817Z",
+    "2.1.0": "2014-11-16T20:29:47.875Z",
+    "2.2.0": "2014-11-16T20:36:42.592Z",
+    "2.2.1": "2014-12-03T20:46:51.469Z",
+    "2.2.2": "2015-01-03T13:27:45.222Z",
+    "2.2.3": "2015-01-06T12:40:04.002Z",
+    "3.0.0": "2015-01-21T12:11:25.510Z",
+    "3.0.1": "2015-01-27T13:21:27.158Z",
+    "3.0.2": "2015-05-21T02:56:37.669Z",
+    "4.0.0": "2015-10-27T09:06:49.549Z",
+    "5.0.0": "2015-10-29T13:08:35.076Z",
+    "5.0.1": "2016-01-12T15:38:27.562Z",
+    "5.0.2": "2016-01-26T14:00:44.523Z",
+    "5.0.3": "2018-04-11T12:03:30.207Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/diffie-hellman",
+  "keywords": [
+    "diffie",
+    "hellman",
+    "diffiehellman",
+    "dh"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/diffie-hellman.git"
+  },
+  "author": {
+    "name": "Calvin Metcalf"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/diffie-hellman/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "ryanj": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/diffie-hellman.min.json
+++ b/test/fixtures/registry-mocks/content/diffie-hellman.min.json
@@ -1,0 +1,338 @@
+{
+  "name": "diffie-hellman",
+  "dist-tags": {
+    "latest": "5.0.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "diffie-hellman",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "5322995a62db56d27da61e66243ebbe0f625bc0e",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "diffie-hellman",
+      "version": "1.0.1",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dist": {
+        "shasum": "9fb7008b97b50d760879a4857e7ff17f1b6e34d3",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "diffie-hellman",
+      "version": "1.0.2",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "739d956f3eea8655bc78a06f0eecdd7732d19a3c",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "diffie-hellman",
+      "version": "1.0.3",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "60afd81fec7cb37663291d2a7707f9bfc4e742ce",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.0.3.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "diffie-hellman",
+      "version": "1.1.0",
+      "dependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "8e966bbc16c36e3b28e1e8e541b524c6135cd4e5",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "diffie-hellman",
+      "version": "1.1.1",
+      "dependencies": {
+        "bn.js": "0.15.2"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "22fe0c522f11e3e1eba649dd33b88869dab84230",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "diffie-hellman",
+      "version": "1.1.2",
+      "dependencies": {
+        "bn.js": "0.15.2"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "a1b3e9ca89f4e6d1e7198a05549afc6096d7c4c0",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-1.1.2.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "diffie-hellman",
+      "version": "2.0.0",
+      "dependencies": {
+        "bn.js": "0.15.2",
+        "miller-rabin": "^1.1.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "67ea1d0cbb0a10d332b5098fb9643fa82408c5d4",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.0.0.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "diffie-hellman",
+      "version": "2.1.0",
+      "dependencies": {
+        "bn.js": "0.15.2",
+        "miller-rabin": "^1.1.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "2d755b0d30e38251ce3529bd7f4ba97633e2f75b",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.1.0.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "diffie-hellman",
+      "version": "2.2.0",
+      "dependencies": {
+        "bn.js": "0.15.2",
+        "miller-rabin": "^1.1.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "8072c466fbfb68e7898a84c56e53bc4e71a4c2e2",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.0.tgz"
+      }
+    },
+    "2.2.1": {
+      "name": "diffie-hellman",
+      "version": "2.2.1",
+      "dependencies": {
+        "bn.js": "0.15.2",
+        "miller-rabin": "^1.1.1"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "3dbd6ccd24f02229c3a6e6798da3aec578b096c5",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.1.tgz"
+      }
+    },
+    "2.2.2": {
+      "name": "diffie-hellman",
+      "version": "2.2.2",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "miller-rabin": "^1.1.2"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "1f79b67f0e3ecaf34bddca5af3ffd34b4cb81f43",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.2.tgz"
+      }
+    },
+    "2.2.3": {
+      "name": "diffie-hellman",
+      "version": "2.2.3",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "miller-rabin": "^1.1.2"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "aaf1edb9ed285d91374fba8a1d0f5204681e529a",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-2.2.3.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "diffie-hellman",
+      "version": "3.0.0",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "miller-rabin": "^1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "3a261d93f55030cba398cb9d92f802a4d9574102",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "diffie-hellman",
+      "version": "3.0.1",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "miller-rabin": "^1.1.2",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "13be8fc4ad657278408cd796b554a93e586ed66a",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz"
+      }
+    },
+    "3.0.2": {
+      "name": "diffie-hellman",
+      "version": "3.0.2",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "miller-rabin": "^2.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "2a565afb1e03589cd284c010d6ebf8077b2886d7",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-3.0.2.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "diffie-hellman",
+      "version": "4.0.0",
+      "dependencies": {
+        "bn.js": "^3.2.0",
+        "miller-rabin": "^3.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "8e1481f15d6eec06543cdfee60d102a3dbd2d49c",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-4.0.0.tgz"
+      }
+    },
+    "5.0.0": {
+      "name": "diffie-hellman",
+      "version": "5.0.0",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "f3c957cfd5419fea048540b39a751d7e4363f031",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.0.tgz"
+      }
+    },
+    "5.0.1": {
+      "name": "diffie-hellman",
+      "version": "5.0.1",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "d33ea6360060e39e321b7b24125694ceda7bd29b",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.1.tgz"
+      }
+    },
+    "5.0.2": {
+      "name": "diffie-hellman",
+      "version": "5.0.2",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "shasum": "b5835739270cfe26acf632099fded2a07f209e5e",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
+      }
+    },
+    "5.0.3": {
+      "name": "diffie-hellman",
+      "version": "5.0.3",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "devDependencies": {
+        "tap-spec": "^1.0.1",
+        "tape": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+        "shasum": "40e8ee98f55a2149607146921c63e1ae5f3d2875",
+        "tarball": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+        "fileCount": 9,
+        "unpackedSize": 17297
+      }
+    }
+  },
+  "modified": "2019-01-02T22:10:21.673Z"
+}

--- a/test/fixtures/registry-mocks/content/dns-equal.json
+++ b/test/fixtures/registry-mocks/content/dns-equal.json
@@ -1,0 +1,113 @@
+{
+  "_id": "dns-equal",
+  "_rev": "1-a8a0d343b162d65a852805b6ee2c669e",
+  "name": "dns-equal",
+  "description": "Compare DNS record strings for equality",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "dns-equal",
+      "version": "1.0.0",
+      "description": "Compare DNS record strings for equality",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^5.4.1"
+      },
+      "scripts": {
+        "test": "standard && node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/dns-equal.git"
+      },
+      "keywords": [
+        "dns",
+        "compare",
+        "comparing",
+        "equal",
+        "equality",
+        "match",
+        "downcase",
+        "lowercase",
+        "case-insensitive"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/dns-equal/issues"
+      },
+      "homepage": "https://github.com/watson/dns-equal#readme",
+      "coordinates": [
+        56.010004025953165,
+        11.961870541375674
+      ],
+      "gitHead": "0d9c5fe125484aff559da3c54431c80b4a622d55",
+      "_id": "dns-equal@1.0.0",
+      "_shasum": "b39e7f1da6eb0a75ba9c17324b34753c47e0654d",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "b39e7f1da6eb0a75ba9c17324b34753c47e0654d",
+        "tarball": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# dns-equal\n\nCompare DNS record strings for equality. Enforces [RFC\n1035](https://tools.ietf.org/html/rfc1035) domain comparison.\n\n[![Build status](https://travis-ci.org/watson/dns-equal.svg?branch=master)](https://travis-ci.org/watson/dns-equal)\n[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)\n\n## Installation\n\n```\nnpm install dns-equal --save\n```\n\n## Usage\n\n```js\nvar dnsEqual = require('dns-equal')\n\nvar domain1 = 'Example.COM'\nvar domain2 = 'example.com'\n\nif (dnsEqual(domain1, domain2)) {\n  console.log('The two domains are the same')\n}\n```\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "watson",
+      "email": "w@tson.dk"
+    }
+  ],
+  "time": {
+    "modified": "2016-01-10T16:46:59.170Z",
+    "created": "2016-01-10T16:46:59.170Z",
+    "1.0.0": "2016-01-10T16:46:59.170Z"
+  },
+  "homepage": "https://github.com/watson/dns-equal#readme",
+  "keywords": [
+    "dns",
+    "compare",
+    "comparing",
+    "equal",
+    "equality",
+    "match",
+    "downcase",
+    "lowercase",
+    "case-insensitive"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/watson/dns-equal.git"
+  },
+  "author": {
+    "name": "Thomas Watson Steen",
+    "email": "w@tson.dk",
+    "url": "https://twitter.com/wa7son"
+  },
+  "bugs": {
+    "url": "https://github.com/watson/dns-equal/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/dns-equal.min.json
+++ b/test/fixtures/registry-mocks/content/dns-equal.min.json
@@ -1,0 +1,20 @@
+{
+  "name": "dns-equal",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "dns-equal",
+      "version": "1.0.0",
+      "devDependencies": {
+        "standard": "^5.4.1"
+      },
+      "dist": {
+        "shasum": "b39e7f1da6eb0a75ba9c17324b34753c47e0654d",
+        "tarball": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz"
+      }
+    }
+  },
+  "modified": "2016-01-10T16:46:59.170Z"
+}

--- a/test/fixtures/registry-mocks/content/dns-packet.json
+++ b/test/fixtures/registry-mocks/content/dns-packet.json
@@ -1,0 +1,2050 @@
+{
+  "_id": "dns-packet",
+  "_rev": "30-20f7f8874480341c2495c314c29c8c47",
+  "name": "dns-packet",
+  "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+  "dist-tags": {
+    "latest": "5.2.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "dns-packet",
+      "version": "1.0.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/dns-packet"
+      },
+      "dependencies": {
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "73df75ad3981b2b225d35c693c49a1a85333336c",
+      "_id": "dns-packet@1.0.0",
+      "_shasum": "e903db3569cfa59d3516995d5597880927872c97",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "e903db3569cfa59d3516995d5597880927872c97",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/dns-packet-1.0.0.tgz_1455828678220_0.24197762180119753"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "dns-packet",
+      "version": "1.0.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/dns-packet"
+      },
+      "dependencies": {
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "d8d3514ea8019524230012e21411be552d0d3a8b",
+      "_id": "dns-packet@1.0.1",
+      "_shasum": "438f1b5df6df95a4ac44a42c6f0657954ea098b4",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "438f1b5df6df95a4ac44a42c6f0657954ea098b4",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/dns-packet-1.0.1.tgz_1455830160654_0.0021190382540225983"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "dns-packet",
+      "version": "1.0.2",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/dns-packet"
+      },
+      "dependencies": {
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "d939033c8317c13c873a26120f73d0ce3d01500b",
+      "_id": "dns-packet@1.0.2",
+      "_shasum": "1c9dd5acae514ccc323f143845cad928f73e5d6a",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "1c9dd5acae514ccc323f143845cad928f73e5d6a",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/dns-packet-1.0.2.tgz_1455830472435_0.21476242318749428"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "dns-packet",
+      "version": "1.1.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/dns-packet"
+      },
+      "dependencies": {
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "b20b693267b60f9aeb83475988ef9d0a578798aa",
+      "_id": "dns-packet@1.1.0",
+      "_shasum": "c11ce43bd9977aa789af72de06b6e4ad6e84730d",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "c11ce43bd9977aa789af72de06b6e4ad6e84730d",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/dns-packet-1.1.0.tgz_1456191463412_0.7309758770279586"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "dns-packet",
+      "version": "1.1.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/dns-packet"
+      },
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "412574eda8f4337b79310ca5f9c08a7e0a49e69f",
+      "_id": "dns-packet@1.1.1",
+      "_shasum": "2369d45038af045f3898e6fa56862aed3f40296c",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "2369d45038af045f3898e6fa56862aed3f40296c",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/dns-packet-1.1.1.tgz_1478838452675_0.8937266955617815"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "dns-packet",
+      "version": "1.2.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "a39813b2d59c48472e870943913303c1c27b4289",
+      "_id": "dns-packet@1.2.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-1DeFd9NyoEuqdcmkGGEJP8ISvppF3VdqDhFV6q0gZxC0lJZIV0bfNqthMPuwoh/zYgMvOc7kpAKcDeszI0SYaA==",
+        "shasum": "ee98421cfdea017fa98e730c4ffd3ca513599297",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-1.2.0.tgz_1502556144060_0.2884097008500248"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "dns-packet",
+      "version": "1.2.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "c61f402d4808a4c072a4df7bbaa434517dfbc10a",
+      "_id": "dns-packet@1.2.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-eisukPHpsFmhEIDnm2mECIiT0huapmdkC0AH1Lvt613Kz2v1kwolrkecvguFazrqnpxvgYdtcMFTsmQzAeRXZQ==",
+        "shasum": "d0124c651d0efb969a80481dddeb25e6c2c12b44",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-1.2.1.tgz_1502569247215_0.9715713816694915"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "dns-packet",
+      "version": "1.2.2",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "f6869562f42584e3bd8d66fdc257965827e35b04",
+      "_id": "dns-packet@1.2.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.3.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
+        "shasum": "a8a26bec7646438963fc86e06f8f8b16d6c8bf7a",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-1.2.2.tgz_1502879702458_0.3107227368745953"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "dns-packet",
+      "version": "1.3.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "0d8bb78efd89a8118168c1ca77baa7afa6e5d79a",
+      "_id": "dns-packet@1.3.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-uyOFFZ3elFVDZ7mq8bfl2PkgIbFr7+29RDyarF1maUuPNHNvBrlgcNkJaEYQh3KouqAyKzVLYvWRT3CWLSbNMA==",
+        "shasum": "7e2b33bf992678a44534c7117d39196bda684d33",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-1.3.0.tgz_1515609832455_0.5738444679882377"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "dns-packet",
+      "version": "1.3.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.15.0",
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "scripts": {
+        "test": "standard && eslint --color *.js && tape test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "main": "index.js",
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "gitHead": "7f35bac5b4680d7bfbb34fbc475ecfdbf9d25092",
+      "_id": "dns-packet@1.3.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+        "shasum": "12aa426981075be500b910eedcd0b47dd7deda5a",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-1.3.1.tgz_1515702163054_0.20508755347691476"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "dns-packet",
+      "version": "2.0.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "standard && eslint --color *.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.15.0",
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js"
+      ],
+      "gitHead": "a77e1bbcc7cd0acd3cf46fe141df869d2b86f366",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@2.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-vaSVKJxPkSW/CNUNsyK+MFgH9GDsicNT7c097rZz5p+1U5cPQw1MPsSevl7xHpXmpedFXfTSFCLhtiYwVW5NGw==",
+        "shasum": "9e9ea4cb5d4d99efdde5a0c5f62406005fced685",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-2.0.0.tgz_1515703092174_0.3792294031009078"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "dns-packet",
+      "version": "3.0.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "standard && eslint --color *.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.15.0",
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js"
+      ],
+      "gitHead": "a7fd815e02f98b892fcfe92940df1c48d57d9d31",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@3.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-ooUyQgvagi3JcpilyPJLvatQNclz34Yd7wF83RWicQ7XWv4mrwoBR4f0d+eD9PkSpUT7BFvR58sy/HlIUZNEsg==",
+        "shasum": "b035ed7194a1995dcab047ae5d959e63a7859229",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-3.0.0.tgz_1515921443783_0.11186015279963613"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "dns-packet",
+      "version": "3.0.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "standard && eslint --color *.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.15.0",
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js",
+        "classes.js"
+      ],
+      "gitHead": "cdf403f93c6603a0a923d0a79bce820ff51ebb8a",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@3.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-TAevu0t7MLB+Fd/ZzvG1AOW+bOuHWo3rerGxzoPMVn+YcmU6BPsltex5QN1XcBP2C7wX5Fysouir8KoqlG3r1Q==",
+        "shasum": "db2fe665093fb4953f4d2dd6165539e83c3e81c2",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-3.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-3.0.1.tgz_1515921928371_0.7476593842729926"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "dns-packet",
+      "version": "4.0.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "eslint --color *.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.17.0",
+        "eslint-config-standard": "^11.0.0-beta.0",
+        "eslint-plugin-import": "^2.8.0",
+        "eslint-plugin-node": "^5.2.1",
+        "eslint-plugin-promise": "^3.6.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.8.0"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js",
+        "classes.js"
+      ],
+      "gitHead": "8000f406c8f4966c03c1813c5f35be5180ffaecb",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@4.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-Q+WQldVgB+QrIJArsJh7JkTAzPjzQVFSr9MUd0z9cTBGbfLWNrfDSec7b14HoYIdJ49hIvj0GrL3gAcMmR/cSg==",
+        "shasum": "38ba2618d6ef5a56209fe24b94a8c2752fb3434c",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet-4.0.0.tgz_1517775136448_0.05204262398183346"
+      },
+      "directories": {}
+    },
+    "4.1.0": {
+      "name": "dns-packet",
+      "version": "4.1.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "eslint --color *.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.17.0",
+        "eslint-config-standard": "^11.0.0-beta.0",
+        "eslint-plugin-import": "^2.8.0",
+        "eslint-plugin-node": "^5.2.1",
+        "eslint-plugin-promise": "^3.6.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.8.0"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js",
+        "classes.js"
+      ],
+      "gitHead": "889924d4f47da5a4df5af0bc86ee052a4d2a6d84",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@4.1.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-cNSQQy+92wZru/sBAEkNvaLozDIjpnAQnMs/RfzjYQtl5HyfIMKw0BevlwelA77UI/aq+mPteHNVyNpgq0k8ZQ==",
+        "shasum": "294ccce3508d2fe7e1f0ff4872f42284cc736f8f",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.1.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 33553
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_4.1.0_1518343747212_0.9313026839236831"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.1": {
+      "name": "dns-packet",
+      "version": "4.1.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "eslint --color *.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.9.0",
+        "eslint-plugin-node": "^6.0.1",
+        "eslint-plugin-promise": "^3.7.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.9.0"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js",
+        "classes.js"
+      ],
+      "gitHead": "40d8e5657f3309ee173a73d085d71d9c72377a8b",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@4.1.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.9.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-YwtiH6TWoXGIVHE/UgorccaS9qStav9yO5ToMy6R3MdCt1YBdiBRykTguTV7vfhHSnSsZzlZ1jNzGqP7VsKmEg==",
+        "shasum": "b676dea595848fd7c71d43b35c83b5fede469d96",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.1.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 33824
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_4.1.1_1522182605309_0.5821739392178391"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.0": {
+      "name": "dns-packet",
+      "version": "4.2.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "eslint --color *.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.10.0",
+        "eslint-plugin-node": "^6.0.1",
+        "eslint-plugin-promise": "^3.7.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.9.0"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js",
+        "classes.js"
+      ],
+      "gitHead": "eddb7ab7e40002db72b8beef9731477ed8200e9c",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@4.2.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.10.1",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
+        "shasum": "3fd6f5ff5a4ec3194ed0b15312693ffe8776b343",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 36719
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_4.2.0_1522854828945_0.005505700658886337"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.0": {
+      "name": "dns-packet",
+      "version": "5.0.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.10.0",
+        "eslint-plugin-node": "^6.0.1",
+        "eslint-plugin-promise": "^3.7.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.9.0"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js",
+        "classes.js"
+      ],
+      "gitHead": "622b9ea3bbdeb91d6377a87e8b0f3e8f3e941e69",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.0.0",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.3.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-2LXAFwItB3+/H493JcvCJVTLBSXPYYOlArUwrEziUWXvsB05CWL6k5T3Qk72IQbnjffe/FPbEjrJksDegWJPkw==",
+        "shasum": "c3d7bcb8a9ec333a6713ab5d954808b5e74eed09",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 47848,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbEPcVCRA9TVsSAnZWagAARe8P+wRDizJVXh4RtliJqXcV\nqxUX1rykgch/gBmvFFp7zW6eRBlHhxWU15LNJocyjL8KRmdJZvATjiZxKXuG\nc45u8VsRrBvTsB1qwwcRThHxRpWDczd9ZZw5iq9EbM55kADwJnkukjkfzzgv\nuC6aYl5qGPpAAydr7Z15AF3zPDJ6DXH+0+HENrW8mcTNy7TlA7zaw/qMb+a+\n2JgFJC1I17ruo4m+RjY7aerKAnz97MKfnALVt9Z8FdOT1G3ScJm+QCpk1A36\n05vLB4PjQ/2h6c+ThiS4szU6c+L0WVzQddZ7Tuoi9XafgiizTxpjvT/DxdPK\n94fi5dvyUFIddptDAggqwobx0QusP7f+GVms9XqBjC95q8NA9FRcua9DbU3R\negHsGGE7A/08Vdt2mizmzxLmDSvTaz+XfFjpF29CY/vvCAJ9Hp3VGr7akTHj\nXbtvg/OtHTEvXggDzP9TaVkpRJX+xAOQXY64g6lMX2+TgD5d0XRykoVxSnRN\nvVjjwKJemqxos4tY73srp0aWIbQvGcYoDyg7P2HmsuRtEHb5a51cH2nnCT6t\npoSD6HH2drbMnp7bXNx+KSXSwmcdH3FpLB8M/sV5WYxVP6y3C9s++B9MnPwg\ne0EvXxhEaXjy4Tzvt93fZdHIj9ZpHJwG2IDxx8IoKD8nTD+CFj39hSPaMS1s\nDrQQ\r\n=ebzy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.0.0_1527838484757_0.8657356893301125"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.1": {
+      "name": "dns-packet",
+      "version": "5.0.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js examples/*.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.0.1",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.13.0",
+        "eslint-plugin-node": "^6.0.1",
+        "eslint-plugin-promise": "^3.8.0",
+        "eslint-plugin-standard": "^3.1.0",
+        "tape": "^4.9.1"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js",
+        "classes.js"
+      ],
+      "gitHead": "93b8c3c03bd834168b318dc9ea981ba03c98b864",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.0.1",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.5.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-1XE76Q6m/kNA+49qnDyoYagqzSDY8kgl7S9tPdkQGJMfER6EfgccDcBa7MgEgzjxgcam/E2sx5WGNIotMLulJg==",
+        "shasum": "bdc914c90cd1d346af89dd436b1135ddc680c57f",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 48069,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbOoJmCRA9TVsSAnZWagAANt8P/2WR5FcA38v63Yp/OnmC\nCXOakVSOt5Up1hSC2T0sAlXvLXfG6D4cTVNf0kiamhrj4z9YjbDax8ySWFgz\nPZXlER3a2VEU5oUBFeqbEQoPpNZdclc1t7JHT/DBByGOEIzwU31ApqWWk8Am\ncuurIrNqCWIV/NrQHYBJcAJH+C/Dqu6Qb2n1NAqPr8rFJK5zQ7btKrSoLlRB\nCmEGWCUUCZlHln758A8NOU4KsdsvtP4iHOQ60ouRDXcyW8rMajTBYP8/MuUG\nCOJY3fWFAJyNluYRmgc3bAt9eGKOsB5i+LSA4PuSMJjGQ4vodRkxOLnN0Epr\naqSoa+Z+DgtLK72VttQDgIyYCvsdo1eIVdr+zYhvZWJcRU9YhVQsVr0Ja2s1\nO8LjrTPnwUiNF6+OLmWTkZibaJe7wz6tOQ88unN++15oK5gyJCMD/xwRaSXT\nXNXmKP8tuT4JDRtpN05A9Y7LhnHO5MUu+dMSTmLI2pSb5o2vGRasWpibtNoS\n5JQ285rKJh7ijfvjNJZY4XpJMslcIn2Y6fm2Yyl6MD28mJhxjB+q3DQm4jQ8\nk/5GoHghaZ4XecFCvQNK2eNa1NyGwVtzi3lG5L1r88CXW1YON3H5Ih3QSnZY\nRPeL5oLz5qsyjUy7wbzGf7AiqHAXGYCCjlX4l26/G+pYCt6IsHPl10I0j4TJ\nerYF\r\n=nFIQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.0.1_1530561126507_0.496263093789713"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.2": {
+      "name": "dns-packet",
+      "version": "5.0.2",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js examples/*.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.2.0",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.13.0",
+        "eslint-plugin-node": "^7.0.1",
+        "eslint-plugin-promise": "^3.8.0",
+        "eslint-plugin-standard": "^3.1.0",
+        "tape": "^4.9.1"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "files": [
+        "index.js",
+        "types.js",
+        "rcodes.js",
+        "opcodes.js",
+        "classes.js"
+      ],
+      "gitHead": "f4c95d6dda79d3fa95adbb8d94bddbb4418f9664",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.0.2",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.5.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-vHTr8EEx3R4SWk92Oaez/En9c2Rw20h/iLvxuSI8X7KBi8OW5clnHHFoaGbz2UkMoyWwsWveL9LLv33yONv5uQ==",
+        "shasum": "ac43c388ffb576a790c6dd71a517a72e3f0620ad",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 48069,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbV2flCRA9TVsSAnZWagAA0DsP/iIlpicNIlpdwe0LZOFp\nI2YF2qoO/ZmfcP3MXNegTr7rbTqAxL7MTEgbN17yyEB3nVz/4VY5gdC9JjrX\nh5dNhAQeYWds0B+lELeAS66n0mQuTSjDdKdq9+DhlvtZSiYvYcrOcVhDJ/Fz\nSQUjwjYBomZII0NLGKynxvUwoOW5aRow9r9Bksv0T2Lzmsl59q8SlUGjQ+Ss\nUZrT6ZlyeVpBw4jP8y7DK+Upjz+qYkC9GoWWvv/W6nSWQswFX0cg6KdoTBG3\n8PwiyQuNwVUIJa7y7lv8IF9qt9looyL7K/TA3WIrG13pwJRWlUz3kqiSyAET\nOqpvvkHDylrmTGfGhCdyJJ0gt5BVsB/u3rOt1Bvkmwl980K5/siaH2rIa336\n9aeNeDjdAkQm2HSPh6nNTtV9cp0zNRYOA8bZ1gDU9HBJqTmJXJ8RquYNs52c\nRgkSXCEe9YTXiiX8jnz1uQP0yZH/a7FuaeHXmILbhWlwFlYi4b2fnvqFp+jL\n98nWqVxbQlfT3+T5ckPDax+ke0fUWsKK1bnkz32QCUGkLuY0cwwmYBix1ty0\nECat89ZStr/TOqpSvoKMGnxUsDnD16UbWXHUbJbKHeGbVGcG+jgyoUHXFDvb\nnj4QNiYGnhj15Vl86HaLHm2Bxm9lYHpChcxv3132n82hziOQFnC/dgnoz/i8\njQ3L\r\n=1FwF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.0.2_1532454884934_0.07220768545546408"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.3": {
+      "name": "dns-packet",
+      "version": "5.0.3",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js examples/*.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-node": "^7.0.1",
+        "eslint-plugin-promise": "^4.0.0",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.1"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "gitHead": "1abf9949624c12f9e66f108be69dcf3ad11e25c5",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.0.3",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.7.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-CqR7YfVUdGqbAMipv+ui0AsLjD4af4K2JiKA/rq+pF1gQ1m+lB0G0B86G8z1ECf8f1bWhf/ZS1tG5yGicWWaRA==",
+        "shasum": "404530537e44bb36c1ac333f13db3b38828e5e3a",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.3.tgz",
+        "fileCount": 9,
+        "unpackedSize": 48068,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbkAwuCRA9TVsSAnZWagAAneYP/2kIUP/7yKzWsgps8cUp\nyAuZbAtqqKc+4wdy9TsK/O/H24Y56yTUdqX2E11MnGfemZz+cm+aV5Az3arE\ndhRswQwa2YwnY+I0KWukyNWKG5u6AYEtiSmPRy7ZbBduuJYt4pryWbPf6G3r\nHq4wxY3MCKpjmouR4sVgwUVpKACfMzBxDpph6XaYTnZplwcFsDbGZ48tsB08\nIswZk5143G3TwKlOYJ0+f5g2M75qiCv8zy3gTCIEKFfSCP/JgMmZV0aBMAzA\nNEndK6vWC6zpKiXtMx1wTEqV2OSQc2d+YfOIDW/Tl306nYcTO3kDCbqBE2rm\npD+gzr9yFv+81+ZuiY55mLXVjUB0xTZyI5VIF+Ty3w2xID4MZKmBUfYX4qvS\nPifLn0qPJqX4ajZhpcAy1wfU2SWqDKpNCPO+mGPD+22fCTL+HReWY2fZ1PD/\nIFEsiGMjHitGSVAR2DnfKmtdU0UxlrZhwKmIzcv3lcLtXbB3jlLbb6Fhiig9\nLMOTYSXhfeUNFzPnE54G9n1Du6J2no26ISXECczPEAf7rDtk/7AV3YJJe+gS\n7SX+B8JhDiZWB9ibrzbqHWvzRjwE7/SkBMHscQ3Wx3Z4MY18wlqMKF6k1Ise\nBKxsB3q8Z/U+7L87AFPqfLxWp2JnGRg7MFTMJYPK6cLJimhYI6Qb67eF/zTR\npdeP\r\n=586L\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.0.3_1536166957716_0.26690714026733553"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.4": {
+      "name": "dns-packet",
+      "version": "5.0.4",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js examples/*.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.7.0",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-node": "^7.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.1"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "gitHead": "85a4aaebd12c9e8031921a5f71a13d445177ff6b",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.0.4",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.11.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-tbBxz5nn6Xkw/xrZ9gLzpGMrnkHjEdoUdB4MaAOGkZdxe+Q2m9ojtuoP7dlGcmy7g9ix/H1qIUwUQBzUx7VVHA==",
+        "shasum": "2830b4630cef12b8c9ad9172843ac600527f31f7",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.4.tgz",
+        "fileCount": 9,
+        "unpackedSize": 48093,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbxg6tCRA9TVsSAnZWagAA3mAQAIYJdp/h7/u+PFmIozLC\nVZJyRZ6CXg0ZTBCB9zMZ10SDhyxsDkJg0u9C7GCkkBRzys9aStRsTtDPMAp0\npltbV/nvUca2Znej/o7K/BKpJY0hMLI59D3e+sDlEJt7lTLRbi3jp1h2fk1q\no0MG+y1KcCkmrbomCFzih6sdQv00nx3vUKB9NJXFH8gBPWGpqxv6GBKGgkQ1\n9bRMm4T2awa0hL4ZXzR0jGfLexagYaxHCSdgem84I3kCvLCdjjROtk2g7df/\neTpwfjWga+QlAPAiFv9fkmGxC+G4vgftEm/lHDtunn0ORvuT4yFixTd3gA8H\nvD9X9be/qLSiISjL7Qhc4f1ZYjlF8pwkg2yqMSBHgQOOOya/tj436djR5HLj\n+onW29zaIOFthJX8gus3l/GwanR4UX9xAWK82eSb0fMWCX16oweImvO9Ksjg\ns2DvCptmAm+DWXzd2tFTD8B6h7q2NyjmUOmF24aH+VSiFXf4VNVK4wrM8kp9\niu3INuAXnxixuURmkxr/+YRjeDaXNqy/YGJnks6QXlM55nmDVisQX+X0hjSr\nrg8da25Gz0rxX55bQRW48LBahyCr35qTG5LfM0r7KDFXN8e6IP+kw+uRpYWV\nNC4fIBHuhorGCAWkSdNQwkO2eHctamBwbOE7qNr3zokYLW54T+m4A/PPVQJO\n9Kok\r\n=Lds/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.0.4_1539706540487_0.2305758034123"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.0": {
+      "name": "dns-packet",
+      "version": "5.1.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js examples/*.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.12.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.15.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.2"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "gitHead": "0d8791efad0a04f0871b4d1c8f0f983f5eb58055",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.1.0",
+      "_nodeVersion": "11.7.0",
+      "_npmVersion": "6.6.0",
+      "dist": {
+        "integrity": "sha512-HFmORCqHq8/8oWQ0UNqpfyFiDvuxX+uw/k0wvu4gpRSo9ohOBwysS6GL1qd4BoYiVchzSOeEcSIUGcpcRvgp/A==",
+        "shasum": "4be2aec09aea7495ea2303e80828e849225dfd82",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.1.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 49159,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcR44ZCRA9TVsSAnZWagAAFl8P+wXcBGGMGt7INwi04iGj\nNCGSFeeKWewFqsHLY/1kVq479w2E8MvIk32qkol5KHTgli6195wfnXzmeUhO\nprQnDElLon27C7AjPAN6fuZnqOY5086ENbIOJ7WA/JjVsUAgPrtoHGZ81WXV\nLe6CHLaF6aaIFQYFtvu3kjhyhuvJp09tJQvL62zUGFLZYAGn5AI005HAvobq\nHqBtOif/vdLDpI2FqdgX+AHnFaYBYLSX3YEz9jLGFw1ePVRqPGvQDw1R0DST\n8C/JntY4jlwa3pIY54XdsvmwLrnHxzCvUnHNeAzA1XUW/5j/GGGQbZYNAs4v\nE4NKRvWo8hhwkEVK18RFQIOFP7ZzVEYejjzUnQ+QGS5NZv1jw2BOAoAOTgvr\nOVQ0Faysr8beZeog76ZC7yD6Qq4yr4b1YfFp0RGRPwJ2rbMrj9BZXSkDPaDX\nUJ8N2QgWizX+BRl3AjeIUuANb8Pi9IxtYLH9e0HbM1G7VxVTNXi7W4GWsshC\nepwQ72Efq7LVl1Aj67asXKH8nzV1BCmwjAOFah6HmnDm5Bz4aKXP55MpZCTu\np83PCYZedJja/gv1MsB/Ptr9EsilVaj+RMnpkKX02YS8/fLLlRxij4NZRxN4\nE9ql2DSoLWz8dYymnRj9d7bc7V+LHkLjjLrihw0eembbxzwk1o4kteZQJg32\nlV3h\r\n=nZcW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.1.0_1548193304572_0.577893756100136"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.1": {
+      "name": "dns-packet",
+      "version": "5.1.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js examples/*.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.12.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.15.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.2"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "gitHead": "b72cefd4c9617d10f71ba50dc355a3c2ab376625",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.1.1",
+      "_nodeVersion": "11.7.0",
+      "_npmVersion": "6.6.0",
+      "dist": {
+        "integrity": "sha512-ae3OSrBktaQdUzG3qygjmp55XqP488Hhc9VE/pqSY7693z/9tmgZ7YYmH7Fjf5pY/xx69FHr6wnEXCYQpL9DHg==",
+        "shasum": "4e392a32bbfa08346c155055915499edce06dd7b",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.1.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 49149,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcR5CaCRA9TVsSAnZWagAAlKwQAJM9fQr8lTDpYyu0bLg3\ntDjwOLtrwgoMaoKTIIqASDtZbLeJzBhkgB6u50dUQ6i3H3BlPmzqagCHVoL4\ngjqs38i1WdZgO4vxxCv8JKYJOmpRnZsGKHbR/qFXQZANVI0PaOzFDjS9SFjt\n2JSQpMUSj3yrpdJgU8BME0qOBbYBQJa7kH9f+qWbi3cT4BVIDzSeUakUyBiz\n+7/YtKT11ukNfn2WjuVufEPOddpLvBSd/61kTRv6aQjRW8Qr8luu9wn1xs6P\nla9Lk2goz6SOOi4Q9wRB1P+i78JNXVHyNYNxlM3cCJ+z3lSy+QjmmZqVVTec\n5mHFYkLTnhhUQi1TSpqYNrSNktAeJyP8j+TZwUYU9hkQWiWy4h+1bVnHImJv\nHgKze1GTJyBDjUrc/R3NOsHZgdfKGxBSbW+VEtdM4BBBbK7NEB3k3GHWgLD9\n0ROV8RuvLk6P70KMxTNytiEqX8MjELV1PDmKPyemSeosWP0Z+PFAMXW6n6KV\nHOt5MvElpOcJhMPTB/5KSuvQW/1m0Duovy9igcIuKyX25hTksQGuAkN/l/p8\nl71zuIpGbmlUM77IrJh76YdrrsKJumcuZlQ9d0icS1oZyiB2I5pcfLgqxxDU\nd1q2MF2NjMSBR8ELX0yKN8sEpYLsMIhFb6EyMioaxJc4Tjsg5daDAK+LyQIN\nxbV4\r\n=y8MU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.1.1_1548193946090_0.5658088676537918"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.2": {
+      "name": "dns-packet",
+      "version": "5.1.2",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js examples/*.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.12.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.15.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.2"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "gitHead": "afa238119f7d6f3ef5b7c672493f8ea86f6d744e",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.1.2",
+      "_nodeVersion": "11.7.0",
+      "_npmVersion": "6.6.0",
+      "dist": {
+        "integrity": "sha512-C+wCs4W1ZwTJLG/S8b9gst1dRD63bnY+o86lqVnxGAVUB9LN2Cq2zUKobaGv5kCqY/y7CJUh2kNEUTii7lcUng==",
+        "shasum": "9f1cbb02ff53edd59938cae6faa6a4f7aac7f922",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.1.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 49273,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcR6RxCRA9TVsSAnZWagAAEEMP+QABQ87ZYawy/jY6QVN9\nm9YadK8Mr+9dXXwLzYnl31pc/CG4QbGQr1OhXwyfj7ZhQOfQ0yGl1QZWPrkl\nZHdUplnqK3k0FzKXpzwmVyD2+2ap8I0SEzjqyR8j3AO/fN1hwByGHEpth3hA\nXLBksyeN0aY/bQ5v8ShxsXf1AzY1xHKHxDpXxUr0PX/L9SdoJ3VBXMPUZ3Q/\nK981JZ2EC8UaO4cJDGjbJMyZflb19trfmI8oIhk5+z0ym4cCLcgGW9UNu3Jr\n88/nO9S1dLoncS/l62D7W4Ec/z607CZNZv3yU8ydTT+v680IE6If2q2rlvgm\nQkb32KXNcUjr4lBOCNwNAhimLx4UlBg7rscFhC73Ih7IYrOLH1KQHh3UAAOh\nz0XU33uxOxGsBT+oxJQ6EAxyy8G5FaAyXDMgpPj1jseEf6JxKArfPf+PBJF2\nDwRYvaqFlv2/PZlefp7XpXUzrkbTQvifpaxMVJRlvJR//pom13sbkHBKH/3p\njeAIsNfFPgNPue0OxEP+VSSh4RZ0kUuBYdozXKGumRKKEP3U+6fPlZHoRwm2\nFumzmKA8iFttbF/t3W7UcEpHOeRysUDC8J/cB6kik40sqqsVxhd8dIVjs2mn\nUoWWTDG2/V9ha29tPUcdQbbgdN7RhvDhEIwKcyYIGf5egqq+8WhqsaU6h/Of\nA3hS\r\n=9VIr\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.1.2_1548199025097_0.7562001862814034"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.0": {
+      "name": "dns-packet",
+      "version": "5.2.0",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "eslint --color *.js examples/*.js && tape test.js"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.14.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.16.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.10.1"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "gitHead": "58801f83bc0e8965b4d942ed5e1cf066dc4e7d66",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.2.0",
+      "_nodeVersion": "11.10.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-1TJGl1axSqCzFe8fnUwyioGTfpXFX2gyG0+gEJtVuq0pN6YMqPRnQRXnBswl0GxxZKb3NTJd6F/zI++yjq4tsQ==",
+        "shasum": "d09167e02cc5224fb6d1547b379c3f756e963695",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 54670,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcbydwCRA9TVsSAnZWagAAFbAP/1UH2rlspfDzEYgpd+VX\nSMoT5CX2/RMbbmbmlU/yDRbvprLDoipgs1fF69NvF6A546sJX7EwVxFLF0ts\nkQRam2ftsturZGABAJbKSslbZum6m0IMCOlnN4Viiw1Z1aRSEItlaWHrfZmG\nYxpep93/oSCQveyBzzjJBxOUB9gO5YHQNF3ZwB7D3knky+B0iYX9Cryjq1HF\n2uDvUZzeOyk7uqgSvSXs6aTdk9m+zBiJQyHnzI1iPY14Ng75acKxr6VgpBq+\nx3LKCfbGE6eTX1gNoOvzmdelgLSmbzZrTQzpu+QWFzv8BmTsIZ16Wq7Y4mxd\nhy6y7jeNzpDnTvaxYXrBhfKYpweT/JTbFcCMSgWJKtYIV1WMRh8OylIQqFYz\nVs1zi5l4hima6qJumQLNJT1t4WnC2leZcRY5ltXwqqREqXvolB3jXW5uEnxm\nItwSHcDr9vduoIyM+3NAPYtuSbR5SAF74lr3u0h9CB525kcUbPGD8mI8Z2gx\nL7zLi7TK9Hc3OpBRof1soV76Kwo4hdUHqiHw4xVbPnk/65cp2vFZrjb+/cnV\nLB0W/lXJqh92OGRM0Umu2grLF5cCeMmMVG6q9WZSM+/LqxoQ1YXOmcq/zgYA\nqgheANiITZIKPXVfooiRWj+qA294WFHqkQu/GumyN+/a8mr0Caw8s6EEC/hK\ncDtF\r\n=65NB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.2.0_1550788464071_0.7144023030682038"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.1": {
+      "name": "dns-packet",
+      "version": "5.2.1",
+      "description": "An abstract-encoding compliant module for encoding / decoding DNS packets",
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/dns-packet.git"
+      },
+      "homepage": "https://github.com/mafintosh/dns-packet",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "clean": "rm -rf coverage .nyc_output/",
+        "lint": "eslint --color *.js examples/*.js",
+        "pretest": "npm run lint",
+        "test": "tape test.js",
+        "coverage": "nyc -r html npm test"
+      },
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.14.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.16.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "nyc": "^13.3.0",
+        "tape": "^4.10.1"
+      },
+      "keywords": [
+        "dns",
+        "packet",
+        "encodings",
+        "encoding",
+        "encoder",
+        "abstract-encoding"
+      ],
+      "gitHead": "cbe05219b4f804bf790793b5d196f5616d1c2b97",
+      "bugs": {
+        "url": "https://github.com/mafintosh/dns-packet/issues"
+      },
+      "_id": "dns-packet@5.2.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-JHj2yJeKOqlxzeuYpN1d56GfhzivAxavNwHj9co3qptECel27B1rLY5PifJAvubsInX5pGLDjAHuCfCUc2Zv/w==",
+        "shasum": "26cec0be92252a1b97ed106482921192a7e08f72",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.1.tgz",
+        "fileCount": 10,
+        "unpackedSize": 55133,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcmhqDCRA9TVsSAnZWagAAmrcP/1Jfkvw52crN9gEwFVaf\nUb2VuKK8EoZzuZibq+Jv9k33z9cddF/AOeuDx8kFbw0DpobNozl4Zm/MvrhG\ngWx89PDv1a+0Yen+0GwygRVTK5xpvJLRARZQEnu4jFzfJrHtrNfJRREogFTI\na8Asd3GXBRg1LY/bj4uoJCedmm3xuzbjNb3DTR9oJSsl9y4HzwRd645jD8eW\nqDx7nXWqNlSTyN1U6Q2rCa4ezOz/Jj4PIoJPa4dW0MWuPZik5olNnCRgpI9g\nT1UZMaoVnmjY8PlbEtwTcGv+DhGEUMR7+vUcg97CClGvPZ+Y46Q1SRB+EAeR\nih3tTApZTLHQAAfJ35P/pKjEKqdznbPU6LLKw/qDQH8ZJsn6LmQtU42uxrZ3\nZW6v4MM6xvjnZ3GuAywg1BqJj5RLwDi0Wvi3HfRWUHNk33hogqiPi8aejsib\n+/mih+UxryxwMjhANC+0/FFvc1e9VOGPRvnyC+uasL42SQI0eMCE0GB34Hd0\np68FQxSGh6vQmykfxwQD4+TsZrd/b6fhyob4egCVg1HQm5FAl0fVhkgv7UYs\nnjGkhs0G2hYm/X3zQqrqaCZNBydSnrujUryvGXZ++hyXbfZiLBMsUM3BPO3D\n2ZqFgVQ5BxanfLdIGRpKu0IuULIhrFI2qpXRJxOM0SCXFkWocxSs7jrL75wK\nOaRE\r\n=1EFM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "silverwind",
+          "email": "npm@silverwind.io"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/dns-packet_5.2.1_1553603203196_0.7618290820650895"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# dns-packet\n[![](https://img.shields.io/npm/v/dns-packet.svg?style=flat)](https://www.npmjs.org/package/dns-packet) [![](https://img.shields.io/npm/dm/dns-packet.svg)](https://www.npmjs.org/package/dns-packet) [![](https://api.travis-ci.org/mafintosh/dns-packet.svg?style=flat)](https://travis-ci.org/mafintosh/dns-packet) [![Coverage Status](https://coveralls.io/repos/github/mafintosh/dns-packet/badge.svg?branch=master)](https://coveralls.io/github/mafintosh/dns-packet?branch=master)\n\nAn [abstract-encoding](https://github.com/mafintosh/abstract-encoding) compliant module for encoding / decoding DNS packets. Lifted out of [multicast-dns](https://github.com/mafintosh/multicast-dns) as a separate module.\n\n```\nnpm install dns-packet\n```\n\n## UDP Usage\n\n``` js\nconst dnsPacket = require('dns-packet')\nconst dgram = require('dgram')\n\nconst socket = dgram.createSocket('udp4')\n\nconst buf = dnsPacket.encode({\n  type: 'query',\n  id: 1,\n  flags: dnsPacket.RECURSION_DESIRED,\n  questions: [{\n    type: 'A',\n    name: 'google.com'\n  }]\n})\n\nsocket.on('message', message => {\n  console.log(dnsPacket.decode(message)) // prints out a response from google dns\n})\n\nsocket.send(buf, 0, buf.length, 53, '8.8.8.8')\n```\n\nAlso see [the UDP example](examples/udp.js).\n\n## TCP, TLS, HTTPS\n\nWhile DNS has traditionally been used over a datagram transport, it is increasingly being carried over TCP for larger responses commonly including DNSSEC responses and TLS or HTTPS for enhanced security. See below examples on how to use `dns-packet` to wrap DNS packets in these protocols:\n\n- [TCP](examples/tcp.js)\n- [DNS over TLS](examples/tls.js)\n- [DNS over HTTPS](examples/doh.js)\n\n## API\n\n#### `var buf = packets.encode(packet, [buf], [offset])`\n\nEncodes a DNS packet into a buffer containing a UDP payload.\n\n#### `var packet = packets.decode(buf, [offset])`\n\nDecode a DNS packet from a buffer containing a UDP payload.\n\n#### `var buf = packets.streamEncode(packet, [buf], [offset])`\n\nEncodes a DNS packet into a buffer containing a TCP payload.\n\n#### `var packet = packets.streamDecode(buf, [offset])`\n\nDecode a DNS packet from a buffer containing a TCP payload.\n\n#### `var len = packets.encodingLength(packet)`\n\nReturns how many bytes are needed to encode the DNS packet\n\n## Packets\n\nPackets look like this\n\n``` js\n{\n  type: 'query|response',\n  id: optionalIdNumber,\n  flags: optionalBitFlags,\n  questions: [...],\n  answers: [...],\n  additionals: [...],\n  authorities: [...]\n}\n```\n\nThe bit flags available are\n\n``` js\npacket.RECURSION_DESIRED\npacket.RECURSION_AVAILABLE\npacket.TRUNCATED_RESPONSE\npacket.AUTHORITATIVE_ANSWER\npacket.AUTHENTIC_DATA\npacket.CHECKING_DISABLED\n```\n\nTo use more than one flag bitwise-or them together\n\n``` js\nvar flags = packet.RECURSION_DESIRED | packet.RECURSION_AVAILABLE\n```\n\nAnd to check for a flag use bitwise-and\n\n``` js\nvar isRecursive = message.flags & packet.RECURSION_DESIRED\n```\n\nA question looks like this\n\n``` js\n{\n  type: 'A', // or SRV, AAAA, etc\n  class: 'IN', // one of IN, CS, CH, HS, ANY. Default: IN\n  name: 'google.com' // which record are you looking for\n}\n```\n\nAnd an answer, additional, or authority looks like this\n\n``` js\n{\n  type: 'A', // or SRV, AAAA, etc\n  class: 'IN', // one of IN, CS, CH, HS\n  name: 'google.com', // which name is this record for\n  ttl: optionalTimeToLiveInSeconds,\n  (record specific data, see below)\n}\n```\n\n## Supported record types\n\n#### `A`\n\n``` js\n{\n  data: 'IPv4 address' // fx 127.0.0.1\n}\n```\n\n#### `AAAA`\n\n``` js\n{\n  data: 'IPv6 address' // fx fe80::1\n}\n```\n\n#### `CAA`\n\n``` js\n{\n  flags: 128, // octet\n  tag: 'issue|issuewild|iodef',\n  value: 'ca.example.net',\n  issuerCritical: false\n}\n```\n\n#### `CNAME`\n\n``` js\n{\n  data: 'cname.to.another.record'\n}\n```\n\n#### `DNAME`\n\n``` js\n{\n  data: 'dname.to.another.record'\n}\n```\n\n#### `DNSKEY`\n\n``` js\n{\n  flags: 257, // 16 bits\n  algorithm: 1, // octet\n  key: Buffer\n}\n```\n\n#### `DS`\n\n``` js\n{\n  keyTag: 12345,\n  algorithm: 8,\n  digestType: 1,\n  digest: Buffer\n}\n```\n\n#### `HINFO`\n\n``` js\n{\n  data: {\n    cpu: 'cpu info',\n    os: 'os info'\n  }\n}\n```\n\n#### `MX`\n\n``` js\n{\n  preference: 10,\n  exchange: 'mail.example.net'\n}\n```\n\n#### `NS`\n\n``` js\n{\n  data: nameServer\n}\n```\n\n#### `NSEC`\n\n``` js\n{\n  nextDomain: 'a.domain',\n  rrtypes: ['A', 'TXT', 'RRSIG']\n}\n```\n\n#### `NSEC3`\n\n``` js\n{\n  algorithm: 1,\n  flags: 0,\n  iterations: 2,\n  salt: Buffer,\n  nextDomain: Buffer, // Hashed per RFC5155\n  rrtypes: ['A', 'TXT', 'RRSIG']\n}\n```\n\n#### `NULL`\n\n``` js\n{\n  data: Buffer('any binary data')\n}\n```\n\n#### `OPT`\n\n[EDNS0](https://tools.ietf.org/html/rfc6891) options.\n\n``` js\n{\n  type: 'OPT',\n  name: '.',\n  udpPayloadSize: 4096,\n  flags: packet.DNSSEC_OK,\n  options: [{\n    // pass in any code/data for generic EDNS0 options\n    code: 12,\n    data: Buffer.alloc(31)\n  }, {\n    // Several EDNS0 options have enhanced support\n    code: 'PADDING',\n    length: 31,\n  }, {\n    code: 'CLIENT_SUBNET',\n    family: 2, // 1 for IPv4, 2 for IPv6\n    sourcePrefixLength: 64, // used to truncate IP address\n    scopePrefixLength: 0,\n    ip: 'fe80::',\n  }, {\n    code: 'TCP_KEEPALIVE',\n    timeout: 150 // increments of 100ms.  This means 15s.\n  }, {\n    code: 'KEY_TAG',\n    tags: [1, 2, 3],\n  }]\n}\n```\n\nThe options `PADDING`, `CLIENT_SUBNET`, `TCP_KEEPALIVE` and `KEY_TAG` support enhanced de/encoding. See [optionscodes.js](https://github.com/mafintosh/dns-packet/blob/master/optioncodes.js) for all supported option codes. If the `data` property is present on a option, it takes precedence. On decoding, `data` will always be defined.\n\n#### `PTR`\n\n``` js\n{\n  data: 'points.to.another.record'\n}\n```\n\n#### `RP`\n\n``` js\n{\n  mbox: 'admin.example.com',\n  txt: 'txt.example.com'\n}\n```\n\n#### `RRSIG`\n\n``` js\n{\n  typeCovered: 'A',\n  algorithm: 8,\n  labels: 1,\n  originalTTL: 3600,\n  expiration: timestamp,\n  inception: timestamp,\n  keyTag: 12345,\n  signersName: 'a.name',\n  signature: Buffer\n}\n```\n\n#### `SOA`\n\n``` js\n{\n  data:\n    {\n      mname: domainName,\n      rname: mailbox,\n      serial: zoneSerial,\n      refresh: refreshInterval,\n      retry: retryInterval,\n      expire: expireInterval,\n      minimum: minimumTTL\n    }\n}\n```\n\n#### `SRV`\n\n``` js\n{\n  data: {\n    port: servicePort,\n    target: serviceHostName,\n    priority: optionalServicePriority,\n    weight: optionalServiceWeight\n  }\n}\n```\n\n#### `TXT`\n\n``` js\n{\n  data: 'text' || Buffer || [ Buffer || 'text' ]\n}\n```\n\nWhen encoding, scalar values are converted to an array and strings are converted to UTF-8 encoded Buffers. When decoding, the return value will always be an array of Buffer.\n\nIf you need another record type, open an issue and we'll try to add it.\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    },
+    {
+      "name": "silverwind",
+      "email": "npm@silverwind.io"
+    }
+  ],
+  "time": {
+    "modified": "2019-03-26T12:26:45.968Z",
+    "created": "2016-02-18T20:51:22.901Z",
+    "1.0.0": "2016-02-18T20:51:22.901Z",
+    "1.0.1": "2016-02-18T21:16:03.313Z",
+    "1.0.2": "2016-02-18T21:21:16.780Z",
+    "1.1.0": "2016-02-23T01:37:46.666Z",
+    "1.1.1": "2016-11-11T04:27:34.451Z",
+    "1.2.0": "2017-08-12T16:42:26.090Z",
+    "1.2.1": "2017-08-12T20:20:48.823Z",
+    "1.2.2": "2017-08-16T10:35:03.380Z",
+    "1.3.0": "2018-01-10T18:43:53.379Z",
+    "1.3.1": "2018-01-11T20:22:43.980Z",
+    "2.0.0": "2018-01-11T20:38:13.114Z",
+    "3.0.0": "2018-01-14T09:17:24.687Z",
+    "3.0.1": "2018-01-14T09:25:29.415Z",
+    "4.0.0": "2018-02-04T20:12:17.459Z",
+    "4.1.0": "2018-02-11T10:09:07.965Z",
+    "4.1.1": "2018-03-27T20:30:05.522Z",
+    "4.2.0": "2018-04-04T15:13:49.023Z",
+    "5.0.0": "2018-06-01T07:34:44.806Z",
+    "5.0.1": "2018-07-02T19:52:06.614Z",
+    "5.0.2": "2018-07-24T17:54:45.045Z",
+    "5.0.3": "2018-09-05T17:02:37.797Z",
+    "5.0.4": "2018-10-16T16:15:40.604Z",
+    "5.1.0": "2019-01-22T21:41:44.710Z",
+    "5.1.1": "2019-01-22T21:52:26.239Z",
+    "5.1.2": "2019-01-22T23:17:05.247Z",
+    "5.2.0": "2019-02-21T22:34:24.201Z",
+    "5.2.1": "2019-03-26T12:26:43.352Z"
+  },
+  "homepage": "https://github.com/mafintosh/dns-packet",
+  "keywords": [
+    "dns",
+    "packet",
+    "encodings",
+    "encoding",
+    "encoder",
+    "abstract-encoding"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mafintosh/dns-packet.git"
+  },
+  "author": {
+    "name": "Mathias Buus"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/dns-packet/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "temasm": true,
+    "silverwind": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/dns-packet.min.json
+++ b/test/fixtures/registry-mocks/content/dns-packet.min.json
@@ -1,0 +1,611 @@
+{
+  "name": "dns-packet",
+  "dist-tags": {
+    "latest": "5.2.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "dns-packet",
+      "version": "1.0.0",
+      "dependencies": {
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "e903db3569cfa59d3516995d5597880927872c97",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "dns-packet",
+      "version": "1.0.1",
+      "dependencies": {
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "438f1b5df6df95a4ac44a42c6f0657954ea098b4",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "dns-packet",
+      "version": "1.0.2",
+      "dependencies": {
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "1c9dd5acae514ccc323f143845cad928f73e5d6a",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "dns-packet",
+      "version": "1.1.0",
+      "dependencies": {
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "c11ce43bd9977aa789af72de06b6e4ad6e84730d",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "dns-packet",
+      "version": "1.1.1",
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "shasum": "2369d45038af045f3898e6fa56862aed3f40296c",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "dns-packet",
+      "version": "1.2.0",
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-1DeFd9NyoEuqdcmkGGEJP8ISvppF3VdqDhFV6q0gZxC0lJZIV0bfNqthMPuwoh/zYgMvOc7kpAKcDeszI0SYaA==",
+        "shasum": "ee98421cfdea017fa98e730c4ffd3ca513599297",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "dns-packet",
+      "version": "1.2.1",
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-eisukPHpsFmhEIDnm2mECIiT0huapmdkC0AH1Lvt613Kz2v1kwolrkecvguFazrqnpxvgYdtcMFTsmQzAeRXZQ==",
+        "shasum": "d0124c651d0efb969a80481dddeb25e6c2c12b44",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "dns-packet",
+      "version": "1.2.2",
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
+        "shasum": "a8a26bec7646438963fc86e06f8f8b16d6c8bf7a",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "dns-packet",
+      "version": "1.3.0",
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-uyOFFZ3elFVDZ7mq8bfl2PkgIbFr7+29RDyarF1maUuPNHNvBrlgcNkJaEYQh3KouqAyKzVLYvWRT3CWLSbNMA==",
+        "shasum": "7e2b33bf992678a44534c7117d39196bda684d33",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.0.tgz"
+      }
+    },
+    "1.3.1": {
+      "name": "dns-packet",
+      "version": "1.3.1",
+      "dependencies": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.15.0",
+        "standard": "^6.0.5",
+        "tape": "^4.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+        "shasum": "12aa426981075be500b910eedcd0b47dd7deda5a",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "dns-packet",
+      "version": "2.0.0",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.15.0",
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-vaSVKJxPkSW/CNUNsyK+MFgH9GDsicNT7c097rZz5p+1U5cPQw1MPsSevl7xHpXmpedFXfTSFCLhtiYwVW5NGw==",
+        "shasum": "9e9ea4cb5d4d99efdde5a0c5f62406005fced685",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "3.0.0": {
+      "name": "dns-packet",
+      "version": "3.0.0",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.15.0",
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-ooUyQgvagi3JcpilyPJLvatQNclz34Yd7wF83RWicQ7XWv4mrwoBR4f0d+eD9PkSpUT7BFvR58sy/HlIUZNEsg==",
+        "shasum": "b035ed7194a1995dcab047ae5d959e63a7859229",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "3.0.1": {
+      "name": "dns-packet",
+      "version": "3.0.1",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.15.0",
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-TAevu0t7MLB+Fd/ZzvG1AOW+bOuHWo3rerGxzoPMVn+YcmU6BPsltex5QN1XcBP2C7wX5Fysouir8KoqlG3r1Q==",
+        "shasum": "db2fe665093fb4953f4d2dd6165539e83c3e81c2",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-3.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "4.0.0": {
+      "name": "dns-packet",
+      "version": "4.0.0",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.17.0",
+        "eslint-config-standard": "^11.0.0-beta.0",
+        "eslint-plugin-import": "^2.8.0",
+        "eslint-plugin-node": "^5.2.1",
+        "eslint-plugin-promise": "^3.6.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-Q+WQldVgB+QrIJArsJh7JkTAzPjzQVFSr9MUd0z9cTBGbfLWNrfDSec7b14HoYIdJ49hIvj0GrL3gAcMmR/cSg==",
+        "shasum": "38ba2618d6ef5a56209fe24b94a8c2752fb3434c",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "4.1.0": {
+      "name": "dns-packet",
+      "version": "4.1.0",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.17.0",
+        "eslint-config-standard": "^11.0.0-beta.0",
+        "eslint-plugin-import": "^2.8.0",
+        "eslint-plugin-node": "^5.2.1",
+        "eslint-plugin-promise": "^3.6.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-cNSQQy+92wZru/sBAEkNvaLozDIjpnAQnMs/RfzjYQtl5HyfIMKw0BevlwelA77UI/aq+mPteHNVyNpgq0k8ZQ==",
+        "shasum": "294ccce3508d2fe7e1f0ff4872f42284cc736f8f",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.1.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 33553
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "4.1.1": {
+      "name": "dns-packet",
+      "version": "4.1.1",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.9.0",
+        "eslint-plugin-node": "^6.0.1",
+        "eslint-plugin-promise": "^3.7.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-YwtiH6TWoXGIVHE/UgorccaS9qStav9yO5ToMy6R3MdCt1YBdiBRykTguTV7vfhHSnSsZzlZ1jNzGqP7VsKmEg==",
+        "shasum": "b676dea595848fd7c71d43b35c83b5fede469d96",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.1.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 33824
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "4.2.0": {
+      "name": "dns-packet",
+      "version": "4.2.0",
+      "dependencies": {
+        "ip": "^1.1.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.10.0",
+        "eslint-plugin-node": "^6.0.1",
+        "eslint-plugin-promise": "^3.7.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-bn1AKpfkFbm0MIioOMHZ5qJzl2uypdBwI4nYNsqvhjsegBhcKJUlCrMPWLx6JEezRjxZmxhtIz/FkBEur2l8Cw==",
+        "shasum": "3fd6f5ff5a4ec3194ed0b15312693ffe8776b343",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-4.2.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 36719
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "5.0.0": {
+      "name": "dns-packet",
+      "version": "5.0.0",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.10.0",
+        "eslint-plugin-node": "^6.0.1",
+        "eslint-plugin-promise": "^3.7.0",
+        "eslint-plugin-standard": "^3.0.1",
+        "tape": "^4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-2LXAFwItB3+/H493JcvCJVTLBSXPYYOlArUwrEziUWXvsB05CWL6k5T3Qk72IQbnjffe/FPbEjrJksDegWJPkw==",
+        "shasum": "c3d7bcb8a9ec333a6713ab5d954808b5e74eed09",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 47848,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbEPcVCRA9TVsSAnZWagAARe8P+wRDizJVXh4RtliJqXcV\nqxUX1rykgch/gBmvFFp7zW6eRBlHhxWU15LNJocyjL8KRmdJZvATjiZxKXuG\nc45u8VsRrBvTsB1qwwcRThHxRpWDczd9ZZw5iq9EbM55kADwJnkukjkfzzgv\nuC6aYl5qGPpAAydr7Z15AF3zPDJ6DXH+0+HENrW8mcTNy7TlA7zaw/qMb+a+\n2JgFJC1I17ruo4m+RjY7aerKAnz97MKfnALVt9Z8FdOT1G3ScJm+QCpk1A36\n05vLB4PjQ/2h6c+ThiS4szU6c+L0WVzQddZ7Tuoi9XafgiizTxpjvT/DxdPK\n94fi5dvyUFIddptDAggqwobx0QusP7f+GVms9XqBjC95q8NA9FRcua9DbU3R\negHsGGE7A/08Vdt2mizmzxLmDSvTaz+XfFjpF29CY/vvCAJ9Hp3VGr7akTHj\nXbtvg/OtHTEvXggDzP9TaVkpRJX+xAOQXY64g6lMX2+TgD5d0XRykoVxSnRN\nvVjjwKJemqxos4tY73srp0aWIbQvGcYoDyg7P2HmsuRtEHb5a51cH2nnCT6t\npoSD6HH2drbMnp7bXNx+KSXSwmcdH3FpLB8M/sV5WYxVP6y3C9s++B9MnPwg\ne0EvXxhEaXjy4Tzvt93fZdHIj9ZpHJwG2IDxx8IoKD8nTD+CFj39hSPaMS1s\nDrQQ\r\n=ebzy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.1": {
+      "name": "dns-packet",
+      "version": "5.0.1",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.0.1",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.13.0",
+        "eslint-plugin-node": "^6.0.1",
+        "eslint-plugin-promise": "^3.8.0",
+        "eslint-plugin-standard": "^3.1.0",
+        "tape": "^4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-1XE76Q6m/kNA+49qnDyoYagqzSDY8kgl7S9tPdkQGJMfER6EfgccDcBa7MgEgzjxgcam/E2sx5WGNIotMLulJg==",
+        "shasum": "bdc914c90cd1d346af89dd436b1135ddc680c57f",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 48069,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbOoJmCRA9TVsSAnZWagAANt8P/2WR5FcA38v63Yp/OnmC\nCXOakVSOt5Up1hSC2T0sAlXvLXfG6D4cTVNf0kiamhrj4z9YjbDax8ySWFgz\nPZXlER3a2VEU5oUBFeqbEQoPpNZdclc1t7JHT/DBByGOEIzwU31ApqWWk8Am\ncuurIrNqCWIV/NrQHYBJcAJH+C/Dqu6Qb2n1NAqPr8rFJK5zQ7btKrSoLlRB\nCmEGWCUUCZlHln758A8NOU4KsdsvtP4iHOQ60ouRDXcyW8rMajTBYP8/MuUG\nCOJY3fWFAJyNluYRmgc3bAt9eGKOsB5i+LSA4PuSMJjGQ4vodRkxOLnN0Epr\naqSoa+Z+DgtLK72VttQDgIyYCvsdo1eIVdr+zYhvZWJcRU9YhVQsVr0Ja2s1\nO8LjrTPnwUiNF6+OLmWTkZibaJe7wz6tOQ88unN++15oK5gyJCMD/xwRaSXT\nXNXmKP8tuT4JDRtpN05A9Y7LhnHO5MUu+dMSTmLI2pSb5o2vGRasWpibtNoS\n5JQ285rKJh7ijfvjNJZY4XpJMslcIn2Y6fm2Yyl6MD28mJhxjB+q3DQm4jQ8\nk/5GoHghaZ4XecFCvQNK2eNa1NyGwVtzi3lG5L1r88CXW1YON3H5Ih3QSnZY\nRPeL5oLz5qsyjUy7wbzGf7AiqHAXGYCCjlX4l26/G+pYCt6IsHPl10I0j4TJ\nerYF\r\n=nFIQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.2": {
+      "name": "dns-packet",
+      "version": "5.0.2",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.2.0",
+        "eslint-config-standard": "^11.0.0",
+        "eslint-plugin-import": "^2.13.0",
+        "eslint-plugin-node": "^7.0.1",
+        "eslint-plugin-promise": "^3.8.0",
+        "eslint-plugin-standard": "^3.1.0",
+        "tape": "^4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-vHTr8EEx3R4SWk92Oaez/En9c2Rw20h/iLvxuSI8X7KBi8OW5clnHHFoaGbz2UkMoyWwsWveL9LLv33yONv5uQ==",
+        "shasum": "ac43c388ffb576a790c6dd71a517a72e3f0620ad",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 48069,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbV2flCRA9TVsSAnZWagAA0DsP/iIlpicNIlpdwe0LZOFp\nI2YF2qoO/ZmfcP3MXNegTr7rbTqAxL7MTEgbN17yyEB3nVz/4VY5gdC9JjrX\nh5dNhAQeYWds0B+lELeAS66n0mQuTSjDdKdq9+DhlvtZSiYvYcrOcVhDJ/Fz\nSQUjwjYBomZII0NLGKynxvUwoOW5aRow9r9Bksv0T2Lzmsl59q8SlUGjQ+Ss\nUZrT6ZlyeVpBw4jP8y7DK+Upjz+qYkC9GoWWvv/W6nSWQswFX0cg6KdoTBG3\n8PwiyQuNwVUIJa7y7lv8IF9qt9looyL7K/TA3WIrG13pwJRWlUz3kqiSyAET\nOqpvvkHDylrmTGfGhCdyJJ0gt5BVsB/u3rOt1Bvkmwl980K5/siaH2rIa336\n9aeNeDjdAkQm2HSPh6nNTtV9cp0zNRYOA8bZ1gDU9HBJqTmJXJ8RquYNs52c\nRgkSXCEe9YTXiiX8jnz1uQP0yZH/a7FuaeHXmILbhWlwFlYi4b2fnvqFp+jL\n98nWqVxbQlfT3+T5ckPDax+ke0fUWsKK1bnkz32QCUGkLuY0cwwmYBix1ty0\nECat89ZStr/TOqpSvoKMGnxUsDnD16UbWXHUbJbKHeGbVGcG+jgyoUHXFDvb\nnj4QNiYGnhj15Vl86HaLHm2Bxm9lYHpChcxv3132n82hziOQFnC/dgnoz/i8\njQ3L\r\n=1FwF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.3": {
+      "name": "dns-packet",
+      "version": "5.0.3",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.5.0",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-node": "^7.0.1",
+        "eslint-plugin-promise": "^4.0.0",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-CqR7YfVUdGqbAMipv+ui0AsLjD4af4K2JiKA/rq+pF1gQ1m+lB0G0B86G8z1ECf8f1bWhf/ZS1tG5yGicWWaRA==",
+        "shasum": "404530537e44bb36c1ac333f13db3b38828e5e3a",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.3.tgz",
+        "fileCount": 9,
+        "unpackedSize": 48068,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbkAwuCRA9TVsSAnZWagAAneYP/2kIUP/7yKzWsgps8cUp\nyAuZbAtqqKc+4wdy9TsK/O/H24Y56yTUdqX2E11MnGfemZz+cm+aV5Az3arE\ndhRswQwa2YwnY+I0KWukyNWKG5u6AYEtiSmPRy7ZbBduuJYt4pryWbPf6G3r\nHq4wxY3MCKpjmouR4sVgwUVpKACfMzBxDpph6XaYTnZplwcFsDbGZ48tsB08\nIswZk5143G3TwKlOYJ0+f5g2M75qiCv8zy3gTCIEKFfSCP/JgMmZV0aBMAzA\nNEndK6vWC6zpKiXtMx1wTEqV2OSQc2d+YfOIDW/Tl306nYcTO3kDCbqBE2rm\npD+gzr9yFv+81+ZuiY55mLXVjUB0xTZyI5VIF+Ty3w2xID4MZKmBUfYX4qvS\nPifLn0qPJqX4ajZhpcAy1wfU2SWqDKpNCPO+mGPD+22fCTL+HReWY2fZ1PD/\nIFEsiGMjHitGSVAR2DnfKmtdU0UxlrZhwKmIzcv3lcLtXbB3jlLbb6Fhiig9\nLMOTYSXhfeUNFzPnE54G9n1Du6J2no26ISXECczPEAf7rDtk/7AV3YJJe+gS\n7SX+B8JhDiZWB9ibrzbqHWvzRjwE7/SkBMHscQ3Wx3Z4MY18wlqMKF6k1Ise\nBKxsB3q8Z/U+7L87AFPqfLxWp2JnGRg7MFTMJYPK6cLJimhYI6Qb67eF/zTR\npdeP\r\n=586L\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.4": {
+      "name": "dns-packet",
+      "version": "5.0.4",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.7.0",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-node": "^7.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-tbBxz5nn6Xkw/xrZ9gLzpGMrnkHjEdoUdB4MaAOGkZdxe+Q2m9ojtuoP7dlGcmy7g9ix/H1qIUwUQBzUx7VVHA==",
+        "shasum": "2830b4630cef12b8c9ad9172843ac600527f31f7",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.0.4.tgz",
+        "fileCount": 9,
+        "unpackedSize": 48093,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbxg6tCRA9TVsSAnZWagAA3mAQAIYJdp/h7/u+PFmIozLC\nVZJyRZ6CXg0ZTBCB9zMZ10SDhyxsDkJg0u9C7GCkkBRzys9aStRsTtDPMAp0\npltbV/nvUca2Znej/o7K/BKpJY0hMLI59D3e+sDlEJt7lTLRbi3jp1h2fk1q\no0MG+y1KcCkmrbomCFzih6sdQv00nx3vUKB9NJXFH8gBPWGpqxv6GBKGgkQ1\n9bRMm4T2awa0hL4ZXzR0jGfLexagYaxHCSdgem84I3kCvLCdjjROtk2g7df/\neTpwfjWga+QlAPAiFv9fkmGxC+G4vgftEm/lHDtunn0ORvuT4yFixTd3gA8H\nvD9X9be/qLSiISjL7Qhc4f1ZYjlF8pwkg2yqMSBHgQOOOya/tj436djR5HLj\n+onW29zaIOFthJX8gus3l/GwanR4UX9xAWK82eSb0fMWCX16oweImvO9Ksjg\ns2DvCptmAm+DWXzd2tFTD8B6h7q2NyjmUOmF24aH+VSiFXf4VNVK4wrM8kp9\niu3INuAXnxixuURmkxr/+YRjeDaXNqy/YGJnks6QXlM55nmDVisQX+X0hjSr\nrg8da25Gz0rxX55bQRW48LBahyCr35qTG5LfM0r7KDFXN8e6IP+kw+uRpYWV\nNC4fIBHuhorGCAWkSdNQwkO2eHctamBwbOE7qNr3zokYLW54T+m4A/PPVQJO\n9Kok\r\n=Lds/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.1.0": {
+      "name": "dns-packet",
+      "version": "5.1.0",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.12.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.15.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.2"
+      },
+      "dist": {
+        "integrity": "sha512-HFmORCqHq8/8oWQ0UNqpfyFiDvuxX+uw/k0wvu4gpRSo9ohOBwysS6GL1qd4BoYiVchzSOeEcSIUGcpcRvgp/A==",
+        "shasum": "4be2aec09aea7495ea2303e80828e849225dfd82",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.1.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 49159,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcR44ZCRA9TVsSAnZWagAAFl8P+wXcBGGMGt7INwi04iGj\nNCGSFeeKWewFqsHLY/1kVq479w2E8MvIk32qkol5KHTgli6195wfnXzmeUhO\nprQnDElLon27C7AjPAN6fuZnqOY5086ENbIOJ7WA/JjVsUAgPrtoHGZ81WXV\nLe6CHLaF6aaIFQYFtvu3kjhyhuvJp09tJQvL62zUGFLZYAGn5AI005HAvobq\nHqBtOif/vdLDpI2FqdgX+AHnFaYBYLSX3YEz9jLGFw1ePVRqPGvQDw1R0DST\n8C/JntY4jlwa3pIY54XdsvmwLrnHxzCvUnHNeAzA1XUW/5j/GGGQbZYNAs4v\nE4NKRvWo8hhwkEVK18RFQIOFP7ZzVEYejjzUnQ+QGS5NZv1jw2BOAoAOTgvr\nOVQ0Faysr8beZeog76ZC7yD6Qq4yr4b1YfFp0RGRPwJ2rbMrj9BZXSkDPaDX\nUJ8N2QgWizX+BRl3AjeIUuANb8Pi9IxtYLH9e0HbM1G7VxVTNXi7W4GWsshC\nepwQ72Efq7LVl1Aj67asXKH8nzV1BCmwjAOFah6HmnDm5Bz4aKXP55MpZCTu\np83PCYZedJja/gv1MsB/Ptr9EsilVaj+RMnpkKX02YS8/fLLlRxij4NZRxN4\nE9ql2DSoLWz8dYymnRj9d7bc7V+LHkLjjLrihw0eembbxzwk1o4kteZQJg32\nlV3h\r\n=nZcW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.1.1": {
+      "name": "dns-packet",
+      "version": "5.1.1",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.12.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.15.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.2"
+      },
+      "dist": {
+        "integrity": "sha512-ae3OSrBktaQdUzG3qygjmp55XqP488Hhc9VE/pqSY7693z/9tmgZ7YYmH7Fjf5pY/xx69FHr6wnEXCYQpL9DHg==",
+        "shasum": "4e392a32bbfa08346c155055915499edce06dd7b",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.1.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 49149,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcR5CaCRA9TVsSAnZWagAAlKwQAJM9fQr8lTDpYyu0bLg3\ntDjwOLtrwgoMaoKTIIqASDtZbLeJzBhkgB6u50dUQ6i3H3BlPmzqagCHVoL4\ngjqs38i1WdZgO4vxxCv8JKYJOmpRnZsGKHbR/qFXQZANVI0PaOzFDjS9SFjt\n2JSQpMUSj3yrpdJgU8BME0qOBbYBQJa7kH9f+qWbi3cT4BVIDzSeUakUyBiz\n+7/YtKT11ukNfn2WjuVufEPOddpLvBSd/61kTRv6aQjRW8Qr8luu9wn1xs6P\nla9Lk2goz6SOOi4Q9wRB1P+i78JNXVHyNYNxlM3cCJ+z3lSy+QjmmZqVVTec\n5mHFYkLTnhhUQi1TSpqYNrSNktAeJyP8j+TZwUYU9hkQWiWy4h+1bVnHImJv\nHgKze1GTJyBDjUrc/R3NOsHZgdfKGxBSbW+VEtdM4BBBbK7NEB3k3GHWgLD9\n0ROV8RuvLk6P70KMxTNytiEqX8MjELV1PDmKPyemSeosWP0Z+PFAMXW6n6KV\nHOt5MvElpOcJhMPTB/5KSuvQW/1m0Duovy9igcIuKyX25hTksQGuAkN/l/p8\nl71zuIpGbmlUM77IrJh76YdrrsKJumcuZlQ9d0icS1oZyiB2I5pcfLgqxxDU\nd1q2MF2NjMSBR8ELX0yKN8sEpYLsMIhFb6EyMioaxJc4Tjsg5daDAK+LyQIN\nxbV4\r\n=y8MU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.1.2": {
+      "name": "dns-packet",
+      "version": "5.1.2",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.12.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.15.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.9.2"
+      },
+      "dist": {
+        "integrity": "sha512-C+wCs4W1ZwTJLG/S8b9gst1dRD63bnY+o86lqVnxGAVUB9LN2Cq2zUKobaGv5kCqY/y7CJUh2kNEUTii7lcUng==",
+        "shasum": "9f1cbb02ff53edd59938cae6faa6a4f7aac7f922",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.1.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 49273,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcR6RxCRA9TVsSAnZWagAAEEMP+QABQ87ZYawy/jY6QVN9\nm9YadK8Mr+9dXXwLzYnl31pc/CG4QbGQr1OhXwyfj7ZhQOfQ0yGl1QZWPrkl\nZHdUplnqK3k0FzKXpzwmVyD2+2ap8I0SEzjqyR8j3AO/fN1hwByGHEpth3hA\nXLBksyeN0aY/bQ5v8ShxsXf1AzY1xHKHxDpXxUr0PX/L9SdoJ3VBXMPUZ3Q/\nK981JZ2EC8UaO4cJDGjbJMyZflb19trfmI8oIhk5+z0ym4cCLcgGW9UNu3Jr\n88/nO9S1dLoncS/l62D7W4Ec/z607CZNZv3yU8ydTT+v680IE6If2q2rlvgm\nQkb32KXNcUjr4lBOCNwNAhimLx4UlBg7rscFhC73Ih7IYrOLH1KQHh3UAAOh\nz0XU33uxOxGsBT+oxJQ6EAxyy8G5FaAyXDMgpPj1jseEf6JxKArfPf+PBJF2\nDwRYvaqFlv2/PZlefp7XpXUzrkbTQvifpaxMVJRlvJR//pom13sbkHBKH/3p\njeAIsNfFPgNPue0OxEP+VSSh4RZ0kUuBYdozXKGumRKKEP3U+6fPlZHoRwm2\nFumzmKA8iFttbF/t3W7UcEpHOeRysUDC8J/cB6kik40sqqsVxhd8dIVjs2mn\nUoWWTDG2/V9ha29tPUcdQbbgdN7RhvDhEIwKcyYIGf5egqq+8WhqsaU6h/Of\nA3hS\r\n=9VIr\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.2.0": {
+      "name": "dns-packet",
+      "version": "5.2.0",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.14.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.16.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "tape": "^4.10.1"
+      },
+      "dist": {
+        "integrity": "sha512-1TJGl1axSqCzFe8fnUwyioGTfpXFX2gyG0+gEJtVuq0pN6YMqPRnQRXnBswl0GxxZKb3NTJd6F/zI++yjq4tsQ==",
+        "shasum": "d09167e02cc5224fb6d1547b379c3f756e963695",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 54670,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcbydwCRA9TVsSAnZWagAAFbAP/1UH2rlspfDzEYgpd+VX\nSMoT5CX2/RMbbmbmlU/yDRbvprLDoipgs1fF69NvF6A546sJX7EwVxFLF0ts\nkQRam2ftsturZGABAJbKSslbZum6m0IMCOlnN4Viiw1Z1aRSEItlaWHrfZmG\nYxpep93/oSCQveyBzzjJBxOUB9gO5YHQNF3ZwB7D3knky+B0iYX9Cryjq1HF\n2uDvUZzeOyk7uqgSvSXs6aTdk9m+zBiJQyHnzI1iPY14Ng75acKxr6VgpBq+\nx3LKCfbGE6eTX1gNoOvzmdelgLSmbzZrTQzpu+QWFzv8BmTsIZ16Wq7Y4mxd\nhy6y7jeNzpDnTvaxYXrBhfKYpweT/JTbFcCMSgWJKtYIV1WMRh8OylIQqFYz\nVs1zi5l4hima6qJumQLNJT1t4WnC2leZcRY5ltXwqqREqXvolB3jXW5uEnxm\nItwSHcDr9vduoIyM+3NAPYtuSbR5SAF74lr3u0h9CB525kcUbPGD8mI8Z2gx\nL7zLi7TK9Hc3OpBRof1soV76Kwo4hdUHqiHw4xVbPnk/65cp2vFZrjb+/cnV\nLB0W/lXJqh92OGRM0Umu2grLF5cCeMmMVG6q9WZSM+/LqxoQ1YXOmcq/zgYA\nqgheANiITZIKPXVfooiRWj+qA294WFHqkQu/GumyN+/a8mr0Caw8s6EEC/hK\ncDtF\r\n=65NB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.2.1": {
+      "name": "dns-packet",
+      "version": "5.2.1",
+      "dependencies": {
+        "ip": "^1.1.5"
+      },
+      "devDependencies": {
+        "eslint": "^5.14.1",
+        "eslint-config-standard": "^12.0.0",
+        "eslint-plugin-import": "^2.16.0",
+        "eslint-plugin-node": "^8.0.1",
+        "eslint-plugin-promise": "^4.0.1",
+        "eslint-plugin-standard": "^4.0.0",
+        "nyc": "^13.3.0",
+        "tape": "^4.10.1"
+      },
+      "dist": {
+        "integrity": "sha512-JHj2yJeKOqlxzeuYpN1d56GfhzivAxavNwHj9co3qptECel27B1rLY5PifJAvubsInX5pGLDjAHuCfCUc2Zv/w==",
+        "shasum": "26cec0be92252a1b97ed106482921192a7e08f72",
+        "tarball": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.2.1.tgz",
+        "fileCount": 10,
+        "unpackedSize": 55133,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcmhqDCRA9TVsSAnZWagAAmrcP/1Jfkvw52crN9gEwFVaf\nUb2VuKK8EoZzuZibq+Jv9k33z9cddF/AOeuDx8kFbw0DpobNozl4Zm/MvrhG\ngWx89PDv1a+0Yen+0GwygRVTK5xpvJLRARZQEnu4jFzfJrHtrNfJRREogFTI\na8Asd3GXBRg1LY/bj4uoJCedmm3xuzbjNb3DTR9oJSsl9y4HzwRd645jD8eW\nqDx7nXWqNlSTyN1U6Q2rCa4ezOz/Jj4PIoJPa4dW0MWuPZik5olNnCRgpI9g\nT1UZMaoVnmjY8PlbEtwTcGv+DhGEUMR7+vUcg97CClGvPZ+Y46Q1SRB+EAeR\nih3tTApZTLHQAAfJ35P/pKjEKqdznbPU6LLKw/qDQH8ZJsn6LmQtU42uxrZ3\nZW6v4MM6xvjnZ3GuAywg1BqJj5RLwDi0Wvi3HfRWUHNk33hogqiPi8aejsib\n+/mih+UxryxwMjhANC+0/FFvc1e9VOGPRvnyC+uasL42SQI0eMCE0GB34Hd0\np68FQxSGh6vQmykfxwQD4+TsZrd/b6fhyob4egCVg1HQm5FAl0fVhkgv7UYs\nnjGkhs0G2hYm/X3zQqrqaCZNBydSnrujUryvGXZ++hyXbfZiLBMsUM3BPO3D\n2ZqFgVQ5BxanfLdIGRpKu0IuULIhrFI2qpXRJxOM0SCXFkWocxSs7jrL75wK\nOaRE\r\n=1EFM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "modified": "2019-03-26T12:26:45.968Z"
+}

--- a/test/fixtures/registry-mocks/content/dns-txt.json
+++ b/test/fixtures/registry-mocks/content/dns-txt.json
@@ -1,0 +1,218 @@
+{
+  "_id": "dns-txt",
+  "_rev": "2-97ac992b6b25c4711cd76709742ffa30",
+  "name": "dns-txt",
+  "description": "Encode/decode DNS-SD TXT record RDATA fields",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "2.0.1": {
+      "name": "dns-txt",
+      "version": "2.0.1",
+      "description": "Encode/decode DNS-SD TXT record RDATA fields",
+      "main": "index.js",
+      "dependencies": {
+        "buffer-indexof": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2",
+        "standard": "^5.3.1"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/dns-txt.git"
+      },
+      "keywords": [
+        "rfc6763",
+        "6763",
+        "rfc6762",
+        "6762",
+        "dns",
+        "mdns",
+        "multicast",
+        "txt",
+        "rdata",
+        "dns-sd",
+        "encode",
+        "decode",
+        "parse",
+        "encoder",
+        "decoder",
+        "parser",
+        "service",
+        "discovery"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/dns-txt/issues"
+      },
+      "homepage": "https://github.com/watson/dns-txt",
+      "coordinates": [
+        55.6665557,
+        12.5801645
+      ],
+      "gitHead": "b0fc6f0ef22c9789e9e378ff0262e23feb789b8a",
+      "_id": "dns-txt@2.0.1",
+      "_shasum": "8ea16313f4b59ee9d2cfc8f64be413b25e227a4e",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "8ea16313f4b59ee9d2cfc8f64be413b25e227a4e",
+        "tarball": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/dns-txt-2.0.1.tgz_1456770217606_0.9772624913603067"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "dns-txt",
+      "version": "2.0.2",
+      "description": "Encode/decode DNS-SD TXT record RDATA fields",
+      "main": "index.js",
+      "dependencies": {
+        "buffer-indexof": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2",
+        "standard": "^5.3.1"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/watson/dns-txt.git"
+      },
+      "keywords": [
+        "rfc6763",
+        "6763",
+        "rfc6762",
+        "6762",
+        "dns",
+        "mdns",
+        "multicast",
+        "txt",
+        "rdata",
+        "dns-sd",
+        "encode",
+        "decode",
+        "parse",
+        "encoder",
+        "decoder",
+        "parser",
+        "service",
+        "discovery"
+      ],
+      "author": {
+        "name": "Thomas Watson Steen",
+        "email": "w@tson.dk",
+        "url": "https://twitter.com/wa7son"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/watson/dns-txt/issues"
+      },
+      "homepage": "https://github.com/watson/dns-txt",
+      "coordinates": [
+        55.6465696,
+        12.5491067
+      ],
+      "gitHead": "8c48aed198f9eb1840e7d12c37a84fcba545c8fa",
+      "_id": "dns-txt@2.0.2",
+      "_shasum": "b91d806f5d27188e4ab3e7d107d881a1cc4642b6",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "b91d806f5d27188e4ab3e7d107d881a1cc4642b6",
+        "tarball": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/dns-txt-2.0.2.tgz_1461509147614_0.3867966157849878"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# dns-txt\n\nEncode or decode the RDATA field in multicast DNS TXT records. For use\nwith DNS-Based Service Discovery. For details see [RFC\n6763](https://tools.ietf.org/html/rfc6763).\n\n[![Build status](https://travis-ci.org/watson/dns-txt.svg?branch=master)](https://travis-ci.org/watson/dns-txt)\n[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://github.com/feross/standard)\n[![abstract-encoding](https://img.shields.io/badge/abstract--encoding-compliant-brightgreen.svg?style=flat)](https://github.com/mafintosh/abstract-encoding)\n\n## Installation\n\n```\nnpm install dns-txt\n```\n\n## Usage\n\n```js\nvar txt = require('dns-txt')()\n\nvar obj = {\n  foo: 1,\n  bar: 2\n}\n\nvar enc = txt.encode(obj) // <Buffer 05 66 6f 6f 3d 31 05 62 61 72 3d 32>\n\ntxt.decode(enc) // { foo: '1', bar: '2' }\n```\n\n## API\n\nThe encoder and decoder conforms to [RFC 6763](https://tools.ietf.org/html/rfc6763).\n\n### Initialize\n\nThe module exposes a constructor function which can be called with an\noptional options object:\n\n```js\nvar txt = require('dns-txt')({ binary: true })\n```\n\nThe options are:\n\n- `binary` - If set to `true` all values will be returned as `Buffer`\n  objects. The default behavior is to turn all values into strings. But\n  according to the RFC the values can be any binary data. If you expect\n  binary data, use this option.\n\n#### `txt.encode(obj, [buffer], [offset])`\n\nTakes a key/value object and returns a buffer with the encoded TXT\nrecord. If a buffer is passed as the second argument the object should\nbe encoded into that buffer. Otherwise a new buffer should be allocated\nIf an offset is passed as the third argument the object should be\nencoded at that byte offset. The byte offset defaults to `0`.\n\nThis module does not actively validate the key/value pairs, but keep the\nfollowing in rules in mind:\n\n- To be RFC compliant, each key should conform with the rules as\n  specified in [section\n  6.4](https://tools.ietf.org/html/rfc6763#section-6.4).\n\n- To be RFC compliant, each value should conform with the rules as\n  specified in [section\n  6.5](https://tools.ietf.org/html/rfc6763#section-6.5).\n\nAfter encoding `txt.encode.bytes` is set to the amount of bytes used to\nencode the object.\n\n#### `txt.decode(buffer, [offset], [length])`\n\nTakes a buffer and returns a decoded key/value object. If an offset is\npassed as the second argument the object should be decoded from that\nbyte offset. The byte offset defaults to `0`. Note that all keys will be\nlowercased and all values will be Buffer objects.\n\nAfter decoding `txt.decode.bytes` is set to the amount of bytes used to\ndecode the object.\n\n#### `txt.encodingLength(obj)`\n\nTakes a single key/value object and returns the number of bytes that the given\nobject would require if encoded.\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "watson",
+      "email": "w@tson.dk"
+    }
+  ],
+  "time": {
+    "modified": "2016-04-24T14:45:50.069Z",
+    "created": "2016-02-29T18:23:41.106Z",
+    "2.0.1": "2016-02-29T18:23:41.106Z",
+    "2.0.2": "2016-04-24T14:45:50.069Z"
+  },
+  "homepage": "https://github.com/watson/dns-txt",
+  "keywords": [
+    "rfc6763",
+    "6763",
+    "rfc6762",
+    "6762",
+    "dns",
+    "mdns",
+    "multicast",
+    "txt",
+    "rdata",
+    "dns-sd",
+    "encode",
+    "decode",
+    "parse",
+    "encoder",
+    "decoder",
+    "parser",
+    "service",
+    "discovery"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/watson/dns-txt.git"
+  },
+  "author": {
+    "name": "Thomas Watson Steen",
+    "email": "w@tson.dk",
+    "url": "https://twitter.com/wa7son"
+  },
+  "bugs": {
+    "url": "https://github.com/watson/dns-txt/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/dns-txt.min.json
+++ b/test/fixtures/registry-mocks/content/dns-txt.min.json
@@ -1,0 +1,39 @@
+{
+  "name": "dns-txt",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "2.0.1": {
+      "name": "dns-txt",
+      "version": "2.0.1",
+      "dependencies": {
+        "buffer-indexof": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2",
+        "standard": "^5.3.1"
+      },
+      "dist": {
+        "shasum": "8ea16313f4b59ee9d2cfc8f64be413b25e227a4e",
+        "tarball": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "dns-txt",
+      "version": "2.0.2",
+      "dependencies": {
+        "buffer-indexof": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2",
+        "standard": "^5.3.1"
+      },
+      "dist": {
+        "shasum": "b91d806f5d27188e4ab3e7d107d881a1cc4642b6",
+        "tarball": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz"
+      }
+    }
+  },
+  "modified": "2016-04-24T14:45:50.069Z"
+}

--- a/test/fixtures/registry-mocks/content/domain-browser.json
+++ b/test/fixtures/registry-mocks/content/domain-browser.json
@@ -1,0 +1,12350 @@
+{
+  "_id": "domain-browser",
+  "_rev": "81-d794bd937dccfb078a79e6875573d6a2",
+  "name": "domain-browser",
+  "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+  "dist-tags": {
+    "latest": "4.19.0",
+    "next": "4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "domain-browser",
+      "version": "1.0.0",
+      "description": "Node's domain for the web browser",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "author": {
+        "name": "Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bevry/domain-browser.git"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "main": "./index.js",
+      "_id": "domain-browser@1.0.0",
+      "dist": {
+        "shasum": "cfaa17f91c1510c37833434a49020258d6309e73",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      }
+    },
+    "1.0.1": {
+      "name": "domain-browser",
+      "version": "1.0.1",
+      "description": "Node's domain for the web browser",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "author": {
+        "name": "Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bevry/domain-browser.git"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "main": "./index.js",
+      "_id": "domain-browser@1.0.1",
+      "dist": {
+        "shasum": "63dbfb46cbd30b99203df34cb8f6180bcb4d0630",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      }
+    },
+    "1.1.0": {
+      "title": "Node's [domain module](http://nodejs.org/api/domain.html) for the web browser",
+      "name": "domain-browser",
+      "version": "1.1.0",
+      "description": "Note, this is merely an evented try...catch with the same API as node. Nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": {
+        "type": "MIT"
+      },
+      "badges": {
+        "travis": true,
+        "npm": true,
+        "gittip": "bevry",
+        "flattr": "344188/balupton-on-Flattr",
+        "paypal": "QB8GQPZAH84N6"
+      },
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "author": {
+        "name": "Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "projectz": "~0.2.5"
+      },
+      "_id": "domain-browser@1.1.0",
+      "dist": {
+        "shasum": "8d129b7bd3a40f5b4a36773eecac93398780964f",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      }
+    },
+    "1.1.1": {
+      "title": "Node's [domain module](http://nodejs.org/api/domain.html) for the web browser",
+      "name": "domain-browser",
+      "version": "1.1.1",
+      "description": "Note, this is merely an evented try...catch with the same API as node. Nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": {
+        "type": "MIT"
+      },
+      "badges": {
+        "travis": true,
+        "npm": true,
+        "gittip": "bevry",
+        "flattr": "344188/balupton-on-Flattr",
+        "paypal": "QB8GQPZAH84N6"
+      },
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "browsers": true,
+      "author": {
+        "name": "Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "projectz": "~0.3.2",
+        "chai": "~1.8.1",
+        "joe": "~1.3.2",
+        "joe-reporter-console": "~1.2.1"
+      },
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "_id": "domain-browser@1.1.1",
+      "dist": {
+        "shasum": "0123c1b9afe3bb7c8a9e856177b2059440957de0",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      }
+    },
+    "1.1.2": {
+      "title": "Node's [domain module](http://nodejs.org/api/domain.html) for the web browser",
+      "name": "domain-browser",
+      "version": "1.1.2",
+      "description": "Note, this is merely an evented try...catch with the same API as node. Nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": {
+        "type": "MIT"
+      },
+      "badges": {
+        "travis": true,
+        "npm": true,
+        "david": true,
+        "daviddev": true,
+        "gittip": "bevry",
+        "flattr": "344188/balupton-on-Flattr",
+        "paypal": "QB8GQPZAH84N6",
+        "bitcoin": "https://coinbase.com/checkouts/9ef59f5479eec1d97d63382c9ebcb93a",
+        "wishlist": "http://amzn.com/w/2F8TXKSNAFG4V"
+      },
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "browsers": true,
+      "author": {
+        "name": "Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "projectz": "~0.3.2",
+        "chai": "~1.9.1",
+        "joe": "~1.4.0",
+        "joe-reporter-console": "~1.2.1"
+      },
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "gitHead": "43e73cbbf2f92887263fe44296675f2304a6e75e",
+      "_id": "domain-browser@1.1.2",
+      "_shasum": "5a21f30a29a9891533915061426974dc2f14e56b",
+      "_from": ".",
+      "_npmVersion": "1.4.13",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      },
+      "dist": {
+        "shasum": "5a21f30a29a9891533915061426974dc2f14e56b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "title": "Node's [domain module](http://nodejs.org/api/domain.html) for the web browser",
+      "name": "domain-browser",
+      "version": "1.1.3",
+      "description": "Note, this is merely an evented try...catch with the same API as node. Nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": {
+        "type": "MIT"
+      },
+      "badges": {
+        "travis": true,
+        "npm": true,
+        "david": true,
+        "daviddev": true,
+        "gittip": "bevry",
+        "flattr": "344188/balupton-on-Flattr",
+        "paypal": "QB8GQPZAH84N6",
+        "bitcoin": "https://coinbase.com/checkouts/9ef59f5479eec1d97d63382c9ebcb93a",
+        "wishlist": "http://amzn.com/w/2F8TXKSNAFG4V"
+      },
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "browsers": true,
+      "author": {
+        "name": "Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "evansolomon",
+          "email": "evan@evanalyze.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "substack",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "projectz": "~0.3.2",
+        "chai": "~1.9.1",
+        "joe": "~1.4.0",
+        "joe-reporter-console": "~1.2.1"
+      },
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "gitHead": "28db05dcf0fbb3b75e8b5ad2391d91721ef16999",
+      "_id": "domain-browser@1.1.3",
+      "_shasum": "ee8b336f1c53dc990b302eac12b4c7fee24923c1",
+      "_from": ".",
+      "_npmVersion": "2.0.0-alpha-5",
+      "_npmUser": {
+        "name": "evansolomon",
+        "email": "evan@evanalyze.com"
+      },
+      "dist": {
+        "shasum": "ee8b336f1c53dc990b302eac12b4c7fee24923c1",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz"
+      }
+    },
+    "1.1.4": {
+      "title": "Node's [domain module](http://nodejs.org/api/domain.html) for the web browser",
+      "name": "domain-browser",
+      "version": "1.1.4",
+      "description": "Note, this is merely an evented try...catch with the same API as node. Nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": {
+        "type": "MIT"
+      },
+      "badges": {
+        "travis": true,
+        "npm": true,
+        "npmdownloads": true,
+        "david": true,
+        "daviddev": true,
+        "gratipay": "bevry",
+        "flattr": "344188/balupton-on-Flattr",
+        "paypal": "QB8GQPZAH84N6",
+        "bitcoin": "https://coinbase.com/checkouts/9ef59f5479eec1d97d63382c9ebcb93a",
+        "wishlist": "http://amzn.com/w/2F8TXKSNAFG4V"
+      },
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "browsers": true,
+      "author": {
+        "name": "Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "evansolomon",
+          "email": "evan@evanalyze.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "evansolomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "substack",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "projectz": "~0.3.17",
+        "chai": "~1.10.0",
+        "joe": "~1.5.0",
+        "joe-reporter-console": "~1.2.1"
+      },
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "gitHead": "6eca9aaaa1db6ab6e5164fd11dcbdd09f8d0adfc",
+      "_id": "domain-browser@1.1.4",
+      "_shasum": "90b42769333e909ce3f13bf3e1023ba4a6d6b723",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      },
+      "dist": {
+        "shasum": "90b42769333e909ce3f13bf3e1023ba4a6d6b723",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+      }
+    },
+    "1.1.5": {
+      "name": "domain-browser",
+      "version": "1.1.5",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "slackin",
+          "patreon",
+          "gratipay",
+          "flattr",
+          "paypal",
+          "bitcoin",
+          "wishlist"
+        ],
+        "config": {
+          "patreonUsername": "bevry",
+          "gratipayUsername": "bevry",
+          "flattrCode": "344188/balupton-on-Flattr",
+          "paypalButtonID": "QB8GQPZAH84N6",
+          "bitcoinURL": "https://bevry.me/bitcoin",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "slackinURL": "https://slack.bevry.me"
+        }
+      },
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "browsers": true,
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "evansolomon",
+          "email": "evan@evanalyze.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net/"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "devDependencies": {
+        "assert-helpers": "^4.1.0",
+        "eslint": "^1.10.3",
+        "joe": "^1.6.0",
+        "joe-reporter-console": "^1.2.1",
+        "projectz": "^1.0.8"
+      },
+      "main": "./index.js",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "scripts": {
+        "clean": "node --harmony nakefile.js clean",
+        "setup": "node --harmony nakefile.js setup",
+        "compile": "node --harmony nakefile.js compile",
+        "watch": "node --harmony nakefile.js watch",
+        "verify": "node --harmony nakefile.js verify",
+        "meta": "node --harmony nakefile.js meta",
+        "prepare": "node --harmony nakefile.js prepare",
+        "release": "node --harmony nakefile.js release",
+        "test": "node --harmony ./test.js"
+      },
+      "dependencies": {
+        "assert-helpers": "^4.1.0"
+      },
+      "gitHead": "c66ee3445e87955e70d0d60d4515f2d26a81b9c4",
+      "_id": "domain-browser@1.1.5",
+      "_shasum": "f33b13721187f2eac62e7effb6c9ceef15be95d4",
+      "_from": ".",
+      "_npmVersion": "3.5.1",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      },
+      "dist": {
+        "shasum": "f33b13721187f2eac62e7effb6c9ceef15be95d4",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.6": {
+      "name": "domain-browser",
+      "version": "1.1.6",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "slackin",
+          "patreon",
+          "gratipay",
+          "flattr",
+          "paypal",
+          "bitcoin",
+          "wishlist"
+        ],
+        "config": {
+          "patreonUsername": "bevry",
+          "gratipayUsername": "bevry",
+          "flattrCode": "344188/balupton-on-Flattr",
+          "paypalButtonID": "QB8GQPZAH84N6",
+          "bitcoinURL": "https://bevry.me/bitcoin",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "slackinURL": "https://slack.bevry.me"
+        }
+      },
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "evansolomon",
+          "email": "evan@evanalyze.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net/"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "browsers": true,
+      "dependencies": {},
+      "devDependencies": {
+        "assert-helpers": "^4.1.0",
+        "eslint": "^1.10.3",
+        "joe": "^1.6.0",
+        "joe-reporter-console": "^1.2.1",
+        "projectz": "^1.0.8"
+      },
+      "main": "./index.js",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "scripts": {
+        "clean": "node --harmony nakefile.js clean",
+        "setup": "node --harmony nakefile.js setup",
+        "compile": "node --harmony nakefile.js compile",
+        "watch": "node --harmony nakefile.js watch",
+        "verify": "node --harmony nakefile.js verify",
+        "meta": "node --harmony nakefile.js meta",
+        "prepare": "node --harmony nakefile.js prepare",
+        "release": "node --harmony nakefile.js release",
+        "test": "node --harmony ./test.js"
+      },
+      "gitHead": "33b467e3779f228a3868f4c892977ed1be5bdceb",
+      "_id": "domain-browser@1.1.6",
+      "_shasum": "1fbc9e02746d72fef124e790505e23046def7360",
+      "_from": ".",
+      "_npmVersion": "3.5.1",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      },
+      "dist": {
+        "shasum": "1fbc9e02746d72fef124e790505e23046def7360",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.7": {
+      "name": "domain-browser",
+      "version": "1.1.7",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "slackin",
+          "patreon",
+          "gratipay",
+          "flattr",
+          "paypal",
+          "bitcoin",
+          "wishlist"
+        ],
+        "config": {
+          "patreonUsername": "bevry",
+          "gratipayUsername": "bevry",
+          "flattrCode": "344188/balupton-on-Flattr",
+          "paypalButtonID": "QB8GQPZAH84N6",
+          "bitcoinURL": "https://bevry.me/bitcoin",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "slackinURL": "https://slack.bevry.me"
+        }
+      },
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "evansolomon",
+          "email": "evan@evanalyze.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net/"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "browsers": true,
+      "main": "./index.js",
+      "jspm": {
+        "map": {
+          "./index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "assert-helpers": "^4.1.0",
+        "eslint": "^1.10.3",
+        "joe": "^1.6.0",
+        "joe-reporter-console": "^1.2.1",
+        "projectz": "^1.0.8"
+      },
+      "scripts": {
+        "clean": "node --harmony nakefile.js clean",
+        "setup": "node --harmony nakefile.js setup",
+        "compile": "node --harmony nakefile.js compile",
+        "watch": "node --harmony nakefile.js watch",
+        "verify": "node --harmony nakefile.js verify",
+        "meta": "node --harmony nakefile.js meta",
+        "prepare": "node --harmony nakefile.js prepare",
+        "release": "node --harmony nakefile.js release",
+        "test": "node --harmony ./test.js"
+      },
+      "gitHead": "9b7f0590a10569078b1b3b5c33f201f0a59d9822",
+      "_id": "domain-browser@1.1.7",
+      "_shasum": "867aa4b093faa05f1de08c06f4d7b21fdf8698bc",
+      "_from": ".",
+      "_npmVersion": "3.5.1",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "balupton",
+        "email": "b@lupton.cc"
+      },
+      "dist": {
+        "shasum": "867aa4b093faa05f1de08c06f4d7b21fdf8698bc",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "domain-browser",
+      "version": "1.2.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "opencollective",
+          "gratipay",
+          "flattr",
+          "paypal",
+          "bitcoin",
+          "wishlist",
+          "---",
+          "slackin"
+        ],
+        "config": {
+          "patreonUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "gratipayUsername": "bevry",
+          "flattrUsername": "balupton",
+          "paypalURL": "https://bevry.me/paypal",
+          "bitcoinURL": "https://bevry.me/bitcoin",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "slackinURL": "https://slack.bevry.me"
+        }
+      },
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.neocities.org/"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      },
+      "editions": [
+        {
+          "description": "Source + ES5 + Require",
+          "directory": "source",
+          "entry": "index.js",
+          "syntaxes": [
+            "javascript",
+            "es5",
+            "require"
+          ]
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "assert-helpers": "^4.5.0",
+        "eslint": "^4.16.0",
+        "joe": "^2.0.2",
+        "joe-reporter-console": "^2.0.1",
+        "projectz": "^1.4.0"
+      },
+      "scripts": {
+        "our:setup": "npm run our:setup:npm",
+        "our:setup:npm": "npm install",
+        "our:clean": "rm -Rf ./docs ./es2015 ./es5 ./out",
+        "our:compile": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:verify": "npm run our:verify:eslint",
+        "our:verify:eslint": "eslint --fix ./source",
+        "our:test": "npm run our:verify && npm test",
+        "our:release": "npm run our:release:prepare && npm run our:release:check && npm run our:release:tag && npm run our:release:push",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:check": "npm run our:release:check:changelog && npm run our:release:check:dirty",
+        "our:release:check:changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check:dirty": "git diff --exit-code",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "test": "node --harmony source/test.js --joe-reporter=console"
+      },
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "gitHead": "d77aeed4098c1e685f46f833392759996742424a",
+      "_id": "domain-browser@1.2.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "dist": {
+        "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+        "shasum": "3d31f50191a6749dd1375a7f522e823d42e54eda",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser-1.2.0.tgz_1516946800947_0.5075918147340417"
+      },
+      "directories": {}
+    },
+    "2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8": {
+      "name": "domain-browser",
+      "version": "2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.2"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "0.8 || 0.10 || 0.12 || 4 || 6 || 8 || 10 || 12 || 13",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "devDependencies": {
+        "assert-helpers": "4.10.0",
+        "kava": "3.2.0",
+        "projectz": "^1.10.0",
+        "valid-directory": "^1.1.1"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "gitHead": "e77f42e5bb08a270b573797c84f18582e4a07ba8",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8",
+      "_nodeVersion": "12.13.0",
+      "_npmVersion": "6.12.0",
+      "dist": {
+        "integrity": "sha512-uZQkz6A1O9+FHIg3nxiF6eAe+407YBCou8DhIyq1SAVp4NhcVcalxeUpjhelr7ZJAFLFaQOesuomzCnsIvjybw==",
+        "shasum": "e22bbc4aafc77f23a15d06213b2a1961fa570bd7",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17470,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd0hwOCRA9TVsSAnZWagAAFBYQAJZ1/ZPhmf2uyfJGOSAm\nzfrWFq1EHqACVisyb4WzaOYaoyAeaNyQM8Qi6bEhCMawC9WlcUjSiQXCwdnN\nkbUVvxwYB26gXAOyg/ZW6s/I65przWXrJkYEGxjgXsRD7l0Uj3CzHiQupAn0\nbDib71DdktMTPsTXZq7ciLfxf5FiHc3DGfZL/ICqgHRUuyvFFvIweMXR/n1R\nUjvJMiibHclSxcjRsbx9AOmDCGW1cL++4/VznbnsZC1C4cKDfMT/XdWRAyln\nIMfJws2vRh17M3MHNpflgmKpshSi9huwpLc9r60p+eKfbHNBIDBGtmWc8n0K\n4E3cuBdItLotM+ZFAMnrVyFCBiNX6AKDh+JdYdAcruFvJEgASK8NLrEwUqBA\nW8tqTsZjUDtxH/gTmi07U5mzM0xwo7sQAe+JzHDAZZLW8z9mGTel3hNlckZ2\nGbxZfJiLCB0nvQysXoW94DZgvgHrrrVzmGAwXBm2+xaE5OLQb33s1eyxUQMl\n9n/XumBtUV8Mf2B3Myy7vb74xE7nBzTICE7XjFYR7ynfgnVuhupe7L0dSY5o\n/6IJgL7WflJhqRbPa0oBVHlqaEkqMiIuI8TmioKYpAJdzMZPX6Pw+flpC7yY\nDY+pJCI4ulbEj6iSF3oDI9d0VuwGAjVRywm375trFbc+pGM3eGsFkS1HYR7R\nE6nk\r\n=/zcY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8_1574050829598_0.7730726844406473"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11": {
+      "name": "domain-browser",
+      "version": "2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "0.8 || 0.10 || 0.12 || 4 || 6 || 8 || 10 || 12 || 13",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "devDependencies": {
+        "assert-helpers": "4.10.0",
+        "kava": "3.2.0",
+        "projectz": "^1.10.0",
+        "valid-directory": "^1.1.1"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "gitHead": "7e249e2d60bff73c856da83c88e69af93e22db11",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11",
+      "_nodeVersion": "12.13.0",
+      "_npmVersion": "6.12.0",
+      "dist": {
+        "integrity": "sha512-VWP6pTQgXT05TCE34HS8Sl+s3M1Xg6zxX2aKYY9nGDn+98uDssiH49KDLlduQW0s25X331XIzrxNEThRdNjKpg==",
+        "shasum": "1f5db2e3c08d25f0a5b26b60b4b6ab522d7caa6f",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17449,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd0h20CRA9TVsSAnZWagAArPEP/jsg+KjDPkCkEhrtvtH0\nrMfvVXcu65QRTyEkuH01CWoVdGkIvEnd1SgA2cDj+gMffurPPd0eqcp3IFfY\nv2R9eKF+ln/7X6jSCz/twZxmMNXKYNp+KWmGtp8J/FWNqR8q7UWZTX6u267m\nbG/6+IWwi/4wJvwceio+S5V1zHyPaeZJAKhIJXJlUbsl9yxPEcLwmDFSgyVM\n/1bcLThbeHUEguaQByoj6r1AwdTNv2w3qt3X7G6kmIKpRc4ZUxnni3l2QzvB\nTXKtxMWmeeqsi3cn00oYx3MRoEHJiGfsPH3K3kSLEWTRYq2JmtEfmBqxifQN\nW+taVppIBf0ZhUJMKOp/lpClIYNaDcWu1UP73ledqEjPTO66ZgVfJWTwz74i\nLvX6nlM+UvyCL3sWtP386VJakTJdmxZJTRlgHD0ghP/TOHHxlslAc2+eQktq\nx+Vqd2DYVGKCScC10J0WCBnhZpwALx8zVylfm8y3Cc81k1Zd8Sd7XFm0rRwi\nIWYxVJe3ANNIg2UD94qM+KzoIq4Rt2Xr3wNIR7aZ+tIJJKzmMUl/8+ZzTBlj\nhDGtRfa6AP+00v1QhwttorB/3nqMXfjHj33jbULCJyculDncB0wu0PZDnJcV\n8o95vq2flurUSIvN9VeQUQWJPuAMAi8yYGkrG1h9ejSx++hDk5E0Zb4TyVTI\nhpGP\r\n=RNt+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11_1574051251404_0.9844166320110841"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b": {
+      "name": "domain-browser",
+      "version": "2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "0.8 || 0.10 || 0.12 || 4 || 6 || 8 || 10 || 12 || 13",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "devDependencies": {
+        "assert-helpers": "4.10.0",
+        "kava": "3.2.0",
+        "projectz": "^1.10.0",
+        "valid-directory": "^1.1.1"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "gitHead": "fc1a8168b8277434656bee6dbf6c762442480e7b",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-+HuKWNuaGN8JfluvCoqFzbrpIf1keBSFXgmLMLViNM0Rr86OLi/ttVNovlDk79lnMAFJlqMQvpUGndNXvd3szg==",
+        "shasum": "c21799f071cfd4c8f28245084b3101d01a087457",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17449,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd2vX4CRA9TVsSAnZWagAAokcQAIdAYCR20W2fTb2g2WfL\nFBMznhMgsIbI0JFJk26/qvOnyccjLtQrwFplIBCFaBamMVEQS4CuOghC93KB\n8Ov5qe5GOOKC2Ggu6ZNEcqm4E4ch+V6iNe+ZqByYVDV5DlOjnQNw85z1mTWq\nVhvxXKyZ6m5uNYfmqSLiGuk3CMQM7iANj7ZbT0rZWmU8Mbuf5piDUhLWwu5b\nwfJT/ON07/a/uXlRysVqpQe8St+TFXyi88LXzVi2RhIcn8TeA9hkDLDfD+EE\nX31FToBt3UeOYoJpiWk/ISu/HpwJiDM7bKDp/LWxGowEd/aTdb5QybagfqEJ\n+j8ponK4yOW4z9JqFFTQQLZKGu2LYf4J/TAWugLXI0uE4mf8Igs6UwHODz6e\nsxYN6MVuI74R2T5Ifh32Y94VxPNfsXxkt5vSi0bIbk0ekhnp7i45efQYpGct\nJe246ItyUWpozQ1VuRlVvgDLnd+9iw2iCmEVv36dsgVVpqyf0lo9DSj5bt1X\n+FHI9h5qZYwLPMq7FV91WOeXMUkQonnwj4CHOlXr+orLEGydupdyX+gQZwbm\naH7WndkPvANEbbIuEJRtR/IRr87tGoKK9ch53uolFx7Ey8HAxXlFDr76DtlP\nRfEMcPTU0PujugOIhmeNpo/2ojnAAOpiaf/bIeMaKNy3ErGJ6yuMs7KM31vj\nc64L\r\n=DQTh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b_1574630903773_0.129171493527368"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571": {
+      "name": "domain-browser",
+      "version": "3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "devDependencies": {
+        "assert-helpers": "5.5.0",
+        "kava": "4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "gitHead": "e110fd711d32b283d002c7046714e39e453b4571",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://github.com/apps/dependabot-preview\">dependabot-preview[bot]</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=dependabot-preview[bot]\" title=\"View the GitHub contributions of dependabot-preview[bot] on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-0jXC/pZjFVNDXf27uS4bPNMgqR2vYLk0Ivro0gWfNrRjWS0Rg2nO8ukzxYcZDCwEAcPxf37cRo3XAffPQiU6ug==",
+        "shasum": "ef09587771ee11fc16a348dd5b5e7f905143c0cb",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18103,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4r2UCRA9TVsSAnZWagAAc/4P/A8Ecu0atI+WvIr0DH5Y\ng5frbnnjcrbEXRUsMuIBJdST07KHp5Ix8hO1n3jxYXxO9Cftc37uy09/zdSN\nLekLfnrKT0ftVDC7Q12rT+U6dWxtp97FQGjZDKp9cZDHuM6RjHtCZoX2pJ9P\nWBhojw0J3A63e7ecqrXgmULP2x9Jj3Joroc+fg9UdWLqP6z1mOpRs5/2rAf3\nGrMdWq8vzZ3uBWRQDIuJLFUer5laFgQ03QvJAyPrQAc28nwTzuijdWP4jnox\nLQwE6ASDjnV69ANhTm31gDZQrqB6MxzV4H4lI6h2j7PQcJGA9QPdlZNlZnVg\nHKGA5xNia1GbjpVfauVE8z/sigkLjMQPT4mnVah4GxOd1v9UHsi2M+RXWqwe\n1ZvbWzId1leobCqELBHd8jyy5ZsZqIVPUcluakFzQRoz5Ogj7iunwwPEEpJZ\n2psF7GEoVbKPGUsIn3B0pU/vBCMTxY+JtoV5sc94d7bcK2ijzTvCrjbJtz6X\noRm7S4rwQs1iyfQzvH6xCJHInLNWicRh2GL1bJFyt+vwWBY4SJYfjxGLiRQt\nZcyVrB9WUF/aLuCQdBbNLlLGJOho5FAT/o+2BCFz+q8qhrJrf5haDSXZNCOL\n8CFYc2m60V12A8vT4jZ4KDe313tvxSjKY9DV5Wa7nmi/grK+pnFD1A4u1Clo\nCYtG\r\n=IE+L\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571_1575140755948_0.3634045094631255"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "domain-browser",
+      "version": "3.0.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "devDependencies": {
+        "assert-helpers": "5.5.0",
+        "kava": "4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "gitHead": "e110fd711d32b283d002c7046714e39e453b4571",
+      "_id": "domain-browser@3.0.0",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-90tprck/x3noRIZ4DRZF926OEcjqN1rLmq2P8tz1LcIWYGUxgmQOPEpB1pD8s59sxFUkjrVORTANpQAOqBm9Iw==",
+        "shasum": "f842575a6292f0cf829cb9e24fcda67c6225c204",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.0.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18046,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4r3SCRA9TVsSAnZWagAAP2YP/Rju1girR6RO9qPW66bi\n7d6AsTnej9M7KR9kYdI6/GeXiD9THvkhg71MjzZDLtFi2ereA/vyL0aexB30\nwOyWqqCG+h49y6HdW6LJ9Lav1SeoPOdMd8CIg7o1lWeS+T1MhL3wLX1IrKSa\n/szsRVOrXrWjZjQLUVMnprwGd/ItTn1XgDLLvV+YudWmw3RdhPMbEiGxyDZr\nBIhmRAI8cLwZlmDJlIe6fGM4eRYIx+QM5bmw++dHagEK2D54jCPPHRF5xNIG\nZWOCpJiH+QHRTu7h72QiIYs62hlHzSJKSrd6EntzER8n//nYg3R2fFGa21kB\nnLyfek54rFO/+BYE+Rit2KOYD3G1VPTSqr3FLDzzKZdj+uc3ToqeqxtEOmsL\nfTtvRzBg6w5aJOV2O1kXl+E0L8m17StpiJoiNvezCK/tyiYiFkglOBT2Z4OS\ny2vvS6KqoTfZ9D0oKjIipCKJi313/qyV7/4XIPjdNzcdZYNjPuu73JVr/lu4\nXZEVsNsmmBaqQRJmhdw/+hw7sKp16OqPjrXvXG+SRZgE1QNnHi0nRweSfBVk\nz6LxCGOMyd8jB3jHse0vvqoYv9ThnR0bNyaFVG3PpD+ejPIguHNEnYHIftl2\n+MmDjdXs6LccbixUDcC4I+LwisAJeYB0AmK6xMtH+0naIkLubHfzFDgmgJX9\nPInW\r\n=EJWv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.0.0_1575140815847_0.7203218046834357"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96": {
+      "name": "domain-browser",
+      "version": "3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "devDependencies": {
+        "assert-helpers": "5.5.0",
+        "kava": "4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "gitHead": "b65292dfe20ee7bdf4423c290f3b61b51f035b96",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://github.com/apps/dependabot-preview\">dependabot-preview[bot]</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=dependabot-preview[bot]\" title=\"View the GitHub contributions of dependabot-preview[bot] on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-C0zCYVbQdDeh4Xm7w5iDPiSSHPQOXBvlGaUmLUEGNpO1lx9Cg799wUb0BR4KwCWX3QcY3PjNo7auZprlhAOoNw==",
+        "shasum": "fea927da2eeb23edd3e873611811813d82dbf5b5",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18300,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4sStCRA9TVsSAnZWagAANk0P/3qmmGnJBXIi5iJ3hXF9\ngWBnY09o23zWYarigvU15wc+bjfX4rtSNEC1c8YxDHF/s9pJkjHmemZufX5V\naB7wBNIFbHHswjXW9jfxd7gZ/QT5S6W+ySRLcfZIskvGI2ZRvh97xMlZaxru\n/usQFouy2PgwH+UylRU7/9nlmcO4Budbzm9jzZSc2NW3RxMyG5KebvlMvKj8\nitjVBbprREFUuT2jWS6HuDRAbbHJA7u2YXNVg5tTjyQA2O1ds0RqqQeibsmd\nWZ3pGLWAlkyqPRlZgR6J935gODNrfkvBTnljqK6lerYTjMU6IoMfXS8kqVFG\nJap9FdehSC+t2Z3phiiqwQvZXge2lyWyHn4fk+0fkHv7tlbLt33NJQ2Czdb5\ngzRIKXRtxK4aQMNpHt0XvoCfPR7rpUXjINSPb36hRn7VajHcFr+Gb+rCjib5\n+hxbh0+zxs6vjT817if2D/6Yh4kxvaWfmLrCUAxNywrrmJXynaXo9SJyn6RA\nzvbHuA+rWDVj/KNCs/qV2pDUxTx+E4SNqh97Ns2OKYz/bnbxOSp7MiluwaN1\nJZzJJGWjYrFi/R4lINlB6l4k94phvm9I/l9gKSmK1VYOvMOJldjAOhQc7xiA\nzFwUAkJSf5Y9C8HQjVhciYsMn4FI1+ry0/O7P4EnOXsZSu2U9u295Tp6/Fem\nILGx\r\n=ikzA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96_1575142573548_0.06880471460073423"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "domain-browser",
+      "version": "3.1.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "devDependencies": {
+        "assert-helpers": "5.5.0",
+        "kava": "4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "gitHead": "b65292dfe20ee7bdf4423c290f3b61b51f035b96",
+      "_id": "domain-browser@3.1.0",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-N0I7aCH+GhEOu/VduHvzHoVFw3a37fpgYA0o4mya6bhOyg2Vi2w/Z+ykWdP9/uAVgSWdwqOQUjwseO6JDgbaHA==",
+        "shasum": "eb21495c08b9e933cdd1c6b201b0b51dc6281e7f",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18243,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4sTqCRA9TVsSAnZWagAAuZ0P+QDsTx42fSTGf3U+gnaH\nI34gexPCX5EjTXPFNclnUdJtFnX6ve7Y6WDOH8bfjg/pVnbYvd9RxUH/lZER\nzfO9V6Q6IFe/MmP7KCer3t6+wAtmbh432TNDB2C6nqjkcmSiTanCDpRHjsk6\nGEX+s1ckYh/rOqGL7bcDGKaw7IoKMx/F0hMxdeTOEBpgK8sfDTEmfNwJXfDQ\n73H4Ou1/1IkW7kKF067YI0foUoTJA6plWG7XY7SsK4oHckb9IXAW6FHvI5va\nosZoCxT1NA21B6EU81wwHj6qCY8zWoguLo8AI5PBeIAa7V3aGuXr4d7SwPMI\ncgJytibauSpqACw4rTVt4uUnNSMJXWMw5c32rz+rXpssu0iIEgQaGdbRAws5\niyQlwXfsIBs5J0cajHzHEtGCQMIYwUos0Tk8bW81sNmb+IS8sSSlk+jBbKfI\n/v7XhOVz2yKgrxqPUaD/GRKwMwwEMCEI2v/CnKnof3mBl/Ty/N4KSxwXdrY0\nvaBhRUqNE7CGIcWUmKHJXEnZMA9QlmS0UsS7ZhqxbkdHQrQOy6wnqOQ5YHl6\nZJYpdN8X5G+Z7goMWyGDG/gP+SUfw0F3oeVw74IOImSOt2pgoyc1epqa6KgC\nIYADlzUo7cxQb4AdtiLgeE1clc9ivJ3+HGVWW+QO6NDOb0mUsrLLYSByRC0o\nEuPb\r\n=gu5M\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.1.0_1575142633053_0.25609217599445455"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751": {
+      "name": "domain-browser",
+      "version": "3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "assert-helpers": "^5.5.0",
+        "kava": "^4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "845435bb55b6697013e785a4d576315890c42751",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://github.com/apps/dependabot-preview\">dependabot-preview[bot]</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=dependabot-preview[bot]\" title=\"View the GitHub contributions of dependabot-preview[bot] on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-smQz02lY11Dm8G4kFKBb/mitX9u4qTOECVwxFX521EAXExH2izC0XdiwHlQXyBhGKa04tnPumGC9BdRVU1GvBg==",
+        "shasum": "08679cb94a78e6a3e1e03c461ca1d2b117f86d66",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18499,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4sVxCRA9TVsSAnZWagAAH+QP/2onvYxrJMUtffjZMGse\nu9SFvc7lN9kkq2N1rQWU0WKeH+AMMq90pXZBCXH5K4UtWx0zqpAiqmEz27Tx\ncADl2L3y0klw4lcojSAyxdFjlXUo7atbrV19ZNEp482J1J/WylEsRpVWfQjq\nEBdRjX/a04SsQANbKD1QnE9Agw2G0vbwPBICjqKpgM6412s+NbM2Co/cZ381\nR+dGr8JwjzOeKV3vJtTNnlVkOadY0TsC9NZerKOj8H0tBJrXO53EDFNPk2De\n/3nRIj7Eli/KpsNNkfKNllUB88KuPUnUA8bBreNgIb1FcENsKeOdO+sfR0V9\nGB8c027HJV43IIsCmmgm5R2Y718Uy7yMbMpYlKlZuyYSWZnwgqoL0bpb9WE/\nqGyCtGieq6rnVERQ9fR4WamulJhp31+2sYUfYvWaLqAQAjwxcLT+Lxq9JdV8\nOUR8L661Ww9ANuVp/5il8wC1mMJDlgtWD6x/Kuy+EehnZ6ZVWiOYry1N1xnp\nPC2ogApjqR6owDQjyPdAb/xrnIJ9MCYcfeiR4La6PxJkiD7mIX+wc66ksbN6\nrDa2X6+yYtwuSrthNJ0MVr8q0h9vRnVTEld9T71JLZQB0PsE26q0MBPjlvww\nfhUz2AsbLc8jUOSm/AdTYIy74tPIddtBhwf7kTiKc5bC3pdd491ofGy0/mbU\naZCD\r\n=OB3g\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751_1575142768725_0.20828024125712608"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.2.0": {
+      "name": "domain-browser",
+      "version": "3.2.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "assert-helpers": "^5.5.0",
+        "kava": "^4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "845435bb55b6697013e785a4d576315890c42751",
+      "_id": "domain-browser@3.2.0",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-VIazvzn/LiJaM63nBcdXrK6c8QRfNSx7ipmTNaPPNKKm5xmY7/JOl2nnk4oCVIzw05R4xvQ7p9FRXeE4dSiG5w==",
+        "shasum": "deb911062e6130b3d54bd9bfcc6e3dec31a39ed4",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.2.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18442,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4sWwCRA9TVsSAnZWagAAYs8P/A4EINk8ziMvNMZbHOZQ\nyWL/kFhF45QZbk5J+ES3i/iYVgU51VkE0uH1TjLpYZiALAzI2tjca4MLbBbt\nB2pbYiY1slULb/tjm450MIESAjBXrmMQGzuYxgZ4dZ49UaIzcINlNPq5MjUV\nlnNl7RQGZ/P1LkJH09L7o7gsOxo3NC5bGkqIVSrHglljFzsNLw2cb6BUAx7O\n8YIkyMVrIGUJSx2YSLLB954/WnEuCuAIxNB7mcZYTabYG2Y3pLzcm6/pUa7z\nf5FgW7TjJmLox/tzXKsfQSBeFGO7jkHlIVLAvwIq575jP6/gVLZ9JnpoHepW\nAYOLCW/lombJYP/mAuXYZinJP6m5ytqp3UbmoYmmMwpLsBSQ3K1uPjj9+SMh\nMi1XLGJH0Mv4G7+E38v8fTjcg3lc6/OwQ6imx5P9aKSKE/ehSlTCgis0o3As\ncGJe6w4/aIsAWTpuvWlZiIqNgjDCmEk/p2S4MDqx8JxBVaCNI8f9kN27mbaR\nKc3rHWj5+agQvYl3QgYBP8QPX2M54FyBY4xVnTX4fgAWCckc+Dky+zfJQ7ch\n3z7WZJXuPPmYSR99jCasJ+R7HapdqaDhcOWsQkvppj+FZjBJ3mHLG5drwxU0\nZS9TB/gmb8+VyEKxRksJOMKKdSOChpv9UWfkwa65gwOI6l7Epo+3odhnbCWV\nQ9kR\r\n=4nTX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.2.0_1575142831843_0.09241480405644031"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7": {
+      "name": "domain-browser",
+      "version": "3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "assert-helpers": "^5.6.0",
+        "kava": "^4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "3c18f188a9cc5457635a5903ba57c738044b09a7",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://github.com/apps/dependabot-preview\">dependabot-preview[bot]</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=dependabot-preview[bot]\" title=\"View the GitHub contributions of dependabot-preview[bot] on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-QNL/9H/AKxSjcL3eiA740kkPr9wfIODgKxTkp+E3Jy+O0v6ldtbKn1F4DPdnxaa9ITKwEoEkFA86uo/RxA7szw==",
+        "shasum": "513cddc0d022924356bc5eead466650e7f3f979d",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18696,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4tD2CRA9TVsSAnZWagAASJYP/2U70w5MH6QZ+AEB0zat\n2Flyuo68Ezu3T6XPJ/Ytpk2/Zyi78EFW7lp1fiPvlTFjx4qJO0bEbuwsLXjj\nezsRnFP3zcqC3a/UYZz2pmJSO4Ng+w+wuvDNjVlAcz2eGaag3lL2fjFsgech\n6WdTX5k9lAPJ83ZvJSsyPdh0B4RYKxfQ4QEqWjJwcuxaLKYcjhFu41PJqa9g\nv1oHLTREyrlKwhmyiQvuRSkaXPB+Qqwp2mJqzb1LHsXDXKOMK4OPD5S+1jlv\nTLMPJnP5XRaOOesOuQDZecExkB5vrBfLuAUfnTl/dd0kgZnlLLbVblB5TbpB\nPKOudQvACS64y/lGHDn+OxIcuAqjNCWOm1VQMZyTdus8n+3XEBkW0JaFp1zc\nB5ogeQQ31OFgRH+L5RZwawaXIQxhGmBblccR24eeyIgKC0ahp4Niwz90hY0d\nnYUqIkRq4eOdeuzhycFPBb7i7t9dh1hDKYxdt5NSEyGLemuJmR6aAvif4A0t\nCceI6a4m2VVJm2UqrTI5x2L7bWEekQ0ESEv9KF0SHwRT4E4+n4nSQSEhHaon\nGc8njgOOcJczRdOaVYx51ilms6m4sN8lsycpVNJb45i9Sup6fjhXABTLpdrQ\nLpUHuu/CNOojoOJUUzNazLC9WVZHN0ccDdBn8h4zQPxfeo5EIuoFB3WNvBcb\n7rST\r\n=jXIy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7_1575145717730_0.9236684746256043"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.3.0": {
+      "name": "domain-browser",
+      "version": "3.3.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "assert-helpers": "^5.6.0",
+        "kava": "^4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "3c18f188a9cc5457635a5903ba57c738044b09a7",
+      "_id": "domain-browser@3.3.0",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-qlgBgkqr3ZvgxNVsVS+hU61kNUeMC8hlKcQGLWmM2I2cCChU9gxQPPMLYldkwqbR5zFHcjC/UPzTIbY42aAHzg==",
+        "shasum": "477aef332c1d4e23569609cda504f14f0d5443bc",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.3.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18639,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4tExCRA9TVsSAnZWagAAxqgQAJ9o+xXiTDsITHhDsl/6\nW6FFywajxvP4enQOv1NqnztJ9IFcoGrcCZFAwTkF6GJuf9KA5aMgJwSnK3zL\nGlgSgFsxPHeDbsIuYOd0E3MUKx0dl6B+aIErUqmQpVYh8/DX7SEP/32izgsh\nNBiA0xcQB82mok/YkYXRF+IO3AFB3ddunxVELKVZbnJ8eDKm/Z73I44Z7Cfr\nnqm7Z1kFU/OijhSoYZwHxbcpHE05jC2BxsVMZkuc17ouiH2O2u451vjYX+qv\npo7XNKzxSWuUDWYaDMpEIvARTNFffhPj37g9EEXb+wHhxm7dz2KZGR4dLhcJ\nnltWGHF77IbRR/nj+kiEx9mydAL5d7RczRs0Q0F9HQ/JYab1aVqlpW62xALQ\nwkQhhC+W27tIn44aqGdDTwFGioet2v2PRFM0kzfeFq8fndzrVdVon8VoJMDs\nyjKWDp/9NAxOMx28oVgKdEXhlh5djO4q9mXvaIVf0FTMH85tnrFLVHG9BF9X\nTOM6CnZFePrSfxLZp1NuYyXxe4YXmfmUhIP1Fj1/xmtihyLQbIrDH7i2c91M\n1q6j0LSwDFASW0LRO99Xn7y1IPuaG/qWs/T9qPXTGwyBHpb+UkYELr3J3Yrf\nOud5FJxvHoUzs1J/HJL2sDSvRMi8mkaIC5yEiRxG+dna11CzTtgqJQwQjdtL\ncHgc\r\n=2et8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.3.0_1575145777003_0.3791495636418749"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147": {
+      "name": "domain-browser",
+      "version": "3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "assert-helpers": "^5.7.0",
+        "kava": "^4.2.0",
+        "projectz": "^1.13.0",
+        "valid-directory": "^1.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "91ac1d9c986aaaa103065ab190fb94a7001a0147",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://github.com/apps/dependabot-preview\">dependabot-preview[bot]</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=dependabot-preview[bot]\" title=\"View the GitHub contributions of dependabot-preview[bot] on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-WSMQezU4GFhyEV0bAWOwgr6/yOLoTkWQ0rxpQ0N2Dmkih74FBwqIOeQR3bb5L9Ir258LIF/G9/bdDzHqByxIPw==",
+        "shasum": "c9c83a98a6b433ff8c7fa53c1016db04a7de5fc9",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18901,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4y2SCRA9TVsSAnZWagAAbCUP+wcCfSziqXwgYdI4NBJQ\niKB6viuIiI+Ai9ND5aCvSzrAsOmuuwV2aDPolONJJKjR/SIjDQY8IwwMoo3t\nfdjjmMGJjc6n9PwDeLh9XntsDzt5khP4QL6beoellcGqDW0cs7jugn7RZ2ey\nK6DOr5TDQaa3VrT6Ue/wd1DzHax2ex6wDZNArVgY6aok+eOLne+3mD0wRunN\nE7oewCJvEOKCMLwN4j6AMTlLnoQpZrtwMI/S96KFDfEeMgWrBdFf1UM/v2pw\n0NlaQI2jnUwdZU3ucervCVYJa3H/cBeu3+OLcDnzB3IM4+8bhLJ6i/77RWHj\nAhFFZpx9cGvljCi16Hue2IhAtKVUb4HACLEYCVIZmOUCJa4nar56J1IJrsmp\nFC8lfUnpd0CjtpNdKy5f51XCrJZ9cCwqDgTT6YVyQKRWWmxoJnisPhn8jmva\n5JAGf7V2x1ct8Qp2YAeZ4oGhDEBE8HtSqbBhnn9RAeOc0jb9kFVswRtcjRCs\ntGaY3D5EdsDdGQk+f0YIi5b116h0xJrf8DwFkXi2o5KKg50ciT8qCVtgVUUk\nk7su5/Mz7X5U8qqWgIdCkM2dgwiqjpLq4w9u3gvquugqLwvxc1VDBtgZuf/f\n5wqThtsPLwQSrY1lj096CGK6KHMRdzm7fKFapvlLN9mqI/XmIE3jcv7+N4aO\nLgys\r\n=i7T5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147_1575169425985_0.9084457023707391"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.4.0": {
+      "name": "domain-browser",
+      "version": "3.4.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "assert-helpers": "^5.7.0",
+        "kava": "^4.2.0",
+        "projectz": "^1.13.0",
+        "valid-directory": "^1.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "91ac1d9c986aaaa103065ab190fb94a7001a0147",
+      "_id": "domain-browser@3.4.0",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-8vhX3KP/Sm91NpdaZ+7JJo/WhyVD/jNeT2NviwMQO8N5fm4E5yEf1vfwV62fqj0FhFPyAVE9bgoqDIRPWdH3HQ==",
+        "shasum": "c1bea57e2fadc6fba9ffcb7c48b8c22079ff8044",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.4.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18844,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4y3UCRA9TVsSAnZWagAAknUQAJEKhDnP9NO6eMN1KcKd\ngmMCXP1Z+5aPTBuWjEWaLuvqJWP7hsA0VgXpz2te2Z5nrvkuMB61aFemhRoh\n1i2uYJd4lhzsoFkJSN/0nTP0PPtY7gWhsi/e9tvdzICSKH94PM2gVT97CVku\ny3lMr3b7R83LxH0NpFqomn+Qrx3U8wYWEDNAcLH/vXPxw7UzTzAvrfXTC67r\nyg00ryAUZ1Lf28T4/ih/mS5NVaOlNaz6i0cjxt7yQrXcO9m3RwtVro6iYoTA\nMVjji07CD7Rz3bgwROXo8nDsRYviY6tln+1rGr0X0/q2HZn5MqKN9VtcE+bZ\nswGnpX7Pxub3YIHHPohPD9RjwxjhD7To+jJ9LVLinMh+lRw2tt9seEb4PqWL\n+a/R40Ew2JsU6/xyuyC8Iji0l3nFCtx653fCvYWkbjWNemcd79pPSAr0GhlS\n/v/tgRESPdOrJwUeWu98O1fyFXp68w/LCKegZtYTJMM3fQx9ifikG5wZ/PTm\nySlZE9dakSHwFkf8kdkIgARJGOEPL8CEfhJRWXI6xiJx+5Y33bSxlY0ZHd24\nS0PUTydYXz6EfpfIpCZMVJ0xa6haHaMZ6qlCqa9g9NDlMK+mOjycBFYE9vce\n+QlJU1QyVuicMF/MLtGnzNuN+lhrygH1eekxvEGYQ9JYePywGm9uTUQfBAad\nE/lF\r\n=bTmx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.4.0_1575169491405_0.23598793481297875"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b": {
+      "name": "domain-browser",
+      "version": "3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "assert-helpers": "^5.8.0",
+        "kava": "^4.3.0",
+        "projectz": "^1.15.0",
+        "valid-directory": "^1.5.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "af878d245489557989a75bbc0e8ed1bc8ae22d6b",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Require: <code>require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is es5 source code with require for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://github.com/apps/dependabot-preview\">dependabot-preview[bot]</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=dependabot-preview[bot]\" title=\"View the GitHub contributions of dependabot-preview[bot] on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-RBNItR3bhzvSuAfMIHOn529OnbtRAfjtS1CcWz7oKCEteVrMCZyxnRPt8VH74TYHq85XnNxqK74HivOGK+P/jw==",
+        "shasum": "d7d7f30f7020a7b92945f97a0989e63cb7afd3a6",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b.tgz",
+        "fileCount": 7,
+        "unpackedSize": 19743,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd7gDrCRA9TVsSAnZWagAAyo8P/049n2EjZGDjIPvg1KxZ\nS7NTR8G8UY+doCLGPQhd9kaQO954nsI1EuVoB7KfLPGrK+EwHYEj/UjLbnLl\nd8HSq/VrjeTqoKfSUUzfB1BAvGkah13NGBaQBJNPwPtkiFVrf3umuwaAtNSY\nkE9Yb9+nwNRcK8PdC1W7egHjExvjqbrZ7JnTFUDp676caVdXFllUWl1ZQuQ8\nEB0CtLBeviXFEHMIj4Hhj4dsqTBlIggmyjuooyL1Qhv/8H6IB131wiY6Z3i7\njXtgooYBkJN4SGcmHfkPJa7RIEc+dmUPQinaGVCKXMlOESiibcOS1dBmjJ8c\nfW3hcIzTXg9QeE0MgYzVbsjlPsKP6M0ZUNNHZNYScOT8vXbXY2t7Z+o+uezh\n4LfcqKQzQ58lTPF8P4JgAMfxwwsSVbpDJadc9qnIl5ZJYB5m7HDRwYnDvD0w\nDztepJI3kVMOos8xuynPp/qTofR2YG0RWvIkAeFzVGyOVaptT3ocHyJqxZ6N\nth2svjuMmZ4SbGcUxFjt/w8avQ63N1dNYDpYkxD+4SPcL2HwfKG5H0FiUiUx\nFfSIYGllIURSSGg3CW1AD8yQM2Fr8NMHlm7+L2EV6UFrEugE3W2+HGt2R2No\nuHEwz6D+W9a4Ji60kjoFPvrHGHp11vTCvHBpyDIoFyXnkwDe7ExmeMUuHTZK\nhayK\r\n=HTSA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b_1575878891283_0.3732322801940231"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.0": {
+      "name": "domain-browser",
+      "version": "3.5.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "domain",
+        "trycatch",
+        "try",
+        "catch",
+        "node-compat",
+        "ender.js",
+        "component",
+        "component.io",
+        "umd",
+        "amd",
+        "require.js",
+        "browser"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "dependabot-preview[bot]",
+          "url": "http://github.com/apps/dependabot-preview"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "editions": [
+        {
+          "description": "es5 source code with require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "8 || 10 || 12",
+            "browsers": true
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "assert-helpers": "^5.8.0",
+        "kava": "^4.3.0",
+        "projectz": "^1.15.0",
+        "valid-directory": "^1.5.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "af878d245489557989a75bbc0e8ed1bc8ae22d6b",
+      "_id": "domain-browser@3.5.0",
+      "_nodeVersion": "12.13.1",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-zrzUu6auyZWRexjCEPJnfWc30Hupxh2lJZOJAF3qa2bCuD4O/55t0FvQt3ZMhEw++gjNkwdkOVZh8yA32w/Vfw==",
+        "shasum": "3a11f5df52fd9d60d7f1c79a62fde2d158c42b09",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.5.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 19686,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd7gIvCRA9TVsSAnZWagAAbZ8QAI44uXFqMKSTSSR2NtXh\neg7XlazjYaDJkraHEwRyQjsgV10zSU4JQBrie1enUa9kNhZDNNvhPj8ikpIF\nKKJGOxezp/D/qE0gHMzKHsze2pGpNBEMApVjpaB2WDkWl/TAv+KFLIYgpgeV\nEiahfK6p5HRGnVCsOgn8ZJe39smHIbQVEq+YvnsU1M2lgFBWLo0r+WqTyCsr\nc1oYjPpUlDaAAQ4KdsZGZsx/e3Kdz0fIFwHsLej0U5u7VgraIgjOJF+Ux+Vv\nNF5pdNjbQXnPhzcxbNGplS4+ETkxe6gvvYleYKX/8Nb9dMipFafG31GP44L1\nLAhqaSDQmceaV0upSEqsnnlH5HXw1MoBhdNqkC9Z+cfCWH5tUXa5kZyzqPLd\nQNBpgEDZqnow5wU7AqUZIkSpgAEIUGUvE8BFP4ern2W/AvII3QDSFcO7iLJr\nWakB9qIOO+yoH/UsOjlvD0hFJ2EPLltOp6sM9Vkp4CXfH7PmeK4Gha6F8Zpb\nc0ZxRU90gdkQT/a9YZxwEy3iM4GhYTmBY54WZjNEJTfGj+I/hjq6qgOnITUn\nKU5JoklCliGnV1UEyRB6VuQiW8haqOCPkZa8+jWKHwwhrj5TE1Ugpo6kz5Lj\nTNkIgzJolk/GqTzwoM9SKFAXfFK6oas6lC/BxQqCC85d5J5cml89S8OnjGnd\nlLXy\r\n=thXp\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_3.5.0_1575879214745_0.47386407752920534"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "domain-browser",
+      "version": "4.0.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.9.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
+        "@babel/preset-env": "^7.9.0",
+        "assert-helpers": "^6.0.0",
+        "kava": "^4.4.0",
+        "projectz": "^1.19.0",
+        "valid-directory": "^1.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "35e285d185e15fda7ec117d33915f63e24706cb1",
+      "_id": "domain-browser@4.0.0",
+      "_nodeVersion": "12.16.1",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-q9seD1JK98fzT69I0sAzp0cxb6gUS1grmCaq6cLxTbm9msb9eqYFXGJU94VOIOi2nKmYmKdUFkTnGvIViuX9qA==",
+        "shasum": "45021cf8d2928f116b89a3308c3c30b746776909",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20306,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJee9ybCRA9TVsSAnZWagAArJgP/3ffWYxJKAlpfwrbUGbi\n7sdYl2huaSuJa6BT4uHG3z+QfelNd3z5uTKFD4PINLRg2EMv1tIJGbt1Ti+A\nxjEf7lebPksr2lPdoaA2SK+yn/vznRjhcf6keLpKXdKz/0PV78N6mAlhmaBK\ncquwMWCL4nmiz9aEZAA2LT0Ld7rGD8iNGIgVBr+xLkfWm7/E9BDqdbFWx313\nAsiX2OG32SA/MFv6bw8bjQUVS7yWjhIdBlalXhJNQSii5Tdjgn45S1y4ljU3\ncsZdxP7oavqTiGge+BkiM9RSF1hHYcHeK8zWgzZSdwXtfocNMz/mt8Q8kvd+\nVqF3CEJfC7LCvDXdjBWVVBwzJG8lUrSRQZMFR1yap/aaKMUO7US0i0ARDHJF\ntYNZmpkC9MK3jKJNgdKWiqAJHowgsGEAI+aR09+5b+fQMJphiZnvmXQq7/Qg\niWKXz+nqWzkgoaoxUVDSuaunX5WzpTZ/xCcMblYxx9iII8CcluQ+nUXOhZ7o\nVo+Pk97G8CUxw0+3V24nCOH9GN0HJAqd4Xgq9agPyIKWILVM0aC3wsYxY0Cj\nq+IZZ3SrJOR+GXGlKgvhBu2z8r8EsYw6rJjr8vb3mCgf65DyNhBJRR6cI3/H\n0PWvGeAik9QNkBbaNAf+7isGv2d7XIgyeWfU5JqNj43a7T7TxdERqaIUIox2\nTNQu\r\n=T71y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.0.0_1585175707371_0.34773224919407664"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1": {
+      "name": "domain-browser",
+      "version": "4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.9.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
+        "@babel/preset-env": "^7.9.0",
+        "assert-helpers": "^6.0.0",
+        "kava": "^4.4.0",
+        "projectz": "^1.19.0",
+        "valid-directory": "^1.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:projectz",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "35e285d185e15fda7ec117d33915f63e24706cb1",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.0.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://github.com/apps/dependabot-preview\">dependabot-preview[bot]</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=dependabot-preview[bot]\" title=\"View the GitHub contributions of dependabot-preview[bot] on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1",
+      "_nodeVersion": "12.16.1",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-IMeYMHoOjcgHJ3LnkzIE2NxsO+AjRBjrrSAzvSSW4Df8+L6GRp4P65qvVjSKCVAriDCtP/3W6gAW0enmYep0Bw==",
+        "shasum": "cc4173777c6f67b148d01a76fb58d59d0d9acee2",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20363,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJee9ypCRA9TVsSAnZWagAAIVIP/A9aTAGk8gNSLL+f+6ID\n+W/0YkYkrL237S5nEnVxxMwuRquYSrqgMKKDge88cSB+BgB0cV0A/D5i+laS\ntFTMAbQWfpSXjOr3wOcfuOy5IVS5j+7tfcVEqhfbSZkiCYRvKk5H1L11GuMs\nh8eyLJY8eKV8pLVIsmD/d3d88SaXpfJG0nPbiPQXbTAH+z97lepPuby6bis2\n6q+IyTrRjpVdeLA67B+PW9YnmfLt06Mnm43tLJoI1pP2Ge7M5WrbO9sJgKsE\nzedpPuKmtgGqDXVn+JwRUCAkYF9lbNpQilG8mK9ehMp0GwQZry1p8Zru4wk4\ngmhLM3hvmn1aj1XXHcIJodYPwfpxOFVYr9aChIneFFBdbJDr+G7wgrMss3/O\ncaHBPzen2ilG4pESPNKwAEcWBa0zYXY242rRLg8/mJTRExTxVwZgcaNotXAB\nrNVSt+tjOpd/XgI5jJE4x8UdIp5sit+OnPq66D4qjsH0r4C3iQuX3/BuHhTV\nycINHcsKq/BkJp7thQhcuo/EwIwOLq7PFQ+murssiDsyiGPMLJqA/Nu767mC\nbsfp75C5sK1eQjpyVwVDVmyPnEAZ0iMPmthOsUxjXpTm4k1UcvyJKH3rdQ/a\nEDLAfc76ipduCPd0jLhFHAca7NlGMamIQXFHSDwGidNr07tLzUwx9v6d5zoA\n4R2y\r\n=eAKq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1_1585175720835_0.21778767782677355"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd": {
+      "name": "domain-browser",
+      "version": "4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "dom",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.0.1",
+        "assert-helpers": "^6.2.0",
+        "kava": "^4.4.0",
+        "projectz": "^1.19.1",
+        "valid-directory": "^1.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "npx @bevry/update-contributors",
+        "our:meta:projectz": "npx projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.1.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"http://balupton.com\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://evansolomon.me\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://substack.net\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"twitter.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"http://github.com/apps/dependabot-preview\">dependabot-preview[bot]</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=dependabot-preview[bot]\" title=\"View the GitHub contributions of dependabot-preview[bot] on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd",
+      "_nodeVersion": "14.1.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-IOTmUBwyavhBuYubftiNTKfb2i3eKKGtcoPfT+nrIhIbh1AZLyS9C7f77uVZ9qghS7b82PTARJRcgMO2fpUMLw==",
+        "shasum": "b9c7f87a824e73a474a4440f64935533c9a6950b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20598,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJesAwxCRA9TVsSAnZWagAAYgkP/0U2xeGllcd5cMMDWp1+\nB76/pWRxULcVBhb6Tzq22aYKdANchLFcEV5x6N6kPpnSu1NQ87PZ9YGhIewy\nOc6ATjbCTowaG8pQUyabO2XD4d5KAkbFQLsA3jBWssPcicSFXxeJ3Q98ZXwB\ngrNu1y/LGG307q8pcyXGwwqCg96IDbwoKplmGLFLpuYlNDfbPtvnM5W/pqdK\nDxjQIePN7PFAdG2QSMGIL82yfOJOFGsGqJGL4H70GwORuLTcqQNtzTqKFD4X\n1uPibc+4f7VlorP/bjxH5hXUEOwQMzNZ/uEHlx3dgCoATuxcTZwZnc82YVyG\nJvtkf7dsSvL5jqiK1lEze2epo2RZ9JWLQ3HlRMBmNM94wvRp6ZHRIuqkfVC9\nNbg61b17r3J5m1iwZdK2jnZQpsE4O3JOCyqQCf7Wx55XC29npeHkcIIIcipr\n/IWibK44+b64jU6G/WCALBiQ0KUKC/EHQ5HW0hbFBYgKuMNc2TOWRY8IuIBw\nGIsyL9+8qIvnhOfKMjGKx4zCik/13ClVDh/yPqTN2FISNIvWFEkFakrOC4Rg\nTO5Pl5N5mvGgirekRksSr7E/hM48UHRXZRc6wOk9F9L7Px8k+TBADe5wlSh6\nrrXRJOjIqiYOXIXexvGmfvGJ7qE/d7SEBVufWdvJpg+cBWKwhFheFZQEok/x\nR4Ys\r\n=j74a\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd_1588595761347_0.7959603396354178"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.0": {
+      "name": "domain-browser",
+      "version": "4.1.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "dom",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "http://balupton.com"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "http://evansolomon.me"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "http://substack.net"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "twitter.com/guybedford"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.0.1",
+        "assert-helpers": "^6.2.0",
+        "kava": "^4.4.0",
+        "projectz": "^1.19.1",
+        "valid-directory": "^1.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "npx @bevry/update-contributors",
+        "our:meta:projectz": "npx projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "npx valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd",
+      "_id": "domain-browser@4.1.0",
+      "_nodeVersion": "14.1.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-8sVi7iK60BKZth+bZ4zd9aOzH/6POpJnowGHhE0qrlfCXSWZK48AhhoHeEuWBYh/gFYhFfvrVwTxfaKVXMK3hg==",
+        "shasum": "b5826ac385d4af8cfbeb253f375d10b31fb8dd1b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.1.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20541,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJesAxpCRA9TVsSAnZWagAAPAwP+wQ+PgdotPpjnFQP0Fjp\nxQIfqIOq9ee/qWt7T1XCW2v5sWdVmgn0dQSZZOiYAl8hBNWsjwhKoErEffmY\n9rKwD5Gk/V0qD0RcuC+KAmB3iePrHu8uFMNg7LLTYwptURNpI4A4dMrUEKLp\nbY5lCbvwD7/ftLIt9S7OUxFLBpdVWJqMfeKnvzCTb1VW/b655QdMf2+NQ2sR\n4D6Ch7cJQSLKmwyyXCXY/0Bt2fF6LRGw10QKlm5MWw0gSYMScZ59DXexC1ic\nGEceCh7R7hsGcN6o2JmaOaPJw/cJ+yrK7iRgWyBGbRspE86M2iU3I6K2bIQL\nHutLmsBgABMc7hJTprdsxi+FNwjcwiGGQezFgIzomUyPXHAb9bEwuIuWB1uU\nEd/xfitNR6yRfSOJmyNcIBKxfkVLfbnZsxUJnjI34svR2YxgWwO3OFZ0Dv64\n0AkYdIiv1SCcFxpZdZRE1Z/q+zNcdLmUhkwzs7HvvbXDsC/YVVSwJ35G87iF\nRBwlHGXFj0xuqnwvrD1bmleDPaPNw6UXXoAxY5adcCxia7CeA3luuNFT8c74\nrCm2AuaviiGP+8PS0fag91A9v1dXCaOIEzBEiu6EmZm5edA2jMfT1HWq4rta\nJ9/cN2zA52j3ZMGnmAJopf21iLrW2h5FzPPiVNoLGkQVZV1s0zGQeitYflIm\nqweQ\r\n=nxY2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.1.0_1588595817210_0.4678984851566521"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3": {
+      "name": "domain-browser",
+      "version": "4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.5.0",
+        "assert-helpers": "^6.4.0",
+        "kava": "^5.0.0",
+        "projectz": "^2.1.0",
+        "valid-directory": "^1.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "999957953d58ee5986062a9adc78dfe9e3f74ab3",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.2.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-U8l/kYbFQT6DiyMN0lEUXwAfdKuURItRsoW/GKq5yESLE+Pz2TF/+LIArzcyoEZfiHV90/BsuzQTkd2jOsYSMQ==",
+        "shasum": "c0ba5b6b3b0155af0db8ce36ab87fff43603956d",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20698,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeugiVCRA9TVsSAnZWagAAUuoP/0c9xrPcrt8xTuTHkQJn\nXIQHHtYjYc63packlsAGAV6mjJWutUKHmsI+4ozOoe3eUyIj56C5ykJxbd+U\noZiNI2yo+HNqAfysLc5VlTrG02EruNBDqz4qeQU27QV9V7sVXV5P5djleGYV\nZzdoZRZ1oU7N04JoA39yoFx9rSoz3N8neKKYxyfH9alSaNmnQOAYP7dl3Pqq\n+1mAr+qWF1RH70jB3KNcaGtKwNb6qTJE6WeUGA5zsYSqDrnlzdV91AxUBXKQ\nuSgq344pZXf40bHVFRnSsLXHBJEe2xRt+nXVzUJj7avfhhnpuqt42fBxHvLY\nXpr/HJhqixhEIVkzcGqhibxTZXpwGdp2wLjXKHAJ83GrXMOl3wlVKFKc5KcZ\niEsTSKJq29GAOFbgqKwqBp76GIMBx4k9LFYeuc+aUoEhhN8NAJazzMJ8/QHU\nSLjaC9P4Lm7rD7Mki43HZ9YjK47OrkHY9VeQV6UoSd1AHlqYBEmFz4lIuqhc\nNIgOehKNR5bXXCx/ebVBPQx2CNJ0S4/B78A7Lsu1zLKjyV+yqPPcLqq3THBW\nlvjhrf7+uOLocfPQ3jMlx4xSA0+vsrDGBhLHsWIxZ19cwM6pBoFX4hYP6OBD\nezyFonq2erRqffxuqoqVXvGOSgTm99QUSuFrwXfGmBj3yK0MBV/T+TX+HiXy\nVmYW\r\n=MJTT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3_1589250197254_0.5489345492674382"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.0": {
+      "name": "domain-browser",
+      "version": "4.2.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.5.0",
+        "assert-helpers": "^6.4.0",
+        "kava": "^5.0.0",
+        "projectz": "^2.1.0",
+        "valid-directory": "^1.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "999957953d58ee5986062a9adc78dfe9e3f74ab3",
+      "_id": "domain-browser@4.2.0",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-6pzohAPOablvbGZDjmuECHSZqZWozsyOiSnAaYJg8vxPIYIogtfqsIwVKv1OJasoB+Su6/CA8iVhjev1a/O48A==",
+        "shasum": "5bac4599fdd1fab1592398d8c270b56550d60ac7",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20641,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeugjICRA9TVsSAnZWagAAresP/RAkSFxnO3fx+3YjBxiU\nlme7nr3ijr+hK2ZsCdtExkuqTSITRq+/7fuLZ5flib21zThjSTF4n015pqXm\n7AmQP7TN6fqcaxXOV19/IhO6dYyGnJyK6LO3yEczXWY5HmbUKzG/jcijYjMN\nivzLffzGUwNPllJETS8J/oeqNL2eyb1ab9G1hPYEvtUuiD68wECn8zG8Lj1b\nd52NL5Pj5h4F1VqhZcgD4Vf2q4TBCdIafCNbPoM7x8m91+AwyTyD48Gr8AP8\nFupu+h2WDbFJQLX3m4tU4GjIC74N0whuPQY1K3lV+SosOAFEFWxcw8hkJYzH\nU0UXGzIUIi2IjdE8vYTz50xLFhKUHn0quq7siKpacQ/ysV6gn3Emj4Fuu+6R\n/HZx8rCfdlT2msP/ZjgpT3hBa9ExqS8Lsm6zMKLDnGSOpuUdLD4aHAhBB3e4\nMtJAdyBxTZEEmbTLdos7XESOI6yw9m0CPTwsiZvJqJhrxMMh3wVI0SzPr5q/\nrTuFASysyTctyKuh3iXpsdpXvHLnLWsTrXsr/RmaD5xsagVgYHWRHq3DqC0h\nhlYicoXXT/EhaDlkzOU3U5yrhcVbatXTSW59uteGQcJak9qR6Sd77NrSL+8m\n6AF6NSC4bYHq4ERJWvuqY5R4iQc2peP/UptXrLI13kYnzADWlXRafvukQ+47\nd+gH\r\n=rqnb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.2.0_1589250247877_0.5976340499968682"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67": {
+      "name": "domain-browser",
+      "version": "4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.6.0",
+        "assert-helpers": "^6.5.0",
+        "kava": "^5.1.0",
+        "projectz": "^2.2.0",
+        "valid-directory": "^2.0.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "fe571a8b20fc5099496a25a6924ecdb201123d67",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.3.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67",
+      "_nodeVersion": "14.3.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-r+CnfUtferbdEaGqyGGU/+D3rkKPi0+49Eaiq+0+MVKcnB4tEbaE8SDRNWu/MKdZbCjhFs2v+A3bMN9UDYO+aA==",
+        "shasum": "a007b9f41c6dc90cd83a7495a74799d028f2acdf",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20891,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexgMuCRA9TVsSAnZWagAA1tkP/iZHLcrgM6EVx3KgbkOC\nHdX524PUInfYuRhCHX/FCleGHZK8IKWD8VKAMSrengRGNuuoNxI0v46yJIT7\nfp62sBAHQ6NR4IcxQKMj0ZBGjZ/r+i9bt9EhG03dDegIrW0qHBaeLlPypSbY\nH2uPf4TWG0wuQxP0pYucUgNoUAh8A6GBjCPFG9to16CMob416+P3DgPr/XPq\nY60aVnVtLzpZQo3KG6iN8RJgBPZ6+8+kuCEazwAFgj9wSFHxx1J1t8d3T14k\nmli1iBZpZ2xhgPM+FUeIQjods42Ryec/MsxpKeTD3s/23BEjbTZ4zIB6mHBU\nwr+q7jV9wWH2OrmJrNN6WoieQNEkv3IRK+16PwFHjnY6JaBnqw1jOH2Yi4VW\neybnCHt/70hjqN9Rmyjk+KoiuCV9yH7CXpVdfA186KgRfafv2uTJ+XZPYbO1\nX7uF5xPgaGU4t7mPraKzjJpkH/cS7sABg79vUw2Hu2nvOzlreIW3HATQYE5m\n+5RnBpz87IVRAPjO1bz3I+zjwiPqYDuZR8kQaukv07uw+YLFd55lnEv37of4\nTeUE/uTfzRcI7VMlNck2HPyrmgQlt/m1fS64O6sHsrpAsI2oS/xlVy7Gql7P\nECXGP5yR0TUGvA68Rise6vj71A1YMXqCJSYhQHnaTO+QeuLY1G9axr0lI/Nf\nABkj\r\n=uFoA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67_1590035245853_0.9546280845492989"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.3.0": {
+      "name": "domain-browser",
+      "version": "4.3.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.6.0",
+        "assert-helpers": "^6.5.0",
+        "kava": "^5.1.0",
+        "projectz": "^2.2.0",
+        "valid-directory": "^2.0.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "fe571a8b20fc5099496a25a6924ecdb201123d67",
+      "_id": "domain-browser@4.3.0",
+      "_nodeVersion": "14.3.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-WwkidIht/Xs+9ZT1y+BSGGzhiATVuzsPx31OeGMuxfB7wYeeZRyGs/XCl0laim1/3hCyOdyF7wdEr8d+hAX2ug==",
+        "shasum": "485d506510a0dca608589fd0ca4a3d5a0a8695f1",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.3.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20834,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexgNkCRA9TVsSAnZWagAA+ksP/jgrcbKZhdOoNwS6dAFd\n2pw74SVP8XfO8OtFdpT0f2QPl1YMWJ4nx6N5mytocPj2TzXC7eVeWjpI0IZp\nUJP0TWHLy/ZC7hULYNwsv1iwPqTJuvYvMJqpzZvqmu+pRue+NmrzYPiSipiV\nl8UIaTbO+5OB7XUWTZyjEir0zJTPtKaj4tRCNtHUt++vviwJRbW8I8fw6dKn\n3Ov7yZIsoLxnCshRcD07+4OWJxvnz40noYB/JS2FqcdifBT+ESkx+jH5AcdF\n3wGLmtQZQM0xRXoyVgMGleS1lbKWBrrPWNYF7+Bl0gWI/asvqft/h9qAp5eY\nUg3HfbkAFy0S6pKSmvf25t1/ywoV38Hg2ATNaNhP3Z+HSsfhWTWMEjmIG/i/\nJdBrDWXq02LxhX8iZELShCRq/2r3W2hZpelv4hJ+ew58/t6vNFedXWxaru+i\nBVTQ+dyQ8psu2TKnGh53TCCGJkBoH4xqVsb2dmxfvlFBFBKiJF3+SfBTyGGL\nx0BkGCdEnsoQCnpGjlfIqyqJq5/OWo4/I6GriKFwNSZ9djFpM0T8l3yhw4+B\neDovYfRtRFwd6f/+hqOcSQRfCOBA7kmdwNgnpvGdPQewp2gKaRdqyB3R5OHL\nztIfxi2vKon9HxWQy1jCJmklUmmzyQlc9lIo+aOouUwGtdxj+WOWZmU3hYZS\nMmLn\r\n=nG9V\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.3.0_1590035299264_0.1299259739478975"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016": {
+      "name": "domain-browser",
+      "version": "4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.7.0",
+        "assert-helpers": "^6.6.0",
+        "kava": "^5.2.0",
+        "projectz": "^2.3.0",
+        "valid-directory": "^2.1.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "8a9154e71e23d06a6f9b5a80f5d2ac8618617016",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.4.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016",
+      "_nodeVersion": "14.3.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-l9q9b0f9PvQqwmYxLWGl3qjrDXtIGBhCjBddllQr7kT68TJ+hMH7FfubUVf+q93Jc6ykcKjie0KrgEHik0n0Mw==",
+        "shasum": "db27ecd855d9ebb642fa3b98d7849a4a6737dc42",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21084,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexpLCCRA9TVsSAnZWagAARoYP/A9E9BMWGD9RAoGesYWB\n8k49caAYNT7hrwqymjuq398FYmvZZfs81a/3/Yr+1xFM7wQg+IhC/yVSakhk\nyCHtpRE632j5/RKheUnGJBsk6Xc1c0hr0qYrmU9BnRGezxbkN0ekup7Fe1Yv\ni1A9ItCxiiTjm4Zctt+nqTDqu8srw5K4BdAQXbBn3gs54rJ7CDGV7TQuaGKV\nrvWVYRRCmLCgHKIxZp0dRDp4fG5kweFgCoAgv4au1Wng23CGfYs2F6BGPvy8\n2RwPDn98a/9LNt8qpzo2VpBIPtThB/zZwAfdxHyAjyu5b0emNiCimPpoaAHI\n7PdlTpLk9D2pjAqOB+q38Ughf01I9MBvzaCgutZZyu2/VgwGVPvbxLpyGHeS\nWXfV/6Pb0/Bytj/3+O4f4jd6f+5NIKxNcb2dkpwR1/KNi61MyH2PZHEORMKM\nfWc5t+F/EH4qQs3eAh7rZKtji2BGZtX7BliL+Uxc8osgSDygSjMgD9PD3rog\nNB1uGSaIofWHajof3Rut366gaio6nla+AEYKY2jhogkSLtSkrWpHi/uJHjSe\nn80COPPgy8qIcWu4APiz6rKSHsgLqEAQXveEWpO7i5U90O04HaCiww8yI2kX\n6c7V4JoPvgMWECDOzAELME+tSZxzHkjDDc6Q/HOUKvo0/BcJa5p5tEWRTpLc\njGwH\r\n=B9hI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016_1590072002023_0.05151829759307969"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.4.0": {
+      "name": "domain-browser",
+      "version": "4.4.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.7.0",
+        "assert-helpers": "^6.6.0",
+        "kava": "^5.2.0",
+        "projectz": "^2.3.0",
+        "valid-directory": "^2.1.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "8a9154e71e23d06a6f9b5a80f5d2ac8618617016",
+      "_id": "domain-browser@4.4.0",
+      "_nodeVersion": "14.3.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-GpKOVUarVuWSPQaCiAD+bMa9yDDKXv2YvvBUqkoNvPckaDCp/Bcks/rwjlLbbE+27esQIogAtXtipLd90SEFFw==",
+        "shasum": "6f0dd2bb97c93c247b87c3dedec4ec767298f945",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.4.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21027,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexpL3CRA9TVsSAnZWagAArZUP/2upu7bYQVu0DxJT2mn+\n8cqRefb3wERC0BsMuv6t5Jy6rQc6PvNY3dmdWLn+Yz5H7gSsrTEP3d/d7dha\nSGTl2sxxpGqWplUBQPtLOW/YAL/Sa/vn3CyWGqSjt3p6uFPr1BCjdTXwC0BD\nodKvlMf6K5lxJGLv0Mo6x0LWlbchAGTTKHeRYHtNBBUzpjQTjb/Q62KvuOx2\n7E5PT18nH8RPahTE8lWafQ7thqaRMN/kJWemBKl1zVjgZRdkVa7BdJTvrtt3\nSNEQGEa/ktnxvb6RO8z3gXqs5Mko/33acRvnusfqdYQCwuP4V+BTjf5V6H6z\naYls9Jj/1hxjk65/MUR/O3QyWMTREErjK0SX6izviC6f3/YkAwt9BlUdR0dM\nwW1n8XzmENpy5p17pRRmUkXv+SDK5mZD1cADi4IBonfej2yD19VuwVWnXJNk\n1V2L+KQPIRbf+7q6a6XcrTlZVgiC0M4qvbezKlCKstaGYqMFmqk0m7HvHfVV\nKKaSEx3WP+seScVgpXT9bIZ0b8oTvCuAk6HOqsR138dHhwZPCOVHvJKMdiSn\nge6SvUE9JS5EYQzoGaxOCg/o1g0CBPLACJZCtRpLT5AmS+Hvd6EiiMkn4JKy\ngwqC3HD72monYd69g/W60AMDTMqw/y6piWMJ1mRQCNQ80dn/iLa8EGMWFOF3\nf/q+\r\n=3Fga\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.4.0_1590072055477_0.9817520113874743"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc": {
+      "name": "domain-browser",
+      "version": "4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.8.0",
+        "assert-helpers": "^6.7.0",
+        "kava": "^5.3.0",
+        "projectz": "^2.5.0",
+        "valid-directory": "^2.2.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.5.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-FHBMOU34/hJJ8PJ63Zn5WbnH2Ewyc1Eaoh3lpLSAr4dKYJbC/re2JNqDYgwAUQrDUb088Pp5L/ew/6iR367kcg==",
+        "shasum": "187b2d48fd87df337561517b1a747b3215b4e2fa",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21278,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe4JMGCRA9TVsSAnZWagAAH40QAKUj8QZw/hUGPWI6jC0Y\ntRn0+lAd9gSxRgvW/sRr55jCQeO3myvlHdmEb2IumubowIgcKuhBM3t31EJG\nS4c8jSTlJ5Jwj4rKGDu9wyie5isJ/MxfVx8HbEg65tPfkVYSaYIp7UYVSVg2\nOnHfywdDV6kAjFOoNIFdtMy1lGaGkPwz0se7cGdzM2MyLFMF4siTp+jzO7/O\n3JZTYuGdlglEJXvkIxZUaeX9feDFNXQbYaO2swcwFUZIQycAiJ11inDMrjns\n5qz9zPaNXQdCEihgKP/Z/98aOy/VDvJEsutIpbLG+Mu+1uApkrBTVI8Y56nd\n/OYx0DU/s8PEU04CyopaOvh2HytIWHidVVSQqV110lBn/elRSO4lxP4xsYpx\nJqd/aUpJB9xlHN0xsTkMlIeY0KyxZeHozWVh6ByGuAGnxODKoF6JqLxDlt+X\nWtwCIEcxafk4CMVeB+BYlUTEOnEaR5Iy0yrBMp1S9cdF2qEfvQsfNhdNsWlG\nTv7ad9sxzEPEX69YqVDaISsovoHa1hPhZfKu5a9LtH6xgEpUcBsN0dLpGTBq\nA5gSef/M/eolz/OVLnoFVGkrGdCXHw1YhsKllA0eJQ1CnrbL7XiQLKVbnb7+\nvzI81whh8ejvW27jQSRmflB7VOAiPJKH9oP6LPKSnE3QiDAykfwvtEtpYdJ1\nkuVi\r\n=ao5u\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc_1591776005982_0.9660234445940155"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.5.0": {
+      "name": "domain-browser",
+      "version": "4.5.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.8.0",
+        "assert-helpers": "^6.7.0",
+        "kava": "^5.3.0",
+        "projectz": "^2.5.0",
+        "valid-directory": "^2.2.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc",
+      "_id": "domain-browser@4.5.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-+WkrFMgZdCQ2nfzvu6rwjLoSrjCAkZup6mSv4Ic9WUDoxgD92TrGpngu1zzYdYRuwroZ8dtIIy0TQ+96VNNptQ==",
+        "shasum": "ebde9fff01ee7cdad1bded20b55978602f5d256e",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21221,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe4JMzCRA9TVsSAnZWagAAnv8P/2S18+oFmJnRF/OXXXD5\nB8fA7N+Y5KFxx8aoCg2sQsYTZDj0/W5xWMmbX1dyzfmSi00Toa6mKD9qvGPg\n6Uc5WUPb56anFk7K9/lDynZlqDVjs8vMPUFlCJhBZ88axtU8HnQX/1gvp7bc\n/i4qJniZrq0QPPff00U9CvANG3JuJzf1rz9LmIPnZr2xunbOPAj2bICezNrv\nwgPt+agowYcO/gQsACP2IeN17jqOuqEQpOblSveuTwRET/ZGiaFJBD7lv5cW\n4gbm7HRPun85aSowhEzZtXY4+oeKZjK4Fb+Yo2zkQ777nffBs9f8+qVrhDhF\nGmaPLOZcTpwbG5o3ZOrC9uR0H8SFujAqqdLbR15RxROHNbSCNKcesWkzmLXi\nehmfGp7EAJMumoAj0AQsFRfOJ0kSlY6xDvWuVxqHUgfVGpd6A4LbKhqIQHHf\nP4uwIcMTARl2hFxHPiQo9XO3erNtKcS+Y8ZSlQQcvYlZxU3Qmobjbtl33mC7\nx3k/VjGkbX2HJwWT+luSz55yjjnRCY8pPw4cnChlBOKHYSwuqCKBoRt0VrOd\ni2mQGezmvG3rHkkRXm3SEb3DIkbYbXQ1bR0NlKTrcCh9ByjF4HB+f/gYt0rs\nsU5KDf+i+QTHTQhyTVxcqLfahzv+TRYK6Ms/hBUeP0FJ8iGH4i31DVEMdtpW\nPaJh\r\n=O+j2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.5.0_1591776050722_0.2564064475840724"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a": {
+      "name": "domain-browser",
+      "version": "4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.9.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.4.0",
+        "projectz": "^2.6.0",
+        "valid-directory": "^2.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "cbd63bebd15bb6b3710a69ed8b62d16486a32d4a",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.6.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-Qq/8y46FDbuwtI/zHEfpO+qW0ypg80u5L/gm6u7/Y82+rECEIsry1ZODrMYSQGAOL0wZRSH0qAwZ8u8m0zGGOA==",
+        "shasum": "c44209c71a43b7c5492f65afab4819aa23c98f09",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21472,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe4NY7CRA9TVsSAnZWagAAMIYP/3OXfxrKgY+xDadWP1IO\nucJDjwihTydFVk5be2snSEdhz2tQd4xKb8nIW7dW/+ToHVqkvUqlrDQz2LnS\nm2m97lNKgikRfsX/VQrTeRmUd0H5F/h/OinOWsrA6sKPPaI5WWOZxPFRehq/\nEnJvT2QEEag9cVRpqbMxWPveO6segaabS1mK5JdLDdoZj37KMfhrpPaUT425\nbBHBsdvrrFydWQ99o9uDdoKcPjgxp4UVmIOu6rpu5/cEbyjSD7pS1F1Y+cNt\n4DZN9K79sFkWMHDdPRZa84DmpC63PxMLhG4msAgKN7FkGwNzdNXrpjrTHkMJ\nPtW1ydJ4VWmKkBwNE2ljVXFj3ShERAP7KCxm62KmYnfHCcoGP2nvLDQjYUBF\n9euNdoCiJjre0fK4BGyjWWhjEuKuZgfcqqjoW/KPuyEoyZOyPqK3Pc/6/HFU\n9c2FAW3PmwaPz0xIOQzJxXSbt51k3qyzQXV3gcvh2EUjOAB507MnVSRMGlgk\nnD/yd0DtZRxJ/tg93oXMye/wUJncVx1FIa2h+8yZryVxa1mWEZTHfKW/oZgF\n4J49ItDUtVm7a02RBoLXmze7SwZDVc3Oc/Q6/B4FveC7cxjtI+kqzRNyG1rQ\nL+HvChTHBYLT3w2y/5M+iYP2w+l0o8MU5ixqq+z2JjRoP9q6FijDxJp7HGZs\nWNoH\r\n=1GM2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a_1591793211409_0.8071661565808528"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.6.0": {
+      "name": "domain-browser",
+      "version": "4.6.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.9.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.4.0",
+        "projectz": "^2.6.0",
+        "valid-directory": "^2.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "cbd63bebd15bb6b3710a69ed8b62d16486a32d4a",
+      "_id": "domain-browser@4.6.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-solVnUBCqwvori4KncIebL5e7LU3I979j0N6iPyv3wPs0Wx5h9CVtF9Od9LsqVC8fjtQmmSbfRbnq99hCeZo6w==",
+        "shasum": "f61dd31507e44b8cc2cb012edaf32c7c06377dd2",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.6.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21415,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe4NZwCRA9TVsSAnZWagAAitwP/iEoYLyXpli+HARb+lbH\nVfUBei18e3s3j5nniY/zIEM4FlaKElhh6f2uRMX7eOpaEikEg9umJErVDyc2\nr7/TKR6eEAnj4Sjy3FNvLrPARZ9gL2RBmZ9TUetlF5liTnsLCjDwREU5+hCZ\n6Qt6yROW9B4ZrAlIVKRcV3w1CrFModp0i2CxXd4j+sLU14ZgMSfXrrQpJyy5\n2OmEpp8mTvKGD0+QiZJ52Y0M5EVp+UqITd/uPJ8n0WAZxSK9/yffnB9vMQmI\nBosjzmvS5yRB1jcy5+NgrS4U0ttjFHavEFFRU/joqYlPp5bQXfVVaS+m9BbE\nNHvxdXK/b99UkUDDlJf5Z3bX7SPp3lEktqJwTYOUZm36KiAfQFif6homXoXU\no9nO+k4E+suCykzRxfM89ElKaSLtJFs8ahx1qL5TLO+zfD7XX5E4d2nCpigT\n6yCOoxqD05/FKPF5lQgpzxBNeBpnX5H//InhiUJeBGlrQth7j+InR74FIICb\nbo9tDzYmD3omPqQgR9E92Iet+a27J9t2x4yv+S3JcKcCDLU+8TSIefnJVlwW\nwQcrPSn1CfLYi2TbcygK4ZRO+CnKy7dnk4/4ptDEBoWzTMvaN3WEiKlJVE/l\nnrGtOpDC8irbyxKXFXxRBXzlIuxoV7LsFgdNfrsc3su575Lz2cIMb6+8Uz4F\nKqB7\r\n=F97w\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.6.0_1591793263995_0.9138464565190987"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31": {
+      "name": "domain-browser",
+      "version": "4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.10.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.5.0",
+        "projectz": "^2.7.0",
+        "valid-directory": "^2.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "44ba6c12bce8c142336a541a237788d3d4453d31",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.7.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-BEsMQ1bcsxzSHkBcyl9qND/OlDpoGu2oCT60Lccq7TzbMOX6itsBJqQ4zkFwLT8gDWTagHJzIo6fegcL9W24Mw==",
+        "shasum": "888dfdbebe1cb44305b25642584126846d62d066",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21667,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7SzvCRA9TVsSAnZWagAAd4sP/0vaDuhyYcttpPsRrmCB\nPzxF+nSkVXyOE4VM2v4vjrtpf8M281yFjS1OV297p1Biv3dMbi0BeXBR5z24\n/YY9IHuVd2Snb24s7LYoUDO6g/7LxCcV9pgY4PH2ipQ8t0TKWbq8tYUCRsvT\nsLNgKF1iPdLFi5rPMsPtUZW+NVqKofXRYPosKdt4Q4Zc4ID8DYxI7ey2UH/4\n+Gzvl7uNuqUXLcQ2BYp4B75tJv8psJTHJyhSZnQnliXd9GfMBSGjmTuDG5ZF\nST8XjD72/cr6RrIH+9asJ/CU/11P7JMlbva4/n/U5r8NynMKLpbTO71larPI\nwg+kuCN9qbYTvNlJKxxa4oMEgcws8rSsbnWUCKIgIBTAyy1qgk6ehq5UQGNV\nok7XbWsqPvlmUjM9zLwi0x1TGe8ywfzE5Ymv2irwcaZCM9Ys83b/0bTUxRJF\nli/nLKZPbz1/B6j5G23xJ1nlASBfYiG3Uliv9z8nx2sQYhY2PJjmEGJUuX6f\nm1V+lvkpm/tgfnGlRvIx+Un3OWS3bTXZH9gVm8VwNao3gfvjue9VE8xK83c6\nRDih/azctOMLdQK0dNv1YRyPNSyCF7ILJ12Z719uh3rrJUreont0v4EWvwWY\njJUFijdQ8GEHIq/10UV3Rxn9jMtH3/Wx5I3BcZrB0ZCUPE4WiaY4xbXQdVSB\nNRd1\r\n=pbWe\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31_1592601839144_0.2284232628403573"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.7.0": {
+      "name": "domain-browser",
+      "version": "4.7.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.10.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.5.0",
+        "projectz": "^2.7.0",
+        "valid-directory": "^2.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "44ba6c12bce8c142336a541a237788d3d4453d31",
+      "_id": "domain-browser@4.7.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-554I4FVhKAqFa5yuDnGNyos+uVBuwypzhBF8nLajXy8uy3oG3noEndI/PRUZ1KZt5cWc6OsFcQ9WGRXLsf2djQ==",
+        "shasum": "deb45b66e79a4d7941af2f66d4e2e5de0f5b9948",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.7.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21610,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7S0oCRA9TVsSAnZWagAA25MP/0SB5YJsx4qreRFdIQs5\nubRHgUndv/NDB1AH634vY9OlSIlTYVfFA0UL3dBHVBGnOQLs+hVVocktFrnQ\nG6509UKRNTG//hXSwE2xr99hXreGb9bvR1a/vlU/XN62wniRuQyniXi/xb12\n6jZs9v9wUH5PamWDsmh4E2HNI5WBvdCJ1qVMtJAnSy72c+OFqSXjSylRbORt\npl+iVkV4B4z6tzKkUmtbAw2BeM1CtwVKHTfdxcYF95LnpeELciXYSDFY9Vmz\nDgLHyTpaQSYxXIPC1ElLU6EO78AwmvwzVrYqREt0aFdGDnGm+gHTY55q7Hio\nX+dHfcg1TMpibUA5os/L7YLMUwTTGzJlU259/M7ONHrmZQAmWheDi4/kr6mc\naLQa33ocb/XTzGnCDmb07mm9O1N06IZEyutp6KPzzQCRSC/9SwTbJZiq7ARp\nHp4XcYsem4Mw+lcoQyfW6QVLayLiuJJ9a9Qrw+b/4uoH0lsJBQPbY3itoBSy\ny5bgFvs2wae1s/ACHTwEH9dIsV8+3AC29B5N6+rZy9qJNuGLPBytIdeKH+5i\nVZSAAOPxzRmiTIpLF9o/vaXmwefprhnm+ma/L+SEyLLofooQsadrygk19t7S\nNZJGgKOfqZGGwaxw2U8ZdmRVhgdZHvC2w83z+boi9Vfgb65KC169D2yaZHGq\nLgIC\r\n=BmRG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.7.0_1592601895771_0.4301267563366984"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e": {
+      "name": "domain-browser",
+      "version": "4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.10.0",
+        "assert-helpers": "^6.10.0",
+        "kava": "^5.5.0",
+        "projectz": "^2.7.0",
+        "valid-directory": "^2.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.8.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-Q8qVg89jYvW62YnvcjQkq4bgLwFVQj9kWdcfYQJOVQZGPRnkKqSvzG2qvl/SUahGRwDDAgGO4d5QdHgj4e65Kg==",
+        "shasum": "5deb6d40adb1cd789e8cc9fdcd87dd9e0facb54a",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21593,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7T9wCRA9TVsSAnZWagAAauUP/0DkGQLWydWv5oK09bi4\nFuPdu9PJtmO5z/qDYPz7dfoiIKUvNKj35NztzZ6vQlrIPv9xZmpBsR2lEkvH\nnq6BjQuWzJqyLvmC93wxUd1CqmhtwLc8fmvhEFRKJt2qwvEYtUJBEU8ykQH8\n7fB8A10sWY8M78vMU5SGifKos3To6H3HNJnd1w2p+vP9qzHh/Isfpmn10GYv\nnEYbdb3UiXzqV6gf472dwQTYlJBK3c2Cczb7vbzg7KM+2nuuJUpw8tmgJWl8\nsGBpG2cVWEhBaPv9lWQSUXYfq3EJyyAuX4cXMhmJzk8m0xQkUHt1QPLp/c+7\nO1lXkfV5lQlWaF+N2R6TzWP18Owsq1XpGcpbPUwnM0eh9zKJoV6jFGSDgcLm\n2bcONzNnpStXXkVR4K/Pa7Hu9J/b5ZqKKLugkGX9R/L+kx7fqQFl4QvQdKjj\nVDoNDJnqPq8T3KhxuHoV9o7t9IA0Vq1iVXtMpC8r4vtPqZrpyXgIVTFBaUQx\nd53E3JVkD2DfbqJdwbOYNIAszmWoohOeHOdY8yK2movUkKyORxDCwnDN/SiJ\nkwma6qTIYL+veOh9w3Cz1+gajjYAvgL9g4fh1ZmNf6PLz3NPLn7P1DASsvb6\ns/Ok4X6VtdEv4d73tOIY0hkGGlD8Szb398xzph0IIg3lslUT2iiP/oUU04Kr\nsW47\r\n=w7PD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e_1592606575740_0.30542976140665834"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.8.0": {
+      "name": "domain-browser",
+      "version": "4.8.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.10.0",
+        "assert-helpers": "^6.10.0",
+        "kava": "^5.5.0",
+        "projectz": "^2.7.0",
+        "valid-directory": "^2.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e",
+      "_id": "domain-browser@4.8.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-VBrL/W6bpH6YDjGWgqtr/jgwr+Eg1ANtQExXeSMlucjGVd+gIR5FM7BmSCRUn/nNLMeTsEwqfgJZVE8bBkzP7A==",
+        "shasum": "ea2f92f55dad0e8e5f9e8a25185f3525df90c306",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.8.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21536,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7T/PCRA9TVsSAnZWagAAmVwP/0yCrKtWTnCLMhsIFXxe\nDPw7oNVLg+SJs77lLmmpadZsZ0hkW0cYWr8zLc/+YHmm8CN/KmxjErCFSG2F\ngn9IjQhKAyq7slwjN5OlGNq6SuTNRlEepa8pGQu+HFA01PsGG43a20Cai+o0\nVOYQZP4jmHm4pJIMWdMVsvELkDx1qryZWIqu7SZkVFDSDU1Szw5t7AHNmXuE\nyFn11wI0PbZsVAlwzs2Tvp0MiEmoVt4LRE9EDrxtSbYN2LZSmgWqJ0b++bdg\nz3N2YZBZOJokVRSOwE1bFvtyjdzw+3QQuLwGdRnsoGF79vL8cyGLbc7DXTmX\nA9zvOINUorCoNEryykZ5qRkLl0vbGA2CjVenCRKjMdmfaDcL4d+uMKAdjYed\nZK/RY1JK5zXFAZiu6XrgftWZKKGyAjEzxd4HZgCtVj94y0TpmX0iM4Q8yWxo\nMnqvS8crSV7IcHvMaoN8jyk2NvSS1bcBEcOy8xpv6CGR5NwKJzefm0n0D8Ms\nHgjUd6D7L2E+O0Rwpvv8UAZP3Pm3ojxJ8WGRBDQ32RxHayC52tO1h6djQp8Q\nrF+hlD2kNYWOF4Gw7MzYE6RZDGQNe/2zFUdTh1e9gmgx47fT8OMlX/+t7f9Y\n3YVvPymD7eyOnwHHU9DneT4cBJq5V4zt/R26r62GpARRU43FoE4n3R7dqVFR\nDPHz\r\n=cxAV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.8.0_1592606670528_0.7559794155914072"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364": {
+      "name": "domain-browser",
+      "version": "4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "1.9.0",
+        "assert-helpers": "6.8.0",
+        "kava": "5.4.0",
+        "projectz": "2.5.0",
+        "valid-directory": "2.2.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "yarn run our:meta:contributors && yarn run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "yarn run our:release:prepare && yarn run our:release:check-changelog && yarn run our:release:check-dirty && yarn run our:release:tag && yarn run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "yarn run our:clean && yarn run our:compile && yarn run our:test && yarn run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "yarn run our:setup:install",
+        "our:setup:install": "yarn install --ignore-engines",
+        "our:test": "yarn run our:verify && yarn test",
+        "our:verify": "yarn run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "95472db14cd803e028437108de3ff4b1970f1364",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.9.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-yWwoVPtE96eE2KqwxDkwgbqAOasJp0W/q2gbIQlwJHhEQqWCrnwx6yiG5kmax7j7o4xGl9r2eZnJRnsot8ir4g==",
+        "shasum": "b87100cf9577bd243e147618b1a14ddaef0ce56b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21813,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7obNCRA9TVsSAnZWagAAD4cP/230nLLCC+N50x2Aqm2t\nmP4uOFx/4gfw2sE90E1NqbuZ0oC7YfQR2vRaxJdy2YYH/GINlaaR0vv4gAHk\ndlsfUcwV1Fs9butsoDpE+BGlPBcg2hvQtmHO1AZ6j4RUx6VLlIs+6fpU+Iex\nmE8ECwsMYxnUtZE0XaboI6cQqBQDmQW0wcHwD1PAbZFe9u63QRdtt2QBg/DK\nWN88cbRW06arI5L+cI+8SaFdFnKr7ZXVmLQR4QK6fY4Zvb8ejZB2Fx4bINVq\neqGWs9C5RJBcO5I03L/PAOteXw7CTvvUfWy8eU9CSKKWNM5dNoX8c/OEWBKF\nKzD//WNNR9EWnyUzDquK2uOMBbzYVtujerdmYENh6RkbQPjn6LDlCmdXagqq\ntSvd+xiMzqrXtji81M4pT4u0sAcA9VDQeGWSzB5Wr8+bK3c6TX3QCJk+LFj8\n8jopzPAFY1P92GnAuy2W7XaBukY2BFvgRL5Tt61vYjcaHn0TwqcTVZsTZTze\n3vViWtkVKcSXBdkTDVE7uaz0XHytXW4fspyrSW/vZc+xQ0EGDUSxCuDb+tQE\n4EIuUH+/YDXUCprGriSwV9Bv1rthLkWtPHACdVfHaz80lFiD3NYyzdz+3acJ\nzkM4rLqm/mrhMW8qQvNvvf0BJTHHZICmhciwbS4hHy8dCd9arUrOtg9Fk5+7\nlrgY\r\n=z0Ta\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364_1592690380901_0.6823621598535319"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.9.0": {
+      "name": "domain-browser",
+      "version": "4.9.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "1.9.0",
+        "assert-helpers": "6.8.0",
+        "kava": "5.4.0",
+        "projectz": "2.5.0",
+        "valid-directory": "2.2.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "yarn run our:meta:contributors && yarn run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "yarn run our:release:prepare && yarn run our:release:check-changelog && yarn run our:release:check-dirty && yarn run our:release:tag && yarn run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "yarn run our:clean && yarn run our:compile && yarn run our:test && yarn run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "yarn run our:setup:install",
+        "our:setup:install": "yarn install --ignore-engines",
+        "our:test": "yarn run our:verify && yarn test",
+        "our:verify": "yarn run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "95472db14cd803e028437108de3ff4b1970f1364",
+      "_id": "domain-browser@4.9.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-OSuBhANHoaAPzbyARusE16PNYMBgrO2z9RpA0qBb0MWaerRjYh5Z5A+lTwsYWAaT/BjFryFRN85rus1QD+Su/g==",
+        "shasum": "37430f89e367a43c882a0096124fa5dddc6e7a9c",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.9.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21756,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7ocPCRA9TVsSAnZWagAA+koP/3+KEv3PrhxHpNS0IeST\nWvsczxlsORUWXW+4GQgPzZsQNA3Uh28ujIAJTFYELZSBPZ43gGPYZB+grJB8\nsb0LMQbW04jAIOymQxA9vGZDJFyrfMSr/WKwWBSMgA9FeCQ6AViV7CFtvX6X\nXrFTXxFaDg1/ddNPSVL7XZyOU7HK+9qBtnaMcwBZBZ31U/cd9WdRQ120vmOk\n4mg7wQGMcSdN0I7ZzyZVSvYjNMDWR9H1M8zECwdupqO2N2L+HFWAHq8Y5/+U\nWMykp50hKePl4FNFI3rC5Ig8ZNf/Iq9LilZKjiqkb08iwGed1qOniuwrPTj8\n/kQNB0+Pec3GRoXBDnsgSe1Kwq7JFP9ugzEG+LMAzd3vGFEYoWUx21hwdm3R\ncVc8ZignL/t2ErFUGOnbDcVdn3sOT2EOhwNbAt8asH0ggYe8Ue8l7JhrgE1T\nZyEZDaMyqUcnADy2GvqJTJYhfOrP79B52p7SF3YXGceOnyNXM6o5tPBZuKeU\nDAHAwkusASwQjOEx2fY8J6nfCEsJhpxGXkvTAi5Ype+x1WBWchbPDJL6iL21\nBpYsLqOfr5hAa+vJmT3D80VjgUUOh+JWSCNEYl5pUp2Zc7zauxFidJNZnlah\nS7mqN1R5OOGbdi/uVJCKgq+g2sx3KHR+0oQZjcIJPprItHUHZpnjA+4/IGHE\neuBG\r\n=SaE1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.9.0_1592690447352_0.3055016356651259"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0": {
+      "name": "domain-browser",
+      "version": "4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.9.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.9.0",
+        "valid-directory": "^2.5.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "yarn run our:meta:contributors && yarn run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "yarn run our:release:prepare && yarn run our:release:check-changelog && yarn run our:release:check-dirty && yarn run our:release:tag && yarn run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "yarn run our:clean && yarn run our:compile && yarn run our:test && yarn run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "yarn run our:setup:install",
+        "our:setup:install": "yarn install --ignore-engines",
+        "our:test": "yarn run our:verify && yarn test",
+        "our:verify": "yarn run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "a76ebb9016346993ef019d898b32ac2d8c71d0c0",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.10.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-4OfTk5C6X3wsJeOkAsgF55CZVud0gRLPRa75iZQHulivnYtf3JfUWYiHaVpUXbPMNa9SsyUCg3RUeOKFiOb2Gg==",
+        "shasum": "cbcb7197fd3ab0739dfd20087b1277a10580c0be",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22015,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe70HPCRA9TVsSAnZWagAAzSMP/io6AWnNky1Biuf58RFd\nvpX2WsfzTYvdaS0y0BEUq7i07DYv957vs533BMS4s47wHEIgzVuWRhaf9RLt\nJBiBLJ0q9kc6hyyXFpAta5pQmkXW1Jopr5twlgMPDtNM9AAvBwPZSLfUhWMu\n0VjNsfnMScnyZrkpoZjC0CTaZoZw1UxahLchJS+nOdU9PtBKjtaE3YCvHJpa\nBdX3mz2P9ottMh7QZ2rlL84egmbF4JWOsIhtUMTkk7CoXfXp9Nps88ov7VtU\nN0l4SUHmsAWhb9HYCQVxeiqeb8H4+avR5pUpaTKMyUrEpOYR9uaFeMwi8h/f\n2Ieyx3UP2JElN7BEE7btgVh+PHsmlghVAme/Ts5q1mDhWVTjF/GVO6c7GKDF\nPe4CULncPzSHCTiVjZiSdu2rEyZ9gjVotq9/bzC92f9gjfeJT7yt8oc3v6Iz\nrIz8t/T1TPCMPBeM7JvLRY3z73JXS0Xpb/9toEQJh5QWW+fGzONCnD9yzy/D\nUS8qILdt+PZD/P36Botm9CjMGtnAKDmIZjzKWHmxuB4XxV2SP4gioiwDXRbO\nVY8PYTUXgtQlcOkADOhlpc+LF8IBW7VRQ0Ps6b2ZQG8GLC3Gtr/NmoUmSXCh\nwYtz5CBQE/wmfOQN6pqX1Kxe0TDODwO9inLzYypR3RCe3BQ6DiTGM3qt8uUk\nsJb/\r\n=VSEG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0_1592738254629_0.6428092265670651"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.10.0": {
+      "name": "domain-browser",
+      "version": "4.10.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.9.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.9.0",
+        "valid-directory": "^2.5.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "yarn run our:meta:contributors && yarn run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "yarn run our:release:prepare && yarn run our:release:check-changelog && yarn run our:release:check-dirty && yarn run our:release:tag && yarn run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "yarn run our:clean && yarn run our:compile && yarn run our:test && yarn run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "yarn run our:setup:install",
+        "our:setup:install": "yarn install --ignore-engines",
+        "our:test": "yarn run our:verify && yarn test",
+        "our:verify": "yarn run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "a76ebb9016346993ef019d898b32ac2d8c71d0c0",
+      "_id": "domain-browser@4.10.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-u5bR0HaHFRhox80GCyI1jTK/3d6b4nvod6dPGtDF1IHx28TSsx3HBy0/rV4TOQBt/HvNErVHWukEMxFDj7YPVg==",
+        "shasum": "9fb317946578f06e27de814b6d098e639d3e085d",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.10.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21958,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe70IJCRA9TVsSAnZWagAAqEIP/21U8Jj9HbYt5NpWlDtr\np4ANzROmOyBrDIQPOkm9o5nGlLCrh5VKJ/e1EiMHNu9lt9MRVtZD20tDKIgT\nyOQWYe5EwU9iuHZqu2S5blHG80naazAZLTnF202r3/SPhlx3OOEhIaOcQJfj\nb5Lo9Yk+W7nfOh4FMVIzHWzhmqbs4U7NUjmKhQ9xjKvcqJtAZBvURJWWL+aV\nszR5Q/waH4Tfr5E+Q1wQrf8WqGKYIOUyt+JX6WaxCspfwxwMoiLJOVyXIrTq\nI3xs7lg/j/4SisEFqcsAzjdzwT4YxjHS/tETaNy+LUSjn0K3v0EDS1khtHlS\nF5oB6JAJFH86TkZpbp01pnXcRMesokFGXmuzBI5FFsTI6DsUTtR5WdR1SSyi\n3FLDqISuc/1oa6P2+YHsjISVnu35pwvpa3gErh08vNHT+ibmqXNWZ+PJka3Q\nAGyCCGUdNZlnDkJPloen2lWdl+/JJZspaeCapp/asxLw8+/VGFHJQgGR8es2\nXtRHb8+deXC48EDz5KUS9O1zSxyLZ4tD+OdPCd1CQDkA3t6zUoA3SnvliBn2\nN4zCdpMxuwFk2CXevfOLKlMwHnc7YRo9h4g63eZPDbDwVP6/+Ahupj8gU5+l\nCjtcDpf1W25lLyJOHKokSJzto/miVlSbsziqnQeWmsvRRAw9g0EeyDTq91Y/\ndlJb\r\n=Ood4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.10.0_1592738313444_0.4780376021082373"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6": {
+      "name": "domain-browser",
+      "version": "4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.12.0",
+        "assert-helpers": "^6.13.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.10.1",
+        "valid-directory": "^2.5.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "yarn run our:meta:contributors && yarn run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "yarn run our:release:prepare && yarn run our:release:check-changelog && yarn run our:release:check-dirty && yarn run our:release:tag && yarn run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "yarn run our:clean && yarn run our:compile && yarn run our:test && yarn run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "yarn run our:setup:install",
+        "our:setup:install": "yarn install --ignore-engines",
+        "our:test": "yarn run our:verify && yarn test",
+        "our:verify": "yarn run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.11.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-JzqisOadNQhqUs3ewo/+Rln0W0hWbfRIqjpLdONjeB7MQQGRWr6sBt5A9MmG7WEVY2fOHc82Ai6qnR9+z58Mwg==",
+        "shasum": "4237fe16b42ec10a1a8569ee4ab17c644e4a0e52",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22213,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9AqYCRA9TVsSAnZWagAAysMP/j0SpkrllZPN4jKY7nGO\nfZN0S/h7mRMtpZuPwFvvkaCnQEevTWu5kEEFIlPyfhq/LK9QJDz+tW+SDOUQ\nlock3+czvgrBH8f2GEjCokPkTMoQLKv83+gLLLYb5LTxvzRbyCJT8prDpooz\nqcwGR/9QXIDeZn9Znw35AyVgj8yEqRF0aetSArE+pOlp7HJh/KmE9oIpRqfj\nj/GDG40RFKFbfkxQm5vJhaaugy72GXp1wzLIgV5qj06MK37c5IOvKoZP3lQo\nfUUps8WChIcrCDrIqIaFdCcg/kmoAwzWPST2XN2cSdqkcHSad8a2FRtqL4n6\n5JYWPL4XTZ2gJ1UbJLpldg15modFIaZoR4MLomEq11SkvjUyGfeiJ3M5ond8\nX3EiqbeHCxHmZl/x01cLIkWZs8+uIjMNogxdkuMhxFYrOBtuc9fBEFhkKucr\nYiRss7CTUWa6Hq+OEFWKxgHm7gprdR8ZbMcC2Yk5d3iXfNSrq1XgMH2LqSnf\nCROUxLak7Of+JCRC+up5FbNYzx0m8N4cYv+WI5DzWS/6oBOqyMT4PYiWg/IV\n2Lu5jxwiDgmClAWMDBxfnDpfVPVEHaKgZmtCAr/QEvcpSvnQSeB5Musg9Kyh\nenHDLCzkC2ujdMi0/ZTf3AipPuJPEdFFX1aTc9hOowYN7UiozJZr98riryn5\ncD2o\r\n=zdS7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6_1593051800031_0.6337894958820092"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.11.0": {
+      "name": "domain-browser",
+      "version": "4.11.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.12.0",
+        "assert-helpers": "^6.13.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.10.1",
+        "valid-directory": "^2.5.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "yarn run our:meta:contributors && yarn run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "yarn run our:release:prepare && yarn run our:release:check-changelog && yarn run our:release:check-dirty && yarn run our:release:tag && yarn run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "yarn run our:clean && yarn run our:compile && yarn run our:test && yarn run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "yarn run our:setup:install",
+        "our:setup:install": "yarn install --ignore-engines",
+        "our:test": "yarn run our:verify && yarn test",
+        "our:verify": "yarn run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6",
+      "_id": "domain-browser@4.11.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-OU7EOarf+LhmK8KuuzWsjxsG5HE2jyYHNiHog5PMJ1nWJH/fTUs4YqZj+6GJamT8hbmcILV/T3EWwdmcsvnKNg==",
+        "shasum": "e1a1a621469b2e0b0d5f83dcc9ebc3d2458e14e4",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.11.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22156,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9ArKCRA9TVsSAnZWagAAmN4QAIV3kJrmwXeqPVwABkkQ\n8wQZWRcSuTaZWXCmtysAHNuXzPWqZ+wP9A3uaGxigPImpGo/WxsEFeCNZd0D\naH9T+pX4H843qa1OnhmvqLkKliMbFpLUaDLeAipKJM+goqZUtHO9Id3IrcMq\nc4w6jdXpSaceEPOJOCUrd3qcHkGO+7y4LChhewJcv69QR2G8rjIv6QNEbONs\nxu9//qi8B8N9Mxye6Dt4VWtnXHX0Fk2KakvSgjOvgK/NEImlZenLJGFr7CQi\n/cZPcRbw00fXACDectbjsKa2ufBzu/+6Qbe8HWJZOdml1bt7YTAjM0Yj4Vt3\nf932Og+rLfLalyDa7GN1WJHLuinerfUsDdnp9vokMyWIKzRF2QcfolhWyj5m\ngYu71spWkN3lmACMshSuY90A9ddqiR6FrQpqmlp4Ytve9ODbEEYHvb5GvrB6\njVrl9jQGL/SOxH02+OkmjhuMs1iaXkoSN90STfkCr+VihEMmokbIpKUz7QSh\nUNADxeg4BTpFCPMa5hgZOAsteuvx4amnEg57gqGuUx/Bc8XcDF7pmX23QNHI\nq0hVUBFnx1/igLn4ovhfGWZdUGKoWXm+ZPpz1u4lg7zxy41EtQ0RFFM+j2Q1\n7Jw0a8WHYdsG5Svw8hBwxOr6ZDg3waUOwkvnwQbwYvBdbbDjwdso0Am5a8m7\nxoE3\r\n=pD+O\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.11.0_1593051850099_0.22373102723115723"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c": {
+      "name": "domain-browser",
+      "version": "4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.12.0",
+        "assert-helpers": "^6.13.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.10.1",
+        "valid-directory": "^2.5.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "yarn run our:meta:contributors && yarn run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "yarn run our:release:prepare && yarn run our:release:check-changelog && yarn run our:release:check-dirty && yarn run our:release:tag && yarn run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "yarn run our:clean && yarn run our:compile && yarn run our:test && yarn run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "yarn run our:setup:install",
+        "our:setup:install": "yarn install --ignore-engines",
+        "our:test": "yarn run our:verify && yarn test",
+        "our:verify": "yarn run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "a6c0b2440f684f8994e7268378c2d2c763a0a95c",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.11.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-JcGoaCOBvk5GjdRIJc092fE7dqBgj5SgB+EKu8JOWf3azQF4X5N3pgz6i2Ymr8O1M+sKGbJ3sH1lanpT2USqtg==",
+        "shasum": "45c9dbfae26ec35f7715a95a581070e00739a523",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22213,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/pRKCRA9TVsSAnZWagAAR9oP/3Oa6nGCtFvFTHcTtDu3\nSFXKzjuq7l12d8Yq0+YU55DobUJ15kBjv0zViFOE1h7UnXzzw8n+nRZ0eSwB\nvcAXX13KRMbieb3IQN4yFse49Q+22csEyVCeg8M5Kbxts/+o7bi/98MhJAjj\n/DHsTGzx71f7dx1XuAs57ub6fI1zaLmFdxJtsuaKp11xZDAkamdGfGnwGSWa\nPvoBX9ao7whcG+CNu8ArXe0w3Td6fOe03g/A2UjFYGDE3h9/rO1285JN1jFC\noZCnT8oMHgjvjH7xAW2k8lTj/lTQQvuqwBSPs65E9hWK6j8Ukth7mfGUxzHe\ngTNg/I57uYAoGb/VH+aT19f19xstSKpJO1+2/dLvJbq8tmpnguaRgZDsJZ8x\nSQInvG8PzPl5BZvMRddK0/O/cAewb7uIwJuxeFz0nnXkZKcGY1vXVd6Z8Obd\npA5RYQAtBT9OzpXlSbuswOUsTiVu7cOKJ/upVm8iJHxI3w2E9Tkv57b2lGYh\nqKude4TI81L/MMSV11kD3pRgvl5Jw0t6sh7Ab2ufFcYOApI66zdNx/60Semz\nzyoqNsMi+BCLl/KjxJncsxghE6RU+pfeqHDp3XtmeCPDR/N0edCgf9KbOIrE\nOwv17szCDp8mdTKXlwhr28dKpVs8sLSBb0nQ0Vx/gfE8SwC1yeN252xCN6D+\nyxWj\r\n=Xqn5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c_1593742409994_0.6174444004431361"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be": {
+      "name": "domain-browser",
+      "version": "4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "exports": {
+        "node": {
+          "require": "./source/index.js"
+        },
+        "browser": {
+          "require": "./source/index.js"
+        }
+      },
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.15.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "b78cfda33834a5d32e213a0aa920adb2aa2022be",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.12.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-6fzebHA9uZZcIVTvBe/I/9nIC+g2hRn3XmO6g1oM0tvtQyMTqiCKHOepygu25DMkZA5Zr2Nor3KvNdq/yu/lKg==",
+        "shasum": "2d1ef6c4924949832e713d68b4e9cbcb1f8bc0d8",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22512,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/qe5CRA9TVsSAnZWagAA7CkP/39p/2Nzy2I0br9KkS+5\n7a3tqykU/R5hykN25jIDpj9oN4/+jWcfKvdC+65CBHMcZoD2UdUugzY2ZUlj\nNd65K5donR7hyxPaRidIxcOAjYltIYZVCHLfjLAkBQLBHcoemOJB12enJ40c\nJM92spwFrM5sjDdSvUythJrr86XHaO3kHQGpgd1NQZ1HaC3pNmDdz6FiT0D9\nxLwPJAGbp2/TjHXdVGw9fVUgv1ACCwLRxEjOt+n2c5jtF70Z8TqX9WSdnYUV\ngrsahB4z75jiQy6TWsmPuRORyWADG0qKQ55vB+X1cjrxAkmywOr85oFdXXnJ\nFTCTjqtkPJxEBpRqslzytJSgQNWQJhvgpKaWz7BrhW+uBfky0/G5ZkRUvs4y\nPmBkAx8eW+uCtN97UROwWTqRHgzS47msJFACqwAYoUCLac7/Taqtf6P+2Vxt\nMtyyhLcUV+sPCIxUzuNDMJXs3rgoQngb1xQEWUJ3DbvH0jd6acjW6MA31WA4\nphokYqQ0sEVy/ixOkaY+zQ0Aunr83w8tCxy7P9OzIqePCkDQaEuKyBex1JSx\ncagi8jVnUSekPV4Wo3Hij1rHaPSpv0MN0blmrk9zCYkB822Acot7icPqMyBB\nV/3Sc0eX/LntfQsIa5HOkGkGrhEng2WhsRu7B4vqjYl9dAg5HhF3BDs1XHfv\nFcol\r\n=/x7O\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be_1593747384763_0.10801534432554272"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.12.0": {
+      "name": "domain-browser",
+      "version": "4.12.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "exports": {
+        "node": {
+          "require": "./source/index.js"
+        },
+        "browser": {
+          "require": "./source/index.js"
+        }
+      },
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.15.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "b78cfda33834a5d32e213a0aa920adb2aa2022be",
+      "_id": "domain-browser@4.12.0",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-Kyd18R6EKCq75SjiE1WeC2RDaB1d9lXzpDeoLtnZ7ZQmJnLr2bs6YkAWlyjdsHcIB7gHt6kV5z6e0XZTgqSB6Q==",
+        "shasum": "6cff10fcca101f5926e555e97ced6401928638f0",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.12.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22455,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/qfDCRA9TVsSAnZWagAAvZ8P/1NX+sKayveE2Bvcp9Ky\nwyQz7914avybSh88c/gbO/JPODEQigpUHZnfDcjFvWY4u+GaOrlr1eF0PfGE\nHEfDLmQxQD+uvLeWOGMI5IpsBx863NX1UoPd8uDN3N/54UJVC89DLUgsr6R3\ntLcVMAEw2spTx7ryjkCypZuRuMnoYmpOpSV4xnbriQZ1i8QJZO3xYlGuGvvw\nO8W5AwP2Ew3NJg9MFv8FevRDCxyA6/pFhkQPNhlysO1j1lTov7SLmsvy8Wof\nOQ68Q61SuvFwX+2i4+zq1KCIXvYazNnfbgwuq9ppgQv5SKffceqaySRuPzfD\nYBbafyA3GrPoCxQVVAg+Gldz1FDQl+pADCj28oTCsEOD0uWVVfoZ2TxCtzFD\nu/0xCoqtk11jkNDqzwpGHLewEiADuNja7UAqwnF0FCLX3DzcF/d7NErf6LsD\nw8CPtcruaVswMlz6RwOLiRELGlBhLzJ9oexPntp141utEmzXEJaYvL+l0UZ/\nwRxzrr6wKSL1doyqmGPlyx7b6dTtvADIzcuP3IKaiTR3EGEbo3fF94FIS0xi\njq2ktW/n/GG4tMT+O6P9kaF8SWTAK/vId6Zz6E64yrkFJ+YWLPsPSXp3mFO3\n7j8B8X/R1JICbt3J4WnUqWIO+HKZog+lRmpCnkCbtNHFLiTcHrF3CgcfCwMr\nM1wk\r\n=ZG+X\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.12.0_1593747394711_0.878263170386647"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466": {
+      "name": "domain-browser",
+      "version": "4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "exports": {
+        "node": {
+          "require": "./source/index.js"
+        },
+        "browser": {
+          "require": "./source/index.js"
+        }
+      },
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.16.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "a847902f29b90e4a13488eb50e83da9cf2d33466",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.13.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-HunDVyOwx3PgDKDM1JvxwS3bkAb8BHfJwMcpU/iQaKWzG8Sr8NPy7AMGVDYYkLw5fzIQuGpwtp+eYFsMKIa4nA==",
+        "shasum": "906224e69caf24744f02d023784486f82938510b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22706,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/rwMCRA9TVsSAnZWagAANIwP/38nukFJx8QchlWo7/HZ\nszV6lwBjS7cDdddYxvZUsiS7R8wfxOW/IT9Uv6XPLNANHtuEmMgiZdiLJmEO\nW30OtPZXiHpiz3G2b/Xm0ZHr58XaZF3hHF082vduc/eCRY2IE/VPwSKay9Wd\naCJA4+NUnLsvN8PtFDXQd5FrA+NzKrgRs+k/uEY3y8IqYyx3AIQCyP23pa90\na4bVfSvz9HRPZpBjSupzim239tvmZVxbb3dhvr+Z+wOJPsmlMoAPXaPyAS0t\nIlaKqL8IXBPvE6E1sjcvsaQbKwdOjwEjdYarGJVcDC3Eptu9d4Gya57xKCuP\nbADRfaYm5voPqY6bs4iQqK97YsckavbBdlDIChvlrfOgBTsu0Tguu05Ez+RG\n8bmMMpa5/HfWZ/dMURy0JI3c/3GA/g3gdNqGHY5FQuc2ZmH4q/T9Utk40046\nkYOAXByFFTNovan8c4benLEXKpSbsY5eX/wdWVfr2wwWtWMFho6CPb0Y6msn\nEHfF4XzrlFM1uWX3Vtu3A6AwWsdMn9j6M0m/l0YIKpQUs5PtLUIMlwC48faB\ns+iTrn8EhcoPYpn6w4lH91hrX4zHkc3lx8UXbYyd7pdAQcH0EN4GhweX+OVp\n8jsbS2ccRNy0w7wA4PdnlL5X4dXQyA+ZbrzrdUOIg9MMVpXpBW/BbGzWzqs2\nqcHA\r\n=uRqk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466_1593752587771_0.7816178420375937"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.13.0": {
+      "name": "domain-browser",
+      "version": "4.13.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "exports": {
+        "node": {
+          "require": "./source/index.js"
+        },
+        "browser": {
+          "require": "./source/index.js"
+        }
+      },
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.16.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "a847902f29b90e4a13488eb50e83da9cf2d33466",
+      "_id": "domain-browser@4.13.0",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-tmRpVC0PevAIF7KdHnTc8KSdXSavuVWfKjxEaYF0m8OB9ATYS5qZRsnEz7xmYymMKsoJK7FW8HKUih/rhTvWog==",
+        "shasum": "b573d0ebc6e8c64792abf2998025936aac63e368",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.13.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22649,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/rw6CRA9TVsSAnZWagAAl8kQAJwpjiARIJ/xMGq5qn4e\n5AD6ZQ3l7jyq+lAIm6lZ+mUY4ofYoksOU1cye/DKDdAyTPQUvWBROdRDq+74\nA7szLuMFHdtJluiR0zDnH5mzBHuinLGl3WhXruYMEiCiVtfQXlM8uuYaBymk\nmhMjsxwI/Ju1NjOqY293nQH5IO7Xq+R4D1EJRUECQwZpNMD9/rUR79rCQYv7\nhWVaGCsmpEYYHDEN6KcC8lL9LVTHnw/jdh+GI5Z0qSdSf7qh5HTcLEqC0wc9\nkfP6N/apwor/oKXYQjI/XS1E23oM4vD7lGGkZ6of78HncND/LmjSgBMaeUV0\n5P6VeJoOXSjWiWFc7Pzan4spYIjvCl0m380tU3ZD6zygV+Cxt52Jaax1MUbm\n7zu+gFm/rC4caTPnVLS3c8/ANN0KFkGIuhPS321uT+2HGUKudgu4KKeBBQqg\nPmZwCQ1/NSXCV3BMrfT4whUcwqULJuA5knj+RvevrZN9Scy7NR6jwveX2wIs\nrzwtT+hkPyMxqB5u2P+ZzSE6oTxI/VqSYj+us3FyojqXhgLxqcA79xqFOppC\nHlIMS/DEgRz9uKKOvMurWStUrtp8N5Gpr5Kxlrd3rxyLc/bRenyysQVnVdvV\ngm97QAQSJZCiJ34Ev2Mp1scFvMDUeaNe2lHZUoF3AxKDzjbGJXAbleP1bXnQ\n2DYz\r\n=QPln\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.13.0_1593752634363_0.7587067847578401"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394": {
+      "name": "domain-browser",
+      "version": "4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.17.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "4034b5722d7f4e73f4e57b104ca26a13f0634394",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.14.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-QL4DMd+7Voqs5JHK51fOU/ijLQG+BRQ/BMZE2aqJTvIiB4Y/+LnVDNFf+79tS7AuA5i4yaJkeU8WwHX9zZPtwA==",
+        "shasum": "3635270d27977e512adcac8a75196af6512e0abf",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22763,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFwM6CRA9TVsSAnZWagAAzKcP/i9uSkIxjACT2hCHP5XZ\n9GnpnpziBugZtMA3U0m89aRWPGUGpaqTL7RAIJy3lb9YN9/gQ0GjWDAT6z9h\nqf64t0krjUCBJZ2wrZkuLqFbeen63DaQn1CHJNe+mHuSaIt2J3rxNNZNcLcF\nl56xB1WLatF5b9ufJP4jrvRrMN6mBkaPzeCt18lVB1vM96+rPJdmI+aRLbp4\nXUjXBAwXX5WQCL0LtDHjhLfUfKFnaP+Un0kfA4ACt9eL4prdTecPZgXESKuw\nzV7prou9TGLdnhofi09TcnzCl+BZM4N2WhEHCdGIu/2JEr12qrHMrrcc15ak\nF7W/QqMHB2FZZgx+szLkEve2oZU+vH/u5vqkdju21pF06D1R6uI8n0zXXo0N\ngchi+2atTou8L8FUv4WukfJcX8Xomg/v5Z0gxpeiKVYGdjG6myvK1MoyaSka\n9/KK8BTYT6I7z231rCgOvZXVLHsD8TbOCCll/E0jNeM/ITj0P57QamempqhC\n4pv8y/Gq8ai/KfulKOAyBIkAmQ29mNvH9rA7FyVkI7o1zhENGV/nm7F/ogmv\nTL74UOwp65KbeIX7HH6bvOgOa5nD5suJgjagL/QSRK+xw1RRXv2C0eIfuqJD\nO1YPxKFUL0f583A7hBCIch0q+tDPF21JM0s6zQhb1cXjGQbaYdYUKwe84XIL\nOfG1\r\n=gi+n\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394_1595343674084_0.47044940753801856"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.14.0": {
+      "name": "domain-browser",
+      "version": "4.14.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.17.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "4034b5722d7f4e73f4e57b104ca26a13f0634394",
+      "_id": "domain-browser@4.14.0",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-c4+ydoH2CjEgtXsv0wL/bYjCeFTSxricBZSFryu8BVfm/r0ciSY1iQy4xwu5MYnhPVyurRi7XR5lYTpf6w4/lA==",
+        "shasum": "a1d4cc60017420899c521fe211ef577fd733b491",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.14.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22706,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFwNrCRA9TVsSAnZWagAAXqIP/RHaVuZTDfBdlo77Ni4M\nEyEp1WWNeDA4f7QqFELtKKP4VTgHrB2yFbHSDu/vn5PLDAzYbAcN08kkWJhn\n6FVq3iqtiWSPU8I/xx/NFCxZeTthZsIavv0jio7iBdvn6eZ7Tf1lbZz6ykHA\njfWiKCXF4enouZiTuLNzSvVsZxUd+oF7uslIc0BEd8Pha54Rp2KpLKulByjp\nUSIhrct5PMPgu7WLuLW8lNJVlGCGe3iGLIbzLww3FhAGRMRcY0l/FwUNAs0h\nv7f8ftRUwCi44Ynh5urttfDkwxVY9X53NgrNDM6afVXhMcSqKbAMWdiZytPv\n5iSVwF+kpd91vwttUloQ2m1k9yNyeJC7Mu0+hRFrQdcjBRnpXJ0Oiyr5ApAi\nqSRz9DhrlFYffPw/HewU6ijUfj54Byy+0v9oC5ETbvtUC+wbr5rGkkkNTlha\nY5PV3BWzKx3tOXNMEmBXrtcUgOW7g6muEf1nmAEo+bOxJRWH4uK1Q5ZI+fAI\nwwweD4nsbQKs/HQeLzm+CmUjaWt98m42CronbwzMIurxmkKhD/wco2YBHiFc\n07TU+zV5Bq8YoXbwEIFnE0Y8W0OPymvIzMtKp44Cq5C2tTH1GYZ56CsqRQED\nkGhm8+JAsGYzmLFa1LBetbRU9+L+Kl42yci+2AcJ9TBpRa9pjyFB+KCIhZor\n1avd\r\n=Ku1Y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.14.0_1595343722719_0.4917891324513315"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.15.0": {
+      "name": "domain-browser",
+      "version": "4.15.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.18.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "ef6a676505a0d1dd2800429f0059faed3eeefe8e",
+      "_id": "domain-browser@4.15.0",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-jg1GWiXhBZI+8Qn9jAcaNhY9yIlOX52TpZYCsQR6XyXBKU1GU3EfDTwVUdwgscdVx6/eTSmi84yw7wCDZrIhHg==",
+        "shasum": "598e0297be1c8747a6054ff0dd33c2343cba4276",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.15.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22901,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFyRnCRA9TVsSAnZWagAA9ZQP/Rvv6Xc250L2sgvprAi4\nH8GlZfbAApTu08104PmxSjbXCHoHnKHUqL2POeu/0ZMXWw7u5+eiZ0lUwgB9\nYYmdfzH8HoT70FcxIxgL3TaWTX2csdDiBy0qwAZ6eFICBEu77Xw+lyYnAZHC\nji0qHgnzK00LFKb+Kex5Ocg3+z9c84E9pqzjMCF9o7xAOKgBNJeN42Kd7UMQ\nrjg9ADDGFLyyVX/0wpj9hBsyFcLfzSzgLsOvZHL12n3XOinJd4AjzWePhAbl\naSPOIu7GsJyWoKioJzI1T21zIsXQtGBKaicMEHgY77Xw+y0oNB3X12Y3cKxK\nbWIPurIyxH7sUCuUGMAcLtQJAmQYMytUQHZTAgDQiGw+YYTUqooIXfmY2dPM\nPWMWZy56vYDIIu4XGdF+Z8LTM6Nvc3B7xzunS4RJ+T9UXElbtpufT/wibVud\nM6Fn2hrW8u+nEZU0Gg4FZuGsmNNHkGS64tc4VZ1EqiA9ywx258p1G1Yri0w3\nc3/7D8YTMNFsn0yibA3wRe8lmRnbereqjdQdfBlc8Wr3cpkd5C1Xgd1EhJot\nGaLJPDJal4/8V2jsrYF+8rxYzwnxOuRzqwWM6pTH4E+rh013c1Nj9ek79/EM\nwditgVo2e6ul10Kbv53/geOY6OWeNxSXRHAv/LpguuYhnsBNBE6ZNqfVLl5T\nDpGV\r\n=0ikY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.15.0_1595352167283_0.4301825914990629"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb": {
+      "name": "domain-browser",
+      "version": "4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.14.0",
+        "assert-helpers": "^6.19.0",
+        "kava": "^5.9.0",
+        "projectz": "^2.12.0",
+        "valid-directory": "^2.7.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "5795a9745381a2d5efb76b7d172ae2418ea873cb",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.16.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb",
+      "_nodeVersion": "14.7.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-OOtd+qweTLWhpQHGY7b5hcwCooIl6XiRkwCm3FUR5fmUCWKpa75xXUTOIx424qKHw5yW1Q6+/YlBQI+oK+KaIQ==",
+        "shasum": "c88ca8ddcd777b86862ca244520399588b41c00a",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23154,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKNu+CRA9TVsSAnZWagAAyl8QAKSZYeI1BOEM+KXUnk7p\nBzTXEi20SMcx6K1o1Vk3wfrahtvY6kuGYTGIcEvHOK+jTcbfM6xlpQBRBYmD\nbGBGfE38MnpSOLl7n6YyYXFJHG90y3U+5AkG3m8ZK2iwTYZTsHOM9w8JHH82\n+7as9W2KrpyYlImp4eILkvRup/AU3WFZK8XRG8JgcFVvuo18AE/VfapIdf3G\noB8urxTFj/LK9afBnjWI3nQlDShGfCizyxEgL2Z9sst4TjpkwAhCIY4XhHux\nP/PVhsX8RuMMjL/q9DxlHnIyBZhzWkvQMUnpKK72dVn2Pm2400YZmJGP+d2F\ng9strD1/0qVydgggK8RHcoJjMLSHGbeyH6Q0BQwE6L0JL2P/604/KAefpjC2\nr36bQd/67M4ziUr+t0UNLtqiuSpCI9TtHPQf/Q/4Ha5A3jWCbqebDUFEGYG7\nNcV/k9xlg4PAKmvXYdCiY1Kwa4uVldnH8+B1BqNBomCR5uo9+UDGXGV5Qshm\nxDqAZT6sHSi6Qc96jvqGnIWgB6XnCAW5h/hLp8R4VwNeHAeQkPa6F+LoNDQb\nPw4sckWT5O04lypekL/rx2YObh7Sq4xdg+2xqaVcTtjc79+wLR4+JQIVufVd\nmrDLsfXE9P9k2T9T+SE9b+qK05ne4qqVULTKD9fOeJJRPRlQHcC1MmOBpZow\nuRNY\r\n=RRhl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb_1596513213938_0.6836918572218114"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.16.0": {
+      "name": "domain-browser",
+      "version": "4.16.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.14.0",
+        "assert-helpers": "^6.19.0",
+        "kava": "^5.9.0",
+        "projectz": "^2.12.0",
+        "valid-directory": "^2.7.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "5795a9745381a2d5efb76b7d172ae2418ea873cb",
+      "_id": "domain-browser@4.16.0",
+      "_nodeVersion": "14.7.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-oppVWKOBKO04ZGw7xyqUopOl4DeL35Nwosev6WNCaLZCXRPnivliimXj1Jvf4H8ASzX7dyIHjh5YHK18byLg8Q==",
+        "shasum": "98820d49e05fec50905071703eff9f21606ee3ec",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.16.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23097,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKNvNCRA9TVsSAnZWagAA93UP/2eG3YTaFK5r47QtJ7KE\nfG8SEQE+eo0avvTkpdP9l/f9WtFx4eK6SIKpbOcES1cBlAowKER+DXTbyDbf\nwsOLYNwU1OdFgoZGl1apWPkHe5YG2CLJt9oueyXcji9UIpZZEr4qcgAmR6ho\nJg/+ts0f9kZXBbLbVIDxcd4gSkoMHhET3D9b4xgsYuDzBbCumIAxvHhRgv0T\nFYHd6o93sBGlYV2fZ9we12jDCHEqKQ53DrfbI+Frw/0Sgys5us4dNeXHUfJX\ng6abU77xrNH2NBzhWaeRW7/USwXgTaeKj2evs2Y4n44rRMxoZfIqwtQRv5/Y\nyu3LMDRB47/9+r79cSR1A4Cm/I6nvVyHn1mPtNVkY5kOfY5/5azw/rhJFwJs\naw7ai+o8ZqHoDqQwQoN/biaic9ZrMdG/zgfvy2YKYjMpcFPK6S70xZHRtJCp\nWePJkz0OX3SQuIfiMKti2B98zoob7lrxBMWIphQob+UllBbRd2oU9MqiL7/g\nNYuKryWjexqHkXKcmsnyzlYGBpUgg90DsMaPKphJY3kg1qzbehmxMueEo4w5\nankVvCHBb3dhsZFg0a+hm+t4Vi7PLIZOimxunTLb0OKlpy08ls3kA1rXBVNf\nqnz+Ei1lQw2cjdqQBgzlJroRp9IFxFdWdZgAkMAa0nZUFDlIsRMLYgmNRc1k\nlm+S\r\n=SKJU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.16.0_1596513228836_0.44713053782525924"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6": {
+      "name": "domain-browser",
+      "version": "4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.15.0",
+        "assert-helpers": "^6.19.0",
+        "kava": "^5.10.0",
+        "projectz": "^2.14.0",
+        "valid-directory": "^3.0.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "2525a0f556e0de18027f04d45ceb0a2de2fa29f6",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.17.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-V+XfR8/LlExgmjxSot0QUlPVDoLHTgUqxqV56RG6xAMFfNfFB79z2PL9dA/85NDEWipF9YGfuxZr9DsW7gNeKA==",
+        "shasum": "510d80f329973640761bbb4d39a0f83bb0ed1195",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23352,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfOt3UCRA9TVsSAnZWagAAz5oP/2S/JRDumlwx6CXGXuzM\nodE0vKFHoR+Y8L/SfYkCsRZYiXsSdvbVIlyLbLLsTU49r0/JXbaoP/l8iyLY\na7PXvqWfwXDKbQJeEbc8H6dMys5lhMrptGiSZGugHwme0w2gaTd3MjxjkxC7\nLgxubWqLkG5uaSd01mATyT62rJDPHf7hxQd5FDEPp38I5i4UcIMRFwAYSdB2\nPMisSKIogQdv+wfXnDEldvGhyIP+T4hQYN687EwnX8FHiLQu0ywxcBk+14Y+\nmeQDyq1Pu2KU/M7M1IUM+D7akB/mDZOChP7kAIaSPPO1oXOOwjuFDfTSPDhy\nF+w91BdE8dWUfgR3y3Kg0vBOG75mgeqLwC5j/phrvOSJ9yNoiqSQgEwJG5cd\nIjX71Kom3/8DWJxPa+oFEZ3ar4KFpwTAvvj1KdylMPMx4g8JGg12sDz/zkCa\nK0erxLlbPZsFq9bR2ecVidxMpAFDdWdFyhGFY5h9ka8/n2MIkl1P2DflaYpW\n/A+hqhJKgXr10QK5bnRPz/3Bj04GxtcbnDrSrhBJ6JKhIfzalXvH2X3Nve8d\nvryfhRDzGWsqmu0vCOdSXb65qj4JrZrQ+YsDedSuf7b25rOfO588ZE+fxCU+\nqvCjtpZ+Q3A5OmwlfyCuS9l2JDsmIv4q5HkiEWok6EH7obpZC9dSIQTf7BIv\n0aqT\r\n=rOE6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6_1597693395532_0.49419712502504054"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.17.0": {
+      "name": "domain-browser",
+      "version": "4.17.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.15.0",
+        "assert-helpers": "^6.19.0",
+        "kava": "^5.10.0",
+        "projectz": "^2.14.0",
+        "valid-directory": "^3.0.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "2525a0f556e0de18027f04d45ceb0a2de2fa29f6",
+      "_id": "domain-browser@4.17.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-Hj9LbFLqt4MBK/rq24/Bk3nhcPlaKfTCFs8XENVqNQray7WtKbo/GYMGDAVW62O83lgRjxvD5UCmtQsN9B/YxA==",
+        "shasum": "a6523549b84483f1868859166f53d08adedc2c1c",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.17.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23295,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfOt4FCRA9TVsSAnZWagAAUv0P/izmdOUQzriGjUHYceU6\nuK/n834JXcy5/jjphfwLFw/En6YobYddTARsK/EtL8HnvX8vMTQfqTU9qEkK\njgj7/mR4nIGpGJ/6RqpjA720wgAGKkKUhkba/GtdHLWe+HGDDqfkwalOx3Be\n+N15LJUBn3KRSlTVXqApQIwSKx0QlzUMt/m06LlxHQNIlYTj4vTx+iAzLPgr\n741UCynsIyOoU71Q4IYxFEWlBfjTnLWwo7Mbqz1nnwMwo03yPbpGODHjD7kJ\njW5/OUiPuPZ6wT/3Mxv8ew9gdhMCcSRMKKq3n0eq0oYNhCSZRvno9GGCNEsC\n6VNBCUowyfv2/aYx6LDA7LdRcUJlKv6XE9j2r9yXipfDfD3iWwZKRaGlxgBp\ni29oiCcPH9gsUdSE+rwPWc2qBdXAx0L6m6x1J/7TjNWv9kKv4HT4SvN/q5fX\nMZ20GMbnyHmP7SpowqeielF+Ann+lzzSpTyILqWRvGtlVWWDFwvedN1cyqVh\n4w13UpgqkIlk/XhA+Xe+XC5Zod2q+6sIp/OHSqpvTnnYWiiAUF+US3Snj5kI\nxM2UHWMDVrbITn0LtctxYx8kSRdo1lAB6rY8GaUu4UZ9ht4Yd88oM5+2cHon\nDDp5o7VGeK+uwgI6gmWG9p0OLxRKr+tOV/15s03HzrARCcTjUkmkOWGvDR+q\nRUra\r\n=KM3F\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.17.0_1597693444490_0.0966529210632705"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.18.0": {
+      "name": "domain-browser",
+      "version": "4.18.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "source",
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.16.0",
+        "assert-helpers": "^7.2.0",
+        "kava": "^5.11.0",
+        "projectz": "^2.15.0",
+        "valid-directory": "^3.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "7dee3feb197584bb413877f7fcde16c497ef38e5",
+      "_id": "domain-browser@4.18.0",
+      "_nodeVersion": "14.9.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-zUa9XMz3NmuabwyUGQcYhm2yiG/3MjUUF4/DEFXUl0X035GyCorUFxX2CbHXFzxPWFg6xNgml7JZng6ORxqszg==",
+        "shasum": "b050d93a417be6920372a1b0e8b81cafe5a19919",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.18.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23748,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfUgP8CRA9TVsSAnZWagAA+ycP/AqlTIDGZ6jpshsZbnWM\nuAuu/UTRd5pEWN93jASEsXyFGLONlzsGP75Jvo9s7KEHsMYJBWJzu4OhCgE9\nBs4hVbw8AJX9g8KVyxk5HqbcfB7PcGjL3ngcS/1mrkvV92EPxdZSLuiDa3Am\n/u5XSotvNRY7vgxdroP0dxoQIPuNcHNKS+A95dRzmdXsV9Ge3l4oBbzL2/Lg\naf0VDv3IbJLGbw6JkFFgZ2e3i+FPSrpjG2NMD0HnDy5KhRyd+16FSmYEbVgb\ndTO7IG+noH74yD0Jq5eXbNbBiCpvRqSWttm5WvjV+kLxWqccsulvePUlCvws\nnGE3X39SL++5JTzg0pYdoN/z0ArSC1O7ZjQ/xxasYWP86IcoZa/Q3fF5QCIh\ntdfOYrN4jpXNYsQyovSpA6BMzHleBNk7B67/LaQzMGxynX0oGQhaebnRhmkn\nl+O1owwRL61uDCnzrq+hAiUdnnpRWt3A5SYh0ccFeUJB3ZFgFogkX5+koqcC\n6RYzJj6T2Lotii9Dm0m4rndtiw3ph7OZdeiohdW6SIwU8wGo4phQMzp7EJZk\n3fIlmFCwJYT550a0E9nZld4gdDTbURtfVRntToCLH0sl6aG5Sw7Ed6E7PFty\nZjHE18kIH44VylJR821IFQv0mEPM9KSiYE5JSKDC0VdoKnl+ZvqXr7Vqwdhf\n5Bvr\r\n=6HZM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.18.0_1599210491882_0.8276392292214187"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf": {
+      "name": "domain-browser",
+      "version": "4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "source",
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.16.0",
+        "assert-helpers": "^7.2.0",
+        "kava": "^5.11.0",
+        "projectz": "^2.15.0",
+        "valid-directory": "^3.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "065f6b95a8f50e8a384176f775a1853a2cd341cf",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.18.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf",
+      "_nodeVersion": "14.9.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-wm/MrAuUjuqH9U1b9vXNHatMZdLr6dSk54DnnnlGW2nfmoTg2uUeKMBCVGM9wBcZvDz5pjD9WiMqATRmEwgdGg==",
+        "shasum": "46d58cfe4eb390d79a28276ce1f6a68792a495f2",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23805,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfUgQiCRA9TVsSAnZWagAAzRgP/27wfP55+lHrhFh9TXAt\ngT9OFYSv6AESi+sEBCvV5AFIhddbMWtxuFB/X+KixvcOi59mM5dhKVskx8z6\n/PlhrJl0Ba3+JotwZiHgdkwOfVeMitNN7bmLp9QAwAhnwSii8Y9c9NLoWFo6\nNdiGrRF5tSFhhMZlrtZWU0AGa9+1j6SsqUE+TgoWPnX2u0jFkqRWVfnxqJzg\nuYloS4a7uplZAXncT+t+4rZcWjIRh7wIZ9DJufOvYvRMolS2zREDOywPLz3i\nByGe9WtrfRKKNIXqL33CT1c/UkGdwnrNIGJcN4NDPpZCngspg5qggqbeJmKY\n4fr0ZZfOS8xg12b/ewiyzi5s5/AJXhjbyDfLqrKCKQnpcsGwGRgka232dBH+\niAiCSPZ1MNCfz5rP7EuqdzBNhJg3cPaWE50tB8dea/sKZFNC2f4hY6wxu0Ux\n9jD/jCnyFtolXZ/tHLRwFXmAOHJk/qOizJcviywrmo4iMtdcJXqXppo9yWss\nv9J7wA+acG6UO8PCgYXeCyltShkihRAX1SRvSjTN08TGoRJc4E3HUfG2G7j7\nxzq2hoNxdis/Z74nf6vxwcdf3A2vAOO4/622UMymQVYqubsoOSFtFkendcQK\nSwGExq4hDjfxyM8/rweauOtuCYQlRgPAM+MBt+qAXVfgLVGuj+IEvTSeQh8u\n7eSS\r\n=AgWu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf_1599210530327_0.18660637198903052"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5": {
+      "name": "domain-browser",
+      "version": "4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "us@bevry.me",
+          "name": "bevryme"
+        },
+        {
+          "email": "evan@evanalyze.com",
+          "name": "evansolomon"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "source",
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 13 || 14",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.16.0",
+        "assert-helpers": "^7.2.0",
+        "kava": "^5.11.0",
+        "projectz": "^2.15.0",
+        "valid-directory": "^3.3.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "c802e4848f1c665b073cb67e5efc27d4063dc1f5",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.18.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5",
+      "_nodeVersion": "14.9.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-lYf72qeK5W95g3rVWuOwh4qveoeFlTrzuCwSgbgsbh+/Ili3SrfJ2xeX6sh93rtmHZ1+oMP1x9mzs8nMwm5pFg==",
+        "shasum": "4567ffb9e2444fa96d43a5f0cd97d1e7bd791f3a",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23805,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfVM0FCRA9TVsSAnZWagAAL0EQAIRrFZIo/v5ZQGC8bOY4\nS7F8emgPfjG7efhfTxj8TceCDYXCWFlT4geluvZbv2V2dyosZeFolCG4m7n5\nVW3gFZ3MYthJ632s+MGexmNrJ7uuSAt/IJr2kY6D2JyPKTExKbGY9mhyOGho\nCqjfqC0pthlBBwmBoaxBzNHG+Hk+GnPGHmZ01nZPATTirew+3OuGvjyRvdJ6\n9KV+DlIG5NahFrVaHFVMULY0foLoLvJgr8NFnx9NXkwGl6FK6m7y+9IPVZh/\nJ6yB9KwSkZ82q6f/Ywd61S2AJ4b43Q7ufwvg3zA01h/zW/da8/fBi+cxGfAd\n0zzuf2FGJodkpnEVvv1lPCKWOzc5jkiNWwhXSRsdK5WEzSdbsNLZ9aLGQNce\nXPaMF/+yszFhDnAryZKDvpYPZlrvdSBRyfrYJrj64iaYLpQpamG3TVoZ3db/\ncV4ZqqgIdMdspBW1mO1YBQT6IAvw/wrcJprzy+Fommuc1nH0WET24/NvRohb\nnSbjLLMtWTkIeBMRTjfICFYv+STwBEyxS7rDqM3X5Ozk9LNVQoNCbjl6ZqqI\ne/UwXqqIy/l/vCIzyrdVgKHgzMRIZffZTnlsoHTPT2/zt7NmXVnI+wrlNjet\nuY6bpXfMoQ1yf60/bQprtIuOUdQqQik/wNFFzfz8ryJhS0RSNkLHDRRK1RKo\nShtl\r\n=QtY/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5_1599393028827_0.7800857158298315"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c": {
+      "name": "domain-browser",
+      "version": "4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "evansolomon",
+          "email": "evan@evanalyze.com"
+        },
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        },
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "bevryme",
+          "email": "us@bevry.me"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "source",
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 14 || 15",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.17.0",
+        "assert-helpers": "^8.1.0",
+        "kava": "^5.12.0",
+        "projectz": "^2.16.0",
+        "valid-directory": "^3.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "1ee8a8832eea2ef541bd184b64ed70aa4697874c",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.19.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-MtCYFQXREDeMnkb27ZhAkGQFK5xNfWJjK1gO741HAbgzavZSLticutVfazf3EttrBeFO6zofdf+CU2Z4lAtzZA==",
+        "shasum": "0c609da3513c7c493018ca12592245de1b3ebc67",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c.tgz",
+        "fileCount": 6,
+        "unpackedSize": 24003,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmf6PCRA9TVsSAnZWagAArhEQAJ2GcISn7z5CUCmCI7ch\nxHda2Fg2Z3/LiKpqQwSrFE7Bcr7O2ktahplz4VWY9pyLygUBXjudnvsb1TL2\nDsqq6cRufJGKpwQ8xFbbaseRjVIgkC4Ce9uw3eIEByTjzVgV0K+D8r52/HVz\nu6GGZuaVQ9Yer1YMQxXDsVbueo+tEmxyb5dEIwwjP0DPtNZu/g3JZlUf27cq\nXM4O5oIfZ2MPcyyQX4fbgL8OXcIgwrKfr8WYstkcHl+KWQgD0Dbtvie77sTo\nAk3tF1zMVg5hWrKAlXId5+OqJJaACXFNiSOv9fxYtv/XnAzMku2Bf8E8WZ1d\nQiAYusWfJqwcq4mVIH9lhP1uxbffYn2LtblVF1RNaUHwZZ64qOvhDX60ZcP4\n6Mz8cARjessSwtoIYLiscEkuRNFXfMQdiMvIvVEcwCq5nipVH3KTmX6qXbvR\nC8fvYFG/k3og/Xx48joL0RAaESYGlTVYG9AcI7IdGe9pHxLjWhnM+XhM8IS7\ncteQk8NTzY/Xdh56tiamWAXZcTymMiGmaafgfa2yNak7D5qURV4Dz/iXXePh\nXTOApzd4SEXI4Uap0TN3ZaHC8eYsUrDZr9c3hBzRtMY6FxHM5jROpp48Iu7E\nnEGF+WwKvQ6TZId4oM93fJxHGvFt2L3R9SagY0rljsE1JJZ6hmFQNA/8l0JP\nWxkB\r\n=AV/o\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c_1603927695485_0.19665278861634916"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.19.0": {
+      "name": "domain-browser",
+      "version": "4.19.0",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "evansolomon",
+          "email": "evan@evanalyze.com"
+        },
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        },
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "bevryme",
+          "email": "us@bevry.me"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "source",
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 14 || 15",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.17.0",
+        "assert-helpers": "^8.1.0",
+        "kava": "^5.12.0",
+        "projectz": "^2.16.0",
+        "valid-directory": "^3.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "1ee8a8832eea2ef541bd184b64ed70aa4697874c",
+      "_id": "domain-browser@4.19.0",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ==",
+        "shasum": "1093e17c0a17dbd521182fe90d49ac1370054af1",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23946,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmf65CRA9TVsSAnZWagAAzvYP/igYdb+1Q0xsJRK9c1S7\nM62EgtwVsTSEYMDgfAqU8sgYVnpepB8O979XQRUTsfoUPIFfkJkRZr8KwMXK\nu14+sRV1Cdut2jJ/kO89YXSXhUIkZ518pPAaPz+Q7qbmTIEoB2wZn1gw+zyV\nEGNAPUarxsA0gNslJKvwk7ayWmqh+OGJvxpUKEXm14dVKhf+PHLRtHD1oYDs\nOnn6ll2lW83XKDi5NUK7Hvy0Lc/WqBN55iJta4J+GtYMZRFsPdO9EMDrTAf3\nUZE+tqZPGm/mq853oNQVoSN/fivyjeCSR9GK26w/6xz344T2RD+N0ZT4TiLR\nZ+bDdGJnOxgWiSUUYPO6hC03E5No+d8Uf2MhVldAnfFkrWl/M2Lz0gnTnmqI\nD7rQDWtcnLX1+Bfd6jpb5W3qT0m2abLXzwCB3f+nO8woegfEbChpBjZYahFv\nklPg4jBf2dK5AOtm1RFQDD2fF4mrN4TRakBgJt5to5qOr8+wWflZExVfPkRV\nY/fjgpwEr3A+Ho2VAv/cDRAu2cXiCOt9j5E1PzSJQqntA7JX4qW54fxpSpE7\nY2uY9o55RwYiMrGOxP8GtEijgju6c39tX7CacYTbqs4YuHtJCgsEHErPOchy\neO/kjGIwsLfRPyPK7pbz8xzmOU4ddlI3Ktfas0JjueoCjQuvwCBBlhdIU4bw\ncV0U\r\n=MX9m\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.19.0_1603927736756_0.33503827084353954"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de": {
+      "name": "domain-browser",
+      "version": "4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de",
+      "description": "Node's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.",
+      "homepage": "https://github.com/bevry/domain-browser",
+      "license": "MIT",
+      "keywords": [
+        "amd",
+        "browser",
+        "catch",
+        "component",
+        "component.io",
+        "domain",
+        "ender.js",
+        "es5",
+        "node",
+        "node-compat",
+        "require.js",
+        "try",
+        "trycatch",
+        "umd"
+      ],
+      "badges": {
+        "list": [
+          "travisci",
+          "npmversion",
+          "npmdownloads",
+          "daviddm",
+          "daviddmdev",
+          "---",
+          "githubsponsors",
+          "patreon",
+          "flattr",
+          "liberapay",
+          "buymeacoffee",
+          "opencollective",
+          "crypto",
+          "paypal",
+          "wishlist"
+        ],
+        "config": {
+          "githubSponsorsUsername": "balupton",
+          "buymeacoffeeUsername": "balupton",
+          "cryptoURL": "https://bevry.me/crypto",
+          "flattrUsername": "balupton",
+          "liberapayUsername": "bevry",
+          "opencollectiveUsername": "bevry",
+          "patreonUsername": "bevry",
+          "paypalURL": "https://bevry.me/paypal",
+          "wishlistURL": "https://bevry.me/wishlist",
+          "travisTLD": "com",
+          "githubUsername": "bevry",
+          "githubRepository": "domain-browser",
+          "githubSlug": "bevry/domain-browser",
+          "npmPackageName": "domain-browser"
+        }
+      },
+      "funding": "https://bevry.me/fund",
+      "author": {
+        "name": "2013+ Bevry Pty Ltd",
+        "email": "us@bevry.me",
+        "url": "http://bevry.me"
+      },
+      "maintainers": [
+        {
+          "name": "evansolomon",
+          "email": "evan@evanalyze.com"
+        },
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        },
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "bevryme",
+          "email": "us@bevry.me"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Benjamin Lupton",
+          "email": "b@lupton.cc",
+          "url": "https://github.com/balupton"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "email": "trysound@yandex.ru",
+          "url": "https://github.com/TrySound"
+        },
+        {
+          "name": "Evan Solomon",
+          "url": "https://github.com/evansolomon"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com",
+          "url": "https://github.com/guybedford"
+        },
+        {
+          "name": "James Halliday",
+          "email": "substack@gmail.com",
+          "url": "https://github.com/substack"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bevry/domain-browser/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bevry/domain-browser.git"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "editions": [
+        {
+          "description": "ES5 source code for web browsers and Node.js with Require for modules",
+          "directory": "source",
+          "entry": "index.js",
+          "tags": [
+            "source",
+            "javascript",
+            "es5",
+            "require"
+          ],
+          "engines": {
+            "node": "10 || 12 || 14 || 15",
+            "browsers": "defaults"
+          }
+        }
+      ],
+      "type": "commonjs",
+      "main": "source/index.js",
+      "browser": "source/index.js",
+      "jspm": {
+        "map": {
+          "source/index.js": {
+            "node": "@node/domain"
+          }
+        }
+      },
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.17.0",
+        "assert-helpers": "^8.1.0",
+        "kava": "^5.12.0",
+        "projectz": "^2.16.0",
+        "valid-directory": "^3.4.0"
+      },
+      "scripts": {
+        "our:clean": "rm -Rf ./docs ./edition* ./es2015 ./es5 ./out ./.next",
+        "our:compile": "echo no need for this project",
+        "our:deploy": "echo no need for this project",
+        "our:meta": "npm run our:meta:contributors && npm run our:meta:projectz",
+        "our:meta:contributors": "update-contributors",
+        "our:meta:projectz": "projectz compile",
+        "our:release": "npm run our:release:prepare && npm run our:release:check-changelog && npm run our:release:check-dirty && npm run our:release:tag && npm run our:release:push",
+        "our:release:check-changelog": "cat ./HISTORY.md | grep v$npm_package_version || (echo add a changelog entry for v$npm_package_version && exit -1)",
+        "our:release:check-dirty": "git diff --exit-code",
+        "our:release:prepare": "npm run our:clean && npm run our:compile && npm run our:test && npm run our:meta",
+        "our:release:push": "git push origin master && git push origin --tags",
+        "our:release:tag": "export MESSAGE=$(cat ./HISTORY.md | sed -n \"/## v$npm_package_version/,/##/p\" | sed 's/## //' | awk 'NR>1{print buf}{buf = $0}') && test \"$MESSAGE\" || (echo 'proper changelog entry not found' && exit -1) && git tag v$npm_package_version -am \"$MESSAGE\"",
+        "our:setup": "npm run our:setup:install",
+        "our:setup:install": "npm install",
+        "our:test": "npm run our:verify && npm test",
+        "our:verify": "npm run our:verify:directory",
+        "our:verify:directory": "valid-directory",
+        "test": "node ./source/test.js"
+      },
+      "gitHead": "eeda285a1a0470ee48d60df8d904f8b47b0997de",
+      "readme": "<!-- TITLE/ -->\n\n<h1>domain-browser</h1>\n\n<!-- /TITLE -->\n\n\n<!-- BADGES/ -->\n\n<span class=\"badge-travisci\"><a href=\"http://travis-ci.com/bevry/domain-browser\" title=\"Check this project's build status on TravisCI\"><img src=\"https://img.shields.io/travis/com/bevry/domain-browser/master.svg\" alt=\"Travis CI Build Status\" /></a></span>\n<span class=\"badge-npmversion\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/v/domain-browser.svg\" alt=\"NPM version\" /></a></span>\n<span class=\"badge-npmdownloads\"><a href=\"https://npmjs.org/package/domain-browser\" title=\"View this project on NPM\"><img src=\"https://img.shields.io/npm/dm/domain-browser.svg\" alt=\"NPM downloads\" /></a></span>\n<span class=\"badge-daviddm\"><a href=\"https://david-dm.org/bevry/domain-browser\" title=\"View the status of this project's dependencies on DavidDM\"><img src=\"https://img.shields.io/david/bevry/domain-browser.svg\" alt=\"Dependency Status\" /></a></span>\n<span class=\"badge-daviddmdev\"><a href=\"https://david-dm.org/bevry/domain-browser#info=devDependencies\" title=\"View the status of this project's development dependencies on DavidDM\"><img src=\"https://img.shields.io/david/dev/bevry/domain-browser.svg\" alt=\"Dev Dependency Status\" /></a></span>\n<br class=\"badge-separator\" />\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<!-- /BADGES -->\n\n\n<!-- DESCRIPTION/ -->\n\nNode's domain module for the web browser. This is merely an evented try...catch with the same API as node, nothing more.\n\n<!-- /DESCRIPTION -->\n\n\n<!-- INSTALL/ -->\n\n<h2>Install</h2>\n\n<a href=\"https://npmjs.com\" title=\"npm is a package manager for javascript\"><h3>npm</h3></a>\n<ul>\n<li>Install: <code>npm install --save domain-browser</code></li>\n<li>Import: <code>import * as pkg from ('domain-browser')</code></li>\n<li>Require: <code>const pkg = require('domain-browser')</code></li>\n</ul>\n\n<a href=\"https://jspm.io\" title=\"Native ES Modules CDN\"><h3>jspm</h3></a>\n\n``` html\n<script type=\"module\">\n    import * as pkg from '//dev.jspm.io/domain-browser@4.19.0'\n</script>\n```\n\n<h3><a href=\"https://editions.bevry.me\" title=\"Editions are the best way to produce and consume packages you care about.\">Editions</a></h3>\n\n<p>This package is published with the following editions:</p>\n\n<ul><li><code>domain-browser</code> aliases <code>domain-browser/source/index.js</code></li>\n<li><code>domain-browser/source/index.js</code> is ES5 source code for web browsers and <a href=\"https://nodejs.org\" title=\"Node.js is a JavaScript runtime built on Chrome's V8 JavaScript engine\">Node.js</a> with <a href=\"https://nodejs.org/dist/latest-v5.x/docs/api/modules.html\" title=\"Node/CJS Modules\">Require</a> for modules</li></ul>\n\n<!-- /INSTALL -->\n\n\n<!-- HISTORY/ -->\n\n<h2>History</h2>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/HISTORY.md#files\">Discover the release history by heading on over to the <code>HISTORY.md</code> file.</a>\n\n<!-- /HISTORY -->\n\n\n<!-- BACKERS/ -->\n\n<h2>Backers</h2>\n\n<h3>Maintainers</h3>\n\nThese amazing people are maintaining this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<h3>Sponsors</h3>\n\nNo sponsors yet! Will you be the first?\n\n<span class=\"badge-githubsponsors\"><a href=\"https://github.com/sponsors/balupton\" title=\"Donate to this project using GitHub Sponsors\"><img src=\"https://img.shields.io/badge/github-donate-yellow.svg\" alt=\"GitHub Sponsors donate button\" /></a></span>\n<span class=\"badge-patreon\"><a href=\"https://patreon.com/bevry\" title=\"Donate to this project using Patreon\"><img src=\"https://img.shields.io/badge/patreon-donate-yellow.svg\" alt=\"Patreon donate button\" /></a></span>\n<span class=\"badge-flattr\"><a href=\"https://flattr.com/profile/balupton\" title=\"Donate to this project using Flattr\"><img src=\"https://img.shields.io/badge/flattr-donate-yellow.svg\" alt=\"Flattr donate button\" /></a></span>\n<span class=\"badge-liberapay\"><a href=\"https://liberapay.com/bevry\" title=\"Donate to this project using Liberapay\"><img src=\"https://img.shields.io/badge/liberapay-donate-yellow.svg\" alt=\"Liberapay donate button\" /></a></span>\n<span class=\"badge-buymeacoffee\"><a href=\"https://buymeacoffee.com/balupton\" title=\"Donate to this project using Buy Me A Coffee\"><img src=\"https://img.shields.io/badge/buy%20me%20a%20coffee-donate-yellow.svg\" alt=\"Buy Me A Coffee donate button\" /></a></span>\n<span class=\"badge-opencollective\"><a href=\"https://opencollective.com/bevry\" title=\"Donate to this project using Open Collective\"><img src=\"https://img.shields.io/badge/open%20collective-donate-yellow.svg\" alt=\"Open Collective donate button\" /></a></span>\n<span class=\"badge-crypto\"><a href=\"https://bevry.me/crypto\" title=\"Donate to this project using Cryptocurrency\"><img src=\"https://img.shields.io/badge/crypto-donate-yellow.svg\" alt=\"crypto donate button\" /></a></span>\n<span class=\"badge-paypal\"><a href=\"https://bevry.me/paypal\" title=\"Donate to this project using Paypal\"><img src=\"https://img.shields.io/badge/paypal-donate-yellow.svg\" alt=\"PayPal donate button\" /></a></span>\n<span class=\"badge-wishlist\"><a href=\"https://bevry.me/wishlist\" title=\"Buy an item on our wishlist for us\"><img src=\"https://img.shields.io/badge/wishlist-donate-yellow.svg\" alt=\"Wishlist browse button\" /></a></span>\n\n<h3>Contributors</h3>\n\nThese amazing people have contributed code to this project:\n\n<ul><li><a href=\"https://github.com/balupton\">Benjamin Lupton</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=balupton\" title=\"View the GitHub contributions of Benjamin Lupton on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/TrySound\">Bogdan Chadkin</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=TrySound\" title=\"View the GitHub contributions of Bogdan Chadkin on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/evansolomon\">Evan Solomon</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=evansolomon\" title=\"View the GitHub contributions of Evan Solomon on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/guybedford\">Guy Bedford</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=guybedford\" title=\"View the GitHub contributions of Guy Bedford on repository bevry/domain-browser\">view contributions</a></li>\n<li><a href=\"https://github.com/substack\">James Halliday</a> — <a href=\"https://github.com/bevry/domain-browser/commits?author=substack\" title=\"View the GitHub contributions of James Halliday on repository bevry/domain-browser\">view contributions</a></li></ul>\n\n<a href=\"https://github.com/bevry/domain-browser/blob/master/CONTRIBUTING.md#files\">Discover how you can contribute by heading on over to the <code>CONTRIBUTING.md</code> file.</a>\n\n<!-- /BACKERS -->\n\n\n<!-- LICENSE/ -->\n\n<h2>License</h2>\n\nUnless stated otherwise all works are:\n\n<ul><li>Copyright &copy; 2013+ <a href=\"http://bevry.me\">Bevry Pty Ltd</a></li></ul>\n\nand licensed under:\n\n<ul><li><a href=\"http://spdx.org/licenses/MIT.html\">MIT License</a></li></ul>\n\n<!-- /LICENSE -->\n",
+      "readmeFilename": "README.md",
+      "_id": "domain-browser@4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de",
+      "_nodeVersion": "14.15.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-OUZ4hmeSOYFIUi+8VKJoBQSbT/irhK+mlFUX5hUlEIOoFJyoAAmW9RRiQWwPkKr9QXX4J24ANMeeV0jeXP+AaQ==",
+        "shasum": "5a1248a517ff83eb2c4c449ab44c83f62523bce7",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de.tgz",
+        "fileCount": 6,
+        "unpackedSize": 24003,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfnsIGCRA9TVsSAnZWagAAbLMQAKROb37ajj0TOP5/tfTa\nxYwgqC3U7KxKOQpowp3UpvSirE47XHZxlj51fuX0vLNtmiVIicl2oqMNIfQm\n3twjihMDXINkxvPrfclT/R+K5tULGvf/Y5W20ZzTcMAo2hTt+FwlYpRXreja\ntoiNOoH0elKFlPWo3N5LrfbHddlON2Hr+uf/zXcRAeu9tMF7/+D6rKQVkH62\nhFAkqYKmamIb7F2MaDbq3PPgmiIIbGQgUb4IayU7hZn7QMeN7ohypxpUBezw\nl2xBZcvEWC93JksVwnn1pTKONOZoNBrIHj3R1xgSDXBfWJpkKRM71Y0KRBqO\nccV04+AT4zs3AZ/ttYk6Je8Gb33/SMt8WVVq97CXZtntuO4QOERXHs87EI62\nu35m5kCtsK8TPRCes8o3057TEJPcRSmBi0SHjtJI67KvaxgN+vkW4upemKjH\nycAPI8dJqwp7tyjmQZf+g0oUzxIpm0TeoD4H20/BiimPlLQgMctWTMDHfyW4\ntM1p2iqIOf49TeNEFBOYxbP3HfyllWdITikc1Qq5E9Je824V95UreX5CPafG\nGrjpkzF/ONwHNMpYfvjMD1khmXByvohnSR4fuaAn51e5aQs7Um6Y3TlhetZj\nzAeM8J0FYCZUg7OKEXV0v+UZNdkmI16KjYSmKcjvZIe8/5Huu6DOkzdJqeiz\n/aIx\r\n=Nqar\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "bevryme",
+        "email": "us@bevry.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/domain-browser_4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de_1604239878167_0.7101532521362057"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "",
+  "maintainers": [
+    {
+      "name": "evansolomon",
+      "email": "evan@evanalyze.com"
+    },
+    {
+      "name": "substack",
+      "email": "substack@gmail.com"
+    },
+    {
+      "name": "balupton",
+      "email": "b@lupton.cc"
+    },
+    {
+      "name": "bevryme",
+      "email": "us@bevry.me"
+    }
+  ],
+  "time": {
+    "modified": "2020-11-01T14:11:20.576Z",
+    "created": "2013-09-18T07:53:46.649Z",
+    "1.0.0": "2013-09-18T07:53:51.840Z",
+    "1.0.1": "2013-09-18T13:26:41.698Z",
+    "1.1.0": "2013-11-01T04:21:17.051Z",
+    "1.1.1": "2013-12-27T12:53:48.729Z",
+    "1.1.2": "2014-06-07T21:03:53.074Z",
+    "1.1.3": "2014-10-11T05:47:12.694Z",
+    "1.1.4": "2015-02-03T14:17:33.817Z",
+    "1.1.5": "2015-12-09T08:48:24.782Z",
+    "1.1.6": "2015-12-11T18:28:12.966Z",
+    "1.1.7": "2015-12-12T03:10:29.042Z",
+    "1.2.0": "2018-01-26T06:06:41.029Z",
+    "2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8": "2019-11-18T04:20:29.754Z",
+    "2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11": "2019-11-18T04:27:32.065Z",
+    "2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b": "2019-11-24T21:28:23.884Z",
+    "3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571": "2019-11-30T19:05:56.084Z",
+    "3.0.0": "2019-11-30T19:06:55.984Z",
+    "3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96": "2019-11-30T19:36:13.674Z",
+    "3.1.0": "2019-11-30T19:37:14.081Z",
+    "3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751": "2019-11-30T19:39:28.835Z",
+    "3.2.0": "2019-11-30T19:40:31.971Z",
+    "3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7": "2019-11-30T20:28:37.846Z",
+    "3.3.0": "2019-11-30T20:29:37.102Z",
+    "3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147": "2019-12-01T03:03:46.107Z",
+    "3.4.0": "2019-12-01T03:04:51.947Z",
+    "3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b": "2019-12-09T08:08:11.438Z",
+    "3.5.0": "2019-12-09T08:13:34.877Z",
+    "4.0.0": "2020-03-25T22:35:07.518Z",
+    "4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1": "2020-03-25T22:35:20.919Z",
+    "4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd": "2020-05-04T12:36:01.455Z",
+    "4.1.0": "2020-05-04T12:36:57.305Z",
+    "4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3": "2020-05-12T02:23:17.374Z",
+    "4.2.0": "2020-05-12T02:24:07.987Z",
+    "4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67": "2020-05-21T04:27:26.023Z",
+    "4.3.0": "2020-05-21T04:28:19.418Z",
+    "4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016": "2020-05-21T14:40:02.252Z",
+    "4.4.0": "2020-05-21T14:40:55.581Z",
+    "4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc": "2020-06-10T08:00:06.191Z",
+    "4.5.0": "2020-06-10T08:00:50.852Z",
+    "4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a": "2020-06-10T12:46:51.564Z",
+    "4.6.0": "2020-06-10T12:47:44.240Z",
+    "4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31": "2020-06-19T21:23:59.268Z",
+    "4.7.0": "2020-06-19T21:24:55.886Z",
+    "4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e": "2020-06-19T22:42:55.850Z",
+    "4.8.0": "2020-06-19T22:44:30.681Z",
+    "4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364": "2020-06-20T21:59:41.049Z",
+    "4.9.0": "2020-06-20T22:00:47.448Z",
+    "4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0": "2020-06-21T11:17:34.722Z",
+    "4.10.0": "2020-06-21T11:18:33.557Z",
+    "4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6": "2020-06-25T02:23:20.189Z",
+    "4.11.0": "2020-06-25T02:24:10.212Z",
+    "4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c": "2020-07-03T02:13:30.141Z",
+    "4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be": "2020-07-03T03:36:24.863Z",
+    "4.12.0": "2020-07-03T03:36:34.858Z",
+    "4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466": "2020-07-03T05:03:07.898Z",
+    "4.13.0": "2020-07-03T05:03:54.534Z",
+    "4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394": "2020-07-21T15:01:14.250Z",
+    "4.14.0": "2020-07-21T15:02:02.903Z",
+    "4.15.0": "2020-07-21T17:22:47.381Z",
+    "4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb": "2020-08-04T03:53:34.104Z",
+    "4.16.0": "2020-08-04T03:53:48.949Z",
+    "4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6": "2020-08-17T19:43:15.641Z",
+    "4.17.0": "2020-08-17T19:44:04.611Z",
+    "4.18.0": "2020-09-04T09:08:11.979Z",
+    "4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf": "2020-09-04T09:08:50.459Z",
+    "4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5": "2020-09-06T11:50:28.949Z",
+    "4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c": "2020-10-28T23:28:15.602Z",
+    "4.19.0": "2020-10-28T23:28:56.907Z",
+    "4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de": "2020-11-01T14:11:18.303Z"
+  },
+  "author": {
+    "name": "2013+ Bevry Pty Ltd",
+    "email": "us@bevry.me",
+    "url": "http://bevry.me"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bevry/domain-browser.git"
+  },
+  "homepage": "https://github.com/bevry/domain-browser",
+  "keywords": [
+    "amd",
+    "browser",
+    "catch",
+    "component",
+    "component.io",
+    "domain",
+    "ender.js",
+    "es5",
+    "node",
+    "node-compat",
+    "require.js",
+    "try",
+    "trycatch",
+    "umd"
+  ],
+  "contributors": [
+    {
+      "name": "Benjamin Lupton",
+      "email": "b@lupton.cc",
+      "url": "https://github.com/balupton"
+    },
+    {
+      "name": "Bogdan Chadkin",
+      "email": "trysound@yandex.ru",
+      "url": "https://github.com/TrySound"
+    },
+    {
+      "name": "Evan Solomon",
+      "url": "https://github.com/evansolomon"
+    },
+    {
+      "name": "Guy Bedford",
+      "email": "guybedford@gmail.com",
+      "url": "https://github.com/guybedford"
+    },
+    {
+      "name": "James Halliday",
+      "email": "substack@gmail.com",
+      "url": "https://github.com/substack"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/bevry/domain-browser/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "",
+  "users": {
+    "simplyianm": true,
+    "alshamiri2": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/domain-browser.min.json
+++ b/test/fixtures/registry-mocks/content/domain-browser.min.json
@@ -1,0 +1,1523 @@
+{
+  "name": "domain-browser",
+  "dist-tags": {
+    "latest": "4.19.0",
+    "next": "4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "domain-browser",
+      "version": "1.0.0",
+      "directories": {
+        "lib": "./"
+      },
+      "dist": {
+        "shasum": "cfaa17f91c1510c37833434a49020258d6309e73",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "1.0.1": {
+      "name": "domain-browser",
+      "version": "1.0.1",
+      "directories": {
+        "lib": "./"
+      },
+      "dist": {
+        "shasum": "63dbfb46cbd30b99203df34cb8f6180bcb4d0630",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "1.1.0": {
+      "name": "domain-browser",
+      "version": "1.1.0",
+      "devDependencies": {
+        "projectz": "~0.2.5"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "dist": {
+        "shasum": "8d129b7bd3a40f5b4a36773eecac93398780964f",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "1.1.1": {
+      "name": "domain-browser",
+      "version": "1.1.1",
+      "devDependencies": {
+        "projectz": "~0.3.2",
+        "chai": "~1.8.1",
+        "joe": "~1.3.2",
+        "joe-reporter-console": "~1.2.1"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "dist": {
+        "shasum": "0123c1b9afe3bb7c8a9e856177b2059440957de0",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "1.1.2": {
+      "name": "domain-browser",
+      "version": "1.1.2",
+      "devDependencies": {
+        "projectz": "~0.3.2",
+        "chai": "~1.9.1",
+        "joe": "~1.4.0",
+        "joe-reporter-console": "~1.2.1"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "dist": {
+        "shasum": "5a21f30a29a9891533915061426974dc2f14e56b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "1.1.3": {
+      "name": "domain-browser",
+      "version": "1.1.3",
+      "devDependencies": {
+        "projectz": "~0.3.2",
+        "chai": "~1.9.1",
+        "joe": "~1.4.0",
+        "joe-reporter-console": "~1.2.1"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "dist": {
+        "shasum": "ee8b336f1c53dc990b302eac12b4c7fee24923c1",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "1.1.4": {
+      "name": "domain-browser",
+      "version": "1.1.4",
+      "devDependencies": {
+        "projectz": "~0.3.17",
+        "chai": "~1.10.0",
+        "joe": "~1.5.0",
+        "joe-reporter-console": "~1.2.1"
+      },
+      "directories": {
+        "lib": "./"
+      },
+      "dist": {
+        "shasum": "90b42769333e909ce3f13bf3e1023ba4a6d6b723",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "1.1.5": {
+      "name": "domain-browser",
+      "version": "1.1.5",
+      "dependencies": {
+        "assert-helpers": "^4.1.0"
+      },
+      "devDependencies": {
+        "assert-helpers": "^4.1.0",
+        "eslint": "^1.10.3",
+        "joe": "^1.6.0",
+        "joe-reporter-console": "^1.2.1",
+        "projectz": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "f33b13721187f2eac62e7effb6c9ceef15be95d4",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "1.1.6": {
+      "name": "domain-browser",
+      "version": "1.1.6",
+      "devDependencies": {
+        "assert-helpers": "^4.1.0",
+        "eslint": "^1.10.3",
+        "joe": "^1.6.0",
+        "joe-reporter-console": "^1.2.1",
+        "projectz": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "1fbc9e02746d72fef124e790505e23046def7360",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "1.1.7": {
+      "name": "domain-browser",
+      "version": "1.1.7",
+      "devDependencies": {
+        "assert-helpers": "^4.1.0",
+        "eslint": "^1.10.3",
+        "joe": "^1.6.0",
+        "joe-reporter-console": "^1.2.1",
+        "projectz": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "867aa4b093faa05f1de08c06f4d7b21fdf8698bc",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "1.2.0": {
+      "name": "domain-browser",
+      "version": "1.2.0",
+      "devDependencies": {
+        "assert-helpers": "^4.5.0",
+        "eslint": "^4.16.0",
+        "joe": "^2.0.2",
+        "joe-reporter-console": "^2.0.1",
+        "projectz": "^1.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+        "shasum": "3d31f50191a6749dd1375a7f522e823d42e54eda",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4",
+        "npm": ">=1.2"
+      }
+    },
+    "2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8": {
+      "name": "domain-browser",
+      "version": "2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8",
+      "devDependencies": {
+        "assert-helpers": "4.10.0",
+        "kava": "3.2.0",
+        "projectz": "^1.10.0",
+        "valid-directory": "^1.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-uZQkz6A1O9+FHIg3nxiF6eAe+407YBCou8DhIyq1SAVp4NhcVcalxeUpjhelr7ZJAFLFaQOesuomzCnsIvjybw==",
+        "shasum": "e22bbc4aafc77f23a15d06213b2a1961fa570bd7",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-2.0.0-next.1574050827.e77f42e5bb08a270b573797c84f18582e4a07ba8.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17470,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd0hwOCRA9TVsSAnZWagAAFBYQAJZ1/ZPhmf2uyfJGOSAm\nzfrWFq1EHqACVisyb4WzaOYaoyAeaNyQM8Qi6bEhCMawC9WlcUjSiQXCwdnN\nkbUVvxwYB26gXAOyg/ZW6s/I65przWXrJkYEGxjgXsRD7l0Uj3CzHiQupAn0\nbDib71DdktMTPsTXZq7ciLfxf5FiHc3DGfZL/ICqgHRUuyvFFvIweMXR/n1R\nUjvJMiibHclSxcjRsbx9AOmDCGW1cL++4/VznbnsZC1C4cKDfMT/XdWRAyln\nIMfJws2vRh17M3MHNpflgmKpshSi9huwpLc9r60p+eKfbHNBIDBGtmWc8n0K\n4E3cuBdItLotM+ZFAMnrVyFCBiNX6AKDh+JdYdAcruFvJEgASK8NLrEwUqBA\nW8tqTsZjUDtxH/gTmi07U5mzM0xwo7sQAe+JzHDAZZLW8z9mGTel3hNlckZ2\nGbxZfJiLCB0nvQysXoW94DZgvgHrrrVzmGAwXBm2+xaE5OLQb33s1eyxUQMl\n9n/XumBtUV8Mf2B3Myy7vb74xE7nBzTICE7XjFYR7ynfgnVuhupe7L0dSY5o\n/6IJgL7WflJhqRbPa0oBVHlqaEkqMiIuI8TmioKYpAJdzMZPX6Pw+flpC7yY\nDY+pJCI4ulbEj6iSF3oDI9d0VuwGAjVRywm375trFbc+pGM3eGsFkS1HYR7R\nE6nk\r\n=/zcY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.2"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11": {
+      "name": "domain-browser",
+      "version": "2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11",
+      "devDependencies": {
+        "assert-helpers": "4.10.0",
+        "kava": "3.2.0",
+        "projectz": "^1.10.0",
+        "valid-directory": "^1.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-VWP6pTQgXT05TCE34HS8Sl+s3M1Xg6zxX2aKYY9nGDn+98uDssiH49KDLlduQW0s25X331XIzrxNEThRdNjKpg==",
+        "shasum": "1f5db2e3c08d25f0a5b26b60b4b6ab522d7caa6f",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-2.0.0-next.1574051249.7e249e2d60bff73c856da83c88e69af93e22db11.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17449,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd0h20CRA9TVsSAnZWagAArPEP/jsg+KjDPkCkEhrtvtH0\nrMfvVXcu65QRTyEkuH01CWoVdGkIvEnd1SgA2cDj+gMffurPPd0eqcp3IFfY\nv2R9eKF+ln/7X6jSCz/twZxmMNXKYNp+KWmGtp8J/FWNqR8q7UWZTX6u267m\nbG/6+IWwi/4wJvwceio+S5V1zHyPaeZJAKhIJXJlUbsl9yxPEcLwmDFSgyVM\n/1bcLThbeHUEguaQByoj6r1AwdTNv2w3qt3X7G6kmIKpRc4ZUxnni3l2QzvB\nTXKtxMWmeeqsi3cn00oYx3MRoEHJiGfsPH3K3kSLEWTRYq2JmtEfmBqxifQN\nW+taVppIBf0ZhUJMKOp/lpClIYNaDcWu1UP73ledqEjPTO66ZgVfJWTwz74i\nLvX6nlM+UvyCL3sWtP386VJakTJdmxZJTRlgHD0ghP/TOHHxlslAc2+eQktq\nx+Vqd2DYVGKCScC10J0WCBnhZpwALx8zVylfm8y3Cc81k1Zd8Sd7XFm0rRwi\nIWYxVJe3ANNIg2UD94qM+KzoIq4Rt2Xr3wNIR7aZ+tIJJKzmMUl/8+ZzTBlj\nhDGtRfa6AP+00v1QhwttorB/3nqMXfjHj33jbULCJyculDncB0wu0PZDnJcV\n8o95vq2flurUSIvN9VeQUQWJPuAMAi8yYGkrG1h9ejSx++hDk5E0Zb4TyVTI\nhpGP\r\n=RNt+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b": {
+      "name": "domain-browser",
+      "version": "2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b",
+      "devDependencies": {
+        "assert-helpers": "4.10.0",
+        "kava": "3.2.0",
+        "projectz": "^1.10.0",
+        "valid-directory": "^1.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-+HuKWNuaGN8JfluvCoqFzbrpIf1keBSFXgmLMLViNM0Rr86OLi/ttVNovlDk79lnMAFJlqMQvpUGndNXvd3szg==",
+        "shasum": "c21799f071cfd4c8f28245084b3101d01a087457",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-2.0.0-next.1574630902.fc1a8168b8277434656bee6dbf6c762442480e7b.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17449,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd2vX4CRA9TVsSAnZWagAAokcQAIdAYCR20W2fTb2g2WfL\nFBMznhMgsIbI0JFJk26/qvOnyccjLtQrwFplIBCFaBamMVEQS4CuOghC93KB\n8Ov5qe5GOOKC2Ggu6ZNEcqm4E4ch+V6iNe+ZqByYVDV5DlOjnQNw85z1mTWq\nVhvxXKyZ6m5uNYfmqSLiGuk3CMQM7iANj7ZbT0rZWmU8Mbuf5piDUhLWwu5b\nwfJT/ON07/a/uXlRysVqpQe8St+TFXyi88LXzVi2RhIcn8TeA9hkDLDfD+EE\nX31FToBt3UeOYoJpiWk/ISu/HpwJiDM7bKDp/LWxGowEd/aTdb5QybagfqEJ\n+j8ponK4yOW4z9JqFFTQQLZKGu2LYf4J/TAWugLXI0uE4mf8Igs6UwHODz6e\nsxYN6MVuI74R2T5Ifh32Y94VxPNfsXxkt5vSi0bIbk0ekhnp7i45efQYpGct\nJe246ItyUWpozQ1VuRlVvgDLnd+9iw2iCmEVv36dsgVVpqyf0lo9DSj5bt1X\n+FHI9h5qZYwLPMq7FV91WOeXMUkQonnwj4CHOlXr+orLEGydupdyX+gQZwbm\naH7WndkPvANEbbIuEJRtR/IRr87tGoKK9ch53uolFx7Ey8HAxXlFDr76DtlP\nRfEMcPTU0PujugOIhmeNpo/2ojnAAOpiaf/bIeMaKNy3ErGJ6yuMs7KM31vj\nc64L\r\n=DQTh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571": {
+      "name": "domain-browser",
+      "version": "3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571",
+      "devDependencies": {
+        "assert-helpers": "5.5.0",
+        "kava": "4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-0jXC/pZjFVNDXf27uS4bPNMgqR2vYLk0Ivro0gWfNrRjWS0Rg2nO8ukzxYcZDCwEAcPxf37cRo3XAffPQiU6ug==",
+        "shasum": "ef09587771ee11fc16a348dd5b5e7f905143c0cb",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.0.0-next.1575140754.e110fd711d32b283d002c7046714e39e453b4571.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18103,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4r2UCRA9TVsSAnZWagAAc/4P/A8Ecu0atI+WvIr0DH5Y\ng5frbnnjcrbEXRUsMuIBJdST07KHp5Ix8hO1n3jxYXxO9Cftc37uy09/zdSN\nLekLfnrKT0ftVDC7Q12rT+U6dWxtp97FQGjZDKp9cZDHuM6RjHtCZoX2pJ9P\nWBhojw0J3A63e7ecqrXgmULP2x9Jj3Joroc+fg9UdWLqP6z1mOpRs5/2rAf3\nGrMdWq8vzZ3uBWRQDIuJLFUer5laFgQ03QvJAyPrQAc28nwTzuijdWP4jnox\nLQwE6ASDjnV69ANhTm31gDZQrqB6MxzV4H4lI6h2j7PQcJGA9QPdlZNlZnVg\nHKGA5xNia1GbjpVfauVE8z/sigkLjMQPT4mnVah4GxOd1v9UHsi2M+RXWqwe\n1ZvbWzId1leobCqELBHd8jyy5ZsZqIVPUcluakFzQRoz5Ogj7iunwwPEEpJZ\n2psF7GEoVbKPGUsIn3B0pU/vBCMTxY+JtoV5sc94d7bcK2ijzTvCrjbJtz6X\noRm7S4rwQs1iyfQzvH6xCJHInLNWicRh2GL1bJFyt+vwWBY4SJYfjxGLiRQt\nZcyVrB9WUF/aLuCQdBbNLlLGJOho5FAT/o+2BCFz+q8qhrJrf5haDSXZNCOL\n8CFYc2m60V12A8vT4jZ4KDe313tvxSjKY9DV5Wa7nmi/grK+pnFD1A4u1Clo\nCYtG\r\n=IE+L\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.0.0": {
+      "name": "domain-browser",
+      "version": "3.0.0",
+      "devDependencies": {
+        "assert-helpers": "5.5.0",
+        "kava": "4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-90tprck/x3noRIZ4DRZF926OEcjqN1rLmq2P8tz1LcIWYGUxgmQOPEpB1pD8s59sxFUkjrVORTANpQAOqBm9Iw==",
+        "shasum": "f842575a6292f0cf829cb9e24fcda67c6225c204",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.0.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18046,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4r3SCRA9TVsSAnZWagAAP2YP/Rju1girR6RO9qPW66bi\n7d6AsTnej9M7KR9kYdI6/GeXiD9THvkhg71MjzZDLtFi2ereA/vyL0aexB30\nwOyWqqCG+h49y6HdW6LJ9Lav1SeoPOdMd8CIg7o1lWeS+T1MhL3wLX1IrKSa\n/szsRVOrXrWjZjQLUVMnprwGd/ItTn1XgDLLvV+YudWmw3RdhPMbEiGxyDZr\nBIhmRAI8cLwZlmDJlIe6fGM4eRYIx+QM5bmw++dHagEK2D54jCPPHRF5xNIG\nZWOCpJiH+QHRTu7h72QiIYs62hlHzSJKSrd6EntzER8n//nYg3R2fFGa21kB\nnLyfek54rFO/+BYE+Rit2KOYD3G1VPTSqr3FLDzzKZdj+uc3ToqeqxtEOmsL\nfTtvRzBg6w5aJOV2O1kXl+E0L8m17StpiJoiNvezCK/tyiYiFkglOBT2Z4OS\ny2vvS6KqoTfZ9D0oKjIipCKJi313/qyV7/4XIPjdNzcdZYNjPuu73JVr/lu4\nXZEVsNsmmBaqQRJmhdw/+hw7sKp16OqPjrXvXG+SRZgE1QNnHi0nRweSfBVk\nz6LxCGOMyd8jB3jHse0vvqoYv9ThnR0bNyaFVG3PpD+ejPIguHNEnYHIftl2\n+MmDjdXs6LccbixUDcC4I+LwisAJeYB0AmK6xMtH+0naIkLubHfzFDgmgJX9\nPInW\r\n=EJWv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96": {
+      "name": "domain-browser",
+      "version": "3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96",
+      "devDependencies": {
+        "assert-helpers": "5.5.0",
+        "kava": "4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-C0zCYVbQdDeh4Xm7w5iDPiSSHPQOXBvlGaUmLUEGNpO1lx9Cg799wUb0BR4KwCWX3QcY3PjNo7auZprlhAOoNw==",
+        "shasum": "fea927da2eeb23edd3e873611811813d82dbf5b5",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.1.0-next.1575142572.b65292dfe20ee7bdf4423c290f3b61b51f035b96.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18300,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4sStCRA9TVsSAnZWagAANk0P/3qmmGnJBXIi5iJ3hXF9\ngWBnY09o23zWYarigvU15wc+bjfX4rtSNEC1c8YxDHF/s9pJkjHmemZufX5V\naB7wBNIFbHHswjXW9jfxd7gZ/QT5S6W+ySRLcfZIskvGI2ZRvh97xMlZaxru\n/usQFouy2PgwH+UylRU7/9nlmcO4Budbzm9jzZSc2NW3RxMyG5KebvlMvKj8\nitjVBbprREFUuT2jWS6HuDRAbbHJA7u2YXNVg5tTjyQA2O1ds0RqqQeibsmd\nWZ3pGLWAlkyqPRlZgR6J935gODNrfkvBTnljqK6lerYTjMU6IoMfXS8kqVFG\nJap9FdehSC+t2Z3phiiqwQvZXge2lyWyHn4fk+0fkHv7tlbLt33NJQ2Czdb5\ngzRIKXRtxK4aQMNpHt0XvoCfPR7rpUXjINSPb36hRn7VajHcFr+Gb+rCjib5\n+hxbh0+zxs6vjT817if2D/6Yh4kxvaWfmLrCUAxNywrrmJXynaXo9SJyn6RA\nzvbHuA+rWDVj/KNCs/qV2pDUxTx+E4SNqh97Ns2OKYz/bnbxOSp7MiluwaN1\nJZzJJGWjYrFi/R4lINlB6l4k94phvm9I/l9gKSmK1VYOvMOJldjAOhQc7xiA\nzFwUAkJSf5Y9C8HQjVhciYsMn4FI1+ry0/O7P4EnOXsZSu2U9u295Tp6/Fem\nILGx\r\n=ikzA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.1.0": {
+      "name": "domain-browser",
+      "version": "3.1.0",
+      "devDependencies": {
+        "assert-helpers": "5.5.0",
+        "kava": "4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-N0I7aCH+GhEOu/VduHvzHoVFw3a37fpgYA0o4mya6bhOyg2Vi2w/Z+ykWdP9/uAVgSWdwqOQUjwseO6JDgbaHA==",
+        "shasum": "eb21495c08b9e933cdd1c6b201b0b51dc6281e7f",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18243,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4sTqCRA9TVsSAnZWagAAuZ0P+QDsTx42fSTGf3U+gnaH\nI34gexPCX5EjTXPFNclnUdJtFnX6ve7Y6WDOH8bfjg/pVnbYvd9RxUH/lZER\nzfO9V6Q6IFe/MmP7KCer3t6+wAtmbh432TNDB2C6nqjkcmSiTanCDpRHjsk6\nGEX+s1ckYh/rOqGL7bcDGKaw7IoKMx/F0hMxdeTOEBpgK8sfDTEmfNwJXfDQ\n73H4Ou1/1IkW7kKF067YI0foUoTJA6plWG7XY7SsK4oHckb9IXAW6FHvI5va\nosZoCxT1NA21B6EU81wwHj6qCY8zWoguLo8AI5PBeIAa7V3aGuXr4d7SwPMI\ncgJytibauSpqACw4rTVt4uUnNSMJXWMw5c32rz+rXpssu0iIEgQaGdbRAws5\niyQlwXfsIBs5J0cajHzHEtGCQMIYwUos0Tk8bW81sNmb+IS8sSSlk+jBbKfI\n/v7XhOVz2yKgrxqPUaD/GRKwMwwEMCEI2v/CnKnof3mBl/Ty/N4KSxwXdrY0\nvaBhRUqNE7CGIcWUmKHJXEnZMA9QlmS0UsS7ZhqxbkdHQrQOy6wnqOQ5YHl6\nZJYpdN8X5G+Z7goMWyGDG/gP+SUfw0F3oeVw74IOImSOt2pgoyc1epqa6KgC\nIYADlzUo7cxQb4AdtiLgeE1clc9ivJ3+HGVWW+QO6NDOb0mUsrLLYSByRC0o\nEuPb\r\n=gu5M\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751": {
+      "name": "domain-browser",
+      "version": "3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751",
+      "devDependencies": {
+        "assert-helpers": "^5.5.0",
+        "kava": "^4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-smQz02lY11Dm8G4kFKBb/mitX9u4qTOECVwxFX521EAXExH2izC0XdiwHlQXyBhGKa04tnPumGC9BdRVU1GvBg==",
+        "shasum": "08679cb94a78e6a3e1e03c461ca1d2b117f86d66",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.2.0-next.1575142767.845435bb55b6697013e785a4d576315890c42751.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18499,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4sVxCRA9TVsSAnZWagAAH+QP/2onvYxrJMUtffjZMGse\nu9SFvc7lN9kkq2N1rQWU0WKeH+AMMq90pXZBCXH5K4UtWx0zqpAiqmEz27Tx\ncADl2L3y0klw4lcojSAyxdFjlXUo7atbrV19ZNEp482J1J/WylEsRpVWfQjq\nEBdRjX/a04SsQANbKD1QnE9Agw2G0vbwPBICjqKpgM6412s+NbM2Co/cZ381\nR+dGr8JwjzOeKV3vJtTNnlVkOadY0TsC9NZerKOj8H0tBJrXO53EDFNPk2De\n/3nRIj7Eli/KpsNNkfKNllUB88KuPUnUA8bBreNgIb1FcENsKeOdO+sfR0V9\nGB8c027HJV43IIsCmmgm5R2Y718Uy7yMbMpYlKlZuyYSWZnwgqoL0bpb9WE/\nqGyCtGieq6rnVERQ9fR4WamulJhp31+2sYUfYvWaLqAQAjwxcLT+Lxq9JdV8\nOUR8L661Ww9ANuVp/5il8wC1mMJDlgtWD6x/Kuy+EehnZ6ZVWiOYry1N1xnp\nPC2ogApjqR6owDQjyPdAb/xrnIJ9MCYcfeiR4La6PxJkiD7mIX+wc66ksbN6\nrDa2X6+yYtwuSrthNJ0MVr8q0h9vRnVTEld9T71JLZQB0PsE26q0MBPjlvww\nfhUz2AsbLc8jUOSm/AdTYIy74tPIddtBhwf7kTiKc5bC3pdd491ofGy0/mbU\naZCD\r\n=OB3g\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.2.0": {
+      "name": "domain-browser",
+      "version": "3.2.0",
+      "devDependencies": {
+        "assert-helpers": "^5.5.0",
+        "kava": "^4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-VIazvzn/LiJaM63nBcdXrK6c8QRfNSx7ipmTNaPPNKKm5xmY7/JOl2nnk4oCVIzw05R4xvQ7p9FRXeE4dSiG5w==",
+        "shasum": "deb911062e6130b3d54bd9bfcc6e3dec31a39ed4",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.2.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18442,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4sWwCRA9TVsSAnZWagAAYs8P/A4EINk8ziMvNMZbHOZQ\nyWL/kFhF45QZbk5J+ES3i/iYVgU51VkE0uH1TjLpYZiALAzI2tjca4MLbBbt\nB2pbYiY1slULb/tjm450MIESAjBXrmMQGzuYxgZ4dZ49UaIzcINlNPq5MjUV\nlnNl7RQGZ/P1LkJH09L7o7gsOxo3NC5bGkqIVSrHglljFzsNLw2cb6BUAx7O\n8YIkyMVrIGUJSx2YSLLB954/WnEuCuAIxNB7mcZYTabYG2Y3pLzcm6/pUa7z\nf5FgW7TjJmLox/tzXKsfQSBeFGO7jkHlIVLAvwIq575jP6/gVLZ9JnpoHepW\nAYOLCW/lombJYP/mAuXYZinJP6m5ytqp3UbmoYmmMwpLsBSQ3K1uPjj9+SMh\nMi1XLGJH0Mv4G7+E38v8fTjcg3lc6/OwQ6imx5P9aKSKE/ehSlTCgis0o3As\ncGJe6w4/aIsAWTpuvWlZiIqNgjDCmEk/p2S4MDqx8JxBVaCNI8f9kN27mbaR\nKc3rHWj5+agQvYl3QgYBP8QPX2M54FyBY4xVnTX4fgAWCckc+Dky+zfJQ7ch\n3z7WZJXuPPmYSR99jCasJ+R7HapdqaDhcOWsQkvppj+FZjBJ3mHLG5drwxU0\nZS9TB/gmb8+VyEKxRksJOMKKdSOChpv9UWfkwa65gwOI6l7Epo+3odhnbCWV\nQ9kR\r\n=4nTX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7": {
+      "name": "domain-browser",
+      "version": "3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7",
+      "devDependencies": {
+        "assert-helpers": "^5.6.0",
+        "kava": "^4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-QNL/9H/AKxSjcL3eiA740kkPr9wfIODgKxTkp+E3Jy+O0v6ldtbKn1F4DPdnxaa9ITKwEoEkFA86uo/RxA7szw==",
+        "shasum": "513cddc0d022924356bc5eead466650e7f3f979d",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.3.0-next.1575145716.3c18f188a9cc5457635a5903ba57c738044b09a7.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18696,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4tD2CRA9TVsSAnZWagAASJYP/2U70w5MH6QZ+AEB0zat\n2Flyuo68Ezu3T6XPJ/Ytpk2/Zyi78EFW7lp1fiPvlTFjx4qJO0bEbuwsLXjj\nezsRnFP3zcqC3a/UYZz2pmJSO4Ng+w+wuvDNjVlAcz2eGaag3lL2fjFsgech\n6WdTX5k9lAPJ83ZvJSsyPdh0B4RYKxfQ4QEqWjJwcuxaLKYcjhFu41PJqa9g\nv1oHLTREyrlKwhmyiQvuRSkaXPB+Qqwp2mJqzb1LHsXDXKOMK4OPD5S+1jlv\nTLMPJnP5XRaOOesOuQDZecExkB5vrBfLuAUfnTl/dd0kgZnlLLbVblB5TbpB\nPKOudQvACS64y/lGHDn+OxIcuAqjNCWOm1VQMZyTdus8n+3XEBkW0JaFp1zc\nB5ogeQQ31OFgRH+L5RZwawaXIQxhGmBblccR24eeyIgKC0ahp4Niwz90hY0d\nnYUqIkRq4eOdeuzhycFPBb7i7t9dh1hDKYxdt5NSEyGLemuJmR6aAvif4A0t\nCceI6a4m2VVJm2UqrTI5x2L7bWEekQ0ESEv9KF0SHwRT4E4+n4nSQSEhHaon\nGc8njgOOcJczRdOaVYx51ilms6m4sN8lsycpVNJb45i9Sup6fjhXABTLpdrQ\nLpUHuu/CNOojoOJUUzNazLC9WVZHN0ccDdBn8h4zQPxfeo5EIuoFB3WNvBcb\n7rST\r\n=jXIy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.3.0": {
+      "name": "domain-browser",
+      "version": "3.3.0",
+      "devDependencies": {
+        "assert-helpers": "^5.6.0",
+        "kava": "^4.1.0",
+        "projectz": "^1.12.0",
+        "valid-directory": "^1.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-qlgBgkqr3ZvgxNVsVS+hU61kNUeMC8hlKcQGLWmM2I2cCChU9gxQPPMLYldkwqbR5zFHcjC/UPzTIbY42aAHzg==",
+        "shasum": "477aef332c1d4e23569609cda504f14f0d5443bc",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.3.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18639,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4tExCRA9TVsSAnZWagAAxqgQAJ9o+xXiTDsITHhDsl/6\nW6FFywajxvP4enQOv1NqnztJ9IFcoGrcCZFAwTkF6GJuf9KA5aMgJwSnK3zL\nGlgSgFsxPHeDbsIuYOd0E3MUKx0dl6B+aIErUqmQpVYh8/DX7SEP/32izgsh\nNBiA0xcQB82mok/YkYXRF+IO3AFB3ddunxVELKVZbnJ8eDKm/Z73I44Z7Cfr\nnqm7Z1kFU/OijhSoYZwHxbcpHE05jC2BxsVMZkuc17ouiH2O2u451vjYX+qv\npo7XNKzxSWuUDWYaDMpEIvARTNFffhPj37g9EEXb+wHhxm7dz2KZGR4dLhcJ\nnltWGHF77IbRR/nj+kiEx9mydAL5d7RczRs0Q0F9HQ/JYab1aVqlpW62xALQ\nwkQhhC+W27tIn44aqGdDTwFGioet2v2PRFM0kzfeFq8fndzrVdVon8VoJMDs\nyjKWDp/9NAxOMx28oVgKdEXhlh5djO4q9mXvaIVf0FTMH85tnrFLVHG9BF9X\nTOM6CnZFePrSfxLZp1NuYyXxe4YXmfmUhIP1Fj1/xmtihyLQbIrDH7i2c91M\n1q6j0LSwDFASW0LRO99Xn7y1IPuaG/qWs/T9qPXTGwyBHpb+UkYELr3J3Yrf\nOud5FJxvHoUzs1J/HJL2sDSvRMi8mkaIC5yEiRxG+dna11CzTtgqJQwQjdtL\ncHgc\r\n=2et8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147": {
+      "name": "domain-browser",
+      "version": "3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147",
+      "devDependencies": {
+        "assert-helpers": "^5.7.0",
+        "kava": "^4.2.0",
+        "projectz": "^1.13.0",
+        "valid-directory": "^1.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-WSMQezU4GFhyEV0bAWOwgr6/yOLoTkWQ0rxpQ0N2Dmkih74FBwqIOeQR3bb5L9Ir258LIF/G9/bdDzHqByxIPw==",
+        "shasum": "c9c83a98a6b433ff8c7fa53c1016db04a7de5fc9",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.4.0-next.1575169424.91ac1d9c986aaaa103065ab190fb94a7001a0147.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18901,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4y2SCRA9TVsSAnZWagAAbCUP+wcCfSziqXwgYdI4NBJQ\niKB6viuIiI+Ai9ND5aCvSzrAsOmuuwV2aDPolONJJKjR/SIjDQY8IwwMoo3t\nfdjjmMGJjc6n9PwDeLh9XntsDzt5khP4QL6beoellcGqDW0cs7jugn7RZ2ey\nK6DOr5TDQaa3VrT6Ue/wd1DzHax2ex6wDZNArVgY6aok+eOLne+3mD0wRunN\nE7oewCJvEOKCMLwN4j6AMTlLnoQpZrtwMI/S96KFDfEeMgWrBdFf1UM/v2pw\n0NlaQI2jnUwdZU3ucervCVYJa3H/cBeu3+OLcDnzB3IM4+8bhLJ6i/77RWHj\nAhFFZpx9cGvljCi16Hue2IhAtKVUb4HACLEYCVIZmOUCJa4nar56J1IJrsmp\nFC8lfUnpd0CjtpNdKy5f51XCrJZ9cCwqDgTT6YVyQKRWWmxoJnisPhn8jmva\n5JAGf7V2x1ct8Qp2YAeZ4oGhDEBE8HtSqbBhnn9RAeOc0jb9kFVswRtcjRCs\ntGaY3D5EdsDdGQk+f0YIi5b116h0xJrf8DwFkXi2o5KKg50ciT8qCVtgVUUk\nk7su5/Mz7X5U8qqWgIdCkM2dgwiqjpLq4w9u3gvquugqLwvxc1VDBtgZuf/f\n5wqThtsPLwQSrY1lj096CGK6KHMRdzm7fKFapvlLN9mqI/XmIE3jcv7+N4aO\nLgys\r\n=i7T5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.4.0": {
+      "name": "domain-browser",
+      "version": "3.4.0",
+      "devDependencies": {
+        "assert-helpers": "^5.7.0",
+        "kava": "^4.2.0",
+        "projectz": "^1.13.0",
+        "valid-directory": "^1.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-8vhX3KP/Sm91NpdaZ+7JJo/WhyVD/jNeT2NviwMQO8N5fm4E5yEf1vfwV62fqj0FhFPyAVE9bgoqDIRPWdH3HQ==",
+        "shasum": "c1bea57e2fadc6fba9ffcb7c48b8c22079ff8044",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.4.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18844,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd4y3UCRA9TVsSAnZWagAAknUQAJEKhDnP9NO6eMN1KcKd\ngmMCXP1Z+5aPTBuWjEWaLuvqJWP7hsA0VgXpz2te2Z5nrvkuMB61aFemhRoh\n1i2uYJd4lhzsoFkJSN/0nTP0PPtY7gWhsi/e9tvdzICSKH94PM2gVT97CVku\ny3lMr3b7R83LxH0NpFqomn+Qrx3U8wYWEDNAcLH/vXPxw7UzTzAvrfXTC67r\nyg00ryAUZ1Lf28T4/ih/mS5NVaOlNaz6i0cjxt7yQrXcO9m3RwtVro6iYoTA\nMVjji07CD7Rz3bgwROXo8nDsRYviY6tln+1rGr0X0/q2HZn5MqKN9VtcE+bZ\nswGnpX7Pxub3YIHHPohPD9RjwxjhD7To+jJ9LVLinMh+lRw2tt9seEb4PqWL\n+a/R40Ew2JsU6/xyuyC8Iji0l3nFCtx653fCvYWkbjWNemcd79pPSAr0GhlS\n/v/tgRESPdOrJwUeWu98O1fyFXp68w/LCKegZtYTJMM3fQx9ifikG5wZ/PTm\nySlZE9dakSHwFkf8kdkIgARJGOEPL8CEfhJRWXI6xiJx+5Y33bSxlY0ZHd24\nS0PUTydYXz6EfpfIpCZMVJ0xa6haHaMZ6qlCqa9g9NDlMK+mOjycBFYE9vce\n+QlJU1QyVuicMF/MLtGnzNuN+lhrygH1eekxvEGYQ9JYePywGm9uTUQfBAad\nE/lF\r\n=bTmx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b": {
+      "name": "domain-browser",
+      "version": "3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b",
+      "devDependencies": {
+        "assert-helpers": "^5.8.0",
+        "kava": "^4.3.0",
+        "projectz": "^1.15.0",
+        "valid-directory": "^1.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-RBNItR3bhzvSuAfMIHOn529OnbtRAfjtS1CcWz7oKCEteVrMCZyxnRPt8VH74TYHq85XnNxqK74HivOGK+P/jw==",
+        "shasum": "d7d7f30f7020a7b92945f97a0989e63cb7afd3a6",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.5.0-next.1575878889.af878d245489557989a75bbc0e8ed1bc8ae22d6b.tgz",
+        "fileCount": 7,
+        "unpackedSize": 19743,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd7gDrCRA9TVsSAnZWagAAyo8P/049n2EjZGDjIPvg1KxZ\nS7NTR8G8UY+doCLGPQhd9kaQO954nsI1EuVoB7KfLPGrK+EwHYEj/UjLbnLl\nd8HSq/VrjeTqoKfSUUzfB1BAvGkah13NGBaQBJNPwPtkiFVrf3umuwaAtNSY\nkE9Yb9+nwNRcK8PdC1W7egHjExvjqbrZ7JnTFUDp676caVdXFllUWl1ZQuQ8\nEB0CtLBeviXFEHMIj4Hhj4dsqTBlIggmyjuooyL1Qhv/8H6IB131wiY6Z3i7\njXtgooYBkJN4SGcmHfkPJa7RIEc+dmUPQinaGVCKXMlOESiibcOS1dBmjJ8c\nfW3hcIzTXg9QeE0MgYzVbsjlPsKP6M0ZUNNHZNYScOT8vXbXY2t7Z+o+uezh\n4LfcqKQzQ58lTPF8P4JgAMfxwwsSVbpDJadc9qnIl5ZJYB5m7HDRwYnDvD0w\nDztepJI3kVMOos8xuynPp/qTofR2YG0RWvIkAeFzVGyOVaptT3ocHyJqxZ6N\nth2svjuMmZ4SbGcUxFjt/w8avQ63N1dNYDpYkxD+4SPcL2HwfKG5H0FiUiUx\nFfSIYGllIURSSGg3CW1AD8yQM2Fr8NMHlm7+L2EV6UFrEugE3W2+HGt2R2No\nuHEwz6D+W9a4Ji60kjoFPvrHGHp11vTCvHBpyDIoFyXnkwDe7ExmeMUuHTZK\nhayK\r\n=HTSA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "3.5.0": {
+      "name": "domain-browser",
+      "version": "3.5.0",
+      "devDependencies": {
+        "assert-helpers": "^5.8.0",
+        "kava": "^4.3.0",
+        "projectz": "^1.15.0",
+        "valid-directory": "^1.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-zrzUu6auyZWRexjCEPJnfWc30Hupxh2lJZOJAF3qa2bCuD4O/55t0FvQt3ZMhEw++gjNkwdkOVZh8yA32w/Vfw==",
+        "shasum": "3a11f5df52fd9d60d7f1c79a62fde2d158c42b09",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-3.5.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 19686,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd7gIvCRA9TVsSAnZWagAAbZ8QAI44uXFqMKSTSSR2NtXh\neg7XlazjYaDJkraHEwRyQjsgV10zSU4JQBrie1enUa9kNhZDNNvhPj8ikpIF\nKKJGOxezp/D/qE0gHMzKHsze2pGpNBEMApVjpaB2WDkWl/TAv+KFLIYgpgeV\nEiahfK6p5HRGnVCsOgn8ZJe39smHIbQVEq+YvnsU1M2lgFBWLo0r+WqTyCsr\nc1oYjPpUlDaAAQ4KdsZGZsx/e3Kdz0fIFwHsLej0U5u7VgraIgjOJF+Ux+Vv\nNF5pdNjbQXnPhzcxbNGplS4+ETkxe6gvvYleYKX/8Nb9dMipFafG31GP44L1\nLAhqaSDQmceaV0upSEqsnnlH5HXw1MoBhdNqkC9Z+cfCWH5tUXa5kZyzqPLd\nQNBpgEDZqnow5wU7AqUZIkSpgAEIUGUvE8BFP4ern2W/AvII3QDSFcO7iLJr\nWakB9qIOO+yoH/UsOjlvD0hFJ2EPLltOp6sM9Vkp4CXfH7PmeK4Gha6F8Zpb\nc0ZxRU90gdkQT/a9YZxwEy3iM4GhYTmBY54WZjNEJTfGj+I/hjq6qgOnITUn\nKU5JoklCliGnV1UEyRB6VuQiW8haqOCPkZa8+jWKHwwhrj5TE1Ugpo6kz5Lj\nTNkIgzJolk/GqTzwoM9SKFAXfFK6oas6lC/BxQqCC85d5J5cml89S8OnjGnd\nlLXy\r\n=thXp\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.0.0": {
+      "name": "domain-browser",
+      "version": "4.0.0",
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.9.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
+        "@babel/preset-env": "^7.9.0",
+        "assert-helpers": "^6.0.0",
+        "kava": "^4.4.0",
+        "projectz": "^1.19.0",
+        "valid-directory": "^1.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-q9seD1JK98fzT69I0sAzp0cxb6gUS1grmCaq6cLxTbm9msb9eqYFXGJU94VOIOi2nKmYmKdUFkTnGvIViuX9qA==",
+        "shasum": "45021cf8d2928f116b89a3308c3c30b746776909",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20306,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJee9ybCRA9TVsSAnZWagAArJgP/3ffWYxJKAlpfwrbUGbi\n7sdYl2huaSuJa6BT4uHG3z+QfelNd3z5uTKFD4PINLRg2EMv1tIJGbt1Ti+A\nxjEf7lebPksr2lPdoaA2SK+yn/vznRjhcf6keLpKXdKz/0PV78N6mAlhmaBK\ncquwMWCL4nmiz9aEZAA2LT0Ld7rGD8iNGIgVBr+xLkfWm7/E9BDqdbFWx313\nAsiX2OG32SA/MFv6bw8bjQUVS7yWjhIdBlalXhJNQSii5Tdjgn45S1y4ljU3\ncsZdxP7oavqTiGge+BkiM9RSF1hHYcHeK8zWgzZSdwXtfocNMz/mt8Q8kvd+\nVqF3CEJfC7LCvDXdjBWVVBwzJG8lUrSRQZMFR1yap/aaKMUO7US0i0ARDHJF\ntYNZmpkC9MK3jKJNgdKWiqAJHowgsGEAI+aR09+5b+fQMJphiZnvmXQq7/Qg\niWKXz+nqWzkgoaoxUVDSuaunX5WzpTZ/xCcMblYxx9iII8CcluQ+nUXOhZ7o\nVo+Pk97G8CUxw0+3V24nCOH9GN0HJAqd4Xgq9agPyIKWILVM0aC3wsYxY0Cj\nq+IZZ3SrJOR+GXGlKgvhBu2z8r8EsYw6rJjr8vb3mCgf65DyNhBJRR6cI3/H\n0PWvGeAik9QNkBbaNAf+7isGv2d7XIgyeWfU5JqNj43a7T7TxdERqaIUIox2\nTNQu\r\n=T71y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1": {
+      "name": "domain-browser",
+      "version": "4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1",
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.9.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
+        "@babel/preset-env": "^7.9.0",
+        "assert-helpers": "^6.0.0",
+        "kava": "^4.4.0",
+        "projectz": "^1.19.0",
+        "valid-directory": "^1.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-IMeYMHoOjcgHJ3LnkzIE2NxsO+AjRBjrrSAzvSSW4Df8+L6GRp4P65qvVjSKCVAriDCtP/3W6gAW0enmYep0Bw==",
+        "shasum": "cc4173777c6f67b148d01a76fb58d59d0d9acee2",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.0.0-next.1585175705.35e285d185e15fda7ec117d33915f63e24706cb1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20363,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJee9ypCRA9TVsSAnZWagAAIVIP/A9aTAGk8gNSLL+f+6ID\n+W/0YkYkrL237S5nEnVxxMwuRquYSrqgMKKDge88cSB+BgB0cV0A/D5i+laS\ntFTMAbQWfpSXjOr3wOcfuOy5IVS5j+7tfcVEqhfbSZkiCYRvKk5H1L11GuMs\nh8eyLJY8eKV8pLVIsmD/d3d88SaXpfJG0nPbiPQXbTAH+z97lepPuby6bis2\n6q+IyTrRjpVdeLA67B+PW9YnmfLt06Mnm43tLJoI1pP2Ge7M5WrbO9sJgKsE\nzedpPuKmtgGqDXVn+JwRUCAkYF9lbNpQilG8mK9ehMp0GwQZry1p8Zru4wk4\ngmhLM3hvmn1aj1XXHcIJodYPwfpxOFVYr9aChIneFFBdbJDr+G7wgrMss3/O\ncaHBPzen2ilG4pESPNKwAEcWBa0zYXY242rRLg8/mJTRExTxVwZgcaNotXAB\nrNVSt+tjOpd/XgI5jJE4x8UdIp5sit+OnPq66D4qjsH0r4C3iQuX3/BuHhTV\nycINHcsKq/BkJp7thQhcuo/EwIwOLq7PFQ+murssiDsyiGPMLJqA/Nu767mC\nbsfp75C5sK1eQjpyVwVDVmyPnEAZ0iMPmthOsUxjXpTm4k1UcvyJKH3rdQ/a\nEDLAfc76ipduCPd0jLhFHAca7NlGMamIQXFHSDwGidNr07tLzUwx9v6d5zoA\n4R2y\r\n=eAKq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd": {
+      "name": "domain-browser",
+      "version": "4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.0.1",
+        "assert-helpers": "^6.2.0",
+        "kava": "^4.4.0",
+        "projectz": "^1.19.1",
+        "valid-directory": "^1.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-IOTmUBwyavhBuYubftiNTKfb2i3eKKGtcoPfT+nrIhIbh1AZLyS9C7f77uVZ9qghS7b82PTARJRcgMO2fpUMLw==",
+        "shasum": "b9c7f87a824e73a474a4440f64935533c9a6950b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.1.0-next.1588595760.aec2e7cec5e1ae1975aaba687f31d9a7d77cbacd.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20598,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJesAwxCRA9TVsSAnZWagAAYgkP/0U2xeGllcd5cMMDWp1+\nB76/pWRxULcVBhb6Tzq22aYKdANchLFcEV5x6N6kPpnSu1NQ87PZ9YGhIewy\nOc6ATjbCTowaG8pQUyabO2XD4d5KAkbFQLsA3jBWssPcicSFXxeJ3Q98ZXwB\ngrNu1y/LGG307q8pcyXGwwqCg96IDbwoKplmGLFLpuYlNDfbPtvnM5W/pqdK\nDxjQIePN7PFAdG2QSMGIL82yfOJOFGsGqJGL4H70GwORuLTcqQNtzTqKFD4X\n1uPibc+4f7VlorP/bjxH5hXUEOwQMzNZ/uEHlx3dgCoATuxcTZwZnc82YVyG\nJvtkf7dsSvL5jqiK1lEze2epo2RZ9JWLQ3HlRMBmNM94wvRp6ZHRIuqkfVC9\nNbg61b17r3J5m1iwZdK2jnZQpsE4O3JOCyqQCf7Wx55XC29npeHkcIIIcipr\n/IWibK44+b64jU6G/WCALBiQ0KUKC/EHQ5HW0hbFBYgKuMNc2TOWRY8IuIBw\nGIsyL9+8qIvnhOfKMjGKx4zCik/13ClVDh/yPqTN2FISNIvWFEkFakrOC4Rg\nTO5Pl5N5mvGgirekRksSr7E/hM48UHRXZRc6wOk9F9L7Px8k+TBADe5wlSh6\nrrXRJOjIqiYOXIXexvGmfvGJ7qE/d7SEBVufWdvJpg+cBWKwhFheFZQEok/x\nR4Ys\r\n=j74a\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.1.0": {
+      "name": "domain-browser",
+      "version": "4.1.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.0.1",
+        "assert-helpers": "^6.2.0",
+        "kava": "^4.4.0",
+        "projectz": "^1.19.1",
+        "valid-directory": "^1.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-8sVi7iK60BKZth+bZ4zd9aOzH/6POpJnowGHhE0qrlfCXSWZK48AhhoHeEuWBYh/gFYhFfvrVwTxfaKVXMK3hg==",
+        "shasum": "b5826ac385d4af8cfbeb253f375d10b31fb8dd1b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.1.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20541,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJesAxpCRA9TVsSAnZWagAAPAwP+wQ+PgdotPpjnFQP0Fjp\nxQIfqIOq9ee/qWt7T1XCW2v5sWdVmgn0dQSZZOiYAl8hBNWsjwhKoErEffmY\n9rKwD5Gk/V0qD0RcuC+KAmB3iePrHu8uFMNg7LLTYwptURNpI4A4dMrUEKLp\nbY5lCbvwD7/ftLIt9S7OUxFLBpdVWJqMfeKnvzCTb1VW/b655QdMf2+NQ2sR\n4D6Ch7cJQSLKmwyyXCXY/0Bt2fF6LRGw10QKlm5MWw0gSYMScZ59DXexC1ic\nGEceCh7R7hsGcN6o2JmaOaPJw/cJ+yrK7iRgWyBGbRspE86M2iU3I6K2bIQL\nHutLmsBgABMc7hJTprdsxi+FNwjcwiGGQezFgIzomUyPXHAb9bEwuIuWB1uU\nEd/xfitNR6yRfSOJmyNcIBKxfkVLfbnZsxUJnjI34svR2YxgWwO3OFZ0Dv64\n0AkYdIiv1SCcFxpZdZRE1Z/q+zNcdLmUhkwzs7HvvbXDsC/YVVSwJ35G87iF\nRBwlHGXFj0xuqnwvrD1bmleDPaPNw6UXXoAxY5adcCxia7CeA3luuNFT8c74\nrCm2AuaviiGP+8PS0fag91A9v1dXCaOIEzBEiu6EmZm5edA2jMfT1HWq4rta\nJ9/cN2zA52j3ZMGnmAJopf21iLrW2h5FzPPiVNoLGkQVZV1s0zGQeitYflIm\nqweQ\r\n=nxY2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3": {
+      "name": "domain-browser",
+      "version": "4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.5.0",
+        "assert-helpers": "^6.4.0",
+        "kava": "^5.0.0",
+        "projectz": "^2.1.0",
+        "valid-directory": "^1.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-U8l/kYbFQT6DiyMN0lEUXwAfdKuURItRsoW/GKq5yESLE+Pz2TF/+LIArzcyoEZfiHV90/BsuzQTkd2jOsYSMQ==",
+        "shasum": "c0ba5b6b3b0155af0db8ce36ab87fff43603956d",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.2.0-next.1589250196.999957953d58ee5986062a9adc78dfe9e3f74ab3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20698,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeugiVCRA9TVsSAnZWagAAUuoP/0c9xrPcrt8xTuTHkQJn\nXIQHHtYjYc63packlsAGAV6mjJWutUKHmsI+4ozOoe3eUyIj56C5ykJxbd+U\noZiNI2yo+HNqAfysLc5VlTrG02EruNBDqz4qeQU27QV9V7sVXV5P5djleGYV\nZzdoZRZ1oU7N04JoA39yoFx9rSoz3N8neKKYxyfH9alSaNmnQOAYP7dl3Pqq\n+1mAr+qWF1RH70jB3KNcaGtKwNb6qTJE6WeUGA5zsYSqDrnlzdV91AxUBXKQ\nuSgq344pZXf40bHVFRnSsLXHBJEe2xRt+nXVzUJj7avfhhnpuqt42fBxHvLY\nXpr/HJhqixhEIVkzcGqhibxTZXpwGdp2wLjXKHAJ83GrXMOl3wlVKFKc5KcZ\niEsTSKJq29GAOFbgqKwqBp76GIMBx4k9LFYeuc+aUoEhhN8NAJazzMJ8/QHU\nSLjaC9P4Lm7rD7Mki43HZ9YjK47OrkHY9VeQV6UoSd1AHlqYBEmFz4lIuqhc\nNIgOehKNR5bXXCx/ebVBPQx2CNJ0S4/B78A7Lsu1zLKjyV+yqPPcLqq3THBW\nlvjhrf7+uOLocfPQ3jMlx4xSA0+vsrDGBhLHsWIxZ19cwM6pBoFX4hYP6OBD\nezyFonq2erRqffxuqoqVXvGOSgTm99QUSuFrwXfGmBj3yK0MBV/T+TX+HiXy\nVmYW\r\n=MJTT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.2.0": {
+      "name": "domain-browser",
+      "version": "4.2.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.5.0",
+        "assert-helpers": "^6.4.0",
+        "kava": "^5.0.0",
+        "projectz": "^2.1.0",
+        "valid-directory": "^1.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-6pzohAPOablvbGZDjmuECHSZqZWozsyOiSnAaYJg8vxPIYIogtfqsIwVKv1OJasoB+Su6/CA8iVhjev1a/O48A==",
+        "shasum": "5bac4599fdd1fab1592398d8c270b56550d60ac7",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20641,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeugjICRA9TVsSAnZWagAAresP/RAkSFxnO3fx+3YjBxiU\nlme7nr3ijr+hK2ZsCdtExkuqTSITRq+/7fuLZ5flib21zThjSTF4n015pqXm\n7AmQP7TN6fqcaxXOV19/IhO6dYyGnJyK6LO3yEczXWY5HmbUKzG/jcijYjMN\nivzLffzGUwNPllJETS8J/oeqNL2eyb1ab9G1hPYEvtUuiD68wECn8zG8Lj1b\nd52NL5Pj5h4F1VqhZcgD4Vf2q4TBCdIafCNbPoM7x8m91+AwyTyD48Gr8AP8\nFupu+h2WDbFJQLX3m4tU4GjIC74N0whuPQY1K3lV+SosOAFEFWxcw8hkJYzH\nU0UXGzIUIi2IjdE8vYTz50xLFhKUHn0quq7siKpacQ/ysV6gn3Emj4Fuu+6R\n/HZx8rCfdlT2msP/ZjgpT3hBa9ExqS8Lsm6zMKLDnGSOpuUdLD4aHAhBB3e4\nMtJAdyBxTZEEmbTLdos7XESOI6yw9m0CPTwsiZvJqJhrxMMh3wVI0SzPr5q/\nrTuFASysyTctyKuh3iXpsdpXvHLnLWsTrXsr/RmaD5xsagVgYHWRHq3DqC0h\nhlYicoXXT/EhaDlkzOU3U5yrhcVbatXTSW59uteGQcJak9qR6Sd77NrSL+8m\n6AF6NSC4bYHq4ERJWvuqY5R4iQc2peP/UptXrLI13kYnzADWlXRafvukQ+47\nd+gH\r\n=rqnb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67": {
+      "name": "domain-browser",
+      "version": "4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.6.0",
+        "assert-helpers": "^6.5.0",
+        "kava": "^5.1.0",
+        "projectz": "^2.2.0",
+        "valid-directory": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-r+CnfUtferbdEaGqyGGU/+D3rkKPi0+49Eaiq+0+MVKcnB4tEbaE8SDRNWu/MKdZbCjhFs2v+A3bMN9UDYO+aA==",
+        "shasum": "a007b9f41c6dc90cd83a7495a74799d028f2acdf",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.3.0-next.1590035244.fe571a8b20fc5099496a25a6924ecdb201123d67.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20891,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexgMuCRA9TVsSAnZWagAA1tkP/iZHLcrgM6EVx3KgbkOC\nHdX524PUInfYuRhCHX/FCleGHZK8IKWD8VKAMSrengRGNuuoNxI0v46yJIT7\nfp62sBAHQ6NR4IcxQKMj0ZBGjZ/r+i9bt9EhG03dDegIrW0qHBaeLlPypSbY\nH2uPf4TWG0wuQxP0pYucUgNoUAh8A6GBjCPFG9to16CMob416+P3DgPr/XPq\nY60aVnVtLzpZQo3KG6iN8RJgBPZ6+8+kuCEazwAFgj9wSFHxx1J1t8d3T14k\nmli1iBZpZ2xhgPM+FUeIQjods42Ryec/MsxpKeTD3s/23BEjbTZ4zIB6mHBU\nwr+q7jV9wWH2OrmJrNN6WoieQNEkv3IRK+16PwFHjnY6JaBnqw1jOH2Yi4VW\neybnCHt/70hjqN9Rmyjk+KoiuCV9yH7CXpVdfA186KgRfafv2uTJ+XZPYbO1\nX7uF5xPgaGU4t7mPraKzjJpkH/cS7sABg79vUw2Hu2nvOzlreIW3HATQYE5m\n+5RnBpz87IVRAPjO1bz3I+zjwiPqYDuZR8kQaukv07uw+YLFd55lnEv37of4\nTeUE/uTfzRcI7VMlNck2HPyrmgQlt/m1fS64O6sHsrpAsI2oS/xlVy7Gql7P\nECXGP5yR0TUGvA68Rise6vj71A1YMXqCJSYhQHnaTO+QeuLY1G9axr0lI/Nf\nABkj\r\n=uFoA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.3.0": {
+      "name": "domain-browser",
+      "version": "4.3.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.6.0",
+        "assert-helpers": "^6.5.0",
+        "kava": "^5.1.0",
+        "projectz": "^2.2.0",
+        "valid-directory": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-WwkidIht/Xs+9ZT1y+BSGGzhiATVuzsPx31OeGMuxfB7wYeeZRyGs/XCl0laim1/3hCyOdyF7wdEr8d+hAX2ug==",
+        "shasum": "485d506510a0dca608589fd0ca4a3d5a0a8695f1",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.3.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20834,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexgNkCRA9TVsSAnZWagAA+ksP/jgrcbKZhdOoNwS6dAFd\n2pw74SVP8XfO8OtFdpT0f2QPl1YMWJ4nx6N5mytocPj2TzXC7eVeWjpI0IZp\nUJP0TWHLy/ZC7hULYNwsv1iwPqTJuvYvMJqpzZvqmu+pRue+NmrzYPiSipiV\nl8UIaTbO+5OB7XUWTZyjEir0zJTPtKaj4tRCNtHUt++vviwJRbW8I8fw6dKn\n3Ov7yZIsoLxnCshRcD07+4OWJxvnz40noYB/JS2FqcdifBT+ESkx+jH5AcdF\n3wGLmtQZQM0xRXoyVgMGleS1lbKWBrrPWNYF7+Bl0gWI/asvqft/h9qAp5eY\nUg3HfbkAFy0S6pKSmvf25t1/ywoV38Hg2ATNaNhP3Z+HSsfhWTWMEjmIG/i/\nJdBrDWXq02LxhX8iZELShCRq/2r3W2hZpelv4hJ+ew58/t6vNFedXWxaru+i\nBVTQ+dyQ8psu2TKnGh53TCCGJkBoH4xqVsb2dmxfvlFBFBKiJF3+SfBTyGGL\nx0BkGCdEnsoQCnpGjlfIqyqJq5/OWo4/I6GriKFwNSZ9djFpM0T8l3yhw4+B\neDovYfRtRFwd6f/+hqOcSQRfCOBA7kmdwNgnpvGdPQewp2gKaRdqyB3R5OHL\nztIfxi2vKon9HxWQy1jCJmklUmmzyQlc9lIo+aOouUwGtdxj+WOWZmU3hYZS\nMmLn\r\n=nG9V\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016": {
+      "name": "domain-browser",
+      "version": "4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.7.0",
+        "assert-helpers": "^6.6.0",
+        "kava": "^5.2.0",
+        "projectz": "^2.3.0",
+        "valid-directory": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-l9q9b0f9PvQqwmYxLWGl3qjrDXtIGBhCjBddllQr7kT68TJ+hMH7FfubUVf+q93Jc6ykcKjie0KrgEHik0n0Mw==",
+        "shasum": "db27ecd855d9ebb642fa3b98d7849a4a6737dc42",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.4.0-next.1590072000.8a9154e71e23d06a6f9b5a80f5d2ac8618617016.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21084,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexpLCCRA9TVsSAnZWagAARoYP/A9E9BMWGD9RAoGesYWB\n8k49caAYNT7hrwqymjuq398FYmvZZfs81a/3/Yr+1xFM7wQg+IhC/yVSakhk\nyCHtpRE632j5/RKheUnGJBsk6Xc1c0hr0qYrmU9BnRGezxbkN0ekup7Fe1Yv\ni1A9ItCxiiTjm4Zctt+nqTDqu8srw5K4BdAQXbBn3gs54rJ7CDGV7TQuaGKV\nrvWVYRRCmLCgHKIxZp0dRDp4fG5kweFgCoAgv4au1Wng23CGfYs2F6BGPvy8\n2RwPDn98a/9LNt8qpzo2VpBIPtThB/zZwAfdxHyAjyu5b0emNiCimPpoaAHI\n7PdlTpLk9D2pjAqOB+q38Ughf01I9MBvzaCgutZZyu2/VgwGVPvbxLpyGHeS\nWXfV/6Pb0/Bytj/3+O4f4jd6f+5NIKxNcb2dkpwR1/KNi61MyH2PZHEORMKM\nfWc5t+F/EH4qQs3eAh7rZKtji2BGZtX7BliL+Uxc8osgSDygSjMgD9PD3rog\nNB1uGSaIofWHajof3Rut366gaio6nla+AEYKY2jhogkSLtSkrWpHi/uJHjSe\nn80COPPgy8qIcWu4APiz6rKSHsgLqEAQXveEWpO7i5U90O04HaCiww8yI2kX\n6c7V4JoPvgMWECDOzAELME+tSZxzHkjDDc6Q/HOUKvo0/BcJa5p5tEWRTpLc\njGwH\r\n=B9hI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.4.0": {
+      "name": "domain-browser",
+      "version": "4.4.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.7.0",
+        "assert-helpers": "^6.6.0",
+        "kava": "^5.2.0",
+        "projectz": "^2.3.0",
+        "valid-directory": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-GpKOVUarVuWSPQaCiAD+bMa9yDDKXv2YvvBUqkoNvPckaDCp/Bcks/rwjlLbbE+27esQIogAtXtipLd90SEFFw==",
+        "shasum": "6f0dd2bb97c93c247b87c3dedec4ec767298f945",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.4.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21027,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexpL3CRA9TVsSAnZWagAArZUP/2upu7bYQVu0DxJT2mn+\n8cqRefb3wERC0BsMuv6t5Jy6rQc6PvNY3dmdWLn+Yz5H7gSsrTEP3d/d7dha\nSGTl2sxxpGqWplUBQPtLOW/YAL/Sa/vn3CyWGqSjt3p6uFPr1BCjdTXwC0BD\nodKvlMf6K5lxJGLv0Mo6x0LWlbchAGTTKHeRYHtNBBUzpjQTjb/Q62KvuOx2\n7E5PT18nH8RPahTE8lWafQ7thqaRMN/kJWemBKl1zVjgZRdkVa7BdJTvrtt3\nSNEQGEa/ktnxvb6RO8z3gXqs5Mko/33acRvnusfqdYQCwuP4V+BTjf5V6H6z\naYls9Jj/1hxjk65/MUR/O3QyWMTREErjK0SX6izviC6f3/YkAwt9BlUdR0dM\nwW1n8XzmENpy5p17pRRmUkXv+SDK5mZD1cADi4IBonfej2yD19VuwVWnXJNk\n1V2L+KQPIRbf+7q6a6XcrTlZVgiC0M4qvbezKlCKstaGYqMFmqk0m7HvHfVV\nKKaSEx3WP+seScVgpXT9bIZ0b8oTvCuAk6HOqsR138dHhwZPCOVHvJKMdiSn\nge6SvUE9JS5EYQzoGaxOCg/o1g0CBPLACJZCtRpLT5AmS+Hvd6EiiMkn4JKy\ngwqC3HD72monYd69g/W60AMDTMqw/y6piWMJ1mRQCNQ80dn/iLa8EGMWFOF3\nf/q+\r\n=3Fga\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc": {
+      "name": "domain-browser",
+      "version": "4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.8.0",
+        "assert-helpers": "^6.7.0",
+        "kava": "^5.3.0",
+        "projectz": "^2.5.0",
+        "valid-directory": "^2.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-FHBMOU34/hJJ8PJ63Zn5WbnH2Ewyc1Eaoh3lpLSAr4dKYJbC/re2JNqDYgwAUQrDUb088Pp5L/ew/6iR367kcg==",
+        "shasum": "187b2d48fd87df337561517b1a747b3215b4e2fa",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.5.0-next.1591776004.d6a2168a5c04655880d9d748d6f6f5c9cc59c3dc.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21278,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe4JMGCRA9TVsSAnZWagAAH40QAKUj8QZw/hUGPWI6jC0Y\ntRn0+lAd9gSxRgvW/sRr55jCQeO3myvlHdmEb2IumubowIgcKuhBM3t31EJG\nS4c8jSTlJ5Jwj4rKGDu9wyie5isJ/MxfVx8HbEg65tPfkVYSaYIp7UYVSVg2\nOnHfywdDV6kAjFOoNIFdtMy1lGaGkPwz0se7cGdzM2MyLFMF4siTp+jzO7/O\n3JZTYuGdlglEJXvkIxZUaeX9feDFNXQbYaO2swcwFUZIQycAiJ11inDMrjns\n5qz9zPaNXQdCEihgKP/Z/98aOy/VDvJEsutIpbLG+Mu+1uApkrBTVI8Y56nd\n/OYx0DU/s8PEU04CyopaOvh2HytIWHidVVSQqV110lBn/elRSO4lxP4xsYpx\nJqd/aUpJB9xlHN0xsTkMlIeY0KyxZeHozWVh6ByGuAGnxODKoF6JqLxDlt+X\nWtwCIEcxafk4CMVeB+BYlUTEOnEaR5Iy0yrBMp1S9cdF2qEfvQsfNhdNsWlG\nTv7ad9sxzEPEX69YqVDaISsovoHa1hPhZfKu5a9LtH6xgEpUcBsN0dLpGTBq\nA5gSef/M/eolz/OVLnoFVGkrGdCXHw1YhsKllA0eJQ1CnrbL7XiQLKVbnb7+\nvzI81whh8ejvW27jQSRmflB7VOAiPJKH9oP6LPKSnE3QiDAykfwvtEtpYdJ1\nkuVi\r\n=ao5u\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.5.0": {
+      "name": "domain-browser",
+      "version": "4.5.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.8.0",
+        "assert-helpers": "^6.7.0",
+        "kava": "^5.3.0",
+        "projectz": "^2.5.0",
+        "valid-directory": "^2.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-+WkrFMgZdCQ2nfzvu6rwjLoSrjCAkZup6mSv4Ic9WUDoxgD92TrGpngu1zzYdYRuwroZ8dtIIy0TQ+96VNNptQ==",
+        "shasum": "ebde9fff01ee7cdad1bded20b55978602f5d256e",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21221,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe4JMzCRA9TVsSAnZWagAAnv8P/2S18+oFmJnRF/OXXXD5\nB8fA7N+Y5KFxx8aoCg2sQsYTZDj0/W5xWMmbX1dyzfmSi00Toa6mKD9qvGPg\n6Uc5WUPb56anFk7K9/lDynZlqDVjs8vMPUFlCJhBZ88axtU8HnQX/1gvp7bc\n/i4qJniZrq0QPPff00U9CvANG3JuJzf1rz9LmIPnZr2xunbOPAj2bICezNrv\nwgPt+agowYcO/gQsACP2IeN17jqOuqEQpOblSveuTwRET/ZGiaFJBD7lv5cW\n4gbm7HRPun85aSowhEzZtXY4+oeKZjK4Fb+Yo2zkQ777nffBs9f8+qVrhDhF\nGmaPLOZcTpwbG5o3ZOrC9uR0H8SFujAqqdLbR15RxROHNbSCNKcesWkzmLXi\nehmfGp7EAJMumoAj0AQsFRfOJ0kSlY6xDvWuVxqHUgfVGpd6A4LbKhqIQHHf\nP4uwIcMTARl2hFxHPiQo9XO3erNtKcS+Y8ZSlQQcvYlZxU3Qmobjbtl33mC7\nx3k/VjGkbX2HJwWT+luSz55yjjnRCY8pPw4cnChlBOKHYSwuqCKBoRt0VrOd\ni2mQGezmvG3rHkkRXm3SEb3DIkbYbXQ1bR0NlKTrcCh9ByjF4HB+f/gYt0rs\nsU5KDf+i+QTHTQhyTVxcqLfahzv+TRYK6Ms/hBUeP0FJ8iGH4i31DVEMdtpW\nPaJh\r\n=O+j2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a": {
+      "name": "domain-browser",
+      "version": "4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.9.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.4.0",
+        "projectz": "^2.6.0",
+        "valid-directory": "^2.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-Qq/8y46FDbuwtI/zHEfpO+qW0ypg80u5L/gm6u7/Y82+rECEIsry1ZODrMYSQGAOL0wZRSH0qAwZ8u8m0zGGOA==",
+        "shasum": "c44209c71a43b7c5492f65afab4819aa23c98f09",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.6.0-next.1591793210.cbd63bebd15bb6b3710a69ed8b62d16486a32d4a.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21472,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe4NY7CRA9TVsSAnZWagAAMIYP/3OXfxrKgY+xDadWP1IO\nucJDjwihTydFVk5be2snSEdhz2tQd4xKb8nIW7dW/+ToHVqkvUqlrDQz2LnS\nm2m97lNKgikRfsX/VQrTeRmUd0H5F/h/OinOWsrA6sKPPaI5WWOZxPFRehq/\nEnJvT2QEEag9cVRpqbMxWPveO6segaabS1mK5JdLDdoZj37KMfhrpPaUT425\nbBHBsdvrrFydWQ99o9uDdoKcPjgxp4UVmIOu6rpu5/cEbyjSD7pS1F1Y+cNt\n4DZN9K79sFkWMHDdPRZa84DmpC63PxMLhG4msAgKN7FkGwNzdNXrpjrTHkMJ\nPtW1ydJ4VWmKkBwNE2ljVXFj3ShERAP7KCxm62KmYnfHCcoGP2nvLDQjYUBF\n9euNdoCiJjre0fK4BGyjWWhjEuKuZgfcqqjoW/KPuyEoyZOyPqK3Pc/6/HFU\n9c2FAW3PmwaPz0xIOQzJxXSbt51k3qyzQXV3gcvh2EUjOAB507MnVSRMGlgk\nnD/yd0DtZRxJ/tg93oXMye/wUJncVx1FIa2h+8yZryVxa1mWEZTHfKW/oZgF\n4J49ItDUtVm7a02RBoLXmze7SwZDVc3Oc/Q6/B4FveC7cxjtI+kqzRNyG1rQ\nL+HvChTHBYLT3w2y/5M+iYP2w+l0o8MU5ixqq+z2JjRoP9q6FijDxJp7HGZs\nWNoH\r\n=1GM2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.6.0": {
+      "name": "domain-browser",
+      "version": "4.6.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.9.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.4.0",
+        "projectz": "^2.6.0",
+        "valid-directory": "^2.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-solVnUBCqwvori4KncIebL5e7LU3I979j0N6iPyv3wPs0Wx5h9CVtF9Od9LsqVC8fjtQmmSbfRbnq99hCeZo6w==",
+        "shasum": "f61dd31507e44b8cc2cb012edaf32c7c06377dd2",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.6.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21415,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe4NZwCRA9TVsSAnZWagAAitwP/iEoYLyXpli+HARb+lbH\nVfUBei18e3s3j5nniY/zIEM4FlaKElhh6f2uRMX7eOpaEikEg9umJErVDyc2\nr7/TKR6eEAnj4Sjy3FNvLrPARZ9gL2RBmZ9TUetlF5liTnsLCjDwREU5+hCZ\n6Qt6yROW9B4ZrAlIVKRcV3w1CrFModp0i2CxXd4j+sLU14ZgMSfXrrQpJyy5\n2OmEpp8mTvKGD0+QiZJ52Y0M5EVp+UqITd/uPJ8n0WAZxSK9/yffnB9vMQmI\nBosjzmvS5yRB1jcy5+NgrS4U0ttjFHavEFFRU/joqYlPp5bQXfVVaS+m9BbE\nNHvxdXK/b99UkUDDlJf5Z3bX7SPp3lEktqJwTYOUZm36KiAfQFif6homXoXU\no9nO+k4E+suCykzRxfM89ElKaSLtJFs8ahx1qL5TLO+zfD7XX5E4d2nCpigT\n6yCOoxqD05/FKPF5lQgpzxBNeBpnX5H//InhiUJeBGlrQth7j+InR74FIICb\nbo9tDzYmD3omPqQgR9E92Iet+a27J9t2x4yv+S3JcKcCDLU+8TSIefnJVlwW\nwQcrPSn1CfLYi2TbcygK4ZRO+CnKy7dnk4/4ptDEBoWzTMvaN3WEiKlJVE/l\nnrGtOpDC8irbyxKXFXxRBXzlIuxoV7LsFgdNfrsc3su575Lz2cIMb6+8Uz4F\nKqB7\r\n=F97w\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31": {
+      "name": "domain-browser",
+      "version": "4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.10.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.5.0",
+        "projectz": "^2.7.0",
+        "valid-directory": "^2.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-BEsMQ1bcsxzSHkBcyl9qND/OlDpoGu2oCT60Lccq7TzbMOX6itsBJqQ4zkFwLT8gDWTagHJzIo6fegcL9W24Mw==",
+        "shasum": "888dfdbebe1cb44305b25642584126846d62d066",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.7.0-next.1592601838.44ba6c12bce8c142336a541a237788d3d4453d31.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21667,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7SzvCRA9TVsSAnZWagAAd4sP/0vaDuhyYcttpPsRrmCB\nPzxF+nSkVXyOE4VM2v4vjrtpf8M281yFjS1OV297p1Biv3dMbi0BeXBR5z24\n/YY9IHuVd2Snb24s7LYoUDO6g/7LxCcV9pgY4PH2ipQ8t0TKWbq8tYUCRsvT\nsLNgKF1iPdLFi5rPMsPtUZW+NVqKofXRYPosKdt4Q4Zc4ID8DYxI7ey2UH/4\n+Gzvl7uNuqUXLcQ2BYp4B75tJv8psJTHJyhSZnQnliXd9GfMBSGjmTuDG5ZF\nST8XjD72/cr6RrIH+9asJ/CU/11P7JMlbva4/n/U5r8NynMKLpbTO71larPI\nwg+kuCN9qbYTvNlJKxxa4oMEgcws8rSsbnWUCKIgIBTAyy1qgk6ehq5UQGNV\nok7XbWsqPvlmUjM9zLwi0x1TGe8ywfzE5Ymv2irwcaZCM9Ys83b/0bTUxRJF\nli/nLKZPbz1/B6j5G23xJ1nlASBfYiG3Uliv9z8nx2sQYhY2PJjmEGJUuX6f\nm1V+lvkpm/tgfnGlRvIx+Un3OWS3bTXZH9gVm8VwNao3gfvjue9VE8xK83c6\nRDih/azctOMLdQK0dNv1YRyPNSyCF7ILJ12Z719uh3rrJUreont0v4EWvwWY\njJUFijdQ8GEHIq/10UV3Rxn9jMtH3/Wx5I3BcZrB0ZCUPE4WiaY4xbXQdVSB\nNRd1\r\n=pbWe\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.7.0": {
+      "name": "domain-browser",
+      "version": "4.7.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.10.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.5.0",
+        "projectz": "^2.7.0",
+        "valid-directory": "^2.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-554I4FVhKAqFa5yuDnGNyos+uVBuwypzhBF8nLajXy8uy3oG3noEndI/PRUZ1KZt5cWc6OsFcQ9WGRXLsf2djQ==",
+        "shasum": "deb45b66e79a4d7941af2f66d4e2e5de0f5b9948",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.7.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21610,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7S0oCRA9TVsSAnZWagAA25MP/0SB5YJsx4qreRFdIQs5\nubRHgUndv/NDB1AH634vY9OlSIlTYVfFA0UL3dBHVBGnOQLs+hVVocktFrnQ\nG6509UKRNTG//hXSwE2xr99hXreGb9bvR1a/vlU/XN62wniRuQyniXi/xb12\n6jZs9v9wUH5PamWDsmh4E2HNI5WBvdCJ1qVMtJAnSy72c+OFqSXjSylRbORt\npl+iVkV4B4z6tzKkUmtbAw2BeM1CtwVKHTfdxcYF95LnpeELciXYSDFY9Vmz\nDgLHyTpaQSYxXIPC1ElLU6EO78AwmvwzVrYqREt0aFdGDnGm+gHTY55q7Hio\nX+dHfcg1TMpibUA5os/L7YLMUwTTGzJlU259/M7ONHrmZQAmWheDi4/kr6mc\naLQa33ocb/XTzGnCDmb07mm9O1N06IZEyutp6KPzzQCRSC/9SwTbJZiq7ARp\nHp4XcYsem4Mw+lcoQyfW6QVLayLiuJJ9a9Qrw+b/4uoH0lsJBQPbY3itoBSy\ny5bgFvs2wae1s/ACHTwEH9dIsV8+3AC29B5N6+rZy9qJNuGLPBytIdeKH+5i\nVZSAAOPxzRmiTIpLF9o/vaXmwefprhnm+ma/L+SEyLLofooQsadrygk19t7S\nNZJGgKOfqZGGwaxw2U8ZdmRVhgdZHvC2w83z+boi9Vfgb65KC169D2yaZHGq\nLgIC\r\n=BmRG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e": {
+      "name": "domain-browser",
+      "version": "4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.10.0",
+        "assert-helpers": "^6.10.0",
+        "kava": "^5.5.0",
+        "projectz": "^2.7.0",
+        "valid-directory": "^2.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-Q8qVg89jYvW62YnvcjQkq4bgLwFVQj9kWdcfYQJOVQZGPRnkKqSvzG2qvl/SUahGRwDDAgGO4d5QdHgj4e65Kg==",
+        "shasum": "5deb6d40adb1cd789e8cc9fdcd87dd9e0facb54a",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.8.0-next.1592606574.c8ac9846ee3b7cf5f1cf6de09e1894a2fd7a361e.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21593,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7T9wCRA9TVsSAnZWagAAauUP/0DkGQLWydWv5oK09bi4\nFuPdu9PJtmO5z/qDYPz7dfoiIKUvNKj35NztzZ6vQlrIPv9xZmpBsR2lEkvH\nnq6BjQuWzJqyLvmC93wxUd1CqmhtwLc8fmvhEFRKJt2qwvEYtUJBEU8ykQH8\n7fB8A10sWY8M78vMU5SGifKos3To6H3HNJnd1w2p+vP9qzHh/Isfpmn10GYv\nnEYbdb3UiXzqV6gf472dwQTYlJBK3c2Cczb7vbzg7KM+2nuuJUpw8tmgJWl8\nsGBpG2cVWEhBaPv9lWQSUXYfq3EJyyAuX4cXMhmJzk8m0xQkUHt1QPLp/c+7\nO1lXkfV5lQlWaF+N2R6TzWP18Owsq1XpGcpbPUwnM0eh9zKJoV6jFGSDgcLm\n2bcONzNnpStXXkVR4K/Pa7Hu9J/b5ZqKKLugkGX9R/L+kx7fqQFl4QvQdKjj\nVDoNDJnqPq8T3KhxuHoV9o7t9IA0Vq1iVXtMpC8r4vtPqZrpyXgIVTFBaUQx\nd53E3JVkD2DfbqJdwbOYNIAszmWoohOeHOdY8yK2movUkKyORxDCwnDN/SiJ\nkwma6qTIYL+veOh9w3Cz1+gajjYAvgL9g4fh1ZmNf6PLz3NPLn7P1DASsvb6\ns/Ok4X6VtdEv4d73tOIY0hkGGlD8Szb398xzph0IIg3lslUT2iiP/oUU04Kr\nsW47\r\n=w7PD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.8.0": {
+      "name": "domain-browser",
+      "version": "4.8.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.10.0",
+        "assert-helpers": "^6.10.0",
+        "kava": "^5.5.0",
+        "projectz": "^2.7.0",
+        "valid-directory": "^2.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-VBrL/W6bpH6YDjGWgqtr/jgwr+Eg1ANtQExXeSMlucjGVd+gIR5FM7BmSCRUn/nNLMeTsEwqfgJZVE8bBkzP7A==",
+        "shasum": "ea2f92f55dad0e8e5f9e8a25185f3525df90c306",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.8.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21536,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7T/PCRA9TVsSAnZWagAAmVwP/0yCrKtWTnCLMhsIFXxe\nDPw7oNVLg+SJs77lLmmpadZsZ0hkW0cYWr8zLc/+YHmm8CN/KmxjErCFSG2F\ngn9IjQhKAyq7slwjN5OlGNq6SuTNRlEepa8pGQu+HFA01PsGG43a20Cai+o0\nVOYQZP4jmHm4pJIMWdMVsvELkDx1qryZWIqu7SZkVFDSDU1Szw5t7AHNmXuE\nyFn11wI0PbZsVAlwzs2Tvp0MiEmoVt4LRE9EDrxtSbYN2LZSmgWqJ0b++bdg\nz3N2YZBZOJokVRSOwE1bFvtyjdzw+3QQuLwGdRnsoGF79vL8cyGLbc7DXTmX\nA9zvOINUorCoNEryykZ5qRkLl0vbGA2CjVenCRKjMdmfaDcL4d+uMKAdjYed\nZK/RY1JK5zXFAZiu6XrgftWZKKGyAjEzxd4HZgCtVj94y0TpmX0iM4Q8yWxo\nMnqvS8crSV7IcHvMaoN8jyk2NvSS1bcBEcOy8xpv6CGR5NwKJzefm0n0D8Ms\nHgjUd6D7L2E+O0Rwpvv8UAZP3Pm3ojxJ8WGRBDQ32RxHayC52tO1h6djQp8Q\nrF+hlD2kNYWOF4Gw7MzYE6RZDGQNe/2zFUdTh1e9gmgx47fT8OMlX/+t7f9Y\n3YVvPymD7eyOnwHHU9DneT4cBJq5V4zt/R26r62GpARRU43FoE4n3R7dqVFR\nDPHz\r\n=cxAV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364": {
+      "name": "domain-browser",
+      "version": "4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364",
+      "devDependencies": {
+        "@bevry/update-contributors": "1.9.0",
+        "assert-helpers": "6.8.0",
+        "kava": "5.4.0",
+        "projectz": "2.5.0",
+        "valid-directory": "2.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-yWwoVPtE96eE2KqwxDkwgbqAOasJp0W/q2gbIQlwJHhEQqWCrnwx6yiG5kmax7j7o4xGl9r2eZnJRnsot8ir4g==",
+        "shasum": "b87100cf9577bd243e147618b1a14ddaef0ce56b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.9.0-next.1592690379.95472db14cd803e028437108de3ff4b1970f1364.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21813,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7obNCRA9TVsSAnZWagAAD4cP/230nLLCC+N50x2Aqm2t\nmP4uOFx/4gfw2sE90E1NqbuZ0oC7YfQR2vRaxJdy2YYH/GINlaaR0vv4gAHk\ndlsfUcwV1Fs9butsoDpE+BGlPBcg2hvQtmHO1AZ6j4RUx6VLlIs+6fpU+Iex\nmE8ECwsMYxnUtZE0XaboI6cQqBQDmQW0wcHwD1PAbZFe9u63QRdtt2QBg/DK\nWN88cbRW06arI5L+cI+8SaFdFnKr7ZXVmLQR4QK6fY4Zvb8ejZB2Fx4bINVq\neqGWs9C5RJBcO5I03L/PAOteXw7CTvvUfWy8eU9CSKKWNM5dNoX8c/OEWBKF\nKzD//WNNR9EWnyUzDquK2uOMBbzYVtujerdmYENh6RkbQPjn6LDlCmdXagqq\ntSvd+xiMzqrXtji81M4pT4u0sAcA9VDQeGWSzB5Wr8+bK3c6TX3QCJk+LFj8\n8jopzPAFY1P92GnAuy2W7XaBukY2BFvgRL5Tt61vYjcaHn0TwqcTVZsTZTze\n3vViWtkVKcSXBdkTDVE7uaz0XHytXW4fspyrSW/vZc+xQ0EGDUSxCuDb+tQE\n4EIuUH+/YDXUCprGriSwV9Bv1rthLkWtPHACdVfHaz80lFiD3NYyzdz+3acJ\nzkM4rLqm/mrhMW8qQvNvvf0BJTHHZICmhciwbS4hHy8dCd9arUrOtg9Fk5+7\nlrgY\r\n=z0Ta\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.9.0": {
+      "name": "domain-browser",
+      "version": "4.9.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "1.9.0",
+        "assert-helpers": "6.8.0",
+        "kava": "5.4.0",
+        "projectz": "2.5.0",
+        "valid-directory": "2.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-OSuBhANHoaAPzbyARusE16PNYMBgrO2z9RpA0qBb0MWaerRjYh5Z5A+lTwsYWAaT/BjFryFRN85rus1QD+Su/g==",
+        "shasum": "37430f89e367a43c882a0096124fa5dddc6e7a9c",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.9.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21756,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe7ocPCRA9TVsSAnZWagAA+koP/3+KEv3PrhxHpNS0IeST\nWvsczxlsORUWXW+4GQgPzZsQNA3Uh28ujIAJTFYELZSBPZ43gGPYZB+grJB8\nsb0LMQbW04jAIOymQxA9vGZDJFyrfMSr/WKwWBSMgA9FeCQ6AViV7CFtvX6X\nXrFTXxFaDg1/ddNPSVL7XZyOU7HK+9qBtnaMcwBZBZ31U/cd9WdRQ120vmOk\n4mg7wQGMcSdN0I7ZzyZVSvYjNMDWR9H1M8zECwdupqO2N2L+HFWAHq8Y5/+U\nWMykp50hKePl4FNFI3rC5Ig8ZNf/Iq9LilZKjiqkb08iwGed1qOniuwrPTj8\n/kQNB0+Pec3GRoXBDnsgSe1Kwq7JFP9ugzEG+LMAzd3vGFEYoWUx21hwdm3R\ncVc8ZignL/t2ErFUGOnbDcVdn3sOT2EOhwNbAt8asH0ggYe8Ue8l7JhrgE1T\nZyEZDaMyqUcnADy2GvqJTJYhfOrP79B52p7SF3YXGceOnyNXM6o5tPBZuKeU\nDAHAwkusASwQjOEx2fY8J6nfCEsJhpxGXkvTAi5Ype+x1WBWchbPDJL6iL21\nBpYsLqOfr5hAa+vJmT3D80VjgUUOh+JWSCNEYl5pUp2Zc7zauxFidJNZnlah\nS7mqN1R5OOGbdi/uVJCKgq+g2sx3KHR+0oQZjcIJPprItHUHZpnjA+4/IGHE\neuBG\r\n=SaE1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0": {
+      "name": "domain-browser",
+      "version": "4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.9.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.9.0",
+        "valid-directory": "^2.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-4OfTk5C6X3wsJeOkAsgF55CZVud0gRLPRa75iZQHulivnYtf3JfUWYiHaVpUXbPMNa9SsyUCg3RUeOKFiOb2Gg==",
+        "shasum": "cbcb7197fd3ab0739dfd20087b1277a10580c0be",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.10.0-next.1592738253.a76ebb9016346993ef019d898b32ac2d8c71d0c0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22015,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe70HPCRA9TVsSAnZWagAAzSMP/io6AWnNky1Biuf58RFd\nvpX2WsfzTYvdaS0y0BEUq7i07DYv957vs533BMS4s47wHEIgzVuWRhaf9RLt\nJBiBLJ0q9kc6hyyXFpAta5pQmkXW1Jopr5twlgMPDtNM9AAvBwPZSLfUhWMu\n0VjNsfnMScnyZrkpoZjC0CTaZoZw1UxahLchJS+nOdU9PtBKjtaE3YCvHJpa\nBdX3mz2P9ottMh7QZ2rlL84egmbF4JWOsIhtUMTkk7CoXfXp9Nps88ov7VtU\nN0l4SUHmsAWhb9HYCQVxeiqeb8H4+avR5pUpaTKMyUrEpOYR9uaFeMwi8h/f\n2Ieyx3UP2JElN7BEE7btgVh+PHsmlghVAme/Ts5q1mDhWVTjF/GVO6c7GKDF\nPe4CULncPzSHCTiVjZiSdu2rEyZ9gjVotq9/bzC92f9gjfeJT7yt8oc3v6Iz\nrIz8t/T1TPCMPBeM7JvLRY3z73JXS0Xpb/9toEQJh5QWW+fGzONCnD9yzy/D\nUS8qILdt+PZD/P36Botm9CjMGtnAKDmIZjzKWHmxuB4XxV2SP4gioiwDXRbO\nVY8PYTUXgtQlcOkADOhlpc+LF8IBW7VRQ0Ps6b2ZQG8GLC3Gtr/NmoUmSXCh\nwYtz5CBQE/wmfOQN6pqX1Kxe0TDODwO9inLzYypR3RCe3BQ6DiTGM3qt8uUk\nsJb/\r\n=VSEG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.10.0": {
+      "name": "domain-browser",
+      "version": "4.10.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.9.0",
+        "assert-helpers": "^6.8.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.9.0",
+        "valid-directory": "^2.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-u5bR0HaHFRhox80GCyI1jTK/3d6b4nvod6dPGtDF1IHx28TSsx3HBy0/rV4TOQBt/HvNErVHWukEMxFDj7YPVg==",
+        "shasum": "9fb317946578f06e27de814b6d098e639d3e085d",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.10.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 21958,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe70IJCRA9TVsSAnZWagAAqEIP/21U8Jj9HbYt5NpWlDtr\np4ANzROmOyBrDIQPOkm9o5nGlLCrh5VKJ/e1EiMHNu9lt9MRVtZD20tDKIgT\nyOQWYe5EwU9iuHZqu2S5blHG80naazAZLTnF202r3/SPhlx3OOEhIaOcQJfj\nb5Lo9Yk+W7nfOh4FMVIzHWzhmqbs4U7NUjmKhQ9xjKvcqJtAZBvURJWWL+aV\nszR5Q/waH4Tfr5E+Q1wQrf8WqGKYIOUyt+JX6WaxCspfwxwMoiLJOVyXIrTq\nI3xs7lg/j/4SisEFqcsAzjdzwT4YxjHS/tETaNy+LUSjn0K3v0EDS1khtHlS\nF5oB6JAJFH86TkZpbp01pnXcRMesokFGXmuzBI5FFsTI6DsUTtR5WdR1SSyi\n3FLDqISuc/1oa6P2+YHsjISVnu35pwvpa3gErh08vNHT+ibmqXNWZ+PJka3Q\nAGyCCGUdNZlnDkJPloen2lWdl+/JJZspaeCapp/asxLw8+/VGFHJQgGR8es2\nXtRHb8+deXC48EDz5KUS9O1zSxyLZ4tD+OdPCd1CQDkA3t6zUoA3SnvliBn2\nN4zCdpMxuwFk2CXevfOLKlMwHnc7YRo9h4g63eZPDbDwVP6/+Ahupj8gU5+l\nCjtcDpf1W25lLyJOHKokSJzto/miVlSbsziqnQeWmsvRRAw9g0EeyDTq91Y/\ndlJb\r\n=Ood4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6": {
+      "name": "domain-browser",
+      "version": "4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.12.0",
+        "assert-helpers": "^6.13.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.10.1",
+        "valid-directory": "^2.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-JzqisOadNQhqUs3ewo/+Rln0W0hWbfRIqjpLdONjeB7MQQGRWr6sBt5A9MmG7WEVY2fOHc82Ai6qnR9+z58Mwg==",
+        "shasum": "4237fe16b42ec10a1a8569ee4ab17c644e4a0e52",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.11.0-next.1593051799.70f3ee4b5aa58c75f8f63922dd1d624e7dfff4c6.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22213,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9AqYCRA9TVsSAnZWagAAysMP/j0SpkrllZPN4jKY7nGO\nfZN0S/h7mRMtpZuPwFvvkaCnQEevTWu5kEEFIlPyfhq/LK9QJDz+tW+SDOUQ\nlock3+czvgrBH8f2GEjCokPkTMoQLKv83+gLLLYb5LTxvzRbyCJT8prDpooz\nqcwGR/9QXIDeZn9Znw35AyVgj8yEqRF0aetSArE+pOlp7HJh/KmE9oIpRqfj\nj/GDG40RFKFbfkxQm5vJhaaugy72GXp1wzLIgV5qj06MK37c5IOvKoZP3lQo\nfUUps8WChIcrCDrIqIaFdCcg/kmoAwzWPST2XN2cSdqkcHSad8a2FRtqL4n6\n5JYWPL4XTZ2gJ1UbJLpldg15modFIaZoR4MLomEq11SkvjUyGfeiJ3M5ond8\nX3EiqbeHCxHmZl/x01cLIkWZs8+uIjMNogxdkuMhxFYrOBtuc9fBEFhkKucr\nYiRss7CTUWa6Hq+OEFWKxgHm7gprdR8ZbMcC2Yk5d3iXfNSrq1XgMH2LqSnf\nCROUxLak7Of+JCRC+up5FbNYzx0m8N4cYv+WI5DzWS/6oBOqyMT4PYiWg/IV\n2Lu5jxwiDgmClAWMDBxfnDpfVPVEHaKgZmtCAr/QEvcpSvnQSeB5Musg9Kyh\nenHDLCzkC2ujdMi0/ZTf3AipPuJPEdFFX1aTc9hOowYN7UiozJZr98riryn5\ncD2o\r\n=zdS7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.11.0": {
+      "name": "domain-browser",
+      "version": "4.11.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.12.0",
+        "assert-helpers": "^6.13.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.10.1",
+        "valid-directory": "^2.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-OU7EOarf+LhmK8KuuzWsjxsG5HE2jyYHNiHog5PMJ1nWJH/fTUs4YqZj+6GJamT8hbmcILV/T3EWwdmcsvnKNg==",
+        "shasum": "e1a1a621469b2e0b0d5f83dcc9ebc3d2458e14e4",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.11.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22156,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9ArKCRA9TVsSAnZWagAAmN4QAIV3kJrmwXeqPVwABkkQ\n8wQZWRcSuTaZWXCmtysAHNuXzPWqZ+wP9A3uaGxigPImpGo/WxsEFeCNZd0D\naH9T+pX4H843qa1OnhmvqLkKliMbFpLUaDLeAipKJM+goqZUtHO9Id3IrcMq\nc4w6jdXpSaceEPOJOCUrd3qcHkGO+7y4LChhewJcv69QR2G8rjIv6QNEbONs\nxu9//qi8B8N9Mxye6Dt4VWtnXHX0Fk2KakvSgjOvgK/NEImlZenLJGFr7CQi\n/cZPcRbw00fXACDectbjsKa2ufBzu/+6Qbe8HWJZOdml1bt7YTAjM0Yj4Vt3\nf932Og+rLfLalyDa7GN1WJHLuinerfUsDdnp9vokMyWIKzRF2QcfolhWyj5m\ngYu71spWkN3lmACMshSuY90A9ddqiR6FrQpqmlp4Ytve9ODbEEYHvb5GvrB6\njVrl9jQGL/SOxH02+OkmjhuMs1iaXkoSN90STfkCr+VihEMmokbIpKUz7QSh\nUNADxeg4BTpFCPMa5hgZOAsteuvx4amnEg57gqGuUx/Bc8XcDF7pmX23QNHI\nq0hVUBFnx1/igLn4ovhfGWZdUGKoWXm+ZPpz1u4lg7zxy41EtQ0RFFM+j2Q1\n7Jw0a8WHYdsG5Svw8hBwxOr6ZDg3waUOwkvnwQbwYvBdbbDjwdso0Am5a8m7\nxoE3\r\n=pD+O\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c": {
+      "name": "domain-browser",
+      "version": "4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.12.0",
+        "assert-helpers": "^6.13.0",
+        "kava": "^5.7.0",
+        "projectz": "^2.10.1",
+        "valid-directory": "^2.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-JcGoaCOBvk5GjdRIJc092fE7dqBgj5SgB+EKu8JOWf3azQF4X5N3pgz6i2Ymr8O1M+sKGbJ3sH1lanpT2USqtg==",
+        "shasum": "45c9dbfae26ec35f7715a95a581070e00739a523",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.11.0-next.1593742408.a6c0b2440f684f8994e7268378c2d2c763a0a95c.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22213,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/pRKCRA9TVsSAnZWagAAR9oP/3Oa6nGCtFvFTHcTtDu3\nSFXKzjuq7l12d8Yq0+YU55DobUJ15kBjv0zViFOE1h7UnXzzw8n+nRZ0eSwB\nvcAXX13KRMbieb3IQN4yFse49Q+22csEyVCeg8M5Kbxts/+o7bi/98MhJAjj\n/DHsTGzx71f7dx1XuAs57ub6fI1zaLmFdxJtsuaKp11xZDAkamdGfGnwGSWa\nPvoBX9ao7whcG+CNu8ArXe0w3Td6fOe03g/A2UjFYGDE3h9/rO1285JN1jFC\noZCnT8oMHgjvjH7xAW2k8lTj/lTQQvuqwBSPs65E9hWK6j8Ukth7mfGUxzHe\ngTNg/I57uYAoGb/VH+aT19f19xstSKpJO1+2/dLvJbq8tmpnguaRgZDsJZ8x\nSQInvG8PzPl5BZvMRddK0/O/cAewb7uIwJuxeFz0nnXkZKcGY1vXVd6Z8Obd\npA5RYQAtBT9OzpXlSbuswOUsTiVu7cOKJ/upVm8iJHxI3w2E9Tkv57b2lGYh\nqKude4TI81L/MMSV11kD3pRgvl5Jw0t6sh7Ab2ufFcYOApI66zdNx/60Semz\nzyoqNsMi+BCLl/KjxJncsxghE6RU+pfeqHDp3XtmeCPDR/N0edCgf9KbOIrE\nOwv17szCDp8mdTKXlwhr28dKpVs8sLSBb0nQ0Vx/gfE8SwC1yeN252xCN6D+\nyxWj\r\n=Xqn5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be": {
+      "name": "domain-browser",
+      "version": "4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.15.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-6fzebHA9uZZcIVTvBe/I/9nIC+g2hRn3XmO6g1oM0tvtQyMTqiCKHOepygu25DMkZA5Zr2Nor3KvNdq/yu/lKg==",
+        "shasum": "2d1ef6c4924949832e713d68b4e9cbcb1f8bc0d8",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.12.0-next.1593747383.b78cfda33834a5d32e213a0aa920adb2aa2022be.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22512,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/qe5CRA9TVsSAnZWagAA7CkP/39p/2Nzy2I0br9KkS+5\n7a3tqykU/R5hykN25jIDpj9oN4/+jWcfKvdC+65CBHMcZoD2UdUugzY2ZUlj\nNd65K5donR7hyxPaRidIxcOAjYltIYZVCHLfjLAkBQLBHcoemOJB12enJ40c\nJM92spwFrM5sjDdSvUythJrr86XHaO3kHQGpgd1NQZ1HaC3pNmDdz6FiT0D9\nxLwPJAGbp2/TjHXdVGw9fVUgv1ACCwLRxEjOt+n2c5jtF70Z8TqX9WSdnYUV\ngrsahB4z75jiQy6TWsmPuRORyWADG0qKQ55vB+X1cjrxAkmywOr85oFdXXnJ\nFTCTjqtkPJxEBpRqslzytJSgQNWQJhvgpKaWz7BrhW+uBfky0/G5ZkRUvs4y\nPmBkAx8eW+uCtN97UROwWTqRHgzS47msJFACqwAYoUCLac7/Taqtf6P+2Vxt\nMtyyhLcUV+sPCIxUzuNDMJXs3rgoQngb1xQEWUJ3DbvH0jd6acjW6MA31WA4\nphokYqQ0sEVy/ixOkaY+zQ0Aunr83w8tCxy7P9OzIqePCkDQaEuKyBex1JSx\ncagi8jVnUSekPV4Wo3Hij1rHaPSpv0MN0blmrk9zCYkB822Acot7icPqMyBB\nV/3Sc0eX/LntfQsIa5HOkGkGrhEng2WhsRu7B4vqjYl9dAg5HhF3BDs1XHfv\nFcol\r\n=/x7O\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.12.0": {
+      "name": "domain-browser",
+      "version": "4.12.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.15.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-Kyd18R6EKCq75SjiE1WeC2RDaB1d9lXzpDeoLtnZ7ZQmJnLr2bs6YkAWlyjdsHcIB7gHt6kV5z6e0XZTgqSB6Q==",
+        "shasum": "6cff10fcca101f5926e555e97ced6401928638f0",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.12.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22455,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/qfDCRA9TVsSAnZWagAAvZ8P/1NX+sKayveE2Bvcp9Ky\nwyQz7914avybSh88c/gbO/JPODEQigpUHZnfDcjFvWY4u+GaOrlr1eF0PfGE\nHEfDLmQxQD+uvLeWOGMI5IpsBx863NX1UoPd8uDN3N/54UJVC89DLUgsr6R3\ntLcVMAEw2spTx7ryjkCypZuRuMnoYmpOpSV4xnbriQZ1i8QJZO3xYlGuGvvw\nO8W5AwP2Ew3NJg9MFv8FevRDCxyA6/pFhkQPNhlysO1j1lTov7SLmsvy8Wof\nOQ68Q61SuvFwX+2i4+zq1KCIXvYazNnfbgwuq9ppgQv5SKffceqaySRuPzfD\nYBbafyA3GrPoCxQVVAg+Gldz1FDQl+pADCj28oTCsEOD0uWVVfoZ2TxCtzFD\nu/0xCoqtk11jkNDqzwpGHLewEiADuNja7UAqwnF0FCLX3DzcF/d7NErf6LsD\nw8CPtcruaVswMlz6RwOLiRELGlBhLzJ9oexPntp141utEmzXEJaYvL+l0UZ/\nwRxzrr6wKSL1doyqmGPlyx7b6dTtvADIzcuP3IKaiTR3EGEbo3fF94FIS0xi\njq2ktW/n/GG4tMT+O6P9kaF8SWTAK/vId6Zz6E64yrkFJ+YWLPsPSXp3mFO3\n7j8B8X/R1JICbt3J4WnUqWIO+HKZog+lRmpCnkCbtNHFLiTcHrF3CgcfCwMr\nM1wk\r\n=ZG+X\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466": {
+      "name": "domain-browser",
+      "version": "4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.16.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-HunDVyOwx3PgDKDM1JvxwS3bkAb8BHfJwMcpU/iQaKWzG8Sr8NPy7AMGVDYYkLw5fzIQuGpwtp+eYFsMKIa4nA==",
+        "shasum": "906224e69caf24744f02d023784486f82938510b",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.13.0-next.1593752586.a847902f29b90e4a13488eb50e83da9cf2d33466.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22706,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/rwMCRA9TVsSAnZWagAANIwP/38nukFJx8QchlWo7/HZ\nszV6lwBjS7cDdddYxvZUsiS7R8wfxOW/IT9Uv6XPLNANHtuEmMgiZdiLJmEO\nW30OtPZXiHpiz3G2b/Xm0ZHr58XaZF3hHF082vduc/eCRY2IE/VPwSKay9Wd\naCJA4+NUnLsvN8PtFDXQd5FrA+NzKrgRs+k/uEY3y8IqYyx3AIQCyP23pa90\na4bVfSvz9HRPZpBjSupzim239tvmZVxbb3dhvr+Z+wOJPsmlMoAPXaPyAS0t\nIlaKqL8IXBPvE6E1sjcvsaQbKwdOjwEjdYarGJVcDC3Eptu9d4Gya57xKCuP\nbADRfaYm5voPqY6bs4iQqK97YsckavbBdlDIChvlrfOgBTsu0Tguu05Ez+RG\n8bmMMpa5/HfWZ/dMURy0JI3c/3GA/g3gdNqGHY5FQuc2ZmH4q/T9Utk40046\nkYOAXByFFTNovan8c4benLEXKpSbsY5eX/wdWVfr2wwWtWMFho6CPb0Y6msn\nEHfF4XzrlFM1uWX3Vtu3A6AwWsdMn9j6M0m/l0YIKpQUs5PtLUIMlwC48faB\ns+iTrn8EhcoPYpn6w4lH91hrX4zHkc3lx8UXbYyd7pdAQcH0EN4GhweX+OVp\n8jsbS2ccRNy0w7wA4PdnlL5X4dXQyA+ZbrzrdUOIg9MMVpXpBW/BbGzWzqs2\nqcHA\r\n=uRqk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.13.0": {
+      "name": "domain-browser",
+      "version": "4.13.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.16.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-tmRpVC0PevAIF7KdHnTc8KSdXSavuVWfKjxEaYF0m8OB9ATYS5qZRsnEz7xmYymMKsoJK7FW8HKUih/rhTvWog==",
+        "shasum": "b573d0ebc6e8c64792abf2998025936aac63e368",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.13.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22649,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe/rw6CRA9TVsSAnZWagAAl8kQAJwpjiARIJ/xMGq5qn4e\n5AD6ZQ3l7jyq+lAIm6lZ+mUY4ofYoksOU1cye/DKDdAyTPQUvWBROdRDq+74\nA7szLuMFHdtJluiR0zDnH5mzBHuinLGl3WhXruYMEiCiVtfQXlM8uuYaBymk\nmhMjsxwI/Ju1NjOqY293nQH5IO7Xq+R4D1EJRUECQwZpNMD9/rUR79rCQYv7\nhWVaGCsmpEYYHDEN6KcC8lL9LVTHnw/jdh+GI5Z0qSdSf7qh5HTcLEqC0wc9\nkfP6N/apwor/oKXYQjI/XS1E23oM4vD7lGGkZ6of78HncND/LmjSgBMaeUV0\n5P6VeJoOXSjWiWFc7Pzan4spYIjvCl0m380tU3ZD6zygV+Cxt52Jaax1MUbm\n7zu+gFm/rC4caTPnVLS3c8/ANN0KFkGIuhPS321uT+2HGUKudgu4KKeBBQqg\nPmZwCQ1/NSXCV3BMrfT4whUcwqULJuA5knj+RvevrZN9Scy7NR6jwveX2wIs\nrzwtT+hkPyMxqB5u2P+ZzSE6oTxI/VqSYj+us3FyojqXhgLxqcA79xqFOppC\nHlIMS/DEgRz9uKKOvMurWStUrtp8N5Gpr5Kxlrd3rxyLc/bRenyysQVnVdvV\ngm97QAQSJZCiJ34Ev2Mp1scFvMDUeaNe2lHZUoF3AxKDzjbGJXAbleP1bXnQ\n2DYz\r\n=QPln\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394": {
+      "name": "domain-browser",
+      "version": "4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.17.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-QL4DMd+7Voqs5JHK51fOU/ijLQG+BRQ/BMZE2aqJTvIiB4Y/+LnVDNFf+79tS7AuA5i4yaJkeU8WwHX9zZPtwA==",
+        "shasum": "3635270d27977e512adcac8a75196af6512e0abf",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.14.0-next.1595343672.4034b5722d7f4e73f4e57b104ca26a13f0634394.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22763,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFwM6CRA9TVsSAnZWagAAzKcP/i9uSkIxjACT2hCHP5XZ\n9GnpnpziBugZtMA3U0m89aRWPGUGpaqTL7RAIJy3lb9YN9/gQ0GjWDAT6z9h\nqf64t0krjUCBJZ2wrZkuLqFbeen63DaQn1CHJNe+mHuSaIt2J3rxNNZNcLcF\nl56xB1WLatF5b9ufJP4jrvRrMN6mBkaPzeCt18lVB1vM96+rPJdmI+aRLbp4\nXUjXBAwXX5WQCL0LtDHjhLfUfKFnaP+Un0kfA4ACt9eL4prdTecPZgXESKuw\nzV7prou9TGLdnhofi09TcnzCl+BZM4N2WhEHCdGIu/2JEr12qrHMrrcc15ak\nF7W/QqMHB2FZZgx+szLkEve2oZU+vH/u5vqkdju21pF06D1R6uI8n0zXXo0N\ngchi+2atTou8L8FUv4WukfJcX8Xomg/v5Z0gxpeiKVYGdjG6myvK1MoyaSka\n9/KK8BTYT6I7z231rCgOvZXVLHsD8TbOCCll/E0jNeM/ITj0P57QamempqhC\n4pv8y/Gq8ai/KfulKOAyBIkAmQ29mNvH9rA7FyVkI7o1zhENGV/nm7F/ogmv\nTL74UOwp65KbeIX7HH6bvOgOa5nD5suJgjagL/QSRK+xw1RRXv2C0eIfuqJD\nO1YPxKFUL0f583A7hBCIch0q+tDPF21JM0s6zQhb1cXjGQbaYdYUKwe84XIL\nOfG1\r\n=gi+n\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.14.0": {
+      "name": "domain-browser",
+      "version": "4.14.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.17.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-c4+ydoH2CjEgtXsv0wL/bYjCeFTSxricBZSFryu8BVfm/r0ciSY1iQy4xwu5MYnhPVyurRi7XR5lYTpf6w4/lA==",
+        "shasum": "a1d4cc60017420899c521fe211ef577fd733b491",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.14.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22706,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFwNrCRA9TVsSAnZWagAAXqIP/RHaVuZTDfBdlo77Ni4M\nEyEp1WWNeDA4f7QqFELtKKP4VTgHrB2yFbHSDu/vn5PLDAzYbAcN08kkWJhn\n6FVq3iqtiWSPU8I/xx/NFCxZeTthZsIavv0jio7iBdvn6eZ7Tf1lbZz6ykHA\njfWiKCXF4enouZiTuLNzSvVsZxUd+oF7uslIc0BEd8Pha54Rp2KpLKulByjp\nUSIhrct5PMPgu7WLuLW8lNJVlGCGe3iGLIbzLww3FhAGRMRcY0l/FwUNAs0h\nv7f8ftRUwCi44Ynh5urttfDkwxVY9X53NgrNDM6afVXhMcSqKbAMWdiZytPv\n5iSVwF+kpd91vwttUloQ2m1k9yNyeJC7Mu0+hRFrQdcjBRnpXJ0Oiyr5ApAi\nqSRz9DhrlFYffPw/HewU6ijUfj54Byy+0v9oC5ETbvtUC+wbr5rGkkkNTlha\nY5PV3BWzKx3tOXNMEmBXrtcUgOW7g6muEf1nmAEo+bOxJRWH4uK1Q5ZI+fAI\nwwweD4nsbQKs/HQeLzm+CmUjaWt98m42CronbwzMIurxmkKhD/wco2YBHiFc\n07TU+zV5Bq8YoXbwEIFnE0Y8W0OPymvIzMtKp44Cq5C2tTH1GYZ56CsqRQED\nkGhm8+JAsGYzmLFa1LBetbRU9+L+Kl42yci+2AcJ9TBpRa9pjyFB+KCIhZor\n1avd\r\n=Ku1Y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.15.0": {
+      "name": "domain-browser",
+      "version": "4.15.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.13.0",
+        "assert-helpers": "^6.18.0",
+        "kava": "^5.8.0",
+        "projectz": "^2.11.0",
+        "valid-directory": "^2.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-jg1GWiXhBZI+8Qn9jAcaNhY9yIlOX52TpZYCsQR6XyXBKU1GU3EfDTwVUdwgscdVx6/eTSmi84yw7wCDZrIhHg==",
+        "shasum": "598e0297be1c8747a6054ff0dd33c2343cba4276",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.15.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 22901,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFyRnCRA9TVsSAnZWagAA9ZQP/Rvv6Xc250L2sgvprAi4\nH8GlZfbAApTu08104PmxSjbXCHoHnKHUqL2POeu/0ZMXWw7u5+eiZ0lUwgB9\nYYmdfzH8HoT70FcxIxgL3TaWTX2csdDiBy0qwAZ6eFICBEu77Xw+lyYnAZHC\nji0qHgnzK00LFKb+Kex5Ocg3+z9c84E9pqzjMCF9o7xAOKgBNJeN42Kd7UMQ\nrjg9ADDGFLyyVX/0wpj9hBsyFcLfzSzgLsOvZHL12n3XOinJd4AjzWePhAbl\naSPOIu7GsJyWoKioJzI1T21zIsXQtGBKaicMEHgY77Xw+y0oNB3X12Y3cKxK\nbWIPurIyxH7sUCuUGMAcLtQJAmQYMytUQHZTAgDQiGw+YYTUqooIXfmY2dPM\nPWMWZy56vYDIIu4XGdF+Z8LTM6Nvc3B7xzunS4RJ+T9UXElbtpufT/wibVud\nM6Fn2hrW8u+nEZU0Gg4FZuGsmNNHkGS64tc4VZ1EqiA9ywx258p1G1Yri0w3\nc3/7D8YTMNFsn0yibA3wRe8lmRnbereqjdQdfBlc8Wr3cpkd5C1Xgd1EhJot\nGaLJPDJal4/8V2jsrYF+8rxYzwnxOuRzqwWM6pTH4E+rh013c1Nj9ek79/EM\nwditgVo2e6ul10Kbv53/geOY6OWeNxSXRHAv/LpguuYhnsBNBE6ZNqfVLl5T\nDpGV\r\n=0ikY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb": {
+      "name": "domain-browser",
+      "version": "4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.14.0",
+        "assert-helpers": "^6.19.0",
+        "kava": "^5.9.0",
+        "projectz": "^2.12.0",
+        "valid-directory": "^2.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-OOtd+qweTLWhpQHGY7b5hcwCooIl6XiRkwCm3FUR5fmUCWKpa75xXUTOIx424qKHw5yW1Q6+/YlBQI+oK+KaIQ==",
+        "shasum": "c88ca8ddcd777b86862ca244520399588b41c00a",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.16.0-next.1596513212.5795a9745381a2d5efb76b7d172ae2418ea873cb.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23154,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKNu+CRA9TVsSAnZWagAAyl8QAKSZYeI1BOEM+KXUnk7p\nBzTXEi20SMcx6K1o1Vk3wfrahtvY6kuGYTGIcEvHOK+jTcbfM6xlpQBRBYmD\nbGBGfE38MnpSOLl7n6YyYXFJHG90y3U+5AkG3m8ZK2iwTYZTsHOM9w8JHH82\n+7as9W2KrpyYlImp4eILkvRup/AU3WFZK8XRG8JgcFVvuo18AE/VfapIdf3G\noB8urxTFj/LK9afBnjWI3nQlDShGfCizyxEgL2Z9sst4TjpkwAhCIY4XhHux\nP/PVhsX8RuMMjL/q9DxlHnIyBZhzWkvQMUnpKK72dVn2Pm2400YZmJGP+d2F\ng9strD1/0qVydgggK8RHcoJjMLSHGbeyH6Q0BQwE6L0JL2P/604/KAefpjC2\nr36bQd/67M4ziUr+t0UNLtqiuSpCI9TtHPQf/Q/4Ha5A3jWCbqebDUFEGYG7\nNcV/k9xlg4PAKmvXYdCiY1Kwa4uVldnH8+B1BqNBomCR5uo9+UDGXGV5Qshm\nxDqAZT6sHSi6Qc96jvqGnIWgB6XnCAW5h/hLp8R4VwNeHAeQkPa6F+LoNDQb\nPw4sckWT5O04lypekL/rx2YObh7Sq4xdg+2xqaVcTtjc79+wLR4+JQIVufVd\nmrDLsfXE9P9k2T9T+SE9b+qK05ne4qqVULTKD9fOeJJRPRlQHcC1MmOBpZow\nuRNY\r\n=RRhl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.16.0": {
+      "name": "domain-browser",
+      "version": "4.16.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.14.0",
+        "assert-helpers": "^6.19.0",
+        "kava": "^5.9.0",
+        "projectz": "^2.12.0",
+        "valid-directory": "^2.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-oppVWKOBKO04ZGw7xyqUopOl4DeL35Nwosev6WNCaLZCXRPnivliimXj1Jvf4H8ASzX7dyIHjh5YHK18byLg8Q==",
+        "shasum": "98820d49e05fec50905071703eff9f21606ee3ec",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.16.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23097,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKNvNCRA9TVsSAnZWagAA93UP/2eG3YTaFK5r47QtJ7KE\nfG8SEQE+eo0avvTkpdP9l/f9WtFx4eK6SIKpbOcES1cBlAowKER+DXTbyDbf\nwsOLYNwU1OdFgoZGl1apWPkHe5YG2CLJt9oueyXcji9UIpZZEr4qcgAmR6ho\nJg/+ts0f9kZXBbLbVIDxcd4gSkoMHhET3D9b4xgsYuDzBbCumIAxvHhRgv0T\nFYHd6o93sBGlYV2fZ9we12jDCHEqKQ53DrfbI+Frw/0Sgys5us4dNeXHUfJX\ng6abU77xrNH2NBzhWaeRW7/USwXgTaeKj2evs2Y4n44rRMxoZfIqwtQRv5/Y\nyu3LMDRB47/9+r79cSR1A4Cm/I6nvVyHn1mPtNVkY5kOfY5/5azw/rhJFwJs\naw7ai+o8ZqHoDqQwQoN/biaic9ZrMdG/zgfvy2YKYjMpcFPK6S70xZHRtJCp\nWePJkz0OX3SQuIfiMKti2B98zoob7lrxBMWIphQob+UllBbRd2oU9MqiL7/g\nNYuKryWjexqHkXKcmsnyzlYGBpUgg90DsMaPKphJY3kg1qzbehmxMueEo4w5\nankVvCHBb3dhsZFg0a+hm+t4Vi7PLIZOimxunTLb0OKlpy08ls3kA1rXBVNf\nqnz+Ei1lQw2cjdqQBgzlJroRp9IFxFdWdZgAkMAa0nZUFDlIsRMLYgmNRc1k\nlm+S\r\n=SKJU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6": {
+      "name": "domain-browser",
+      "version": "4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.15.0",
+        "assert-helpers": "^6.19.0",
+        "kava": "^5.10.0",
+        "projectz": "^2.14.0",
+        "valid-directory": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-V+XfR8/LlExgmjxSot0QUlPVDoLHTgUqxqV56RG6xAMFfNfFB79z2PL9dA/85NDEWipF9YGfuxZr9DsW7gNeKA==",
+        "shasum": "510d80f329973640761bbb4d39a0f83bb0ed1195",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.17.0-next.1597693394.2525a0f556e0de18027f04d45ceb0a2de2fa29f6.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23352,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfOt3UCRA9TVsSAnZWagAAz5oP/2S/JRDumlwx6CXGXuzM\nodE0vKFHoR+Y8L/SfYkCsRZYiXsSdvbVIlyLbLLsTU49r0/JXbaoP/l8iyLY\na7PXvqWfwXDKbQJeEbc8H6dMys5lhMrptGiSZGugHwme0w2gaTd3MjxjkxC7\nLgxubWqLkG5uaSd01mATyT62rJDPHf7hxQd5FDEPp38I5i4UcIMRFwAYSdB2\nPMisSKIogQdv+wfXnDEldvGhyIP+T4hQYN687EwnX8FHiLQu0ywxcBk+14Y+\nmeQDyq1Pu2KU/M7M1IUM+D7akB/mDZOChP7kAIaSPPO1oXOOwjuFDfTSPDhy\nF+w91BdE8dWUfgR3y3Kg0vBOG75mgeqLwC5j/phrvOSJ9yNoiqSQgEwJG5cd\nIjX71Kom3/8DWJxPa+oFEZ3ar4KFpwTAvvj1KdylMPMx4g8JGg12sDz/zkCa\nK0erxLlbPZsFq9bR2ecVidxMpAFDdWdFyhGFY5h9ka8/n2MIkl1P2DflaYpW\n/A+hqhJKgXr10QK5bnRPz/3Bj04GxtcbnDrSrhBJ6JKhIfzalXvH2X3Nve8d\nvryfhRDzGWsqmu0vCOdSXb65qj4JrZrQ+YsDedSuf7b25rOfO588ZE+fxCU+\nqvCjtpZ+Q3A5OmwlfyCuS9l2JDsmIv4q5HkiEWok6EH7obpZC9dSIQTf7BIv\n0aqT\r\n=rOE6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.17.0": {
+      "name": "domain-browser",
+      "version": "4.17.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.15.0",
+        "assert-helpers": "^6.19.0",
+        "kava": "^5.10.0",
+        "projectz": "^2.14.0",
+        "valid-directory": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Hj9LbFLqt4MBK/rq24/Bk3nhcPlaKfTCFs8XENVqNQray7WtKbo/GYMGDAVW62O83lgRjxvD5UCmtQsN9B/YxA==",
+        "shasum": "a6523549b84483f1868859166f53d08adedc2c1c",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.17.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23295,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfOt4FCRA9TVsSAnZWagAAUv0P/izmdOUQzriGjUHYceU6\nuK/n834JXcy5/jjphfwLFw/En6YobYddTARsK/EtL8HnvX8vMTQfqTU9qEkK\njgj7/mR4nIGpGJ/6RqpjA720wgAGKkKUhkba/GtdHLWe+HGDDqfkwalOx3Be\n+N15LJUBn3KRSlTVXqApQIwSKx0QlzUMt/m06LlxHQNIlYTj4vTx+iAzLPgr\n741UCynsIyOoU71Q4IYxFEWlBfjTnLWwo7Mbqz1nnwMwo03yPbpGODHjD7kJ\njW5/OUiPuPZ6wT/3Mxv8ew9gdhMCcSRMKKq3n0eq0oYNhCSZRvno9GGCNEsC\n6VNBCUowyfv2/aYx6LDA7LdRcUJlKv6XE9j2r9yXipfDfD3iWwZKRaGlxgBp\ni29oiCcPH9gsUdSE+rwPWc2qBdXAx0L6m6x1J/7TjNWv9kKv4HT4SvN/q5fX\nMZ20GMbnyHmP7SpowqeielF+Ann+lzzSpTyILqWRvGtlVWWDFwvedN1cyqVh\n4w13UpgqkIlk/XhA+Xe+XC5Zod2q+6sIp/OHSqpvTnnYWiiAUF+US3Snj5kI\nxM2UHWMDVrbITn0LtctxYx8kSRdo1lAB6rY8GaUu4UZ9ht4Yd88oM5+2cHon\nDDp5o7VGeK+uwgI6gmWG9p0OLxRKr+tOV/15s03HzrARCcTjUkmkOWGvDR+q\nRUra\r\n=KM3F\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.18.0": {
+      "name": "domain-browser",
+      "version": "4.18.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.16.0",
+        "assert-helpers": "^7.2.0",
+        "kava": "^5.11.0",
+        "projectz": "^2.15.0",
+        "valid-directory": "^3.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-zUa9XMz3NmuabwyUGQcYhm2yiG/3MjUUF4/DEFXUl0X035GyCorUFxX2CbHXFzxPWFg6xNgml7JZng6ORxqszg==",
+        "shasum": "b050d93a417be6920372a1b0e8b81cafe5a19919",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.18.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23748,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfUgP8CRA9TVsSAnZWagAA+ycP/AqlTIDGZ6jpshsZbnWM\nuAuu/UTRd5pEWN93jASEsXyFGLONlzsGP75Jvo9s7KEHsMYJBWJzu4OhCgE9\nBs4hVbw8AJX9g8KVyxk5HqbcfB7PcGjL3ngcS/1mrkvV92EPxdZSLuiDa3Am\n/u5XSotvNRY7vgxdroP0dxoQIPuNcHNKS+A95dRzmdXsV9Ge3l4oBbzL2/Lg\naf0VDv3IbJLGbw6JkFFgZ2e3i+FPSrpjG2NMD0HnDy5KhRyd+16FSmYEbVgb\ndTO7IG+noH74yD0Jq5eXbNbBiCpvRqSWttm5WvjV+kLxWqccsulvePUlCvws\nnGE3X39SL++5JTzg0pYdoN/z0ArSC1O7ZjQ/xxasYWP86IcoZa/Q3fF5QCIh\ntdfOYrN4jpXNYsQyovSpA6BMzHleBNk7B67/LaQzMGxynX0oGQhaebnRhmkn\nl+O1owwRL61uDCnzrq+hAiUdnnpRWt3A5SYh0ccFeUJB3ZFgFogkX5+koqcC\n6RYzJj6T2Lotii9Dm0m4rndtiw3ph7OZdeiohdW6SIwU8wGo4phQMzp7EJZk\n3fIlmFCwJYT550a0E9nZld4gdDTbURtfVRntToCLH0sl6aG5Sw7Ed6E7PFty\nZjHE18kIH44VylJR821IFQv0mEPM9KSiYE5JSKDC0VdoKnl+ZvqXr7Vqwdhf\n5Bvr\r\n=6HZM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf": {
+      "name": "domain-browser",
+      "version": "4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.16.0",
+        "assert-helpers": "^7.2.0",
+        "kava": "^5.11.0",
+        "projectz": "^2.15.0",
+        "valid-directory": "^3.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-wm/MrAuUjuqH9U1b9vXNHatMZdLr6dSk54DnnnlGW2nfmoTg2uUeKMBCVGM9wBcZvDz5pjD9WiMqATRmEwgdGg==",
+        "shasum": "46d58cfe4eb390d79a28276ce1f6a68792a495f2",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.18.0-next.1599210529.065f6b95a8f50e8a384176f775a1853a2cd341cf.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23805,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfUgQiCRA9TVsSAnZWagAAzRgP/27wfP55+lHrhFh9TXAt\ngT9OFYSv6AESi+sEBCvV5AFIhddbMWtxuFB/X+KixvcOi59mM5dhKVskx8z6\n/PlhrJl0Ba3+JotwZiHgdkwOfVeMitNN7bmLp9QAwAhnwSii8Y9c9NLoWFo6\nNdiGrRF5tSFhhMZlrtZWU0AGa9+1j6SsqUE+TgoWPnX2u0jFkqRWVfnxqJzg\nuYloS4a7uplZAXncT+t+4rZcWjIRh7wIZ9DJufOvYvRMolS2zREDOywPLz3i\nByGe9WtrfRKKNIXqL33CT1c/UkGdwnrNIGJcN4NDPpZCngspg5qggqbeJmKY\n4fr0ZZfOS8xg12b/ewiyzi5s5/AJXhjbyDfLqrKCKQnpcsGwGRgka232dBH+\niAiCSPZ1MNCfz5rP7EuqdzBNhJg3cPaWE50tB8dea/sKZFNC2f4hY6wxu0Ux\n9jD/jCnyFtolXZ/tHLRwFXmAOHJk/qOizJcviywrmo4iMtdcJXqXppo9yWss\nv9J7wA+acG6UO8PCgYXeCyltShkihRAX1SRvSjTN08TGoRJc4E3HUfG2G7j7\nxzq2hoNxdis/Z74nf6vxwcdf3A2vAOO4/622UMymQVYqubsoOSFtFkendcQK\nSwGExq4hDjfxyM8/rweauOtuCYQlRgPAM+MBt+qAXVfgLVGuj+IEvTSeQh8u\n7eSS\r\n=AgWu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5": {
+      "name": "domain-browser",
+      "version": "4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.16.0",
+        "assert-helpers": "^7.2.0",
+        "kava": "^5.11.0",
+        "projectz": "^2.15.0",
+        "valid-directory": "^3.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-lYf72qeK5W95g3rVWuOwh4qveoeFlTrzuCwSgbgsbh+/Ili3SrfJ2xeX6sh93rtmHZ1+oMP1x9mzs8nMwm5pFg==",
+        "shasum": "4567ffb9e2444fa96d43a5f0cd97d1e7bd791f3a",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.18.0-next.1599393027.c802e4848f1c665b073cb67e5efc27d4063dc1f5.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23805,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfVM0FCRA9TVsSAnZWagAAL0EQAIRrFZIo/v5ZQGC8bOY4\nS7F8emgPfjG7efhfTxj8TceCDYXCWFlT4geluvZbv2V2dyosZeFolCG4m7n5\nVW3gFZ3MYthJ632s+MGexmNrJ7uuSAt/IJr2kY6D2JyPKTExKbGY9mhyOGho\nCqjfqC0pthlBBwmBoaxBzNHG+Hk+GnPGHmZ01nZPATTirew+3OuGvjyRvdJ6\n9KV+DlIG5NahFrVaHFVMULY0foLoLvJgr8NFnx9NXkwGl6FK6m7y+9IPVZh/\nJ6yB9KwSkZ82q6f/Ywd61S2AJ4b43Q7ufwvg3zA01h/zW/da8/fBi+cxGfAd\n0zzuf2FGJodkpnEVvv1lPCKWOzc5jkiNWwhXSRsdK5WEzSdbsNLZ9aLGQNce\nXPaMF/+yszFhDnAryZKDvpYPZlrvdSBRyfrYJrj64iaYLpQpamG3TVoZ3db/\ncV4ZqqgIdMdspBW1mO1YBQT6IAvw/wrcJprzy+Fommuc1nH0WET24/NvRohb\nnSbjLLMtWTkIeBMRTjfICFYv+STwBEyxS7rDqM3X5Ozk9LNVQoNCbjl6ZqqI\ne/UwXqqIy/l/vCIzyrdVgKHgzMRIZffZTnlsoHTPT2/zt7NmXVnI+wrlNjet\nuY6bpXfMoQ1yf60/bQprtIuOUdQqQik/wNFFzfz8ryJhS0RSNkLHDRRK1RKo\nShtl\r\n=QtY/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c": {
+      "name": "domain-browser",
+      "version": "4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.17.0",
+        "assert-helpers": "^8.1.0",
+        "kava": "^5.12.0",
+        "projectz": "^2.16.0",
+        "valid-directory": "^3.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-MtCYFQXREDeMnkb27ZhAkGQFK5xNfWJjK1gO741HAbgzavZSLticutVfazf3EttrBeFO6zofdf+CU2Z4lAtzZA==",
+        "shasum": "0c609da3513c7c493018ca12592245de1b3ebc67",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0-next.1603927694.1ee8a8832eea2ef541bd184b64ed70aa4697874c.tgz",
+        "fileCount": 6,
+        "unpackedSize": 24003,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmf6PCRA9TVsSAnZWagAArhEQAJ2GcISn7z5CUCmCI7ch\nxHda2Fg2Z3/LiKpqQwSrFE7Bcr7O2ktahplz4VWY9pyLygUBXjudnvsb1TL2\nDsqq6cRufJGKpwQ8xFbbaseRjVIgkC4Ce9uw3eIEByTjzVgV0K+D8r52/HVz\nu6GGZuaVQ9Yer1YMQxXDsVbueo+tEmxyb5dEIwwjP0DPtNZu/g3JZlUf27cq\nXM4O5oIfZ2MPcyyQX4fbgL8OXcIgwrKfr8WYstkcHl+KWQgD0Dbtvie77sTo\nAk3tF1zMVg5hWrKAlXId5+OqJJaACXFNiSOv9fxYtv/XnAzMku2Bf8E8WZ1d\nQiAYusWfJqwcq4mVIH9lhP1uxbffYn2LtblVF1RNaUHwZZ64qOvhDX60ZcP4\n6Mz8cARjessSwtoIYLiscEkuRNFXfMQdiMvIvVEcwCq5nipVH3KTmX6qXbvR\nC8fvYFG/k3og/Xx48joL0RAaESYGlTVYG9AcI7IdGe9pHxLjWhnM+XhM8IS7\ncteQk8NTzY/Xdh56tiamWAXZcTymMiGmaafgfa2yNak7D5qURV4Dz/iXXePh\nXTOApzd4SEXI4Uap0TN3ZaHC8eYsUrDZr9c3hBzRtMY6FxHM5jROpp48Iu7E\nnEGF+WwKvQ6TZId4oM93fJxHGvFt2L3R9SagY0rljsE1JJZ6hmFQNA/8l0JP\nWxkB\r\n=AV/o\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.19.0": {
+      "name": "domain-browser",
+      "version": "4.19.0",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.17.0",
+        "assert-helpers": "^8.1.0",
+        "kava": "^5.12.0",
+        "projectz": "^2.16.0",
+        "valid-directory": "^3.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ==",
+        "shasum": "1093e17c0a17dbd521182fe90d49ac1370054af1",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23946,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmf65CRA9TVsSAnZWagAAzvYP/igYdb+1Q0xsJRK9c1S7\nM62EgtwVsTSEYMDgfAqU8sgYVnpepB8O979XQRUTsfoUPIFfkJkRZr8KwMXK\nu14+sRV1Cdut2jJ/kO89YXSXhUIkZ518pPAaPz+Q7qbmTIEoB2wZn1gw+zyV\nEGNAPUarxsA0gNslJKvwk7ayWmqh+OGJvxpUKEXm14dVKhf+PHLRtHD1oYDs\nOnn6ll2lW83XKDi5NUK7Hvy0Lc/WqBN55iJta4J+GtYMZRFsPdO9EMDrTAf3\nUZE+tqZPGm/mq853oNQVoSN/fivyjeCSR9GK26w/6xz344T2RD+N0ZT4TiLR\nZ+bDdGJnOxgWiSUUYPO6hC03E5No+d8Uf2MhVldAnfFkrWl/M2Lz0gnTnmqI\nD7rQDWtcnLX1+Bfd6jpb5W3qT0m2abLXzwCB3f+nO8woegfEbChpBjZYahFv\nklPg4jBf2dK5AOtm1RFQDD2fF4mrN4TRakBgJt5to5qOr8+wWflZExVfPkRV\nY/fjgpwEr3A+Ho2VAv/cDRAu2cXiCOt9j5E1PzSJQqntA7JX4qW54fxpSpE7\nY2uY9o55RwYiMrGOxP8GtEijgju6c39tX7CacYTbqs4YuHtJCgsEHErPOchy\neO/kjGIwsLfRPyPK7pbz8xzmOU4ddlI3Ktfas0JjueoCjQuvwCBBlhdIU4bw\ncV0U\r\n=MX9m\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    },
+    "4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de": {
+      "name": "domain-browser",
+      "version": "4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de",
+      "devDependencies": {
+        "@bevry/update-contributors": "^1.17.0",
+        "assert-helpers": "^8.1.0",
+        "kava": "^5.12.0",
+        "projectz": "^2.16.0",
+        "valid-directory": "^3.4.0"
+      },
+      "dist": {
+        "integrity": "sha512-OUZ4hmeSOYFIUi+8VKJoBQSbT/irhK+mlFUX5hUlEIOoFJyoAAmW9RRiQWwPkKr9QXX4J24ANMeeV0jeXP+AaQ==",
+        "shasum": "5a1248a517ff83eb2c4c449ab44c83f62523bce7",
+        "tarball": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0-next.1604239876.eeda285a1a0470ee48d60df8d904f8b47b0997de.tgz",
+        "fileCount": 6,
+        "unpackedSize": 24003,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfnsIGCRA9TVsSAnZWagAAbLMQAKROb37ajj0TOP5/tfTa\nxYwgqC3U7KxKOQpowp3UpvSirE47XHZxlj51fuX0vLNtmiVIicl2oqMNIfQm\n3twjihMDXINkxvPrfclT/R+K5tULGvf/Y5W20ZzTcMAo2hTt+FwlYpRXreja\ntoiNOoH0elKFlPWo3N5LrfbHddlON2Hr+uf/zXcRAeu9tMF7/+D6rKQVkH62\nhFAkqYKmamIb7F2MaDbq3PPgmiIIbGQgUb4IayU7hZn7QMeN7ohypxpUBezw\nl2xBZcvEWC93JksVwnn1pTKONOZoNBrIHj3R1xgSDXBfWJpkKRM71Y0KRBqO\nccV04+AT4zs3AZ/ttYk6Je8Gb33/SMt8WVVq97CXZtntuO4QOERXHs87EI62\nu35m5kCtsK8TPRCes8o3057TEJPcRSmBi0SHjtJI67KvaxgN+vkW4upemKjH\nycAPI8dJqwp7tyjmQZf+g0oUzxIpm0TeoD4H20/BiimPlLQgMctWTMDHfyW4\ntM1p2iqIOf49TeNEFBOYxbP3HfyllWdITikc1Qq5E9Je824V95UreX5CPafG\nGrjpkzF/ONwHNMpYfvjMD1khmXByvohnSR4fuaAn51e5aQs7Um6Y3TlhetZj\nzAeM8J0FYCZUg7OKEXV0v+UZNdkmI16KjYSmKcjvZIe8/5Huu6DOkzdJqeiz\n/aIx\r\n=Nqar\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://bevry.me/fund"
+    }
+  },
+  "modified": "2020-11-01T14:11:20.576Z"
+}

--- a/test/fixtures/registry-mocks/content/duplexify.json
+++ b/test/fixtures/registry-mocks/content/duplexify.json
@@ -1,0 +1,2442 @@
+{
+  "_id": "duplexify",
+  "_rev": "66-71d9cb4a3f6f727e73fe15383fedfa1a",
+  "name": "duplexify",
+  "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+  "dist-tags": {
+    "latest": "4.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "duplexify",
+      "version": "1.0.0",
+      "description": "Similar to duplexer2 except it supports both streams2 and streams1 as input and it allows you to set the readable and writable part asynchroniously",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.0.0",
+      "_shasum": "611dae618208b35234aab006ca879c15a2f389b2",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "611dae618208b35234aab006ca879c15a2f389b2",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "duplexify",
+      "version": "1.1.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.1.0",
+      "_shasum": "b31b373ed480811517021dbd80e580e1c58e5022",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b31b373ed480811517021dbd80e580e1c58e5022",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "duplexify",
+      "version": "1.2.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.2.0",
+      "_shasum": "9d687ab816dfb5f00dd4c3c7a088b91a702a26e7",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9d687ab816dfb5f00dd4c3c7a088b91a702a26e7",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "duplexify",
+      "version": "1.2.1",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.2.1",
+      "_shasum": "2fefe208b27ca5d3ff4b66ec49c42ee6de083024",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2fefe208b27ca5d3ff4b66ec49c42ee6de083024",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "duplexify",
+      "version": "1.3.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.3.0",
+      "_shasum": "2c4f1606b9204b4ded00c9446fd5e2a57dda999e",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2c4f1606b9204b4ded00c9446fd5e2a57dda999e",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "duplexify",
+      "version": "1.4.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.4.0",
+      "_shasum": "0ab17f9e2932076d5793942e7bd63b2d17313b74",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0ab17f9e2932076d5793942e7bd63b2d17313b74",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "duplexify",
+      "version": "1.5.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.5.0",
+      "_shasum": "6a383b036d35b0dec831a102cf30f748de7d6f37",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6a383b036d35b0dec831a102cf30f748de7d6f37",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "duplexify",
+      "version": "1.5.1",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.5.1",
+      "_shasum": "d0cd104b208c0be0ed1ed76865941386c4968f6e",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d0cd104b208c0be0ed1ed76865941386c4968f6e",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "duplexify",
+      "version": "1.5.2",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.5.2",
+      "_shasum": "337c932dd9546f2729fabd263cb40e9b7d0b1c99",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "337c932dd9546f2729fabd263cb40e9b7d0b1c99",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.3": {
+      "name": "duplexify",
+      "version": "1.5.3",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@1.5.3",
+      "_shasum": "6ad610d9b5368f10521a89f83e6fcd47e6339a08",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6ad610d9b5368f10521a89f83e6fcd47e6339a08",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "duplexify",
+      "version": "2.0.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@2.0.0",
+      "_shasum": "2ec9a8687627d3a19411ed17521599d7e4f58e7a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2ec9a8687627d3a19411ed17521599d7e4f58e7a",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "duplexify",
+      "version": "3.0.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "_id": "duplexify@3.0.0",
+      "_shasum": "67c60f3b1d909f47955e0be0f20c4d454ad4e25c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "67c60f3b1d909f47955e0be0f20c4d454ad4e25c",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "duplexify",
+      "version": "3.0.1",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "90440f630b8cf8ad033cc4a7787ab2766c57b0f0",
+      "_id": "duplexify@3.0.1",
+      "_shasum": "a120cb51b4ff08ce6daf9c92cdd28ed169c2a44f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a120cb51b4ff08ce6daf9c92cdd28ed169c2a44f",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "duplexify",
+      "version": "3.1.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "e891eeb58b590ddfc9e33b74df922b9bcbb168af",
+      "_id": "duplexify@3.1.0",
+      "_shasum": "ad27ec00154c2c4d9c767e4c6c8baa4e6bdf5135",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ad27ec00154c2c4d9c767e4c6c8baa4e6bdf5135",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.1": {
+      "name": "duplexify",
+      "version": "3.1.1",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "1f7a163d86f452914e619e443d0c891c5cd2879f",
+      "_id": "duplexify@3.1.1",
+      "_shasum": "4e8a47327bb9e432a70a171001e8071031c24349",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4e8a47327bb9e432a70a171001e8071031c24349",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.2": {
+      "name": "duplexify",
+      "version": "3.1.2",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "75305d61a063501bf0084cd47a10baa9c974b6be",
+      "_id": "duplexify@3.1.2",
+      "_shasum": "baa404d7be78a5b851a1234519f198b3e1bcd831",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "baa404d7be78a5b851a1234519f198b3e1bcd831",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.3": {
+      "name": "duplexify",
+      "version": "3.1.3",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.0.27-1"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "27f24f4ec8e10d6da00fa50295f1afaf5754fe4b",
+      "_id": "duplexify@3.1.3",
+      "_shasum": "062c65018a56332560eeaf13cdaaede408d1a3da",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "062c65018a56332560eeaf13cdaaede408d1a3da",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.2.0": {
+      "name": "duplexify",
+      "version": "3.2.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.0.27-1"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "874c8733d25fee359e98146f3d3307e53535e1c0",
+      "_id": "duplexify@3.2.0",
+      "_shasum": "293974e3cef2e78fbb234e4fd84e20e0ad9d2d60",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "293974e3cef2e78fbb234e4fd84e20e0ad9d2d60",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.3.0": {
+      "name": "duplexify",
+      "version": "3.3.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.0.27-1"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "7e55731e36518b4cdc466b9a11b1201d51a7608f",
+      "_id": "duplexify@3.3.0",
+      "_shasum": "f5025c4b1f49f998b7399cd2d008e2895d18d247",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "1.6.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f5025c4b1f49f998b7399cd2d008e2895d18d247",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.4.0": {
+      "name": "duplexify",
+      "version": "3.4.0",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.1.13"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "8b3b34995b1a79793c709ba5cae4011b6e13dea2",
+      "_id": "duplexify@3.4.0",
+      "_shasum": "830f7878a4c45818076104953930382cc7097833",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "830f7878a4c45818076104953930382cc7097833",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.4.1": {
+      "name": "duplexify",
+      "version": "3.4.1",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.1.13"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "2be4a0dab319d4185e2cc92614b9453dfddc5889",
+      "_id": "duplexify@3.4.1",
+      "_shasum": "eb0e8a2040e27e2db9ff8d8d36d3a1b4427fc502",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "2.1.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "eb0e8a2040e27e2db9ff8d8d36d3a1b4427fc502",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.2": {
+      "name": "duplexify",
+      "version": "3.4.2",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "ba1aed77e6f36adcac0ca01d750f2cc5baa9ff1c",
+      "_id": "duplexify@3.4.2",
+      "_shasum": "71a578af03e0d063eb8f1326affd5e5600145e1b",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "71a578af03e0d063eb8f1326affd5e5600145e1b",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.3": {
+      "name": "duplexify",
+      "version": "3.4.3",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "0ecf524c3903ad55d3a2d4ce17939240105ce470",
+      "_id": "duplexify@3.4.3",
+      "_shasum": "af6a7b10d928b095f8ad854d072bb90998db850d",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "af6a7b10d928b095f8ad854d072bb90998db850d",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/duplexify-3.4.3.tgz_1456243581005_0.08543725567869842"
+      },
+      "directories": {}
+    },
+    "3.4.4": {
+      "name": "duplexify",
+      "version": "3.4.4",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "69420891905a33c01ee15af60e241c04f4148219",
+      "_id": "duplexify@3.4.4",
+      "_shasum": "96153bcc07e1284d44beea5036834544084e77a9",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "96153bcc07e1284d44beea5036834544084e77a9",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/duplexify-3.4.4.tgz_1468010820573_0.21394471800886095"
+      },
+      "directories": {}
+    },
+    "3.4.5": {
+      "name": "duplexify",
+      "version": "3.4.5",
+      "description": "Turn a writeable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "338de6776ce9b25d7ab6e91d766166245a8f070a",
+      "_id": "duplexify@3.4.5",
+      "_shasum": "0e7e287a775af753bf57e6e7b7f21f183f6c3a53",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "0e7e287a775af753bf57e6e7b7f21f183f6c3a53",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/duplexify-3.4.5.tgz_1468011872327_0.44416941492818296"
+      },
+      "directories": {}
+    },
+    "3.4.6": {
+      "name": "duplexify",
+      "version": "3.4.6",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "bf26523a410ce6215e5a5e29092b35cebe514859",
+      "_id": "duplexify@3.4.6",
+      "_shasum": "1e586a13028caf31d5144a059813f9b071fec557",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.2.6",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "1e586a13028caf31d5144a059813f9b071fec557",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/duplexify-3.4.6.tgz_1476804899240_0.6424867499154061"
+      },
+      "directories": {}
+    },
+    "3.5.0": {
+      "name": "duplexify",
+      "version": "3.5.0",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "97f525d36ce275e52435611d70b3a77a7234eaa1",
+      "_id": "duplexify@3.5.0",
+      "_shasum": "1aa773002e1578457e9d9d4a50b0ccaaebcbd604",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "1aa773002e1578457e9d9d4a50b0ccaaebcbd604",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/duplexify-3.5.0.tgz_1477317448157_0.2257942291907966"
+      },
+      "directories": {}
+    },
+    "3.5.1": {
+      "name": "duplexify",
+      "version": "3.5.1",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "4996109a6a371d07990601378142b8f25780bd3d",
+      "_id": "duplexify@3.5.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+        "shasum": "4e1516be68838bc90a49994f0b39a6e5960befcd",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify-3.5.1.tgz_1501620245530_0.8725061865989119"
+      },
+      "directories": {}
+    },
+    "3.5.2": {
+      "name": "duplexify",
+      "version": "3.5.2",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "46930b4df4d36bf4329df15c25a26c121fae6ff0",
+      "_id": "duplexify@3.5.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-ZEW5cBIFLmk/HtEv3ko94dk5NjdAAkIaYkP5I/SRi7iY2OU/eyAVMKQx7WYhnPXwJVRMp8+Q9Vz2VvFKo+LFZw==",
+        "shasum": "7681871c9ae8b3714a486b3970a3fc729bae3520",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify-3.5.2.tgz_1515600162290_0.6900210857857019"
+      },
+      "directories": {}
+    },
+    "3.5.3": {
+      "name": "duplexify",
+      "version": "3.5.3",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "0fd3535da85bc7c4cc196f63bad84bed184446ac",
+      "_id": "duplexify@3.5.3",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+        "shasum": "8b5818800df92fd0125b27ab896491912858243e",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify-3.5.3.tgz_1515600869021_0.9974729833193123"
+      },
+      "directories": {}
+    },
+    "3.5.4": {
+      "name": "duplexify",
+      "version": "3.5.4",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "2d220034d4b1966aa179cb5b3191f0270253abd5",
+      "_id": "duplexify@3.5.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+        "shasum": "4bb46c1796eabebeec4ca9a2e66b808cb7a3d8b4",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17195
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify_3.5.4_1519997687265_0.32809036777750067"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.6.0": {
+      "name": "duplexify",
+      "version": "3.6.0",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "f81db336f8b576f9b39afa2ea2a7bc12da3bb6b1",
+      "_id": "duplexify@3.6.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.11.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+        "shasum": "592903f5d80b38d037220541264d69a198fb3410",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17028,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa7Da4CRA9TVsSAnZWagAAI/MP/jhjYwvqItkwaxMrtysy\n72hUFU9D4JPxCDMuGg3fl+dwfwl15YFynNO6Gsye3OP/BB4HpQbsjfb7KE1L\ne8YQFmr+omFnYyhHlOOprzmIrrRHk7Z/J+V0TN5IiCVh4aB/5kElXAUoXAO0\ng98gfnUv9OIDAiv/GqiMP/5gzjcuHzpsf08fitMGTOoD7l7PHq8wrbRf/Irn\noerndhQ/2F6Cp+/YUJ2hu+56JDW20MDRHRNqBb9yixgnfzPn6xjRYKpIbktw\nUW5BdoyVRibrSoTi+p4TLg9JweU5++SHWBweGnBk2jyuuz6VADJ9eP4Qwp2v\njfFzTYPWjimRyx2WP7bhVAWiV+7tM9ngyV4Yr9grzdHVTa4olrWyYlqBTfoV\na/VMmxufrjfkJ4Kf9fhXcBIfDisryesgX+PCjvSDqZ07TTnuVYgBnKM3JFeX\nTbQ14q2yfmNk21QinQjNmCOLuMp2XI+tyHTFB+Cc+UT9y9lSSQm87ZktpZS3\n+Lz30cae9kVI20NQCFIOHrcyMzI/ooGSsT6g8wvpD/+fp9Hy1D0LQXq4kEsy\nKO9oj3fQMWdaqgZRH+30VpmBU+0IJUz4zU72HzVwM/LlCU/GISFF2z1odOen\nH4X03+88HDjRMuimaRermdvcQGZQabXSn1ImiUqC7PKDGlgCd6BndE+YyoNQ\nUoqs\r\n=Y7X8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify_3.6.0_1525429943186_0.29469811383753375"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.6.1": {
+      "name": "duplexify",
+      "version": "3.6.1",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "683ee893bb34202d1f00228e184ca38dfb849d50",
+      "_id": "duplexify@3.6.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.11.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+        "shasum": "b1a7a29c4abfd639585efaecce80d666b1e34125",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbwmsbCRA9TVsSAnZWagAAelEP/A5VZxVzcgJVZsek36p8\nmh0PPoafTY4hFj7njFmelYerEg+djzOYmMdx1opAhb+wsbM874UCZ0ysSv62\nF6D+71ifkPIk0jJ4ep7RhDsti9M0ea58qyrP6F4i89puvUSlgoD42sNKX9sK\nG91R2SqiG9ZfUsL0aMwmhAsIPfLdVFitHJHYvtXXFDktjktpBCYv2K6IWCdT\nRgw0iypZYPd62v6n0ZuuZAXrPTZ9ctvUFB7vAkrHCXkPw/WnN03+n8yVUQ41\nCttvsDHr5kH13TEUqTkAefTodV0gZgm82P8sUTLwJ5nl7vQ4/XkAb5wH73xR\nh+4hx7ov3MfusqGc+YNcGcpavtawy8r8c8ZZffQwA6Ny0MkH4pjBSHsOfmyP\nIu5M6m+RfGGsxhwucjIjM1UKkdFGF32ZxJD36qdYRkhB9SLhVHAmpX7tqEsd\nwKhmHBHCTFKOpYPtko5fU4WhjuEh2CdMtyhaHSDHyOoXRNRD2f5VETFQLseU\n+4H9QIwZ0w/fkSVdzjEoJgXa04pkJkpG83szcqiZCzSGnirqJElkPuK7Yb9n\noez0INla69TClboFVd5isMbmtOC50DSwBrdx58Fy9HkpT4ocaPFMwBemBYwp\nzuklUttd3i9O1dYo08wY8i/9Qr0P3MHmLSqUvMZwYcvOZ0lDyNjua1XyRQ8r\nKAmT\r\n=mMMu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify_3.6.1_1539468058997_0.5627181059372255"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.7.0": {
+      "name": "duplexify",
+      "version": "3.7.0",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "db96c6b2e5edadc50534fc09be75030baca1175f",
+      "_id": "duplexify@3.7.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-+PSTXcTZi+Ez+AkJNYzxWvncsmelRzwrAbGF6Y/RNSK9BmnTVEOFVoYSXDHizQUQe3SSerq0YoS3utU7TUfeHg==",
+        "shasum": "f4cae6c26675bc37a89ae8eba712de8c48ca23ad",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcWALkCRA9TVsSAnZWagAALzYQAJJV9jV6JHvo5YQ0Hieg\n9E7QXokHW4Hq46ljsk9jvQcqUoietWmLeD+3zrgeQoNm0y7GqqPgdqEe2/uv\nbbXYJ/hLWyjxqIRk0Srs2E68KpdGHd4jpxJML98s0W6jxyt7cwwb2hEds6Jg\nAPH3fWyStVrLjvNIIWP5AOe2FnQS2NXgJXlqsHoUqR69sSsDmO0x5jW7GHW/\nEF4GFyKZGvnxquZKuQrMVYAHOYVCZLImf5Fe9LPE6j/YvqZgWmWk0OYIzMFZ\nZx9I6KGtavVEkxmuX9N0QduWcnVKHUiOBBQfbRrvmjX3phibgnLvyEHysWAr\nst+HZtvmFpQsDzHEKL4P76epUEZ8P7Irf+mAHbHUi9lwHvQQALMYh41mcivS\nIMoecna1afgKGuha21AGcuq2+aiyqzxDaVr4pPn9OrDTDlTPLxD+tJmH/1sY\nbdY8Zac9T1Wn89UPeR3pX3LTvWtHWOXnmCawOdTGuQosZ+YcXzOthw8rRjtM\n1boccGSw+fnuodzMQwaL7YNpZA7hiObu9jBSFapKEFgy4zTuRDfdVU/RWCLL\nmuV5cd0VzMH6cCKp1DnAJboa3PDUB03Xx5uh24ReQ/4xYxrlYOHNp3Ox53Vu\nH6HMLZvNL3UAUy0WlQmuxx8acugqhxLRDl7WBEjZkOa9uh2V6XoaRQIlBeyH\nvI+0\r\n=TYkV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify_3.7.0_1549271779797_0.30578102504805904"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.7.1": {
+      "name": "duplexify",
+      "version": "3.7.1",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "f6af4f971bf4c99750f44751b99942675f0ab5df",
+      "_id": "duplexify@3.7.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+        "shasum": "2a4df5317f6ccfd91f86d6fd25d8d8a103b88309",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17129,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcWGpECRA9TVsSAnZWagAAwegP+wVmE/yTLEAQqBFl7Lg0\nFzP/KE3nlxPZEOBFREnM6TOH+R6qhiJ0FfrtGSy4/gjgUs/FgSPcbWrmDf91\nWQ6ZmjfW8s5Ms8rQ2kPzLd2g8zFNdyxjRadEhL0ecRrhBjwfmONXeXEUKz8l\nM5EauN9tdldv4V5f8g1sHhvDDz6mmfErtKv43J2LgFoRqlpl4esY9EdIF3Ei\nIAoU2NFCmUGKBEpzqrsOwMJ6Vyw9QdWO7BJIny79/x/86lCBWZR0br1hAs3W\nx+mQHZrZ80pd3RFDdZzrJQqb90keg10RMByB6rexQ1ZHFW14MYfsyGLblQo5\nJjcJRlWB5ldHq26Zc5zuW79X9b/t7LU52/3UZN4EDCkWSK5/nK6UTN49W6bm\n6Z+z6ewHUKAT/ar5W+8Lh3ZSDj6Dh8ElpwUEsORUQxuAbKlERuHlCX7KmRkG\ntyBrreHOYm1R3gRK1ye03TfTYOXFZhoBCLSZCbsAqEiqlHr7GR+bR0O9eYDz\nAzgUAAwoaEegMht9y3EaGtByWKl91Pb4ejW0ZiefzrADCVHzFa0/eXlny8p6\nEsGOiiIWQqnXJiVPKzsi6teYcH9Cxf8VZfeBgc2NuHkMOrW41LR0J/95G+wk\nJlvxrB9tbM7B69F6g1uoCJ9zXG9l9gVnXgJxVn4YUYRVOwIVtIVJz8e5cpqK\nUWnJ\r\n=n3Aw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify_3.7.1_1549298243866_0.6164307625554561"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "duplexify",
+      "version": "4.0.0",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "9dc80c1387d92270f2878c467e84a897973a71f7",
+      "_id": "duplexify@4.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-yY3mlX6uXXe53lt9TnyIIlPZD9WfBEl+OU/8YLiU+p0xxaNRMjLE+rIEURR5/F1H41z9iMHcmVRxRS89tKCUcQ==",
+        "shasum": "9eddda497bf43dddd2d143d31f7a4e68ad1e53a9",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-4.0.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17129,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcWGp2CRA9TVsSAnZWagAA71MQAKBBZuFlPK0/cXSWRcyO\n6jq+t/AC7Gc6P3xo12AkoIrRljl/9T5xPA1CjdCqj3cZ9zZYbNbumAPZqrjK\nnP3w9qAL+/fON7yf5pK+CPGmmQuDgs0Q9vSSEQCscBzTj4PE0JrES65w7eE0\nN6NipmzkVBWCQOvj7arfw3rPxgEpppA0uPRmeEsGYQU4WNlsdg+oOhcAeo5F\ntvFskdbo7X9yyYow+lo4DKDmKKTiggrhxcHhYfYKw5dit7A/e0m0i/P2nEOU\n2d9dST4o+fxiRuSoOSYd8fpCze7R4+7n400PVMVXbaWptI2aipZgHrbZEkqV\nt4smVIN3wuREkqPT7bJH/jYo8g1aEDHPAskdrgzLgbuZDoOzu16rjZRRmoU/\nShN5NxOOWVQb+Ej9C2ECRZclmWShzKv82+eTKs+euJheFf4BpMIgWt74oEDJ\nRL2nAFCLNFkRjliT4+h17aRmjEoQW81jyrz9G9SFP6n3uY+INJSF6jnITqRQ\niuRYlDg1mZMFdRTbCTVTbcEw3x9ZDXmZkx3RUXEu5MhT/lW4eCaatTTl90rQ\nEJBuS9noJBSaw3PzdOQCIbmqfJ5zzNFOrxUzGHQGP9s0abh1DZOTApLkIAbo\ncyrWl8frrRA+ePUJ99cSov8xd0XZ+r1XM4FmctOVr52nEuCOCxmvY2fa4iJI\n8CaK\r\n=9YpT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify_4.0.0_1549298293718_0.7767198343160726"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.0": {
+      "name": "duplexify",
+      "version": "4.1.0",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "197f4b78ef90a78bcf7ec9799bb3f517811a952e",
+      "_id": "duplexify@4.1.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-30gnPrBwCIjXLKHz8SyIIyv4JLEneQKFQcyfhPZxd/e2O3qi0kq/k9AEksUuTsrRmpGJTHwWO7o/sM92K7P4Rw==",
+        "shasum": "b26c51659c83cb03d78c3e70acef202dede7c031",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18154,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/49VCRA9TVsSAnZWagAAKFgP/1EO4Kny9+l9yF3JfJe7\n796HuV1BomEix1tH4HaywixbcE93pYUvq6/iX0TrMZ1iR1dcLnqOvND35z+9\nc+b0w7WgBhQt8FIrPVXtFKliz+KbQUeqZH4ZAO9QkJxf1hvv3h3pwdAkFJQL\n7KdmIRcaci0//bXctnXGxs9VYJcKGu4lzDDk29h0U40n47zybAmrN2944jY5\nUPTv1MruZ6QGyjm9jDfqPYyPGG1XzzPdLp/WS5m6KtGJ0rPqllwa/QDaPopu\nsaejN5OaB1Qur3QQT8gCR+SUqgVcKIHCb71wUddCGyPdS2it2wcvVfHCseFo\n72yTiF2pU8qGK8E/ndBL4PFDNzgSH+IzzPmQjussEymjq8pPHHf1bBT3pvCe\ncNGKfzhbeDI1iWFmn82ry9qRm5Gk25aXdQ3fOKn7QaVhC/VGgLYh7MBczsG7\nQtkLBGWGIzLptIRWf93nIaMwUaN1bsZLCabS+kbdAeO5++pTlnrYPBnMBLN4\nNhFz1W56p2+I62c1ckZMlQ5zKpJNA5eZ04zg+XTiQONVJyo/L9dRgil3KUQr\nnadtUW2iOOMkhXwotCKQCFVN5Khf1xprxDxQ14K6CIui7PqvwGclI1pxf2Hb\nXXXufrk5l5huIzAdWLcKEJzxUw+wL93UgXo+9cNFaDoBU/FNqzyZAeYGlXuA\nINkE\r\n=vLGs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify_4.1.0_1560252244402_0.8046017340355003"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.1": {
+      "name": "duplexify",
+      "version": "4.1.1",
+      "description": "Turn a writable and readable stream into a streams2 duplex stream with support for async initialization and streams1/streams2 input",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/duplexify.git"
+      },
+      "keywords": [
+        "duplex",
+        "streams2",
+        "streams",
+        "stream",
+        "writable",
+        "readable",
+        "async"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/duplexify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/duplexify",
+      "gitHead": "8f8032881187e3db8ba8f64106daa999f63dc785",
+      "_id": "duplexify@4.1.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+        "shasum": "7027dc374f157b122a8ae08c2d3ea4d2d953aa61",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18227,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAVyzCRA9TVsSAnZWagAABAIP/2WSr6iuUAkcr9rky3rA\nQ+CQXr0z4JnN2+rGPDpGmBDC/SyKutY5dSMcIWP8gYFdIFY9+yThDpfaJP7N\nAaplhjnVFYA/k0Wt4kOWiRlfgvQUal/QV7y6vHgZG7K3NJ4mGfMC/WNTa84c\nL6F0Ydc9WWplBT1XTg4IPmoqNWNYHKeEsXg29df8mL8UNZWCx4dNKQJac+VI\n7Z1yZVIiiRao8zreg/WwaNin7iJ/hl2Mewhed9sDbj24B040BgOjWieEKnv6\neCtW6NEvFY+RsjX9eP3eA51UJMtKhionf4kJGr6op03yK/UTihrfJFVMSKZ3\nc7R384iCKGBcloMnrHgX+RPrDl5rMSHejgctaW5wjScj3XRhm/XmyHGd3NCo\nxdEo4uqNsN3FeLznLDoKkNped+kPN1B+cYmTVG415fTPxZVUAcotSXHJ/nLZ\nYGbC68+vc+zdeyJSeDopcSeUrIpuXNuX0dEsxChWd+8LpsgSWzOWzvMCZMXh\n6+WxI6wDpHZ6m2r0MzxKnyEcrgSNG9yjju6VtSNGNClNzx7GKW1qJJiIetAN\ngt8mHiOQP+kI+qZMcZlashvxx9yZ+t14REjOsXMRQAVJRcP3GkK9X9vARNSK\nrt7uDQEYgVp9NT+ADhY9zpuFp2vM/NabIcmunhSFJb2PteoIsUKOjEE3FsDw\nmOOj\r\n=WFSw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/duplexify_4.1.1_1560370354584_0.1075957544084507"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# duplexify\n\nTurn a writeable and readable stream into a single streams2 duplex stream.\n\nSimilar to [duplexer2](https://github.com/deoxxa/duplexer2) except it supports both streams2 and streams1 as input\nand it allows you to set the readable and writable part asynchronously using `setReadable(stream)` and `setWritable(stream)`\n\n```\nnpm install duplexify\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/duplexify.svg?style=flat)](http://travis-ci.org/mafintosh/duplexify)\n\n## Usage\n\nUse `duplexify(writable, readable, streamOptions)` (or `duplexify.obj(writable, readable)` to create an object stream)\n\n``` js\nvar duplexify = require('duplexify')\n\n// turn writableStream and readableStream into a single duplex stream\nvar dup = duplexify(writableStream, readableStream)\n\ndup.write('hello world') // will write to writableStream\ndup.on('data', function(data) {\n  // will read from readableStream\n})\n```\n\nYou can also set the readable and writable parts asynchronously\n\n``` js\nvar dup = duplexify()\n\ndup.write('hello world') // write will buffer until the writable\n                         // part has been set\n\n// wait a bit ...\ndup.setReadable(readableStream)\n\n// maybe wait some more?\ndup.setWritable(writableStream)\n```\n\nIf you call `setReadable` or `setWritable` multiple times it will unregister the previous readable/writable stream.\nTo disable the readable or writable part call `setReadable` or `setWritable` with `null`.\n\nIf the readable or writable streams emits an error or close it will destroy both streams and bubble up the event.\nYou can also explicitly destroy the streams by calling `dup.destroy()`. The `destroy` method optionally takes an\nerror object as argument, in which case the error is emitted as part of the `error` event.\n\n``` js\ndup.on('error', function(err) {\n  console.log('readable or writable emitted an error - close will follow')\n})\n\ndup.on('close', function() {\n  console.log('the duplex stream is destroyed')\n})\n\ndup.destroy() // calls destroy on the readable and writable part (if present)\n```\n\n## HTTP request example\n\nTurn a node core http request into a duplex stream is as easy as\n\n``` js\nvar duplexify = require('duplexify')\nvar http = require('http')\n\nvar request = function(opts) {\n  var req = http.request(opts)\n  var dup = duplexify(req)\n  req.on('response', function(res) {\n    dup.setReadable(res)\n  })\n  return dup\n}\n\nvar req = request({\n  method: 'GET',\n  host: 'www.google.com',\n  port: 80\n})\n\nreq.end()\nreq.pipe(process.stdout)\n```\n\n## License\n\nMIT\n\n## Related\n\n`duplexify` is part of the [mississippi stream utility collection](https://github.com/maxogden/mississippi) which includes more useful stream modules similar to this one.\n",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-06-12T20:12:37.758Z",
+    "created": "2014-07-07T16:47:19.676Z",
+    "1.0.0": "2014-07-07T16:47:19.676Z",
+    "1.1.0": "2014-07-07T21:25:52.700Z",
+    "1.2.0": "2014-07-12T21:36:58.044Z",
+    "1.2.1": "2014-07-12T21:43:23.864Z",
+    "1.3.0": "2014-07-13T12:45:52.832Z",
+    "1.4.0": "2014-07-13T12:51:01.328Z",
+    "1.5.0": "2014-07-21T12:14:20.057Z",
+    "1.5.1": "2014-07-21T12:25:30.267Z",
+    "1.5.2": "2014-07-22T18:33:42.615Z",
+    "1.5.3": "2014-07-22T21:44:56.410Z",
+    "2.0.0": "2014-07-23T00:02:46.284Z",
+    "3.0.0": "2014-07-23T13:09:09.259Z",
+    "3.0.1": "2014-07-25T19:09:30.423Z",
+    "3.1.0": "2014-08-07T20:20:01.206Z",
+    "3.1.1": "2014-08-15T23:09:36.697Z",
+    "3.1.2": "2014-08-15T23:24:01.925Z",
+    "3.1.3": "2014-08-19T07:45:04.328Z",
+    "3.2.0": "2014-08-30T15:55:02.423Z",
+    "3.3.0": "2015-04-14T19:05:01.297Z",
+    "3.4.0": "2015-05-17T09:09:41.271Z",
+    "3.4.1": "2015-05-27T14:47:16.097Z",
+    "3.4.2": "2015-06-15T04:47:04.104Z",
+    "3.4.3": "2016-02-23T16:06:25.764Z",
+    "3.4.4": "2016-07-08T20:47:01.044Z",
+    "3.4.5": "2016-07-08T21:04:32.777Z",
+    "3.4.6": "2016-10-18T15:35:01.402Z",
+    "3.5.0": "2016-10-24T13:57:29.954Z",
+    "3.5.1": "2017-08-01T20:44:06.446Z",
+    "3.5.2": "2018-01-10T16:02:43.335Z",
+    "3.5.3": "2018-01-10T16:14:29.938Z",
+    "3.5.4": "2018-03-02T13:34:47.313Z",
+    "3.6.0": "2018-05-04T10:32:23.233Z",
+    "3.6.1": "2018-10-13T22:00:59.151Z",
+    "3.7.0": "2019-02-04T09:16:19.916Z",
+    "3.7.1": "2019-02-04T16:37:23.968Z",
+    "4.0.0": "2019-02-04T16:38:13.795Z",
+    "4.1.0": "2019-06-11T11:24:04.564Z",
+    "4.1.1": "2019-06-12T20:12:34.752Z"
+  },
+  "homepage": "https://github.com/mafintosh/duplexify",
+  "keywords": [
+    "duplex",
+    "streams2",
+    "streams",
+    "stream",
+    "writable",
+    "readable",
+    "async"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mafintosh/duplexify.git"
+  },
+  "author": {
+    "name": "Mathias Buus"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/duplexify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "timhudson": true,
+    "julien-f": true,
+    "fivdi": true,
+    "tclay": true,
+    "alexkval": true,
+    "incendiary": true,
+    "xu_q90": true,
+    "stringparser": true,
+    "bammoo": true,
+    "programmer.severson": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/duplexify.min.json
+++ b/test/fixtures/registry-mocks/content/duplexify.min.json
@@ -1,0 +1,703 @@
+{
+  "name": "duplexify",
+  "dist-tags": {
+    "latest": "4.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "duplexify",
+      "version": "1.0.0",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "611dae618208b35234aab006ca879c15a2f389b2",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "duplexify",
+      "version": "1.1.0",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "b31b373ed480811517021dbd80e580e1c58e5022",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "duplexify",
+      "version": "1.2.0",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "9d687ab816dfb5f00dd4c3c7a088b91a702a26e7",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "duplexify",
+      "version": "1.2.1",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "2fefe208b27ca5d3ff4b66ec49c42ee6de083024",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.2.1.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "duplexify",
+      "version": "1.3.0",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "2c4f1606b9204b4ded00c9446fd5e2a57dda999e",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.3.0.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "duplexify",
+      "version": "1.4.0",
+      "dependencies": {
+        "end-of-stream": "0.1.5"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "0ab17f9e2932076d5793942e7bd63b2d17313b74",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.4.0.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "duplexify",
+      "version": "1.5.0",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "6a383b036d35b0dec831a102cf30f748de7d6f37",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.5.0.tgz"
+      }
+    },
+    "1.5.1": {
+      "name": "duplexify",
+      "version": "1.5.1",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "d0cd104b208c0be0ed1ed76865941386c4968f6e",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.5.1.tgz"
+      }
+    },
+    "1.5.2": {
+      "name": "duplexify",
+      "version": "1.5.2",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "337c932dd9546f2729fabd263cb40e9b7d0b1c99",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.5.2.tgz"
+      }
+    },
+    "1.5.3": {
+      "name": "duplexify",
+      "version": "1.5.3",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "6ad610d9b5368f10521a89f83e6fcd47e6339a08",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-1.5.3.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "duplexify",
+      "version": "2.0.0",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "2ec9a8687627d3a19411ed17521599d7e4f58e7a",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-2.0.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "duplexify",
+      "version": "3.0.0",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "67c60f3b1d909f47955e0be0f20c4d454ad4e25c",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "duplexify",
+      "version": "3.0.1",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "a120cb51b4ff08ce6daf9c92cdd28ed169c2a44f",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.0.1.tgz"
+      }
+    },
+    "3.1.0": {
+      "name": "duplexify",
+      "version": "3.1.0",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "ad27ec00154c2c4d9c767e4c6c8baa4e6bdf5135",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.1.0.tgz"
+      }
+    },
+    "3.1.1": {
+      "name": "duplexify",
+      "version": "3.1.1",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "4e8a47327bb9e432a70a171001e8071031c24349",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.1.1.tgz"
+      }
+    },
+    "3.1.2": {
+      "name": "duplexify",
+      "version": "3.1.2",
+      "dependencies": {
+        "end-of-stream": "1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "baa404d7be78a5b851a1234519f198b3e1bcd831",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.1.2.tgz"
+      }
+    },
+    "3.1.3": {
+      "name": "duplexify",
+      "version": "3.1.3",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.0.27-1"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "062c65018a56332560eeaf13cdaaede408d1a3da",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.1.3.tgz"
+      }
+    },
+    "3.2.0": {
+      "name": "duplexify",
+      "version": "3.2.0",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.0.27-1"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "293974e3cef2e78fbb234e4fd84e20e0ad9d2d60",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.2.0.tgz"
+      }
+    },
+    "3.3.0": {
+      "name": "duplexify",
+      "version": "3.3.0",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.0.27-1"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "f5025c4b1f49f998b7399cd2d008e2895d18d247",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.3.0.tgz"
+      }
+    },
+    "3.4.0": {
+      "name": "duplexify",
+      "version": "3.4.0",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.1.13"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "830f7878a4c45818076104953930382cc7097833",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz"
+      }
+    },
+    "3.4.1": {
+      "name": "duplexify",
+      "version": "3.4.1",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^1.1.13"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "eb0e8a2040e27e2db9ff8d8d36d3a1b4427fc502",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.1.tgz"
+      }
+    },
+    "3.4.2": {
+      "name": "duplexify",
+      "version": "3.4.2",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "71a578af03e0d063eb8f1326affd5e5600145e1b",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz"
+      }
+    },
+    "3.4.3": {
+      "name": "duplexify",
+      "version": "3.4.3",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "af6a7b10d928b095f8ad854d072bb90998db850d",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.3.tgz"
+      }
+    },
+    "3.4.4": {
+      "name": "duplexify",
+      "version": "3.4.4",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "96153bcc07e1284d44beea5036834544084e77a9",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.4.tgz"
+      }
+    },
+    "3.4.5": {
+      "name": "duplexify",
+      "version": "3.4.5",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "0e7e287a775af753bf57e6e7b7f21f183f6c3a53",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.5.tgz"
+      }
+    },
+    "3.4.6": {
+      "name": "duplexify",
+      "version": "3.4.6",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "1e586a13028caf31d5144a059813f9b071fec557",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.6.tgz"
+      }
+    },
+    "3.5.0": {
+      "name": "duplexify",
+      "version": "3.5.0",
+      "dependencies": {
+        "end-of-stream": "1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.4.6",
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "1aa773002e1578457e9d9d4a50b0ccaaebcbd604",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz"
+      }
+    },
+    "3.5.1": {
+      "name": "duplexify",
+      "version": "3.5.1",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+        "shasum": "4e1516be68838bc90a49994f0b39a6e5960befcd",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz"
+      }
+    },
+    "3.5.2": {
+      "name": "duplexify",
+      "version": "3.5.2",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-ZEW5cBIFLmk/HtEv3ko94dk5NjdAAkIaYkP5I/SRi7iY2OU/eyAVMKQx7WYhnPXwJVRMp8+Q9Vz2VvFKo+LFZw==",
+        "shasum": "7681871c9ae8b3714a486b3970a3fc729bae3520",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.2.tgz"
+      }
+    },
+    "3.5.3": {
+      "name": "duplexify",
+      "version": "3.5.3",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+        "shasum": "8b5818800df92fd0125b27ab896491912858243e",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz"
+      }
+    },
+    "3.5.4": {
+      "name": "duplexify",
+      "version": "3.5.4",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+        "shasum": "4bb46c1796eabebeec4ca9a2e66b808cb7a3d8b4",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17195
+      }
+    },
+    "3.6.0": {
+      "name": "duplexify",
+      "version": "3.6.0",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+        "shasum": "592903f5d80b38d037220541264d69a198fb3410",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17028,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa7Da4CRA9TVsSAnZWagAAI/MP/jhjYwvqItkwaxMrtysy\n72hUFU9D4JPxCDMuGg3fl+dwfwl15YFynNO6Gsye3OP/BB4HpQbsjfb7KE1L\ne8YQFmr+omFnYyhHlOOprzmIrrRHk7Z/J+V0TN5IiCVh4aB/5kElXAUoXAO0\ng98gfnUv9OIDAiv/GqiMP/5gzjcuHzpsf08fitMGTOoD7l7PHq8wrbRf/Irn\noerndhQ/2F6Cp+/YUJ2hu+56JDW20MDRHRNqBb9yixgnfzPn6xjRYKpIbktw\nUW5BdoyVRibrSoTi+p4TLg9JweU5++SHWBweGnBk2jyuuz6VADJ9eP4Qwp2v\njfFzTYPWjimRyx2WP7bhVAWiV+7tM9ngyV4Yr9grzdHVTa4olrWyYlqBTfoV\na/VMmxufrjfkJ4Kf9fhXcBIfDisryesgX+PCjvSDqZ07TTnuVYgBnKM3JFeX\nTbQ14q2yfmNk21QinQjNmCOLuMp2XI+tyHTFB+Cc+UT9y9lSSQm87ZktpZS3\n+Lz30cae9kVI20NQCFIOHrcyMzI/ooGSsT6g8wvpD/+fp9Hy1D0LQXq4kEsy\nKO9oj3fQMWdaqgZRH+30VpmBU+0IJUz4zU72HzVwM/LlCU/GISFF2z1odOen\nH4X03+88HDjRMuimaRermdvcQGZQabXSn1ImiUqC7PKDGlgCd6BndE+YyoNQ\nUoqs\r\n=Y7X8\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.6.1": {
+      "name": "duplexify",
+      "version": "3.6.1",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+        "shasum": "b1a7a29c4abfd639585efaecce80d666b1e34125",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbwmsbCRA9TVsSAnZWagAAelEP/A5VZxVzcgJVZsek36p8\nmh0PPoafTY4hFj7njFmelYerEg+djzOYmMdx1opAhb+wsbM874UCZ0ysSv62\nF6D+71ifkPIk0jJ4ep7RhDsti9M0ea58qyrP6F4i89puvUSlgoD42sNKX9sK\nG91R2SqiG9ZfUsL0aMwmhAsIPfLdVFitHJHYvtXXFDktjktpBCYv2K6IWCdT\nRgw0iypZYPd62v6n0ZuuZAXrPTZ9ctvUFB7vAkrHCXkPw/WnN03+n8yVUQ41\nCttvsDHr5kH13TEUqTkAefTodV0gZgm82P8sUTLwJ5nl7vQ4/XkAb5wH73xR\nh+4hx7ov3MfusqGc+YNcGcpavtawy8r8c8ZZffQwA6Ny0MkH4pjBSHsOfmyP\nIu5M6m+RfGGsxhwucjIjM1UKkdFGF32ZxJD36qdYRkhB9SLhVHAmpX7tqEsd\nwKhmHBHCTFKOpYPtko5fU4WhjuEh2CdMtyhaHSDHyOoXRNRD2f5VETFQLseU\n+4H9QIwZ0w/fkSVdzjEoJgXa04pkJkpG83szcqiZCzSGnirqJElkPuK7Yb9n\noez0INla69TClboFVd5isMbmtOC50DSwBrdx58Fy9HkpT4ocaPFMwBemBYwp\nzuklUttd3i9O1dYo08wY8i/9Qr0P3MHmLSqUvMZwYcvOZ0lDyNjua1XyRQ8r\nKAmT\r\n=mMMu\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.7.0": {
+      "name": "duplexify",
+      "version": "3.7.0",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-+PSTXcTZi+Ez+AkJNYzxWvncsmelRzwrAbGF6Y/RNSK9BmnTVEOFVoYSXDHizQUQe3SSerq0YoS3utU7TUfeHg==",
+        "shasum": "f4cae6c26675bc37a89ae8eba712de8c48ca23ad",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcWALkCRA9TVsSAnZWagAALzYQAJJV9jV6JHvo5YQ0Hieg\n9E7QXokHW4Hq46ljsk9jvQcqUoietWmLeD+3zrgeQoNm0y7GqqPgdqEe2/uv\nbbXYJ/hLWyjxqIRk0Srs2E68KpdGHd4jpxJML98s0W6jxyt7cwwb2hEds6Jg\nAPH3fWyStVrLjvNIIWP5AOe2FnQS2NXgJXlqsHoUqR69sSsDmO0x5jW7GHW/\nEF4GFyKZGvnxquZKuQrMVYAHOYVCZLImf5Fe9LPE6j/YvqZgWmWk0OYIzMFZ\nZx9I6KGtavVEkxmuX9N0QduWcnVKHUiOBBQfbRrvmjX3phibgnLvyEHysWAr\nst+HZtvmFpQsDzHEKL4P76epUEZ8P7Irf+mAHbHUi9lwHvQQALMYh41mcivS\nIMoecna1afgKGuha21AGcuq2+aiyqzxDaVr4pPn9OrDTDlTPLxD+tJmH/1sY\nbdY8Zac9T1Wn89UPeR3pX3LTvWtHWOXnmCawOdTGuQosZ+YcXzOthw8rRjtM\n1boccGSw+fnuodzMQwaL7YNpZA7hiObu9jBSFapKEFgy4zTuRDfdVU/RWCLL\nmuV5cd0VzMH6cCKp1DnAJboa3PDUB03Xx5uh24ReQ/4xYxrlYOHNp3Ox53Vu\nH6HMLZvNL3UAUy0WlQmuxx8acugqhxLRDl7WBEjZkOa9uh2V6XoaRQIlBeyH\nvI+0\r\n=TYkV\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.7.1": {
+      "name": "duplexify",
+      "version": "3.7.1",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+        "shasum": "2a4df5317f6ccfd91f86d6fd25d8d8a103b88309",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17129,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcWGpECRA9TVsSAnZWagAAwegP+wVmE/yTLEAQqBFl7Lg0\nFzP/KE3nlxPZEOBFREnM6TOH+R6qhiJ0FfrtGSy4/gjgUs/FgSPcbWrmDf91\nWQ6ZmjfW8s5Ms8rQ2kPzLd2g8zFNdyxjRadEhL0ecRrhBjwfmONXeXEUKz8l\nM5EauN9tdldv4V5f8g1sHhvDDz6mmfErtKv43J2LgFoRqlpl4esY9EdIF3Ei\nIAoU2NFCmUGKBEpzqrsOwMJ6Vyw9QdWO7BJIny79/x/86lCBWZR0br1hAs3W\nx+mQHZrZ80pd3RFDdZzrJQqb90keg10RMByB6rexQ1ZHFW14MYfsyGLblQo5\nJjcJRlWB5ldHq26Zc5zuW79X9b/t7LU52/3UZN4EDCkWSK5/nK6UTN49W6bm\n6Z+z6ewHUKAT/ar5W+8Lh3ZSDj6Dh8ElpwUEsORUQxuAbKlERuHlCX7KmRkG\ntyBrreHOYm1R3gRK1ye03TfTYOXFZhoBCLSZCbsAqEiqlHr7GR+bR0O9eYDz\nAzgUAAwoaEegMht9y3EaGtByWKl91Pb4ejW0ZiefzrADCVHzFa0/eXlny8p6\nEsGOiiIWQqnXJiVPKzsi6teYcH9Cxf8VZfeBgc2NuHkMOrW41LR0J/95G+wk\nJlvxrB9tbM7B69F6g1uoCJ9zXG9l9gVnXgJxVn4YUYRVOwIVtIVJz8e5cpqK\nUWnJ\r\n=n3Aw\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.0": {
+      "name": "duplexify",
+      "version": "4.0.0",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-yY3mlX6uXXe53lt9TnyIIlPZD9WfBEl+OU/8YLiU+p0xxaNRMjLE+rIEURR5/F1H41z9iMHcmVRxRS89tKCUcQ==",
+        "shasum": "9eddda497bf43dddd2d143d31f7a4e68ad1e53a9",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-4.0.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 17129,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcWGp2CRA9TVsSAnZWagAA71MQAKBBZuFlPK0/cXSWRcyO\n6jq+t/AC7Gc6P3xo12AkoIrRljl/9T5xPA1CjdCqj3cZ9zZYbNbumAPZqrjK\nnP3w9qAL+/fON7yf5pK+CPGmmQuDgs0Q9vSSEQCscBzTj4PE0JrES65w7eE0\nN6NipmzkVBWCQOvj7arfw3rPxgEpppA0uPRmeEsGYQU4WNlsdg+oOhcAeo5F\ntvFskdbo7X9yyYow+lo4DKDmKKTiggrhxcHhYfYKw5dit7A/e0m0i/P2nEOU\n2d9dST4o+fxiRuSoOSYd8fpCze7R4+7n400PVMVXbaWptI2aipZgHrbZEkqV\nt4smVIN3wuREkqPT7bJH/jYo8g1aEDHPAskdrgzLgbuZDoOzu16rjZRRmoU/\nShN5NxOOWVQb+Ej9C2ECRZclmWShzKv82+eTKs+euJheFf4BpMIgWt74oEDJ\nRL2nAFCLNFkRjliT4+h17aRmjEoQW81jyrz9G9SFP6n3uY+INJSF6jnITqRQ\niuRYlDg1mZMFdRTbCTVTbcEw3x9ZDXmZkx3RUXEu5MhT/lW4eCaatTTl90rQ\nEJBuS9noJBSaw3PzdOQCIbmqfJ5zzNFOrxUzGHQGP9s0abh1DZOTApLkIAbo\ncyrWl8frrRA+ePUJ99cSov8xd0XZ+r1XM4FmctOVr52nEuCOCxmvY2fa4iJI\n8CaK\r\n=9YpT\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.1.0": {
+      "name": "duplexify",
+      "version": "4.1.0",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-30gnPrBwCIjXLKHz8SyIIyv4JLEneQKFQcyfhPZxd/e2O3qi0kq/k9AEksUuTsrRmpGJTHwWO7o/sM92K7P4Rw==",
+        "shasum": "b26c51659c83cb03d78c3e70acef202dede7c031",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18154,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/49VCRA9TVsSAnZWagAAKFgP/1EO4Kny9+l9yF3JfJe7\n796HuV1BomEix1tH4HaywixbcE93pYUvq6/iX0TrMZ1iR1dcLnqOvND35z+9\nc+b0w7WgBhQt8FIrPVXtFKliz+KbQUeqZH4ZAO9QkJxf1hvv3h3pwdAkFJQL\n7KdmIRcaci0//bXctnXGxs9VYJcKGu4lzDDk29h0U40n47zybAmrN2944jY5\nUPTv1MruZ6QGyjm9jDfqPYyPGG1XzzPdLp/WS5m6KtGJ0rPqllwa/QDaPopu\nsaejN5OaB1Qur3QQT8gCR+SUqgVcKIHCb71wUddCGyPdS2it2wcvVfHCseFo\n72yTiF2pU8qGK8E/ndBL4PFDNzgSH+IzzPmQjussEymjq8pPHHf1bBT3pvCe\ncNGKfzhbeDI1iWFmn82ry9qRm5Gk25aXdQ3fOKn7QaVhC/VGgLYh7MBczsG7\nQtkLBGWGIzLptIRWf93nIaMwUaN1bsZLCabS+kbdAeO5++pTlnrYPBnMBLN4\nNhFz1W56p2+I62c1ckZMlQ5zKpJNA5eZ04zg+XTiQONVJyo/L9dRgil3KUQr\nnadtUW2iOOMkhXwotCKQCFVN5Khf1xprxDxQ14K6CIui7PqvwGclI1pxf2Hb\nXXXufrk5l5huIzAdWLcKEJzxUw+wL93UgXo+9cNFaDoBU/FNqzyZAeYGlXuA\nINkE\r\n=vLGs\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.1.1": {
+      "name": "duplexify",
+      "version": "4.1.1",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.5.2",
+        "tape": "^4.0.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-DY3xVEmVHTv1wSzKNbwoU6nVjzI369Y6sPoqfYr0/xlx3IdX2n94xIszTcjPO8W8ZIv0Wb0PXNcjuZyT4wiICA==",
+        "shasum": "7027dc374f157b122a8ae08c2d3ea4d2d953aa61",
+        "tarball": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 18227,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAVyzCRA9TVsSAnZWagAABAIP/2WSr6iuUAkcr9rky3rA\nQ+CQXr0z4JnN2+rGPDpGmBDC/SyKutY5dSMcIWP8gYFdIFY9+yThDpfaJP7N\nAaplhjnVFYA/k0Wt4kOWiRlfgvQUal/QV7y6vHgZG7K3NJ4mGfMC/WNTa84c\nL6F0Ydc9WWplBT1XTg4IPmoqNWNYHKeEsXg29df8mL8UNZWCx4dNKQJac+VI\n7Z1yZVIiiRao8zreg/WwaNin7iJ/hl2Mewhed9sDbj24B040BgOjWieEKnv6\neCtW6NEvFY+RsjX9eP3eA51UJMtKhionf4kJGr6op03yK/UTihrfJFVMSKZ3\nc7R384iCKGBcloMnrHgX+RPrDl5rMSHejgctaW5wjScj3XRhm/XmyHGd3NCo\nxdEo4uqNsN3FeLznLDoKkNped+kPN1B+cYmTVG415fTPxZVUAcotSXHJ/nLZ\nYGbC68+vc+zdeyJSeDopcSeUrIpuXNuX0dEsxChWd+8LpsgSWzOWzvMCZMXh\n6+WxI6wDpHZ6m2r0MzxKnyEcrgSNG9yjju6VtSNGNClNzx7GKW1qJJiIetAN\ngt8mHiOQP+kI+qZMcZlashvxx9yZ+t14REjOsXMRQAVJRcP3GkK9X9vARNSK\nrt7uDQEYgVp9NT+ADhY9zpuFp2vM/NabIcmunhSFJb2PteoIsUKOjEE3FsDw\nmOOj\r\n=WFSw\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-06-12T20:12:37.758Z"
+}

--- a/test/fixtures/registry-mocks/content/ee-first.json
+++ b/test/fixtures/registry-mocks/content/ee-first.json
@@ -1,0 +1,496 @@
+{
+  "_id": "ee-first",
+  "_rev": "22-990712b104a4beb0b4974a5d1607ec96",
+  "name": "ee-first",
+  "description": "return the first event in a set of ee/event pairs",
+  "dist-tags": {
+    "latest": "1.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "ee-first",
+      "description": "return the first event in a set of ee/event pairs",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonathanong/ee-first"
+      },
+      "devDependencies": {
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/jonathanong/ee-first/issues"
+      },
+      "homepage": "https://github.com/jonathanong/ee-first",
+      "_id": "ee-first@1.0.0",
+      "_shasum": "f06454b54ed5921b51011c6b2f45e2f383ca6ea2",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f06454b54ed5921b51011c6b2f45e2f383ca6ea2",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "ee-first",
+      "description": "return the first event in a set of ee/event pairs",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonathanong/ee-first"
+      },
+      "dependencies": {
+        "sliced": "0"
+      },
+      "devDependencies": {
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/jonathanong/ee-first/issues"
+      },
+      "homepage": "https://github.com/jonathanong/ee-first",
+      "_id": "ee-first@1.0.1",
+      "_shasum": "8d5e4fdba0f4a7cb8e790731cd275f938ee42f59",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8d5e4fdba0f4a7cb8e790731cd275f938ee42f59",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "ee-first",
+      "description": "return the first event in a set of ee/event pairs",
+      "version": "1.0.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonathanong/ee-first"
+      },
+      "devDependencies": {
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/jonathanong/ee-first/issues"
+      },
+      "homepage": "https://github.com/jonathanong/ee-first",
+      "_id": "ee-first@1.0.2",
+      "_shasum": "775dd7c8ed52233f2339563ae4d33c9a9cb2be3c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "775dd7c8ed52233f2339563ae4d33c9a9cb2be3c",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "ee-first",
+      "description": "return the first event in a set of ee/event pairs",
+      "version": "1.0.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonathanong/ee-first"
+      },
+      "devDependencies": {
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/jonathanong/ee-first/issues"
+      },
+      "homepage": "https://github.com/jonathanong/ee-first",
+      "_id": "ee-first@1.0.3",
+      "_shasum": "6c98c4089abecb5a7b85c1ac449aa603d3b3dabe",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6c98c4089abecb5a7b85c1ac449aa603d3b3dabe",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "ee-first",
+      "description": "return the first event in a set of ee/event pairs",
+      "version": "1.0.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonathanong/ee-first"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "1"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "fbd53b0166f23d7712d551c4dd01673f87a74e88",
+      "bugs": {
+        "url": "https://github.com/jonathanong/ee-first/issues"
+      },
+      "homepage": "https://github.com/jonathanong/ee-first",
+      "_id": "ee-first@1.0.4",
+      "_shasum": "44dbff0250fe667e8a042ec445afd1a9c4a1aeb2",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "44dbff0250fe667e8a042ec445afd1a9c4a1aeb2",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "ee-first",
+      "description": "return the first event in a set of ee/event pairs",
+      "version": "1.0.5",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonathanong/ee-first"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "1"
+      },
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "c9d9a6881863c0d2fcc2e4ac99a170088c205304",
+      "bugs": {
+        "url": "https://github.com/jonathanong/ee-first/issues"
+      },
+      "homepage": "https://github.com/jonathanong/ee-first",
+      "_id": "ee-first@1.0.5",
+      "_shasum": "8c9b212898d8cd9f1a9436650ce7be202c9e9ff0",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8c9b212898d8cd9f1a9436650ce7be202c9e9ff0",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "ee-first",
+      "description": "return the first event in a set of ee/event pairs",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonathanong/ee-first"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "1"
+      },
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "a6412004da4745941af2fc98ec30c8da570da7ea",
+      "bugs": {
+        "url": "https://github.com/jonathanong/ee-first/issues"
+      },
+      "homepage": "https://github.com/jonathanong/ee-first",
+      "_id": "ee-first@1.1.0",
+      "_shasum": "6a0d7c6221e490feefd92ec3f441c9ce8cd097f4",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6a0d7c6221e490feefd92ec3f441c9ce8cd097f4",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "ee-first",
+      "description": "return the first event in a set of ee/event pairs",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonathanong/ee-first"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5"
+      },
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "512e0ce4cc3643f603708f965a97b61b1a9c0441",
+      "bugs": {
+        "url": "https://github.com/jonathanong/ee-first/issues"
+      },
+      "homepage": "https://github.com/jonathanong/ee-first",
+      "_id": "ee-first@1.1.1",
+      "_shasum": "590c61156b0ae2f4f0255732a158b266bc56b21d",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "590c61156b0ae2f4f0255732a158b266bc56b21d",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# EE First\n\n[![NPM version][npm-image]][npm-url]\n[![Build status][travis-image]][travis-url]\n[![Test coverage][coveralls-image]][coveralls-url]\n[![License][license-image]][license-url]\n[![Downloads][downloads-image]][downloads-url]\n[![Gittip][gittip-image]][gittip-url]\n\nGet the first event in a set of event emitters and event pairs,\nthen clean up after itself.\n\n## Install\n\n```sh\n$ npm install ee-first\n```\n\n## API\n\n```js\nvar first = require('ee-first')\n```\n\n### first(arr, listener)\n\nInvoke `listener` on the first event from the list specified in `arr`. `arr` is\nan array of arrays, with each array in the format `[ee, ...event]`. `listener`\nwill be called only once, the first time any of the given events are emitted. If\n`error` is one of the listened events, then if that fires first, the `listener`\nwill be given the `err` argument.\n\nThe `listener` is invoked as `listener(err, ee, event, args)`, where `err` is the\nfirst argument emitted from an `error` event, if applicable; `ee` is the event\nemitter that fired; `event` is the string event name that fired; and `args` is an\narray of the arguments that were emitted on the event.\n\n```js\nvar ee1 = new EventEmitter()\nvar ee2 = new EventEmitter()\n\nfirst([\n  [ee1, 'close', 'end', 'error'],\n  [ee2, 'error']\n], function (err, ee, event, args) {\n  // listener invoked\n})\n```\n\n#### .cancel()\n\nThe group of listeners can be cancelled before being invoked and have all the event\nlisteners removed from the underlying event emitters.\n\n```js\nvar thunk = first([\n  [ee1, 'close', 'end', 'error'],\n  [ee2, 'error']\n], function (err, ee, event, args) {\n  // listener invoked\n})\n\n// cancel and clean up\nthunk.cancel()\n```\n\n[npm-image]: https://img.shields.io/npm/v/ee-first.svg?style=flat-square\n[npm-url]: https://npmjs.org/package/ee-first\n[github-tag]: http://img.shields.io/github/tag/jonathanong/ee-first.svg?style=flat-square\n[github-url]: https://github.com/jonathanong/ee-first/tags\n[travis-image]: https://img.shields.io/travis/jonathanong/ee-first.svg?style=flat-square\n[travis-url]: https://travis-ci.org/jonathanong/ee-first\n[coveralls-image]: https://img.shields.io/coveralls/jonathanong/ee-first.svg?style=flat-square\n[coveralls-url]: https://coveralls.io/r/jonathanong/ee-first?branch=master\n[license-image]: http://img.shields.io/npm/l/ee-first.svg?style=flat-square\n[license-url]: LICENSE.md\n[downloads-image]: http://img.shields.io/npm/dm/ee-first.svg?style=flat-square\n[downloads-url]: https://npmjs.org/package/ee-first\n[gittip-image]: https://img.shields.io/gittip/jonathanong.svg?style=flat-square\n[gittip-url]: https://www.gittip.com/jonathanong/\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "jongleberry",
+      "email": "jonathanrichardong@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2016-11-01T17:18:18.975Z",
+    "created": "2014-06-11T01:31:59.902Z",
+    "1.0.0": "2014-06-11T01:31:59.902Z",
+    "1.0.1": "2014-06-11T01:50:57.486Z",
+    "1.0.2": "2014-06-11T03:50:16.688Z",
+    "1.0.3": "2014-06-11T04:22:46.000Z",
+    "1.0.4": "2014-08-15T20:04:59.878Z",
+    "1.0.5": "2014-08-15T21:20:58.889Z",
+    "1.1.0": "2014-10-22T05:53:29.380Z",
+    "1.1.1": "2015-05-25T19:18:28.732Z"
+  },
+  "homepage": "https://github.com/jonathanong/ee-first",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jonathanong/ee-first"
+  },
+  "author": {
+    "name": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com"
+  },
+  "bugs": {
+    "url": "https://github.com/jonathanong/ee-first/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "users": {
+    "zhangyaochun": true,
+    "bapinney": true,
+    "monjer": true,
+    "mojaray2k": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/ee-first.min.json
+++ b/test/fixtures/registry-mocks/content/ee-first.min.json
@@ -1,0 +1,104 @@
+{
+  "name": "ee-first",
+  "dist-tags": {
+    "latest": "1.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "ee-first",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "f06454b54ed5921b51011c6b2f45e2f383ca6ea2",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "ee-first",
+      "version": "1.0.1",
+      "dependencies": {
+        "sliced": "0"
+      },
+      "devDependencies": {
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "8d5e4fdba0f4a7cb8e790731cd275f938ee42f59",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "ee-first",
+      "version": "1.0.2",
+      "devDependencies": {
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "775dd7c8ed52233f2339563ae4d33c9a9cb2be3c",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "ee-first",
+      "version": "1.0.3",
+      "devDependencies": {
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "6c98c4089abecb5a7b85c1ac449aa603d3b3dabe",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "ee-first",
+      "version": "1.0.4",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "44dbff0250fe667e8a042ec445afd1a9c4a1aeb2",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "ee-first",
+      "version": "1.0.5",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "8c9b212898d8cd9f1a9436650ce7be202c9e9ff0",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "ee-first",
+      "version": "1.1.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "6a0d7c6221e490feefd92ec3f441c9ce8cd097f4",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "ee-first",
+      "version": "1.1.1",
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5"
+      },
+      "dist": {
+        "shasum": "590c61156b0ae2f4f0255732a158b266bc56b21d",
+        "tarball": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      }
+    }
+  },
+  "modified": "2016-11-01T17:18:18.975Z"
+}

--- a/test/fixtures/registry-mocks/content/elliptic.json
+++ b/test/fixtures/registry-mocks/content/elliptic.json
@@ -1,0 +1,5222 @@
+{
+  "_id": "elliptic",
+  "_rev": "151-74236c4c7d4c7201565122d194714176",
+  "name": "elliptic",
+  "description": "EC cryptography",
+  "dist-tags": {
+    "latest": "6.5.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "elliptic",
+      "version": "0.1.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "elliptic@0.1.0",
+      "_shasum": "25c28f157470efe8fbccc290bf30261e28777dcd",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "25c28f157470efe8fbccc290bf30261e28777dcd",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "elliptic",
+      "version": "0.2.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "_id": "elliptic@0.2.0",
+      "_shasum": "bedbb8376437d8b7f139610d33cef4f76b5a0cd2",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bedbb8376437d8b7f139610d33cef4f76b5a0cd2",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "elliptic",
+      "version": "0.3.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "_id": "elliptic@0.3.0",
+      "_shasum": "32167b06a350390a58beaaad9c245c35434614f6",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "32167b06a350390a58beaaad9c245c35434614f6",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "elliptic",
+      "version": "0.4.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "hash.js": "^0.1.0"
+      },
+      "_id": "elliptic@0.4.0",
+      "_shasum": "6f318c44c9108eea4f52625b971442fbdfc52285",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6f318c44c9108eea4f52625b971442fbdfc52285",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "elliptic",
+      "version": "0.5.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.1.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.5.0",
+      "_shasum": "d66122e6e8a22024ec57cd91840f028012f87283",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d66122e6e8a22024ec57cd91840f028012f87283",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "elliptic",
+      "version": "0.6.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.1.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.6.0",
+      "_shasum": "f624887ebd068e7706f758c2f37e3c7db38f2789",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f624887ebd068e7706f758c2f37e3c7db38f2789",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "elliptic",
+      "version": "0.6.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.1.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.6.1",
+      "_shasum": "545c229f029ba75fb1d89f3997194ffca5d7a25f",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "545c229f029ba75fb1d89f3997194ffca5d7a25f",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "elliptic",
+      "version": "0.7.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.2.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.7.0",
+      "_shasum": "df438baaac83a4e2a45f82bd478a854f6c569f0b",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "df438baaac83a4e2a45f82bd478a854f6c569f0b",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "elliptic",
+      "version": "0.8.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.3.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.8.0",
+      "_shasum": "67658dd7ff907dfae3bd7df9bafcc7d9b8c6fe3a",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "67658dd7ff907dfae3bd7df9bafcc7d9b8c6fe3a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "elliptic",
+      "version": "0.9.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.3.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.9.0",
+      "_shasum": "715b3dfc66182988ce3cd03d6a762c24d0443754",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "715b3dfc66182988ce3cd03d6a762c24d0443754",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.1": {
+      "name": "elliptic",
+      "version": "0.9.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.3.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.9.1",
+      "_shasum": "5404b4cf62301557604895f82a8466da3617059e",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5404b4cf62301557604895f82a8466da3617059e",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.2": {
+      "name": "elliptic",
+      "version": "0.9.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.3.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.9.2",
+      "_shasum": "9a0117f7ffdee38646538f3313fcc606d8ad5d40",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9a0117f7ffdee38646538f3313fcc606d8ad5d40",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.9.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "elliptic",
+      "version": "0.10.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.4.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.10.0",
+      "_shasum": "6b9bf2c5daf083a15c1bd4fcefa56f56a51d1327",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6b9bf2c5daf083a15c1bd4fcefa56f56a51d1327",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.1": {
+      "name": "elliptic",
+      "version": "0.10.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.4.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.10.1",
+      "_shasum": "efd9cef24e3b710fb1f1cb5080d08538870d153c",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "efd9cef24e3b710fb1f1cb5080d08538870d153c",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.2": {
+      "name": "elliptic",
+      "version": "0.10.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.4.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.10.2",
+      "_shasum": "5bd5ccf61f259b71232b996b9cdca9c4ba53523c",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5bd5ccf61f259b71232b996b9cdca9c4ba53523c",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.10.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "elliptic",
+      "version": "0.11.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.5.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.11.0",
+      "_shasum": "e82e434e9405cf53f0cf4510ac2cf4759c79a278",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e82e434e9405cf53f0cf4510ac2cf4759c79a278",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.11.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.1": {
+      "name": "elliptic",
+      "version": "0.11.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.5.4",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.11.1",
+      "_shasum": "2407c5e7199bf935d457c816b291149fa05a95b4",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2407c5e7199bf935d457c816b291149fa05a95b4",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.11.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.12.0": {
+      "name": "elliptic",
+      "version": "0.12.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.6.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.12.0",
+      "_shasum": "a3e31678e743f036f23d17d5917166501403f841",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a3e31678e743f036f23d17d5917166501403f841",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.12.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.1": {
+      "name": "elliptic",
+      "version": "0.13.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.7.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.13.1",
+      "_shasum": "b60844bea509c92e70af60068ce71ed386225651",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b60844bea509c92e70af60068ce71ed386225651",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.13.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.2": {
+      "name": "elliptic",
+      "version": "0.13.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.8.0",
+        "hash.js": "^0.2.0"
+      },
+      "_id": "elliptic@0.13.2",
+      "_shasum": "d5b61a076464f06741faf6d261f2df3a5662763d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d5b61a076464f06741faf6d261f2df3a5662763d",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.13.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.14.0": {
+      "name": "elliptic",
+      "version": "0.14.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.10.0",
+        "hash.js": "^0.2.0",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.14.0",
+      "_shasum": "eef663a2252ef2418da671955e1ca4691acfce47",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "eef663a2252ef2418da671955e1ca4691acfce47",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.14.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.14.1": {
+      "name": "elliptic",
+      "version": "0.14.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.10.0",
+        "hash.js": "^0.2.0",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.14.1",
+      "_shasum": "ea2c26aecf7e31938138ab6453f68b9511d69159",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ea2c26aecf7e31938138ab6453f68b9511d69159",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.14.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.14.2": {
+      "name": "elliptic",
+      "version": "0.14.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.10.1",
+        "hash.js": "^0.2.0",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.14.2",
+      "_shasum": "d0774db33dc958b3c426620b75586091b6c96d2c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d0774db33dc958b3c426620b75586091b6c96d2c",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.14.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.0": {
+      "name": "elliptic",
+      "version": "0.15.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.2",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.15.0",
+      "_shasum": "c55a184c3379563b45f36a78b5fe33914de72bd2",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c55a184c3379563b45f36a78b5fe33914de72bd2",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.1": {
+      "name": "elliptic",
+      "version": "0.15.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.2",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.15.1",
+      "_shasum": "40b70e9859c8744cdf5be85a7c1af8d749980e04",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "40b70e9859c8744cdf5be85a7c1af8d749980e04",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.2": {
+      "name": "elliptic",
+      "version": "0.15.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.2",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.15.2",
+      "_shasum": "0ae5f2fb19db51989e5a8abf1c525037941c934a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0ae5f2fb19db51989e5a8abf1c525037941c934a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.3": {
+      "name": "elliptic",
+      "version": "0.15.3",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.5",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.15.3",
+      "_shasum": "02ae691992646e6086152411d757fd08e422efe7",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "02ae691992646e6086152411d757fd08e422efe7",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.4": {
+      "name": "elliptic",
+      "version": "0.15.4",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.5",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.15.4",
+      "_shasum": "fb7ea8778d995c7e5a8927273f3e0b08e7353c5f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fb7ea8778d995c7e5a8927273f3e0b08e7353c5f",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.5": {
+      "name": "elliptic",
+      "version": "0.15.5",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.15.5",
+      "_shasum": "ca8c77805e99b5483251caaf71396d1d5bdae250",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ca8c77805e99b5483251caaf71396d1d5bdae250",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.6": {
+      "name": "elliptic",
+      "version": "0.15.6",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.15.6",
+      "_shasum": "5a82f941000e5daab7fb98987d70410cd42f0065",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5a82f941000e5daab7fb98987d70410cd42f0065",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.7": {
+      "name": "elliptic",
+      "version": "0.15.7",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "_id": "elliptic@0.15.7",
+      "_shasum": "33a3cfb88eeeeb04f0bbd06040f2cfc2fba93d2a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "33a3cfb88eeeeb04f0bbd06040f2cfc2fba93d2a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.8": {
+      "name": "elliptic",
+      "version": "0.15.8",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "2f0a0b193308f40f7d43006ec8b5bf0743a25752",
+      "_id": "elliptic@0.15.8",
+      "_shasum": "14046870b5d5261438f59b3c174693a89d976a85",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "14046870b5d5261438f59b3c174693a89d976a85",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.8.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.9": {
+      "name": "elliptic",
+      "version": "0.15.9",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "d04e686825113844cf073895e8840645c1de3d35",
+      "_id": "elliptic@0.15.9",
+      "_shasum": "009fcc41fb3d5a111afb527f7fb3bb267f905bc7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "009fcc41fb3d5a111afb527f7fb3bb267f905bc7",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.9.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.10": {
+      "name": "elliptic",
+      "version": "0.15.10",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "a92e9c75590b7913f06d31b16c9f550ddda5f2b6",
+      "_id": "elliptic@0.15.10",
+      "_shasum": "b60abd01bc4b7908e01eef3b93bddf6f5775e267",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b60abd01bc4b7908e01eef3b93bddf6f5775e267",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.10.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.11": {
+      "name": "elliptic",
+      "version": "0.15.11",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.14.1",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "02faf054accde00a42446399fb9d3c04dcb83c8d",
+      "_id": "elliptic@0.15.11",
+      "_shasum": "37c5dab7fd714ee88c2178fcd2ef2216d2f31809",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "37c5dab7fd714ee88c2178fcd2ef2216d2f31809",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.11.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.12": {
+      "name": "elliptic",
+      "version": "0.15.12",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "637f0c2f24d3e514236942af457706aef0bc66f1",
+      "_id": "elliptic@0.15.12",
+      "_shasum": "bafa7542ebdb9aaa2edf7cdaa86108ce6f12d4e9",
+      "_from": ".",
+      "_npmVersion": "2.1.2",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bafa7542ebdb9aaa2edf7cdaa86108ce6f12d4e9",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.12.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.13": {
+      "name": "elliptic",
+      "version": "0.15.13",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "274e36de37c1be8f25425ba563bcde65213566fc",
+      "_id": "elliptic@0.15.13",
+      "_shasum": "918c6b833a9e7d8ad974027d02ac4912d025f2f4",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "918c6b833a9e7d8ad974027d02ac4912d025f2f4",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.13.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.14": {
+      "name": "elliptic",
+      "version": "0.15.14",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "e080857a1604369909d53f2f187a3b69eba113ed",
+      "_id": "elliptic@0.15.14",
+      "_shasum": "4d8cc82f030f9c7646ac60a729f0f793e083be6e",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4d8cc82f030f9c7646ac60a729f0f793e083be6e",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.14.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.15": {
+      "name": "elliptic",
+      "version": "0.15.15",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "4bf1f50607285bff4ae19521217dbc801c3d36af",
+      "_id": "elliptic@0.15.15",
+      "_shasum": "63269184a856d6e00871e84f37a8401ff84e4aea",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "63269184a856d6e00871e84f37a8401ff84e4aea",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.15.tgz"
+      },
+      "directories": {}
+    },
+    "0.15.17": {
+      "name": "elliptic",
+      "version": "0.15.17",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "e8c243a4bdbddb7220607b504a0f8ecfff48918d",
+      "_id": "elliptic@0.15.17",
+      "_shasum": "43f2bc8046c838df1ac99e5242da1b1b4bc59937",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43f2bc8046c838df1ac99e5242da1b1b4bc59937",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.17.tgz"
+      },
+      "directories": {}
+    },
+    "0.16.0": {
+      "name": "elliptic",
+      "version": "0.16.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^0.3.2",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "be0e860d9b2443ae5dd98c5128925b922f9e6c28",
+      "_id": "elliptic@0.16.0",
+      "_shasum": "9bc84e75ccd97e3e452c97371726c535314d1a57",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9bc84e75ccd97e3e452c97371726c535314d1a57",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.16.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "elliptic",
+      "version": "1.0.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "aaf14882e64fc7dedd4613d7e08cfa7fff303fe6",
+      "_id": "elliptic@1.0.0",
+      "_shasum": "28d927ae8c16c6f65e452a714b36da4095603e39",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "28d927ae8c16c6f65e452a714b36da4095603e39",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "elliptic",
+      "version": "1.0.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "17dc013761dd1efcfb868e2b06b0b897627b40be",
+      "_id": "elliptic@1.0.1",
+      "_shasum": "d180376b66a17d74995c837796362ac4d22aefe3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d180376b66a17d74995c837796362ac4d22aefe3",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "elliptic",
+      "version": "2.0.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "3bba0ba2c3d28e5698afc86850ec70334d6dbafd",
+      "_id": "elliptic@2.0.0",
+      "_shasum": "5c237269b13af8aa2dbf663f265df7e2cc521774",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "1.0.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5c237269b13af8aa2dbf663f265df7e2cc521774",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "elliptic",
+      "version": "2.0.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "3dc8d7deace15773c379083eadb220252108fe0e",
+      "_id": "elliptic@2.0.1",
+      "_shasum": "58814b471e011eaf7e42fa444fdffcfc0d3de8df",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "1.0.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "58814b471e011eaf7e42fa444fdffcfc0d3de8df",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "elliptic",
+      "version": "2.0.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^1.2.4",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "d459a0ef6318340399d9fe2533118255aa35c5cc",
+      "_id": "elliptic@2.0.2",
+      "_shasum": "5891ba666d3103ddf311b14ec5de3fca74402afd",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5891ba666d3103ddf311b14ec5de3fca74402afd",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "elliptic",
+      "version": "3.0.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "6a6c943a3fe1d0ca6529dbb49816e81c4a8ce16c",
+      "_id": "elliptic@3.0.1",
+      "_shasum": "831c923399aeffb50766af1b05fdf71eba60acbf",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "831c923399aeffb50766af1b05fdf71eba60acbf",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "elliptic",
+      "version": "3.0.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "2713e49ab3f643b9db5dab9eadc762ff7073f267",
+      "_id": "elliptic@3.0.2",
+      "_shasum": "fc07233e8bd1c1a108cb0997fa6757c7b1a7c0bc",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fc07233e8bd1c1a108cb0997fa6757c7b1a7c0bc",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.3": {
+      "name": "elliptic",
+      "version": "3.0.3",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/elliptic"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "c8d7cf551fdf2ce3ecc5264b29084244ae6aa2b2",
+      "_id": "elliptic@3.0.3",
+      "_shasum": "865c9b420bfbe55006b9f969f97a0d2c44966595",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "1.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "865c9b420bfbe55006b9f969f97a0d2c44966595",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.4": {
+      "name": "elliptic",
+      "version": "3.0.4",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "dfef517a0dcf145faec353fb88fdee6646d95ad4",
+      "_id": "elliptic@3.0.4",
+      "_shasum": "67dbcf68dd1e843eef77b0b05376bd1db4f92f5e",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "67dbcf68dd1e843eef77b0b05376bd1db4f92f5e",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "elliptic",
+      "version": "3.1.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.3",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "d86cd2a8178f7e7cecbd6dd92eea084e2ab44c13",
+      "_id": "elliptic@3.1.0",
+      "_shasum": "c21682ef762769b56a74201609105da11d5f60cc",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c21682ef762769b56a74201609105da11d5f60cc",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "elliptic",
+      "version": "4.0.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^2.1.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "e3e2bc5374b25b8169369252e3bd3ef5732c7972",
+      "_id": "elliptic@4.0.0",
+      "_shasum": "32976ad71b274c1111d82f895837dac8ea45c073",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "32976ad71b274c1111d82f895837dac8ea45c073",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-4.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.1.0": {
+      "name": "elliptic",
+      "version": "4.1.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^2.1.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "e4f2675e2cb2c7a5c4a0187d0e18db18470799b0",
+      "_id": "elliptic@4.1.0",
+      "_shasum": "1a660618d3d09190200149cbe0452e6a5bbe08d7",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1a660618d3d09190200149cbe0452e6a5bbe08d7",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-4.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "elliptic",
+      "version": "5.0.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^3.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "397d5f72750a55ce1a6497965f5ad17f0aa299cb",
+      "_id": "elliptic@5.0.0",
+      "_shasum": "1bdd76d5f560da765cf0ba38243f8f4481ebe01c",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1bdd76d5f560da765cf0ba38243f8f4481ebe01c",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-5.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "5.1.0": {
+      "name": "elliptic",
+      "version": "5.1.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^3.1.1",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "4f12b8f6bcb16e38d4a038af2d963dc10d175bde",
+      "_id": "elliptic@5.1.0",
+      "_shasum": "5658dfa7625a6a8fc687a5b8f249376bb271e6e9",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5658dfa7625a6a8fc687a5b8f249376bb271e6e9",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-5.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "5.2.0": {
+      "name": "elliptic",
+      "version": "5.2.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^3.1.1",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "742c61edd9687c672ea378ea8209cefbcf962ea9",
+      "_id": "elliptic@5.2.0",
+      "_shasum": "123fd155fd6637e57e416d95ac803c9fe7cb95bc",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "123fd155fd6637e57e416d95ac803c9fe7cb95bc",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.2.1": {
+      "name": "elliptic",
+      "version": "5.2.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^3.1.1",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "676db36e64399e5b4c0e31ae5aa4cdf8e8362014",
+      "_id": "elliptic@5.2.1",
+      "_shasum": "fa294b6563c6ddbc9ba3dc8594687ae840858f10",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "fa294b6563c6ddbc9ba3dc8594687ae840858f10",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.0.0": {
+      "name": "elliptic",
+      "version": "6.0.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "2477fae5cd1d0fe7adb546ad16ff6bfb8268b4ca",
+      "_id": "elliptic@6.0.0",
+      "_shasum": "c48120001e5d9c26fd5e5ed05361f09b0e838106",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "c48120001e5d9c26fd5e5ed05361f09b0e838106",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.0.1": {
+      "name": "elliptic",
+      "version": "6.0.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "a9eb628eec9a2f562e67947c5417e9b2435d0a2d",
+      "_id": "elliptic@6.0.1",
+      "_shasum": "91d573ecb2a3c274b8c07e0d1f35ff19f07e6978",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "91d573ecb2a3c274b8c07e0d1f35ff19f07e6978",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.0.2": {
+      "name": "elliptic",
+      "version": "6.0.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "330106da186712d228d79bc71ae8e7e68565fa9d",
+      "_id": "elliptic@6.0.2",
+      "_shasum": "219b96cd92aa9885d91d31c1fd42eaa5eb4483a9",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "219b96cd92aa9885d91d31c1fd42eaa5eb4483a9",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.1.0": {
+      "name": "elliptic",
+      "version": "6.1.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "b465fea90447f3b6c0b3f55e5fd6ecdedc1282f2",
+      "_id": "elliptic@6.1.0",
+      "_shasum": "68130e03823b4ce024955ad1be195e148099d654",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "68130e03823b4ce024955ad1be195e148099d654",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.2.0": {
+      "name": "elliptic",
+      "version": "6.2.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "6d25d373141cade9f71404cc18a2b407849bd418",
+      "_id": "elliptic@6.2.0",
+      "_shasum": "695e7233fee853883f19d6c103c3cffdb1527e12",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "695e7233fee853883f19d6c103c3cffdb1527e12",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.2.1": {
+      "name": "elliptic",
+      "version": "6.2.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "a706516830ff575b540953dda154a1f83d010314",
+      "_id": "elliptic@6.2.1",
+      "_shasum": "72ade423d4144e967446cc2bfbed4d088d154e71",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "72ade423d4144e967446cc2bfbed4d088d154e71",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.2.2": {
+      "name": "elliptic",
+      "version": "6.2.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "make lint && istanbul test _mocha --reporter=spec test/*-test.js",
+        "coveralls": "cat ./coverage/lcov.info | coveralls"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "628eb61186a7f1c81247cf991d808dc9ead83645",
+      "_id": "elliptic@6.2.2",
+      "_shasum": "806bfa651a5aa4996a1e79c92b573761ea7d7574",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "806bfa651a5aa4996a1e79c92b573761ea7d7574",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.2.3": {
+      "name": "elliptic",
+      "version": "6.2.3",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "coverage": "npm run unit --coverage",
+        "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls",
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/*.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/*.js",
+        "lint": "npm run jscs && npm run jshint",
+        "test": "npm run lint && npm run unit",
+        "unit": "istanbul test _mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "c32f20b22b420eb6af3c6dda28963deb7facf823",
+      "_id": "elliptic@6.2.3",
+      "_shasum": "18e46d7306b0951275a2d42063270a14b74ebe99",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "18e46d7306b0951275a2d42063270a14b74ebe99",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "6.2.4": {
+      "name": "elliptic",
+      "version": "6.2.4",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "de388fb57550940624eb421feb2d7d7f24087f13",
+      "_id": "elliptic@6.2.4",
+      "_shasum": "f8a8917c3024233ac37d8901e17cca425851c7d8",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "f8a8917c3024233ac37d8901e17cca425851c7d8",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.2.4.tgz_1463780933643_0.6566972529981285"
+      },
+      "directories": {}
+    },
+    "6.2.5": {
+      "name": "elliptic",
+      "version": "6.2.5",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "fa5ffdc2d008fd6b1eb6e34864c977ea2748b7ce",
+      "_id": "elliptic@6.2.5",
+      "_shasum": "24846340477dfce75c56b8ff4b1d6d6ec258e06a",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "24846340477dfce75c56b8ff4b1d6d6ec258e06a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.2.5.tgz_1463781139171_0.8202476925216615"
+      },
+      "directories": {}
+    },
+    "6.2.6": {
+      "name": "elliptic",
+      "version": "6.2.6",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "0d7910d46075c31325838d35cb0685f449f32868",
+      "_id": "elliptic@6.2.6",
+      "_shasum": "f3f9371440a4af3ee459460a8078d65ad7f9a581",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "f3f9371440a4af3ee459460a8078d65ad7f9a581",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.2.6.tgz_1464201676702_0.483377248281613"
+      },
+      "directories": {}
+    },
+    "6.2.7": {
+      "name": "elliptic",
+      "version": "6.2.7",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "6a8ef1457bb8f45102d6678fc1095165f77d55d3",
+      "_id": "elliptic@6.2.7",
+      "_shasum": "dce82efbf176eefa7495d4be3e8b9f5b5694b295",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "dce82efbf176eefa7495d4be3e8b9f5b5694b295",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.2.7.tgz_1464201793202_0.12479878286831081"
+      },
+      "directories": {}
+    },
+    "6.2.8": {
+      "name": "elliptic",
+      "version": "6.2.8",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "236f37395bdf9e4af1dfc8e84f6353bce540b93e",
+      "_id": "elliptic@6.2.8",
+      "_shasum": "44a25b3d1550bebb74d0b6d22d89940206b51739",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "44a25b3d1550bebb74d0b6d22d89940206b51739",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.2.8.tgz_1464746004719_0.6379144776146859"
+      },
+      "directories": {}
+    },
+    "6.3.0": {
+      "name": "elliptic",
+      "version": "6.3.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "7b1c732b2370a44d39345f5c9087f42e70988590",
+      "_id": "elliptic@6.3.0",
+      "_shasum": "1b5e9eba9940f12a474651c712190d373bc8b21a",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "1b5e9eba9940f12a474651c712190d373bc8b21a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.3.0.tgz_1465877833597_0.14170785737223923"
+      },
+      "directories": {}
+    },
+    "6.3.1": {
+      "name": "elliptic",
+      "version": "6.3.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "c53f5cf3d832c0073eb4a4ed423a464cbce68f3e",
+      "_id": "elliptic@6.3.1",
+      "_shasum": "17781f2109ab0ec686b146bdcff5d2e8c6aeceda",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "17781f2109ab0ec686b146bdcff5d2e8c6aeceda",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.3.1.tgz_1465921413402_0.5202967382501811"
+      },
+      "directories": {}
+    },
+    "6.3.2": {
+      "name": "elliptic",
+      "version": "6.3.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "cbace4683a4a548dc0306ef36756151a20299cd5",
+      "_id": "elliptic@6.3.2",
+      "_shasum": "e4c81e0829cf0a65ab70e998b8232723b5c1bc48",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "e4c81e0829cf0a65ab70e998b8232723b5c1bc48",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.3.2.tgz_1473938837205_0.3108903462998569"
+      },
+      "directories": {}
+    },
+    "6.3.3": {
+      "name": "elliptic",
+      "version": "6.3.3",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "gitHead": "63aee8d697e9b7fac37ece24222029117a890a7e",
+      "_id": "elliptic@6.3.3",
+      "_shasum": "5482d9646d54bcb89fd7d994fc9e2e9568876e3f",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "5482d9646d54bcb89fd7d994fc9e2e9568876e3f",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.3.3.tgz_1486422837740_0.10658654430881143"
+      },
+      "directories": {}
+    },
+    "6.4.0": {
+      "name": "elliptic",
+      "version": "6.4.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "gitHead": "6b0d2b76caae91471649c8e21f0b1d3ba0f96090",
+      "_id": "elliptic@6.4.0",
+      "_shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/elliptic-6.4.0.tgz_1487798866428_0.30510620190761983"
+      },
+      "directories": {}
+    },
+    "6.4.1": {
+      "name": "elliptic",
+      "version": "6.4.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "gitHead": "523da1cf71ddcfd607fbdee1858bc2af47f0e700",
+      "_id": "elliptic@6.4.1",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+        "shasum": "c2d0b7776911b86722c632c3c06c60f2f819939a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118371,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJba7vUCRA9TVsSAnZWagAA+gcP/jWaj5GmDZ0YFi/X4g5O\nx+pxu9i3HbP9YqywT7rz3XFXSaytu0LQDeDEbddl523X69tsbKfzHRTcnW8n\n2r0VjPhttRm+0RpEhBwjSIK34VkQA1xIWh2ugOToKXVCFVLM5VFDPGzbiN6x\n/hpL7gj1hoCRVmuhjnqFQ+vPKACKfv1Eq4CsRmu2focmP37kQpWQlweD/z4V\nJF4NxA33Fvp13Fl+9g4sPHyhUVsW9ojVaG3Ijn70pCaGQM18UPlbODkWQ1QX\nAgteOFjkIOtcalJk3B3qsM8GZeHEcAFvt2T73miJkHdCGNmRQS45Ede+gnj0\nlLlZJsCCKUHtTqrlprHo6AgMnBZufmytyozYAHC1/JYniazSBi2yPHtQeniR\nl69BfiRBdD2rNrMPwmCNRkMqrgel5WMGpaD0xdaFAHF1Ru2ZQFKsA7KvPGgp\nA20+LN11cCib67Pg5XDyrZ92T3yXec+6gQ3iq9d9UBZKFGl0P8ebVqq1LrUJ\na6nekwMpRISWnKcqV72XVmQdBmUWHq9VfVLsWJzVIJqtpHmUO7q74ACP3i4W\n0/F1REeI0YEhh3NjeStdDecfjlu7PY0pLQpbk2I3ms+6DO+cAfeDEev5jFBK\nwQabRNhITeT1FVtxZAcApj33fnCdqwaWr1NS00K5ZRqhDTTzPr/O4KRN4CR1\npstU\r\n=UVBB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/elliptic_6.4.1_1533787091502_0.6309761823717674"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.5.0": {
+      "name": "elliptic",
+      "version": "6.5.0",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "gitHead": "475f066aebd14681591f0f0f18a2abc0ded8c390",
+      "_id": "elliptic@6.5.0",
+      "_nodeVersion": "12.2.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+        "shasum": "2b8ed4c891b7de3200e14412a5b8248c7af505ca",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118006,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdEu6jCRA9TVsSAnZWagAAJh4QAJXJ18MReidNMHrxFJGv\ngSONMB2uz0lWJ7eEUyggaCA/Tr6w4RBA6Ilne0Wou3jTAGou+GClpAde6Hkb\nEq1iq1brx+5gHeY3rGs8GB+T3c1JsVz+2t6934esXGM6IJNmG91TaCMSbuwQ\nTWHD62RxFylLYjffBIWt6KLximZnXcvAES0Qu7VUql1SlfvmGtaHlQAhvtLj\nG+ayBnSnWMcEvDPJdfnKi67PlGMa334spEmWzcqobFySr+y/ufiZRCp+wiSl\ndCwbFNMaH4fue+dhq1m7jGO/euFQvJw2Jf32zT/ToaM768nH8yHrrZ8lMRjs\ngCUymge8kbI5W1WA8wla7+J52Exbo6LbcBqSupVhVw6gXkOdjQCOkywBXa1c\nPiFxwOUSfdFATpkUi3/8serYCgv9NgGzvQ0rjej0//1+he6q7UUyKn9wyrdH\nMntmi18UgyQ8c1NrshKAOCb1oeniCEv7B1adfH2axH9uvMiVP8N5BMfAUNE1\nnkCD3lDXRz/7C+90DiI+h2MS3+az8ciqMTbpKlw3HrmUyCex+KvLq9+wNLGf\nyaJGd/r6NT0pu36v0M2+ul266/RbbY6D1ED/cl8gDZRFTT/SfTCkU+QAn2Mg\nfAlnn9BXogYR1XM1GNrnGUVkY7ngORiAGez5DU7P93jMpdSS9OtwAHHi1Oto\nbZ+X\r\n=LuMF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/elliptic_6.5.0_1561521826385_0.20848274510512943"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.5.1": {
+      "name": "elliptic",
+      "version": "6.5.1",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^3.0.4",
+        "grunt": "^1.0.4",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^9.0.1",
+        "istanbul": "^0.4.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.6.0",
+        "mocha": "^6.1.4"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "gitHead": "71e4e8e2f5b8f0bdbfbe106c72cc9fbc746d3d60",
+      "_id": "elliptic@6.5.1",
+      "_nodeVersion": "12.2.0",
+      "_npmVersion": "6.11.2",
+      "dist": {
+        "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+        "shasum": "c380f5f909bf1b9b4428d028cd18d3b0efd6b52b",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118051,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdbyK2CRA9TVsSAnZWagAAZR0P/jpSTQHkhgrh51Ql5iEp\nk19ZPvn6rvDRJdjPBgZfimuE8jYbzRrqEk0O8OJvWJAgBUz7RGcWsYjXEb0v\ncapOYnS9iL7EGmrZm/zIk2wB4K4vqbY1brh1WSGtZPJOotaTebfrepkUcqrk\nr2ZDg5YryX+gMD2QjumRSb3xXHbQukPvM9cc5WF5ZRaEzgQxRwtwwqzNejs1\np1DzKTNqBWzDGyl3NRdNPO8sEfcaf8LCyCu85OEFR1B7HytR1TH2B1uX7bNb\n82pw62BtmFbafa3VmFxeYk6Yqi5dHXUqsqLIGAsJJyaRsVOyLe/BuT7dHWgX\nEh8bQP4quLm2WZFIIRSUml4QXHiviMyUHfYITg05T/ODZejseHy65LYGgTsS\nQtsu+tDv+a4h+2FWNfkeVyinkEMNetlp+vPkSKVFeNLbCRFTR9ufgZqLn2IL\nnxpLdHLt9y6HaWDSSWwUwUYnK7WRiF8zP1cNRqZWyf7IPLHyRruwpkUFk9/u\nc6J3IgBQpgXfLxxXJTqqDvENmmMGtcJRWN0wtDLWNcYhm5f2px9m5vdxIj0U\nQn+6IZMgxTPsuA4w3iyagWbl/xtuEEw2XZUB++TztGfUtMImRFNEOqI3LO6V\n9CnJKpeVDPckXgDBwHJF9w6ywriLQKyR9rG8hl+nlonSbohg2hdQdB7TTeWJ\n1/J0\r\n=uYn+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/elliptic_6.5.1_1567564470143_0.35768573259267966"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.5.2": {
+      "name": "elliptic",
+      "version": "6.5.2",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^3.0.8",
+        "grunt": "^1.0.4",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^9.0.1",
+        "istanbul": "^0.4.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.10.3",
+        "mocha": "^6.2.2"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "gitHead": "60489415e545efdfd3010ae74b9726facbf08ca8",
+      "_id": "elliptic@6.5.2",
+      "_nodeVersion": "12.11.0",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+        "shasum": "05c5678d7173c049d8ca433552224a495d0e3762",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118072,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd2DHgCRA9TVsSAnZWagAAfx0P/RYZUDcD1KNqpERJSTgL\nlA3wXXXVB78IVwSy9laMD1GdDpsMy71PHjFMZL1NM2ZaZUUi7eiNaYf8sFrP\nQWadLsl3M2tkW6T4AkgxJXMEmbf3k9hCy+ZvRdWKJUF0g44WORvK2SNzDI/C\nIuBZ9xfTS5dZ3jZJOMZNZO4+PHzMQ/pzCGXafuuzsryPlcx0PvIN66xTRQbo\n/ByAl3lIK/C5HsFUkaSxcabcSmZrVuwDw8ciKGrBXjWkXAqLzO0u9HEczucP\n+RNNFvocrTB4ge/4yV4cdGSF7QXkzJ7hPqQgnhj0TrJO//qBERKXffQq91Hr\nU/xdUsX/dnIqpzpV81E36L+0VIxxg66/21ba4qlsho0i57v83Y6jLH3wFud4\n/LGzynTDiwySpREE9Gb3tnXSR3OuZstyJORQwEglAQIp7QcneqGOghNgY4am\nuFkM/6rAJi4tGw8uBn0tgRQZHtmy8XwNtuN/ShRoBzBayN2XVmJrApUxPpJK\nu+v3O0skLnpsXqgCpskrRK4dWtgkItxSZn91DZ219eGZvpFOgS8Jnb/bA07B\nZ7mGgM0B91Bc4ZbUGyGyv17j/p5fItlA0nqX6itwNjBI+BeYlenWXG3JfEjd\npteBvQyvxCHtcnc987HIm6VYGFvj1xlI7eLD4fQXPbuos0jbyEo2ndIU8jIT\nJVlS\r\n=BoXv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/elliptic_6.5.2_1574449632470_0.8146993695516966"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.5.3": {
+      "name": "elliptic",
+      "version": "6.5.3",
+      "description": "EC cryptography",
+      "main": "lib/elliptic.js",
+      "scripts": {
+        "jscs": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "jshint": "jscs benchmarks/*.js lib/*.js lib/**/*.js lib/**/**/*.js test/index.js",
+        "lint": "npm run jscs && npm run jshint",
+        "unit": "istanbul test _mocha --reporter=spec test/index.js",
+        "test": "npm run lint && npm run unit",
+        "version": "grunt dist && git add dist/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/elliptic.git"
+      },
+      "keywords": [
+        "EC",
+        "Elliptic",
+        "curve",
+        "Cryptography"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/elliptic/issues"
+      },
+      "homepage": "https://github.com/indutny/elliptic",
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^3.0.8",
+        "grunt": "^1.0.4",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^9.0.1",
+        "istanbul": "^0.4.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.10.3",
+        "mocha": "^6.2.2"
+      },
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "gitHead": "8647803dc3d90506aa03021737f7b061ba959ae1",
+      "_id": "elliptic@6.5.3",
+      "_nodeVersion": "13.9.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+        "shasum": "cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118531,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe64kfCRA9TVsSAnZWagAAnnEP/jFxX0m9YZshgdiItHkR\nVLy+kvaHKZyosZySjGqIXkJn9JQ2wzOt4YCKVyaRnrAlSxJm7D7x568Uq1fl\nOgIdY/t2VDgwgiOIYZ7RzpE4AKLnEw45LX4XvzXlQ6xxD8YV1J7AltlxYhNl\nIm8ofDd2zOTqwrRicnAUaVR0PoQwnLhKUsOaRUPSqP9WByDKq5qNjLb6Hcxi\nZVsZHaaIPQFzMah9Kxn8aAGGf9f8WizUq84qjJnL27ATTJsjrzku3V/elMvC\nljY7OtcWf+En6yZigHfK3eYVnYuZmpUmPmtP6+mcAcqnp2LDu+Tj0I0NUJjW\nbYIlOzutL1W5U6dSKwI8yi1OwR+NuXcJDu8b05cXpI2V85CbZ9uBu1uhloNY\nytwVzVkuZD1GifAjCMfe3Zjlha6KOvo5ASatWS1u9cxD887wuJA/rWpFMGgF\n/lkZASJzcij6gwDpSMmkpX3OJUE7xTrPv+8QBt7HBH22nqZm41l3HRFEH/3r\n/pkRGVI6MiyILzYHgQOo716Fbnj9u9NFXoeAcQm/fBDaaDTG/XYK34gmF2Iy\nRqbmsFNRoQ5HYbdIwHEzom2gkT8Zm9Gac+zUpIt+I/Z1wvvdai7K3VI9wHgw\n8e8+TsyJ6KB2iCo8h0uvwWrIm/dk3dAdnW19X3jxqhGc8QEV/mh/VORaXuE1\nkv4D\r\n=45uD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/elliptic_6.5.3_1592494366350_0.7296651468879995"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Elliptic [![Build Status](https://secure.travis-ci.org/indutny/elliptic.png)](http://travis-ci.org/indutny/elliptic) [![Coverage Status](https://coveralls.io/repos/indutny/elliptic/badge.svg?branch=master&service=github)](https://coveralls.io/github/indutny/elliptic?branch=master) [![Code Climate](https://codeclimate.com/github/indutny/elliptic/badges/gpa.svg)](https://codeclimate.com/github/indutny/elliptic)\n\n[![Saucelabs Test Status](https://saucelabs.com/browser-matrix/gh-indutny-elliptic.svg)](https://saucelabs.com/u/gh-indutny-elliptic)\n\nFast elliptic-curve cryptography in a plain javascript implementation.\n\nNOTE: Please take a look at http://safecurves.cr.yp.to/ before choosing a curve\nfor your cryptography operations.\n\n## Incentive\n\nECC is much slower than regular RSA cryptography, the JS implementations are\neven more slower.\n\n## Benchmarks\n\n```bash\n$ node benchmarks/index.js\nBenchmarking: sign\nelliptic#sign x 262 ops/sec ±0.51% (177 runs sampled)\neccjs#sign x 55.91 ops/sec ±0.90% (144 runs sampled)\n------------------------\nFastest is elliptic#sign\n========================\nBenchmarking: verify\nelliptic#verify x 113 ops/sec ±0.50% (166 runs sampled)\neccjs#verify x 48.56 ops/sec ±0.36% (125 runs sampled)\n------------------------\nFastest is elliptic#verify\n========================\nBenchmarking: gen\nelliptic#gen x 294 ops/sec ±0.43% (176 runs sampled)\neccjs#gen x 62.25 ops/sec ±0.63% (129 runs sampled)\n------------------------\nFastest is elliptic#gen\n========================\nBenchmarking: ecdh\nelliptic#ecdh x 136 ops/sec ±0.85% (156 runs sampled)\n------------------------\nFastest is elliptic#ecdh\n========================\n```\n\n## API\n\n### ECDSA\n\n```javascript\nvar EC = require('elliptic').ec;\n\n// Create and initialize EC context\n// (better do it once and reuse it)\nvar ec = new EC('secp256k1');\n\n// Generate keys\nvar key = ec.genKeyPair();\n\n// Sign the message's hash (input must be an array, or a hex-string)\nvar msgHash = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];\nvar signature = key.sign(msgHash);\n\n// Export DER encoded signature in Array\nvar derSign = signature.toDER();\n\n// Verify signature\nconsole.log(key.verify(msgHash, derSign));\n\n// CHECK WITH NO PRIVATE KEY\n\nvar pubPoint = key.getPublic();\nvar x = pubPoint.getX();\nvar y = pubPoint.getY();\n\n// Public Key MUST be either:\n// 1) '04' + hex string of x + hex string of y; or\n// 2) object with two hex string properties (x and y); or\n// 3) object with two buffer properties (x and y)\nvar pub = pubPoint.encode('hex');                                 // case 1\nvar pub = { x: x.toString('hex'), y: y.toString('hex') };         // case 2\nvar pub = { x: x.toBuffer(), y: y.toBuffer() };                   // case 3\nvar pub = { x: x.toArrayLike(Buffer), y: y.toArrayLike(Buffer) }; // case 3\n\n// Import public key\nvar key = ec.keyFromPublic(pub, 'hex');\n\n// Signature MUST be either:\n// 1) DER-encoded signature as hex-string; or\n// 2) DER-encoded signature as buffer; or\n// 3) object with two hex-string properties (r and s); or\n// 4) object with two buffer properties (r and s)\n\nvar signature = '3046022100...'; // case 1\nvar signature = new Buffer('...'); // case 2\nvar signature = { r: 'b1fc...', s: '9c42...' }; // case 3\n\n// Verify signature\nconsole.log(key.verify(msgHash, signature));\n```\n\n### EdDSA\n\n```javascript\nvar EdDSA = require('elliptic').eddsa;\n\n// Create and initialize EdDSA context\n// (better do it once and reuse it)\nvar ec = new EdDSA('ed25519');\n\n// Create key pair from secret\nvar key = ec.keyFromSecret('693e3c...'); // hex string, array or Buffer\n\n// Sign the message's hash (input must be an array, or a hex-string)\nvar msgHash = [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];\nvar signature = key.sign(msgHash).toHex();\n\n// Verify signature\nconsole.log(key.verify(msgHash, signature));\n\n// CHECK WITH NO PRIVATE KEY\n\n// Import public key\nvar pub = '0a1af638...';\nvar key = ec.keyFromPublic(pub, 'hex');\n\n// Verify signature\nvar signature = '70bed1...';\nconsole.log(key.verify(msgHash, signature));\n```\n\n### ECDH\n\n```javascript\nvar EC = require('elliptic').ec;\nvar ec = new EC('curve25519');\n\n// Generate keys\nvar key1 = ec.genKeyPair();\nvar key2 = ec.genKeyPair();\n\nvar shared1 = key1.derive(key2.getPublic());\nvar shared2 = key2.derive(key1.getPublic());\n\nconsole.log('Both shared secrets are BN instances');\nconsole.log(shared1.toString(16));\nconsole.log(shared2.toString(16));\n```\n\nthree and more members:\n```javascript\nvar EC = require('elliptic').ec;\nvar ec = new EC('curve25519');\n\nvar A = ec.genKeyPair();\nvar B = ec.genKeyPair();\nvar C = ec.genKeyPair();\n\nvar AB = A.getPublic().mul(B.getPrivate())\nvar BC = B.getPublic().mul(C.getPrivate())\nvar CA = C.getPublic().mul(A.getPrivate())\n\nvar ABC = AB.mul(C.getPrivate())\nvar BCA = BC.mul(A.getPrivate())\nvar CAB = CA.mul(B.getPrivate())\n\nconsole.log(ABC.getX().toString(16))\nconsole.log(BCA.getX().toString(16))\nconsole.log(CAB.getX().toString(16))\n```\n\nNOTE: `.derive()` returns a [BN][1] instance.\n\n## Supported curves\n\nElliptic.js support following curve types:\n\n* Short Weierstrass\n* Montgomery\n* Edwards\n* Twisted Edwards\n\nFollowing curve 'presets' are embedded into the library:\n\n* `secp256k1`\n* `p192`\n* `p224`\n* `p256`\n* `p384`\n* `p521`\n* `curve25519`\n* `ed25519`\n\nNOTE: That `curve25519` could not be used for ECDSA, use `ed25519` instead.\n\n### Implementation details\n\nECDSA is using deterministic `k` value generation as per [RFC6979][0]. Most of\nthe curve operations are performed on non-affine coordinates (either projective\nor extended), various windowing techniques are used for different cases.\n\nAll operations are performed in reduction context using [bn.js][1], hashing is\nprovided by [hash.js][2]\n\n### Related projects\n\n* [eccrypto][3]: isomorphic implementation of ECDSA, ECDH and ECIES for both\n  browserify and node (uses `elliptic` for browser and [secp256k1-node][4] for\n  node)\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2014.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n\n[0]: http://tools.ietf.org/html/rfc6979\n[1]: https://github.com/indutny/bn.js\n[2]: https://github.com/indutny/hash.js\n[3]: https://github.com/bitchan/eccrypto\n[4]: https://github.com/wanderer/secp256k1-node\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-06-18T15:32:48.908Z",
+    "created": "2014-04-23T16:15:41.559Z",
+    "0.1.0": "2014-04-23T16:15:41.559Z",
+    "0.2.0": "2014-04-25T12:25:26.289Z",
+    "0.3.0": "2014-04-25T20:23:37.794Z",
+    "0.4.0": "2014-04-25T21:15:57.382Z",
+    "0.5.0": "2014-04-26T12:05:35.447Z",
+    "0.6.0": "2014-04-26T22:58:26.494Z",
+    "0.6.1": "2014-04-27T22:34:24.959Z",
+    "0.7.0": "2014-04-29T09:37:30.033Z",
+    "0.8.0": "2014-05-04T23:11:07.401Z",
+    "0.9.0": "2014-05-05T09:45:52.523Z",
+    "0.9.1": "2014-05-05T13:12:19.629Z",
+    "0.9.2": "2014-05-05T13:17:17.892Z",
+    "0.10.0": "2014-05-08T23:45:13.793Z",
+    "0.10.1": "2014-05-09T07:32:15.877Z",
+    "0.10.2": "2014-05-10T18:19:58.531Z",
+    "0.11.0": "2014-05-16T16:55:23.828Z",
+    "0.11.1": "2014-05-17T08:37:20.198Z",
+    "0.12.0": "2014-05-17T16:19:36.145Z",
+    "0.13.1": "2014-05-18T12:28:24.053Z",
+    "0.13.2": "2014-05-21T19:21:51.812Z",
+    "0.14.0": "2014-05-23T16:11:19.979Z",
+    "0.14.1": "2014-05-23T19:36:00.017Z",
+    "0.14.2": "2014-05-24T17:17:21.564Z",
+    "0.15.0": "2014-05-25T17:45:58.005Z",
+    "0.15.1": "2014-05-25T18:03:03.107Z",
+    "0.15.2": "2014-05-27T08:43:10.478Z",
+    "0.15.3": "2014-05-27T18:54:53.615Z",
+    "0.15.4": "2014-05-31T22:57:16.563Z",
+    "0.15.5": "2014-05-31T22:58:14.487Z",
+    "0.15.6": "2014-06-06T04:59:56.367Z",
+    "0.15.7": "2014-06-18T04:45:06.606Z",
+    "0.15.8": "2014-08-27T14:06:50.499Z",
+    "0.15.9": "2014-09-07T20:52:30.353Z",
+    "0.15.10": "2014-09-09T15:21:32.246Z",
+    "0.15.11": "2014-09-25T10:25:31.472Z",
+    "0.15.12": "2014-11-02T19:42:24.649Z",
+    "0.15.13": "2014-11-04T15:53:18.171Z",
+    "0.15.14": "2014-11-05T17:05:41.069Z",
+    "0.15.15": "2014-11-27T16:03:15.490Z",
+    "0.15.16": "2015-01-02T11:42:48.481Z",
+    "0.15.17": "2015-01-02T11:45:01.604Z",
+    "0.16.0": "2015-01-02T18:03:38.604Z",
+    "1.0.0": "2015-01-05T21:00:09.264Z",
+    "1.0.1": "2015-01-12T15:02:29.678Z",
+    "2.0.0": "2015-01-18T19:42:47.681Z",
+    "2.0.1": "2015-01-21T16:04:05.829Z",
+    "2.0.2": "2015-02-07T02:07:47.680Z",
+    "3.0.0": "2015-02-09T20:44:23.489Z",
+    "3.0.1": "2015-02-09T20:44:38.016Z",
+    "3.0.2": "2015-02-14T11:41:23.366Z",
+    "3.0.3": "2015-02-27T19:06:37.668Z",
+    "3.0.4": "2015-06-03T12:03:38.374Z",
+    "3.1.0": "2015-06-11T00:06:57.056Z",
+    "4.0.0": "2015-06-25T02:58:57.140Z",
+    "4.1.0": "2015-07-04T03:25:38.671Z",
+    "5.0.0": "2015-07-07T22:56:31.891Z",
+    "5.1.0": "2015-07-20T03:04:23.753Z",
+    "5.2.0": "2015-10-23T15:49:50.687Z",
+    "5.2.1": "2015-10-28T22:12:41.172Z",
+    "6.0.0": "2015-10-28T22:14:32.118Z",
+    "6.0.1": "2015-11-02T21:06:29.601Z",
+    "6.0.2": "2015-11-07T20:24:29.820Z",
+    "6.1.0": "2016-01-17T05:57:54.838Z",
+    "6.2.0": "2016-01-22T18:31:04.707Z",
+    "6.2.1": "2016-01-24T22:26:48.751Z",
+    "6.2.2": "2016-01-25T20:16:53.622Z",
+    "6.2.3": "2016-01-29T08:00:44.416Z",
+    "6.2.4": "2016-05-20T21:48:54.607Z",
+    "6.2.5": "2016-05-20T21:52:21.803Z",
+    "6.2.6": "2016-05-25T18:41:19.032Z",
+    "6.2.7": "2016-05-25T18:43:15.918Z",
+    "6.2.8": "2016-06-01T01:53:27.222Z",
+    "6.3.0": "2016-06-14T04:17:16.632Z",
+    "6.3.1": "2016-06-14T16:23:36.965Z",
+    "6.3.2": "2016-09-15T11:27:18.557Z",
+    "6.3.3": "2017-02-06T23:13:58.436Z",
+    "6.4.0": "2017-02-22T21:27:47.116Z",
+    "6.4.1": "2018-08-09T03:58:11.648Z",
+    "6.5.0": "2019-06-26T04:03:46.523Z",
+    "6.5.1": "2019-09-04T02:34:30.284Z",
+    "6.5.2": "2019-11-22T19:07:12.647Z",
+    "6.5.3": "2020-06-18T15:32:46.559Z"
+  },
+  "homepage": "https://github.com/indutny/elliptic",
+  "keywords": [
+    "EC",
+    "Elliptic",
+    "curve",
+    "Cryptography"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/elliptic.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/elliptic/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "ricmoo": true,
+    "charmander": true,
+    "substack": true,
+    "freshlygrazed": true,
+    "invelo": true,
+    "shanewholloway": true,
+    "erikvold": true,
+    "bobxuyang": true,
+    "thejeshgn.com": true,
+    "thejeshgn": true,
+    "you21979": true,
+    "nickeltobias": true,
+    "vandeurenglenn": true,
+    "meeh": true,
+    "bhaskarmelkani": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/elliptic.min.json
+++ b/test/fixtures/registry-mocks/content/elliptic.min.json
@@ -1,0 +1,1682 @@
+{
+  "name": "elliptic",
+  "dist-tags": {
+    "latest": "6.5.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "elliptic",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "25c28f157470efe8fbccc290bf30261e28777dcd",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "elliptic",
+      "version": "0.2.0",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "bedbb8376437d8b7f139610d33cef4f76b5a0cd2",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "elliptic",
+      "version": "0.3.0",
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "32167b06a350390a58beaaad9c245c35434614f6",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.3.0.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "elliptic",
+      "version": "0.4.0",
+      "dependencies": {
+        "hash.js": "^0.1.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "6f318c44c9108eea4f52625b971442fbdfc52285",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.4.0.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "elliptic",
+      "version": "0.5.0",
+      "dependencies": {
+        "bn.js": "^0.1.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "d66122e6e8a22024ec57cd91840f028012f87283",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.5.0.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "elliptic",
+      "version": "0.6.0",
+      "dependencies": {
+        "bn.js": "^0.1.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "f624887ebd068e7706f758c2f37e3c7db38f2789",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.6.0.tgz"
+      }
+    },
+    "0.6.1": {
+      "name": "elliptic",
+      "version": "0.6.1",
+      "dependencies": {
+        "bn.js": "^0.1.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "545c229f029ba75fb1d89f3997194ffca5d7a25f",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.6.1.tgz"
+      }
+    },
+    "0.7.0": {
+      "name": "elliptic",
+      "version": "0.7.0",
+      "dependencies": {
+        "bn.js": "^0.2.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "df438baaac83a4e2a45f82bd478a854f6c569f0b",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.7.0.tgz"
+      }
+    },
+    "0.8.0": {
+      "name": "elliptic",
+      "version": "0.8.0",
+      "dependencies": {
+        "bn.js": "^0.3.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "67658dd7ff907dfae3bd7df9bafcc7d9b8c6fe3a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.8.0.tgz"
+      }
+    },
+    "0.9.0": {
+      "name": "elliptic",
+      "version": "0.9.0",
+      "dependencies": {
+        "bn.js": "^0.3.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "715b3dfc66182988ce3cd03d6a762c24d0443754",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.9.0.tgz"
+      }
+    },
+    "0.9.1": {
+      "name": "elliptic",
+      "version": "0.9.1",
+      "dependencies": {
+        "bn.js": "^0.3.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "5404b4cf62301557604895f82a8466da3617059e",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.9.1.tgz"
+      }
+    },
+    "0.9.2": {
+      "name": "elliptic",
+      "version": "0.9.2",
+      "dependencies": {
+        "bn.js": "^0.3.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "9a0117f7ffdee38646538f3313fcc606d8ad5d40",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.9.2.tgz"
+      }
+    },
+    "0.10.0": {
+      "name": "elliptic",
+      "version": "0.10.0",
+      "dependencies": {
+        "bn.js": "^0.4.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "6b9bf2c5daf083a15c1bd4fcefa56f56a51d1327",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.10.0.tgz"
+      }
+    },
+    "0.10.1": {
+      "name": "elliptic",
+      "version": "0.10.1",
+      "dependencies": {
+        "bn.js": "^0.4.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "efd9cef24e3b710fb1f1cb5080d08538870d153c",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.10.1.tgz"
+      }
+    },
+    "0.10.2": {
+      "name": "elliptic",
+      "version": "0.10.2",
+      "dependencies": {
+        "bn.js": "^0.4.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "5bd5ccf61f259b71232b996b9cdca9c4ba53523c",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.10.2.tgz"
+      }
+    },
+    "0.11.0": {
+      "name": "elliptic",
+      "version": "0.11.0",
+      "dependencies": {
+        "bn.js": "^0.5.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "e82e434e9405cf53f0cf4510ac2cf4759c79a278",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.11.0.tgz"
+      }
+    },
+    "0.11.1": {
+      "name": "elliptic",
+      "version": "0.11.1",
+      "dependencies": {
+        "bn.js": "^0.5.4",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "2407c5e7199bf935d457c816b291149fa05a95b4",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.11.1.tgz"
+      }
+    },
+    "0.12.0": {
+      "name": "elliptic",
+      "version": "0.12.0",
+      "dependencies": {
+        "bn.js": "^0.6.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "a3e31678e743f036f23d17d5917166501403f841",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.12.0.tgz"
+      }
+    },
+    "0.13.1": {
+      "name": "elliptic",
+      "version": "0.13.1",
+      "dependencies": {
+        "bn.js": "^0.7.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "b60844bea509c92e70af60068ce71ed386225651",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.13.1.tgz"
+      }
+    },
+    "0.13.2": {
+      "name": "elliptic",
+      "version": "0.13.2",
+      "dependencies": {
+        "bn.js": "^0.8.0",
+        "hash.js": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "d5b61a076464f06741faf6d261f2df3a5662763d",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.13.2.tgz"
+      }
+    },
+    "0.14.0": {
+      "name": "elliptic",
+      "version": "0.14.0",
+      "dependencies": {
+        "bn.js": "^0.10.0",
+        "hash.js": "^0.2.0",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "eef663a2252ef2418da671955e1ca4691acfce47",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.14.0.tgz"
+      }
+    },
+    "0.14.1": {
+      "name": "elliptic",
+      "version": "0.14.1",
+      "dependencies": {
+        "bn.js": "^0.10.0",
+        "hash.js": "^0.2.0",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "ea2c26aecf7e31938138ab6453f68b9511d69159",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.14.1.tgz"
+      }
+    },
+    "0.14.2": {
+      "name": "elliptic",
+      "version": "0.14.2",
+      "dependencies": {
+        "bn.js": "^0.10.1",
+        "hash.js": "^0.2.0",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "d0774db33dc958b3c426620b75586091b6c96d2c",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.14.2.tgz"
+      }
+    },
+    "0.15.0": {
+      "name": "elliptic",
+      "version": "0.15.0",
+      "dependencies": {
+        "bn.js": "^0.11.2",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "c55a184c3379563b45f36a78b5fe33914de72bd2",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.0.tgz"
+      }
+    },
+    "0.15.1": {
+      "name": "elliptic",
+      "version": "0.15.1",
+      "dependencies": {
+        "bn.js": "^0.11.2",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "40b70e9859c8744cdf5be85a7c1af8d749980e04",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.1.tgz"
+      }
+    },
+    "0.15.2": {
+      "name": "elliptic",
+      "version": "0.15.2",
+      "dependencies": {
+        "bn.js": "^0.11.2",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "0ae5f2fb19db51989e5a8abf1c525037941c934a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.2.tgz"
+      }
+    },
+    "0.15.3": {
+      "name": "elliptic",
+      "version": "0.15.3",
+      "dependencies": {
+        "bn.js": "^0.11.5",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "02ae691992646e6086152411d757fd08e422efe7",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.3.tgz"
+      }
+    },
+    "0.15.4": {
+      "name": "elliptic",
+      "version": "0.15.4",
+      "dependencies": {
+        "bn.js": "^0.11.5",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "fb7ea8778d995c7e5a8927273f3e0b08e7353c5f",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.4.tgz"
+      }
+    },
+    "0.15.5": {
+      "name": "elliptic",
+      "version": "0.15.5",
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "ca8c77805e99b5483251caaf71396d1d5bdae250",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.5.tgz"
+      }
+    },
+    "0.15.6": {
+      "name": "elliptic",
+      "version": "0.15.6",
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "5a82f941000e5daab7fb98987d70410cd42f0065",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.6.tgz"
+      }
+    },
+    "0.15.7": {
+      "name": "elliptic",
+      "version": "0.15.7",
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1",
+        "uglify-js": "^2.4.13"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "33a3cfb88eeeeb04f0bbd06040f2cfc2fba93d2a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.7.tgz"
+      }
+    },
+    "0.15.8": {
+      "name": "elliptic",
+      "version": "0.15.8",
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "14046870b5d5261438f59b3c174693a89d976a85",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.8.tgz"
+      }
+    },
+    "0.15.9": {
+      "name": "elliptic",
+      "version": "0.15.9",
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "009fcc41fb3d5a111afb527f7fb3bb267f905bc7",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.9.tgz"
+      }
+    },
+    "0.15.10": {
+      "name": "elliptic",
+      "version": "0.15.10",
+      "dependencies": {
+        "bn.js": "^0.11.6",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "b60abd01bc4b7908e01eef3b93bddf6f5775e267",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.10.tgz"
+      }
+    },
+    "0.15.11": {
+      "name": "elliptic",
+      "version": "0.15.11",
+      "dependencies": {
+        "bn.js": "^0.14.1",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "37c5dab7fd714ee88c2178fcd2ef2216d2f31809",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.11.tgz"
+      }
+    },
+    "0.15.12": {
+      "name": "elliptic",
+      "version": "0.15.12",
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "bafa7542ebdb9aaa2edf7cdaa86108ce6f12d4e9",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.12.tgz"
+      }
+    },
+    "0.15.13": {
+      "name": "elliptic",
+      "version": "0.15.13",
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "918c6b833a9e7d8ad974027d02ac4912d025f2f4",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.13.tgz"
+      }
+    },
+    "0.15.14": {
+      "name": "elliptic",
+      "version": "0.15.14",
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "4d8cc82f030f9c7646ac60a729f0f793e083be6e",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.14.tgz"
+      }
+    },
+    "0.15.15": {
+      "name": "elliptic",
+      "version": "0.15.15",
+      "dependencies": {
+        "bn.js": "^0.15.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "63269184a856d6e00871e84f37a8401ff84e4aea",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.15.tgz"
+      }
+    },
+    "0.15.17": {
+      "name": "elliptic",
+      "version": "0.15.17",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^0.2.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "43f2bc8046c838df1ac99e5242da1b1b4bc59937",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.15.17.tgz"
+      }
+    },
+    "0.16.0": {
+      "name": "elliptic",
+      "version": "0.16.0",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^0.3.2",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "9bc84e75ccd97e3e452c97371726c535314d1a57",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-0.16.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "elliptic",
+      "version": "1.0.0",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "28d927ae8c16c6f65e452a714b36da4095603e39",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "elliptic",
+      "version": "1.0.1",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "d180376b66a17d74995c837796362ac4d22aefe3",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-1.0.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "elliptic",
+      "version": "2.0.0",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "5c237269b13af8aa2dbf663f265df7e2cc521774",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "elliptic",
+      "version": "2.0.1",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^1.18.2",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "58814b471e011eaf7e42fa444fdffcfc0d3de8df",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "elliptic",
+      "version": "2.0.2",
+      "dependencies": {
+        "bn.js": "^1.2.4",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "5891ba666d3103ddf311b14ec5de3fca74402afd",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-2.0.2.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "elliptic",
+      "version": "3.0.1",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "831c923399aeffb50766af1b05fdf71eba60acbf",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.1.tgz"
+      }
+    },
+    "3.0.2": {
+      "name": "elliptic",
+      "version": "3.0.2",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "fc07233e8bd1c1a108cb0997fa6757c7b1a7c0bc",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.2.tgz"
+      }
+    },
+    "3.0.3": {
+      "name": "elliptic",
+      "version": "3.0.3",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "865c9b420bfbe55006b9f969f97a0d2c44966595",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz"
+      }
+    },
+    "3.0.4": {
+      "name": "elliptic",
+      "version": "3.0.4",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "67dbcf68dd1e843eef77b0b05376bd1db4f92f5e",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.4.tgz"
+      }
+    },
+    "3.1.0": {
+      "name": "elliptic",
+      "version": "3.1.0",
+      "dependencies": {
+        "bn.js": "^2.0.3",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "c21682ef762769b56a74201609105da11d5f60cc",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-3.1.0.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "elliptic",
+      "version": "4.0.0",
+      "dependencies": {
+        "bn.js": "^2.1.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "32976ad71b274c1111d82f895837dac8ea45c073",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-4.0.0.tgz"
+      }
+    },
+    "4.1.0": {
+      "name": "elliptic",
+      "version": "4.1.0",
+      "dependencies": {
+        "bn.js": "^2.1.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "1a660618d3d09190200149cbe0452e6a5bbe08d7",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-4.1.0.tgz"
+      }
+    },
+    "5.0.0": {
+      "name": "elliptic",
+      "version": "5.0.0",
+      "dependencies": {
+        "bn.js": "^3.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "1bdd76d5f560da765cf0ba38243f8f4481ebe01c",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-5.0.0.tgz"
+      }
+    },
+    "5.1.0": {
+      "name": "elliptic",
+      "version": "5.1.0",
+      "dependencies": {
+        "bn.js": "^3.1.1",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "5658dfa7625a6a8fc687a5b8f249376bb271e6e9",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-5.1.0.tgz"
+      }
+    },
+    "5.2.0": {
+      "name": "elliptic",
+      "version": "5.2.0",
+      "dependencies": {
+        "bn.js": "^3.1.1",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "123fd155fd6637e57e416d95ac803c9fe7cb95bc",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.0.tgz"
+      }
+    },
+    "5.2.1": {
+      "name": "elliptic",
+      "version": "5.2.1",
+      "dependencies": {
+        "bn.js": "^3.1.1",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "fa294b6563c6ddbc9ba3dc8594687ae840858f10",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-5.2.1.tgz"
+      }
+    },
+    "6.0.0": {
+      "name": "elliptic",
+      "version": "6.0.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "c48120001e5d9c26fd5e5ed05361f09b0e838106",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.0.0.tgz"
+      }
+    },
+    "6.0.1": {
+      "name": "elliptic",
+      "version": "6.0.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "91d573ecb2a3c274b8c07e0d1f35ff19f07e6978",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.0.1.tgz"
+      }
+    },
+    "6.0.2": {
+      "name": "elliptic",
+      "version": "6.0.2",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "219b96cd92aa9885d91d31c1fd42eaa5eb4483a9",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.0.2.tgz"
+      }
+    },
+    "6.1.0": {
+      "name": "elliptic",
+      "version": "6.1.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "68130e03823b4ce024955ad1be195e148099d654",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.1.0.tgz"
+      }
+    },
+    "6.2.0": {
+      "name": "elliptic",
+      "version": "6.2.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "695e7233fee853883f19d6c103c3cffdb1527e12",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.0.tgz"
+      }
+    },
+    "6.2.1": {
+      "name": "elliptic",
+      "version": "6.2.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "72ade423d4144e967446cc2bfbed4d088d154e71",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.1.tgz"
+      }
+    },
+    "6.2.2": {
+      "name": "elliptic",
+      "version": "6.2.2",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^3.44.2",
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.11.3",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0",
+        "uglify-js": "^2.4.13"
+      },
+      "dist": {
+        "shasum": "806bfa651a5aa4996a1e79c92b573761ea7d7574",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.2.tgz"
+      }
+    },
+    "6.2.3": {
+      "name": "elliptic",
+      "version": "6.2.3",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.3",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "18e46d7306b0951275a2d42063270a14b74ebe99",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.3.tgz"
+      }
+    },
+    "6.2.4": {
+      "name": "elliptic",
+      "version": "6.2.4",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "f8a8917c3024233ac37d8901e17cca425851c7d8",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.4.tgz"
+      }
+    },
+    "6.2.5": {
+      "name": "elliptic",
+      "version": "6.2.5",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "24846340477dfce75c56b8ff4b1d6d6ec258e06a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.5.tgz"
+      }
+    },
+    "6.2.6": {
+      "name": "elliptic",
+      "version": "6.2.6",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "f3f9371440a4af3ee459460a8078d65ad7f9a581",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.6.tgz"
+      }
+    },
+    "6.2.7": {
+      "name": "elliptic",
+      "version": "6.2.7",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "dce82efbf176eefa7495d4be3e8b9f5b5694b295",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.7.tgz"
+      }
+    },
+    "6.2.8": {
+      "name": "elliptic",
+      "version": "6.2.8",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "44a25b3d1550bebb74d0b6d22d89940206b51739",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.2.8.tgz"
+      }
+    },
+    "6.3.0": {
+      "name": "elliptic",
+      "version": "6.3.0",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "1b5e9eba9940f12a474651c712190d373bc8b21a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.0.tgz"
+      }
+    },
+    "6.3.1": {
+      "name": "elliptic",
+      "version": "6.3.1",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "17781f2109ab0ec686b146bdcff5d2e8c6aeceda",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.1.tgz"
+      }
+    },
+    "6.3.2": {
+      "name": "elliptic",
+      "version": "6.3.2",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "e4c81e0829cf0a65ab70e998b8232723b5c1bc48",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.2.tgz"
+      }
+    },
+    "6.3.3": {
+      "name": "elliptic",
+      "version": "6.3.3",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "5482d9646d54bcb89fd7d994fc9e2e9568876e3f",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz"
+      }
+    },
+    "6.4.0": {
+      "name": "elliptic",
+      "version": "6.4.0",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "cac9af8762c85836187003c8dfe193e5e2eae5df",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+      }
+    },
+    "6.4.1": {
+      "name": "elliptic",
+      "version": "6.4.1",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+        "shasum": "c2d0b7776911b86722c632c3c06c60f2f819939a",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118371,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJba7vUCRA9TVsSAnZWagAA+gcP/jWaj5GmDZ0YFi/X4g5O\nx+pxu9i3HbP9YqywT7rz3XFXSaytu0LQDeDEbddl523X69tsbKfzHRTcnW8n\n2r0VjPhttRm+0RpEhBwjSIK34VkQA1xIWh2ugOToKXVCFVLM5VFDPGzbiN6x\n/hpL7gj1hoCRVmuhjnqFQ+vPKACKfv1Eq4CsRmu2focmP37kQpWQlweD/z4V\nJF4NxA33Fvp13Fl+9g4sPHyhUVsW9ojVaG3Ijn70pCaGQM18UPlbODkWQ1QX\nAgteOFjkIOtcalJk3B3qsM8GZeHEcAFvt2T73miJkHdCGNmRQS45Ede+gnj0\nlLlZJsCCKUHtTqrlprHo6AgMnBZufmytyozYAHC1/JYniazSBi2yPHtQeniR\nl69BfiRBdD2rNrMPwmCNRkMqrgel5WMGpaD0xdaFAHF1Ru2ZQFKsA7KvPGgp\nA20+LN11cCib67Pg5XDyrZ92T3yXec+6gQ3iq9d9UBZKFGl0P8ebVqq1LrUJ\na6nekwMpRISWnKcqV72XVmQdBmUWHq9VfVLsWJzVIJqtpHmUO7q74ACP3i4W\n0/F1REeI0YEhh3NjeStdDecfjlu7PY0pLQpbk2I3ms+6DO+cAfeDEev5jFBK\nwQabRNhITeT1FVtxZAcApj33fnCdqwaWr1NS00K5ZRqhDTTzPr/O4KRN4CR1\npstU\r\n=UVBB\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "6.5.0": {
+      "name": "elliptic",
+      "version": "6.5.0",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^2.11.3",
+        "grunt": "^0.4.5",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^8.6.2",
+        "istanbul": "^0.4.2",
+        "jscs": "^2.9.0",
+        "jshint": "^2.6.0",
+        "mocha": "^2.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+        "shasum": "2b8ed4c891b7de3200e14412a5b8248c7af505ca",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118006,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdEu6jCRA9TVsSAnZWagAAJh4QAJXJ18MReidNMHrxFJGv\ngSONMB2uz0lWJ7eEUyggaCA/Tr6w4RBA6Ilne0Wou3jTAGou+GClpAde6Hkb\nEq1iq1brx+5gHeY3rGs8GB+T3c1JsVz+2t6934esXGM6IJNmG91TaCMSbuwQ\nTWHD62RxFylLYjffBIWt6KLximZnXcvAES0Qu7VUql1SlfvmGtaHlQAhvtLj\nG+ayBnSnWMcEvDPJdfnKi67PlGMa334spEmWzcqobFySr+y/ufiZRCp+wiSl\ndCwbFNMaH4fue+dhq1m7jGO/euFQvJw2Jf32zT/ToaM768nH8yHrrZ8lMRjs\ngCUymge8kbI5W1WA8wla7+J52Exbo6LbcBqSupVhVw6gXkOdjQCOkywBXa1c\nPiFxwOUSfdFATpkUi3/8serYCgv9NgGzvQ0rjej0//1+he6q7UUyKn9wyrdH\nMntmi18UgyQ8c1NrshKAOCb1oeniCEv7B1adfH2axH9uvMiVP8N5BMfAUNE1\nnkCD3lDXRz/7C+90DiI+h2MS3+az8ciqMTbpKlw3HrmUyCex+KvLq9+wNLGf\nyaJGd/r6NT0pu36v0M2+ul266/RbbY6D1ED/cl8gDZRFTT/SfTCkU+QAn2Mg\nfAlnn9BXogYR1XM1GNrnGUVkY7ngORiAGez5DU7P93jMpdSS9OtwAHHi1Oto\nbZ+X\r\n=LuMF\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "6.5.1": {
+      "name": "elliptic",
+      "version": "6.5.1",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^3.0.4",
+        "grunt": "^1.0.4",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^9.0.1",
+        "istanbul": "^0.4.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.6.0",
+        "mocha": "^6.1.4"
+      },
+      "dist": {
+        "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+        "shasum": "c380f5f909bf1b9b4428d028cd18d3b0efd6b52b",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118051,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdbyK2CRA9TVsSAnZWagAAZR0P/jpSTQHkhgrh51Ql5iEp\nk19ZPvn6rvDRJdjPBgZfimuE8jYbzRrqEk0O8OJvWJAgBUz7RGcWsYjXEb0v\ncapOYnS9iL7EGmrZm/zIk2wB4K4vqbY1brh1WSGtZPJOotaTebfrepkUcqrk\nr2ZDg5YryX+gMD2QjumRSb3xXHbQukPvM9cc5WF5ZRaEzgQxRwtwwqzNejs1\np1DzKTNqBWzDGyl3NRdNPO8sEfcaf8LCyCu85OEFR1B7HytR1TH2B1uX7bNb\n82pw62BtmFbafa3VmFxeYk6Yqi5dHXUqsqLIGAsJJyaRsVOyLe/BuT7dHWgX\nEh8bQP4quLm2WZFIIRSUml4QXHiviMyUHfYITg05T/ODZejseHy65LYGgTsS\nQtsu+tDv+a4h+2FWNfkeVyinkEMNetlp+vPkSKVFeNLbCRFTR9ufgZqLn2IL\nnxpLdHLt9y6HaWDSSWwUwUYnK7WRiF8zP1cNRqZWyf7IPLHyRruwpkUFk9/u\nc6J3IgBQpgXfLxxXJTqqDvENmmMGtcJRWN0wtDLWNcYhm5f2px9m5vdxIj0U\nQn+6IZMgxTPsuA4w3iyagWbl/xtuEEw2XZUB++TztGfUtMImRFNEOqI3LO6V\n9CnJKpeVDPckXgDBwHJF9w6ywriLQKyR9rG8hl+nlonSbohg2hdQdB7TTeWJ\n1/J0\r\n=uYn+\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "6.5.2": {
+      "name": "elliptic",
+      "version": "6.5.2",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^3.0.8",
+        "grunt": "^1.0.4",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^9.0.1",
+        "istanbul": "^0.4.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.10.3",
+        "mocha": "^6.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+        "shasum": "05c5678d7173c049d8ca433552224a495d0e3762",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118072,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd2DHgCRA9TVsSAnZWagAAfx0P/RYZUDcD1KNqpERJSTgL\nlA3wXXXVB78IVwSy9laMD1GdDpsMy71PHjFMZL1NM2ZaZUUi7eiNaYf8sFrP\nQWadLsl3M2tkW6T4AkgxJXMEmbf3k9hCy+ZvRdWKJUF0g44WORvK2SNzDI/C\nIuBZ9xfTS5dZ3jZJOMZNZO4+PHzMQ/pzCGXafuuzsryPlcx0PvIN66xTRQbo\n/ByAl3lIK/C5HsFUkaSxcabcSmZrVuwDw8ciKGrBXjWkXAqLzO0u9HEczucP\n+RNNFvocrTB4ge/4yV4cdGSF7QXkzJ7hPqQgnhj0TrJO//qBERKXffQq91Hr\nU/xdUsX/dnIqpzpV81E36L+0VIxxg66/21ba4qlsho0i57v83Y6jLH3wFud4\n/LGzynTDiwySpREE9Gb3tnXSR3OuZstyJORQwEglAQIp7QcneqGOghNgY4am\nuFkM/6rAJi4tGw8uBn0tgRQZHtmy8XwNtuN/ShRoBzBayN2XVmJrApUxPpJK\nu+v3O0skLnpsXqgCpskrRK4dWtgkItxSZn91DZ219eGZvpFOgS8Jnb/bA07B\nZ7mGgM0B91Bc4ZbUGyGyv17j/p5fItlA0nqX6itwNjBI+BeYlenWXG3JfEjd\npteBvQyvxCHtcnc987HIm6VYGFvj1xlI7eLD4fQXPbuos0jbyEo2ndIU8jIT\nJVlS\r\n=BoXv\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "6.5.3": {
+      "name": "elliptic",
+      "version": "6.5.3",
+      "dependencies": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "devDependencies": {
+        "brfs": "^1.4.3",
+        "coveralls": "^3.0.8",
+        "grunt": "^1.0.4",
+        "grunt-browserify": "^5.0.0",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.0",
+        "grunt-contrib-copy": "^1.0.0",
+        "grunt-contrib-uglify": "^1.0.1",
+        "grunt-mocha-istanbul": "^3.0.1",
+        "grunt-saucelabs": "^9.0.1",
+        "istanbul": "^0.4.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.10.3",
+        "mocha": "^6.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+        "shasum": "cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6",
+        "tarball": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+        "fileCount": 17,
+        "unpackedSize": 118531,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe64kfCRA9TVsSAnZWagAAnnEP/jFxX0m9YZshgdiItHkR\nVLy+kvaHKZyosZySjGqIXkJn9JQ2wzOt4YCKVyaRnrAlSxJm7D7x568Uq1fl\nOgIdY/t2VDgwgiOIYZ7RzpE4AKLnEw45LX4XvzXlQ6xxD8YV1J7AltlxYhNl\nIm8ofDd2zOTqwrRicnAUaVR0PoQwnLhKUsOaRUPSqP9WByDKq5qNjLb6Hcxi\nZVsZHaaIPQFzMah9Kxn8aAGGf9f8WizUq84qjJnL27ATTJsjrzku3V/elMvC\nljY7OtcWf+En6yZigHfK3eYVnYuZmpUmPmtP6+mcAcqnp2LDu+Tj0I0NUJjW\nbYIlOzutL1W5U6dSKwI8yi1OwR+NuXcJDu8b05cXpI2V85CbZ9uBu1uhloNY\nytwVzVkuZD1GifAjCMfe3Zjlha6KOvo5ASatWS1u9cxD887wuJA/rWpFMGgF\n/lkZASJzcij6gwDpSMmkpX3OJUE7xTrPv+8QBt7HBH22nqZm41l3HRFEH/3r\n/pkRGVI6MiyILzYHgQOo716Fbnj9u9NFXoeAcQm/fBDaaDTG/XYK34gmF2Iy\nRqbmsFNRoQ5HYbdIwHEzom2gkT8Zm9Gac+zUpIt+I/Z1wvvdai7K3VI9wHgw\n8e8+TsyJ6KB2iCo8h0uvwWrIm/dk3dAdnW19X3jxqhGc8QEV/mh/VORaXuE1\nkv4D\r\n=45uD\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-06-18T15:32:48.908Z"
+}

--- a/test/fixtures/registry-mocks/content/emojis-list.json
+++ b/test/fixtures/registry-mocks/content/emojis-list.json
@@ -1,0 +1,629 @@
+{
+  "_id": "emojis-list",
+  "_rev": "12-ba26a8bd2c7999fa4f84d0910c2dbbf7",
+  "name": "emojis-list",
+  "description": "Complete list of standard emojis.",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "emojis-list",
+      "description": "Complete list of standard emojis.",
+      "homepage": "https://github.com/Kikobeats/emojis-list",
+      "version": "1.0.0",
+      "main": "./index.js",
+      "author": {
+        "name": "Kiko Beats",
+        "email": "josefrancisco.verdu@gmail.com",
+        "url": "https://github.com/Kikobeats"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kikobeats/emojis-list.git"
+      },
+      "bugs": {
+        "url": "https://github.com/Kikobeats/emojis-list/issues"
+      },
+      "keywords": [
+        "emoji",
+        "list",
+        "complete",
+        "archive",
+        "standard"
+      ],
+      "engines": {
+        "node": ">= 0.10.0",
+        "npm": ">= 1.4.0"
+      },
+      "scripts": {
+        "test": "sh test/test.sh"
+      },
+      "license": "MIT",
+      "gitHead": "9f0564cff4cda151c1751a91113eb0390ec9477a",
+      "_id": "emojis-list@1.0.0",
+      "_shasum": "603c10b88c64800df15f897df6814a48a48ee3e2",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.10.24",
+      "_npmUser": {
+        "name": "kikobeats",
+        "email": "josefrancisco.verdu@gmail.com"
+      },
+      "dist": {
+        "shasum": "603c10b88c64800df15f897df6814a48a48ee3e2",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "kikobeats",
+          "email": "josefrancisco.verdu@gmail.com"
+        }
+      ],
+      "deprecated": "Use v2.x, it's content all emojis on the world and webpack support.",
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "emojis-list",
+      "description": "Complete list of standard emojis.",
+      "homepage": "https://github.com/Kikobeats/emojis-list",
+      "version": "1.0.1",
+      "main": "./index.js",
+      "author": {
+        "name": "Kiko Beats",
+        "email": "josefrancisco.verdu@gmail.com",
+        "url": "https://github.com/Kikobeats"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kikobeats/emojis-list.git"
+      },
+      "bugs": {
+        "url": "https://github.com/Kikobeats/emojis-list/issues"
+      },
+      "keywords": [
+        "archive",
+        "complete",
+        "emoji",
+        "list",
+        "standard"
+      ],
+      "devDependencies": {
+        "acho": "~2.5.3",
+        "browserify": "~13.0.0",
+        "coffeeify": "~2.0.1",
+        "download": "~4.4.3",
+        "gulp": "~3.9.1",
+        "gulp-header": "~1.7.1",
+        "gulp-uglify": "~1.5.3",
+        "gulp-util": "~3.0.7",
+        "tmp": "0.0.28",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "test": "echo 'YOLO'"
+      },
+      "license": "MIT",
+      "gitHead": "9a937b25ca102064be2bc3689fa91b6eca1f45fd",
+      "_id": "emojis-list@1.0.1",
+      "_shasum": "501365f8084c4d5e21b50c8d51ac780accd3ef78",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.9.0",
+      "_npmUser": {
+        "name": "kikobeats",
+        "email": "josefrancisco.verdu@gmail.com"
+      },
+      "dist": {
+        "shasum": "501365f8084c4d5e21b50c8d51ac780accd3ef78",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "kikobeats",
+          "email": "josefrancisco.verdu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/emojis-list-1.0.1.tgz_1460542426465_0.9635178474709392"
+      },
+      "deprecated": "Use v2.x, it's content all emojis on the world and webpack support.",
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "emojis-list",
+      "description": "Complete list of standard emojis.",
+      "homepage": "https://github.com/Kikobeats/emojis-list",
+      "version": "1.0.2",
+      "main": "./index.js",
+      "author": {
+        "name": "Kiko Beats",
+        "email": "josefrancisco.verdu@gmail.com",
+        "url": "https://github.com/Kikobeats"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kikobeats/emojis-list.git"
+      },
+      "bugs": {
+        "url": "https://github.com/Kikobeats/emojis-list/issues"
+      },
+      "keywords": [
+        "archive",
+        "complete",
+        "emoji",
+        "list",
+        "standard"
+      ],
+      "devDependencies": {
+        "acho": "~2.5.3",
+        "browserify": "~13.0.0",
+        "coffeeify": "~2.0.1",
+        "download": "~4.4.3",
+        "gulp": "~3.9.1",
+        "gulp-header": "~1.7.1",
+        "gulp-uglify": "~1.5.3",
+        "gulp-util": "~3.0.7",
+        "tmp": "0.0.28",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "test": "echo 'YOLO'"
+      },
+      "license": "MIT",
+      "gitHead": "7ae3849dd3dd8ee548923ecdf157dac01d03b445",
+      "_id": "emojis-list@1.0.2",
+      "_shasum": "c12a4dbfc44bf335a680e893f6f45aa353a4f633",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.9.0",
+      "_npmUser": {
+        "name": "kikobeats",
+        "email": "josefrancisco.verdu@gmail.com"
+      },
+      "dist": {
+        "shasum": "c12a4dbfc44bf335a680e893f6f45aa353a4f633",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "kikobeats",
+          "email": "josefrancisco.verdu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/emojis-list-1.0.2.tgz_1462440092633_0.7450358234345913"
+      },
+      "deprecated": "Use v2.x, it's content all emojis on the world and webpack support.",
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "emojis-list",
+      "description": "Complete list of standard emojis.",
+      "homepage": "https://github.com/Kikobeats/emojis-list",
+      "version": "1.0.3",
+      "main": "./index.js",
+      "author": {
+        "name": "Kiko Beats",
+        "email": "josefrancisco.verdu@gmail.com",
+        "url": "https://github.com/Kikobeats"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kikobeats/emojis-list.git"
+      },
+      "bugs": {
+        "url": "https://github.com/Kikobeats/emojis-list/issues"
+      },
+      "keywords": [
+        "archive",
+        "complete",
+        "emoji",
+        "list",
+        "standard"
+      ],
+      "devDependencies": {
+        "acho": "~2.5.3",
+        "browserify": "~13.0.1",
+        "coffeeify": "~2.0.1",
+        "download": "~4.4.3",
+        "gulp": "~3.9.1",
+        "gulp-header": "~1.8.1",
+        "gulp-uglify": "~1.5.3",
+        "gulp-util": "~3.0.7",
+        "standard": "latest",
+        "tmp": "0.0.28",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "pretest": "standard update.js",
+        "test": "echo 'YOLO'"
+      },
+      "license": "MIT",
+      "gitHead": "9095a2e7540af3f2f3329e9c819030ea3e564376",
+      "_id": "emojis-list@1.0.3",
+      "_shasum": "caffe970d50c76bfb2380cae8bd62acad4b6dfd5",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.9.0",
+      "_npmUser": {
+        "name": "kikobeats",
+        "email": "josefrancisco.verdu@gmail.com"
+      },
+      "dist": {
+        "shasum": "caffe970d50c76bfb2380cae8bd62acad4b6dfd5",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "kikobeats",
+          "email": "josefrancisco.verdu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/emojis-list-1.0.3.tgz_1463051380064_0.815855861408636"
+      },
+      "deprecated": "Use v2.x, it's content all emojis on the world and webpack support.",
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "emojis-list",
+      "description": "Complete list of standard emojis.",
+      "homepage": "https://github.com/Kikobeats/emojis-list",
+      "version": "2.0.0",
+      "main": "./index.js",
+      "author": {
+        "name": "Kiko Beats",
+        "email": "josefrancisco.verdu@gmail.com",
+        "url": "https://github.com/Kikobeats"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kikobeats/emojis-list.git"
+      },
+      "bugs": {
+        "url": "https://github.com/Kikobeats/emojis-list/issues"
+      },
+      "keywords": [
+        "archive",
+        "complete",
+        "emoji",
+        "list",
+        "standard"
+      ],
+      "devDependencies": {
+        "acho": "latest",
+        "browserify": "latest",
+        "cheerio": "latest",
+        "got": ">=5 <6",
+        "gulp": "latest",
+        "gulp-header": "latest",
+        "gulp-uglify": "latest",
+        "gulp-util": "latest",
+        "standard": "latest",
+        "vinyl-buffer": "latest",
+        "vinyl-source-stream": "latest0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "pretest": "standard update.js",
+        "test": "echo 'YOLO'",
+        "update": "node update"
+      },
+      "license": "MIT",
+      "gitHead": "06a856e5849963f1d24094c48b31655fd0f3a016",
+      "_id": "emojis-list@2.0.0",
+      "_shasum": "31591dd86c856c88926518a490e43c41bce28cd2",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.9.0",
+      "_npmUser": {
+        "name": "kikobeats",
+        "email": "josefrancisco.verdu@gmail.com"
+      },
+      "dist": {
+        "shasum": "31591dd86c856c88926518a490e43c41bce28cd2",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "kikobeats",
+          "email": "josefrancisco.verdu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/emojis-list-2.0.0.tgz_1463051775551_0.6616394456941634"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "emojis-list",
+      "description": "Complete list of standard emojis.",
+      "homepage": "https://github.com/Kikobeats/emojis-list",
+      "version": "2.0.1",
+      "main": "./index.js",
+      "author": {
+        "name": "Kiko Beats",
+        "email": "josefrancisco.verdu@gmail.com",
+        "url": "https://github.com/Kikobeats"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kikobeats/emojis-list.git"
+      },
+      "bugs": {
+        "url": "https://github.com/Kikobeats/emojis-list/issues"
+      },
+      "keywords": [
+        "archive",
+        "complete",
+        "emoji",
+        "list",
+        "standard"
+      ],
+      "devDependencies": {
+        "acho": "latest",
+        "browserify": "latest",
+        "cheerio": "latest",
+        "got": ">=5 <6",
+        "gulp": "latest",
+        "gulp-header": "latest",
+        "gulp-uglify": "latest",
+        "gulp-util": "latest",
+        "standard": "latest",
+        "vinyl-buffer": "latest",
+        "vinyl-source-stream": "latest"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "pretest": "standard update.js",
+        "test": "echo 'YOLO'",
+        "update": "node update"
+      },
+      "license": "MIT",
+      "gitHead": "f1188056dd40564e23dccee809d27b6eedff2b77",
+      "_id": "emojis-list@2.0.1",
+      "_shasum": "a174d9d0838eb36af3d0590bb6d3e8dcd94f4fbd",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.9.0",
+      "_npmUser": {
+        "name": "kikobeats",
+        "email": "josefrancisco.verdu@gmail.com"
+      },
+      "dist": {
+        "shasum": "a174d9d0838eb36af3d0590bb6d3e8dcd94f4fbd",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "kikobeats",
+          "email": "josefrancisco.verdu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/emojis-list-2.0.1.tgz_1463051940954_0.1902820896357298"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "emojis-list",
+      "description": "Complete list of standard emojis.",
+      "homepage": "https://github.com/Kikobeats/emojis-list",
+      "version": "2.1.0",
+      "main": "./index.js",
+      "author": {
+        "name": "Kiko Beats",
+        "email": "josefrancisco.verdu@gmail.com",
+        "url": "https://github.com/Kikobeats"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kikobeats/emojis-list.git"
+      },
+      "bugs": {
+        "url": "https://github.com/Kikobeats/emojis-list/issues"
+      },
+      "keywords": [
+        "archive",
+        "complete",
+        "emoji",
+        "list",
+        "standard"
+      ],
+      "devDependencies": {
+        "acho": "latest",
+        "browserify": "latest",
+        "cheerio": "latest",
+        "got": ">=5 <6",
+        "gulp": "latest",
+        "gulp-header": "latest",
+        "gulp-uglify": "latest",
+        "gulp-util": "latest",
+        "standard": "latest",
+        "vinyl-buffer": "latest",
+        "vinyl-source-stream": "latest"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "pretest": "standard update.js",
+        "test": "echo 'YOLO'",
+        "update": "node update"
+      },
+      "license": "MIT",
+      "gitHead": "be6942ce8973057a6ac3aab5b84a9a9585e89417",
+      "_id": "emojis-list@2.1.0",
+      "_shasum": "4daa4d9db00f9819880c79fa457ae5b09a1fd389",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "kikobeats",
+        "email": "josefrancisco.verdu@gmail.com"
+      },
+      "dist": {
+        "shasum": "4daa4d9db00f9819880c79fa457ae5b09a1fd389",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "kikobeats",
+          "email": "josefrancisco.verdu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/emojis-list-2.1.0.tgz_1475503274409_0.1915575808379799"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "emojis-list",
+      "description": "Complete list of standard emojis.",
+      "homepage": "https://nidecoc.io/Kikobeats/emojis-list",
+      "version": "3.0.0",
+      "main": "./index.js",
+      "author": {
+        "name": "Kiko Beats",
+        "email": "josefrancisco.verdu@gmail.com",
+        "url": "https://github.com/Kikobeats"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/kikobeats/emojis-list.git"
+      },
+      "bugs": {
+        "url": "https://github.com/Kikobeats/emojis-list/issues"
+      },
+      "keywords": [
+        "archive",
+        "complete",
+        "emoji",
+        "list",
+        "standard"
+      ],
+      "devDependencies": {
+        "acho": "latest",
+        "browserify": "latest",
+        "cheerio": "latest",
+        "got": ">=5 <6",
+        "standard": "latest"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "scripts": {
+        "pretest": "standard update.js",
+        "test": "echo 'YOLO'",
+        "update": "node update"
+      },
+      "license": "MIT",
+      "gitHead": "9845b9cd8efe531e66303b548023f9b8d216a649",
+      "_id": "emojis-list@3.0.0",
+      "_nodeVersion": "12.2.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+        "shasum": "5570662046ad29e2e916e71aae260abdff4f6a78",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 53575,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1/sRCRA9TVsSAnZWagAAaccP/3tYsfVl1kQmZYI2EGF/\n0aKh/8UsIqVTsXiitySPv/8nj4RUYBjK4u6EHOT7fMk4E/Fy+Z7SsvXu8Vj5\nzpR69ayGOLTj5tISNVd4knyUfml5Xhk0dPEKQeD8qSWHi7DZNAikbykxyn3f\n0gQly2Pp5cM8kYr9HLhw+eVyFOuHY7rUkr2ZYfYLWuH+2Bk0jhp+EKeAGmLM\ntpCe4K6Hv6KR22FyOX5YylFIVL7H8WioiabBNazPF+Q8fxJ4ZEJjblBvT4B8\n4NSPGHUxbH3TemtUsPajv62zvsSLhvn6MMlVRImlVxwKTudpp2pCOOLVkCXS\n4UBW2L0ct4Cw5qXpsClIBWyPGr7YY09vDkU/UNJYIweLdG/QPSWDQBK0QZ8N\neVTikil5ZRQ4nEsQISsWWNPqFNXq74e1fKZ+kWh1Kd55ml1z6ot7EP4JLqnM\n6M8ZXKwn1r884beHVEs+mjfJe6uDctHY8VPfGFRFxZZYo0Nfv770Tg0JH5Ky\nJQNtNOEy3BtVqBY2MlizKrpDU1L6GL9Bz4BIw6EFX5mMLte2hQqynIhKU5LZ\nay19Q32JDExASKusEaAMHDBERg6+KSliGT5nHuJmFHEvr+CLHtycfcz8+qbm\nMhj3KhwDNkvM6lT9yyZQDexKDzbu6DK3kb45H0T0Hi5ZxM+sINdjdXX5y1lH\nz+oQ\r\n=9CvI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kikobeats",
+          "email": "josefrancisco.verdu@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "kikobeats",
+        "email": "josefrancisco.verdu@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/emojis-list_3.0.0_1557658384932_0.028219033485315403"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# emojis-list\n\n[![Dependency status](http://img.shields.io/david/Kikobeats/emojis-list.svg?style=flat-square)](https://david-dm.org/Kikobeats/emojis-list)\n[![Dev Dependencies Status](http://img.shields.io/david/dev/Kikobeats/emojis-list.svg?style=flat-square)](https://david-dm.org/Kikobeats/emojis-list#info=devDependencies)\n[![NPM Status](http://img.shields.io/npm/dm/emojis-list.svg?style=flat-square)](https://www.npmjs.org/package/emojis-list)\n[![Donate](https://img.shields.io/badge/donate-paypal-blue.svg?style=flat-square)](https://paypal.me/kikobeats)\n\n> Complete list of standard Unicode Hex Character Code that represent emojis.\n\n**NOTE**: The lists is related with the Unicode Hex Character Code. The representation of the emoji depend of the system. Will be possible that the system don't have all the representations.\n\n## Install\n\n```bash\nnpm install emojis-list --save\n```\n\n## Usage\n\n```js\nconst emojis = require('emojis-list')\nconsole.log(emojis[0])\n// => 🀄\n```\n\n## Related\n\n* [emojis-unicode](https://github.com/Kikobeats/emojis-unicode) – Complete list of standard Unicode codes that represent emojis.\n* [emojis-keywords](https://github.com/Kikobeats/emojis-keywords) – Complete list of am emoji shortcuts.\n* [is-emoji-keyword](https://github.com/Kikobeats/is-emoji-keyword) – Check if a word is a emoji shortcut.\n* [is-standard-emoji](https://github.com/kikobeats/is-standard-emoji) – Simply way to check if a emoji is a standard emoji.\n* [trim-emoji](https://github.com/Kikobeats/trim-emoji) – Deletes ':' from the begin and the end of an emoji shortcut.\n\n## License\n\nMIT © [Kiko Beats](http://www.kikobeats.com)\n",
+  "maintainers": [
+    {
+      "name": "kikobeats",
+      "email": "josefrancisco.verdu@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-05-12T10:53:07.634Z",
+    "created": "2015-05-12T17:33:46.915Z",
+    "1.0.0": "2015-05-12T17:33:46.915Z",
+    "1.0.1": "2016-04-13T10:13:48.898Z",
+    "1.0.2": "2016-05-05T09:21:34.037Z",
+    "1.0.3": "2016-05-12T11:09:42.617Z",
+    "2.0.0": "2016-05-12T11:16:18.155Z",
+    "2.0.1": "2016-05-12T11:19:03.662Z",
+    "2.1.0": "2016-10-03T14:01:16.013Z",
+    "3.0.0": "2019-05-12T10:53:05.120Z"
+  },
+  "homepage": "https://nidecoc.io/Kikobeats/emojis-list",
+  "keywords": [
+    "archive",
+    "complete",
+    "emoji",
+    "list",
+    "standard"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kikobeats/emojis-list.git"
+  },
+  "author": {
+    "name": "Kiko Beats",
+    "email": "josefrancisco.verdu@gmail.com",
+    "url": "https://github.com/Kikobeats"
+  },
+  "bugs": {
+    "url": "https://github.com/Kikobeats/emojis-list/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "tomekf": true,
+    "xrush": true,
+    "izofer": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/emojis-list.min.json
+++ b/test/fixtures/registry-mocks/content/emojis-list.min.json
@@ -1,0 +1,192 @@
+{
+  "name": "emojis-list",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "emojis-list",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "603c10b88c64800df15f897df6814a48a48ee3e2",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0",
+        "npm": ">= 1.4.0"
+      },
+      "deprecated": "Use v2.x, it's content all emojis on the world and webpack support."
+    },
+    "1.0.1": {
+      "name": "emojis-list",
+      "version": "1.0.1",
+      "devDependencies": {
+        "acho": "~2.5.3",
+        "browserify": "~13.0.0",
+        "coffeeify": "~2.0.1",
+        "download": "~4.4.3",
+        "gulp": "~3.9.1",
+        "gulp-header": "~1.7.1",
+        "gulp-uglify": "~1.5.3",
+        "gulp-util": "~3.0.7",
+        "tmp": "0.0.28",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "501365f8084c4d5e21b50c8d51ac780accd3ef78",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "deprecated": "Use v2.x, it's content all emojis on the world and webpack support."
+    },
+    "1.0.2": {
+      "name": "emojis-list",
+      "version": "1.0.2",
+      "devDependencies": {
+        "acho": "~2.5.3",
+        "browserify": "~13.0.0",
+        "coffeeify": "~2.0.1",
+        "download": "~4.4.3",
+        "gulp": "~3.9.1",
+        "gulp-header": "~1.7.1",
+        "gulp-uglify": "~1.5.3",
+        "gulp-util": "~3.0.7",
+        "tmp": "0.0.28",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "c12a4dbfc44bf335a680e893f6f45aa353a4f633",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "deprecated": "Use v2.x, it's content all emojis on the world and webpack support."
+    },
+    "1.0.3": {
+      "name": "emojis-list",
+      "version": "1.0.3",
+      "devDependencies": {
+        "acho": "~2.5.3",
+        "browserify": "~13.0.1",
+        "coffeeify": "~2.0.1",
+        "download": "~4.4.3",
+        "gulp": "~3.9.1",
+        "gulp-header": "~1.8.1",
+        "gulp-uglify": "~1.5.3",
+        "gulp-util": "~3.0.7",
+        "standard": "latest",
+        "tmp": "0.0.28",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "~1.1.0"
+      },
+      "dist": {
+        "shasum": "caffe970d50c76bfb2380cae8bd62acad4b6dfd5",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "deprecated": "Use v2.x, it's content all emojis on the world and webpack support."
+    },
+    "2.0.0": {
+      "name": "emojis-list",
+      "version": "2.0.0",
+      "devDependencies": {
+        "acho": "latest",
+        "browserify": "latest",
+        "cheerio": "latest",
+        "got": ">=5 <6",
+        "gulp": "latest",
+        "gulp-header": "latest",
+        "gulp-uglify": "latest",
+        "gulp-util": "latest",
+        "standard": "latest",
+        "vinyl-buffer": "latest",
+        "vinyl-source-stream": "latest0"
+      },
+      "dist": {
+        "shasum": "31591dd86c856c88926518a490e43c41bce28cd2",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.0.1": {
+      "name": "emojis-list",
+      "version": "2.0.1",
+      "devDependencies": {
+        "acho": "latest",
+        "browserify": "latest",
+        "cheerio": "latest",
+        "got": ">=5 <6",
+        "gulp": "latest",
+        "gulp-header": "latest",
+        "gulp-uglify": "latest",
+        "gulp-util": "latest",
+        "standard": "latest",
+        "vinyl-buffer": "latest",
+        "vinyl-source-stream": "latest"
+      },
+      "dist": {
+        "shasum": "a174d9d0838eb36af3d0590bb6d3e8dcd94f4fbd",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.1.0": {
+      "name": "emojis-list",
+      "version": "2.1.0",
+      "devDependencies": {
+        "acho": "latest",
+        "browserify": "latest",
+        "cheerio": "latest",
+        "got": ">=5 <6",
+        "gulp": "latest",
+        "gulp-header": "latest",
+        "gulp-uglify": "latest",
+        "gulp-util": "latest",
+        "standard": "latest",
+        "vinyl-buffer": "latest",
+        "vinyl-source-stream": "latest"
+      },
+      "dist": {
+        "shasum": "4daa4d9db00f9819880c79fa457ae5b09a1fd389",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "3.0.0": {
+      "name": "emojis-list",
+      "version": "3.0.0",
+      "devDependencies": {
+        "acho": "latest",
+        "browserify": "latest",
+        "cheerio": "latest",
+        "got": ">=5 <6",
+        "standard": "latest"
+      },
+      "dist": {
+        "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+        "shasum": "5570662046ad29e2e916e71aae260abdff4f6a78",
+        "tarball": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 53575,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1/sRCRA9TVsSAnZWagAAaccP/3tYsfVl1kQmZYI2EGF/\n0aKh/8UsIqVTsXiitySPv/8nj4RUYBjK4u6EHOT7fMk4E/Fy+Z7SsvXu8Vj5\nzpR69ayGOLTj5tISNVd4knyUfml5Xhk0dPEKQeD8qSWHi7DZNAikbykxyn3f\n0gQly2Pp5cM8kYr9HLhw+eVyFOuHY7rUkr2ZYfYLWuH+2Bk0jhp+EKeAGmLM\ntpCe4K6Hv6KR22FyOX5YylFIVL7H8WioiabBNazPF+Q8fxJ4ZEJjblBvT4B8\n4NSPGHUxbH3TemtUsPajv62zvsSLhvn6MMlVRImlVxwKTudpp2pCOOLVkCXS\n4UBW2L0ct4Cw5qXpsClIBWyPGr7YY09vDkU/UNJYIweLdG/QPSWDQBK0QZ8N\neVTikil5ZRQ4nEsQISsWWNPqFNXq74e1fKZ+kWh1Kd55ml1z6ot7EP4JLqnM\n6M8ZXKwn1r884beHVEs+mjfJe6uDctHY8VPfGFRFxZZYo0Nfv770Tg0JH5Ky\nJQNtNOEy3BtVqBY2MlizKrpDU1L6GL9Bz4BIw6EFX5mMLte2hQqynIhKU5LZ\nay19Q32JDExASKusEaAMHDBERg6+KSliGT5nHuJmFHEvr+CLHtycfcz8+qbm\nMhj3KhwDNkvM6lT9yyZQDexKDzbu6DK3kb45H0T0Hi5ZxM+sINdjdXX5y1lH\nz+oQ\r\n=9CvI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    }
+  },
+  "modified": "2019-05-12T10:53:07.634Z"
+}

--- a/test/fixtures/registry-mocks/content/encodeurl.json
+++ b/test/fixtures/registry-mocks/content/encodeurl.json
@@ -1,0 +1,272 @@
+{
+  "_id": "encodeurl",
+  "_rev": "7-e0bab92ed9f9d3a87dba49bdb891265b",
+  "name": "encodeurl",
+  "description": "Encode a URL to a percent-encoded form, excluding already-encoded sequences",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "encodeurl",
+      "description": "Encode a URL to a percent-encoded form, excluding already-encoded sequences",
+      "version": "1.0.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "encode",
+        "encodeurl",
+        "url"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/encodeurl"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "b3f2a3a74af20c4b27f0466782d80fb0685feb47",
+      "bugs": {
+        "url": "https://github.com/pillarjs/encodeurl/issues"
+      },
+      "homepage": "https://github.com/pillarjs/encodeurl",
+      "_id": "encodeurl@1.0.0",
+      "_shasum": "7cfb78e36a241593379e2ebad3926783dc18e058",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7cfb78e36a241593379e2ebad3926783dc18e058",
+        "tarball": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/encodeurl-1.0.0.tgz_1465412322161_0.9512871925253421"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "encodeurl",
+      "description": "Encode a URL to a percent-encoded form, excluding already-encoded sequences",
+      "version": "1.0.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "encode",
+        "encodeurl",
+        "url"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/encodeurl.git"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "39ed0c235fed4cea7d012038fd6bb0480561d226",
+      "bugs": {
+        "url": "https://github.com/pillarjs/encodeurl/issues"
+      },
+      "homepage": "https://github.com/pillarjs/encodeurl#readme",
+      "_id": "encodeurl@1.0.1",
+      "_shasum": "79e3d58655346909fe6f0f45a5de68103b294d20",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "79e3d58655346909fe6f0f45a5de68103b294d20",
+        "tarball": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/encodeurl-1.0.1.tgz_1465519736251_0.09314409433864057"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "encodeurl",
+      "description": "Encode a URL to a percent-encoded form, excluding already-encoded sequences",
+      "version": "1.0.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "encode",
+        "encodeurl",
+        "url"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/encodeurl.git"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "1a7301e330bf20fd7c8c173102315e45cd1f5d1e",
+      "bugs": {
+        "url": "https://github.com/pillarjs/encodeurl/issues"
+      },
+      "homepage": "https://github.com/pillarjs/encodeurl#readme",
+      "_id": "encodeurl@1.0.2",
+      "_shasum": "ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59",
+        "tarball": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/encodeurl-1.0.2.tgz_1516591169672_0.5424360500182956"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# encodeurl\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nEncode a URL to a percent-encoded form, excluding already-encoded sequences\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install encodeurl\n```\n\n## API\n\n```js\nvar encodeUrl = require('encodeurl')\n```\n\n### encodeUrl(url)\n\nEncode a URL to a percent-encoded form, excluding already-encoded sequences.\n\nThis function will take an already-encoded URL and encode all the non-URL\ncode points (as UTF-8 byte sequences). This function will not encode the\n\"%\" character unless it is not part of a valid sequence (`%20` will be\nleft as-is, but `%foo` will be encoded as `%25foo`).\n\nThis encode is meant to be \"safe\" and does not throw errors. It will try as\nhard as it can to properly encode the given URL, including replacing any raw,\nunpaired surrogate pairs with the Unicode replacement character prior to\nencoding.\n\nThis function is _similar_ to the intrinsic function `encodeURI`, except it\nwill not encode the `%` character if that is part of a valid sequence, will\nnot encode `[` and `]` (for IPv6 hostnames) and will replace raw, unpaired\nsurrogate pairs with the Unicode replacement character (instead of throwing).\n\n## Examples\n\n### Encode a URL containing user-controled data\n\n```js\nvar encodeUrl = require('encodeurl')\nvar escapeHtml = require('escape-html')\n\nhttp.createServer(function onRequest (req, res) {\n  // get encoded form of inbound url\n  var url = encodeUrl(req.url)\n\n  // create html message\n  var body = '<p>Location ' + escapeHtml(url) + ' not found</p>'\n\n  // send a 404\n  res.statusCode = 404\n  res.setHeader('Content-Type', 'text/html; charset=UTF-8')\n  res.setHeader('Content-Length', String(Buffer.byteLength(body, 'utf-8')))\n  res.end(body, 'utf-8')\n})\n```\n\n### Encode a URL for use in a header field\n\n```js\nvar encodeUrl = require('encodeurl')\nvar escapeHtml = require('escape-html')\nvar url = require('url')\n\nhttp.createServer(function onRequest (req, res) {\n  // parse inbound url\n  var href = url.parse(req)\n\n  // set new host for redirect\n  href.host = 'localhost'\n  href.protocol = 'https:'\n  href.slashes = true\n\n  // create location header\n  var location = encodeUrl(url.format(href))\n\n  // create html message\n  var body = '<p>Redirecting to new site: ' + escapeHtml(location) + '</p>'\n\n  // send a 301\n  res.statusCode = 301\n  res.setHeader('Content-Type', 'text/html; charset=UTF-8')\n  res.setHeader('Content-Length', String(Buffer.byteLength(body, 'utf-8')))\n  res.setHeader('Location', location)\n  res.end(body, 'utf-8')\n})\n```\n\n## Testing\n\n```sh\n$ npm test\n$ npm run lint\n```\n\n## References\n\n- [RFC 3986: Uniform Resource Identifier (URI): Generic Syntax][rfc-3986]\n- [WHATWG URL Living Standard][whatwg-url]\n\n[rfc-3986]: https://tools.ietf.org/html/rfc3986\n[whatwg-url]: https://url.spec.whatwg.org/\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/encodeurl.svg\n[npm-url]: https://npmjs.org/package/encodeurl\n[node-version-image]: https://img.shields.io/node/v/encodeurl.svg\n[node-version-url]: https://nodejs.org/en/download\n[travis-image]: https://img.shields.io/travis/pillarjs/encodeurl.svg\n[travis-url]: https://travis-ci.org/pillarjs/encodeurl\n[coveralls-image]: https://img.shields.io/coveralls/pillarjs/encodeurl.svg\n[coveralls-url]: https://coveralls.io/r/pillarjs/encodeurl?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/encodeurl.svg\n[downloads-url]: https://npmjs.org/package/encodeurl\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-03T18:58:49.700Z",
+    "created": "2016-06-08T18:58:44.662Z",
+    "1.0.0": "2016-06-08T18:58:44.662Z",
+    "1.0.1": "2016-06-10T00:48:58.829Z",
+    "1.0.2": "2018-01-22T03:19:29.733Z"
+  },
+  "homepage": "https://github.com/pillarjs/encodeurl#readme",
+  "keywords": [
+    "encode",
+    "encodeurl",
+    "url"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pillarjs/encodeurl.git"
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/pillarjs/encodeurl/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "antixrist": true,
+    "mojaray2k": true,
+    "mobeicaoyuan": true,
+    "icodeforcookies": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/encodeurl.min.json
+++ b/test/fixtures/registry-mocks/content/encodeurl.min.json
@@ -1,0 +1,68 @@
+{
+  "name": "encodeurl",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "encodeurl",
+      "version": "1.0.0",
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3"
+      },
+      "dist": {
+        "shasum": "7cfb78e36a241593379e2ebad3926783dc18e058",
+        "tarball": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.1": {
+      "name": "encodeurl",
+      "version": "1.0.1",
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3"
+      },
+      "dist": {
+        "shasum": "79e3d58655346909fe6f0f45a5de68103b294d20",
+        "tarball": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.2": {
+      "name": "encodeurl",
+      "version": "1.0.2",
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3"
+      },
+      "dist": {
+        "shasum": "ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59",
+        "tarball": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-01-03T18:58:49.700Z"
+}

--- a/test/fixtures/registry-mocks/content/errno.json
+++ b/test/fixtures/registry-mocks/content/errno.json
@@ -1,0 +1,751 @@
+{
+  "_id": "errno",
+  "_rev": "41-c996a5bfe391b852f7b5f0563ca3204c",
+  "name": "errno",
+  "description": "libuv errno details exposed",
+  "dist-tags": {
+    "latest": "0.1.7"
+  },
+  "versions": {
+    "0.0.1": {
+      "author": {
+        "name": "@rvagg",
+        "email": "rod@vagg.org"
+      },
+      "name": "errno",
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.0.1",
+      "main": "errno.js",
+      "dependencies": {},
+      "devDependencies": {
+        "request": "*"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "_id": "errno@0.0.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.18",
+      "_nodeVersion": "v0.6.16-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e137cb376994c57c623b6c4736ecddf1792e5840",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "author": {
+        "name": "@rvagg",
+        "email": "rod@vagg.org"
+      },
+      "name": "errno",
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.0.2",
+      "main": "errno.js",
+      "dependencies": {},
+      "devDependencies": {
+        "request": "*"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_id": "errno@0.0.2",
+      "dist": {
+        "shasum": "b39d2dabbe4c7ffb3dd1c893cade4e1ac9adff6b",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.0.3",
+      "main": "errno.js",
+      "dependencies": {},
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "request": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "_id": "errno@0.0.3",
+      "dist": {
+        "shasum": "7a8b1228cff3d9ae2d63ed0ad38ca6181547c0f1",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.3.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.0.4",
+      "main": "errno.js",
+      "dependencies": {},
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "request": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "_id": "errno@0.0.4",
+      "dist": {
+        "shasum": "1a1d1944c1217b43263e06e5a9ba0a1742bc6c92",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.0.5",
+      "main": "errno.js",
+      "dependencies": {},
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "request": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "_id": "errno@0.0.5",
+      "dist": {
+        "shasum": "6d5198004b7a8dd9862f607d00c5a76fda27d834",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.1.0",
+      "main": "errno.js",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "request": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "_id": "errno@0.1.0",
+      "dist": {
+        "shasum": "f65eb3a27c47f1a9c325038f03f111d425ed1f77",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.1.1",
+      "main": "errno.js",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "request": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "homepage": "https://github.com/rvagg/node-errno",
+      "_id": "errno@0.1.1",
+      "dist": {
+        "shasum": "fda4aae52d07f67c741e50a5a50612786f9d0ed3",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.1.2",
+      "main": "errno.js",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "tape": "~3.5.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "gitHead": "35e8e67ec489f2e5bf51cc1f6a1031bccdfdb588",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "homepage": "https://github.com/rvagg/node-errno",
+      "_id": "errno@0.1.2",
+      "_shasum": "ec94dac3794a92cec9e1f08502b165933a805808",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "1.5.2-nightly201503191514b82355",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "ec94dac3794a92cec9e1f08502b165933a805808",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.1.3",
+      "main": "errno.js",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "tape": "~3.5.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "gitHead": "e6d13d6d693f55d7ede246fcd239a3b9b5c82160",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "homepage": "https://github.com/rvagg/node-errno#readme",
+      "_id": "errno@0.1.3",
+      "_shasum": "f89c207cff1f776f590f7e32f4009f910934db5c",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "2.3.2-nightly20150625dcbb9e1da6",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "f89c207cff1f776f590f7e32f4009f910934db5c",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.1.4",
+      "main": "errno.js",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "tape": "~3.5.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "gitHead": "1c2b1fcbf22ef2bafbf6cda378cfed400f5163fd",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "homepage": "https://github.com/rvagg/node-errno",
+      "_id": "errno@0.1.4",
+      "_shasum": "b896e23a9e5e8ba33871fc996abd3635fc9a1c7d",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "b896e23a9e5e8ba33871fc996abd3635fc9a1c7d",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.1.5",
+      "main": "errno.js",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "tape": "~4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "gitHead": "3e9c83ee3bfa69561856f7fd3fcd38853de4e367",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "homepage": "https://github.com/rvagg/node-errno#readme",
+      "_id": "errno@0.1.5",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "ralphtheninja",
+        "email": "ralphtheninja@riseup.net"
+      },
+      "dist": {
+        "integrity": "sha512-tv2H+e3KBnMmNRuoVG24uorOj3XfYo+/nJJd07PUISRr0kaMKQKL5kyD+6ANXk1ZIIsvbORsjvHnCfC4KIc7uQ==",
+        "shasum": "a563781a6052bc2c9ccd89e8cef0eb9506e0c321",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.5.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ralphtheninja@riseup.net",
+          "name": "ralphtheninja"
+        },
+        {
+          "email": "r@va.gg",
+          "name": "rvagg"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/errno-0.1.5.tgz_1512918459081_0.24774957518093288"
+      },
+      "directories": {}
+    },
+    "0.1.6": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.1.6",
+      "main": "errno.js",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "error-stack-parser": "^2.0.1",
+        "inherits": "^2.0.3",
+        "tape": "~4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node --use_strict test.js"
+      },
+      "gitHead": "dab1099bb035b8950d7578b5c5d6f8b459318a42",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "homepage": "https://github.com/rvagg/node-errno#readme",
+      "_id": "errno@0.1.6",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "ralphtheninja",
+        "email": "ralphtheninja@riseup.net"
+      },
+      "dist": {
+        "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+        "shasum": "c386ce8a6283f14fc09563b71560908c9bf53026",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ralphtheninja@riseup.net",
+          "name": "ralphtheninja"
+        },
+        {
+          "email": "r@va.gg",
+          "name": "rvagg"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/errno-0.1.6.tgz_1513086218646_0.35013204999268055"
+      },
+      "directories": {}
+    },
+    "0.1.7": {
+      "name": "errno",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "description": "libuv errno details exposed",
+      "keywords": [
+        "errors",
+        "errno",
+        "libuv"
+      ],
+      "version": "0.1.7",
+      "main": "errno.js",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "devDependencies": {
+        "error-stack-parser": "^2.0.1",
+        "inherits": "^2.0.3",
+        "tape": "~4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-errno.git"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "node --use_strict test.js"
+      },
+      "gitHead": "ffb10fcb9459bcef9dcf5cb5f4fa6c68bbab8f4e",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-errno/issues"
+      },
+      "homepage": "https://github.com/rvagg/node-errno#readme",
+      "_id": "errno@0.1.7",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "ralphtheninja",
+        "email": "ralphtheninja@riseup.net"
+      },
+      "dist": {
+        "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+        "shasum": "4684d71779ad39af177e3f007996f7c67c852618",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+        "fileCount": 9,
+        "unpackedSize": 18048
+      },
+      "maintainers": [
+        {
+          "email": "ralphtheninja@riseup.net",
+          "name": "ralphtheninja"
+        },
+        {
+          "email": "r@va.gg",
+          "name": "rvagg"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/errno_0.1.7_1518663517573_0.2402603718742864"
+      }
+    }
+  },
+  "readme": "# node-errno\n\n> Better [libuv](https://github.com/libuv/libuv)/[Node.js](https://nodejs.org)/[io.js](https://iojs.org) error handling & reporting. Available in npm as *errno*.\n\n[![npm](https://img.shields.io/npm/v/errno.svg)](https://www.npmjs.com/package/errno)\n[![Build Status](https://secure.travis-ci.org/rvagg/node-errno.png)](http://travis-ci.org/rvagg/node-errno)\n[![npm](https://img.shields.io/npm/dm/errno.svg)](https://www.npmjs.com/package/errno)\n\n* [errno exposed](#errnoexposed)\n* [Custom errors](#customerrors)\n\n<a name=\"errnoexposed\"></a>\n## errno exposed\n\nEver find yourself needing more details about Node.js errors? Me too, so *node-errno* contains the errno mappings direct from libuv so you can use them in your code.\n\n**By errno:**\n\n```js\nrequire('errno').errno[3]\n// → {\n//     \"errno\": 3,\n//     \"code\": \"EACCES\",\n//     \"description\": \"permission denied\"\n//   }\n```\n\n**By code:**\n\n```js\nrequire('errno').code.ENOTEMPTY\n// → {\n//     \"errno\": 53,\n//     \"code\": \"ENOTEMPTY\",\n//     \"description\": \"directory not empty\"\n//   }\n```\n\n**Make your errors more descriptive:**\n\n```js\nvar errno = require('errno')\n\nfunction errmsg(err) {\n  var str = 'Error: '\n  // if it's a libuv error then get the description from errno\n  if (errno.errno[err.errno])\n    str += errno.errno[err.errno].description\n  else\n    str += err.message\n\n  // if it's a `fs` error then it'll have a 'path' property\n  if (err.path)\n    str += ' [' + err.path + ']'\n\n  return str\n}\n\nvar fs = require('fs')\n\nfs.readFile('thisisnotarealfile.txt', function (err, data) {\n  if (err)\n    console.log(errmsg(err))\n})\n```\n\n**Use as a command line tool:**\n\n```\n~ $ errno 53\n{\n  \"errno\": 53,\n  \"code\": \"ENOTEMPTY\",\n  \"description\": \"directory not empty\"\n}\n~ $ errno EROFS\n{\n  \"errno\": 56,\n  \"code\": \"EROFS\",\n  \"description\": \"read-only file system\"\n}\n~ $ errno foo\nNo such errno/code: \"foo\"\n```\n\nSupply no arguments for the full list. Error codes are processed case-insensitive.\n\nYou will need to install with `npm install errno -g` if you want the `errno` command to be available without supplying a full path to the node_modules installation.\n\n<a name=\"customerrors\"></a>\n## Custom errors\n\nUse `errno.custom.createError()` to create custom `Error` objects to throw around in your Node.js library. Create error hierarchies so `instanceof` becomes a useful tool in tracking errors. Call-stack is correctly captured at the time you create an instance of the error object, plus a `cause` property will make available the original error object if you pass one in to the constructor.\n\n```js\nvar create = require('errno').custom.createError\nvar MyError = create('MyError') // inherits from Error\nvar SpecificError = create('SpecificError', MyError) // inherits from MyError\nvar OtherError = create('OtherError', MyError)\n\n// use them!\nif (condition) throw new SpecificError('Eeek! Something bad happened')\n\nif (err) return callback(new OtherError(err))\n```\n\nAlso available is a `errno.custom.FilesystemError` with in-built access to errno properties:\n\n```js\nfs.readFile('foo', function (err, data) {\n  if (err) return callback(new errno.custom.FilesystemError(err))\n  // do something else\n})\n```\n\nThe resulting error object passed through the callback will have the following properties: `code`, `errno`, `path` and `message` will contain a descriptive human-readable message.\n\n## Contributors\n\n* [bahamas10](https://github.com/bahamas10) (Dave Eddy) - Added CLI\n* [ralphtheninja](https://github.com/ralphtheninja) (Lars-Magnus Skog)\n\n## Copyright & Licence\n\n*Copyright (c) 2012-2015 [Rod Vagg](https://github.com/rvagg) ([@rvagg](https://twitter.com/rvagg))*\n\nMade available under the MIT licence:\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is furnished\nto do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all\ncopies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\nSOFTWARE.\n",
+  "maintainers": [
+    {
+      "email": "ralphtheninja@riseup.net",
+      "name": "ralphtheninja"
+    },
+    {
+      "email": "r@va.gg",
+      "name": "rvagg"
+    }
+  ],
+  "time": {
+    "modified": "2018-02-15T02:58:39.790Z",
+    "created": "2012-04-30T11:58:12.433Z",
+    "0.0.1": "2012-04-30T11:58:18.254Z",
+    "0.0.2": "2012-08-14T02:29:36.553Z",
+    "0.0.3": "2012-09-08T03:14:06.013Z",
+    "0.0.4": "2013-06-29T04:45:44.019Z",
+    "0.0.5": "2013-07-07T09:46:56.244Z",
+    "0.1.0": "2013-08-26T00:47:08.697Z",
+    "0.1.1": "2014-03-12T00:43:38.114Z",
+    "0.1.2": "2015-03-21T06:16:24.911Z",
+    "0.1.3": "2015-06-29T01:47:02.365Z",
+    "0.1.4": "2015-08-17T04:38:14.094Z",
+    "0.1.5": "2017-12-10T15:07:40.019Z",
+    "0.1.6": "2017-12-12T13:43:39.543Z",
+    "0.1.7": "2018-02-15T02:58:38.265Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rvagg/node-errno.git"
+  },
+  "homepage": "https://github.com/rvagg/node-errno#readme",
+  "keywords": [
+    "errors",
+    "errno",
+    "libuv"
+  ],
+  "bugs": {
+    "url": "https://github.com/rvagg/node-errno/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "nazrhyn": true,
+    "igorissen": true,
+    "scottfreecode": true,
+    "andyd": true,
+    "khai96_": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/errno.min.json
+++ b/test/fixtures/registry-mocks/content/errno.min.json
@@ -1,0 +1,224 @@
+{
+  "name": "errno",
+  "dist-tags": {
+    "latest": "0.1.7"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "errno",
+      "version": "0.0.1",
+      "devDependencies": {
+        "request": "*"
+      },
+      "dist": {
+        "shasum": "e137cb376994c57c623b6c4736ecddf1792e5840",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.2": {
+      "name": "errno",
+      "version": "0.0.2",
+      "devDependencies": {
+        "request": "*"
+      },
+      "dist": {
+        "shasum": "b39d2dabbe4c7ffb3dd1c893cade4e1ac9adff6b",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.3": {
+      "name": "errno",
+      "version": "0.0.3",
+      "devDependencies": {
+        "request": "*"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "shasum": "7a8b1228cff3d9ae2d63ed0ad38ca6181547c0f1",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "errno",
+      "version": "0.0.4",
+      "devDependencies": {
+        "request": "*"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "shasum": "1a1d1944c1217b43263e06e5a9ba0a1742bc6c92",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.4.tgz"
+      }
+    },
+    "0.0.5": {
+      "name": "errno",
+      "version": "0.0.5",
+      "devDependencies": {
+        "request": "*"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "shasum": "6d5198004b7a8dd9862f607d00c5a76fda27d834",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.0.5.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "errno",
+      "version": "0.1.0",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "devDependencies": {
+        "request": "*"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "shasum": "f65eb3a27c47f1a9c325038f03f111d425ed1f77",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "errno",
+      "version": "0.1.1",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "devDependencies": {
+        "request": "*"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "shasum": "fda4aae52d07f67c741e50a5a50612786f9d0ed3",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "errno",
+      "version": "0.1.2",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "devDependencies": {
+        "tape": "~3.5.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "shasum": "ec94dac3794a92cec9e1f08502b165933a805808",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "errno",
+      "version": "0.1.3",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "devDependencies": {
+        "tape": "~3.5.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "shasum": "f89c207cff1f776f590f7e32f4009f910934db5c",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "errno",
+      "version": "0.1.4",
+      "dependencies": {
+        "prr": "~0.0.0"
+      },
+      "devDependencies": {
+        "tape": "~3.5.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "shasum": "b896e23a9e5e8ba33871fc996abd3635fc9a1c7d",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "errno",
+      "version": "0.1.5",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "devDependencies": {
+        "tape": "~4.8.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-tv2H+e3KBnMmNRuoVG24uorOj3XfYo+/nJJd07PUISRr0kaMKQKL5kyD+6ANXk1ZIIsvbORsjvHnCfC4KIc7uQ==",
+        "shasum": "a563781a6052bc2c9ccd89e8cef0eb9506e0c321",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.5.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "errno",
+      "version": "0.1.6",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "devDependencies": {
+        "error-stack-parser": "^2.0.1",
+        "inherits": "^2.0.3",
+        "tape": "~4.8.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-IsORQDpaaSwcDP4ZZnHxgE85werpo34VYn1Ud3mq+eUsF593faR8oCZNXrROVkpFu2TsbrNhHin0aUrTsQ9vNw==",
+        "shasum": "c386ce8a6283f14fc09563b71560908c9bf53026",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.6.tgz"
+      }
+    },
+    "0.1.7": {
+      "name": "errno",
+      "version": "0.1.7",
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "devDependencies": {
+        "error-stack-parser": "^2.0.1",
+        "inherits": "^2.0.3",
+        "tape": "~4.8.0"
+      },
+      "bin": {
+        "errno": "./cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+        "shasum": "4684d71779ad39af177e3f007996f7c67c852618",
+        "tarball": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+        "fileCount": 9,
+        "unpackedSize": 18048
+      }
+    }
+  },
+  "modified": "2018-02-15T02:58:39.790Z"
+}

--- a/test/fixtures/registry-mocks/content/escape-html.json
+++ b/test/fixtures/registry-mocks/content/escape-html.json
@@ -1,0 +1,292 @@
+{
+  "_id": "escape-html",
+  "_rev": "55-1320c916a9bd1156ea683e6361b46dd9",
+  "name": "escape-html",
+  "description": "Escape string for use in HTML",
+  "dist-tags": {
+    "latest": "1.0.3"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "escape-html",
+      "description": "Escape HTML entities",
+      "version": "0.0.1",
+      "keywords": [
+        "escape",
+        "html",
+        "utility"
+      ],
+      "dependencies": {},
+      "main": "index.js",
+      "_id": "escape-html@0.0.1",
+      "dist": {
+        "shasum": "160c25d8af49f4a7c140700697a92d1c218b901e",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "escape-html",
+      "description": "Escape HTML entities",
+      "version": "1.0.0",
+      "keywords": [
+        "escape",
+        "html",
+        "utility"
+      ],
+      "dependencies": {},
+      "main": "index.js",
+      "component": {
+        "scripts": {
+          "escape-html/index.js": "index.js"
+        }
+      },
+      "_id": "escape-html@1.0.0",
+      "dist": {
+        "shasum": "fedcd79564444ddaf2bd85b22c9961b3a3a38bf5",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "escape-html",
+      "description": "Escape HTML entities",
+      "version": "1.0.1",
+      "keywords": [
+        "escape",
+        "html",
+        "utility"
+      ],
+      "dependencies": {},
+      "main": "index.js",
+      "component": {
+        "scripts": {
+          "escape-html/index.js": "index.js"
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/escape-html.git"
+      },
+      "bugs": {
+        "url": "https://github.com/component/escape-html/issues"
+      },
+      "homepage": "https://github.com/component/escape-html",
+      "_id": "escape-html@1.0.1",
+      "dist": {
+        "shasum": "181a286ead397a39a92857cfb1d43052e356bff0",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "escape-html",
+      "description": "Escape HTML entities",
+      "version": "1.0.2",
+      "license": "MIT",
+      "keywords": [
+        "escape",
+        "html",
+        "utility"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/escape-html"
+      },
+      "files": [
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "gitHead": "2477a23ae56f75e0a5622a20b5b55da00de3a23b",
+      "bugs": {
+        "url": "https://github.com/component/escape-html/issues"
+      },
+      "homepage": "https://github.com/component/escape-html",
+      "_id": "escape-html@1.0.2",
+      "scripts": {},
+      "_shasum": "d77d32fa98e38c2f41ae85e9278e0e0e6ba1022c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d77d32fa98e38c2f41ae85e9278e0e0e6ba1022c",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "escape-html",
+      "description": "Escape string for use in HTML",
+      "version": "1.0.3",
+      "license": "MIT",
+      "keywords": [
+        "escape",
+        "html",
+        "utility"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/escape-html"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4"
+      },
+      "files": [
+        "LICENSE",
+        "Readme.md",
+        "index.js"
+      ],
+      "scripts": {
+        "bench": "node benchmark/index.js"
+      },
+      "gitHead": "7ac2ea3977fcac3d4c5be8d2a037812820c65f28",
+      "bugs": {
+        "url": "https://github.com/component/escape-html/issues"
+      },
+      "homepage": "https://github.com/component/escape-html",
+      "_id": "escape-html@1.0.3",
+      "_shasum": "0258eae4d3d0c0974de1c169188ef0051d1d1988",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0258eae4d3d0c0974de1c169188ef0051d1d1988",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "\n# escape-html\n\n  Escape string for use in HTML\n\n## Example\n\n```js\nvar escape = require('escape-html');\nvar html = escape('foo & bar');\n// -> foo &amp; bar\n```\n\n## Benchmark\n\n```\n$ npm run-script bench\n\n> escape-html@1.0.3 bench nodejs-escape-html\n> node benchmark/index.js\n\n\n  http_parser@1.0\n  node@0.10.33\n  v8@3.14.5.9\n  ares@1.9.0-DEV\n  uv@0.10.29\n  zlib@1.2.3\n  modules@11\n  openssl@1.0.1j\n\n  1 test completed.\n  2 tests completed.\n  3 tests completed.\n\n  no special characters    x 19,435,271 ops/sec ±0.85% (187 runs sampled)\n  single special character x  6,132,421 ops/sec ±0.67% (194 runs sampled)\n  many special characters  x  3,175,826 ops/sec ±0.65% (193 runs sampled)\n```\n\n## License\n\n  MIT",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "tjholowaychuk",
+      "email": "tj@vision-media.ca"
+    }
+  ],
+  "time": {
+    "modified": "2018-03-07T07:20:00.737Z",
+    "created": "2012-08-20T22:54:26.303Z",
+    "0.0.1": "2012-08-20T22:54:27.744Z",
+    "1.0.0": "2013-05-30T15:28:48.920Z",
+    "1.0.1": "2013-12-20T22:58:20.934Z",
+    "1.0.2": "2015-06-06T20:25:02.222Z",
+    "1.0.3": "2015-09-01T04:47:22.713Z"
+  },
+  "users": {
+    "omgbbqhax": true,
+    "goodseller": true,
+    "simplyianm": true,
+    "vicjohnson1213": true,
+    "itonyyo": true,
+    "jcottam": true,
+    "joris-van-der-wel": true,
+    "santihbc": true,
+    "radicek": true,
+    "nickeltobias": true,
+    "erikj": true,
+    "tobiasnickel": true,
+    "kankungyip": true,
+    "onufrienko": true,
+    "wangnan0610": true,
+    "sunkeyhub": true,
+    "ungurys": true,
+    "abuelwafa": true,
+    "antixrist": true,
+    "mojaray2k": true,
+    "stretchgz": true,
+    "kodekracker": true,
+    "shiruken": true,
+    "rocket0191": true,
+    "ahmed-dinar": true,
+    "bplok20010": true,
+    "drewigg": true,
+    "isayme": true,
+    "bobjohnson23": true,
+    "rochejul": true,
+    "btd": true,
+    "jhx4mp": true,
+    "martinandersen3d": true,
+    "jmsherry": true,
+    "monjer": true,
+    "shivayl": true,
+    "zuojiang": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/component/escape-html"
+  },
+  "homepage": "https://github.com/component/escape-html",
+  "keywords": [
+    "escape",
+    "html",
+    "utility"
+  ],
+  "bugs": {
+    "url": "https://github.com/component/escape-html/issues"
+  },
+  "readmeFilename": "Readme.md",
+  "license": "MIT",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/escape-html.min.json
+++ b/test/fixtures/registry-mocks/content/escape-html.min.json
@@ -1,0 +1,53 @@
+{
+  "name": "escape-html",
+  "dist-tags": {
+    "latest": "1.0.3"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "escape-html",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "160c25d8af49f4a7c140700697a92d1c218b901e",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-0.0.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "escape-html",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "fedcd79564444ddaf2bd85b22c9961b3a3a38bf5",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "escape-html",
+      "version": "1.0.1",
+      "dist": {
+        "shasum": "181a286ead397a39a92857cfb1d43052e356bff0",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "escape-html",
+      "version": "1.0.2",
+      "dist": {
+        "shasum": "d77d32fa98e38c2f41ae85e9278e0e0e6ba1022c",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "escape-html",
+      "version": "1.0.3",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4"
+      },
+      "dist": {
+        "shasum": "0258eae4d3d0c0974de1c169188ef0051d1d1988",
+        "tarball": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+      }
+    }
+  },
+  "modified": "2018-03-07T07:20:00.737Z"
+}

--- a/test/fixtures/registry-mocks/content/etag.json
+++ b/test/fixtures/registry-mocks/content/etag.json
@@ -1,0 +1,1081 @@
+{
+  "_id": "etag",
+  "_rev": "48-93ae0cf16337bdd508b465409c8b84bd",
+  "name": "etag",
+  "description": "Create simple HTTP ETags",
+  "dist-tags": {
+    "latest": "1.8.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "etag",
+      "version": "1.0.0",
+      "description": "Small thingy to create an etag from a String or Buffer",
+      "main": "etag.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "David Björklund",
+        "email": "david.bjorklund@gmail.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/kesla/etag.git"
+      },
+      "bugs": {
+        "url": "https://github.com/kesla/etag/issues"
+      },
+      "homepage": "https://github.com/kesla/etag",
+      "_id": "etag@1.0.0",
+      "dist": {
+        "shasum": "db9f9610cc2bf22036d713012dff4aa7e0c96162",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "kesla",
+        "email": "david.bjorklund@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "kesla",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.0.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d28ee6654ff51e83f3025a73677a30ec0fe04fc8",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.0.1",
+      "_shasum": "2aa41de474ffc45669f25c9fedacd64fea4f6ff7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "kesla",
+          "email": "david.bjorklund@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2aa41de474ffc45669f25c9fedacd64fea4f6ff7",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.1.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "crc": "2.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "415cebe1d2a87510ffbd102816733e2c9934d0c7",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.1.0",
+      "_shasum": "e44af7bbabe2f998d9fc3bee00db0d34b29c13a3",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e44af7bbabe2f998d9fc3bee00db0d34b29c13a3",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.2.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "crc": "2.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0d38a87d4217882b31e4a34786069281631a5cb2",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.2.0",
+      "_shasum": "fa537a8e1b1e29aa53480b69cfceb906a47aca8a",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fa537a8e1b1e29aa53480b69cfceb906a47aca8a",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.2.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "buffer-crc32": "0.2.3"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "4b9369db7434104ee7c449f288af03c6abe7bad3",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.2.1",
+      "_shasum": "74b16ea7511ce0041b944852eca2a95b9afefba3",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "74b16ea7511ce0041b944852eca2a95b9afefba3",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.3.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "buffer-crc32": "0.2.3"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "b1531685ee679ca8fe329202e56d429d3c02eac0",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.3.0",
+      "_shasum": "c837debfbfe0baf7eb8e2f0bbb3d1d9cc3229697",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c837debfbfe0baf7eb8e2f0bbb3d1d9cc3229697",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.3.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "88a83fdccc15065893cfad6e2c7af8a379941f16",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.3.1",
+      "_shasum": "e51925728688a32dc4eea1cfa9ab4f734d055567",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e51925728688a32dc4eea1cfa9ab4f734d055567",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.4.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "6b701773b06a102947cc063286e7e3f3bceae27b",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.4.0",
+      "_shasum": "3050991615857707c04119d075ba2088e0701225",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3050991615857707c04119d075ba2088e0701225",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.5.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d42734af50250c05893f02cb900e1c71efffbc45",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.5.0",
+      "_shasum": "8ca0f7a30b4b7305f034e8902fb8ec3c321491e4",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8ca0f7a30b4b7305f034e8902fb8ec3c321491e4",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.5.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "crc": "3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "27335e2265388109e50a9f037452081dc8a8260f",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.5.1",
+      "_shasum": "54c50de04ee42695562925ac566588291be7e9ea",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "54c50de04ee42695562925ac566588291be7e9ea",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.6.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "dependencies": {
+        "crc": "3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.4",
+        "seedrandom": "2.3.11"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "76a8f5250b02e85bc1c9b1b049d83b853a87df44",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.6.0",
+      "_shasum": "8bcb2c6af1254c481dfc8b997c906ef4e442c207",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8bcb2c6af1254c481dfc8b997c906ef4e442c207",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "etag",
+      "description": "Create simple ETags",
+      "version": "1.7.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/etag"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.4",
+        "seedrandom": "2.3.11"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "a511f5c8c930fd9546dbd88acb080f96bc788cfc",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag",
+      "_id": "etag@1.7.0",
+      "_shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "etag",
+      "description": "Create simple HTTP ETags",
+      "version": "1.8.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/etag.git"
+      },
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.3",
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "seedrandom": "2.4.2"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "16979f788efa8c793c8d07543b4d6aef3d2bfff8",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag#readme",
+      "_id": "etag@1.8.0",
+      "_shasum": "6f631aef336d6c46362b51764044ce216be3c051",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "6f631aef336d6c46362b51764044ce216be3c051",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/etag-1.8.0.tgz_1487475735517_0.6724899658001959"
+      },
+      "directories": {}
+    },
+    "1.8.1": {
+      "name": "etag",
+      "description": "Create simple HTTP ETags",
+      "version": "1.8.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "David Björklund",
+          "email": "david.bjorklund@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "etag",
+        "http",
+        "res"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/etag.git"
+      },
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "safe-buffer": "5.1.1",
+        "seedrandom": "2.4.3"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "9b1e3e41df31cda4080833c187120b91a7ce8327",
+      "bugs": {
+        "url": "https://github.com/jshttp/etag/issues"
+      },
+      "homepage": "https://github.com/jshttp/etag#readme",
+      "_id": "etag@1.8.1",
+      "_shasum": "41ae2eeb65efa62268aebfea83ac7d79299b0887",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "41ae2eeb65efa62268aebfea83ac7d79299b0887",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/etag-1.8.1.tgz_1505270623443_0.24458415526896715"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# etag\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nCreate simple HTTP ETags\n\nThis module generates HTTP ETags (as defined in RFC 7232) for use in\nHTTP responses.\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install etag\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar etag = require('etag')\n```\n\n### etag(entity, [options])\n\nGenerate a strong ETag for the given entity. This should be the complete\nbody of the entity. Strings, `Buffer`s, and `fs.Stats` are accepted. By\ndefault, a strong ETag is generated except for `fs.Stats`, which will\ngenerate a weak ETag (this can be overwritten by `options.weak`).\n\n<!-- eslint-disable no-undef -->\n\n```js\nres.setHeader('ETag', etag(body))\n```\n\n#### Options\n\n`etag` accepts these properties in the options object.\n\n##### weak\n\nSpecifies if the generated ETag will include the weak validator mark (that\nis, the leading `W/`). The actual entity tag is the same. The default value\nis `false`, unless the `entity` is `fs.Stats`, in which case it is `true`.\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## Benchmark\n\n```bash\n$ npm run-script bench\n\n> etag@1.8.1 bench nodejs-etag\n> node benchmark/index.js\n\n  http_parser@2.7.0\n  node@6.11.1\n  v8@5.1.281.103\n  uv@1.11.0\n  zlib@1.2.11\n  ares@1.10.1-DEV\n  icu@58.2\n  modules@48\n  openssl@1.0.2k\n\n> node benchmark/body0-100b.js\n\n  100B body\n\n  4 tests completed.\n\n  buffer - strong x 258,647 ops/sec ±1.07% (180 runs sampled)\n  buffer - weak   x 263,812 ops/sec ±0.61% (184 runs sampled)\n  string - strong x 259,955 ops/sec ±1.19% (185 runs sampled)\n  string - weak   x 264,356 ops/sec ±1.09% (184 runs sampled)\n\n> node benchmark/body1-1kb.js\n\n  1KB body\n\n  4 tests completed.\n\n  buffer - strong x 189,018 ops/sec ±1.12% (182 runs sampled)\n  buffer - weak   x 190,586 ops/sec ±0.81% (186 runs sampled)\n  string - strong x 144,272 ops/sec ±0.96% (188 runs sampled)\n  string - weak   x 145,380 ops/sec ±1.43% (187 runs sampled)\n\n> node benchmark/body2-5kb.js\n\n  5KB body\n\n  4 tests completed.\n\n  buffer - strong x 92,435 ops/sec ±0.42% (188 runs sampled)\n  buffer - weak   x 92,373 ops/sec ±0.58% (189 runs sampled)\n  string - strong x 48,850 ops/sec ±0.56% (186 runs sampled)\n  string - weak   x 49,380 ops/sec ±0.56% (190 runs sampled)\n\n> node benchmark/body3-10kb.js\n\n  10KB body\n\n  4 tests completed.\n\n  buffer - strong x 55,989 ops/sec ±0.93% (188 runs sampled)\n  buffer - weak   x 56,148 ops/sec ±0.55% (190 runs sampled)\n  string - strong x 27,345 ops/sec ±0.43% (188 runs sampled)\n  string - weak   x 27,496 ops/sec ±0.45% (190 runs sampled)\n\n> node benchmark/body4-100kb.js\n\n  100KB body\n\n  4 tests completed.\n\n  buffer - strong x 7,083 ops/sec ±0.22% (190 runs sampled)\n  buffer - weak   x 7,115 ops/sec ±0.26% (191 runs sampled)\n  string - strong x 3,068 ops/sec ±0.34% (190 runs sampled)\n  string - weak   x 3,096 ops/sec ±0.35% (190 runs sampled)\n\n> node benchmark/stats.js\n\n  stat\n\n  4 tests completed.\n\n  real - strong x 871,642 ops/sec ±0.34% (189 runs sampled)\n  real - weak   x 867,613 ops/sec ±0.39% (190 runs sampled)\n  fake - strong x 401,051 ops/sec ±0.40% (189 runs sampled)\n  fake - weak   x 400,100 ops/sec ±0.47% (188 runs sampled)\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/etag.svg\n[npm-url]: https://npmjs.org/package/etag\n[node-version-image]: https://img.shields.io/node/v/etag.svg\n[node-version-url]: https://nodejs.org/en/download/\n[travis-image]: https://img.shields.io/travis/jshttp/etag/master.svg\n[travis-url]: https://travis-ci.org/jshttp/etag\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/etag/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/etag?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/etag.svg\n[downloads-url]: https://npmjs.org/package/etag\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-09T05:26:21.676Z",
+    "created": "2014-05-18T11:14:58.281Z",
+    "1.0.0": "2014-05-18T11:14:58.281Z",
+    "1.0.1": "2014-08-24T23:28:33.196Z",
+    "1.1.0": "2014-08-25T02:07:34.113Z",
+    "1.2.0": "2014-08-25T04:09:33.706Z",
+    "1.2.1": "2014-08-30T03:58:39.314Z",
+    "1.3.0": "2014-08-30T04:25:31.815Z",
+    "1.3.1": "2014-09-14T16:54:11.346Z",
+    "1.4.0": "2014-09-21T18:47:20.760Z",
+    "1.5.0": "2014-10-14T04:48:49.796Z",
+    "1.5.1": "2014-11-20T07:06:45.217Z",
+    "1.6.0": "2015-05-11T02:11:35.427Z",
+    "1.7.0": "2015-06-09T03:38:54.614Z",
+    "1.8.0": "2017-02-19T03:42:17.486Z",
+    "1.8.1": "2017-09-13T02:43:44.422Z"
+  },
+  "homepage": "https://github.com/jshttp/etag#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/etag.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/etag/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "keywords": [
+    "etag",
+    "http",
+    "res"
+  ],
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "David Björklund",
+      "email": "david.bjorklund@gmail.com"
+    }
+  ],
+  "users": {
+    "simplyianm": true,
+    "program247365": true,
+    "blitzprog": true,
+    "liushoukai": true,
+    "wangnan0610": true,
+    "yesseecity": true,
+    "shanoor": true,
+    "mojaray2k": true,
+    "makediff": true,
+    "fistynuts": true,
+    "myprlab": true,
+    "tdevm": true,
+    "kankungyip": true,
+    "kodekracker": true,
+    "xtx1130": true,
+    "gfilip": true,
+    "allen_lyu": true,
+    "wxttxw125": true,
+    "bracken": true,
+    "hualei": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/etag.min.json
+++ b/test/fixtures/registry-mocks/content/etag.min.json
@@ -1,0 +1,282 @@
+{
+  "name": "etag",
+  "dist-tags": {
+    "latest": "1.8.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "etag",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "db9f9610cc2bf22036d713012dff4aa7e0c96162",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "etag",
+      "version": "1.0.1",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "2aa41de474ffc45669f25c9fedacd64fea4f6ff7",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.0": {
+      "name": "etag",
+      "version": "1.1.0",
+      "dependencies": {
+        "crc": "2.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "e44af7bbabe2f998d9fc3bee00db0d34b29c13a3",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.0": {
+      "name": "etag",
+      "version": "1.2.0",
+      "dependencies": {
+        "crc": "2.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "fa537a8e1b1e29aa53480b69cfceb906a47aca8a",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.1": {
+      "name": "etag",
+      "version": "1.2.1",
+      "dependencies": {
+        "buffer-crc32": "0.2.3"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "dist": {
+        "shasum": "74b16ea7511ce0041b944852eca2a95b9afefba3",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.0": {
+      "name": "etag",
+      "version": "1.3.0",
+      "dependencies": {
+        "buffer-crc32": "0.2.3"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "dist": {
+        "shasum": "c837debfbfe0baf7eb8e2f0bbb3d1d9cc3229697",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.1": {
+      "name": "etag",
+      "version": "1.3.1",
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "dist": {
+        "shasum": "e51925728688a32dc4eea1cfa9ab4f734d055567",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.4.0": {
+      "name": "etag",
+      "version": "1.4.0",
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "dist": {
+        "shasum": "3050991615857707c04119d075ba2088e0701225",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.0": {
+      "name": "etag",
+      "version": "1.5.0",
+      "dependencies": {
+        "crc": "3.0.0"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "dist": {
+        "shasum": "8ca0f7a30b4b7305f034e8902fb8ec3c321491e4",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.1": {
+      "name": "etag",
+      "version": "1.5.1",
+      "dependencies": {
+        "crc": "3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "seedrandom": "~2.3.6"
+      },
+      "dist": {
+        "shasum": "54c50de04ee42695562925ac566588291be7e9ea",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.0": {
+      "name": "etag",
+      "version": "1.6.0",
+      "dependencies": {
+        "crc": "3.2.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.4",
+        "seedrandom": "2.3.11"
+      },
+      "dist": {
+        "shasum": "8bcb2c6af1254c481dfc8b997c906ef4e442c207",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.7.0": {
+      "name": "etag",
+      "version": "1.7.0",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.4",
+        "seedrandom": "2.3.11"
+      },
+      "dist": {
+        "shasum": "03d30b5f67dd6e632d2945d30d6652731a34d5d8",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.8.0": {
+      "name": "etag",
+      "version": "1.8.0",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.3",
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "seedrandom": "2.4.2"
+      },
+      "dist": {
+        "shasum": "6f631aef336d6c46362b51764044ce216be3c051",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.8.1": {
+      "name": "etag",
+      "version": "1.8.1",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "safe-buffer": "5.1.1",
+        "seedrandom": "2.4.3"
+      },
+      "dist": {
+        "shasum": "41ae2eeb65efa62268aebfea83ac7d79299b0887",
+        "tarball": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2019-01-09T05:26:21.676Z"
+}

--- a/test/fixtures/registry-mocks/content/eventemitter3.json
+++ b/test/fixtures/registry-mocks/content/eventemitter3.json
@@ -1,0 +1,2703 @@
+{
+  "_id": "eventemitter3",
+  "_rev": "91-3273ec4892ea731d6daba3cc706300a0",
+  "name": "eventemitter3",
+  "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+  "dist-tags": {
+    "latest": "4.0.7"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "eventemitter3",
+      "version": "0.0.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface. This the source of the same EventEmitter that is used in Primus.",
+      "main": "index.js",
+      "scripts": {
+        "test": "NODE_ENV=testing ./node_modules/.bin/mocha $(find test -name '*.test.js')"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/3rd-Eden/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "reactor",
+        "pub/sub",
+        "event",
+        "emitter"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/3rd-Eden/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "mocha": "~1.13.0",
+        "pre-commit": "0.0.4",
+        "chai": "~1.8.0"
+      },
+      "_id": "eventemitter3@0.0.0",
+      "dist": {
+        "shasum": "90a5cc3c2ef715169ceaed893d797ae1951c8119",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "eventemitter3",
+      "version": "0.0.1",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface. This the source of the same EventEmitter that is used in Primus.",
+      "main": "index.js",
+      "scripts": {
+        "test": "NODE_ENV=testing ./node_modules/.bin/mocha $(find test -name '*.test.js')"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/3rd-Eden/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "reactor",
+        "pub/sub",
+        "event",
+        "emitter"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/3rd-Eden/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "mocha": "~1.13.0",
+        "pre-commit": "0.0.4",
+        "chai": "~1.8.0"
+      },
+      "_id": "eventemitter3@0.0.1",
+      "dist": {
+        "shasum": "052227d4fc69b1d3f1ec0e569b248e264ccd795b",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "eventemitter3",
+      "version": "0.1.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface. This the source of the same EventEmitter that is used in Primus.",
+      "main": "index.js",
+      "scripts": {
+        "test": "NODE_ENV=testing ./node_modules/.bin/mocha $(find test -name '*.test.js')"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/3rd-Eden/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "reactor",
+        "pub/sub",
+        "event",
+        "emitter"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/3rd-Eden/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "mocha": "1.13.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.8.x"
+      },
+      "homepage": "https://github.com/3rd-Eden/EventEmitter3",
+      "_id": "eventemitter3@0.1.0",
+      "dist": {
+        "shasum": "727e1600ea477f50f1f11328cb9a5abf752c1dff",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "eventemitter3",
+      "version": "0.1.1",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface. This the source of the same EventEmitter that is used in Primus.",
+      "main": "index.js",
+      "scripts": {
+        "test": "NODE_ENV=testing ./node_modules/.bin/mocha $(find test -name '*.test.js')"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/3rd-Eden/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "reactor",
+        "pub/sub",
+        "event",
+        "emitter"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/3rd-Eden/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "mocha": "1.13.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.8.x"
+      },
+      "homepage": "https://github.com/3rd-Eden/EventEmitter3",
+      "_id": "eventemitter3@0.1.1",
+      "dist": {
+        "shasum": "7ea62a9d6b8343cb17ddb07f6ae8d3881ecdb8c3",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "eventemitter3",
+      "version": "0.1.2",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface. This the source of the same EventEmitter that is used in Primus.",
+      "main": "index.js",
+      "scripts": {
+        "test": "NODE_ENV=testing ./node_modules/.bin/mocha $(find test -name '*.test.js')"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/3rd-Eden/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "reactor",
+        "pub/sub",
+        "publish",
+        "subscribe",
+        "event",
+        "emitter",
+        "addListener",
+        "addEventListener"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/3rd-Eden/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "mocha": "1.18.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.9.x"
+      },
+      "homepage": "https://github.com/3rd-Eden/EventEmitter3",
+      "_id": "eventemitter3@0.1.2",
+      "dist": {
+        "shasum": "4ede96d72b971a217987df4f1d4ca54dd8d20b79",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "eventemitter3",
+      "version": "0.1.3",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface. This the source of the same EventEmitter that is used in Primus.",
+      "main": "index.js",
+      "scripts": {
+        "test": "NODE_ENV=testing ./node_modules/.bin/mocha $(find test -name '*.test.js')"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/3rd-Eden/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "reactor",
+        "pub/sub",
+        "publish",
+        "subscribe",
+        "event",
+        "emitter",
+        "addListener",
+        "addEventListener"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/3rd-Eden/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "mocha": "1.18.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.9.x"
+      },
+      "homepage": "https://github.com/3rd-Eden/EventEmitter3",
+      "_id": "eventemitter3@0.1.3",
+      "_shasum": "6b8ac1392ff0a5b4d87e893bdbee79887a86d95a",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6b8ac1392ff0a5b4d87e893bdbee79887a86d95a",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "eventemitter3",
+      "version": "0.1.4",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface. This the source of the same EventEmitter that is used in Primus.",
+      "main": "index.js",
+      "scripts": {
+        "test": "NODE_ENV=testing ./node_modules/.bin/mocha $(find test -name '*.test.js')"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/3rd-Eden/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/3rd-Eden/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "mocha": "1.18.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.9.x"
+      },
+      "homepage": "https://github.com/3rd-Eden/EventEmitter3",
+      "_id": "eventemitter3@0.1.4",
+      "_shasum": "da2be74b7a1a4760272e1390f975503be5cb7e24",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "da2be74b7a1a4760272e1390f975503be5cb7e24",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "eventemitter3",
+      "version": "0.1.5",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface. This the source of the same EventEmitter that is used in Primus.",
+      "main": "index.js",
+      "scripts": {
+        "test": "NODE_ENV=testing ./node_modules/.bin/mocha $(find test -name '*.test.js')"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/3rd-Eden/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/3rd-Eden/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "mocha": "1.18.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.9.x"
+      },
+      "homepage": "https://github.com/3rd-Eden/EventEmitter3",
+      "_id": "eventemitter3@0.1.5",
+      "_shasum": "fbb0655172b87911ba782bb7175409c801e5059f",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fbb0655172b87911ba782bb7175409c801e5059f",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.6": {
+      "name": "eventemitter3",
+      "version": "0.1.6",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "965f7968e2a8eb580e1f63b7863fb957b3516b36",
+      "homepage": "https://github.com/primus/EventEmitter3",
+      "_id": "eventemitter3@0.1.6",
+      "_shasum": "8c7ac44b87baab55cd50c828dc38778eac052ea5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8c7ac44b87baab55cd50c828dc38778eac052ea5",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "eventemitter3",
+      "version": "1.0.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "gitHead": "b13ef8bdb57b02c97c81c0c4a569befa30e8339a",
+      "homepage": "https://github.com/primus/EventEmitter3",
+      "_id": "eventemitter3@1.0.0",
+      "_shasum": "c738401cb6d29e46e00ee623521689082a52e1cf",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c738401cb6d29e46e00ee623521689082a52e1cf",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "eventemitter3",
+      "version": "1.0.1",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "gitHead": "cd22a430db13950f3c16a72f943f61a96c9663ce",
+      "homepage": "https://github.com/primus/EventEmitter3",
+      "_id": "eventemitter3@1.0.1",
+      "_shasum": "75a110a2e1bcc5de7999fead1910fcb058f51a14",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "75a110a2e1bcc5de7999fead1910fcb058f51a14",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "eventemitter3",
+      "version": "1.0.2",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/EventEmitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "gitHead": "8274c16a934efc7a127766ae191a8a9d0065c1a4",
+      "homepage": "https://github.com/primus/EventEmitter3",
+      "_id": "eventemitter3@1.0.2",
+      "_shasum": "1163487c15b37566bf4ea8dbd5ccb5ddd5c0a9e8",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1163487c15b37566bf4ea8dbd5ccb5ddd5c0a9e8",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "eventemitter3",
+      "version": "1.0.3",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "sync": "node versions.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/EventEmitter3/issues"
+      },
+      "pre-commit": "sync, test",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "gitHead": "1b479ec043fe41156bbf73295674828451b78ea6",
+      "homepage": "https://github.com/primus/EventEmitter3#readme",
+      "_id": "eventemitter3@1.0.3",
+      "_shasum": "15295f06dca6e1f35453a860b0fd43876367e258",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "15295f06dca6e1f35453a860b0fd43876367e258",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "eventemitter3",
+      "version": "1.1.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "sync": "node versions.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/EventEmitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/EventEmitter3/issues"
+      },
+      "pre-commit": "sync, test",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "gitHead": "0cd64db5b271fa2ec3a53f006dd968f8c94f66ff",
+      "homepage": "https://github.com/primus/EventEmitter3",
+      "_id": "eventemitter3@1.1.0",
+      "_shasum": "8d94b51448fa4ae11f8725aeebb7c0c48a8e71ac",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8d94b51448fa4ae11f8725aeebb7c0c48a8e71ac",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "eventemitter3",
+      "version": "1.1.1",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "test-browser": "zuul --browser-name ${BROWSER_NAME} --browser-version ${BROWSER_VERSION} -- test.js",
+        "test-node": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "sync": "node versions.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "pre-commit": "sync, test",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x",
+        "zuul": "3.0.x"
+      },
+      "gitHead": "91f571f40c918d71220747791c05ec33f3402a56",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@1.1.1",
+      "_shasum": "47786bdaa087caf7b1b75e73abc5c7d540158cd0",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "47786bdaa087caf7b1b75e73abc5c7d540158cd0",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "eventemitter3",
+      "version": "1.2.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "sync": "node versions.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "pre-commit": "sync, test",
+      "devDependencies": {
+        "assume": "1.3.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.4.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "gitHead": "c78d597fed80952c259b916c0a1f4dca91d940e4",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@1.2.0",
+      "_shasum": "1c86991d816ad1e504750e73874224ecf3bec508",
+      "_from": ".",
+      "_npmVersion": "3.8.0",
+      "_nodeVersion": "4.3.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1c86991d816ad1e504750e73874224ecf3bec508",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/eventemitter3-1.2.0.tgz_1458148661717_0.1867425285745412"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "eventemitter3",
+      "version": "2.0.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "sync": "node versions.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "pre-commit": "sync, test",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.0.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "5d4cd1928eacf51877e73c6d01ec4daf66f3e547",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@2.0.0",
+      "_shasum": "605f34e75ea702681fcd06b2f4ee2e7b4e019006",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.5.0",
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "dist": {
+        "shasum": "605f34e75ea702681fcd06b2f4ee2e7b4e019006",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/eventemitter3-2.0.0.tgz_1473423580446_0.5355233517475426"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "eventemitter3",
+      "version": "2.0.1",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "scripts": {
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "sync": "node versions.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "pre-commit": "sync, test",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.0.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "58f3909300bb6503749c813cf1abaa0058a9778c",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@2.0.1",
+      "_shasum": "59c8930b1d8f4da54ad752854948f44330e7f39c",
+      "_from": ".",
+      "_npmVersion": "3.10.7",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "dist": {
+        "shasum": "59c8930b1d8f4da54ad752854948f44330e7f39c",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/eventemitter3-2.0.1.tgz_1474959547234_0.053572222124785185"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "eventemitter3",
+      "version": "2.0.2",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "sync": "node versions.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "pre-commit": "sync, test",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.1.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "a9eedef2a58deae7006028662a83d88579486886",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@2.0.2",
+      "_shasum": "20ce4891909ce9f35b088c94fab40e2c96f473ac",
+      "_from": ".",
+      "_npmVersion": "3.10.7",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "dist": {
+        "shasum": "20ce4891909ce9f35b088c94fab40e2c96f473ac",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/eventemitter3-2.0.2.tgz_1475216591620_0.3523867195472121"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "eventemitter3",
+      "version": "2.0.3",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "build": "mkdir -p umd && browserify index.js -s EventEmitter3 | uglifyjs -m -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha",
+        "test-browser": "zuul -- test.js",
+        "prepublish": "npm run build",
+        "sync": "node versions.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "pre-commit": "sync, test",
+      "devDependencies": {
+        "assume": "~1.4.1",
+        "browserify": "~14.1.0",
+        "mocha": "~3.2.0",
+        "nyc": "~10.2.0",
+        "pre-commit": "~1.2.0",
+        "uglify-js": "~2.8.20",
+        "zuul": "~3.11.1"
+      },
+      "gitHead": "9afe1b539e52ec4b8eb4e07d69a5deb5f25c326b",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@2.0.3",
+      "_shasum": "b5e1079b59fb5e1ba2771c0a993be060a58c99ba",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "dist": {
+        "shasum": "b5e1079b59fb5e1ba2771c0a993be060a58c99ba",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/eventemitter3-2.0.3.tgz_1490971867525_0.8374074944294989"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "eventemitter3",
+      "version": "3.0.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "build": "mkdir -p umd && browserify index.js -s EventEmitter3 | uglifyjs -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run build"
+      },
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "umd"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~14.5.0",
+        "mocha": "~4.0.0",
+        "nyc": "~11.3.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.2.0"
+      },
+      "gitHead": "e36eab836feeafe7101e06e7e736d368f27b21ec",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@3.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-62TxCtz4m2LRaOERVEvLJJ4A6rsg8lC9Xm+FLg2y/1fB/v4ZZ9JCOn+/Ppl5KkH6sRih6bhix724PVanmXYZJQ==",
+        "shasum": "fc29ecf233bd19fbd527bb4089bbf665dc90c1e3",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3-3.0.0.tgz_1511976245786_0.8547864067368209"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "eventemitter3",
+      "version": "3.0.1",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "build": "mkdir -p umd && browserify index.js -s EventEmitter3 | uglifyjs -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run build"
+      },
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "umd"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~15.2.0",
+        "mocha": "~5.0.0",
+        "nyc": "~11.4.1",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.3.0"
+      },
+      "gitHead": "81025e2543554263f282774e248c18c69fd89e96",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@3.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA==",
+        "shasum": "4ce66c3fc5b5a6b9f2245e359e1938f1ab10f960",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20382
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_3.0.1_1517990256516_0.4655667565871582"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "eventemitter3",
+      "version": "3.1.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "umd"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~16.2.0",
+        "mocha": "~5.1.0",
+        "nyc": "~11.7.1",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.2.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.3.0"
+      },
+      "gitHead": "5261097d5109946920d0d9d083da7186c838ce30",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@3.1.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.11.1",
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+        "shasum": "090b4d6cdbd645ed10bf750d4b5407942d7ba163",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 36241,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa4NzSCRA9TVsSAnZWagAAYsYP/j3zNmW2uWdBC2A1cPSn\nMsgv21wWhhuCkg7qc1aotD4X2/L/0xYBwI5jbKvXVicz2NQUgcJG68q3BriU\nskYbjblLpct5R9BzPiwEMm6wRmHk0JN0Fz5bBtk1EA4xaQHugkbzrOLLhxxM\nkAa84X4wLJunz/JmTGn4akyz92FzMM6oOxZfNzzIXepw1eAxQF5YGLFRitC7\nKeJQv/p2d0dLb73MjyvDC0IPe7R1ZwMeUF06A2w+Z04/jLK8mdumM9hws9kj\nbhq5WLePhMEgnvLIlHDBAevqj4qBgXaS5GsbNCC7Za6xJaz1fLLkx+jGl8A3\nw8EGDY+DkxmKHgMPrIqM6eCNOYcCc35tUCVsSf73GFqGA+f8luuasRqI23VM\nqbBScHy08sESdFkOeaqZByJClN7zl10CVQTU5Gm/vXNFNjmx8yxYlsJRqUGq\nT8GHlr3q4oEjFmLbcR9tIYwYGx/QyNYeB2DZ0HKu51LNtWeFVbYx+TKnG8zB\nDNNdNbyaAiGOEPXXhUxjUsywxgZatymqtiPQhxd0blnIOSZHJsm1qYBggXbk\nGYLigxrN6D6bBsW4+6c74v7CbaEP3zulHAMukIQQoE5gjfq49J9vP8CjBG0w\nxE7WMeXlre4YdNrBUTxPA312/f9VtypiFzqnj7cSENsm/tynZjCR4xAdJG9z\n++Gc\r\n=f2la\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_3.1.0_1524686033911_0.48391916986617156"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.1": {
+      "name": "eventemitter3",
+      "version": "3.1.1",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.2.0",
+        "mocha": "~6.1.0",
+        "nyc": "~14.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.5.0"
+      },
+      "gitHead": "52941321ad3f42c976eefcd706e891d06a0376bf",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@3.1.1",
+      "_nodeVersion": "11.14.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-MXmFv3KYbv7MPjPeGlFCTieXB9zNvmHfy4fXzZbrdMeUUk3pxQ8SS0cJ6CcwUDZnIL3ZDa01qQFzhlusB8s51Q==",
+        "shasum": "1ab02a344af74f5cbf528969601bf0fd6aeebf98",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 36256,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcxyTtCRA9TVsSAnZWagAA7xgQAIcgU0Xe8sCjBrhQNTEd\n0tx5RLC/63afKnoM5GDTDOYZUu6aHxDnSH0i4J60AZ6NzS2zH1YCfsLj28t9\nhZ6rb3SDEwK1d7iz1wSytR0QclImlDvtvcAoP/XgUFFZIQFRkLaP7xicFCZd\ndRwTYvUScV/leuljCtN/NXfmo6U6MrWj+xYlhk8GfDchVEg+W7uTXozWIdGf\nUkvmtoOzXky8InN82J49nT/9uvDoqVL+tAi/ppzCd/tcy71U81TXgoDPfGUw\nQx8C9X29DiWohJDkmNLAiVCAjB+RpzgTAf3V8/eJuyNu9BcHL4yJJIjvA+vQ\nJ3nGarNUHNU/7ct0B8ZXvwxCgzdHtYNtqchzT3z3wDNdRCL4lUdulaonoFBB\nBijbOCTggmH1Bd0BM7PnIYv9dGC833zlKd8eyzS3ijT8s1u8tw0WlbCbW25/\nWjr8jhf6fJCH2xZskxE+erQxJLfCk71gNNwBrVIA8UTFyzBcDIPEiM2Hq5OM\nEG/0ECHWAaW6WpCU6icINJ9lK8rU9eWMv7ihArRTRmVS4rVqm565Bgn438+1\n6v6VlfH7qFi1R4QjwzX/S7DHjufsloeHM35lhh9evSHkUr+xjPy7iXhtJBey\njfn4jbghy7Yw5cclCJpc2EZ4BJYrjlAqgTVQpe+PopK6TG8DORhKINfz1EcT\nqdii\r\n=bLMn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_3.1.1_1556554988590_0.9851152735788387"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.2": {
+      "name": "eventemitter3",
+      "version": "3.1.2",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.2.0",
+        "mocha": "~6.1.0",
+        "nyc": "~14.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.5.0"
+      },
+      "gitHead": "54b25612832e6ab21efc836b99e4d0b0f69eeb69",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@3.1.2",
+      "_nodeVersion": "11.14.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+        "shasum": "2d3d48f9c346698fce83a85d7d664e98535df6e7",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 36240,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcx9cvCRA9TVsSAnZWagAA0n0P/3tqCbPIQ0J24jWYn2Aj\nm/RQ0ALKXFjQF2wf2p1peIpYZuaZnh5P3QaBMH17kYDo5S969nOYxrj0BUwu\nn/reAHnJQxXJGD9IYz22wWoVnwfUewoAGwdeOwTdxDNfrPDBJky42e0u1UvO\nS04QbCeyG8+wNH1eJDtoPsMcs2AN4Ppd2JfwV/SkKlmILD0Tp2wmf8Es5zRB\n0BsYnd4nTqMNHeQbTdQ5bfUs9cMtRE/CzPvwisIX3nhVUPQtc3vw6IuAsg0y\nYCvyrpqRqF/mwmmDFIWKnVZa2ExDAFkgaWvzOdVO1v+orLkQbvAP29k6XG47\nt7q8t6uH2iInp+tErRYzWTm+ZVFgIrvWe6/SLb1LHGYiBxCvULMDLjXA/cng\nHWumLkPjWNy6kUj9Qv/G5519smAfGoUEIc5Q2e7/u22jfGODjko08f31YgNr\nF412cUUK89FKpBv4DhSeAvXWVu3/v10g98vzaPaTf1H8RCs2wADgeWPcaqrw\nrXg3ii2HPCGI00Qhuiv6LfwieP2oHyxRiZP6IH2VA+CFV2RuPie03xHTosJm\nTf6S1c+hU1cFEg5SvP+NF0CiDVe8kn12nZMW077GjvzWsjsqTT0a7vuSxqPu\ngolJvF9rYcQVIVHMC/n+GAlTcfyLANJXwQ5R2D3GPUwD4C0HH5pdANUgiufQ\nLf98\r\n=Mfmc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_3.1.2_1556600623068_0.2887200458648349"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "eventemitter3",
+      "version": "4.0.0",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.2.0",
+        "mocha": "~6.1.0",
+        "nyc": "~14.1.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.6.0"
+      },
+      "gitHead": "3673253ddeaa4398205bb9513315397e678c7fa0",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@4.0.0",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+        "shasum": "d65176163887ee59f386d64c82610b696a4a74eb",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37015,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdCjhECRA9TVsSAnZWagAAz0sP/jkDyKdZ8sk50fqmttAc\n2UDQYGw76sKL19pI+TPqXoqhlxoP5WsdX1+Wz4MgNBOmzp/iyGoNgokW+aUJ\nbNf6trdIS76blPItTI647EzKur/4AVmAjzz9UbjRdA77HyZ3eE2V+p8vc5eK\nMtr2B6oiGwUw8Cq/1sKBZPySNElEU/OWeRRXyrym4hzYxFYPokx7DGRmYWLv\niK85HBi6aW0zoj5bpC9FzNO3yHGFI+KFKUhhp/N+R2c5bY4IfVqbdfa8dk0H\niYy+CiF3rAudBPGxX2dYukPIaMcM1AQmjyqGqE21hrs9JGxKZ2wsi5zWEYZS\nc4Wow0oQEW/FetDdJJBLp5Epp9vVzly1C/htwZoIZ8Ki9vsERKKw2ZqyY9Ps\nW5BVxdbNxKVILt5jq1qlGoNY9QI17O0mez/etVGgFu31hqoOzGclC+IvaEpI\nRX+d5QfcSrzM/TocYD7mL/TI+Wk1tw0dklFvoM2OZRRalts4F2TyTHfFDiCJ\nmArUlwkFPq4pFlM4nGDH6I3f7KT7omWooHqNNk9bkl4qpF9KdbCzioEzoD2V\nvv55C8Lxz/MDFDc2MZujbj8Q5aUoGS9L6VK07dHyrYSUnsGXnNBDhlEcn+Sa\nsAgPPs6+kLzjPyOhDltBjjj7yZwOcsK0MPaqlFdDRidn/3DJh0G/cX5EyRDN\nZWY9\r\n=WGFs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_4.0.0_1560950851696_0.6319974648156976"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.1": {
+      "name": "eventemitter3",
+      "version": "4.0.1",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.5.0",
+        "mocha": "~7.1.0",
+        "nyc": "~15.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.9.0"
+      },
+      "gitHead": "e8797605bfae450c67943f377e0e64f5d80dacd4",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@4.0.1",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-MnI0l35oYL2C/c80rjJN7qu50MDx39yYE7y7oYck2YA3v+y7EaAenY8IU8AP4d1RWqE8VAKWFGSh3rfP87ll3g==",
+        "shasum": "3bcf626b0d3b16ce22ee88625a3772706300ba1f",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37507,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeuEABCRA9TVsSAnZWagAA7dYP/16kWKmiPXs8v5KwW5Po\nO0mRMW7pl0y6rKsRusLfibti8xuUX796UkqbrF1G103h8W0k322O0yuCeGdp\niQDIDPAgx0lMKUKH2ky4ySs6sVw7YvKUwa0OtMHGvu0LJhWaQPiOBjlTwbL/\nRVUYJ6mfE0deMblXfbnS8IxE0/rN2T8vvTjFCIuVIXNwD5yDzZnB+oFP0FLW\n7RhOyTYPosdEK3PCOUjvnBrPEaOAYqz0ahVMuahOyqNAFOJT/tcAKN0xXOOW\nveNwncBbjQWaQv2S8v/Dt3OpjhjTLEUcbefWuTDixwP8AQ8pBHadhUuAAM9v\nppovzLm52PT0iZo9ewm8C/Dqr8Qrf84JgEjYKo2wsfFyVaia73pBRKCOugA7\nIlbEmUsZbyUrnedixb7Y2bXuJU4WZGKhhGhPNsyAs3LnYso1NZuLEsmWECIv\nOjUMc6GLcSVFnS2wSsw+BaJAyENQu7TrkH322eE4iB/CIR3fD79BqIbSAzFI\nUI9PVBpQnm6UCM5jtCnRzQnsVuih4/pHd4DBh1dklRilHThUCUUO5N7BeRQl\nm4XQKGNh5U+MlkQx305u/HXQ7OBPQxJHpYerbIhcd45uB6c9YI+4B8FuhHkl\nd6q2CtifGcBeqN/ggHxohnVU55yQMXHAgXX1s13Pvhw59+I6ROzE8+KdRsb9\nvB0E\r\n=R9PK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_4.0.1_1589133313200_0.0028477019643091683"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.2": {
+      "name": "eventemitter3",
+      "version": "4.0.2",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.5.0",
+        "mocha": "~7.1.0",
+        "nyc": "~15.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.9.0"
+      },
+      "gitHead": "6ffdbbcd28a010d7c86239e5e339a38c1c963730",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@4.0.2",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-c8VhEv9UueTlJtfhTx5mbt94l/N1nrfN8j3H1kgl/APEv/y4E95ny3lABssobpcX+4vy/fBtrdhWi44VxTSsog==",
+        "shasum": "08daca70c33379e6b8dddc56516671f2a4c0172f",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37800,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeuVgzCRA9TVsSAnZWagAA6m8P/0Esx0PohpCn1fvO/Rpk\nuzfAPzkx/zhDm0o3ltEGT2aVpdXe2aX9047u8kE0lynwdFUIiO5Td8I23Y9Q\ngM07wiyis66zVgsckJA5EucnnXGY7OWC1mV1ePMPj8mnxi1mL5bJ/ickNkrZ\npQF78lW13341IuYHTH35YzRNNxLQfcbiIQ4nFHEHUYUAi4NEiz1MC/x5OOxt\nHSI1/u6pMz4rPbHtar7rtQzCCOqVe4J5Q/d7Nx6Bx3z5EJ37TcTkp6vda4/P\nPwNB9fqszV7jHE2QZXEaw4u7mIaR973dzxm9W3YWALdslfQ80WpUv0eTtR+l\nEWtCCx/yrnQIFWmPzZ5JavpuWM5pNkV7KP5E/NWdg/AmOgmASh6gFuDJ+Rng\nj8voGKGo9zshJhIutl8ZMy2sS68ukMutDVrZ9Xl+JhIdPJGROhOeiyrL5xgG\nL+vf8xp3+eiSPfXj7/MLt0WJdueDRtyIhgKhis/KW2sAkumUVUaRfhWFk16g\nHf8arNLIDTAhtYBIjq+mUxIujsyQLayfLgoxgGWEjMcVWAeUIqEpwBEXbV9d\nQl7V1kR0/yV0t1JASDZxGQQWWk+ZwDyeRFDPjD82ejFFifCkWJLtVj/WjCGt\nVXTmPU9Sr1eS8mLVtCP+UFeWP048NxzN1L6zGyvcOe0cqqzhWjvn3RRX1OOb\nbn9N\r\n=AG2s\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_4.0.2_1589205042722_0.9263808447016044"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.3": {
+      "name": "eventemitter3",
+      "version": "4.0.3",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.5.0",
+        "mocha": "~7.1.0",
+        "nyc": "~15.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.9.0"
+      },
+      "gitHead": "5f89ad3d8e84ccd5da072a2f051997764cc9d3a9",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@4.0.3",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-HyaFeyfTa18nYjft59vEPsvuq6ZVcrCC1rBw6Fx8ZV9NcuUITBNCnTOyr0tHHkkHn//d+lzhsL1YybgtLQ7lng==",
+        "shasum": "850b43083fdb36a246f03168f189e9054f90bdb4",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.3.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37763,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeuVw+CRA9TVsSAnZWagAA50wP+gKNMf0lYlrKcZqYTAqM\nVzZovbf/ptx0kxNrILEUzrXfGzhotzpDw5PClh3OxocoB0kDZrSVS2pn8qhG\nUHJngoaMvacN1HGtjgDWALAma/gA2swhGbe4voicnEzAINH0L0g3FCN3DN9R\nS757IjonbsLy4XhoOqWQ0NQSvDfe8eYmIuD+bmXzlAzt148LZ3ryP+yjT3q8\nqqahkBcO+9bJj1uKu8SuhoiNULNJe3sWRZ+4lGDdEKuAEPDoOLmeCiLlDFzK\nvH7UySLvdMQeJC4lGwpJwxOHKqRzcIp4ehF+M8wvPcCP0P9Ybek2tdVPQUP3\nG1Ffoh2dlx4EWuLAO6SjhxiC1im90XosQf1R+NBr21Ly8otILsTMMVAYmTTV\nQnwD1L8mFZ2MqqpNn2cb73LmleSYz2g/V4tJj3CQKWXrFuVNz5pwVIhhFCTh\nUXKq/CLqZ64LrAJoxTxRlrN/IfoHrmZYx9LDHGwNOKfJzBcF2nsW5DI25bar\neOZ4AXv5Bf+7Iq6nIFH1d7shbYAKZq70OdFUbfpcccDlERCuN7zPnDU4Xj/N\nn57uKTL8FnjUgGElFacSOPMRCoIx5QBoCuZ2G1Dv+WWecm+B6bgQjnuXd4//\n8tj40loPv3VZhRfdGPNYO4z0oNPml7w/L8foUAqE4dMkzRGh2F4TvkuD+iEb\nf7Zt\r\n=3/C3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_4.0.3_1589206078038_0.7199565811605375"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.4": {
+      "name": "eventemitter3",
+      "version": "4.0.4",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.5.0",
+        "mocha": "~7.1.0",
+        "nyc": "~15.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.9.0"
+      },
+      "gitHead": "b73f1902ae9564b70c960e363a904118804f8392",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@4.0.4",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+        "shasum": "b5463ace635a083d018bdc7c917b4c5f10a85384",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37780,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeuojlCRA9TVsSAnZWagAAUQIP/ijIqEN/78xdqiV6NdY6\ngf69c1ptPoiBIQbTJLQZiKd4CxmPNp0yXotTu30rkIfEkfvsmDwZII2HLZZG\nvd1NsS5kG7biTQk0fa2G16CImFLwoBsxk1KZrbmu/X63GtdCfmCSmCVKu/Sz\nIUkPTeQP8NoPKDs0ZWK32XgZ3qvRItmA/lQfj+PwnWqW3Vw4PqDJIWUtSAEL\nWmNaZreCIzElYX3pzJE3ccBnx011QnvXiEEMe2EgBrHl1qDfdrgLTVxVfjLj\nQUW9wVI6kh+irOKjNdYHbWtygJmX74As2F3T4XAHgqOpSgxbFZycxeUqALgQ\nsSMOkcsdWcXwX3sCOQ+sV7GB7oJk2S7YfLmFbfqYdepTeytSe7aftbD+zbC1\nbSF+mxqbXBNJjvB2XprWTd8NHgiDksyDNE2VWHNSBacN4bQXYtnc3gNerd4k\neGwl3n6j2FyY6cyH24eE5BtqouWJvy/e8IHgbS4wLmbzJ1x9cwh0bEsuJOzf\nEkAzED+MephrBNaRBvjDGdwrPFRsZ5QzFR3BxoQ4Uu7Usu0jQeupCzUs/+yY\nE7pMd+etJ6a9XgFBjj3um891aE1qTpjd2iERyQqldIQAnf7O69lq+BTlJIqF\ntuAEbhQnAZd+rcCZrUYCk4Ls+W4TCj9L0y4pqzT1ggk/crUxl/kkWxFuhfGw\nKNh4\r\n=rUKI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_4.0.4_1589283044478_0.019940923541620803"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.5": {
+      "name": "eventemitter3",
+      "version": "4.0.5",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.5.0",
+        "mocha": "^8.0.1",
+        "nyc": "^15.1.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.9.0"
+      },
+      "gitHead": "47251a0649bec2e030ff6f11d056713a31985af9",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@4.0.5",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-QR0rh0YiPuxuDQ6+T9GAO/xWTExXpxIes1Nl9RykNGTnE1HJmkuEfxJH9cubjIOQZ/GH4qNBR4u8VSHaKiWs4g==",
+        "shasum": "51d81e4f1ccc8311a04f0c20121ea824377ea6d9",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.5.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37792,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfQOOVCRA9TVsSAnZWagAAphoQAJtDutCAL8K6VV7UZOwG\nkopJjm9XmxHkAKx/ENe0HG0YMkasPnoHY1kMoKlvJbOjK6algYi4J2Co+ACK\n0Dx4D6G7asPwN0DOQTaJ7O876Apiz+elXlBH47Syh35xgeUVMel9GwwttXx1\nYIfmYSfEyM9R16aFowT7afWMY4N+s/rcgH+zMw/k6h7PrF+wKKGBhBMkS5FN\nyfJ0Arir2WBSn5lmVms/oX3ZOY+kBX90PE491hVFs6em1HjS8fTLt87Vmw+b\n0t49B7g8jpiOzd9BHOwI7lAvy+Q8y9X40abYen/a6S20R0OdBAn8+TcDjR2c\n+jlFJLI3meJkdaCzHv7vQk/TDylHbFk5Ej6foofgKL/2wO2tevU2c1dIJoZv\ny+W+v3aKFFWr4SNqJvLJP83u60xck/Ij3uM2utHZ2aIU2k4u07PxIFcLWb8n\nP4rYVUgKHZzNo2AnbhYETvfHWg8x031gPEBquEY13ajRQUCdhU/HgGhqQiE1\ndPMdc94whJyGTe9bMSUi2YIoO7tBnJuYKTjcVeg+XR8yqSRQ0+HZtH7wovDd\n5nqw/6+SNmhtDBgAMDtCXScK+WFzxeNgR8zUKZ8gaLknI4swQiV/KqKtVSSD\nxg8Hw5Xa2mMMq3Z+9r9NaHXX8Lkumsx+rn+ZHZU79vbnzGCxbkM8LpSKKQlN\nexQq\r\n=8Mou\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_4.0.5_1598088084558_0.6499614230865858"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.6": {
+      "name": "eventemitter3",
+      "version": "4.0.6",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.5.0",
+        "mocha": "^8.0.1",
+        "nyc": "^15.1.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.9.0"
+      },
+      "gitHead": "38de307205e78c574a53379b71f53058d45236c8",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@4.0.6",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-s3GJL04SQoM+gn2c14oyqxvZ3Pcq7cduSDqy3sBFXx6UPSUmgVYwQM9zwkTn9je0lrfg0gHEwR42pF3Q2dCQkQ==",
+        "shasum": "1258f6fa51b4908aadc2cd624fcd6e64f99f49d6",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.6.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfRUR+CRA9TVsSAnZWagAAaaQP/1kEhIVrZcYvKC8P9QkH\njsuUiWdMOlI1KlXmkN4WaLSWY2A3w7hK2I7lYFe1e86LW8w63SERxO0+1LRc\nWIQGVSK7GAA3rPsva/OMk3pk3vZJGQSv1g141gDuZxckspVzvk/p4YRyiBTY\nloHeTvQW1D8iOrsBXnKlZ4uq1sT5EqvG3RbCPa0zLrYSvcfiNOKrOxxSjbxR\nFFF2Ewjoutp9BJtcfbpJnYjFJZDmNohO5ie6+NFK1gCwzKJqqyx524IllJC4\nBkkym2WRiRvHMUhwTQkmGILfiupTxjDvl4XqAh1BabKh1GO8/2XDGgBv8jHu\nwm4joCU+nFfFFudA/AjRhxrRUAsXZUcL3GGa3yC0mrdIqUQflKoT3BjoYm9B\n2/IN64RX5Vtc1uU7aQQr2Pm+DxYAZpIZHmcAveR/BLGDTg43HXyc7MHMbgD/\ng8PCberJty37kqYMGidw69d3sl7OGP/mtYrswTL97dOCJwDD9iB72zGGefG9\n02qQttBNSzRbYQGzwxqNeML04/oedAbIZnEVPY1Fc3A1SGAtbarHSTmStV9P\nWguN2ibRF+7f3FnDxULRSVmZSH3Rk7rkikSkungEKMozLuFUt8LwwM4+rriL\nPDcSQUdFT+nEv0vXtn4i8qnKRD9RRFEJDOfSR/zonk+WKF+MCYLRRXszi9Mr\nwH5o\r\n=Q3kF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_4.0.6_1598375037581_0.9154824044601892"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.7": {
+      "name": "eventemitter3",
+      "version": "4.0.7",
+      "description": "EventEmitter3 focuses on performance while maintaining a Node.js AND browser compatible interface.",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "browserify": "rm -rf umd && mkdir umd && browserify index.js -s EventEmitter3 -o umd/eventemitter3.js",
+        "minify": "uglifyjs umd/eventemitter3.js --source-map -cm -o umd/eventemitter3.min.js",
+        "benchmark": "find benchmarks/run -name '*.js' -exec benchmarks/start.sh {} \\;",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "test-browser": "node test/browser.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/primus/eventemitter3.git"
+      },
+      "keywords": [
+        "EventEmitter",
+        "EventEmitter2",
+        "EventEmitter3",
+        "Events",
+        "addEventListener",
+        "addListener",
+        "emit",
+        "emits",
+        "emitter",
+        "event",
+        "once",
+        "pub/sub",
+        "publish",
+        "reactor",
+        "subscribe"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/primus/eventemitter3/issues"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.5.0",
+        "mocha": "^8.0.1",
+        "nyc": "^15.1.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.9.0"
+      },
+      "gitHead": "00ac01a329b7f2fb29058b6a3aff6850ac304f12",
+      "homepage": "https://github.com/primus/eventemitter3#readme",
+      "_id": "eventemitter3@4.0.7",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+        "shasum": "2de9b68f6528d5644ef5c59526a1b4a07306169f",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37967,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfR3iVCRA9TVsSAnZWagAA+1YP/RN7vVEWHMzDnY73iQbq\n092QpDsL71RWTTM7Gezwv2L1ANE+GXLA1ZuVZ7LpFMOwkvYv4ep7TuUbVL3I\nuXq60DSql7VVzKhAPL5omm9XaWwbPk7RzuNtstl4u+XcOW+QUEf87JT4SIz/\nZtNKbfvvHArGre5BY1RP2WWmNn4YnPOuGYEehoUeI1l72Ni4uAj0HIJFPak/\nh5SbLshoewiHrYH7IchgXR+gjQAgMeRoLqeGIgEFDl78hejNFZ1FR21B69LM\n9ApOc1I6ghZy04QjfOYlliCgt526fkhlingzjQe5M8czBNvrrpz6rQMZPkHy\nYHLcuEqaoAZW+gK6hlBjhGRHqTgTuLCwn9DfB02YaeFg3InEdzFgnOhv9QiE\nQR146zowzAStPvIPPX+Yb6Ip9M1lIeTwVGLjqW8zkTlQ/wYJU+nUnArMYi6r\nfVesF2Ud3JPmSWLcgiwlhc8Nntm0poBF1Vut/Cyo67D0MLq2qqf9VZ8fFxuM\ngTmuDylKrhHDzGrW9rCdz2v4mP8o1s8D51z1MVUeBaiUS2xTP9r2ROE5bDRN\nk04pbQgawdAxWoFnHO0AATBZBxsvs5WQqCitv+o/4UyTxHyPnJvR9vh+q4q/\nwtrW3TXZsUSzYu2LMTFD2XUYjnmmglTjg/yIMQe/vyN1/hFn4els9ADvzzc7\nnqbC\r\n=x1qZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventemitter3_4.0.7_1598519444845_0.23416295962222833"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# EventEmitter3\n\n[![Version npm](https://img.shields.io/npm/v/eventemitter3.svg?style=flat-square)](https://www.npmjs.com/package/eventemitter3)[![Build Status](https://img.shields.io/travis/primus/eventemitter3/master.svg?style=flat-square)](https://travis-ci.org/primus/eventemitter3)[![Dependencies](https://img.shields.io/david/primus/eventemitter3.svg?style=flat-square)](https://david-dm.org/primus/eventemitter3)[![Coverage Status](https://img.shields.io/coveralls/primus/eventemitter3/master.svg?style=flat-square)](https://coveralls.io/r/primus/eventemitter3?branch=master)[![IRC channel](https://img.shields.io/badge/IRC-irc.freenode.net%23primus-00a8ff.svg?style=flat-square)](https://webchat.freenode.net/?channels=primus)\n\n[![Sauce Test Status](https://saucelabs.com/browser-matrix/eventemitter3.svg)](https://saucelabs.com/u/eventemitter3)\n\nEventEmitter3 is a high performance EventEmitter. It has been micro-optimized\nfor various of code paths making this, one of, if not the fastest EventEmitter\navailable for Node.js and browsers. The module is API compatible with the\nEventEmitter that ships by default with Node.js but there are some slight\ndifferences:\n\n- Domain support has been removed.\n- We do not `throw` an error when you emit an `error` event and nobody is\n  listening.\n- The `newListener` and `removeListener` events have been removed as they\n  are useful only in some uncommon use-cases.\n- The `setMaxListeners`, `getMaxListeners`, `prependListener` and\n  `prependOnceListener` methods are not available.\n- Support for custom context for events so there is no need to use `fn.bind`.\n- The `removeListener` method removes all matching listeners, not only the\n  first.\n\nIt's a drop in replacement for existing EventEmitters, but just faster. Free\nperformance, who wouldn't want that? The EventEmitter is written in EcmaScript 3\nso it will work in the oldest browsers and node versions that you need to\nsupport.\n\n## Installation\n\n```bash\n$ npm install --save eventemitter3\n```\n\n## CDN\n\nRecommended CDN:\n\n```text\nhttps://unpkg.com/eventemitter3@latest/umd/eventemitter3.min.js\n```\n\n## Usage\n\nAfter installation the only thing you need to do is require the module:\n\n```js\nvar EventEmitter = require('eventemitter3');\n```\n\nAnd you're ready to create your own EventEmitter instances. For the API\ndocumentation, please follow the official Node.js documentation:\n\nhttp://nodejs.org/api/events.html\n\n### Contextual emits\n\nWe've upgraded the API of the `EventEmitter.on`, `EventEmitter.once` and\n`EventEmitter.removeListener` to accept an extra argument which is the `context`\nor `this` value that should be set for the emitted events. This means you no\nlonger have the overhead of an event that required `fn.bind` in order to get a\ncustom `this` value.\n\n```js\nvar EE = new EventEmitter()\n  , context = { foo: 'bar' };\n\nfunction emitted() {\n  console.log(this === context); // true\n}\n\nEE.once('event-name', emitted, context);\nEE.on('another-event', emitted, context);\nEE.removeListener('another-event', emitted, context);\n```\n\n### Tests and benchmarks\n\nThis module is well tested. You can run:\n\n- `npm test` to run the tests under Node.js.\n- `npm run test-browser` to run the tests in real browsers via Sauce Labs.\n\nWe also have a set of benchmarks to compare EventEmitter3 with some available\nalternatives. To run the benchmarks run `npm run benchmark`.\n\nTests and benchmarks are not included in the npm package. If you want to play\nwith them you have to clone the GitHub repository.\nNote that you will have to run an additional `npm i` in the benchmarks folder\nbefore `npm run benchmark`.\n\n## License\n\n[MIT](LICENSE)\n",
+  "maintainers": [
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "3rdeden"
+    },
+    {
+      "email": "luigipinca@gmail.com",
+      "name": "lpinca"
+    },
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "v1"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-27T09:10:47.223Z",
+    "created": "2013-09-25T19:19:08.536Z",
+    "0.0.0": "2013-09-25T19:19:12.021Z",
+    "0.0.1": "2013-10-09T15:36:58.698Z",
+    "0.1.0": "2014-01-13T20:24:52.761Z",
+    "0.1.1": "2014-01-15T21:17:43.720Z",
+    "0.1.2": "2014-04-09T10:59:42.145Z",
+    "0.1.3": "2014-08-21T07:37:37.939Z",
+    "0.1.4": "2014-08-21T09:02:10.457Z",
+    "0.1.5": "2014-08-22T07:12:30.643Z",
+    "0.1.6": "2014-11-17T19:08:04.989Z",
+    "1.0.0": "2015-04-22T08:53:23.576Z",
+    "1.0.1": "2015-04-22T13:39:04.428Z",
+    "1.0.2": "2015-05-07T08:32:32.355Z",
+    "1.0.3": "2015-05-12T08:44:05.088Z",
+    "1.1.0": "2015-05-12T10:43:40.461Z",
+    "1.1.1": "2015-06-14T14:09:40.824Z",
+    "1.2.0": "2016-03-16T17:17:43.950Z",
+    "2.0.0": "2016-09-09T12:19:40.852Z",
+    "2.0.1": "2016-09-27T06:59:08.929Z",
+    "2.0.2": "2016-09-30T06:23:12.675Z",
+    "2.0.3": "2017-03-31T14:51:09.611Z",
+    "3.0.0": "2017-11-29T17:24:06.788Z",
+    "3.0.1": "2018-02-07T07:57:37.228Z",
+    "3.1.0": "2018-04-25T19:53:53.968Z",
+    "3.1.1": "2019-04-29T16:23:08.792Z",
+    "3.1.2": "2019-04-30T05:03:43.245Z",
+    "4.0.0": "2019-06-19T13:27:31.801Z",
+    "4.0.1": "2020-05-10T17:55:13.351Z",
+    "4.0.2": "2020-05-11T13:50:42.859Z",
+    "4.0.3": "2020-05-11T14:07:58.155Z",
+    "4.0.4": "2020-05-12T11:30:44.612Z",
+    "4.0.5": "2020-08-22T09:21:24.706Z",
+    "4.0.6": "2020-08-25T17:03:57.720Z",
+    "4.0.7": "2020-08-27T09:10:44.974Z"
+  },
+  "author": {
+    "name": "Arnout Kazemier"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/primus/eventemitter3.git"
+  },
+  "homepage": "https://github.com/primus/eventemitter3#readme",
+  "keywords": [
+    "EventEmitter",
+    "EventEmitter2",
+    "EventEmitter3",
+    "Events",
+    "addEventListener",
+    "addListener",
+    "emit",
+    "emits",
+    "emitter",
+    "event",
+    "once",
+    "pub/sub",
+    "publish",
+    "reactor",
+    "subscribe"
+  ],
+  "bugs": {
+    "url": "https://github.com/primus/eventemitter3/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "V1": true,
+    "borjes": true,
+    "yxqme": true,
+    "koulmomo": true,
+    "lpinca": true,
+    "mikemimik": true,
+    "nickleefly": true,
+    "rochejul": true,
+    "wangnan0610": true,
+    "ziflex": true,
+    "hifaraz": true,
+    "shanewholloway": true,
+    "codebyren": true,
+    "largepuma": true,
+    "mojaray2k": true,
+    "staydan": true,
+    "rocket0191": true,
+    "lestad": true,
+    "zhongyuan": true,
+    "brend": true,
+    "kontrax": true,
+    "xyyjk": true,
+    "oleg_tsyba": true,
+    "arnold-almeida": true,
+    "nbuchanan": true,
+    "travis346": true,
+    "drmercer": true,
+    "dwqs": true,
+    "cedx": true,
+    "addamx": true,
+    "perevezentsev": true,
+    "nilz3ro": true,
+    "r_java": true,
+    "jarvis1024": true,
+    "black-black-cat": true,
+    "heartnett": true,
+    "cr8tiv": true,
+    "arcticicestudio": true,
+    "sinahwz": true,
+    "dandrewgarvin": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/eventemitter3.min.json
+++ b/test/fixtures/registry-mocks/content/eventemitter3.min.json
@@ -1,0 +1,571 @@
+{
+  "name": "eventemitter3",
+  "dist-tags": {
+    "latest": "4.0.7"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "eventemitter3",
+      "version": "0.0.0",
+      "devDependencies": {
+        "mocha": "~1.13.0",
+        "pre-commit": "0.0.4",
+        "chai": "~1.8.0"
+      },
+      "dist": {
+        "shasum": "90a5cc3c2ef715169ceaed893d797ae1951c8119",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "eventemitter3",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "~1.13.0",
+        "pre-commit": "0.0.4",
+        "chai": "~1.8.0"
+      },
+      "dist": {
+        "shasum": "052227d4fc69b1d3f1ec0e569b248e264ccd795b",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.0.1.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "eventemitter3",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "1.13.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.8.x"
+      },
+      "dist": {
+        "shasum": "727e1600ea477f50f1f11328cb9a5abf752c1dff",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "eventemitter3",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "1.13.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.8.x"
+      },
+      "dist": {
+        "shasum": "7ea62a9d6b8343cb17ddb07f6ae8d3881ecdb8c3",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "eventemitter3",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": "1.18.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.9.x"
+      },
+      "dist": {
+        "shasum": "4ede96d72b971a217987df4f1d4ca54dd8d20b79",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "eventemitter3",
+      "version": "0.1.3",
+      "devDependencies": {
+        "mocha": "1.18.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.9.x"
+      },
+      "dist": {
+        "shasum": "6b8ac1392ff0a5b4d87e893bdbee79887a86d95a",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "eventemitter3",
+      "version": "0.1.4",
+      "devDependencies": {
+        "mocha": "1.18.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.9.x"
+      },
+      "dist": {
+        "shasum": "da2be74b7a1a4760272e1390f975503be5cb7e24",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "eventemitter3",
+      "version": "0.1.5",
+      "devDependencies": {
+        "mocha": "1.18.x",
+        "pre-commit": "0.0.x",
+        "chai": "1.9.x"
+      },
+      "dist": {
+        "shasum": "fbb0655172b87911ba782bb7175409c801e5059f",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.5.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "eventemitter3",
+      "version": "0.1.6",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "8c7ac44b87baab55cd50c828dc38778eac052ea5",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "eventemitter3",
+      "version": "1.0.0",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "dist": {
+        "shasum": "c738401cb6d29e46e00ee623521689082a52e1cf",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "eventemitter3",
+      "version": "1.0.1",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "dist": {
+        "shasum": "75a110a2e1bcc5de7999fead1910fcb058f51a14",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "eventemitter3",
+      "version": "1.0.2",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "dist": {
+        "shasum": "1163487c15b37566bf4ea8dbd5ccb5ddd5c0a9e8",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "eventemitter3",
+      "version": "1.0.3",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "dist": {
+        "shasum": "15295f06dca6e1f35453a860b0fd43876367e258",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.0.3.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "eventemitter3",
+      "version": "1.1.0",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "dist": {
+        "shasum": "8d94b51448fa4ae11f8725aeebb7c0c48a8e71ac",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "eventemitter3",
+      "version": "1.1.1",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x",
+        "zuul": "3.0.x"
+      },
+      "dist": {
+        "shasum": "47786bdaa087caf7b1b75e73abc5c7d540158cd0",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "eventemitter3",
+      "version": "1.2.0",
+      "devDependencies": {
+        "assume": "1.3.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.4.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "dist": {
+        "shasum": "1c86991d816ad1e504750e73874224ecf3bec508",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "eventemitter3",
+      "version": "2.0.0",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.0.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "605f34e75ea702681fcd06b2f4ee2e7b4e019006",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "eventemitter3",
+      "version": "2.0.1",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.0.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "59c8930b1d8f4da54ad752854948f44330e7f39c",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "eventemitter3",
+      "version": "2.0.2",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.1.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "20ce4891909ce9f35b088c94fab40e2c96f473ac",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "eventemitter3",
+      "version": "2.0.3",
+      "devDependencies": {
+        "assume": "~1.4.1",
+        "browserify": "~14.1.0",
+        "mocha": "~3.2.0",
+        "nyc": "~10.2.0",
+        "pre-commit": "~1.2.0",
+        "uglify-js": "~2.8.20",
+        "zuul": "~3.11.1"
+      },
+      "dist": {
+        "shasum": "b5e1079b59fb5e1ba2771c0a993be060a58c99ba",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "eventemitter3",
+      "version": "3.0.0",
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~14.5.0",
+        "mocha": "~4.0.0",
+        "nyc": "~11.3.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-62TxCtz4m2LRaOERVEvLJJ4A6rsg8lC9Xm+FLg2y/1fB/v4ZZ9JCOn+/Ppl5KkH6sRih6bhix724PVanmXYZJQ==",
+        "shasum": "fc29ecf233bd19fbd527bb4089bbf665dc90c1e3",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "eventemitter3",
+      "version": "3.0.1",
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~15.2.0",
+        "mocha": "~5.0.0",
+        "nyc": "~11.4.1",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA==",
+        "shasum": "4ce66c3fc5b5a6b9f2245e359e1938f1ab10f960",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20382
+      }
+    },
+    "3.1.0": {
+      "name": "eventemitter3",
+      "version": "3.1.0",
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~16.2.0",
+        "mocha": "~5.1.0",
+        "nyc": "~11.7.1",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.2.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+        "shasum": "090b4d6cdbd645ed10bf750d4b5407942d7ba163",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 36241,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa4NzSCRA9TVsSAnZWagAAYsYP/j3zNmW2uWdBC2A1cPSn\nMsgv21wWhhuCkg7qc1aotD4X2/L/0xYBwI5jbKvXVicz2NQUgcJG68q3BriU\nskYbjblLpct5R9BzPiwEMm6wRmHk0JN0Fz5bBtk1EA4xaQHugkbzrOLLhxxM\nkAa84X4wLJunz/JmTGn4akyz92FzMM6oOxZfNzzIXepw1eAxQF5YGLFRitC7\nKeJQv/p2d0dLb73MjyvDC0IPe7R1ZwMeUF06A2w+Z04/jLK8mdumM9hws9kj\nbhq5WLePhMEgnvLIlHDBAevqj4qBgXaS5GsbNCC7Za6xJaz1fLLkx+jGl8A3\nw8EGDY+DkxmKHgMPrIqM6eCNOYcCc35tUCVsSf73GFqGA+f8luuasRqI23VM\nqbBScHy08sESdFkOeaqZByJClN7zl10CVQTU5Gm/vXNFNjmx8yxYlsJRqUGq\nT8GHlr3q4oEjFmLbcR9tIYwYGx/QyNYeB2DZ0HKu51LNtWeFVbYx+TKnG8zB\nDNNdNbyaAiGOEPXXhUxjUsywxgZatymqtiPQhxd0blnIOSZHJsm1qYBggXbk\nGYLigxrN6D6bBsW4+6c74v7CbaEP3zulHAMukIQQoE5gjfq49J9vP8CjBG0w\nxE7WMeXlre4YdNrBUTxPA312/f9VtypiFzqnj7cSENsm/tynZjCR4xAdJG9z\n++Gc\r\n=f2la\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.1.1": {
+      "name": "eventemitter3",
+      "version": "3.1.1",
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.2.0",
+        "mocha": "~6.1.0",
+        "nyc": "~14.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-MXmFv3KYbv7MPjPeGlFCTieXB9zNvmHfy4fXzZbrdMeUUk3pxQ8SS0cJ6CcwUDZnIL3ZDa01qQFzhlusB8s51Q==",
+        "shasum": "1ab02a344af74f5cbf528969601bf0fd6aeebf98",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 36256,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcxyTtCRA9TVsSAnZWagAA7xgQAIcgU0Xe8sCjBrhQNTEd\n0tx5RLC/63afKnoM5GDTDOYZUu6aHxDnSH0i4J60AZ6NzS2zH1YCfsLj28t9\nhZ6rb3SDEwK1d7iz1wSytR0QclImlDvtvcAoP/XgUFFZIQFRkLaP7xicFCZd\ndRwTYvUScV/leuljCtN/NXfmo6U6MrWj+xYlhk8GfDchVEg+W7uTXozWIdGf\nUkvmtoOzXky8InN82J49nT/9uvDoqVL+tAi/ppzCd/tcy71U81TXgoDPfGUw\nQx8C9X29DiWohJDkmNLAiVCAjB+RpzgTAf3V8/eJuyNu9BcHL4yJJIjvA+vQ\nJ3nGarNUHNU/7ct0B8ZXvwxCgzdHtYNtqchzT3z3wDNdRCL4lUdulaonoFBB\nBijbOCTggmH1Bd0BM7PnIYv9dGC833zlKd8eyzS3ijT8s1u8tw0WlbCbW25/\nWjr8jhf6fJCH2xZskxE+erQxJLfCk71gNNwBrVIA8UTFyzBcDIPEiM2Hq5OM\nEG/0ECHWAaW6WpCU6icINJ9lK8rU9eWMv7ihArRTRmVS4rVqm565Bgn438+1\n6v6VlfH7qFi1R4QjwzX/S7DHjufsloeHM35lhh9evSHkUr+xjPy7iXhtJBey\njfn4jbghy7Yw5cclCJpc2EZ4BJYrjlAqgTVQpe+PopK6TG8DORhKINfz1EcT\nqdii\r\n=bLMn\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.1.2": {
+      "name": "eventemitter3",
+      "version": "3.1.2",
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.2.0",
+        "mocha": "~6.1.0",
+        "nyc": "~14.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+        "shasum": "2d3d48f9c346698fce83a85d7d664e98535df6e7",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 36240,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcx9cvCRA9TVsSAnZWagAA0n0P/3tqCbPIQ0J24jWYn2Aj\nm/RQ0ALKXFjQF2wf2p1peIpYZuaZnh5P3QaBMH17kYDo5S969nOYxrj0BUwu\nn/reAHnJQxXJGD9IYz22wWoVnwfUewoAGwdeOwTdxDNfrPDBJky42e0u1UvO\nS04QbCeyG8+wNH1eJDtoPsMcs2AN4Ppd2JfwV/SkKlmILD0Tp2wmf8Es5zRB\n0BsYnd4nTqMNHeQbTdQ5bfUs9cMtRE/CzPvwisIX3nhVUPQtc3vw6IuAsg0y\nYCvyrpqRqF/mwmmDFIWKnVZa2ExDAFkgaWvzOdVO1v+orLkQbvAP29k6XG47\nt7q8t6uH2iInp+tErRYzWTm+ZVFgIrvWe6/SLb1LHGYiBxCvULMDLjXA/cng\nHWumLkPjWNy6kUj9Qv/G5519smAfGoUEIc5Q2e7/u22jfGODjko08f31YgNr\nF412cUUK89FKpBv4DhSeAvXWVu3/v10g98vzaPaTf1H8RCs2wADgeWPcaqrw\nrXg3ii2HPCGI00Qhuiv6LfwieP2oHyxRiZP6IH2VA+CFV2RuPie03xHTosJm\nTf6S1c+hU1cFEg5SvP+NF0CiDVe8kn12nZMW077GjvzWsjsqTT0a7vuSxqPu\ngolJvF9rYcQVIVHMC/n+GAlTcfyLANJXwQ5R2D3GPUwD4C0HH5pdANUgiufQ\nLf98\r\n=Mfmc\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.0": {
+      "name": "eventemitter3",
+      "version": "4.0.0",
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.2.0",
+        "mocha": "~6.1.0",
+        "nyc": "~14.1.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+        "shasum": "d65176163887ee59f386d64c82610b696a4a74eb",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37015,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdCjhECRA9TVsSAnZWagAAz0sP/jkDyKdZ8sk50fqmttAc\n2UDQYGw76sKL19pI+TPqXoqhlxoP5WsdX1+Wz4MgNBOmzp/iyGoNgokW+aUJ\nbNf6trdIS76blPItTI647EzKur/4AVmAjzz9UbjRdA77HyZ3eE2V+p8vc5eK\nMtr2B6oiGwUw8Cq/1sKBZPySNElEU/OWeRRXyrym4hzYxFYPokx7DGRmYWLv\niK85HBi6aW0zoj5bpC9FzNO3yHGFI+KFKUhhp/N+R2c5bY4IfVqbdfa8dk0H\niYy+CiF3rAudBPGxX2dYukPIaMcM1AQmjyqGqE21hrs9JGxKZ2wsi5zWEYZS\nc4Wow0oQEW/FetDdJJBLp5Epp9vVzly1C/htwZoIZ8Ki9vsERKKw2ZqyY9Ps\nW5BVxdbNxKVILt5jq1qlGoNY9QI17O0mez/etVGgFu31hqoOzGclC+IvaEpI\nRX+d5QfcSrzM/TocYD7mL/TI+Wk1tw0dklFvoM2OZRRalts4F2TyTHfFDiCJ\nmArUlwkFPq4pFlM4nGDH6I3f7KT7omWooHqNNk9bkl4qpF9KdbCzioEzoD2V\nvv55C8Lxz/MDFDc2MZujbj8Q5aUoGS9L6VK07dHyrYSUnsGXnNBDhlEcn+Sa\nsAgPPs6+kLzjPyOhDltBjjj7yZwOcsK0MPaqlFdDRidn/3DJh0G/cX5EyRDN\nZWY9\r\n=WGFs\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.1": {
+      "name": "eventemitter3",
+      "version": "4.0.1",
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.5.0",
+        "mocha": "~7.1.0",
+        "nyc": "~15.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-MnI0l35oYL2C/c80rjJN7qu50MDx39yYE7y7oYck2YA3v+y7EaAenY8IU8AP4d1RWqE8VAKWFGSh3rfP87ll3g==",
+        "shasum": "3bcf626b0d3b16ce22ee88625a3772706300ba1f",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37507,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeuEABCRA9TVsSAnZWagAA7dYP/16kWKmiPXs8v5KwW5Po\nO0mRMW7pl0y6rKsRusLfibti8xuUX796UkqbrF1G103h8W0k322O0yuCeGdp\niQDIDPAgx0lMKUKH2ky4ySs6sVw7YvKUwa0OtMHGvu0LJhWaQPiOBjlTwbL/\nRVUYJ6mfE0deMblXfbnS8IxE0/rN2T8vvTjFCIuVIXNwD5yDzZnB+oFP0FLW\n7RhOyTYPosdEK3PCOUjvnBrPEaOAYqz0ahVMuahOyqNAFOJT/tcAKN0xXOOW\nveNwncBbjQWaQv2S8v/Dt3OpjhjTLEUcbefWuTDixwP8AQ8pBHadhUuAAM9v\nppovzLm52PT0iZo9ewm8C/Dqr8Qrf84JgEjYKo2wsfFyVaia73pBRKCOugA7\nIlbEmUsZbyUrnedixb7Y2bXuJU4WZGKhhGhPNsyAs3LnYso1NZuLEsmWECIv\nOjUMc6GLcSVFnS2wSsw+BaJAyENQu7TrkH322eE4iB/CIR3fD79BqIbSAzFI\nUI9PVBpQnm6UCM5jtCnRzQnsVuih4/pHd4DBh1dklRilHThUCUUO5N7BeRQl\nm4XQKGNh5U+MlkQx305u/HXQ7OBPQxJHpYerbIhcd45uB6c9YI+4B8FuhHkl\nd6q2CtifGcBeqN/ggHxohnVU55yQMXHAgXX1s13Pvhw59+I6ROzE8+KdRsb9\nvB0E\r\n=R9PK\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.2": {
+      "name": "eventemitter3",
+      "version": "4.0.2",
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.5.0",
+        "mocha": "~7.1.0",
+        "nyc": "~15.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-c8VhEv9UueTlJtfhTx5mbt94l/N1nrfN8j3H1kgl/APEv/y4E95ny3lABssobpcX+4vy/fBtrdhWi44VxTSsog==",
+        "shasum": "08daca70c33379e6b8dddc56516671f2a4c0172f",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37800,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeuVgzCRA9TVsSAnZWagAA6m8P/0Esx0PohpCn1fvO/Rpk\nuzfAPzkx/zhDm0o3ltEGT2aVpdXe2aX9047u8kE0lynwdFUIiO5Td8I23Y9Q\ngM07wiyis66zVgsckJA5EucnnXGY7OWC1mV1ePMPj8mnxi1mL5bJ/ickNkrZ\npQF78lW13341IuYHTH35YzRNNxLQfcbiIQ4nFHEHUYUAi4NEiz1MC/x5OOxt\nHSI1/u6pMz4rPbHtar7rtQzCCOqVe4J5Q/d7Nx6Bx3z5EJ37TcTkp6vda4/P\nPwNB9fqszV7jHE2QZXEaw4u7mIaR973dzxm9W3YWALdslfQ80WpUv0eTtR+l\nEWtCCx/yrnQIFWmPzZ5JavpuWM5pNkV7KP5E/NWdg/AmOgmASh6gFuDJ+Rng\nj8voGKGo9zshJhIutl8ZMy2sS68ukMutDVrZ9Xl+JhIdPJGROhOeiyrL5xgG\nL+vf8xp3+eiSPfXj7/MLt0WJdueDRtyIhgKhis/KW2sAkumUVUaRfhWFk16g\nHf8arNLIDTAhtYBIjq+mUxIujsyQLayfLgoxgGWEjMcVWAeUIqEpwBEXbV9d\nQl7V1kR0/yV0t1JASDZxGQQWWk+ZwDyeRFDPjD82ejFFifCkWJLtVj/WjCGt\nVXTmPU9Sr1eS8mLVtCP+UFeWP048NxzN1L6zGyvcOe0cqqzhWjvn3RRX1OOb\nbn9N\r\n=AG2s\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.3": {
+      "name": "eventemitter3",
+      "version": "4.0.3",
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.5.0",
+        "mocha": "~7.1.0",
+        "nyc": "~15.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-HyaFeyfTa18nYjft59vEPsvuq6ZVcrCC1rBw6Fx8ZV9NcuUITBNCnTOyr0tHHkkHn//d+lzhsL1YybgtLQ7lng==",
+        "shasum": "850b43083fdb36a246f03168f189e9054f90bdb4",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.3.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37763,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeuVw+CRA9TVsSAnZWagAA50wP+gKNMf0lYlrKcZqYTAqM\nVzZovbf/ptx0kxNrILEUzrXfGzhotzpDw5PClh3OxocoB0kDZrSVS2pn8qhG\nUHJngoaMvacN1HGtjgDWALAma/gA2swhGbe4voicnEzAINH0L0g3FCN3DN9R\nS757IjonbsLy4XhoOqWQ0NQSvDfe8eYmIuD+bmXzlAzt148LZ3ryP+yjT3q8\nqqahkBcO+9bJj1uKu8SuhoiNULNJe3sWRZ+4lGDdEKuAEPDoOLmeCiLlDFzK\nvH7UySLvdMQeJC4lGwpJwxOHKqRzcIp4ehF+M8wvPcCP0P9Ybek2tdVPQUP3\nG1Ffoh2dlx4EWuLAO6SjhxiC1im90XosQf1R+NBr21Ly8otILsTMMVAYmTTV\nQnwD1L8mFZ2MqqpNn2cb73LmleSYz2g/V4tJj3CQKWXrFuVNz5pwVIhhFCTh\nUXKq/CLqZ64LrAJoxTxRlrN/IfoHrmZYx9LDHGwNOKfJzBcF2nsW5DI25bar\neOZ4AXv5Bf+7Iq6nIFH1d7shbYAKZq70OdFUbfpcccDlERCuN7zPnDU4Xj/N\nn57uKTL8FnjUgGElFacSOPMRCoIx5QBoCuZ2G1Dv+WWecm+B6bgQjnuXd4//\n8tj40loPv3VZhRfdGPNYO4z0oNPml7w/L8foUAqE4dMkzRGh2F4TvkuD+iEb\nf7Zt\r\n=3/C3\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.4": {
+      "name": "eventemitter3",
+      "version": "4.0.4",
+      "devDependencies": {
+        "assume": "~2.2.0",
+        "browserify": "~16.5.0",
+        "mocha": "~7.1.0",
+        "nyc": "~15.0.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~2.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+        "shasum": "b5463ace635a083d018bdc7c917b4c5f10a85384",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37780,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeuojlCRA9TVsSAnZWagAAUQIP/ijIqEN/78xdqiV6NdY6\ngf69c1ptPoiBIQbTJLQZiKd4CxmPNp0yXotTu30rkIfEkfvsmDwZII2HLZZG\nvd1NsS5kG7biTQk0fa2G16CImFLwoBsxk1KZrbmu/X63GtdCfmCSmCVKu/Sz\nIUkPTeQP8NoPKDs0ZWK32XgZ3qvRItmA/lQfj+PwnWqW3Vw4PqDJIWUtSAEL\nWmNaZreCIzElYX3pzJE3ccBnx011QnvXiEEMe2EgBrHl1qDfdrgLTVxVfjLj\nQUW9wVI6kh+irOKjNdYHbWtygJmX74As2F3T4XAHgqOpSgxbFZycxeUqALgQ\nsSMOkcsdWcXwX3sCOQ+sV7GB7oJk2S7YfLmFbfqYdepTeytSe7aftbD+zbC1\nbSF+mxqbXBNJjvB2XprWTd8NHgiDksyDNE2VWHNSBacN4bQXYtnc3gNerd4k\neGwl3n6j2FyY6cyH24eE5BtqouWJvy/e8IHgbS4wLmbzJ1x9cwh0bEsuJOzf\nEkAzED+MephrBNaRBvjDGdwrPFRsZ5QzFR3BxoQ4Uu7Usu0jQeupCzUs/+yY\nE7pMd+etJ6a9XgFBjj3um891aE1qTpjd2iERyQqldIQAnf7O69lq+BTlJIqF\ntuAEbhQnAZd+rcCZrUYCk4Ls+W4TCj9L0y4pqzT1ggk/crUxl/kkWxFuhfGw\nKNh4\r\n=rUKI\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.5": {
+      "name": "eventemitter3",
+      "version": "4.0.5",
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.5.0",
+        "mocha": "^8.0.1",
+        "nyc": "^15.1.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-QR0rh0YiPuxuDQ6+T9GAO/xWTExXpxIes1Nl9RykNGTnE1HJmkuEfxJH9cubjIOQZ/GH4qNBR4u8VSHaKiWs4g==",
+        "shasum": "51d81e4f1ccc8311a04f0c20121ea824377ea6d9",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.5.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37792,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfQOOVCRA9TVsSAnZWagAAphoQAJtDutCAL8K6VV7UZOwG\nkopJjm9XmxHkAKx/ENe0HG0YMkasPnoHY1kMoKlvJbOjK6algYi4J2Co+ACK\n0Dx4D6G7asPwN0DOQTaJ7O876Apiz+elXlBH47Syh35xgeUVMel9GwwttXx1\nYIfmYSfEyM9R16aFowT7afWMY4N+s/rcgH+zMw/k6h7PrF+wKKGBhBMkS5FN\nyfJ0Arir2WBSn5lmVms/oX3ZOY+kBX90PE491hVFs6em1HjS8fTLt87Vmw+b\n0t49B7g8jpiOzd9BHOwI7lAvy+Q8y9X40abYen/a6S20R0OdBAn8+TcDjR2c\n+jlFJLI3meJkdaCzHv7vQk/TDylHbFk5Ej6foofgKL/2wO2tevU2c1dIJoZv\ny+W+v3aKFFWr4SNqJvLJP83u60xck/Ij3uM2utHZ2aIU2k4u07PxIFcLWb8n\nP4rYVUgKHZzNo2AnbhYETvfHWg8x031gPEBquEY13ajRQUCdhU/HgGhqQiE1\ndPMdc94whJyGTe9bMSUi2YIoO7tBnJuYKTjcVeg+XR8yqSRQ0+HZtH7wovDd\n5nqw/6+SNmhtDBgAMDtCXScK+WFzxeNgR8zUKZ8gaLknI4swQiV/KqKtVSSD\nxg8Hw5Xa2mMMq3Z+9r9NaHXX8Lkumsx+rn+ZHZU79vbnzGCxbkM8LpSKKQlN\nexQq\r\n=8Mou\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.6": {
+      "name": "eventemitter3",
+      "version": "4.0.6",
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.5.0",
+        "mocha": "^8.0.1",
+        "nyc": "^15.1.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-s3GJL04SQoM+gn2c14oyqxvZ3Pcq7cduSDqy3sBFXx6UPSUmgVYwQM9zwkTn9je0lrfg0gHEwR42pF3Q2dCQkQ==",
+        "shasum": "1258f6fa51b4908aadc2cd624fcd6e64f99f49d6",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.6.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfRUR+CRA9TVsSAnZWagAAaaQP/1kEhIVrZcYvKC8P9QkH\njsuUiWdMOlI1KlXmkN4WaLSWY2A3w7hK2I7lYFe1e86LW8w63SERxO0+1LRc\nWIQGVSK7GAA3rPsva/OMk3pk3vZJGQSv1g141gDuZxckspVzvk/p4YRyiBTY\nloHeTvQW1D8iOrsBXnKlZ4uq1sT5EqvG3RbCPa0zLrYSvcfiNOKrOxxSjbxR\nFFF2Ewjoutp9BJtcfbpJnYjFJZDmNohO5ie6+NFK1gCwzKJqqyx524IllJC4\nBkkym2WRiRvHMUhwTQkmGILfiupTxjDvl4XqAh1BabKh1GO8/2XDGgBv8jHu\nwm4joCU+nFfFFudA/AjRhxrRUAsXZUcL3GGa3yC0mrdIqUQflKoT3BjoYm9B\n2/IN64RX5Vtc1uU7aQQr2Pm+DxYAZpIZHmcAveR/BLGDTg43HXyc7MHMbgD/\ng8PCberJty37kqYMGidw69d3sl7OGP/mtYrswTL97dOCJwDD9iB72zGGefG9\n02qQttBNSzRbYQGzwxqNeML04/oedAbIZnEVPY1Fc3A1SGAtbarHSTmStV9P\nWguN2ibRF+7f3FnDxULRSVmZSH3Rk7rkikSkungEKMozLuFUt8LwwM4+rriL\nPDcSQUdFT+nEv0vXtn4i8qnKRD9RRFEJDOfSR/zonk+WKF+MCYLRRXszi9Mr\nwH5o\r\n=Q3kF\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.7": {
+      "name": "eventemitter3",
+      "version": "4.0.7",
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.5.0",
+        "mocha": "^8.0.1",
+        "nyc": "^15.1.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+        "shasum": "2de9b68f6528d5644ef5c59526a1b4a07306169f",
+        "tarball": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37967,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfR3iVCRA9TVsSAnZWagAA+1YP/RN7vVEWHMzDnY73iQbq\n092QpDsL71RWTTM7Gezwv2L1ANE+GXLA1ZuVZ7LpFMOwkvYv4ep7TuUbVL3I\nuXq60DSql7VVzKhAPL5omm9XaWwbPk7RzuNtstl4u+XcOW+QUEf87JT4SIz/\nZtNKbfvvHArGre5BY1RP2WWmNn4YnPOuGYEehoUeI1l72Ni4uAj0HIJFPak/\nh5SbLshoewiHrYH7IchgXR+gjQAgMeRoLqeGIgEFDl78hejNFZ1FR21B69LM\n9ApOc1I6ghZy04QjfOYlliCgt526fkhlingzjQe5M8czBNvrrpz6rQMZPkHy\nYHLcuEqaoAZW+gK6hlBjhGRHqTgTuLCwn9DfB02YaeFg3InEdzFgnOhv9QiE\nQR146zowzAStPvIPPX+Yb6Ip9M1lIeTwVGLjqW8zkTlQ/wYJU+nUnArMYi6r\nfVesF2Ud3JPmSWLcgiwlhc8Nntm0poBF1Vut/Cyo67D0MLq2qqf9VZ8fFxuM\ngTmuDylKrhHDzGrW9rCdz2v4mP8o1s8D51z1MVUeBaiUS2xTP9r2ROE5bDRN\nk04pbQgawdAxWoFnHO0AATBZBxsvs5WQqCitv+o/4UyTxHyPnJvR9vh+q4q/\nwtrW3TXZsUSzYu2LMTFD2XUYjnmmglTjg/yIMQe/vyN1/hFn4els9ADvzzc7\nnqbC\r\n=x1qZ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-08-27T09:10:47.223Z"
+}

--- a/test/fixtures/registry-mocks/content/eventsource.json
+++ b/test/fixtures/registry-mocks/content/eventsource.json
@@ -1,0 +1,2508 @@
+{
+  "_id": "eventsource",
+  "_rev": "65-936adaff608aab938e13e9f29e517297",
+  "name": "eventsource",
+  "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+  "dist-tags": {
+    "latest": "1.0.7"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "eventsource",
+      "version": "0.0.1",
+      "description": "EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "nodeunit": "0.6.4"
+      },
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "_id": "eventsource@0.0.1",
+      "dependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.6.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "c93d59063dfc91b10c2708f4bd0aa2233e243324",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.2": {
+      "name": "eventsource",
+      "version": "0.0.2",
+      "description": "EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "nodeunit": "0.6.4"
+      },
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "_id": "eventsource@0.0.2",
+      "dependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.6.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "753ec5f169050130052130b07441102564b16cf1",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.3": {
+      "name": "eventsource",
+      "version": "0.0.3",
+      "description": "EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "dox": "0.1.x",
+        "jison": "0.3.x"
+      },
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "_id": "eventsource@0.0.3",
+      "dependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "8ea901b5877dc2c02373f283ea2fea72878d1fa4",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.4": {
+      "name": "eventsource",
+      "version": "0.0.4",
+      "description": "EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "dox": "0.1.x",
+        "jison": "0.3.x"
+      },
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "_id": "eventsource@0.0.4",
+      "dependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.105",
+      "_nodeVersion": "v0.6.1",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "c17ef87e477ffba2adb20832ebe0d410d0998f24",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.5": {
+      "name": "eventsource",
+      "version": "0.0.5",
+      "description": "EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "dox": "0.1.x",
+        "jison": "0.3.x"
+      },
+      "scripts": {
+        "test": "make run-tests"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "_id": "eventsource@0.0.5",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.0.105",
+      "_nodeVersion": "v0.6.1",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "015db0a5aa32d9654e0c173b129897db5e6d39e1",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.6": {
+      "name": "eventsource",
+      "version": "0.0.6",
+      "description": "EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "dox": "0.1.x",
+        "jison": "0.3.x"
+      },
+      "scripts": {
+        "test": "make run-tests"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_id": "eventsource@0.0.6",
+      "dist": {
+        "shasum": "9e8f6c056bf71e886d9ab08a9c5fba1e834f6210",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.6.tgz"
+      },
+      "_npmVersion": "1.1.62",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.7": {
+      "name": "eventsource",
+      "version": "0.0.7",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        },
+        {
+          "name": "Scott Moak",
+          "email": "scott.moak@mybrainoncode.com"
+        },
+        {
+          "name": "William Wicks"
+        },
+        {
+          "name": "Devon Adkisson"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "~1.9.0",
+        "jison": "~0.4.4"
+      },
+      "scripts": {
+        "test": "make run-tests"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_id": "eventsource@0.0.7",
+      "dist": {
+        "shasum": "d052a2ade1e588e9a9d2eb6a7743ddb3379d882b",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.2",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.8": {
+      "name": "eventsource",
+      "version": "0.0.8",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        },
+        {
+          "name": "Scott Moak",
+          "email": "scott.moak@mybrainoncode.com"
+        },
+        {
+          "name": "William Wicks"
+        },
+        {
+          "name": "Devon Adkisson"
+        },
+        {
+          "name": "FrozenCow",
+          "email": "frozencow@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "~1.9.0",
+        "jison": "~0.4.4"
+      },
+      "scripts": {
+        "test": "make run-tests"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_id": "eventsource@0.0.8",
+      "dist": {
+        "shasum": "3431160f8cfcf22821a01853c210c4d359ee1151",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.9": {
+      "name": "eventsource",
+      "version": "0.0.9",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        },
+        {
+          "name": "Scott Moak",
+          "email": "scott.moak@mybrainoncode.com"
+        },
+        {
+          "name": "William Wicks"
+        },
+        {
+          "name": "Devon Adkisson"
+        },
+        {
+          "name": "FrozenCow",
+          "email": "frozencow@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "~1.9.0",
+        "jison": "~0.4.4"
+      },
+      "scripts": {
+        "test": "make run-tests"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_id": "eventsource@0.0.9",
+      "dist": {
+        "shasum": "ff59a6245e0fe2dfc6f921a5c9ace3b341002716",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.0.10": {
+      "name": "eventsource",
+      "version": "0.0.10",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        },
+        {
+          "name": "Scott Moak",
+          "email": "scott.moak@mybrainoncode.com"
+        },
+        {
+          "name": "William Wicks"
+        },
+        {
+          "name": "Devon Adkisson"
+        },
+        {
+          "name": "FrozenCow",
+          "email": "frozencow@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "~1.9.0",
+        "jison": "~0.4.4"
+      },
+      "scripts": {
+        "test": "make run-tests"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_id": "eventsource@0.0.10",
+      "dist": {
+        "shasum": "4d3a0f9b2c70083444fee3c39a7b2bfcf2221cbb",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.1.0": {
+      "name": "eventsource",
+      "version": "0.1.0",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        },
+        {
+          "name": "Scott Moak",
+          "email": "scott.moak@mybrainoncode.com"
+        },
+        {
+          "name": "William Wicks"
+        },
+        {
+          "name": "Devon Adkisson"
+        },
+        {
+          "name": "FrozenCow",
+          "email": "frozencow@gmail.com"
+        },
+        {
+          "name": "mbieser",
+          "email": "29erpilot@gmail.com"
+        },
+        {
+          "name": "qqueue",
+          "email": "queue@hakase.org"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "~1.17.1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_id": "eventsource@0.1.0",
+      "dist": {
+        "shasum": "b9f5bd8f173402e6758438d9cfba46643cd25a0a",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ]
+    },
+    "0.1.1": {
+      "name": "eventsource",
+      "version": "0.1.1",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        },
+        {
+          "name": "Scott Moak",
+          "email": "scott.moak@mybrainoncode.com"
+        },
+        {
+          "name": "William Wicks"
+        },
+        {
+          "name": "Devon Adkisson"
+        },
+        {
+          "name": "FrozenCow",
+          "email": "frozencow@gmail.com"
+        },
+        {
+          "name": "mbieser",
+          "email": "29erpilot@gmail.com"
+        },
+        {
+          "name": "qqueue",
+          "email": "queue@hakase.org"
+        },
+        {
+          "name": "Romain Gauthier"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "~1.19.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_id": "eventsource@0.1.1",
+      "_shasum": "28e2eb6e15a7d89c6ffc92238aad1930eacb5da1",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "28e2eb6e15a7d89c6ffc92238aad1930eacb5da1",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "eventsource",
+      "version": "0.1.2",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        },
+        {
+          "name": "Scott Moak",
+          "email": "scott.moak@mybrainoncode.com"
+        },
+        {
+          "name": "William Wicks"
+        },
+        {
+          "name": "Devon Adkisson"
+        },
+        {
+          "name": "FrozenCow",
+          "email": "frozencow@gmail.com"
+        },
+        {
+          "name": "mbieser",
+          "email": "29erpilot@gmail.com"
+        },
+        {
+          "name": "qqueue",
+          "email": "queue@hakase.org"
+        },
+        {
+          "name": "Romain Gauthier"
+        },
+        {
+          "name": "Lesterpig",
+          "email": "loick.bt@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "_id": "eventsource@0.1.2",
+      "_shasum": "0d1c4777b017c66ec74f3920ca6fec32a3bfcbe3",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0d1c4777b017c66ec74f3920ca6fec32a3bfcbe3",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "eventsource",
+      "version": "0.1.3",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Aslak Hellesøy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "Einar Otto Stangvik",
+          "email": "einaros+gh@gmail.com"
+        },
+        {
+          "name": "Dan North",
+          "email": "tastapod@gmail.com"
+        },
+        {
+          "name": "Scott Moak",
+          "email": "scott.moak@mybrainoncode.com"
+        },
+        {
+          "name": "William Wicks"
+        },
+        {
+          "name": "Devon Adkisson"
+        },
+        {
+          "name": "FrozenCow",
+          "email": "frozencow@gmail.com"
+        },
+        {
+          "name": "mbieser",
+          "email": "29erpilot@gmail.com"
+        },
+        {
+          "name": "qqueue",
+          "email": "queue@hakase.org"
+        },
+        {
+          "name": "Romain Gauthier"
+        },
+        {
+          "name": "Lesterpig",
+          "email": "loick.bt@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "gitHead": "256e577becc8c62510383b78d25e60897eb0d262",
+      "_id": "eventsource@0.1.3",
+      "_shasum": "6e802fc06a5ff964869bc95fb75ce2e99f1fedce",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6e802fc06a5ff964869bc95fb75ce2e99f1fedce",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "eventsource",
+      "version": "0.1.4",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "postpublish": "git push && git push --tags"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "dependencies": {
+        "original": "^0.0.5"
+      },
+      "gitHead": "739bcc847806616e5c14d32e128d93faacac2c98",
+      "_id": "eventsource@0.1.4",
+      "_shasum": "b667d5d99948f9cbd8b249f154ac2a01b4f5ce22",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b667d5d99948f9cbd8b249f154ac2a01b4f5ce22",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "eventsource",
+      "version": "0.1.5",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "postpublish": "git push && git push --tags"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "dependencies": {
+        "original": ">=0.0.5"
+      },
+      "gitHead": "de40fd04dce861216324bd6a6fe3d3e87e3fedd7",
+      "_id": "eventsource@0.1.5",
+      "_shasum": "e5bd748a2f4063d39199ed5061dedb1558848e5f",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e5bd748a2f4063d39199ed5061dedb1558848e5f",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.5.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "eventsource",
+      "version": "0.1.6",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "postpublish": "git push && git push --tags"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "dependencies": {
+        "original": ">=0.0.5"
+      },
+      "gitHead": "c93edb547891f7cbd8d576751427445029bb782b",
+      "_id": "eventsource@0.1.6",
+      "_shasum": "0acede849ed7dd1ccc32c811bb11b944d4f29232",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0acede849ed7dd1ccc32c811bb11b944d4f29232",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "eventsource",
+      "version": "0.2.0",
+      "description": "W3C compliant EventSource client for Node.js",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource-node",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource-node/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource-node/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^2.4.5",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "webpack": "^1.12.13"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "gitHead": "bd819d5a58c2d9f6bcd18eb5cbcd8523907a6a45",
+      "_id": "eventsource@0.2.0",
+      "_shasum": "f017d4689c5dd0a2836b1ba616b30a9734fc8eeb",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "dist": {
+        "shasum": "f017d4689c5dd0a2836b1ba616b30a9734fc8eeb",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/eventsource-0.2.0.tgz_1455204080022_0.468941783066839"
+      }
+    },
+    "0.2.1": {
+      "name": "eventsource",
+      "version": "0.2.1",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^2.4.5",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "webpack": "^1.12.14"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "gitHead": "d7b9f6838797736769ab416f9db97239513a949f",
+      "_id": "eventsource@0.2.1",
+      "_shasum": "662bf85f376e73b5c34c2ee17db566b8419a6232",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "aslakhellesoy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "dist": {
+        "shasum": "662bf85f376e73b5c34c2ee17db566b8419a6232",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/eventsource-0.2.1.tgz_1456693499748_0.8380360226146877"
+      }
+    },
+    "0.2.2": {
+      "name": "eventsource",
+      "version": "0.2.2",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/aslakhellesoy/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/aslakhellesoy/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/aslakhellesoy/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/aslakhellesoy/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^2.4.5",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "webpack": "^1.12.14"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "gitHead": "b59da74de5916c45489f6362724f5225bae89e9a",
+      "_id": "eventsource@0.2.2",
+      "_shasum": "8ac0576cbd16ee83478b3faaf27bdc7b7c8fcca9",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "rexxars@gmail.com"
+      },
+      "dist": {
+        "shasum": "8ac0576cbd16ee83478b3faaf27bdc7b7c8fcca9",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/eventsource-0.2.2.tgz_1488300037355_0.723630438093096"
+      }
+    },
+    "0.2.3": {
+      "name": "eventsource",
+      "version": "0.2.3",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^3.2.0",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "webpack": "^2.4.1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "gitHead": "d763f3a2421f62f4e125d64e62f7a87eac155bca",
+      "_id": "eventsource@0.2.3",
+      "_shasum": "30b8f21b40d86968eaeebd199a95072ee54b0df3",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "rexxars@gmail.com"
+      },
+      "dist": {
+        "shasum": "30b8f21b40d86968eaeebd199a95072ee54b0df3",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/eventsource-0.2.3.tgz_1492430130836_0.005509671987965703"
+      }
+    },
+    "1.0.0": {
+      "name": "eventsource",
+      "version": "1.0.0",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^3.2.0",
+        "nyc": "^10.2.0",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^2.4.1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec && standard",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags",
+        "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "standard": {
+        "ignore": [
+          "example/eventsource-polyfill.js"
+        ]
+      },
+      "gitHead": "3a4445f431560ef67c9cdbe74c238c94a5aecf3b",
+      "_id": "eventsource@1.0.0",
+      "_shasum": "27f11c7a3ea5e129870de1b3ad05d09da60e2a20",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "rexxars@gmail.com"
+      },
+      "dist": {
+        "shasum": "27f11c7a3ea5e129870de1b3ad05d09da60e2a20",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/eventsource-1.0.0.tgz_1492450536869_0.8871331766713411"
+      }
+    },
+    "1.0.1": {
+      "name": "eventsource",
+      "version": "1.0.1",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^3.2.0",
+        "nyc": "^10.2.0",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^2.4.1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec && standard",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags",
+        "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "standard": {
+        "ignore": [
+          "example/eventsource-polyfill.js"
+        ]
+      },
+      "gitHead": "9ae13c008b09fbd525bfd3ddce7139b3c8bfd3d0",
+      "_id": "eventsource@1.0.1",
+      "_shasum": "a41b029d19a83d098701ed415c9578b7025b2cdb",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "rexxars@gmail.com"
+      },
+      "dist": {
+        "shasum": "a41b029d19a83d098701ed415c9578b7025b2cdb",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/eventsource-1.0.1.tgz_1494404201251_0.5732321164105088"
+      }
+    },
+    "1.0.2": {
+      "name": "eventsource",
+      "version": "1.0.2",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.15.3",
+        "mocha": "^3.4.2",
+        "nyc": "^10.3.2",
+        "serve-static": "^1.12.3",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^2.6.1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec && standard",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags",
+        "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "standard": {
+        "ignore": [
+          "example/eventsource-polyfill.js"
+        ]
+      },
+      "gitHead": "c2b00782096c3cc57c921b716f98584a03ef952b",
+      "_id": "eventsource@1.0.2",
+      "_shasum": "2f35ad0f52e40527b787251aab25956eba6e49c8",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "rexxars@gmail.com"
+      },
+      "dist": {
+        "shasum": "2f35ad0f52e40527b787251aab25956eba6e49c8",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventsource-1.0.2.tgz_1495977669376_0.15441277250647545"
+      }
+    },
+    "1.0.3": {
+      "name": "eventsource",
+      "version": "1.0.3",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.15.3",
+        "mocha": "^3.4.2",
+        "nyc": "^11.0.2",
+        "serve-static": "^1.12.3",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^3.0.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec && standard",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags",
+        "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "standard": {
+        "ignore": [
+          "example/eventsource-polyfill.js"
+        ]
+      },
+      "gitHead": "7771296da494810092921f338a109f4f50301c55",
+      "_id": "eventsource@1.0.3",
+      "_shasum": "b8d4af2a63ef7f940ef9b22007f7317dc413ae30",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "rexxars@gmail.com"
+      },
+      "dist": {
+        "shasum": "b8d4af2a63ef7f940ef9b22007f7317dc413ae30",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventsource-1.0.3.tgz_1497899130781_0.23276749649085104"
+      }
+    },
+    "1.0.4": {
+      "name": "eventsource",
+      "version": "1.0.4",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.15.3",
+        "mocha": "^3.4.2",
+        "nyc": "^11.0.2",
+        "serve-static": "^1.12.3",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^3.0.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec && standard",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags",
+        "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "standard": {
+        "ignore": [
+          "example/eventsource-polyfill.js"
+        ]
+      },
+      "gitHead": "9c80e0aef9f438fbd7cf4fc61b4b4ab793773617",
+      "_id": "eventsource@1.0.4",
+      "_shasum": "029450d04ebd34e4cf061788c595faa5f4c10843",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "rexxars@gmail.com"
+      },
+      "dist": {
+        "shasum": "029450d04ebd34e4cf061788c595faa5f4c10843",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventsource-1.0.4.tgz_1497899471781_0.1646825314965099"
+      }
+    },
+    "1.0.5": {
+      "name": "eventsource",
+      "version": "1.0.5",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "express": "^4.15.3",
+        "mocha": "^3.4.2",
+        "nyc": "^11.0.2",
+        "serve-static": "^1.12.3",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^3.0.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec && standard",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags",
+        "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "standard": {
+        "ignore": [
+          "example/eventsource-polyfill.js"
+        ]
+      },
+      "gitHead": "db39df4ec31ce0a1d624c8b1bd1bcb17ae8b3cff",
+      "_id": "eventsource@1.0.5",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.1.4",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "rexxars@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-IzjLaND9GBK3+fBPhmvG/Yq3FhSDGHnucJCDWhNsneLlN+HX5jeaSpl3Folr2PipGmyUsd/T2Vrua+s6I2aTgQ==",
+        "shasum": "1f012c9df0bd8832fd6b1744fea00ccdd479f046",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventsource-1.0.5.tgz_1500393708327_0.3151747293304652"
+      }
+    },
+    "1.0.6": {
+      "name": "eventsource",
+      "version": "1.0.6",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "buffer-from": "^1.1.1",
+        "express": "^4.15.3",
+        "mocha": "^3.5.3",
+        "nyc": "^11.2.1",
+        "serve-static": "^1.12.3",
+        "ssestream": "^1.0.0",
+        "standard": "^10.0.2",
+        "webpack": "^3.5.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec && standard",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags",
+        "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "standard": {
+        "ignore": [
+          "example/eventsource-polyfill.js"
+        ]
+      },
+      "gitHead": "6503549b8a1bb94be902956b2ddf1d959535b5de",
+      "_id": "eventsource@1.0.6",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "espen@hovlandsdal.com"
+      },
+      "dist": {
+        "integrity": "sha512-4PLkvCFuPlFqjEnW2bvHQGwEOMuwK2Whz39WLdY6b5wDXz1/OXSui5jdqQzVh8K8AXKEoeLL24XdYIn/9u23lQ==",
+        "shasum": "5cacde6c686f55135cfbb85c4e90a3b66c46124a",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.6.tgz",
+        "fileCount": 14,
+        "unpackedSize": 443626,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfmajCRA9TVsSAnZWagAArzIP/0If9O6M34qhTxfmDfiK\nXST/33HPa+pzDBzWtK0QsRPYoABt2kWEG1mSaibTtDzQJBUETJVI/gVzcyBk\nceWYMXrLqGQoYyQOMlwHA2IcUpUuk5/pmEpLMRX/piJ3ziJF+nWx2SIPTkpI\nQ7fK1062DN9Hz3INUBmKeo8flwUfOHVWXssS10AVmWB53AkrMBseHtssXhoU\nP/WEBfgmz/GC+BotYXx1zObJYDqlIN3nwyj6oEA+x+Lg7jDaS1ONBkn0DJ6q\nrqTNGbXce4QtrGOTid0Y6vxqO1Y9tl17SqmfpS4lK0qSlJmXGqBeEBW6zn9x\nckcvRjcfe6WntIglLNrRfkNHfXmhKiMkHFeqXS24NtsM4IBS9FcIX6HQwo+Q\nK2XrT7dGfOaCfp9a1c4ffn9EnNxc8KCmPyMDeu+SbuCNG1CDur0jSkbXypsr\ntGys60uHwf5X4IpxpQMIksVC8R/3RzgZuSCcleNtv5i6TI1niN7yoMxz+nPX\nFCr5kPj3aI1SNlNi+qfApEfpiNrohPSQYaAghCoHLb/S8b+3rp/7Pd4pT7ky\nYnusk9jGxnSVJeDgHbJ2gsGquImv81navSYLKZKBJEqwKWU3ABaSff2dOdez\n8aPEGAuOKi6ExQiCniHx78iEmpj8gxrkBgtgyKkZeoipCpp16bnhXmEzHQ74\nZuJH\r\n=l6dz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventsource_1.0.6_1535010466354_0.02630811406203093"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.7": {
+      "name": "eventsource",
+      "version": "1.0.7",
+      "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
+      "keywords": [
+        "eventsource",
+        "http",
+        "streaming",
+        "sse",
+        "polyfill"
+      ],
+      "homepage": "http://github.com/EventSource/eventsource",
+      "author": {
+        "name": "Aslak Hellesøy",
+        "email": "aslak.hellesoy@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/EventSource/eventsource.git"
+      },
+      "bugs": {
+        "url": "http://github.com/EventSource/eventsource/issues"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "./lib/eventsource",
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/EventSource/eventsource/raw/master/LICENSE"
+        }
+      ],
+      "devDependencies": {
+        "buffer-from": "^1.1.1",
+        "express": "^4.15.3",
+        "mocha": "^3.5.3",
+        "nyc": "^11.2.1",
+        "serve-static": "^1.12.3",
+        "ssestream": "^1.0.0",
+        "standard": "^10.0.2",
+        "webpack": "^3.5.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec && standard",
+        "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
+        "postpublish": "git push && git push --tags",
+        "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      },
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "standard": {
+        "ignore": [
+          "example/eventsource-polyfill.js"
+        ]
+      },
+      "gitHead": "5209cc181df083bee9d2bbab12a88f7a262fd7b7",
+      "_id": "eventsource@1.0.7",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "rexxars",
+        "email": "espen@hovlandsdal.com"
+      },
+      "dist": {
+        "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+        "shasum": "8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+        "fileCount": 14,
+        "unpackedSize": 444756,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbhGFrCRA9TVsSAnZWagAADW8P/RR8yx2oX70lJevugxGU\nFmfZVq/Xbi7qBOztwpEgl4yxLWJ3W3Sb6XdYcgK2eu0TmAvWxj/BZS/jbYEn\nOWHbK5rVVCcTkDh6FwpkevsqEOXChZeEd9q+jW3R9QT5gNBKTlun0PIY5Oo5\nj1n0GazE7E08CA0/zGtLl4CRfQ00ZlXw6R4AE46wQluy+RBHrcqX29bhXdHf\n8exq/cQfF9kD8Trb+q+kY6dOaJaQZGHELeOp5+QUAKbsZe5dFoTxms33QIyj\nSvbkT7Q/mVFJ/2WtVg7aSZUAyDNLROGGiM+/fblUlXHK8bcG7qNUwHBd5PJ/\nEbG+J56+n/kScFRErkm65bVIfvjHDobOyO/80tPLI7iVPPppjuXUNrYz4eSX\nRRV9WkyIe9f4fIu236xXnNrY6Dry1hS/eH3A/tsXmdQ1COLu2oDWVKY/z5WF\nZZs1h/13izc1UERhiXTWABCtlmuTuvSYyQ8bjJiOxpGpR4xu5DzYqHx6i7Fc\nS2by36Ze14Dy2n1jdCw8E00mbevzGXRcIRRYRCepR4tN4fgwSAuBu6lUVFli\n90QafbR9TqWQ/UvhjutTiqTiZyTJtRkRT3Xo5Xz/KX2tA3051L/JI52OpvuN\nUXdo2uRsree9RSbStHFe1lr8GCDGRmck7cxsbbfsDDId3hFkaPUzLpmhMwDI\nLYQB\r\n=mi34\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "aslakhellesoy",
+          "email": "aslak.hellesoy@gmail.com"
+        },
+        {
+          "name": "rexxars",
+          "email": "rexxars@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/eventsource_1.0.7_1535402346703_0.3313250326612529"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# EventSource [![npm version](http://img.shields.io/npm/v/eventsource.svg?style=flat-square)](http://browsenpm.org/package/eventsource)[![Build Status](http://img.shields.io/travis/EventSource/eventsource/master.svg?style=flat-square)](https://travis-ci.org/EventSource/eventsource)[![NPM Downloads](https://img.shields.io/npm/dm/eventsource.svg?style=flat-square)](http://npm-stat.com/charts.html?package=eventsource&from=2015-09-01)[![Dependencies](https://img.shields.io/david/EventSource/eventsource.svg?style=flat-square)](https://david-dm.org/EventSource/eventsource)\n\nThis library is a pure JavaScript implementation of the [EventSource](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) client. The API aims to be W3C compatible.\n\nYou can use it with Node.js or as a browser polyfill for\n[browsers that don't have native `EventSource` support](http://caniuse.com/#feat=eventsource).\n\n## Install\n\n    npm install eventsource\n\n## Example\n\n    npm install\n    node ./example/sse-server.js\n    node ./example/sse-client.js    # Node.js client\n    open http://localhost:8080      # Browser client - both native and polyfill\n    curl http://localhost:8080/sse  # Enjoy the simplicity of SSE\n\n## Browser Polyfill\n\nJust add `example/eventsource-polyfill.js` file to your web page:\n\n```html\n<script src=/eventsource-polyfill.js></script>\n```\n\nNow you will have two global constructors:\n\n```javascript\nwindow.EventSourcePolyfill\nwindow.EventSource // Unchanged if browser has defined it. Otherwise, same as window.EventSourcePolyfill\n```\n\nIf you're using [webpack](https://webpack.github.io/) or [browserify](http://browserify.org/)\nyou can of course build your own. (The `example/eventsource-polyfill.js` is built with webpack).\n\n## Extensions to the W3C API\n\n### Setting HTTP request headers\n\nYou can define custom HTTP headers for the initial HTTP request. This can be useful for e.g. sending cookies\nor to specify an initial `Last-Event-ID` value.\n\nHTTP headers are defined by assigning a `headers` attribute to the optional `eventSourceInitDict` argument:\n\n```javascript\nvar eventSourceInitDict = {headers: {'Cookie': 'test=test'}};\nvar es = new EventSource(url, eventSourceInitDict);\n```\n\n### Allow unauthorized HTTPS requests\n\nBy default, https requests that cannot be authorized will cause the connection to fail and an exception\nto be emitted. You can override this behaviour, along with other https options:\n\n```javascript\nvar eventSourceInitDict = {https: {rejectUnauthorized: false}};\nvar es = new EventSource(url, eventSourceInitDict);\n```\n\nNote that for Node.js < v0.10.x this option has no effect - unauthorized HTTPS requests are *always* allowed.\n\n### HTTP status code on error events\n\nUnauthorized and redirect error status codes (for example 401, 403, 301, 307) are available in the `status` property in the error event.\n\n```javascript\nes.onerror = function (err) {\n  if (err) {\n    if (err.status === 401 || err.status === 403) {\n      console.log('not authorized');\n    }\n  }\n};\n```\n\n### HTTP/HTTPS proxy\n\nYou can define a `proxy` option for the HTTP request to be used. This is typically useful if you are behind a corporate firewall.\n\n```javascript\nvar es = new EventSource(url, {proxy: 'http://your.proxy.com'});\n```\n\n\n## License\n\nMIT-licensed. See LICENSE\n",
+  "maintainers": [
+    {
+      "name": "aslakhellesoy",
+      "email": "aslak.hellesoy@gmail.com"
+    },
+    {
+      "name": "rexxars",
+      "email": "rexxars@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-08T11:00:41.702Z",
+    "created": "2012-02-08T12:17:52.893Z",
+    "0.0.1": "2012-02-08T12:17:54.543Z",
+    "0.0.2": "2012-02-08T13:42:20.639Z",
+    "0.0.3": "2012-02-10T16:07:31.200Z",
+    "0.0.4": "2012-02-10T23:21:12.025Z",
+    "0.0.5": "2012-02-12T13:28:45.587Z",
+    "0.0.6": "2013-01-24T22:56:35.113Z",
+    "0.0.7": "2013-04-19T19:20:21.373Z",
+    "0.0.8": "2013-09-12T17:37:20.531Z",
+    "0.0.9": "2013-10-24T17:28:14.769Z",
+    "0.0.10": "2013-11-21T16:52:12.244Z",
+    "0.1.0": "2014-03-07T22:30:47.332Z",
+    "0.1.1": "2014-05-18T19:09:16.803Z",
+    "0.1.2": "2014-08-07T13:10:09.591Z",
+    "0.1.3": "2014-09-17T15:47:53.533Z",
+    "0.1.4": "2014-10-31T09:54:47.380Z",
+    "0.1.5": "2015-02-08T23:48:21.148Z",
+    "0.1.6": "2015-02-09T08:26:42.461Z",
+    "0.2.0": "2016-02-11T15:21:21.828Z",
+    "0.2.1": "2016-02-28T21:05:01.132Z",
+    "0.2.2": "2017-02-28T16:40:39.409Z",
+    "0.2.3": "2017-04-17T11:55:31.406Z",
+    "1.0.0": "2017-04-17T17:35:37.399Z",
+    "1.0.1": "2017-05-10T08:16:43.416Z",
+    "1.0.2": "2017-05-28T13:21:10.664Z",
+    "1.0.3": "2017-06-19T19:05:32.083Z",
+    "1.0.4": "2017-06-19T19:11:13.052Z",
+    "1.0.5": "2017-07-18T16:01:49.605Z",
+    "1.0.6": "2018-08-23T07:47:46.497Z",
+    "1.0.7": "2018-08-27T20:39:06.840Z"
+  },
+  "author": {
+    "name": "Aslak Hellesøy",
+    "email": "aslak.hellesoy@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/EventSource/eventsource.git"
+  },
+  "homepage": "http://github.com/EventSource/eventsource",
+  "keywords": [
+    "eventsource",
+    "http",
+    "streaming",
+    "sse",
+    "polyfill"
+  ],
+  "bugs": {
+    "url": "http://github.com/EventSource/eventsource/issues"
+  },
+  "readmeFilename": "README.md",
+  "users": {
+    "jessaustin": true,
+    "qubyte": true,
+    "gigerlin": true,
+    "jruif": true,
+    "nichoth": true,
+    "floby": true,
+    "rbecheras": true,
+    "staydan": true,
+    "stone_breaker": true,
+    "xgheaven": true,
+    "kael": true,
+    "shanewholloway": true,
+    "jzaefferer": true,
+    "rmanalan": true,
+    "hualei": true
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/eventsource.min.json
+++ b/test/fixtures/registry-mocks/content/eventsource.min.json
@@ -1,0 +1,634 @@
+{
+  "name": "eventsource",
+  "dist-tags": {
+    "latest": "1.0.7"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "eventsource",
+      "version": "0.0.1",
+      "devDependencies": {
+        "nodeunit": "0.6.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "c93d59063dfc91b10c2708f4bd0aa2233e243324",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.2": {
+      "name": "eventsource",
+      "version": "0.0.2",
+      "devDependencies": {
+        "nodeunit": "0.6.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "753ec5f169050130052130b07441102564b16cf1",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.3": {
+      "name": "eventsource",
+      "version": "0.0.3",
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "dox": "0.1.x",
+        "jison": "0.3.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "8ea901b5877dc2c02373f283ea2fea72878d1fa4",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.4": {
+      "name": "eventsource",
+      "version": "0.0.4",
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "dox": "0.1.x",
+        "jison": "0.3.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "c17ef87e477ffba2adb20832ebe0d410d0998f24",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.5": {
+      "name": "eventsource",
+      "version": "0.0.5",
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "dox": "0.1.x",
+        "jison": "0.3.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "015db0a5aa32d9654e0c173b129897db5e6d39e1",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.0.6": {
+      "name": "eventsource",
+      "version": "0.0.6",
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "dox": "0.1.x",
+        "jison": "0.3.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "9e8f6c056bf71e886d9ab08a9c5fba1e834f6210",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.0.7": {
+      "name": "eventsource",
+      "version": "0.0.7",
+      "devDependencies": {
+        "mocha": "~1.9.0",
+        "jison": "~0.4.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "d052a2ade1e588e9a9d2eb6a7743ddb3379d882b",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.7.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.0.8": {
+      "name": "eventsource",
+      "version": "0.0.8",
+      "devDependencies": {
+        "mocha": "~1.9.0",
+        "jison": "~0.4.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "3431160f8cfcf22821a01853c210c4d359ee1151",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.8.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.0.9": {
+      "name": "eventsource",
+      "version": "0.0.9",
+      "devDependencies": {
+        "mocha": "~1.9.0",
+        "jison": "~0.4.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "ff59a6245e0fe2dfc6f921a5c9ace3b341002716",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.9.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.0.10": {
+      "name": "eventsource",
+      "version": "0.0.10",
+      "devDependencies": {
+        "mocha": "~1.9.0",
+        "jison": "~0.4.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "4d3a0f9b2c70083444fee3c39a7b2bfcf2221cbb",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.0.10.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.1.0": {
+      "name": "eventsource",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "~1.17.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "b9f5bd8f173402e6758438d9cfba46643cd25a0a",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.1.1": {
+      "name": "eventsource",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "~1.19.0"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "28e2eb6e15a7d89c6ffc92238aad1930eacb5da1",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.1.2": {
+      "name": "eventsource",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "0d1c4777b017c66ec74f3920ca6fec32a3bfcbe3",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.1.3": {
+      "name": "eventsource",
+      "version": "0.1.3",
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "6e802fc06a5ff964869bc95fb75ce2e99f1fedce",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.1.4": {
+      "name": "eventsource",
+      "version": "0.1.4",
+      "dependencies": {
+        "original": "^0.0.5"
+      },
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "b667d5d99948f9cbd8b249f154ac2a01b4f5ce22",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.1.5": {
+      "name": "eventsource",
+      "version": "0.1.5",
+      "dependencies": {
+        "original": ">=0.0.5"
+      },
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "e5bd748a2f4063d39199ed5061dedb1558848e5f",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.1.6": {
+      "name": "eventsource",
+      "version": "0.1.6",
+      "dependencies": {
+        "original": ">=0.0.5"
+      },
+      "devDependencies": {
+        "mocha": ">=1.21.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "0acede849ed7dd1ccc32c811bb11b944d4f29232",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.2.0": {
+      "name": "eventsource",
+      "version": "0.2.0",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^2.4.5",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "webpack": "^1.12.13"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "f017d4689c5dd0a2836b1ba616b30a9734fc8eeb",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.2.1": {
+      "name": "eventsource",
+      "version": "0.2.1",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^2.4.5",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "webpack": "^1.12.14"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "662bf85f376e73b5c34c2ee17db566b8419a6232",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.2.2": {
+      "name": "eventsource",
+      "version": "0.2.2",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^2.4.5",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "webpack": "^1.12.14"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "8ac0576cbd16ee83478b3faaf27bdc7b7c8fcca9",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.2.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.2.3": {
+      "name": "eventsource",
+      "version": "0.2.3",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^3.2.0",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "webpack": "^2.4.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "30b8f21b40d86968eaeebd199a95072ee54b0df3",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-0.2.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "1.0.0": {
+      "name": "eventsource",
+      "version": "1.0.0",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^3.2.0",
+        "nyc": "^10.2.0",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^2.4.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "27f11c7a3ea5e129870de1b3ad05d09da60e2a20",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "1.0.1": {
+      "name": "eventsource",
+      "version": "1.0.1",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.13.4",
+        "mocha": "^3.2.0",
+        "nyc": "^10.2.0",
+        "serve-static": "^1.10.2",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^2.4.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "a41b029d19a83d098701ed415c9578b7025b2cdb",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "1.0.2": {
+      "name": "eventsource",
+      "version": "1.0.2",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.15.3",
+        "mocha": "^3.4.2",
+        "nyc": "^10.3.2",
+        "serve-static": "^1.12.3",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^2.6.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "2f35ad0f52e40527b787251aab25956eba6e49c8",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "1.0.3": {
+      "name": "eventsource",
+      "version": "1.0.3",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.15.3",
+        "mocha": "^3.4.2",
+        "nyc": "^11.0.2",
+        "serve-static": "^1.12.3",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^3.0.0"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "b8d4af2a63ef7f940ef9b22007f7317dc413ae30",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "1.0.4": {
+      "name": "eventsource",
+      "version": "1.0.4",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.15.3",
+        "mocha": "^3.4.2",
+        "nyc": "^11.0.2",
+        "serve-static": "^1.12.3",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^3.0.0"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "029450d04ebd34e4cf061788c595faa5f4c10843",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "1.0.5": {
+      "name": "eventsource",
+      "version": "1.0.5",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "express": "^4.15.3",
+        "mocha": "^3.4.2",
+        "nyc": "^11.0.2",
+        "serve-static": "^1.12.3",
+        "sse": "^0.0.6",
+        "standard": "^10.0.2",
+        "webpack": "^3.0.0"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-IzjLaND9GBK3+fBPhmvG/Yq3FhSDGHnucJCDWhNsneLlN+HX5jeaSpl3Folr2PipGmyUsd/T2Vrua+s6I2aTgQ==",
+        "shasum": "1f012c9df0bd8832fd6b1744fea00ccdd479f046",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "1.0.6": {
+      "name": "eventsource",
+      "version": "1.0.6",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "buffer-from": "^1.1.1",
+        "express": "^4.15.3",
+        "mocha": "^3.5.3",
+        "nyc": "^11.2.1",
+        "serve-static": "^1.12.3",
+        "ssestream": "^1.0.0",
+        "standard": "^10.0.2",
+        "webpack": "^3.5.6"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-4PLkvCFuPlFqjEnW2bvHQGwEOMuwK2Whz39WLdY6b5wDXz1/OXSui5jdqQzVh8K8AXKEoeLL24XdYIn/9u23lQ==",
+        "shasum": "5cacde6c686f55135cfbb85c4e90a3b66c46124a",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.6.tgz",
+        "fileCount": 14,
+        "unpackedSize": 443626,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfmajCRA9TVsSAnZWagAArzIP/0If9O6M34qhTxfmDfiK\nXST/33HPa+pzDBzWtK0QsRPYoABt2kWEG1mSaibTtDzQJBUETJVI/gVzcyBk\nceWYMXrLqGQoYyQOMlwHA2IcUpUuk5/pmEpLMRX/piJ3ziJF+nWx2SIPTkpI\nQ7fK1062DN9Hz3INUBmKeo8flwUfOHVWXssS10AVmWB53AkrMBseHtssXhoU\nP/WEBfgmz/GC+BotYXx1zObJYDqlIN3nwyj6oEA+x+Lg7jDaS1ONBkn0DJ6q\nrqTNGbXce4QtrGOTid0Y6vxqO1Y9tl17SqmfpS4lK0qSlJmXGqBeEBW6zn9x\nckcvRjcfe6WntIglLNrRfkNHfXmhKiMkHFeqXS24NtsM4IBS9FcIX6HQwo+Q\nK2XrT7dGfOaCfp9a1c4ffn9EnNxc8KCmPyMDeu+SbuCNG1CDur0jSkbXypsr\ntGys60uHwf5X4IpxpQMIksVC8R/3RzgZuSCcleNtv5i6TI1niN7yoMxz+nPX\nFCr5kPj3aI1SNlNi+qfApEfpiNrohPSQYaAghCoHLb/S8b+3rp/7Pd4pT7ky\nYnusk9jGxnSVJeDgHbJ2gsGquImv81navSYLKZKBJEqwKWU3ABaSff2dOdez\n8aPEGAuOKi6ExQiCniHx78iEmpj8gxrkBgtgyKkZeoipCpp16bnhXmEzHQ74\nZuJH\r\n=l6dz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "1.0.7": {
+      "name": "eventsource",
+      "version": "1.0.7",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "devDependencies": {
+        "buffer-from": "^1.1.1",
+        "express": "^4.15.3",
+        "mocha": "^3.5.3",
+        "nyc": "^11.2.1",
+        "serve-static": "^1.12.3",
+        "ssestream": "^1.0.0",
+        "standard": "^10.0.2",
+        "webpack": "^3.5.6"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+        "shasum": "8fbc72c93fcd34088090bc0a4e64f4b5cee6d8d0",
+        "tarball": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+        "fileCount": 14,
+        "unpackedSize": 444756,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbhGFrCRA9TVsSAnZWagAADW8P/RR8yx2oX70lJevugxGU\nFmfZVq/Xbi7qBOztwpEgl4yxLWJ3W3Sb6XdYcgK2eu0TmAvWxj/BZS/jbYEn\nOWHbK5rVVCcTkDh6FwpkevsqEOXChZeEd9q+jW3R9QT5gNBKTlun0PIY5Oo5\nj1n0GazE7E08CA0/zGtLl4CRfQ00ZlXw6R4AE46wQluy+RBHrcqX29bhXdHf\n8exq/cQfF9kD8Trb+q+kY6dOaJaQZGHELeOp5+QUAKbsZe5dFoTxms33QIyj\nSvbkT7Q/mVFJ/2WtVg7aSZUAyDNLROGGiM+/fblUlXHK8bcG7qNUwHBd5PJ/\nEbG+J56+n/kScFRErkm65bVIfvjHDobOyO/80tPLI7iVPPppjuXUNrYz4eSX\nRRV9WkyIe9f4fIu236xXnNrY6Dry1hS/eH3A/tsXmdQ1COLu2oDWVKY/z5WF\nZZs1h/13izc1UERhiXTWABCtlmuTuvSYyQ8bjJiOxpGpR4xu5DzYqHx6i7Fc\nS2by36Ze14Dy2n1jdCw8E00mbevzGXRcIRRYRCepR4tN4fgwSAuBu6lUVFli\n90QafbR9TqWQ/UvhjutTiqTiZyTJtRkRT3Xo5Xz/KX2tA3051L/JI52OpvuN\nUXdo2uRsree9RSbStHFe1lr8GCDGRmck7cxsbbfsDDId3hFkaPUzLpmhMwDI\nLYQB\r\n=mi34\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    }
+  },
+  "modified": "2019-01-08T11:00:41.702Z"
+}

--- a/test/fixtures/registry-mocks/content/evp_bytestokey.json
+++ b/test/fixtures/registry-mocks/content/evp_bytestokey.json
@@ -1,0 +1,352 @@
+{
+  "_id": "evp_bytestokey",
+  "_rev": "7-34fe1c21a347d25a892270015d5e9d65",
+  "name": "evp_bytestokey",
+  "description": "The insecure key derivation algorithm from OpenSSL",
+  "dist-tags": {
+    "latest": "1.0.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "evp_bytestokey",
+      "version": "1.0.0",
+      "description": "he super secure key derivation algorithm from openssl",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/EVP_BytesToKey.git"
+      },
+      "keywords": [
+        "crypto",
+        "openssl"
+      ],
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/EVP_BytesToKey/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/EVP_BytesToKey",
+      "dependencies": {
+        "create-hash": "^1.1.1"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "563bd30d95a7771ff0a18afc82cf92ed18f008d3",
+      "_id": "evp_bytestokey@1.0.0",
+      "_shasum": "497b66ad9fef65cd7c08a6180824ba1476b66e53",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "497b66ad9fef65cd7c08a6180824ba1476b66e53",
+        "tarball": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "evp_bytestokey",
+      "version": "1.0.1",
+      "description": "The insecure key derivation algorithm from OpenSSL",
+      "keywords": [
+        "crypto",
+        "openssl"
+      ],
+      "homepage": "https://github.com/crypto-browserify/EVP_BytesToKey",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/EVP_BytesToKey/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Kirill Fomichev",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/EVP_BytesToKey.git"
+      },
+      "scripts": {
+        "coverage": "nyc tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "test:prepare": "node-gyp rebuild",
+        "unit": "tape test/*.js",
+        "install": "node-gyp rebuild"
+      },
+      "devDependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.4.0",
+        "nyc": "^8.1.0",
+        "standard": "^8.0.0",
+        "tape": "^4.6.0"
+      },
+      "gypfile": true,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      },
+      "gitHead": "17a7dd425c5412881ac6cd80b10390ab0943214c",
+      "_id": "evp_bytestokey@1.0.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-RNZXcRCZDNw9O8Jt2LFKufGSG31ok3l+tyodgqcDX637C8bhfuDZJgcBr0K2h3r3Lvbnot6yFdRD1Xo5TL6fZg==",
+        "shasum": "7a0fa93c760ddff02ec417906572870e812d0dc0",
+        "tarball": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/evp_bytestokey-1.0.1.tgz_1503350976253_0.4808340894524008"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "evp_bytestokey",
+      "version": "1.0.2",
+      "description": "The insecure key derivation algorithm from OpenSSL",
+      "keywords": [
+        "crypto",
+        "openssl"
+      ],
+      "homepage": "https://github.com/crypto-browserify/EVP_BytesToKey",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/EVP_BytesToKey/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Kirill Fomichev",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/EVP_BytesToKey.git"
+      },
+      "scripts": {
+        "coverage": "nyc tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "test:prepare": "node-gyp rebuild",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.4.0",
+        "nyc": "^8.1.0",
+        "standard": "^8.0.0",
+        "tape": "^4.6.0"
+      },
+      "gypfile": false,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      },
+      "gitHead": "df89a89d2cf5ef762557ff0b3a817f18ce00ace0",
+      "_id": "evp_bytestokey@1.0.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-ni0r0lrm7AOzsh2qC5mi9sj8S0gmj5fLNjfFpxN05FB4tAVZEKotbkjOtLPqTCX/CXT7NsUr6juZb4IFJeNNdA==",
+        "shasum": "f66bb88ecd57f71a766821e20283ea38c68bf80a",
+        "tarball": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/evp_bytestokey-1.0.2.tgz_1503352313286_0.022157371742650867"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "evp_bytestokey",
+      "version": "1.0.3",
+      "description": "The insecure key derivation algorithm from OpenSSL",
+      "keywords": [
+        "crypto",
+        "openssl"
+      ],
+      "homepage": "https://github.com/crypto-browserify/EVP_BytesToKey",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/EVP_BytesToKey/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Calvin Metcalf",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Kirill Fomichev",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/EVP_BytesToKey.git"
+      },
+      "scripts": {
+        "coverage": "nyc tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "test:prepare": "node-gyp rebuild",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.4.0",
+        "nyc": "^8.1.0",
+        "standard": "^8.0.0",
+        "tape": "^4.6.0"
+      },
+      "gypfile": false,
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      },
+      "gitHead": "5b83312539cf4d21989e99562c09ba32a65070c8",
+      "_id": "evp_bytestokey@1.0.3",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+        "shasum": "7fcbdb198dc71959432efe13842684e0525acb02",
+        "tarball": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/evp_bytestokey-1.0.3.tgz_1504606836017_0.7082570272032171"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# EVP\\_BytesToKey\n[![NPM Package](https://img.shields.io/npm/v/evp_bytestokey.svg?style=flat-square)](https://www.npmjs.org/package/evp_bytestokey)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/EVP_BytesToKey.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/EVP_BytesToKey)\n[![Dependency status](https://img.shields.io/david/crypto-browserify/EVP_BytesToKey.svg?style=flat-square)](https://david-dm.org/crypto-browserify/EVP_BytesToKey#info=dependencies)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nThe insecure [key derivation algorithm from OpenSSL.][1]\n\n**WARNING: DO NOT USE, except for compatibility reasons.**\n\nMD5 is insecure.\n\nUse at least `scrypt` or `pbkdf2-hmac-sha256` instead.\n\n\n## API\n`EVP_BytesToKey(password, salt, keyLen, ivLen)`\n\n* `password` - `Buffer`, password used to derive the key data.\n* `salt` - 8 byte `Buffer` or `null`, salt is used as a salt in the derivation.\n* `keyBits` - `number`, key length in **bits**.\n* `ivLen` - `number`, iv length in bytes.\n\n*Returns*: `{ key: Buffer, iv: Buffer }`\n\n\n## Examples\nMD5 with `aes-256-cbc`:\n\n```js\nconst crypto = require('crypto')\nconst EVP_BytesToKey = require('evp_bytestokey')\n\nconst result = EVP_BytesToKey(\n  'my-secret-password',\n  null,\n  32,\n  16\n)\n// =>\n// { key: <Buffer e3 4f 96 f3 86 24 82 7c c2 5d ff 23 18 6f 77 72 54 45 7f 49 d4 be 4b dd 4f 6e 1b cc 92 a4 27 33>,\n//   iv: <Buffer 85 71 9a bf ae f4 1e 74 dd 46 b6 13 79 56 f5 5b> }\n\nconst cipher = crypto.createCipheriv('aes-256-cbc', result.key, result.iv)\n```\n\n## LICENSE [MIT](LICENSE)\n\n[1]: https://wiki.openssl.org/index.php/Manual:EVP_BytesToKey(3)\n[2]: https://nodejs.org/api/crypto.html#crypto_class_hash\n",
+  "maintainers": [
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    }
+  ],
+  "time": {
+    "modified": "2017-09-24T12:09:09.174Z",
+    "created": "2015-09-27T14:44:27.075Z",
+    "1.0.0": "2015-09-27T14:44:27.075Z",
+    "1.0.1": "2017-08-21T21:29:36.372Z",
+    "1.0.2": "2017-08-21T21:51:53.562Z",
+    "1.0.3": "2017-09-05T10:20:36.240Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/EVP_BytesToKey",
+  "keywords": [
+    "crypto",
+    "openssl"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/EVP_BytesToKey.git"
+  },
+  "author": {
+    "name": "Calvin Metcalf",
+    "email": "calvin.metcalf@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/EVP_BytesToKey/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "dlv_201": true,
+    "princetoad": true
+  },
+  "contributors": [
+    {
+      "name": "Kirill Fomichev",
+      "email": "fanatid@ya.ru"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/evp_bytestokey.min.json
+++ b/test/fixtures/registry-mocks/content/evp_bytestokey.min.json
@@ -1,0 +1,86 @@
+{
+  "name": "evp_bytestokey",
+  "dist-tags": {
+    "latest": "1.0.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "evp_bytestokey",
+      "version": "1.0.0",
+      "dependencies": {
+        "create-hash": "^1.1.1"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tap-spec": "^4.1.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "497b66ad9fef65cd7c08a6180824ba1476b66e53",
+        "tarball": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "evp_bytestokey",
+      "version": "1.0.1",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.4.0",
+        "nyc": "^8.1.0",
+        "standard": "^8.0.0",
+        "tape": "^4.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-RNZXcRCZDNw9O8Jt2LFKufGSG31ok3l+tyodgqcDX637C8bhfuDZJgcBr0K2h3r3Lvbnot6yFdRD1Xo5TL6fZg==",
+        "shasum": "7a0fa93c760ddff02ec417906572870e812d0dc0",
+        "tarball": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.1.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "1.0.2": {
+      "name": "evp_bytestokey",
+      "version": "1.0.2",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.4.0",
+        "nyc": "^8.1.0",
+        "standard": "^8.0.0",
+        "tape": "^4.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-ni0r0lrm7AOzsh2qC5mi9sj8S0gmj5fLNjfFpxN05FB4tAVZEKotbkjOtLPqTCX/CXT7NsUr6juZb4IFJeNNdA==",
+        "shasum": "f66bb88ecd57f71a766821e20283ea38c68bf80a",
+        "tarball": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "evp_bytestokey",
+      "version": "1.0.3",
+      "dependencies": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.4.0",
+        "nyc": "^8.1.0",
+        "standard": "^8.0.0",
+        "tape": "^4.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+        "shasum": "7fcbdb198dc71959432efe13842684e0525acb02",
+        "tarball": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz"
+      }
+    }
+  },
+  "modified": "2017-09-24T12:09:09.174Z"
+}

--- a/test/fixtures/registry-mocks/content/express.json
+++ b/test/fixtures/registry-mocks/content/express.json
@@ -1,0 +1,34442 @@
+{
+  "_id": "express",
+  "_rev": "3909-36868b43af9ecfdbcfc405eaa8ba64f7",
+  "name": "express",
+  "description": "Fast, unopinionated, minimalist web framework",
+  "dist-tags": {
+    "latest": "4.17.1",
+    "next": "5.0.0-alpha.8"
+  },
+  "versions": {
+    "0.14.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "0.14.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        }
+      ],
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      },
+      "_id": "express@0.14.0",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-0.14.0.tgz",
+        "shasum": "7b33a9fb54c605a3be46c1d3dbbc821acf1d2efb"
+      },
+      "deprecated": "express 0.x series is deprecated"
+    },
+    "0.14.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "0.14.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        }
+      ],
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      },
+      "_id": "express@0.14.1",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-0.14.1.tgz",
+        "shasum": "40b0119ea0549892b03b5bb56c79cdff468d04b4"
+      },
+      "deprecated": "express 0.x series is deprecated"
+    },
+    "1.0.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.3.0"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.0",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-3",
+      "_nodeVersion": "v0.2.4",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0.tgz",
+        "shasum": "48a43d78a96eb9232f631d23cc8de8f854d8e0e9"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.3.0"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.1",
+      "_engineSupported": true,
+      "_npmVersion": "0.2.13-1",
+      "_nodeVersion": "v0.2.5",
+      "dist": {
+        "shasum": "53ad8442c3feb46588f08698f1872c4dbf24137f",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.1.tgz"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.3.0"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.2",
+      "_engineSupported": true,
+      "_npmVersion": "0.2.13-1",
+      "_nodeVersion": "v0.2.6",
+      "dist": {
+        "shasum": "5985fd1986b2275d8e96976a8b8de011dc823e0d",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.2.tgz"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.3.0"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.3",
+      "_engineSupported": true,
+      "_npmVersion": "0.2.13-1",
+      "_nodeVersion": "v0.2.6",
+      "dist": {
+        "shasum": "e07fd860c4af7ffddc77653fd1fd930fce26cb61",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.3.tgz"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.5.x",
+        "qs": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.4",
+      "_engineSupported": true,
+      "_npmVersion": "0.2.16",
+      "_nodeVersion": "v0.2.6",
+      "modules": {
+        "index.js": "lib/express/index.js",
+        "request.js": "lib/express/request.js",
+        "response.js": "lib/express/response.js",
+        "server.js": "lib/express/server.js",
+        "utils.js": "lib/express/utils.js",
+        "view.js": "lib/express/view.js"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "fab80c530d40b04f4f558f7f03b2cbf0f9040b14",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.4.tgz"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.5.0",
+        "qs": ">= 0.0.2"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.5",
+      "_engineSupported": true,
+      "_npmVersion": "0.2.16",
+      "_nodeVersion": "v0.2.6",
+      "modules": {
+        "index.js": "lib/express/index.js",
+        "request.js": "lib/express/request.js",
+        "response.js": "lib/express/response.js",
+        "server.js": "lib/express/server.js",
+        "utils.js": "lib/express/utils.js",
+        "view.js": "lib/express/view.js"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "2d32dff93a8c454e9a717c43b856c5369efc2856",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.5.tgz"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.5.0",
+        "qs": ">= 0.0.2"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.6",
+      "_engineSupported": true,
+      "_npmVersion": "0.2.16",
+      "_nodeVersion": "v0.2.6",
+      "modules": {
+        "index.js": "lib/express/index.js",
+        "request.js": "lib/express/request.js",
+        "response.js": "lib/express/response.js",
+        "server.js": "lib/express/server.js",
+        "utils.js": "lib/express/utils.js",
+        "view.js": "lib/express/view.js"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "9aee1508f0e9ce4cc2eabdda94ec8793898306f9",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.6.tgz"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.5.0",
+        "qs": ">= 0.0.2"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.7",
+      "_engineSupported": true,
+      "_npmVersion": "0.2.16",
+      "_nodeVersion": "v0.2.6",
+      "modules": {
+        "index.js": "lib/express/index.js",
+        "request.js": "lib/express/request.js",
+        "response.js": "lib/express/response.js",
+        "server.js": "lib/express/server.js",
+        "utils.js": "lib/express/utils.js",
+        "view.js": "lib/express/view.js"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "ccb14eee039e4177ce410fe5f074e96f68629e6c",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.7.tgz"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.8": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.5.0 < 1.0.0",
+        "qs": ">= 0.0.5"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "main": "index",
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0 < 0.4.0"
+      },
+      "_id": "express@1.0.8",
+      "_engineSupported": false,
+      "_npmVersion": "0.3.13",
+      "_nodeVersion": "v0.4.2",
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "fe254667ad612c23dd87d61180dc194cda1f7d38",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.8.tgz"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "2.0.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.0.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.1.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.0.0",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.2",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f9f715cf54e9b6f3f00115fe7e1188964d0a74b2",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.1.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.1.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.1.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.1.0",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.3",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "34542d68cf298d5a89d74dc1c8f96b5c4e1b00a7",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.1.0.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.1.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.1.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.1.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.1.1",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.3",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "4ab83c3509050ef917532cdb174bc23d8a007af4",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.1.1.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.2.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.2.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.2.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.2.0",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.3",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "ab38a7eaad67a1c28495021a798d234086d73dea",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.2.0.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.2.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.2.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.2.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.2.1",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.4",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "a4937f9d5e661282cd62d88e227132f79ccbe25f",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.2.1.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.2.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.2.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.3.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.2.2",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.5",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "19c26d4cd36018896fc90a9eef3300052b3e01d2",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.2.2.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.0",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.18",
+      "_nodeVersion": "v0.4.6",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "c32ae9a32a364077976352349eac54820cf21e3e",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.0.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.1",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.18",
+      "_nodeVersion": "v0.4.6",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "15a9459c9b9e785d52d14a62595a29d7cbab4882",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.1.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.2",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.18",
+      "_nodeVersion": "v0.4.6",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "ad6a3071d59a3bf1a4ed0b1b2942d9f0e510a028",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.2.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "devDependencies": {},
+      "_id": "express@2.3.3",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.7",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "936507d26e0433598679a645a87e403b3292547c",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.3.tgz"
+      },
+      "scripts": {},
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "devDependencies": {},
+      "_id": "express@2.3.4",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.7",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "8db976504b3f7f1da32abc845c45c20610a1ffd0",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.4.tgz"
+      },
+      "scripts": {},
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "devDependencies": {},
+      "_id": "express@2.3.5",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.7",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "a3113d0d9db4ea118e2c12b044a04c16741e799b",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.5.tgz"
+      },
+      "scripts": {},
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.6",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.7",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "8598e2995fc7c7427b7c3aed53837be652e873c7",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.6.tgz"
+      },
+      "scripts": {},
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.7",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "6d008ca32c4a23110032e67f4c40843c068e13b7",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.7.tgz"
+      },
+      "scripts": {},
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.8": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.8",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "fac5808b93b5abf84906c886fe314a0d4f44fa89",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.8.tgz"
+      },
+      "scripts": {},
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.9": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.9",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.9",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e5b6a5dc5452e9bcaf8936297f9f0e111b71a2a7",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.9.tgz"
+      },
+      "scripts": {},
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.10": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.10",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.10",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "09b5e939b28af0705d1ac46265c703db1016310c",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.10.tgz"
+      },
+      "scripts": {},
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.11": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.11",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.3.11",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.3",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "1dcd3a404332565a64c8290797e183707612f25a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.11.tgz"
+      },
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.12": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.3.12",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.5.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.3.12/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.3.12",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.14",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "9e750c8e50ff976f89b4ed9e1ca6d534bad23014",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.12.tgz"
+      },
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.4.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.5.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.4.0/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.4.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.14",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "c6cad05e9ec481a91e3817ca25cfd55ea37c00ce",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.4.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.4.1/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.4.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.14",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "006d435d5ca4332e51cc56ec3a69c707e40d62b4",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.4.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.4.2/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.4.2",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.14",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "bfdd3dfd9c387e3196ac9dc8c7ff8d3a930d4d1a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.4.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.4.3/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.4.3",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.14",
+      "_nodeVersion": "v0.4.9",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "5f52dd1e2cddbb83b3483cfb4c8c5c24d3975450",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.3.tgz"
+      },
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.4.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.4.4/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.4.4",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.24",
+      "_nodeVersion": "v0.4.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "ae677e39c6f489e328cb7994b88ebee7db19b6d9",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.4.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.4.5/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.4.5",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.24",
+      "_nodeVersion": "v0.4.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "b042984190df1ea06cc6e89c3eb4dfa848376322",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.4.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.4.6/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.4.6",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.24",
+      "_nodeVersion": "v0.4.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "df8152c5a40bd89ad74ab07e5ef999fac5a00916",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.4.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.7.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.4.7/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.4.7",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.24",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "872bbf5427e062100901ade6e80ff577ac24de3f",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.7.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/tj/.npm/express/2.5.0/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "express@2.5.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.24",
+      "_nodeVersion": "v0.5.9",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "3f9716eaa0e7380025fbb2c6c9942e3d9c9ed3b9",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.8.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.104",
+      "_nodeVersion": "v0.6.1",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "0644284c2c219264e2955fe94717ce7b462cd5d6",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.8.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.2",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "d58c41f7dff9a69696cffcc8e9bde4e81cbbcbef",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.3",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "65c909b778715753797129b9ea39bca6a248d6f1",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.4",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "3090710723a13acfe000817b0fbeea13d8faee4b",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.5",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "d15d4ffe5c420adda0645680361bb21c836b6e7c",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.6",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "1f2a96d01e1285797dae715d9ac93d9c60dd772a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.7",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "9f8fa92be38cb3c11959e99e18806cda19fd359f",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.8": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": "1.2.4",
+        "qs": "0.4.x",
+        "mkdirp": "0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.8",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f166b55d4e8c6d2307ef88ad1768209613f7452a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.9": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.9",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": "1.2.4",
+        "qs": "0.4.x",
+        "mkdirp": "0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.9",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.9",
+      "_nodeVersion": "v0.6.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "62d111ccaccf425182e1f30e541f84b551a72f2c",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.10": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.10",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": "1.2.4",
+        "qs": "0.4.x",
+        "mkdirp": "0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@2.5.10",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.24",
+      "_nodeVersion": "v0.6.19",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "b1cdaf0c7e98e33125e6f8476800bdeb7f7efc8a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.11": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.5.11",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "1.x",
+        "mime": "1.2.4",
+        "qs": "0.4.x",
+        "mkdirp": "0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "test": "make test",
+        "prepublish": "npm prune"
+      },
+      "_id": "express@2.5.11",
+      "dist": {
+        "shasum": "4ce8ea1f3635e69e49f0ebb497b6a4b0a51ce6f0",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.11.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {},
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "3.0.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.6.0",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0",
+      "dist": {
+        "shasum": "41e202f3627ea442be9e86d5ec51246ad72339ed",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0.tgz"
+      },
+      "_npmVersion": "1.1.63",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.6.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.1",
+      "dist": {
+        "shasum": "36a5008d158a97e82817f45b89561633b61a1be8",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.1.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.6.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.2",
+      "dist": {
+        "shasum": "fd93ed32f9a938cf79b7c4df95a2458d412f09b9",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.2.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.0",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.3",
+      "dist": {
+        "shasum": "007c7590b1ab31219e6d8d71f86ad5086204868c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.3.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.1",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.1.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.4",
+      "dist": {
+        "shasum": "04a8e939145940a6bb3b215d736ec2c1584ee0a8",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.4.tgz"
+      },
+      "_npmVersion": "1.1.68",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.1",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.1.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.5",
+      "dist": {
+        "shasum": "4c6e5850e6b5e8ca2af57f21ed7097de50948b73",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.5.tgz"
+      },
+      "_npmVersion": "1.1.66",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.1.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.6",
+      "dist": {
+        "shasum": "d274fcb868b95788bf4af62168d75d13fd77d8b4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.6.tgz"
+      },
+      "_npmVersion": "1.1.66",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.1.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.1.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.1.0",
+      "dist": {
+        "shasum": "f869b2d92320f5c3dd496c172e06f02b6ad43310",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.2",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.1.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.1.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.4",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "~0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "~0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.1.1",
+      "dist": {
+        "shasum": "2cc065f642856be506686399aadeff375a701468",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.1.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.1.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.5",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "~0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "~0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.1.2",
+      "dist": {
+        "shasum": "52a02c8db8f22bbfa0d7478d847cd45161f985f7",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.2.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.6",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "~0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "~0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.2.0",
+      "dist": {
+        "shasum": "7b66d6c66b038038eedf452804222b3077374ae0",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.2.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.7",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "qs": "0.6.1"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.2.1",
+      "dist": {
+        "shasum": "fd9ce6c0b8e4fda80772cef9af6e756434628d84",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.2.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.8",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "qs": "0.6.3"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.2.2",
+      "dist": {
+        "shasum": "22c6cb2e0efc20833670425cd820c5f4bb119f8b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.2.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.9",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "qs": "0.6.4"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.2.3",
+      "dist": {
+        "shasum": "9952eb764953ad40e4caa1f0b8715f7ba667f477",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.2.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.9",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.2.4",
+      "dist": {
+        "shasum": "f39fcba9a224011058fb581647688b12df94f585",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.2.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.10",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.2.5",
+      "dist": {
+        "shasum": "d2c86134d9fa1573b8004d23c6dc0d50bc8efe20",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.2.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.7.11",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.2.6",
+      "dist": {
+        "shasum": "d8a9fe065adc23c5b41ec2c689c672b261430ffc",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.0",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.1",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.3.0",
+      "dist": {
+        "shasum": "f89f8fc1ddfb7ffdfc9db3103a75881cd64dce7f",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.1",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.1",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.3.1",
+      "dist": {
+        "shasum": "4bb79fb3548313d9e1a49ffdc5aa369a936127d7",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.2",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.3.2",
+      "dist": {
+        "shasum": "d70c4888da2f35c9fa80e6747323ec6afeb6f947",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.3",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.2",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.3.3",
+      "dist": {
+        "shasum": "c9b5244edad7c6b85dae94e5cf1b29162470c933",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.4",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.3",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.3.4",
+      "dist": {
+        "shasum": "9abf22017213a8f6f54a421ce22b8ec27b7def62",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.5",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.3.5",
+      "dist": {
+        "shasum": "3fd077660c9ccae4710fcfb326290a01d1e72566",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.5",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.3.6",
+      "dist": {
+        "shasum": "c1082fdb55b9de2ce399252eb4e048da2ed9918d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0-beta": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.0-beta",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        }
+      ],
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      },
+      "_id": "express@1.0.0-beta",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0beta.tgz",
+        "shasum": "f8c485ec1aa2d8612c667a0fca08603abdb27246"
+      }
+    },
+    "1.0.0-beta2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.0-beta2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        }
+      ],
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      },
+      "_id": "express@1.0.0-beta2",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0beta2.tgz",
+        "shasum": "4e9f6f94405c969173e09a20ba3f0d27020ec9e9"
+      }
+    },
+    "1.0.0-rc": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.0-rc",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.2.2"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      },
+      "_id": "express@1.0.0-rc",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0rc.tgz",
+        "shasum": "cc9545ae107dac12821f997e3dd43c5df223ba13"
+      }
+    },
+    "1.0.0-rc2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.0-rc2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.2.4"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      },
+      "_id": "express@1.0.0-rc2",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0rc2.tgz",
+        "shasum": "040b7790e1ab041e8218835376c5d21bba634bac"
+      }
+    },
+    "1.0.0-rc3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.0-rc3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.2.5"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.0-rc3",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0rc3.tgz",
+        "shasum": "ae5ee7dfbe436192adad65c7817c5ae78a8b4f93"
+      }
+    },
+    "1.0.0-rc4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "1.0.0-rc4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 0.2.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "_id": "express@1.0.0-rc4",
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0rc4.tgz",
+        "shasum": "c5363c021717c02728c692fedc632cac9a869160"
+      }
+    },
+    "2.0.0-beta": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.0.0-beta",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.0.1",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.0.0-beta",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.13",
+      "_nodeVersion": "v0.4.2",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "c2095479887128f161ee13211e7b886edb4d9f98",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0beta.tgz"
+      }
+    },
+    "2.0.0-beta2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.0.0-beta2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.0.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.0.0-beta2",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.1",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "274e49af300145688e87ed2f5c5e59f6e26af135",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0beta2.tgz"
+      }
+    },
+    "2.0.0-beta3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.0.0-beta3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.0.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.0.0-beta3",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.2",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f9c1324023729c4eb96688023e989fe2f8565c61",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0beta3.tgz"
+      }
+    },
+    "2.0.0-rc": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.0.0-rc",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.0.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.0.0-rc",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.2",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "6d3da0301b6cdce94ee437ae40ae6c8c7f5d7ccf",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0rc.tgz"
+      }
+    },
+    "2.0.0-rc2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.0.0-rc2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.1.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.0.0-rc2",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.2",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "381e1388bcd56d0449dbbf2272975f907488f710",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0rc2.tgz"
+      }
+    },
+    "2.0.0-rc3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "2.0.0-rc3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": ">= 1.1.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "keywords": [
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful"
+      ],
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "_id": "express@2.0.0-rc3",
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.2",
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "538a35c8b0e2b08c455a20528b8d6a5568e901c1",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0rc3.tgz"
+      }
+    },
+    "3.0.0-alpha1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-alpha1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.1.2",
+        "commander": "0.5.2",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.5.0 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@3.0.0-alpha1",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.9",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "252902b7ed3a4b18a9163c51bdab519282cf2401",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-alpha2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-alpha2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.2.1",
+        "commander": "0.5.2",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "crc": "0.1.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.5.0 < 0.7.0"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@3.0.0-alpha2",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.9",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e82f7ba6b2c3e678c44343d0ba4fe339ca928e6c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-alpha3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-alpha3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.2.2",
+        "commander": "0.5.2",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@3.0.0-alpha3",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "a65af40b696d39310c434d810adc9c4942fc2f9c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-alpha4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-alpha4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.2.2",
+        "commander": "0.5.2",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@3.0.0-alpha4",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "9bc6be2bcfbbd74dba66063808d3a75ad4bd7edb",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-alpha5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-alpha5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.2.2",
+        "commander": "0.6.0",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@3.0.0-alpha5",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "d01ff9c2ebd769744ee90cc89561a1c8ca5340ac",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-beta1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-beta1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.3.0",
+        "commander": "0.6.1",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.2",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@3.0.0-beta1",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "557dda7815bffb84dea4cd3c09e1fe6538b2262f",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-beta2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-beta2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.3.1",
+        "commander": "0.6.1",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.2",
+        "cookie": "0.0.3",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@3.0.0-beta2",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.6.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "2755a16a2f7054c06d93f3a17dd6cbd0d5aa8698",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-beta3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-beta3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.3.3",
+        "commander": "0.6.1",
+        "mkdirp": "0.3.2",
+        "cookie": "0.0.3",
+        "crc": "0.2.0",
+        "fresh": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express.git"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "express@3.0.0-beta3",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.24",
+      "_nodeVersion": "v0.6.19",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e8425ee5f1d1c649c2e0627f437a331e9b9da867",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-beta4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-beta4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.3.4",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.3",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0-beta4",
+      "dist": {
+        "shasum": "0f7e5bb2db67e81b4d1c752300954133df276063",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-beta6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-beta6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.3.8",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "response-send": "0.0.1",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.3",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.2",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0-beta6",
+      "dist": {
+        "shasum": "3eef2ed7ce7511170df4d15f4d2dade10dbc6614",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-beta7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-beta7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.3.9",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "response-send": "0.0.1",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.3",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.3",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0-beta7",
+      "dist": {
+        "shasum": "92e854f2814e05a333d2acfde43585cfda21d9aa",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-rc1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-rc1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.4.1",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.3",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0-rc1",
+      "dist": {
+        "shasum": "b96bc45e19a0fece6b4c26c297db2f958a50643a",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-rc2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-rc2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.4.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.3",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0-rc2",
+      "dist": {
+        "shasum": "ffa79ccee41abc97f2c57576cc433339200fcd33",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-rc3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-rc3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.4.3",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.3",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0-rc3",
+      "dist": {
+        "shasum": "740d4e14335a1e92a19493930def0c747a0367b4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-rc4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-rc4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.4.4",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.4",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "publishConfig": {
+        "tag": "3.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0-rc4",
+      "dist": {
+        "shasum": "f07490f3578a87e06d4244d58c18d6f6e2c5fc33",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0-rc5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.0.0-rc5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.5.0",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "_id": "express@3.0.0-rc5",
+      "dist": {
+        "shasum": "c63b56257f33a74498dbc0ba8986a3d5b627fc9d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc5.tgz"
+      },
+      "_npmVersion": "1.1.61",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.7",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.3.7",
+      "dist": {
+        "shasum": "de0b67ae1b04999fe7141940c2749f5b435a8fcd",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.3.8": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.3.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.8.8",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.3.8",
+      "dist": {
+        "shasum": "8e98ac30d81f4c95b85d71d2af6cf84f62ef19bd",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.9.0",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.4.0",
+      "dist": {
+        "shasum": "6ed289da0d5f55ac30997cf832e5fc36f784071e",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.9.1",
+        "commander": "2.0.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "2",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.4.1",
+      "dist": {
+        "shasum": "3b4fb8862b6a1dfce3dc760629833d0cfef9314c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.9.2",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "2",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.4.2",
+      "dist": {
+        "shasum": "3cfaa66fb1e1fac5012129b473f0e2143544aa07",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.10.1",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "2",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.4.3",
+      "dist": {
+        "shasum": "d0d237d60cd9c741b50da88379527e2a1d804627",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.11.0",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "2",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.8.1 - 1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.4.4",
+      "dist": {
+        "shasum": "0b63ae626c96b71b78d13dfce079c10351635a86",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.13",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.11.1",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.14.0",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.0.2",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.4.5",
+      "dist": {
+        "shasum": "dc82aa4d932f0d0ee93e8e7ee9824d73bb00d47a",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.11.2",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.14.0",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.0.2",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.4.6",
+      "dist": {
+        "shasum": "85b6004076f9004f806e9f49c90487d1f6f89c43",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.12.0",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "merge-descriptors": "0.0.1",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "_id": "express@3.4.7",
+      "dist": {
+        "shasum": "3b939c47d2aa44dfecf77d50da2123c5bd313366",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.4.8": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.4.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.12.0",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "merge-descriptors": "0.0.1",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.4.8",
+      "dist": {
+        "shasum": "aa7a8986de07053337f4bc5ed9a6453d9cc8e2e1",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0-rc1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.0.0-rc1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.0.0-rc1",
+      "dist": {
+        "shasum": "a9f3f89e4726e2ff60f62ab625c960eaa2cba3a6",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0-rc1.tgz"
+      },
+      "_from": "https://github.com/visionmedia/express/archive/4.0.0-rc1.tar.gz",
+      "_resolved": "https://github.com/visionmedia/express/archive/4.0.0-rc1.tar.gz",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0-rc2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.0.0-rc2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.0.0-rc2",
+      "dist": {
+        "shasum": "0b3fc3b853b393cdb5042dc9960498015ed06b96",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0-rc2.tgz"
+      },
+      "_from": "https://github.com/visionmedia/express/archive/4.0.0-rc2.tar.gz",
+      "_resolved": "https://github.com/visionmedia/express/archive/4.0.0-rc2.tar.gz",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.5.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.5.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.14.1",
+        "commander": "1.3.2",
+        "range-parser": "1.0.0",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.1",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.17.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.9.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.5.0",
+      "dist": {
+        "shasum": "703f299aa2a7fce122025b61a2e170d536b35019",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0-rc3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.0.0-rc3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.0.1",
+        "path-to-regexp": "0.1.0",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.0.0-rc3",
+      "dist": {
+        "shasum": "da0113235684e89d36bd7796440809e889ee8692",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0-rc3.tgz"
+      },
+      "_from": "https://github.com/visionmedia/express/archive/4.0.0-rc3.tar.gz",
+      "_resolved": "https://github.com/visionmedia/express/archive/4.0.0-rc3.tar.gz",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0-rc4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.0.0-rc4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.0.0-rc4",
+      "dist": {
+        "shasum": "1cedc8790f47b776b9d100f5388e5fb652ea4388",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0-rc4.tgz"
+      },
+      "_from": "https://github.com/visionmedia/express/archive/4.0.0-rc4.tar.gz",
+      "_resolved": "https://github.com/visionmedia/express/archive/4.0.0-rc4.tar.gz",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.5.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.5.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.14.1",
+        "commander": "1.3.2",
+        "range-parser": "1.0.0",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.1",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.17.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.9.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.5.1",
+      "dist": {
+        "shasum": "4b333e1117faca336a538f4c724140b9ce1a87e7",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.5.1.tgz"
+      },
+      "_from": "https://github.com/visionmedia/express/archive/3.5.1.tar.gz",
+      "_resolved": "https://github.com/visionmedia/express/archive/3.5.1.tar.gz",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.0.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.0.0",
+      "dist": {
+        "shasum": "274dc82933c9f574cc38a0ce5ea8172be9c6b094",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0.tgz"
+      },
+      "_from": "https://github.com/visionmedia/express/archive/4.0.0.tar.gz",
+      "_resolved": "https://github.com/visionmedia/express/archive/4.0.0.tar.gz",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.5.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.5.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.14.5",
+        "commander": "1.3.2",
+        "range-parser": "1.0.0",
+        "mkdirp": "0.4.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.18.2",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.11.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.5.2",
+      "dist": {
+        "shasum": "aab0d2b31ef21259eac24dc45c43378fcf144b6d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.5.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.1.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.1.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.1",
+        "type-is": "1.1.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "body-parser": "1.0.2",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "express-session": "1.0.3",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "static-favicon": "1.0.2",
+        "hjs": "~0.0.6",
+        "should": "~3.3.1",
+        "supertest": "~0.11.0",
+        "method-override": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.1.0",
+      "dist": {
+        "shasum": "a822be824cf88e8ad67ec5df75d02887de6058b4",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.1.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.1.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.1",
+        "type-is": "1.1.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "body-parser": "1.0.2",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "express-session": "1.0.3",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "static-favicon": "1.0.2",
+        "hjs": "~0.0.6",
+        "should": "~3.3.1",
+        "supertest": "~0.11.0",
+        "method-override": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.1.1",
+      "dist": {
+        "shasum": "266f08c3cbc21fc1831e954073dda8cf3cae002f",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.5.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.5.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.14.5",
+        "commander": "1.3.2",
+        "range-parser": "1.0.0",
+        "mkdirp": "0.4.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.18.2",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.11.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.5.3",
+      "dist": {
+        "shasum": "af440e1ddad078934ec78241420b40bbc56dc2ad",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.5.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.1.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.1.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.1",
+        "type-is": "1.1.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "body-parser": "1.0.2",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "express-session": "1.0.3",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "static-favicon": "1.0.2",
+        "hjs": "~0.0.6",
+        "should": "~3.3.1",
+        "supertest": "~0.11.0",
+        "method-override": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.1.2",
+      "dist": {
+        "shasum": "cb1d114255718a65a1bcd6958036ef720c529487",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.6.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.6.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "connect": "2.15.0",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.18.2",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.12.1"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "main": "index",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.6.0",
+      "dist": {
+        "shasum": "94c7b0f8f506b046d4d9770b40992f224026e5d5",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.2.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.2.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.1",
+        "type-is": "1.1.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "body-parser": "~1.1.2",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "should": "~3.3.1",
+        "supertest": "~0.12.0",
+        "method-override": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "express-session": "1.0.4",
+        "morgan": "1.0.1",
+        "vhost": "1.0.0"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "make test"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.2.0",
+      "dist": {
+        "shasum": "3121993a45126693e8bf897aefb4dd783762dc60",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.7.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.7.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "connect": "2.16.2",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "coveralls": "2.10.0",
+        "ejs": "~0.8.4",
+        "istanbul": "0.2.10",
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/ && cat ./coverage/lcov.info | coveralls"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.7.0",
+      "dist": {
+        "shasum": "74f62f00ab2d7d49f19a9b6c81fb80b00e495868",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.7.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.8.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.8.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "connect": "2.17.1",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.8.0",
+      "dist": {
+        "shasum": "f243c1752630b21b5e898cc586d1d39690422876",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.8.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.3.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.3.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "supertest": "~0.12.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.2.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.0",
+        "method-override": "1.0.1",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.3.0",
+      "dist": {
+        "shasum": "3a65f18e40be9ea124f11c435b88b07430ef6fea",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.3.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.3.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "supertest": "~0.12.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.2.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.0",
+        "method-override": "1.0.1",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.3.1",
+      "_shasum": "656b2c148d1db3e2ac53727b799f0e34ecc7d713",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "656b2c148d1db3e2ac53727b799f0e34ecc7d713",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.8.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.8.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "connect": "2.17.3",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.8.1",
+      "_shasum": "884148c879c5ae88243c635dee4d91956b750143",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "884148c879c5ae88243c635dee4d91956b750143",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.3.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.3.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "supertest": "~0.12.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.2.2",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "1.0.2",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.3.2",
+      "_shasum": "b8332c55d7b2f69f2d90e14c0958431e3a1a25dc",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b8332c55d7b2f69f2d90e14c0958431e3a1a25dc",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.9.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.9.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.18.0",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "send": "0.4.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.9.0",
+      "_shasum": "da991c3ff90bb5b9f26842e3e3f70c8caa4797c8",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "da991c3ff90bb5b9f26842e3e3f70c8caa4797c8",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.4.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.4.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "buffer-crc32": "0.2.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "send": "0.4.0",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.2.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.2.2",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "1.0.2",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.4.0",
+      "_shasum": "1ffd7dbe7a24fb2940ad0570611a3312b76d8f37",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1ffd7dbe7a24fb2940ad0570611a3312b76d8f37",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.4.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.4.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "buffer-crc32": "0.2.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "serve-static": "1.2.1",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.3.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "2.0.1",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.4.1",
+      "_shasum": "9e0364d1c74e076d7409d302429a384b10dfbd42",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9e0364d1c74e076d7409d302429a384b10dfbd42",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.10.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.10.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.1",
+        "commander": "1.3.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.10.0",
+      "_shasum": "508aebb75685a84fe5873b080a2f759c5e0f4a97",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "508aebb75685a84fe5873b080a2f759c5e0f4a97",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.10.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.10.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.2",
+        "commander": "1.3.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.10.1",
+      "dist": {
+        "shasum": "259578cd1238731560460e833bc8b2a10b031b4d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.10.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.10.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.3",
+        "commander": "1.3.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.10.2",
+      "_shasum": "4fa0df0a6dd3956255cc23ade6c6576911d8e467",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4fa0df0a6dd3956255cc23ade6c6576911d8e467",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.10.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.10.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.4",
+        "commander": "1.3.2",
+        "debug": "1.0.0",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.10.3",
+      "_shasum": "d669d5fa2d79fa6349af5fa6338d646bc346ada5",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d669d5fa2d79fa6349af5fa6338d646bc346ada5",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.10.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.10.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.5",
+        "commander": "1.3.2",
+        "debug": "1.0.1",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.10.4",
+      "_shasum": "527bd28b0e17cd41722617ab88cb4a41b15f497d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "527bd28b0e17cd41722617ab88cb4a41b15f497d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.4.tgz"
+      },
+      "directories": {}
+    },
+    "4.4.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.4.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "buffer-crc32": "0.2.1",
+        "debug": "1.0.1",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.2",
+        "serve-static": "1.2.2",
+        "type-is": "1.2.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.3.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "2.0.2",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.4.2",
+      "dist": {
+        "shasum": "ff6c8a513d31cc60cabe0f71848dea3cb4f56df6",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.10.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.10.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.6",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "73c5533e665743d305e266eee134c48d88d2dcfd",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.10.5",
+      "_shasum": "842c0bcb4f6b7fc6323fa3030f24d0e9f82c5501",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "842c0bcb4f6b7fc6323fa3030f24d0e9f82c5501",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.5.tgz"
+      },
+      "directories": {}
+    },
+    "4.4.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.4.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "1.0.3",
+        "buffer-crc32": "0.2.1",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "serve-static": "1.2.3",
+        "type-is": "1.2.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.3.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "2.0.2",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "ac573cf830fc73284293055df7034c4b11aa5459",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.4.3",
+      "_shasum": "c52525743153f00452fe8b13fee1e94330a208a0",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c52525743153f00452fe8b13fee1e94330a208a0",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.11.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.11.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.3",
+        "connect": "2.20.2",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.11.0",
+      "dist": {
+        "shasum": "f1c8e1c991a444dd7ae331bfb7f1a4557fcfd2ee",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.11.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.4.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.4.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.5",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "serve-static": "1.2.3",
+        "type-is": "1.2.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.5.0",
+        "method-override": "2.0.2",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.4.4",
+      "dist": {
+        "shasum": "198bfd931c16ce869e54af5fb0515064fb8ea431",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.12.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.12.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.3",
+        "connect": "2.21.0",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.12.0",
+      "dist": {
+        "shasum": "8f00c9bef6f4d186f4a481ad831844dd7d73336e",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.12.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.12.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.12.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "0.2.3",
+        "connect": "2.21.1",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.12",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.12.1",
+      "dist": {
+        "shasum": "f13d260d1ac6ebc4913a42dfee913cdc65dd96d4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.12.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.4.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "4.4.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.5",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "serve-static": "1.2.3",
+        "type-is": "1.2.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.5.0",
+        "method-override": "2.0.2",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.4.5",
+      "dist": {
+        "shasum": "5f2f302f277187abd721c3a36e44d86c5e3f03eb",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.13.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.13.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "0.0.1",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.22.0",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.12",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.13.0",
+      "dist": {
+        "shasum": "69ac1d62732992e9529dc3b21eb40f23cc64438b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.13.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.5.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.5.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.2",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "serve-static": "~1.3.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.14",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.6.1",
+        "method-override": "2.0.2",
+        "multiparty": "~3.3.0",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.5.0",
+      "dist": {
+        "shasum": "64c68b9e41f66339c95a462f37f94ff436724bd7",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "4.5.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.5.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.2",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "serve-static": "~1.3.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.14",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.6.1",
+        "method-override": "2.0.2",
+        "multiparty": "~3.3.0",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.5.1",
+      "dist": {
+        "shasum": "4bc3e6ec9db28e575fe591c36fbb781ffef6fe7c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.5.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "3.14.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.14.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.23.0",
+        "commander": "1.3.2",
+        "debug": "1.0.3",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.14.0",
+      "dist": {
+        "shasum": "91f28701eedbce71ddca15b0fb92cfeff1401afb",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.14.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.6.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.3",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.3",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.1.3",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.6.0",
+        "serve-static": "~1.3.2",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.6.5",
+        "method-override": "~2.1.1",
+        "multiparty": "~3.3.0",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.6.0",
+      "dist": {
+        "shasum": "abaf229003006ada5a4dc5d99abbc7095570af7d",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "4.6.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.6.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.3",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.3",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.1.3",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.6.0",
+        "serve-static": "~1.3.2",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.6.5",
+        "method-override": "~2.1.1",
+        "multiparty": "~3.3.0",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.6.1",
+      "dist": {
+        "shasum": "c806e51755cb453ba17fac2f343caff6af885df4",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.6.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "3.15.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.15.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.24.0",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.2",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.0",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.15.0",
+      "dist": {
+        "shasum": "c9ac9eb2c38c34a650597300a06848d2e7001aa4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.15.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "4.7.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.7.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.2",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.0",
+        "serve-static": "~1.4.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.0",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.0",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.0",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.7.0",
+      "dist": {
+        "shasum": "9b38ca8eb3bf75fdcd9fad39ad85d02f5ef80b4b",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "3.15.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.15.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.24.1",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.3",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.15.1",
+      "dist": {
+        "shasum": "ce6800e0fa51c1c9700f246fc90eb8bcde8172e1",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.15.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "4.7.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.7.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.3",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.1",
+        "serve-static": "~1.4.1",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.0",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.0",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.0",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.7.1",
+      "dist": {
+        "shasum": "06c0aa7d03d5ea5565bb0249b2da3671a24062d3",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "3.15.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.15.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.24.2",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.15.2",
+      "dist": {
+        "shasum": "a45f213bcfc5022914223d5d67747661cc7515a1",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.15.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "4.7.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.7.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.2",
+        "serve-static": "~1.4.2",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.2",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.7.2",
+      "dist": {
+        "shasum": "2cbae61efab6c2db72a547ff3bf380e637c08590",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        }
+      ],
+      "directories": {}
+    },
+    "4.7.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.7.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.3",
+        "serve-static": "~1.4.3",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.2",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "52775a52ad9e00fbd38056af6ed0cddb4286d3d2",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.7.3",
+      "_shasum": "9fde138763113224c8204a48209511d0c2d27284",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9fde138763113224c8204a48209511d0c2d27284",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.15.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.15.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.24.3",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.4",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "15590d75b26f1e4b95b565f8306c763ee860d3e2",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.15.3",
+      "_shasum": "993a9ef1c2d67f2525d086a67dc187edeab6f025",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        }
+      ],
+      "dist": {
+        "shasum": "993a9ef1c2d67f2525d086a67dc187edeab6f025",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.15.3.tgz"
+      },
+      "directories": {}
+    },
+    "4.7.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.7.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.4",
+        "serve-static": "~1.4.4",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.2",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "b886eb52cf955c2f29ad31b514607d4e38c1dbaf",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.7.4",
+      "_shasum": "caf59389cf0b31b1314bf44d3355c2a80cfa217c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        }
+      ],
+      "dist": {
+        "shasum": "caf59389cf0b31b1314bf44d3355c2a80cfa217c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.4.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.0",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "c652cf7eedc3f4b9eb6de6c1c8c31fcf33f33c85",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.16.0",
+      "_shasum": "289dc292da617d06ac21bc1f4b2ee0e9a09a9c38",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        }
+      ],
+      "dist": {
+        "shasum": "289dc292da617d06ac21bc1f4b2ee0e9a09a9c38",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.0.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "serve-static": "~1.5.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.0",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "4aea02310ad7738fb1b3bac08de5424d82bfe4c6",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.8.0",
+      "_shasum": "a6079da464ec502ecaef4e11faa7e127f5593d85",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a6079da464ec502ecaef4e11faa7e127f5593d85",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.1",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "ea427c1bb4667be345d786c5120c435dbca3d13a",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.16.1",
+      "_shasum": "fc5cc9627c8c2837da21119b8d909247b0b40ba0",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fc5cc9627c8c2837da21119b8d909247b0b40ba0",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.1.0",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "serve-static": "~1.5.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.1",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "e8f8ea7e05c27eb10286ec62a5f4df533deeeff8",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.8.1",
+      "_shasum": "24cf5a613156d5d95bc8c2fa843cf12e2a1be6c9",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "24cf5a613156d5d95bc8c2fa843cf12e2a1be6c9",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.2",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "ddac571fdf36aef1381c53dd4766f5e9054b1aa3",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.16.2",
+      "_shasum": "5ed1411187b64e05fef8b70671d3bf9fdf9bc7eb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5ed1411187b64e05fef8b70671d3bf9fdf9bc7eb",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.2.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.2.0",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "serve-static": "~1.5.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.1",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "22ca953e96e66e142e2e89ba1fa3386a876ce55f",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.8.2",
+      "_shasum": "99fd5c03a8d885ba83981599619d71d088e46d3c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "99fd5c03a8d885ba83981599619d71d088e46d3c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.3",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "d13e6135844e1c949ac0f10f307130c4df153085",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.16.3",
+      "_shasum": "89157f5e6a84365036ed93ae1e413ab1bd6ce1a5",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "89157f5e6a84365036ed93ae1e413ab1bd6ce1a5",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.4",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "7119f2b16d610af6e4eb6d79292c52e2e8c506d9",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.16.4",
+      "_shasum": "d0dae63fc0d5a24ef48901d6b31d5e5791226033",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d0dae63fc0d5a24ef48901d6b31d5e5791226033",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.4.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.2.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "serve-static": "~1.5.1",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.1",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "1643ae442c724e1ea14383b62675cb13c49e3f49",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.8.3",
+      "_shasum": "a2c95b9079cda0473a04448f6b6c1e7fc20bf200",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a2c95b9079cda0473a04448f6b6c1e7fc20bf200",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.5",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "0dddd772c0096b62ab67295083fb1795c353f0ff",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.16.5",
+      "_shasum": "70dc7fd31be9d7bea32312ce0e461dd4ca5bb58b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "70dc7fd31be9d7bea32312ce0e461dd4ca5bb58b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.5.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.6",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "f13f4652da58c42e30c59e2b0b5b0d58b1d97bb7",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@3.16.6",
+      "_shasum": "585104615f0b857750856424bcfaa4c16b3cce1c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "585104615f0b857750856424bcfaa4c16b3cce1c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.6.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/express"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.2.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.2",
+        "serve-static": "~1.5.2",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.4",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.5",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.2",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "0cf02d4667264cea9682d49941f1242ac6f289df",
+      "bugs": {
+        "url": "https://github.com/visionmedia/express/issues"
+      },
+      "homepage": "https://github.com/visionmedia/express",
+      "_id": "express@4.8.4",
+      "_shasum": "b14d432cc1897e10b1915cf9b648f8930deadb0e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b14d432cc1897e10b1915cf9b648f8930deadb0e",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.4.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.7",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "0b12cc0cacbd8948079a0ca78b87d540def950eb",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.16.7",
+      "_shasum": "788aab5d66e85060211d6fea08eb2986f2f2631c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "788aab5d66e85060211d6fea08eb2986f2f2631c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.7.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.5": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.2.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "serve-static": "~1.5.3",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.5",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.6",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.3",
+        "morgan": "~1.2.3",
+        "multiparty": "~3.3.2",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "27f195374d7372f3270357873239f2c2962aafcc",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.8.5",
+      "_shasum": "59cf7666c29bf7cb8545a1acd43dd81a52cb26d9",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "59cf7666c29bf7cb8545a1acd43dd81a52cb26d9",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.5.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.8": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.8",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "0299bee8fae527c02c42dee8ced22a1f63f05093",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.16.8",
+      "_shasum": "46307b9e35a52e523b9d58a16e4c128cd21f43f4",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "46307b9e35a52e523b9d58a16e4c128cd21f43f4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.8.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.6": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.0",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "serve-static": "~1.5.3",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.6",
+        "cookie-parser": "~1.3.2",
+        "express-session": "~1.7.6",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.3",
+        "morgan": "~1.2.3",
+        "multiparty": "~3.3.2",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "b6ae091bdfa5d1717b65eba8dbba3d67ad999438",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.8.6",
+      "_shasum": "703b2aa835dafab9840bb890bc55557d96516acd",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "703b2aa835dafab9840bb890bc55557d96516acd",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.6.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.9": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.9",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.9",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "4d032cda058596e1ae89924ff69e80c3849ef4ff",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.16.9",
+      "_shasum": "993747be5669700280d9682cb61ad138939847fc",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "993747be5669700280d9682cb61ad138939847fc",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.9.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.7": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "serve-static": "~1.5.3",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.7",
+        "cookie-parser": "~1.3.2",
+        "express-session": "~1.7.6",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.3",
+        "morgan": "~1.2.3",
+        "multiparty": "~3.3.2",
+        "vhost": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "46f0bfc65f151a900e7c36a81b950c79b2c1a596",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.8.7",
+      "_shasum": "e4290dd5ff9c5a1a1af6f7a1c0c53021adf8564d",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e4290dd5ff9c5a1a1af6f7a1c0c53021adf8564d",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.7.tgz"
+      },
+      "directories": {}
+    },
+    "3.16.10": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.16.10",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.10",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.5",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "3d188fe13e1901222cd830dcdc9772a34b9bd745",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.16.10",
+      "_shasum": "c68c5ac30e9e890b812c11408dcde183c411bb56",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c68c5ac30e9e890b812c11408dcde183c411bb56",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.10.tgz"
+      },
+      "directories": {}
+    },
+    "4.8.8": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.8.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.5",
+        "serve-static": "~1.5.4",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.7.0",
+        "cookie-parser": "~1.3.2",
+        "express-session": "~1.7.6",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.3",
+        "morgan": "~1.2.3",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "621d074bd87dd7a7064c5607dbed05b97f80fcc0",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.8.8",
+      "_shasum": "6aba348ccdfa87608040b12ca0010107a0aac28e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6aba348ccdfa87608040b12ca0010107a0aac28e",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.8.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.26.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "~1.0.2",
+        "send": "0.9.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "fa1fcd9fec14234f3fde38b6f4929bb2043fedef",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.0",
+      "_shasum": "e882e8921dbd193042559b52f7d0250f749ec7ac",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e882e8921dbd193042559b52f7d0250f749ec7ac",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.26.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "~1.0.2",
+        "send": "0.9.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "4b1b8e420f4f4ee95e835e2eebc41a66dba556f2",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.1",
+      "_shasum": "82b357f0bc78733b1ac1070224f89a37dea76a74",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "82b357f0bc78733b1ac1070224f89a37dea76a74",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "buffer-crc32": "0.2.3",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.1",
+        "serve-static": "~1.6.1",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.2",
+        "express-session": "~1.8.1",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.0",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "1716e3b067af5acaeeee4165a865e0b670300aee",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.0",
+      "_shasum": "9b2ea4ebce57c7ac710604c74f6c303ab344a7f3",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9b2ea4ebce57c7ac710604c74f6c303ab344a7f3",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.1",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "f29399c4e1f644a64e08a45251f113d361bdfbb3",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.2",
+      "_shasum": "9593dd94af5d4776ea2b6dbff8c4d850a3381353",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9593dd94af5d4776ea2b6dbff8c4d850a3381353",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.2.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "serve-static": "~1.6.2",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "947fb8b27425851f3316ae9d39df5035085dde4a",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.1",
+      "_shasum": "70536ee2a8f2c302c4df45e23f4fcc7e4c2c9603",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "70536ee2a8f2c302c4df45e23f4fcc7e4c2c9603",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "serve-static": "~1.6.2",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "91891e3aee6f2a0b1c4db1e0b499338d05bda91b",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.2",
+      "_shasum": "988fbe666dfb1ba7f13edf7f27fea2a8bd101439",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "988fbe666dfb1ba7f13edf7f27fea2a8bd101439",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.1",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.2",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "63286e1192c695630a9c221c93b98d3b982fc5c7",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.3",
+      "_shasum": "cc25ea448a0f23225385948511f0bedb2dfa92c2",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cc25ea448a0f23225385948511f0bedb2dfa92c2",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.3.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.2",
+        "qs": "2.2.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "serve-static": "~1.6.2",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "bc38d896ea6bb8049e08467c0ff7fcf40956e744",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.3",
+      "_shasum": "6aadd470fbb0fdd2550536ab33b63c3fcb7f1028",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6aadd470fbb0fdd2550536ab33b63c3fcb7f1028",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.2",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.2",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "b09afad7b19d87bbc5acae6220e79f4765fb69c3",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.4",
+      "_shasum": "38d2749198f4d2d6b19433bd1105d065eb975a14",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "38d2749198f4d2d6b19433bd1105d065eb975a14",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.4.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.2",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "serve-static": "~1.6.2",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "8e46af1b1dd543b9933b86613a16ddcb7dc286be",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.4",
+      "_shasum": "008e18c92add61fcb534968e04c7e0102a66690b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "008e18c92add61fcb534968e04c7e0102a66690b",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.4.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.3",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "43e2cd79cba6acddb0d2c0de6dceb5874e21f5e5",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.5",
+      "_shasum": "859f4f7bd8d4b8656982592d432f6a0ee06afd30",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "859f4f7bd8d4b8656982592d432f6a0ee06afd30",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.5.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.5": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "serve-static": "~1.6.3",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "daadf6033b013319360850a6fc51911533a84512",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.5",
+      "_shasum": "7f62aa84ac8f5e96acfb98e2944dde0bf1cf8688",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7f62aa84ac8f5e96acfb98e2944dde0bf1cf8688",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.5.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.4",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "cc18da5cdfd6edbe1878b80f1c37cf0d6b86bcb6",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.6",
+      "_shasum": "e2f9a6a48b85233afc4f7b6c5cd6799c53f5f46f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e2f9a6a48b85233afc4f7b6c5cd6799c53f5f46f",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.6.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.7": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.5",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "9f292d873ef3124ed1760ca3647780452b34daf0",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.7",
+      "_shasum": "4261113907252e0b4b8346a342d321fe7fd11d75",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4261113907252e0b4b8346a342d321fe7fd11d75",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.7.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.6": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "serve-static": "~1.6.4",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "efd2dfb8c82e42b43f3d7f03181381d390d9174d",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.6",
+      "_shasum": "0b3e3970784d9133c4335c299539e6d895dbb208",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0b3e3970784d9133c4335c299539e6d895dbb208",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.6.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.7": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "serve-static": "~1.6.4",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "b0e4e641f93e422e4704f79f2ba3d3dcd0c5d8e6",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.7",
+      "_shasum": "ae3e0bdf0095749467fde125afd77e7988ff0fbb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ae3e0bdf0095749467fde125afd77e7988ff0fbb",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.7.tgz"
+      },
+      "directories": {}
+    },
+    "3.17.8": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.17.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.6",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "6d39d0f8a809eed1b75e0d5bd4d2dad3d2190f25",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.17.8",
+      "_shasum": "f0a451865f31938ea518a924c6f521df2d474d4b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f0a451865f31938ea518a924c6f521df2d474d4b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.8.tgz"
+      },
+      "directories": {}
+    },
+    "4.9.8": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.9.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "license": "MIT",
+      "homepage": "http://expressjs.com/",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "serve-static": "~1.6.4",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.4",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "prepublish": "npm prune",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "f15bba7309f2e0a17f7b7a5552b9618f074078c8",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.9.8",
+      "_shasum": "f360f596baeabbd0e5223b603d6eb578d9d2d10d",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f360f596baeabbd0e5223b603d6eb578d9d2d10d",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.8.tgz"
+      },
+      "directories": {}
+    },
+    "3.18.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.18.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.0",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "366000184f6fa2ae39b96c4806c7ab625a01e71c",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.18.0",
+      "_shasum": "ff1f4ee689ba6e622a087e397994f7c2115c5c57",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ff1f4ee689ba6e622a087e397994f7c2115c5c57",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.18.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.18.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.1",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "88dfd36eaafa7a0349401a6142413dbb4030ab78",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.18.1",
+      "_shasum": "0bbd6269abbdb53482166b0b5a9a04e311be9977",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0bbd6269abbdb53482166b0b5a9a04e311be9977",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.3.0",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.1",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.4.1",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "d40dc651f3561a4978fdc9c40e7fc802261d99ce",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.0",
+      "_shasum": "52719d5a1cde4edd47b87da43b1a7c337d761a12",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "52719d5a1cde4edd47b87da43b1a7c337d761a12",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.18.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.18.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.2",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "a12ae729bdb1e59f4f5962f0429fd116fd1fba24",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.18.2",
+      "_shasum": "7f92bce77e4f606a8defcf6aed54f8cfa0e044ca",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7f92bce77e4f606a8defcf6aed54f8cfa0e044ca",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.2.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.3.2",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.1",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.4.1",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "8bb013ec9567ae95a649c7537e1689944749d493",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.1",
+      "_shasum": "a291c812bc8b0ed6ab877366fe0e68a2368fde7e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a291c812bc8b0ed6ab877366fe0e68a2368fde7e",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "5.0.0-alpha.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "5.0.0-alpha.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.3.2",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.1",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.4.1",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "4052c15c7f10b79fb7c54f3837ffe118f7a99811",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@5.0.0-alpha.1",
+      "_shasum": "415df02c51ae01c221362fca59b03591d956b2d7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "415df02c51ae01c221362fca59b03591d956b2d7",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.18.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.18.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.3",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.2.1",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "28c6952d1c40d2ed840967206c1a7fc8d21da71b",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.18.3",
+      "_shasum": "4020829da766557f308161b3d0ea01c838b2aff6",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4020829da766557f308161b3d0ea01c838b2aff6",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.3.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.3.2",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.2.1",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.1",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.4.1",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "ac56cf46063e461fbaf53c2c869a1a657e8adbe1",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.2",
+      "_shasum": "df06dde94d968932829d440a2004c5efe64495b0",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "df06dde94d968932829d440a2004c5efe64495b0",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.18.4": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.18.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.4",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.4",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.3.0",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "6c8bcd5c4e049b5c212036a2e6cfe9ac98d5b9f8",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.18.4",
+      "_shasum": "7b40ad2c10a987692ee97a387c21593011f03712",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7b40ad2c10a987692ee97a387c21593011f03712",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.4.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.3.0",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "7fcc8b190d7a8a3f3743bc19b4ec0d349e50cc20",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.3",
+      "_shasum": "08006c11d0c519339963bf643c3d76c2765f9349",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "08006c11d0c519339963bf643c3d76c2765f9349",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.3.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.3.0",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "656e214937889536b0faa73097422061315496f2",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.4",
+      "_shasum": "31aa70acdad6b6093945c30523df8537336deb58",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "31aa70acdad6b6093945c30523df8537336deb58",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.4.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.5": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.4",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.3.0",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "4d8093302f752725874d6b31b57720d4cab6d078",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.5",
+      "_shasum": "cdcff3ea56f9cd8017043356553661cbae161f4f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cdcff3ea56f9cd8017043356553661cbae161f4f",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.5.tgz"
+      },
+      "directories": {}
+    },
+    "3.18.5": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.18.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.6",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.4",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "262b60537fd39c76420246d38c813a1743bf223e",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.18.5",
+      "_shasum": "bf0feb8562f82419ffdacf7c2315755758bfd7ec",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bf0feb8562f82419ffdacf7c2315755758bfd7ec",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.5.tgz"
+      },
+      "directories": {}
+    },
+    "3.18.6": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.18.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.6",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.4",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "4405b849a9ea62dfa76f32031e187c844f8e217d",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.18.6",
+      "_shasum": "cbcc7cb610d061ac619e5d090a5539353a3e870b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cbcc7cb610d061ac619e5d090a5539353a3e870b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.6.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.6": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.4",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "b78bd3d1fd6caf8228a1875078fecce936cb2e46",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.6",
+      "_shasum": "a9015979ccf38b11a39c0f726dcf6c4b85a4e758",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a9015979ccf38b11a39c0f726dcf6c4b85a4e758",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.6.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.7": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.2",
+        "type-is": "~1.5.5",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "ff5e96c88b23ebf0bb9bf99f9195b5b40215502f",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.7",
+      "_shasum": "0652f8cd5d0e2949d77b7dea7c5208161ec81ac6",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0652f8cd5d0e2949d77b7dea7c5208161ec81ac6",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.7.tgz"
+      },
+      "directories": {}
+    },
+    "3.19.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.19.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.28.1",
+        "content-disposition": "0.5.0",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.5",
+        "range-parser": "~1.0.2",
+        "send": "0.11.0",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.0.8",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "should": "~4.4.4",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "ee3f2b073cbd947a5108b0ed68faf8172a4af2ca",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.19.0",
+      "_shasum": "cdac51029ccd012840d74c8c9a05834ac3a23a25",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cdac51029ccd012840d74c8c9a05834ac3a23a25",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.19.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.10.8": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.10.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.5",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.2",
+        "type-is": "~1.5.5",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.10.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.8.2",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "08939683c7a2e5d7dc928d310ebab65878bffff3",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.10.8",
+      "_shasum": "2d83571e065c0efb2679c0a5f9ae66aeaa47024a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2d83571e065c0efb2679c0a5f9ae66aeaa47024a",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.8.tgz"
+      },
+      "directories": {}
+    },
+    "4.11.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.11.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.5",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.11.0",
+        "serve-static": "~1.8.0",
+        "type-is": "~1.5.5",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.0.8",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "should": "~4.4.4",
+        "supertest": "~0.15.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.10.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.10.1",
+        "jade": "~1.9.0",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.0",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "40f7a8eaa297c26f74c1a5dbc13ab705b6f97b45",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.11.0",
+      "_shasum": "ad5b5157b74a95fc5c59442efad0306e7b1aeb99",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ad5b5157b74a95fc5c59442efad0306e7b1aeb99",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.11.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.19.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.19.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.28.2",
+        "content-disposition": "0.5.0",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.5",
+        "range-parser": "~1.0.2",
+        "send": "0.11.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "should": "~4.6.1",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "0c567b3282821c98a84640956e7fb4bf236be30e",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.19.1",
+      "_shasum": "2b65f584a4c9856ff656595680f522a106b81693",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2b65f584a4c9856ff656595680f522a106b81693",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.19.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.11.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.11.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.5",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.11.1",
+        "serve-static": "~1.8.1",
+        "type-is": "~1.5.5",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "should": "~4.6.1",
+        "supertest": "~0.15.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.10.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.10.1",
+        "jade": "~1.9.1",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "45ebb6cdf45710f4fba93ae41c9dbd16afae83fe",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.11.1",
+      "_shasum": "36d04dd27aa1667634e987529767f9c99de7903f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "36d04dd27aa1667634e987529767f9c99de7903f",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.11.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.19.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.19.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.28.3",
+        "content-disposition": "0.5.0",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.6",
+        "range-parser": "~1.0.2",
+        "send": "0.11.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~4.6.2",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "86328767fe6b253bdbf99343049cc57f1c3a1fbb",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.19.2",
+      "_shasum": "7f9b3ad8ae0f29d2df98cb3d8649dec8bcc47bf6",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7f9b3ad8ae0f29d2df98cb3d8649dec8bcc47bf6",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.19.2.tgz"
+      },
+      "directories": {}
+    },
+    "4.11.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.11.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.3",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.6",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.11.1",
+        "serve-static": "~1.8.1",
+        "type-is": "~1.5.6",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~4.6.2",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.11.0",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.10.2",
+        "jade": "~1.9.1",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "63ab25579bda70b4927a179b580a9c580b6c7ada",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.11.2",
+      "_shasum": "8df3d5a9ac848585f00a0777601823faecd3b148",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8df3d5a9ac848585f00a0777601823faecd3b148",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.11.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.20.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.20.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.29.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.6",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.0",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "85755e32d9d262db702bee84830462b5275c27e4",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.20.0",
+      "_shasum": "9dac561e31a08e7d2852790d86d17c7b70bdd9ac",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9dac561e31a08e7d2852790d86d17c7b70bdd9ac",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.20.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.12.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.12.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.6",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "serve-static": "~1.9.1",
+        "type-is": "~1.6.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.6",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.1",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.12.0",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.4",
+        "express-session": "~1.10.3",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "51f960f2977566f8d671fc0e8154466a1b3d78ca",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.12.0",
+      "_shasum": "739660fce86acbc11ba9c37dc96ff009dc9975e8",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "739660fce86acbc11ba9c37dc96ff009dc9975e8",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.20.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.20.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.29.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.6",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.6",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.0",
+        "supertest": "~0.15.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "b2311c74024ceeb90cd7f4c473b856593106ba65",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.20.1",
+      "_shasum": "982701ba766a67a8bcc6f6d92366a1d0794e2c55",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "982701ba766a67a8bcc6f6d92366a1d0794e2c55",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.20.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.12.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.12.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.6",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "serve-static": "~1.9.1",
+        "type-is": "~1.6.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.6",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.1",
+        "supertest": "~0.15.0",
+        "body-parser": "~1.12.0",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.4",
+        "express-session": "~1.10.3",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "1e6d2654a284f00c4bb92e201d87982e3dfb9a7c",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.12.1",
+      "_shasum": "bb784ce513d39f2b283fa2736303f89ba7951aeb",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bb784ce513d39f2b283fa2736303f89ba7951aeb",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.12.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.12.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.6",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "serve-static": "~1.9.1",
+        "type-is": "~1.6.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.6",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.1",
+        "supertest": "~0.15.0",
+        "body-parser": "~1.12.0",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.4",
+        "express-session": "~1.10.3",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "dee9fbbbda2f2483c657cf912f68db1a5ba1fcac",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.12.2",
+      "_shasum": "7e72ad4c1b4edf07536a6d1e2acec0161d8564bd",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e72ad4c1b4edf07536a6d1e2acec0161d8564bd",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.20.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.20.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.29.1",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.7",
+        "range-parser": "~1.0.2",
+        "send": "0.12.2",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.8",
+        "marked": "0.3.3",
+        "mocha": "~2.2.1",
+        "should": "~5.2.0",
+        "supertest": "~0.15.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "011e5dc24185eb213cfc09e027498ca34c742103",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.20.2",
+      "_shasum": "c604027746e60f3da0a4b43063375d21c3235858",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c604027746e60f3da0a4b43063375d21c3235858",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.20.2.tgz"
+      },
+      "directories": {}
+    },
+    "4.12.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.12.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.5",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.4",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.7",
+        "qs": "2.4.1",
+        "range-parser": "~1.0.2",
+        "send": "0.12.2",
+        "serve-static": "~1.9.2",
+        "type-is": "~1.6.1",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.8",
+        "marked": "0.3.3",
+        "mocha": "~2.2.1",
+        "should": "~5.2.0",
+        "supertest": "~0.15.0",
+        "body-parser": "~1.12.2",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.4",
+        "cookie-session": "~1.1.0",
+        "express-session": "~1.10.4",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.2",
+        "morgan": "~1.5.2",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "f56463f8bf24015736978d0dc4d398fa22a9d758",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.12.3",
+      "_shasum": "6b9d94aec5ae03270d86d390c277a8c5a5ad0ee2",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@nbtsc.org"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6b9d94aec5ae03270d86d390c277a8c5a5ad0ee2",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.20.3": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.20.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.29.2",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
+        "send": "0.12.3",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "6.0.1",
+        "supertest": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "b149430114b42299be84b5c1dfe25a8303605db5",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.20.3",
+      "_shasum": "5085ab3f5ff761cf7e1597e9b9df156f1094aded",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5085ab3f5ff761cf7e1597e9b9df156f1094aded",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.20.3.tgz"
+      },
+      "directories": {}
+    },
+    "4.12.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.12.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.7",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.1",
+        "etag": "~1.6.0",
+        "finalhandler": "0.3.6",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.8",
+        "qs": "2.4.2",
+        "range-parser": "~1.0.2",
+        "send": "0.12.3",
+        "serve-static": "~1.9.3",
+        "type-is": "~1.6.2",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "6.0.1",
+        "supertest": "1.0.1",
+        "body-parser": "~1.12.4",
+        "connect-redis": "~2.3.0",
+        "cookie-parser": "~1.3.4",
+        "cookie-session": "~1.1.0",
+        "express-session": "~1.11.2",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.3",
+        "morgan": "~1.5.3",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "e9c9f95ade0f20a048861ac886d4767a839d5286",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.12.4",
+      "_shasum": "8fec2510255bc6b2e58107c48239c0fa307c1aa2",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8fec2510255bc6b2e58107c48239c0fa307c1aa2",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.4.tgz"
+      },
+      "directories": {}
+    },
+    "3.21.0": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.21.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "1.0.2",
+        "connect": "2.30.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.1",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "115dbe1a4d817d925d2dc87731a7ceb1663152ed",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.21.0",
+      "_shasum": "8ff7c424a92d15ee1a27c4bc8425ddba2c14aa38",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8ff7c424a92d15ee1a27c4bc8425ddba2c14aa38",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.21.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.13.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.13.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.9",
+        "array-flatten": "1.1.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.6",
+        "proxy-addr": "~1.0.8",
+        "qs": "2.4.2",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.3",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.1",
+        "connect-redis": "~2.3.0",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.1.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.3",
+        "morgan": "~1.6.0",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "6c7a36733891ddd6089ee4f267d731383bf58ea9",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.13.0",
+      "_shasum": "0678bdbc72715170b3fcc917052f046cb9689add",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0678bdbc72715170b3fcc917052f046cb9689add",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.21.1": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.21.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "~1.0.3",
+        "connect": "2.30.1",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.1",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.2",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "3c0ff8133bace4a0dc1356b8d8e6e83b38d2dd95",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.21.1",
+      "_shasum": "427b1f4e68dcfd5da6809892fe19219d52ce6b55",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "427b1f4e68dcfd5da6809892fe19219d52ce6b55",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.21.1.tgz"
+      },
+      "directories": {}
+    },
+    "4.13.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.13.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.10",
+        "array-flatten": "1.1.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.6",
+        "proxy-addr": "~1.0.8",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.4",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.2",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.2",
+        "connect-redis": "~2.3.0",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.3",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "2ac25098548f739c4f2b526b2a00aa60a74c8e75",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.13.1",
+      "_shasum": "f117aa1d1f6bedbc8de5b6d71fc31a5acd0f63df",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f117aa1d1f6bedbc8de5b6d71fc31a5acd0f63df",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.1.tgz"
+      },
+      "directories": {}
+    },
+    "5.0.0-alpha.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "5.0.0-alpha.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.10",
+        "array-flatten": "1.1.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-is-absolute": "1.0.0",
+        "path-to-regexp": "0.1.6",
+        "proxy-addr": "~1.0.8",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.2",
+        "router": "~1.1.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.4",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.2",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.2",
+        "connect-redis": "~2.3.0",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.3",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "2c668f87c7c14245d9400cd1357b7dbb38526a3c",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@5.0.0-alpha.2",
+      "_shasum": "fd54177f657b6a4c4540727702edd1cbaa3a6ac5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fd54177f657b6a4c4540727702edd1cbaa3a6ac5",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.2.tgz"
+      },
+      "directories": {}
+    },
+    "3.21.2": {
+      "name": "express",
+      "description": "Sinatra inspired web development framework",
+      "version": "3.21.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "basic-auth": "~1.0.3",
+        "connect": "2.30.2",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.1",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.3",
+        "istanbul": "0.3.9",
+        "marked": "0.3.5",
+        "mocha": "2.2.5",
+        "should": "7.0.2",
+        "supertest": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "bin/",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "cb59086305367d9fcd7d63b53cfca1a3e4ef77d7",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@3.21.2",
+      "_shasum": "0c2903ee5c54e63d65a96170764703550665a3de",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0c2903ee5c54e63d65a96170764703550665a3de",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.21.2.tgz"
+      },
+      "directories": {}
+    },
+    "4.13.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.13.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.0.8",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.6",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.3",
+        "istanbul": "0.3.17",
+        "marked": "0.3.5",
+        "mocha": "2.2.5",
+        "should": "7.0.2",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.3",
+        "connect-redis": "~2.4.1",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.5",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "97b2d70d8adfb4649fd8ca9adc73c47ffcc4bf5b",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.13.2",
+      "_shasum": "e4259f58d8ca85f54b820d7057b02ef90b471f1d",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e4259f58d8ca85f54b820d7057b02ef90b471f1d",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.2.tgz"
+      },
+      "directories": {}
+    },
+    "4.13.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.13.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/strongloop/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.0.8",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.6",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.3",
+        "istanbul": "0.3.17",
+        "marked": "0.3.5",
+        "mocha": "2.2.5",
+        "should": "7.0.2",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.3",
+        "connect-redis": "~2.4.1",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.5",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "ef7ad681b245fba023843ce94f6bcb8e275bbb8e",
+      "bugs": {
+        "url": "https://github.com/strongloop/express/issues"
+      },
+      "_id": "express@4.13.3",
+      "_shasum": "ddb2f1fb4502bf33598d2b032b037960ca6c80a3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "rfeng",
+          "email": "enjoyjava@gmail.com"
+        },
+        {
+          "name": "aredridel",
+          "email": "aredridel@dinhe.net"
+        },
+        {
+          "name": "strongloop",
+          "email": "callback@strongloop.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ddb2f1fb4502bf33598d2b032b037960ca6c80a3",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.3.tgz"
+      },
+      "directories": {}
+    },
+    "4.13.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.13.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/express"
+      },
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.1",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.5",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.1",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.0.10",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.3",
+        "send": "0.13.1",
+        "serve-static": "~1.10.2",
+        "type-is": "~1.6.6",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.4",
+        "istanbul": "0.4.2",
+        "marked": "0.3.5",
+        "mocha": "2.3.4",
+        "should": "7.1.1",
+        "supertest": "1.1.0",
+        "body-parser": "~1.14.2",
+        "connect-redis": "~2.4.1",
+        "cookie-parser": "~1.4.1",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.13.0",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.5",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "193bed2649c55c1fd362e46cd4702c773f3e7434",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "homepage": "https://github.com/expressjs/express",
+      "_id": "express@4.13.4",
+      "_shasum": "3c0b76f3c77590c8345739061ec0bd3ba067ec24",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3c0b76f3c77590c8345739061ec0bd3ba067ec24",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.4.tgz"
+      },
+      "directories": {}
+    },
+    "4.14.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.14.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/express"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.1",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.5.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.2",
+        "qs": "6.2.0",
+        "range-parser": "~1.2.0",
+        "send": "0.14.1",
+        "serve-static": "~1.11.1",
+        "type-is": "~1.6.13",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "body-parser": "~1.15.1",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.4.2",
+        "istanbul": "0.4.3",
+        "marked": "0.3.5",
+        "method-override": "~2.3.6",
+        "mocha": "2.5.3",
+        "morgan": "~1.7.0",
+        "should": "9.0.2",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.13.0",
+        "jade": "~1.11.0",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "9375a9afa9d7baa814b454c7a6818a7471aaef00",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.14.0",
+      "_shasum": "c1ee3f42cdc891fb3dc650a8922d51ec847d0d66",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c1ee3f42cdc891fb3dc650a8922d51ec847d0d66",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.14.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/express-4.14.0.tgz_1466095407850_0.17484632693231106"
+      },
+      "directories": {}
+    },
+    "4.14.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.14.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.5.1",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.2.0",
+        "range-parser": "~1.2.0",
+        "send": "0.14.2",
+        "serve-static": "~1.11.2",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.16.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.5",
+        "express-session": "1.15.0",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "~2.3.6",
+        "mocha": "3.2.0",
+        "morgan": "~1.7.0",
+        "multiparty": "4.1.3",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "0437c513f2dbc8d1dfc5a3e35fe35182bd3a671e",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.14.1",
+      "_shasum": "646c237f766f148c2120aff073817b9e4d7e0d33",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "646c237f766f148c2120aff073817b9e4d7e0d33",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.14.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/express-4.14.1.tgz_1485642795215_0.5481494057457894"
+      },
+      "directories": {}
+    },
+    "5.0.0-alpha.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "5.0.0-alpha.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "2.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.5.1",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.2.0",
+        "range-parser": "~1.2.0",
+        "router": "~1.1.5",
+        "send": "0.14.2",
+        "serve-static": "~1.11.2",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.16.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.5",
+        "express-session": "1.15.0",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "~2.3.6",
+        "mocha": "3.2.0",
+        "morgan": "~1.7.0",
+        "multiparty": "4.1.3",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "c8d9223e93ee0c08490e4840f3278314ccb221a5",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@5.0.0-alpha.3",
+      "_shasum": "19d63b931bf0f64c42725952ef0602c381fe64db",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "19d63b931bf0f64c42725952ef0602c381fe64db",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/express-5.0.0-alpha.3.tgz_1485660519206_0.28520536865107715"
+      },
+      "directories": {}
+    },
+    "4.15.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.15.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.3.1",
+        "range-parser": "~1.2.0",
+        "send": "0.15.0",
+        "serve-static": "1.12.0",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "504a51c040f22c80c7e52377c0ef00b1c8b2a76b",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.15.0",
+      "_shasum": "8fb125829f70a04a59e1c40ceb8dea19cf5c879c",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "8fb125829f70a04a59e1c40ceb8dea19cf5c879c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/express-4.15.0.tgz_1488407333719_0.7790739571209997"
+      },
+      "directories": {}
+    },
+    "5.0.0-alpha.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "5.0.0-alpha.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "2.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.3.1",
+        "range-parser": "~1.2.0",
+        "router": "~1.3.0",
+        "send": "0.15.0",
+        "serve-static": "1.12.0",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "a3a9166c521008576da724e83221c05a1aa92245",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@5.0.0-alpha.4",
+      "_shasum": "cd96a23fa9e3fce471f9637376b1c7b9d70b865e",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "cd96a23fa9e3fce471f9637376b1c7b9d70b865e",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/express-5.0.0-alpha.4.tgz_1488414607195_0.16105826874263585"
+      },
+      "directories": {}
+    },
+    "4.15.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.15.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.3.1",
+        "range-parser": "~1.2.0",
+        "send": "0.15.1",
+        "serve-static": "1.12.1",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "d32ed68b2995e0322100ace29d86e7a86b9c6378",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.15.1",
+      "_shasum": "e32897816d94cc477e45f0149a8966bc938a329b",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "e32897816d94cc477e45f0149a8966bc938a329b",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/express-4.15.1.tgz_1488776911316_0.193040527170524"
+      },
+      "directories": {}
+    },
+    "4.15.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.15.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.4.0",
+        "range-parser": "~1.2.0",
+        "send": "0.15.1",
+        "serve-static": "1.12.1",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.1",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "d43b074f0b3b56a91f240e62798c932ba104b79a",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.15.2",
+      "_shasum": "af107fc148504457f2dca9a6f2571d7129b97b35",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "af107fc148504457f2dca9a6f2571d7129b97b35",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/express-4.15.2.tgz_1488807764132_0.2808149973861873"
+      },
+      "directories": {}
+    },
+    "5.0.0-alpha.5": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "5.0.0-alpha.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "2.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.4.0",
+        "range-parser": "~1.2.0",
+        "router": "~1.3.0",
+        "send": "0.15.1",
+        "serve-static": "1.12.1",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.1",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "21f725e0ef9e1e9a8ea51e8486e9cadeae956774",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@5.0.0-alpha.5",
+      "_shasum": "e37423a8d82826fb915c7dd166e2900bfa3552e6",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "e37423a8d82826fb915c7dd166e2900bfa3552e6",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/express-5.0.0-alpha.5.tgz_1488808263893_0.666542848572135"
+      },
+      "directories": {}
+    },
+    "4.15.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.15.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.7",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.3",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.4",
+        "qs": "6.4.0",
+        "range-parser": "~1.2.0",
+        "send": "0.15.3",
+        "serve-static": "1.12.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.1",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.2",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.8",
+        "mocha": "3.4.1",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.1",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "6da454c7fb37e68ed65ffe0371aa688b89f5bd6e",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.15.3",
+      "_shasum": "bab65d0f03aa80c358408972fc700f916944b662",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "6.10.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "bab65d0f03aa80c358408972fc700f916944b662",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hacksparrow",
+          "email": "captain@hacksparrow.com"
+        },
+        {
+          "name": "jasnell",
+          "email": "jasnell@gmail.com"
+        },
+        {
+          "name": "mikeal",
+          "email": "mikeal.rogers@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/express-4.15.3.tgz_1495030658380_0.1599606357049197"
+      },
+      "directories": {}
+    },
+    "4.15.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.15.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.4",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.5",
+        "qs": "6.5.0",
+        "range-parser": "~1.2.0",
+        "send": "0.15.4",
+        "serve-static": "1.12.4",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.0",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.5",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.9",
+        "mocha": "3.5.0",
+        "morgan": "1.8.2",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.1",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "a4bd4373b2c3b2521ee4c499cb8e90e98f78bfa5",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.15.4",
+      "_shasum": "032e2253489cf8fce02666beca3d11ed7a2daed1",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "032e2253489cf8fce02666beca3d11ed7a2daed1",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.4.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express-4.15.4.tgz_1502071931644_0.23451056680642068"
+      },
+      "directories": {}
+    },
+    "4.15.5": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.15.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.6",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.5",
+        "qs": "6.5.0",
+        "range-parser": "~1.2.0",
+        "send": "0.15.6",
+        "serve-static": "1.12.6",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.18.1",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.1",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.5",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.9",
+        "mocha": "3.5.3",
+        "morgan": "1.8.2",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "ea3d60565242c47be97088ead2708d7b88390858",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.15.5",
+      "_shasum": "670235ca9598890a5ae8170b83db722b842ed927",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "670235ca9598890a5ae8170b83db722b842ed927",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.5.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express-4.15.5.tgz_1506317115180_0.2818172036204487"
+      },
+      "directories": {}
+    },
+    "5.0.0-alpha.6": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "5.0.0-alpha.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "2.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.6",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.5",
+        "qs": "6.5.0",
+        "range-parser": "~1.2.0",
+        "router": "~1.3.1",
+        "send": "0.15.6",
+        "serve-static": "1.12.6",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.18.1",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.1",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.5",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.9",
+        "mocha": "3.5.3",
+        "morgan": "1.8.2",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "f4120a645301366891775d1f03925449239a2cb7",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@5.0.0-alpha.6",
+      "_shasum": "85dc44d7e90d4809041407f388f239b5bd2f681e",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "85dc44d7e90d4809041407f388f239b5bd2f681e",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.6.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express-5.0.0-alpha.6.tgz_1506317557150_0.7998493011109531"
+      },
+      "directories": {}
+    },
+    "4.16.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.16.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.0",
+        "serve-static": "1.13.0",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.10",
+        "mocha": "3.5.3",
+        "morgan": "1.9.0",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "f974d22c66d3cd91634ddaba1ef8bcaa8e49daf4",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.16.0",
+      "_shasum": "b519638e4eb58e7178c81b498ef22f798cb2e255",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "b519638e4eb58e7178c81b498ef22f798cb2e255",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express-4.16.0.tgz_1506622949495_0.9396109508816153"
+      },
+      "directories": {}
+    },
+    "4.16.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.16.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.10",
+        "mocha": "3.5.3",
+        "morgan": "1.9.0",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "e3f7f51f5f5475ca1ad091b1f8b7293f79467d29",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.16.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-STB7LZ4N0L+81FJHGla2oboUHTk4PaN1RsOkoRh9OSeEKylvF5hwKYVX1xCLFaCT7MD0BNG/gX2WFMLqY6EMBw==",
+        "shasum": "6b33b560183c9b253b7b62144df33a4654ac9ed0",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express-4.16.1.tgz_1506717522230_0.9567146771587431"
+      },
+      "directories": {}
+    },
+    "4.16.2": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.16.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.10",
+        "mocha": "3.5.3",
+        "morgan": "1.9.0",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks --no-exit test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks --no-exit test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks --no-exit test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks --no-exit test/ test/acceptance/"
+      },
+      "gitHead": "351396f971280ab79faddcf9782ea50f4e88358d",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.16.2",
+      "_shasum": "e35c6dfe2d64b7dca0a5cd4f21781be3299e076c",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "e35c6dfe2d64b7dca0a5cd4f21781be3299e076c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.2.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express-4.16.2.tgz_1507605225187_0.6328138182871044"
+      },
+      "directories": {}
+    },
+    "4.16.3": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.16.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.17",
+        "method-override": "2.3.10",
+        "mocha": "3.5.3",
+        "morgan": "1.9.0",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.1",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "files": [
+        "LICENSE",
+        "History.md",
+        "Readme.md",
+        "index.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks --no-exit test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks --no-exit test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks --no-exit test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks --no-exit test/ test/acceptance/"
+      },
+      "gitHead": "3ed5090ca91f6a387e66370d57ead94d886275e1",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.16.3",
+      "_shasum": "6af8a502350db3246ecc4becf6b5a34d22f7ed53",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.13.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "6af8a502350db3246ecc4becf6b5a34d22f7ed53",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+        "fileCount": 16,
+        "unpackedSize": 205577
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express_4.16.3_1520877014027_0.020052903698088542"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.16.4": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.16.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.0",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.5.1",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "dc538f6e810bd462c98ee7e6aae24c64d4b1da93",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.16.4",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.12.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+        "shasum": "fddef61926109e24c515ea97fd2f1bdbf62df12e",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+        "fileCount": 16,
+        "unpackedSize": 206123,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbvsqSCRA9TVsSAnZWagAAPFwP/iCvznxNrmvgY9ox7w2k\ncS/ej9HZJ5NGjBEWtae1F2bjJ2V7rOxVTGTlqiPMSNIzTgw3fpFkIXp9kCA4\nY03NOsYUjYscGjXR6f2fvOVJ/Si5FKlqr7Ow6WMBClrdo/CMCc8kH9fxtPja\nHla58xiU7ftlzUHIjGmmnHFzAjAeGj+3e3v1omuoeP6mPuxlwYoQ0MuD0sFa\n9qJAFZ0MBrfvoQBI8G++GZZhxalhefuibWi1ErRw3F5cLfvhjKi4HGPh+sDu\nc63D99wQIJIq4HumwX0JNW7OywuL28wgxgtvKyg0iCVR/BnAYiEA0UZUVI4h\nsX1Kuht1oHEp1iGOvGALYotPiovnDCAra+2zPM1p8oZKdXHEpkAygG3mCiD5\nyWlWrFo5jJudULWzMtHp6F0RwQJjpSavnkbusKWZvO717/1Ku5FIM4cnTWVK\nELGmb011jRPMvwFqv1C04SvhBT+UrXe4kd0qwJWQEDT1aWzbjbaroPmVQ+l1\nxzUkHRHm7vYCBE0RxQ4FImNWlYYQVVyBSroYwxvJnP6H8m/DR7oxDPDoJcBn\nXXETuH8Ca+q8KjwdrstVXCwKfB+zs0Z41/oOWKrhsDY2B9HwmyOOA8EtG4QO\np2waBrigD8L4T/Y3II4T144z2MclVid7DulrzKCMiE6yoTqvrH64FfWkLQqG\n11u8\r\n=ZruB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express_4.16.4_1539230354097_0.4680196437483164"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.0-alpha.7": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "5.0.0-alpha.7",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "array-flatten": "2.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "3.1.0",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-is-absolute": "1.0.1",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "router": "2.0.0-alpha.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.0",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.5.1",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "readme": "[![Express Logo](https://i.cloudup.com/zfY6lL7eFa-3000x3000.png)](http://expressjs.com/)\n\n  Fast, unopinionated, minimalist web framework for [node](http://nodejs.org).\n\n  [![NPM Version][npm-image]][npm-url]\n  [![NPM Downloads][downloads-image]][downloads-url]\n  [![Linux Build][travis-image]][travis-url]\n  [![Windows Build][appveyor-image]][appveyor-url]\n  [![Test Coverage][coveralls-image]][coveralls-url]\n\n```js\nvar express = require('express')\nvar app = express()\n\napp.get('/', function (req, res) {\n  res.send('Hello World')\n})\n\napp.listen(3000)\n```\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/).\n\nBefore installing, [download and install Node.js](https://nodejs.org/en/download/).\nNode.js 0.10 or higher is required.\n\nInstallation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```bash\n$ npm install express\n```\n\nFollow [our installing guide](http://expressjs.com/en/starter/installing.html)\nfor more information.\n\n## Features\n\n  * Robust routing\n  * Focus on high performance\n  * Super-high test coverage\n  * HTTP helpers (redirection, caching, etc)\n  * View system supporting 14+ template engines\n  * Content negotiation\n  * Executable for generating applications quickly\n\n## Docs & Community\n\n  * [Website and Documentation](http://expressjs.com/) - [[website repo](https://github.com/expressjs/expressjs.com)]\n  * [#express](https://webchat.freenode.net/?channels=express) on freenode IRC\n  * [GitHub Organization](https://github.com/expressjs) for Official Middleware & Modules\n  * Visit the [Wiki](https://github.com/expressjs/express/wiki)\n  * [Google Group](https://groups.google.com/group/express-js) for discussion\n  * [Gitter](https://gitter.im/expressjs/express) for support and discussion\n\n**PROTIP** Be sure to read [Migrating from 3.x to 4.x](https://github.com/expressjs/express/wiki/Migrating-from-3.x-to-4.x) as well as [New features in 4.x](https://github.com/expressjs/express/wiki/New-features-in-4.x).\n\n### Security Issues\n\nIf you discover a security vulnerability in Express, please see [Security Policies and Procedures](Security.md).\n\n## Quick Start\n\n  The quickest way to get started with express is to utilize the executable [`express(1)`](https://github.com/expressjs/generator) to generate an application as shown below:\n\n  Install the executable. The executable's major version will match Express's:\n\n```bash\n$ npm install -g express-generator@4\n```\n\n  Create the app:\n\n```bash\n$ express /tmp/foo && cd /tmp/foo\n```\n\n  Install dependencies:\n\n```bash\n$ npm install\n```\n\n  Start the server:\n\n```bash\n$ npm start\n```\n\n## Philosophy\n\n  The Express philosophy is to provide small, robust tooling for HTTP servers, making\n  it a great solution for single page applications, web sites, hybrids, or public\n  HTTP APIs.\n\n  Express does not force you to use any specific ORM or template engine. With support for over\n  14 template engines via [Consolidate.js](https://github.com/tj/consolidate.js),\n  you can quickly craft your perfect framework.\n\n## Examples\n\n  To view the examples, clone the Express repo and install the dependencies:\n\n```bash\n$ git clone git://github.com/expressjs/express.git --depth 1\n$ cd express\n$ npm install\n```\n\n  Then run whichever example you want:\n\n```bash\n$ node examples/content-negotiation\n```\n\n## Tests\n\n  To run the test suite, first install the dependencies, then run `npm test`:\n\n```bash\n$ npm install\n$ npm test\n```\n\n## People\n\nThe original author of Express is [TJ Holowaychuk](https://github.com/tj)\n\nThe current lead maintainer is [Douglas Christopher Wilson](https://github.com/dougwilson)\n\n[List of all contributors](https://github.com/expressjs/express/graphs/contributors)\n\n## License\n\n  [MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/express.svg\n[npm-url]: https://npmjs.org/package/express\n[downloads-image]: https://img.shields.io/npm/dm/express.svg\n[downloads-url]: https://npmjs.org/package/express\n[travis-image]: https://img.shields.io/travis/expressjs/express/master.svg?label=linux\n[travis-url]: https://travis-ci.org/expressjs/express\n[appveyor-image]: https://img.shields.io/appveyor/ci/dougwilson/express/master.svg?label=windows\n[appveyor-url]: https://ci.appveyor.com/project/dougwilson/express\n[coveralls-image]: https://img.shields.io/coveralls/expressjs/express/master.svg\n[coveralls-url]: https://coveralls.io/r/expressjs/express?branch=master\n[gratipay-image-visionmedia]: https://img.shields.io/gratipay/visionmedia.svg\n[gratipay-url-visionmedia]: https://gratipay.com/visionmedia/\n[gratipay-image-dougwilson]: https://img.shields.io/gratipay/dougwilson.svg\n[gratipay-url-dougwilson]: https://gratipay.com/dougwilson/\n",
+      "readmeFilename": "Readme.md",
+      "gitHead": "5f0c829d7ca7da746ee859f13a54631000f8a9b5",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@5.0.0-alpha.7",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.12.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==",
+        "shasum": "879bfb1bd52834646a9d8c3a773863c36e4d494c",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.7.tgz",
+        "fileCount": 11,
+        "unpackedSize": 179029,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb09eLCRA9TVsSAnZWagAA/1AP/269JF2vhXEO9n3MaQLu\nSs95oz9PfsYyucun0Qgjjd5OyERY7IwtkbYoMn60M18w8ni1JR9kjqQ8m07t\nUIpgUBnfnytj9L7qlnmPMF2Uzrh6YwX5gg1jzx0Tri8EwehllZg3f5o2nxPX\nduG87uxNzxUszo52FXRR98Vz6vVup0/0smLa8jtq+VxXRhW3zGcU+zTAIoyy\nP7bvI4Zg5RKWzABTIfBsqW9sxJ6yT0Xa/otiO/IJ3YjJb2f76FdAN1RwrEnA\nvherLVx1V6EooqhkrS0W45Ong2KEytpHWTKj5APDpggffflfJyiON2BqvrPI\nmSDESQzyArpgwckBaSofLcydD7aaGtYP/NpATT3khrWw3UkFeeG0LGGulz7e\nbPN8PFuSXiZ5dfcBXNQsViSF6jkghg0y8bffC3h4VewsKKfgLKehwOjn+Mp4\n7dyZ0KcCJn/xcCCJJFAkJJB9j4Pfqxj1D2hlUMXfSj6L7unmbOnwsFtL0m32\nb0w+WkUxy8DR+UFGUUHGK5bNE9OsX5tYSWm9RH8Z8cco5rgLBkk3Lxq1rSjY\nzLrM5FsakMWgSlI1BTN5gXX9TYumCzke4vI8emkxe8lR3l+XPz2wP/+HB1wg\nfxSecAWnJKwkDAtBifHB8eiOWNLoSnJiOkWk0VnkSXa9Aw95yED1B/sAv/i5\nk5y/\r\n=n8Sg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "captain@hacksparrow.com",
+          "name": "hacksparrow"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express_5.0.0-alpha.7_1540609930884_0.050413303730304504"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.17.0": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.17.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.1",
+        "cookie-parser": "~1.4.4",
+        "cookie-session": "1.3.3",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.16.1",
+        "hbs": "4.0.4",
+        "istanbul": "0.4.5",
+        "marked": "0.6.2",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "10c7756764fbe969b307b15a72fd074479c00f8d",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.17.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-1Z7/t3Z5ZnBG252gKUPyItc4xdeaA0X934ca2ewckAsVsw9EG71i++ZHZPYnus8g/s5Bty8IMpSVEuRkmwwPRQ==",
+        "shasum": "288af62228a73f4c8ea2990ba3b791bb87cd4438",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.17.0.tgz",
+        "fileCount": 16,
+        "unpackedSize": 208134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3hUVCRA9TVsSAnZWagAA3oUP/3V7aiaEhUSyQ9lyDnPF\nxiRwGy0XNIoNRyZbw8gMN2/7V/jjV+H/vWdo9gSr3NJAGsGlS8AtT0uNvKv/\nrssr3WA65/J9QNdCixePj/LHilRzOSMKxnIhk20bVh186vEx7fwehqXbifcS\nNIoSieQRnllJCVH0JudVim4AMWdy3Y2vOLV1kE6UpDs41c3eXzUfFEVxI+WD\nXjUrfHsRCK/IZ5No2Hw8uwF2Y2pnuRHFC0ehIWn+Foijy87doiFidxdn2ybg\nFjdo+AFH3LX2RBR4o7UugtDV1wB0ymRVRNSIk6xoKmMGi5RNE5dhPxNkEvk7\nX5nK18AhRzRFIIZDhHtOZE9wWvlf/25p0y8CmzKrXkpmiuzcby4EneyV0Muk\n8WmbnEO1ah7SATsVf0d/AnR1tCXE+0wLXvVrq9Z1BAkeW1rsR9OHqzpLGCc3\njmYqyrN+2iyPeqy/cemnU52fmUC/Kfj8q8Uv2RCxJo9cAKKp+ljaMXCiJMcP\nrYPu4X0n0ijSLVF1dAQkDs05MVbZeCl5RM0GhPndFwcdCBc1JdJSYK/6ylHK\nFDoB5YBzxglMPL8iMwbDhS2+N25vRDAWr52GKTwJFmcfW04/EXrFEgm2gk1/\nmRLojES3L7P5L96c9P2SVzp7YjWFw71OkQctzlDrNC28VOU3ie95pYQyHV5/\n64mY\r\n=ZTgO\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express_4.17.0_1558058260571_0.7920489008241873"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.17.1": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "4.17.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.1",
+        "cookie-parser": "~1.4.4",
+        "cookie-session": "1.3.3",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.16.1",
+        "hbs": "4.0.4",
+        "istanbul": "0.4.5",
+        "marked": "0.6.2",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "gitHead": "e1b45ebd050b6f06aa38cda5aaf0c21708b0c71e",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@4.17.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+        "shasum": "4491fc38605cf51f8629d39c2b5d026f98a4c134",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+        "fileCount": 16,
+        "unpackedSize": 208133,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc6hU/CRA9TVsSAnZWagAAFc4QAJzqxI1sgdfreUHk+NIa\n38jYea65Xg8N9JgZVF67j7aXqPT6VXhGu2j54oveGIkr+RL2Xm58RrRWn+Sg\nVWOOSZzotLKtx1qCYS4ozPRYvujKMLYDeiLxePDCSrrLYt48+IJwkHF04Un1\nJ0ZUmtlEqgLL85gvaCrKa9qF8TfwbQhhIzQ914vum11tJ506ePpffN2xFY0M\nsHf0CiuV1OFOD7Wne/RR7DVsxQwZ/FXomkxLJm8+T+T9ZYm3WQxWVD7BRQpA\nN08+zkPd1XMEZiVZkR9Ie4+7ydZomJE8PNCOt5SzvEW6ekDW10QuuF0521Wj\n5lHp4AflVFq1LTJB0WDR6VIPJRp0H5aYTh1tBRxWHUx/EP2LfFS/XEz1bUvm\nBDVj2e1iA4ZWz8aeu9p/2N8Zp05WGINF3/E4YG9smxxs5EDJZGA9k1DAj6US\nzKWTOemaqypRshFWThvfA70a1Rcwdj+0XGboscg/S20XTT0FvG2GLkEY0OO/\niHBy5fKYplUQsths48V8I9P9Gx6U534iaFJlxlzzVEsDleBkH+NBSP8OB7dx\n8N/0ZQDBY6JWL5ZSW9yVY2FzrTEmUOPC1Rts5Uj4m7SBmu8yK154ylnPQ4T6\nMr0jG8XQPYhTLc5pYNTFZNV1Ydu4d01xIrLhGy/3dc7kRlwy3FN5ceNVsB88\njyN+\r\n=QYw2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express_4.17.1_1558844734329_0.21547943776855627"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.0-alpha.8": {
+      "name": "express",
+      "description": "Fast, unopinionated, minimalist web framework",
+      "version": "5.0.0-alpha.8",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Aaron Heckmann",
+          "email": "aaron.heckmann+github@gmail.com"
+        },
+        {
+          "name": "Ciaran Jessup",
+          "email": "ciaranj@gmail.com"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Guillermo Rauch",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com"
+        },
+        {
+          "name": "Roman Shtylman",
+          "email": "shtylman+expressjs@gmail.com"
+        },
+        {
+          "name": "Young Jae Sim",
+          "email": "hanul@hanul.me"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/express.git"
+      },
+      "homepage": "http://expressjs.com/",
+      "keywords": [
+        "express",
+        "framework",
+        "sinatra",
+        "web",
+        "rest",
+        "restful",
+        "router",
+        "app",
+        "api"
+      ],
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "2.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "3.1.0",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-is-absolute": "1.0.1",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "router": "2.0.0-alpha.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.1",
+        "cookie-parser": "~1.4.4",
+        "cookie-session": "1.3.3",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.16.1",
+        "hbs": "4.0.4",
+        "istanbul": "0.4.5",
+        "marked": "0.6.2",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --require test/support/env --reporter spec --bail --check-leaks test/ test/acceptance/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --require test/support/env --reporter spec --check-leaks test/ test/acceptance/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require test/support/env --reporter dot --check-leaks test/ test/acceptance/",
+        "test-tap": "mocha --require test/support/env --reporter tap --check-leaks test/ test/acceptance/"
+      },
+      "readme": "[![Express Logo](https://i.cloudup.com/zfY6lL7eFa-3000x3000.png)](http://expressjs.com/)\n\n  Fast, unopinionated, minimalist web framework for [node](http://nodejs.org).\n\n  [![NPM Version][npm-image]][npm-url]\n  [![NPM Downloads][downloads-image]][downloads-url]\n  [![Linux Build][travis-image]][travis-url]\n  [![Windows Build][appveyor-image]][appveyor-url]\n  [![Test Coverage][coveralls-image]][coveralls-url]\n\n```js\nconst express = require('express')\nconst app = express()\n\napp.get('/', function (req, res) {\n  res.send('Hello World')\n})\n\napp.listen(3000)\n```\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/).\n\nBefore installing, [download and install Node.js](https://nodejs.org/en/download/).\nNode.js 0.10 or higher is required.\n\nInstallation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```bash\n$ npm install express\n```\n\nFollow [our installing guide](http://expressjs.com/en/starter/installing.html)\nfor more information.\n\n## Features\n\n  * Robust routing\n  * Focus on high performance\n  * Super-high test coverage\n  * HTTP helpers (redirection, caching, etc)\n  * View system supporting 14+ template engines\n  * Content negotiation\n  * Executable for generating applications quickly\n\n## Docs & Community\n\n  * [Website and Documentation](http://expressjs.com/) - [[website repo](https://github.com/expressjs/expressjs.com)]\n  * [#express](https://webchat.freenode.net/?channels=express) on freenode IRC\n  * [GitHub Organization](https://github.com/expressjs) for Official Middleware & Modules\n  * Visit the [Wiki](https://github.com/expressjs/express/wiki)\n  * [Google Group](https://groups.google.com/group/express-js) for discussion\n  * [Gitter](https://gitter.im/expressjs/express) for support and discussion\n\n**PROTIP** Be sure to read [Migrating from 3.x to 4.x](https://github.com/expressjs/express/wiki/Migrating-from-3.x-to-4.x) as well as [New features in 4.x](https://github.com/expressjs/express/wiki/New-features-in-4.x).\n\n### Security Issues\n\nIf you discover a security vulnerability in Express, please see [Security Policies and Procedures](Security.md).\n\n## Quick Start\n\n  The quickest way to get started with express is to utilize the executable [`express(1)`](https://github.com/expressjs/generator) to generate an application as shown below:\n\n  Install the executable. The executable's major version will match Express's:\n\n```bash\n$ npm install -g express-generator@4\n```\n\n  Create the app:\n\n```bash\n$ express /tmp/foo && cd /tmp/foo\n```\n\n  Install dependencies:\n\n```bash\n$ npm install\n```\n\n  Start the server:\n\n```bash\n$ npm start\n```\n\n  View the website at: http://localhost:3000\n\n## Philosophy\n\n  The Express philosophy is to provide small, robust tooling for HTTP servers, making\n  it a great solution for single page applications, web sites, hybrids, or public\n  HTTP APIs.\n\n  Express does not force you to use any specific ORM or template engine. With support for over\n  14 template engines via [Consolidate.js](https://github.com/tj/consolidate.js),\n  you can quickly craft your perfect framework.\n\n## Examples\n\n  To view the examples, clone the Express repo and install the dependencies:\n\n```bash\n$ git clone git://github.com/expressjs/express.git --depth 1\n$ cd express\n$ npm install\n```\n\n  Then run whichever example you want:\n\n```bash\n$ node examples/content-negotiation\n```\n\n## Tests\n\n  To run the test suite, first install the dependencies, then run `npm test`:\n\n```bash\n$ npm install\n$ npm test\n```\n\n## Contributing\n\n[Contributing Guide](Contributing.md)\n\n## People\n\nThe original author of Express is [TJ Holowaychuk](https://github.com/tj)\n\nThe current lead maintainer is [Douglas Christopher Wilson](https://github.com/dougwilson)\n\n[List of all contributors](https://github.com/expressjs/express/graphs/contributors)\n\n## License\n\n  [MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/express.svg\n[npm-url]: https://npmjs.org/package/express\n[downloads-image]: https://img.shields.io/npm/dm/express.svg\n[downloads-url]: https://npmjs.org/package/express\n[travis-image]: https://img.shields.io/travis/expressjs/express/master.svg?label=linux\n[travis-url]: https://travis-ci.org/expressjs/express\n[appveyor-image]: https://img.shields.io/appveyor/ci/dougwilson/express/master.svg?label=windows\n[appveyor-url]: https://ci.appveyor.com/project/dougwilson/express\n[coveralls-image]: https://img.shields.io/coveralls/expressjs/express/master.svg\n[coveralls-url]: https://coveralls.io/r/expressjs/express?branch=master\n",
+      "readmeFilename": "Readme.md",
+      "gitHead": "bd04d8a87fbe22e6fabaa6a5451a885c0790043a",
+      "bugs": {
+        "url": "https://github.com/expressjs/express/issues"
+      },
+      "_id": "express@5.0.0-alpha.8",
+      "_nodeVersion": "13.11.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-PL8wTLgaNOiq7GpXt187/yWHkrNSfbr4H0yy+V0fpqJt5wpUzBi9DprAkwGKBFOqWHylJ8EyPy34V5u9YArfng==",
+        "shasum": "b9dd3a568eab791e3391db47f9e6ab91e61b13fe",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.8.tgz",
+        "fileCount": 11,
+        "unpackedSize": 181194,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJee/3fCRA9TVsSAnZWagAAzf8P/2dMh5PO1SR+CZLuGvPE\nOcR9dd4+epUcIgK6antdYjzMm+HHHMTnObyS523wd9Xm2nWLNDI70nSNHUbn\nxIjlGp9o+NMtvv0RnKKkG+xnlidfrkt7SVvlVzr5D65m6UNxp8bP01KElCNh\nqkAO7ipVYFhzEWFbFJWljN9kR1mCSp4qpL+vTn1wn8xSryYH/+ZRc8rBBlCA\nzBUfx3cQAaH8fy6Cij/bzTdcGWqucBrTP6wgRZca3EDKaOhC8JSf072ISqZM\nAwIUANiYZKPGDv5AUh2T1C8jG4tKdoROr9iqIrsHn9iW8Ppk5R4odblZtDNW\nhROzSfS7i5lFZFxhMZCnrV5aN/zbBiRtMIpFGns0EYWd07l5fMRA817ItntM\nbBZB4MJBH91SoTonBg8Elo5oE9428kdHDKiNi+eK6C3ndqAE0KzgeOIBmol4\n4V3Q4/v6MxSAjGWO9Kw3wKjpCJ4B3LV3F4NwKGHDQlWidkCKQOFg5ylCmDcw\n+7z8/GeahapeWRtkifAhavX0rNYiRUjrgY0yeR98YFOg1K4yvYSXxbY4Xv2B\nWqxikjXqPXk6PavumvJizunzxGVKfOpiQ6XFcIkpfIEJ3JRfU8LUgx+EhAIq\nB35/nbzY8E3f3RCINhqV3y+rBsHhPmnElCASaL5iO5A9CaltyfyZPA+ciMS4\neKlV\r\n=P2Q8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jasnell@gmail.com",
+          "name": "jasnell"
+        },
+        {
+          "email": "mikeal.rogers@gmail.com",
+          "name": "mikeal"
+        }
+      ],
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/express_5.0.0-alpha.8_1585184222586_0.14737233815620043"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "jasnell@gmail.com",
+      "name": "jasnell"
+    },
+    {
+      "email": "mikeal.rogers@gmail.com",
+      "name": "mikeal"
+    }
+  ],
+  "author": {
+    "name": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca"
+  },
+  "time": {
+    "modified": "2020-11-06T02:46:30.572Z",
+    "created": "2010-12-29T19:38:25.450Z",
+    "0.14.0": "2010-12-29T19:38:25.450Z",
+    "0.14.1": "2010-12-29T19:38:25.450Z",
+    "1.0.0beta": "2010-12-29T19:38:25.450Z",
+    "1.0.0beta2": "2010-12-29T19:38:25.450Z",
+    "1.0.0rc": "2010-12-29T19:38:25.450Z",
+    "1.0.0rc2": "2010-12-29T19:38:25.450Z",
+    "1.0.0rc3": "2010-12-29T19:38:25.450Z",
+    "1.0.0rc4": "2010-12-29T19:38:25.450Z",
+    "1.0.0": "2010-12-29T19:38:25.450Z",
+    "1.0.1": "2010-12-29T19:38:25.450Z",
+    "1.0.2": "2011-01-11T02:09:30.004Z",
+    "1.0.3": "2011-01-13T22:09:07.840Z",
+    "1.0.4": "2011-02-05T19:13:15.043Z",
+    "1.0.5": "2011-02-05T19:16:30.839Z",
+    "1.0.6": "2011-02-07T21:45:32.271Z",
+    "1.0.7": "2011-02-07T22:26:51.313Z",
+    "2.0.0-pre": "2011-02-21T21:46:44.987Z",
+    "1.0.8": "2011-03-02T02:58:14.314Z",
+    "2.0.0beta": "2011-03-04T00:19:22.568Z",
+    "2.0.0beta2": "2011-03-07T17:40:46.229Z",
+    "2.0.0beta3": "2011-03-09T23:46:02.495Z",
+    "2.0.0rc": "2011-03-14T22:01:43.971Z",
+    "2.0.0rc2": "2011-03-17T18:01:26.604Z",
+    "2.0.0rc3": "2011-03-17T20:02:05.880Z",
+    "2.0.0": "2011-03-18T01:06:40.271Z",
+    "2.1.0": "2011-03-24T20:47:46.219Z",
+    "2.1.1": "2011-03-29T17:40:33.337Z",
+    "2.2.0": "2011-03-30T18:40:56.080Z",
+    "2.2.1": "2011-04-04T19:23:50.483Z",
+    "2.2.2": "2011-04-12T09:44:57.909Z",
+    "2.3.0": "2011-04-25T16:50:01.384Z",
+    "2.3.1": "2011-04-26T22:26:27.392Z",
+    "2.3.2": "2011-04-27T16:13:33.518Z",
+    "2.3.3": "2011-05-03T18:31:39.123Z",
+    "2.3.4": "2011-05-08T17:54:04.615Z",
+    "2.3.5": "2011-05-20T02:07:37.117Z",
+    "2.3.6": "2011-05-20T16:42:09.750Z",
+    "2.3.7": "2011-05-23T22:54:25.787Z",
+    "2.3.8": "2011-05-25T04:53:16.574Z",
+    "2.3.9": "2011-05-25T17:18:34.557Z",
+    "2.3.10": "2011-05-27T16:20:13.495Z",
+    "2.3.11": "2011-06-04T17:51:29.978Z",
+    "2.3.12": "2011-06-22T20:56:29.997Z",
+    "2.4.0": "2011-06-28T16:41:30.571Z",
+    "2.4.1": "2011-07-06T16:57:15.476Z",
+    "2.4.2": "2011-07-07T03:15:52.511Z",
+    "2.4.3": "2011-07-14T19:58:45.646Z",
+    "2.4.4": "2011-08-05T11:30:40.300Z",
+    "2.4.5": "2011-08-19T17:13:10.685Z",
+    "2.4.6": "2011-08-22T17:20:21.180Z",
+    "2.4.7": "2011-10-05T22:42:01.025Z",
+    "2.5.0": "2011-10-24T23:01:02.271Z",
+    "2.5.1": "2011-11-18T16:04:40.126Z",
+    "2.5.2": "2011-12-10T19:09:42.049Z",
+    "2.5.3": "2011-12-30T23:31:24.241Z",
+    "2.5.4": "2012-01-02T16:36:02.493Z",
+    "2.5.5": "2012-01-08T20:31:55.978Z",
+    "2.5.6": "2012-01-13T23:40:26.942Z",
+    "2.5.7": "2012-02-06T18:06:55.405Z",
+    "2.5.8": "2012-02-08T20:08:32.863Z",
+    "2.5.9": "2012-04-03T02:21:28.801Z",
+    "3.0.0alpha1": "2012-04-20T01:52:04.759Z",
+    "3.0.0alpha2": "2012-04-28T23:49:44.341Z",
+    "3.0.0alpha3": "2012-05-08T00:59:57.918Z",
+    "3.0.0alpha4": "2012-05-11T00:11:58.696Z",
+    "3.0.0alpha5": "2012-05-30T23:48:32.953Z",
+    "3.0.0beta1": "2012-06-01T19:27:26.608Z",
+    "3.0.0beta2": "2012-06-06T21:47:02.734Z",
+    "3.0.0beta3": "2012-06-15T18:40:57.491Z",
+    "2.5.10": "2012-06-15T22:51:26.681Z",
+    "3.0.0beta4": "2012-06-27T20:42:23.155Z",
+    "2.5.11": "2012-07-04T18:24:06.584Z",
+    "3.0.0beta5": "2012-07-03T17:20:29.622Z",
+    "3.0.0beta6": "2012-07-13T16:19:35.230Z",
+    "3.0.0beta7": "2012-07-17T02:28:35.931Z",
+    "3.0.0rc1": "2012-07-24T20:33:00.953Z",
+    "3.0.0rc2": "2012-08-03T20:33:05.751Z",
+    "3.0.0rc3": "2012-08-14T03:24:13.107Z",
+    "3.0.0rc4": "2012-08-31T05:13:49.677Z",
+    "3.0.0rc5": "2012-10-09T15:44:52.115Z",
+    "3.0.0": "2012-10-23T22:30:10.025Z",
+    "3.0.1": "2012-11-02T00:27:52.006Z",
+    "3.0.2": "2012-11-08T17:15:53.794Z",
+    "3.0.3": "2012-11-13T17:13:59.443Z",
+    "3.0.4": "2012-12-06T01:10:32.144Z",
+    "3.0.5": "2012-12-19T21:45:36.784Z",
+    "3.0.6": "2013-01-05T02:51:07.217Z",
+    "3.1.0": "2013-01-26T04:27:35.979Z",
+    "3.1.1": "2013-04-01T18:26:15.149Z",
+    "3.1.2": "2013-04-12T19:14:26.989Z",
+    "3.2.0": "2013-04-15T19:35:06.932Z",
+    "3.2.1": "2013-04-30T02:17:29.901Z",
+    "3.2.2": "2013-05-03T19:55:21.494Z",
+    "3.2.3": "2013-05-07T14:55:36.616Z",
+    "3.2.4": "2013-05-09T16:18:31.698Z",
+    "3.2.5": "2013-05-22T04:02:26.880Z",
+    "3.2.6": "2013-06-03T00:15:56.897Z",
+    "3.3.0": "2013-06-26T17:07:53.250Z",
+    "3.3.1": "2013-06-27T15:32:58.392Z",
+    "3.3.2": "2013-07-03T18:25:57.781Z",
+    "3.3.3": "2013-07-04T20:40:14.018Z",
+    "3.3.4": "2013-07-08T21:42:52.735Z",
+    "3.3.5": "2013-08-10T21:51:21.087Z",
+    "3.3.6": "2013-08-27T20:49:22.441Z",
+    "3.3.7": "2013-08-28T17:04:42.417Z",
+    "1.0.0-beta": "2013-08-28T17:04:36.588Z",
+    "1.0.0-beta2": "2013-08-28T17:04:36.588Z",
+    "1.0.0-rc": "2013-08-28T17:04:36.588Z",
+    "1.0.0-rc2": "2013-08-28T17:04:36.588Z",
+    "1.0.0-rc3": "2013-08-28T17:04:36.588Z",
+    "1.0.0-rc4": "2013-08-28T17:04:36.588Z",
+    "2.0.0-beta": "2013-08-28T17:04:36.588Z",
+    "2.0.0-beta2": "2013-08-28T17:04:36.588Z",
+    "2.0.0-beta3": "2013-08-28T17:04:36.588Z",
+    "2.0.0-rc": "2013-08-28T17:04:36.588Z",
+    "2.0.0-rc2": "2013-08-28T17:04:36.588Z",
+    "2.0.0-rc3": "2013-08-28T17:04:36.588Z",
+    "3.0.0-alpha1": "2013-08-28T17:04:36.588Z",
+    "3.0.0-alpha2": "2013-08-28T17:04:36.588Z",
+    "3.0.0-alpha3": "2013-08-28T17:04:36.588Z",
+    "3.0.0-alpha4": "2013-08-28T17:04:36.588Z",
+    "3.0.0-alpha5": "2013-08-28T17:04:36.588Z",
+    "3.0.0-beta1": "2013-08-28T17:04:36.588Z",
+    "3.0.0-beta2": "2013-08-28T17:04:36.588Z",
+    "3.0.0-beta3": "2013-08-28T17:04:36.588Z",
+    "3.0.0-beta4": "2013-08-28T17:04:36.588Z",
+    "3.0.0-beta6": "2013-08-28T17:04:36.588Z",
+    "3.0.0-beta7": "2013-08-28T17:04:36.588Z",
+    "3.0.0-rc1": "2013-08-28T17:04:36.588Z",
+    "3.0.0-rc2": "2013-08-28T17:04:36.588Z",
+    "3.0.0-rc3": "2013-08-28T17:04:36.588Z",
+    "3.0.0-rc4": "2013-08-28T17:04:36.588Z",
+    "3.0.0-rc5": "2013-08-28T17:04:36.588Z",
+    "3.3.8": "2013-09-02T15:01:16.142Z",
+    "3.4.0": "2013-09-07T19:25:10.243Z",
+    "3.4.1": "2013-10-16T01:34:32.939Z",
+    "3.4.2": "2013-10-19T02:04:44.007Z",
+    "3.4.3": "2013-10-23T18:19:57.170Z",
+    "3.4.4": "2013-10-29T17:34:18.760Z",
+    "3.4.5": "2013-11-27T23:54:53.947Z",
+    "3.4.6": "2013-12-01T20:21:22.058Z",
+    "3.4.7": "2013-12-11T07:57:53.225Z",
+    "3.4.8": "2014-01-14T04:51:15.079Z",
+    "4.0.0-rc1": "2014-03-02T16:19:53.255Z",
+    "4.0.0-rc2": "2014-03-05T06:34:13.334Z",
+    "3.5.0": "2014-03-06T22:58:36.227Z",
+    "4.0.0-rc3": "2014-03-12T01:39:53.076Z",
+    "4.0.0-rc4": "2014-03-25T02:54:51.021Z",
+    "3.5.1": "2014-03-25T20:59:05.986Z",
+    "4.0.0": "2014-04-09T20:39:26.853Z",
+    "3.5.2": "2014-04-24T20:40:38.736Z",
+    "4.1.0": "2014-04-24T22:17:52.003Z",
+    "4.1.1": "2014-04-27T23:50:27.414Z",
+    "3.5.3": "2014-05-08T17:53:16.987Z",
+    "4.1.2": "2014-05-08T18:44:48.652Z",
+    "3.6.0": "2014-05-09T21:07:22.124Z",
+    "4.2.0": "2014-05-12T02:04:12.759Z",
+    "3.7.0": "2014-05-18T14:42:22.970Z",
+    "3.8.0": "2014-05-21T06:08:40.496Z",
+    "4.3.0": "2014-05-21T06:14:40.424Z",
+    "4.3.1": "2014-05-23T23:12:59.820Z",
+    "3.8.1": "2014-05-28T03:43:39.629Z",
+    "4.3.2": "2014-05-29T04:20:38.007Z",
+    "3.9.0": "2014-05-31T01:38:23.252Z",
+    "4.4.0": "2014-05-31T04:02:21.301Z",
+    "4.4.1": "2014-06-03T01:27:48.550Z",
+    "3.10.0": "2014-06-03T04:42:47.299Z",
+    "3.10.1": "2014-06-03T21:19:53.358Z",
+    "3.10.2": "2014-06-04T01:36:31.574Z",
+    "3.10.3": "2014-06-06T03:41:14.284Z",
+    "3.10.4": "2014-06-09T22:56:08.589Z",
+    "4.4.2": "2014-06-10T00:43:04.926Z",
+    "3.10.5": "2014-06-12T04:36:07.939Z",
+    "4.4.3": "2014-06-12T04:42:49.755Z",
+    "3.11.0": "2014-06-20T03:43:59.969Z",
+    "4.4.4": "2014-06-20T21:13:47.878Z",
+    "3.12.0": "2014-06-22T02:35:24.439Z",
+    "3.12.1": "2014-06-27T00:19:58.083Z",
+    "4.4.5": "2014-06-27T03:54:22.452Z",
+    "3.13.0": "2014-07-04T05:08:17.751Z",
+    "4.5.0": "2014-07-05T01:04:36.156Z",
+    "4.5.1": "2014-07-06T23:47:58.312Z",
+    "3.14.0": "2014-07-11T17:31:04.739Z",
+    "4.6.0": "2014-07-12T03:40:29.872Z",
+    "4.6.1": "2014-07-13T02:19:51.397Z",
+    "3.15.0": "2014-07-23T05:08:16.821Z",
+    "4.7.0": "2014-07-26T01:34:51.642Z",
+    "3.15.1": "2014-07-26T21:50:06.966Z",
+    "4.7.1": "2014-07-26T23:02:44.448Z",
+    "3.15.2": "2014-07-27T19:55:02.602Z",
+    "4.7.2": "2014-07-27T20:02:46.467Z",
+    "4.7.3": "2014-08-04T20:13:29.114Z",
+    "3.15.3": "2014-08-04T22:25:19.592Z",
+    "4.7.4": "2014-08-04T22:25:30.807Z",
+    "3.16.0": "2014-08-06T05:39:52.833Z",
+    "4.8.0": "2014-08-06T06:50:05.516Z",
+    "3.16.1": "2014-08-06T22:06:59.615Z",
+    "4.8.1": "2014-08-06T22:20:06.968Z",
+    "3.16.2": "2014-08-07T15:58:53.103Z",
+    "4.8.2": "2014-08-07T16:04:06.418Z",
+    "3.16.3": "2014-08-08T02:31:12.394Z",
+    "3.16.4": "2014-08-11T02:22:05.422Z",
+    "4.8.3": "2014-08-11T02:29:06.849Z",
+    "3.16.5": "2014-08-12T02:29:20.292Z",
+    "3.16.6": "2014-08-15T03:52:36.175Z",
+    "4.8.4": "2014-08-15T04:25:24.580Z",
+    "3.16.7": "2014-08-19T02:45:51.457Z",
+    "4.8.5": "2014-08-19T03:05:35.447Z",
+    "3.16.8": "2014-08-28T01:17:12.818Z",
+    "4.8.6": "2014-08-28T01:52:46.246Z",
+    "3.16.9": "2014-08-30T05:23:37.535Z",
+    "4.8.7": "2014-08-30T05:37:53.120Z",
+    "3.16.10": "2014-09-05T06:16:49.692Z",
+    "4.8.8": "2014-09-05T06:25:37.392Z",
+    "3.17.0": "2014-09-09T03:22:41.705Z",
+    "3.17.1": "2014-09-09T03:48:36.412Z",
+    "4.9.0": "2014-09-09T04:33:18.960Z",
+    "3.17.2": "2014-09-16T07:18:56.609Z",
+    "4.9.1": "2014-09-17T06:54:31.479Z",
+    "4.9.2": "2014-09-18T03:52:10.190Z",
+    "3.17.3": "2014-09-18T17:40:22.718Z",
+    "4.9.3": "2014-09-18T17:45:34.733Z",
+    "3.17.4": "2014-09-20T06:02:17.235Z",
+    "4.9.4": "2014-09-20T06:07:23.529Z",
+    "3.17.5": "2014-09-24T23:41:41.338Z",
+    "4.9.5": "2014-09-25T00:24:49.436Z",
+    "3.17.6": "2014-10-03T04:05:10.920Z",
+    "3.17.7": "2014-10-08T21:22:35.229Z",
+    "4.9.6": "2014-10-09T02:35:55.395Z",
+    "4.9.7": "2014-10-10T20:43:34.045Z",
+    "3.17.8": "2014-10-16T04:36:53.277Z",
+    "4.9.8": "2014-10-18T02:05:05.528Z",
+    "3.18.0": "2014-10-18T05:10:21.951Z",
+    "3.18.1": "2014-10-23T05:30:25.689Z",
+    "4.10.0": "2014-10-24T02:36:30.641Z",
+    "3.18.2": "2014-10-29T05:14:04.974Z",
+    "4.10.1": "2014-10-29T05:21:08.596Z",
+    "5.0.0-alpha.1": "2014-11-07T02:54:34.556Z",
+    "3.18.3": "2014-11-09T23:38:00.888Z",
+    "4.10.2": "2014-11-10T00:10:27.638Z",
+    "3.18.4": "2014-11-23T20:52:49.813Z",
+    "4.10.3": "2014-11-24T03:12:32.210Z",
+    "4.10.4": "2014-11-25T05:19:30.905Z",
+    "4.10.5": "2014-12-11T05:08:02.089Z",
+    "3.18.5": "2014-12-12T04:24:32.541Z",
+    "3.18.6": "2014-12-13T02:45:59.136Z",
+    "4.10.6": "2014-12-13T04:17:13.785Z",
+    "4.10.7": "2015-01-05T00:40:37.634Z",
+    "3.19.0": "2015-01-09T06:36:21.099Z",
+    "4.10.8": "2015-01-13T17:48:23.443Z",
+    "4.11.0": "2015-01-14T04:21:56.291Z",
+    "3.19.1": "2015-01-21T08:23:41.579Z",
+    "4.11.1": "2015-01-21T08:34:52.857Z",
+    "3.19.2": "2015-02-01T20:24:05.444Z",
+    "4.11.2": "2015-02-01T20:45:09.837Z",
+    "3.20.0": "2015-02-19T02:53:28.667Z",
+    "4.12.0": "2015-02-23T06:58:39.027Z",
+    "3.20.1": "2015-03-01T04:23:20.434Z",
+    "4.12.1": "2015-03-02T01:13:30.608Z",
+    "4.12.2": "2015-03-03T05:46:29.969Z",
+    "3.20.2": "2015-03-17T05:06:28.342Z",
+    "4.12.3": "2015-03-17T22:04:53.210Z",
+    "3.20.3": "2015-05-18T04:06:45.934Z",
+    "4.12.4": "2015-05-18T04:41:14.788Z",
+    "3.21.0": "2015-06-19T01:42:28.037Z",
+    "4.13.0": "2015-06-21T06:50:18.321Z",
+    "3.21.1": "2015-07-06T04:55:30.351Z",
+    "4.13.1": "2015-07-06T05:42:59.627Z",
+    "5.0.0-alpha.2": "2015-07-07T05:46:20.081Z",
+    "3.21.2": "2015-07-31T20:17:34.079Z",
+    "4.13.2": "2015-07-31T21:10:49.838Z",
+    "4.13.3": "2015-08-03T05:04:40.888Z",
+    "4.13.4": "2016-01-22T02:15:21.453Z",
+    "4.14.0": "2016-06-16T16:43:30.648Z",
+    "4.14.1": "2017-01-28T22:33:15.950Z",
+    "5.0.0-alpha.3": "2017-01-29T03:28:41.274Z",
+    "4.15.0": "2017-03-01T22:28:55.984Z",
+    "5.0.0-alpha.4": "2017-03-02T00:30:07.791Z",
+    "4.15.1": "2017-03-06T05:08:33.474Z",
+    "4.15.2": "2017-03-06T13:42:44.853Z",
+    "5.0.0-alpha.5": "2017-03-06T13:51:05.877Z",
+    "4.15.3": "2017-05-17T14:17:40.516Z",
+    "4.15.4": "2017-08-07T02:12:12.791Z",
+    "4.15.5": "2017-09-25T05:25:16.528Z",
+    "5.0.0-alpha.6": "2017-09-25T05:32:38.266Z",
+    "4.16.0": "2017-09-28T18:22:30.775Z",
+    "4.16.1": "2017-09-29T20:38:43.661Z",
+    "4.16.2": "2017-10-10T03:13:46.364Z",
+    "4.16.3": "2018-03-12T17:50:14.119Z",
+    "4.16.4": "2018-10-11T03:59:14.308Z",
+    "5.0.0-alpha.7": "2018-10-27T03:12:11.060Z",
+    "4.17.0": "2019-05-17T01:57:40.690Z",
+    "4.17.1": "2019-05-26T04:25:34.606Z",
+    "5.0.0-alpha.8": "2020-03-26T00:57:02.755Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/expressjs/express.git"
+  },
+  "users": {
+    "422303771": true,
+    "coverslide": true,
+    "gevorg": true,
+    "kwerty": true,
+    "wojohowitz": true,
+    "danmilon": true,
+    "puerkitobio": true,
+    "raoulmillais": true,
+    "mvolkmann": true,
+    "pid": true,
+    "naholyr": true,
+    "troygoode": true,
+    "shawnb576": true,
+    "linus": true,
+    "vasc": true,
+    "tomgallacher": true,
+    "qbert65536": true,
+    "guybrush": true,
+    "dodo": true,
+    "adamalex": true,
+    "lwille": true,
+    "bat": true,
+    "sunny": true,
+    "mbrevoort": true,
+    "airportyh": true,
+    "qbit": true,
+    "hyqhyq_3": true,
+    "langpavel": true,
+    "kevinohara80": true,
+    "yazgazan": true,
+    "alejandromg": true,
+    "tootallnate": true,
+    "kislitsyn": true,
+    "tellnes": true,
+    "enome": true,
+    "nornalbion": true,
+    "thlorenz": true,
+    "lovebug356": true,
+    "dolphin278": true,
+    "vrtak-cz": true,
+    "sjonnet": true,
+    "aaron": true,
+    "vincent": true,
+    "coiscir": true,
+    "fgribreau": true,
+    "isao": true,
+    "hughsk": true,
+    "sjonnet19": true,
+    "tylerstalder": true,
+    "vtsvang": true,
+    "gillesruppert": true,
+    "xenomuta": true,
+    "alexandru.topliceanu": true,
+    "chakrit": true,
+    "maff": true,
+    "jswartwood": true,
+    "p-baleine": true,
+    "tokuhirom": true,
+    "appsunited": true,
+    "travishorn": true,
+    "drudge": true,
+    "m42am": true,
+    "fibo": true,
+    "cschram": true,
+    "vincentmac": true,
+    "holsee": true,
+    "andreychizh": true,
+    "andrewnewdigate": true,
+    "juzerali": true,
+    "bencevans": true,
+    "balderdashy": true,
+    "ivanvotti": true,
+    "chilts": true,
+    "grancalavera": true,
+    "lobo": true,
+    "vicapow": true,
+    "konklone": true,
+    "gimenete": true,
+    "parmentf": true,
+    "esp": true,
+    "bryanburgers": true,
+    "sandeepmistry": true,
+    "iv": true,
+    "ebababi": true,
+    "fiws": true,
+    "fairwinds.dp": true,
+    "ljharb": true,
+    "shtylman": true,
+    "hortinstein": true,
+    "freethenation": true,
+    "megadrive": true,
+    "fiveisprime": true,
+    "nexum": true,
+    "evanlucas": true,
+    "lupomontero": true,
+    "jpillora": true,
+    "cj.nichols": true,
+    "leesei": true,
+    "booyaa": true,
+    "ianmcburnie": true,
+    "ruzz311": true,
+    "jdavis": true,
+    "sironfoot": true,
+    "eknkc": true,
+    "maxmaximov": true,
+    "srl": true,
+    "hfcorriez": true,
+    "oroce": true,
+    "nickleefly": true,
+    "drewfolta": true,
+    "sadjow": true,
+    "stid": true,
+    "zonetti": true,
+    "cparker15": true,
+    "lemulot": true,
+    "igorissen": true,
+    "john.pinch": true,
+    "devoidfury": true,
+    "ovjang": true,
+    "bigluck": true,
+    "antonnguyen": true,
+    "cedrickchee": true,
+    "paulj": true,
+    "cmilhench": true,
+    "trylobot": true,
+    "elgs": true,
+    "coroneos": true,
+    "nak2k": true,
+    "jmar777": true,
+    "zaphod1984": true,
+    "mcwhittemore": true,
+    "klaemo": true,
+    "webpro": true,
+    "ryuugan": true,
+    "inca": true,
+    "blakeembrey": true,
+    "joliva": true,
+    "raitucarp": true,
+    "andrew12": true,
+    "victorquinn": true,
+    "chrisweb": true,
+    "cuprobot": true,
+    "apfelbox": true,
+    "ajumell": true,
+    "gableroux": true,
+    "adamrenny": true,
+    "everywhere.js": true,
+    "paolo.delmundo": true,
+    "svmatthews": true,
+    "fizerkhan": true,
+    "paazmaya": true,
+    "kubakubula": true,
+    "arash": true,
+    "ioncreature": true,
+    "aniketpant": true,
+    "tigefa": true,
+    "pana": true,
+    "spekkionu": true,
+    "mhaidarh": true,
+    "einfallstoll": true,
+    "xtopher": true,
+    "fishrock123": true,
+    "mpinteractiv": true,
+    "darosh": true,
+    "samuelrn": true,
+    "t3chnoboy": true,
+    "tpwk": true,
+    "yoavf": true,
+    "yosuke-furukawa": true,
+    "antouank": true,
+    "hypergeometric": true,
+    "gammasoft": true,
+    "villadora": true,
+    "mananvaghasiya": true,
+    "chpopov": true,
+    "youxiachai": true,
+    "deepakkapoor": true,
+    "elisee": true,
+    "joaocampinhos": true,
+    "cobaimelan": true,
+    "bredele": true,
+    "karudo": true,
+    "tam": true,
+    "oliversalzburg": true,
+    "takethefire": true,
+    "itfanr": true,
+    "leonardorb": true,
+    "paulomcnally": true,
+    "mahnunchik": true,
+    "jwyune": true,
+    "sahebjot94": true,
+    "dapadoupas": true,
+    "nickrsearcy": true,
+    "henrytseng": true,
+    "themiddleman": true,
+    "ddo": true,
+    "nosch": true,
+    "jacques": true,
+    "reekdeb": true,
+    "marshallswain": true,
+    "oddjobsman": true,
+    "jorgemsrs": true,
+    "pwaleczek": true,
+    "webjay": true,
+    "patmcc": true,
+    "mdemo": true,
+    "briandemant": true,
+    "mike-feldmeier": true,
+    "freebaser": true,
+    "rabchev": true,
+    "gazzwi86": true,
+    "aselzer": true,
+    "aminrx": true,
+    "nazomikan": true,
+    "haruths": true,
+    "priyaranjan": true,
+    "kentcdodds": true,
+    "mikestopcontinues": true,
+    "crabb": true,
+    "leodutra": true,
+    "powerplex": true,
+    "green_goo": true,
+    "utils": true,
+    "mackenziestarr": true,
+    "fourq": true,
+    "gustavorps": true,
+    "zerious": true,
+    "codykm": true,
+    "rrobayna": true,
+    "brentlintner": true,
+    "nathanboktae": true,
+    "dhenderson": true,
+    "elwafdy": true,
+    "catesandrew": true,
+    "vlain": true,
+    "aliem": true,
+    "volkanongun": true,
+    "jsdevel": true,
+    "ceram1": true,
+    "johannestegner": true,
+    "greelgorke": true,
+    "mertcna": true,
+    "brad426": true,
+    "skipzero": true,
+    "owenlancaster": true,
+    "fmm": true,
+    "nagorkin": true,
+    "coderaiser": true,
+    "ajduke": true,
+    "cbednarski": true,
+    "santimacia": true,
+    "loganallenc": true,
+    "rosterloh": true,
+    "steindaniel": true,
+    "tcskrovseth": true,
+    "hibrahimsafak": true,
+    "alexu84": true,
+    "markymark": true,
+    "evkline": true,
+    "jacoborus": true,
+    "horaci": true,
+    "nbu": true,
+    "capaj": true,
+    "biggora": true,
+    "ricardotk002": true,
+    "antoniobrandao": true,
+    "tehdb": true,
+    "phalanxia": true,
+    "ericlondon": true,
+    "csbun": true,
+    "koorchik": true,
+    "brandtabbott": true,
+    "obihann": true,
+    "wangxian": true,
+    "wadjetz": true,
+    "redmed": true,
+    "mamsori": true,
+    "funroll": true,
+    "gdbtek": true,
+    "julienfouilhe": true,
+    "roryrjb": true,
+    "leventkaragol": true,
+    "tim_rach": true,
+    "voxpelli": true,
+    "maxzhang": true,
+    "caligone": true,
+    "nchmouli": true,
+    "niccai": true,
+    "jameswarren": true,
+    "shawnzhu": true,
+    "jproulx": true,
+    "chamnap": true,
+    "gabeio": true,
+    "ericheiker": true,
+    "beyoung": true,
+    "nyakto": true,
+    "davidhalldor": true,
+    "cocopas": true,
+    "nitroduna": true,
+    "davidwbradford": true,
+    "andydrew": true,
+    "alinex": true,
+    "morkro": true,
+    "fanchangyong": true,
+    "runningtalus": true,
+    "mmierswa": true,
+    "ctesniere": true,
+    "jasonw": true,
+    "konzi": true,
+    "lone112": true,
+    "adamk": true,
+    "lspecian": true,
+    "ijin82": true,
+    "toogle": true,
+    "bcatherall": true,
+    "nba1090": true,
+    "phajej": true,
+    "gyoridavid": true,
+    "kein": true,
+    "doriel": true,
+    "iwill": true,
+    "sampsa": true,
+    "anorak": true,
+    "hacksparrow": true,
+    "nmrugg": true,
+    "uris77": true,
+    "azat": true,
+    "lifeuser": true,
+    "fill": true,
+    "juriwiens": true,
+    "matteospampani": true,
+    "sosana": true,
+    "zeusdeux": true,
+    "dabielf": true,
+    "bohacc": true,
+    "holic": true,
+    "alekzzz": true,
+    "mjvestal": true,
+    "gaborsar": true,
+    "nromano": true,
+    "oliboy50": true,
+    "agent_9191": true,
+    "inta": true,
+    "djbrandl": true,
+    "davidchase": true,
+    "edalorzo": true,
+    "jakub.knejzlik": true,
+    "tiger2wander": true,
+    "afollestad": true,
+    "yan_te": true,
+    "scriptnull": true,
+    "beth_rogers465": true,
+    "freshwork": true,
+    "sithengineer": true,
+    "majdi": true,
+    "joshmu": true,
+    "zacbarton": true,
+    "josephdavisco": true,
+    "davidrlee": true,
+    "ambdxtrch": true,
+    "matthewbschneider": true,
+    "ramanshalupau": true,
+    "faustman": true,
+    "dizlexik": true,
+    "japh": true,
+    "onuma1004": true,
+    "janez89": true,
+    "guyellis": true,
+    "michaeljcalkins": true,
+    "nohponex": true,
+    "dennispassway": true,
+    "agaskill": true,
+    "joelbair": true,
+    "travelingtechguy": true,
+    "dejanr": true,
+    "dutchmansa": true,
+    "christophwitzko": true,
+    "thitinun": true,
+    "scull7": true,
+    "pilsy": true,
+    "markcancellieri": true,
+    "mkdarkness": true,
+    "pawerda": true,
+    "olson.dev": true,
+    "arrc": true,
+    "strangemother": true,
+    "flupe": true,
+    "tonchmx": true,
+    "tmypawa": true,
+    "tonijz": true,
+    "tsangint": true,
+    "brunolemos": true,
+    "nodecode": true,
+    "dercoder": true,
+    "tmn": true,
+    "aabrego": true,
+    "leighakin": true,
+    "dofy": true,
+    "aliaseldhose": true,
+    "boustanihani": true,
+    "corefive": true,
+    "mr.raindrop": true,
+    "iamontheinet": true,
+    "hellocodeming": true,
+    "ricardofbarros": true,
+    "ryanthejuggler": true,
+    "mswanson1524": true,
+    "alxe.master": true,
+    "mehranhatami": true,
+    "moxiaohe": true,
+    "truongpv": true,
+    "wangxu88323": true,
+    "kxbrand": true,
+    "xiaokai": true,
+    "venjee": true,
+    "jmorris": true,
+    "danielrohers": true,
+    "goblindegook": true,
+    "orion-": true,
+    "atd": true,
+    "davidepedone": true,
+    "alex.hortopan": true,
+    "fran.tr": true,
+    "vipxjb": true,
+    "synchronous": true,
+    "rifaqat": true,
+    "hyperian-chairman": true,
+    "ieb": true,
+    "hex7c0": true,
+    "sinaghazi": true,
+    "zhaoyou": true,
+    "nischi": true,
+    "bluejeansandrain": true,
+    "sroccaserra": true,
+    "bjrmatos": true,
+    "lantrix": true,
+    "yourhoneysky": true,
+    "madou": true,
+    "zlatip": true,
+    "dennisgnl": true,
+    "ricardopereira": true,
+    "bmpvieira": true,
+    "nelsonaba": true,
+    "akshayp": true,
+    "jonathandion": true,
+    "thebearingedge": true,
+    "leon.domingo": true,
+    "eliagrady": true,
+    "t1st3": true,
+    "jits": true,
+    "tcauduro": true,
+    "tpei": true,
+    "hemphillcc": true,
+    "olso": true,
+    "writech": true,
+    "pmdroid": true,
+    "navarroaxel": true,
+    "diosney": true,
+    "llambda": true,
+    "jeffersonwilliammachado": true,
+    "mtscout6": true,
+    "guumaster": true,
+    "gejiawen": true,
+    "karmadude": true,
+    "kungkk": true,
+    "zolern": true,
+    "henryfour": true,
+    "bkimminich": true,
+    "louxiaojian": true,
+    "mnova": true,
+    "cyberien": true,
+    "adagio": true,
+    "atheken": true,
+    "formix": true,
+    "salvatorelab": true,
+    "jesus81": true,
+    "marcuspoehls": true,
+    "sofiarose": true,
+    "sir79": true,
+    "r3nya": true,
+    "snekse": true,
+    "lestoni": true,
+    "guisouza": true,
+    "xjhznick": true,
+    "marinangelo": true,
+    "hartzis": true,
+    "tsavela": true,
+    "glencfl": true,
+    "sjoenh": true,
+    "crissdev": true,
+    "jovenbarola": true,
+    "lbrentcarpenter": true,
+    "shawn_ljw": true,
+    "quintonparker": true,
+    "co3moz": true,
+    "raidou": true,
+    "ajsnapshots": true,
+    "marksyzm": true,
+    "smalesys": true,
+    "trycatch9264": true,
+    "kewin": true,
+    "sevisilex": true,
+    "sarwan": true,
+    "drscript": true,
+    "hemanth": true,
+    "wxnet": true,
+    "blog": true,
+    "kyr": true,
+    "myschool": true,
+    "krisbarrett": true,
+    "oakley349": true,
+    "sergiodxa": true,
+    "byossarian": true,
+    "danielhuisman": true,
+    "claus": true,
+    "dimitriwalters": true,
+    "justindmassey": true,
+    "davidfmiller": true,
+    "mitica": true,
+    "ajk": true,
+    "juliuss": true,
+    "gregvanbrug": true,
+    "ataiemajid_63": true,
+    "piotr23": true,
+    "devlaundry": true,
+    "shaomq": true,
+    "dgarlitt": true,
+    "congcong": true,
+    "jostw": true,
+    "kingcron": true,
+    "yuvalziegler": true,
+    "spiros.politis": true,
+    "peterjlord": true,
+    "song940": true,
+    "yhnavein": true,
+    "ivangaravito": true,
+    "blackmagic": true,
+    "steventhuriot": true,
+    "ali1k": true,
+    "zolomon": true,
+    "ffphp": true,
+    "mavenave": true,
+    "dnedev": true,
+    "knight-of-design": true,
+    "mihaiv": true,
+    "swak": true,
+    "rcijvat": true,
+    "vernak2539": true,
+    "cath": true,
+    "swmoon203": true,
+    "birkestroem": true,
+    "dearyhud": true,
+    "themanspeaker": true,
+    "jamhall": true,
+    "yerke": true,
+    "eddieajau": true,
+    "clintonc": true,
+    "jisbert": true,
+    "kasperstuck": true,
+    "stennettm": true,
+    "victorxw": true,
+    "jrbedard": true,
+    "kodamatic": true,
+    "richarddavenport": true,
+    "thorsson": true,
+    "vmichalak": true,
+    "larixk": true,
+    "irfan3": true,
+    "hollobit": true,
+    "dwayneford": true,
+    "rgraves90": true,
+    "akarzim": true,
+    "kaiquewdev": true,
+    "satoyami": true,
+    "magemagic": true,
+    "kenjisan4u": true,
+    "thiagomata": true,
+    "ikoala": true,
+    "whirlwin": true,
+    "chrisayn": true,
+    "pythonic": true,
+    "tomas-sereikis": true,
+    "eterna2": true,
+    "cdubois": true,
+    "mnemr": true,
+    "pedrozgz": true,
+    "yaniv": true,
+    "jurgis": true,
+    "rkazakov": true,
+    "mr.d": true,
+    "melias": true,
+    "pillar0514": true,
+    "masonwan": true,
+    "tudou": true,
+    "azder": true,
+    "cdokolas": true,
+    "jeanpokou": true,
+    "tjhart": true,
+    "dhuyvetter": true,
+    "damienp33": true,
+    "yunfour": true,
+    "dvk": true,
+    "tsm91": true,
+    "rckbt": true,
+    "seldo": true,
+    "stephenhowells": true,
+    "evanhahn": true,
+    "absurdusadeptus": true,
+    "chesleybrown": true,
+    "ziehlke": true,
+    "thomasfr": true,
+    "sushant711": true,
+    "trevin": true,
+    "carloscarcamo": true,
+    "danj": true,
+    "octod": true,
+    "gaboo": true,
+    "n370": true,
+    "vivangkumar": true,
+    "elliotchong": true,
+    "scotttesler": true,
+    "f124275809": true,
+    "nmrony": true,
+    "didelco": true,
+    "fank": true,
+    "lucasmciruzzi": true,
+    "codematix": true,
+    "romaincausse": true,
+    "meme": true,
+    "aitorllj93": true,
+    "jimster305": true,
+    "frknbasaran": true,
+    "agtlucas": true,
+    "farukscan": true,
+    "alexandermac": true,
+    "chrisdevwords": true,
+    "sangallimarco": true,
+    "stpettersens": true,
+    "clunt": true,
+    "kh3phr3n": true,
+    "dlpowless": true,
+    "stuligan": true,
+    "kikar": true,
+    "liujiajia": true,
+    "sametsisartenep": true,
+    "xavierharrell": true,
+    "earthling0": true,
+    "ageorgios": true,
+    "valeriu-zdrobau": true,
+    "fdaciuk": true,
+    "moe.duffdude": true,
+    "ayoungh": true,
+    "crewmoss": true,
+    "nadimix": true,
+    "mendlik": true,
+    "amovah": true,
+    "clhenrick": true,
+    "haeck": true,
+    "pnevares": true,
+    "bausmeier": true,
+    "benoror": true,
+    "jvivs": true,
+    "andreaspag": true,
+    "brentchow": true,
+    "ferrari": true,
+    "x_soth": true,
+    "wheredevel": true,
+    "servicesolahart": true,
+    "melvingruesbeck": true,
+    "hal9zillion": true,
+    "phoward8020": true,
+    "itsnauman": true,
+    "zerodi": true,
+    "j3kz": true,
+    "mykhael": true,
+    "sija": true,
+    "drdanryan": true,
+    "flockonus": true,
+    "theodor.lindekaer": true,
+    "thunsaker": true,
+    "klarence1": true,
+    "sobering": true,
+    "radjivf": true,
+    "aburczy": true,
+    "mubaidr": true,
+    "gregjopa": true,
+    "vchouhan": true,
+    "danielsd10": true,
+    "rebugger": true,
+    "noddycha": true,
+    "evo2mind": true,
+    "kulakowka": true,
+    "gbabula": true,
+    "mccarter": true,
+    "hexkode": true,
+    "goodseller": true,
+    "sevcanalkan": true,
+    "ysk8": true,
+    "rchanaud": true,
+    "marco.jahn": true,
+    "anmol1771": true,
+    "zemgalis": true,
+    "kachar": true,
+    "mispidis": true,
+    "joeyblue": true,
+    "justintormey": true,
+    "manxisuo": true,
+    "jimrobs": true,
+    "fwhenin": true,
+    "jaa": true,
+    "jahnestacado": true,
+    "nei": true,
+    "sahilsk": true,
+    "ximex": true,
+    "joaocunha": true,
+    "safinalexey": true,
+    "tchcxp": true,
+    "mnlfischer": true,
+    "lifecube": true,
+    "labithiotis": true,
+    "cannobbio": true,
+    "broxmgs": true,
+    "dpkg": true,
+    "fabianbach": true,
+    "plord": true,
+    "trigu": true,
+    "chrisfrancis27": true,
+    "shinyweb": true,
+    "docksteaderluke": true,
+    "truonghuutien": true,
+    "brecht": true,
+    "vboctor": true,
+    "alexey_detr": true,
+    "vishnuvathsan": true,
+    "barenko": true,
+    "brogrammer": true,
+    "drewigg": true,
+    "jamescostian": true,
+    "asawq2006": true,
+    "warapitiya": true,
+    "koulmomo": true,
+    "plechazunga": true,
+    "alphavibe": true,
+    "visormatt": true,
+    "borjes": true,
+    "mukundbhudia": true,
+    "nicekiwi": true,
+    "season19840122": true,
+    "keeyanajones": true,
+    "blitzprog": true,
+    "ftornik": true,
+    "subchen": true,
+    "simplyianm": true,
+    "martijn-van-beek": true,
+    "austinkeeley": true,
+    "risyasin": true,
+    "paeblits": true,
+    "novium": true,
+    "epuigvros": true,
+    "hephaestus": true,
+    "rbartoli": true,
+    "mp2526": true,
+    "sreeram7": true,
+    "session": true,
+    "nateth": true,
+    "hallaji": true,
+    "jmshahen": true,
+    "gsholtz": true,
+    "itonyyo": true,
+    "mistertakaashi": true,
+    "mathiasgilson": true,
+    "colscript": true,
+    "parkerproject": true,
+    "temasm": true,
+    "hagb4rd": true,
+    "damer": true,
+    "chrisdeaton": true,
+    "duanlinfei": true,
+    "frozzerrer": true,
+    "ckaatz": true,
+    "chadwatson": true,
+    "dockawash": true,
+    "vitaly.tomilov": true,
+    "bradcozine": true,
+    "alejcerro": true,
+    "josuehenry14": true,
+    "marcghorayeb": true,
+    "sm0ck1": true,
+    "kilpiban": true,
+    "pengzhisun": true,
+    "npm.acxiom.yuyu": true,
+    "markthethomas": true,
+    "samsingh": true,
+    "anticom": true,
+    "godion": true,
+    "codefoster": true,
+    "du2b": true,
+    "alemohamad": true,
+    "kai_": true,
+    "oheard": true,
+    "montyanderson": true,
+    "jarvis.ji": true,
+    "mkiser": true,
+    "dcondrey": true,
+    "lupideo": true,
+    "reecegoddard": true,
+    "yvesroos": true,
+    "rockbottestboom100": true,
+    "yjsosa": true,
+    "ernie55ernie": true,
+    "makediff": true,
+    "tfentonz": true,
+    "rsp": true,
+    "dac2205": true,
+    "tmcguire": true,
+    "famousgarkin": true,
+    "qqqppp9998": true,
+    "dlaume": true,
+    "rajibbrunel": true,
+    "felipemena1": true,
+    "sua": true,
+    "subnormal": true,
+    "iamwiz": true,
+    "castasamu": true,
+    "leyyinad": true,
+    "tagkiller": true,
+    "wfsm": true,
+    "wildsky": true,
+    "jasoncmcg": true,
+    "chong.john": true,
+    "erincinci": true,
+    "dolymood": true,
+    "y-a-v-a": true,
+    "sanketss84": true,
+    "brandondoran": true,
+    "thom_nic": true,
+    "gabrielsanterre": true,
+    "yasirmturk": true,
+    "leidottw": true,
+    "saravananr": true,
+    "cabrinha98": true,
+    "ishitcno1": true,
+    "junjiansyu": true,
+    "damianof": true,
+    "jimkropa": true,
+    "joris-van-der-wel": true,
+    "nmadd": true,
+    "jeseab": true,
+    "scottkay": true,
+    "nxtonic": true,
+    "alexleventer": true,
+    "thefriendlydev": true,
+    "plitat": true,
+    "buzuli": true,
+    "chriscorwin": true,
+    "brandouellette": true,
+    "defunctzombie": true,
+    "ivansky": true,
+    "cdll": true,
+    "aliemre": true,
+    "disheart": true,
+    "chaseshu": true,
+    "mschot": true,
+    "gokaygurcan": true,
+    "maysay": true,
+    "thepanuto": true,
+    "jprempeh": true,
+    "maskedcoder": true,
+    "abdullahceylan": true,
+    "raczo": true,
+    "elrolito": true,
+    "phyllipe": true,
+    "avence12": true,
+    "developers-loginradius": true,
+    "mfunkie": true,
+    "mauperruolo": true,
+    "duchenerc": true,
+    "glider": true,
+    "sharp": true,
+    "django.janny": true,
+    "mjaczynski": true,
+    "jyounce": true,
+    "sezgin": true,
+    "manten": true,
+    "nickmeldrum": true,
+    "sewillia": true,
+    "tzsiga": true,
+    "cestrensem": true,
+    "denistv": true,
+    "wkaifang": true,
+    "lionft": true,
+    "donkanee": true,
+    "johnny.young": true,
+    "saravntbe": true,
+    "thecodeparadox": true,
+    "bpatel": true,
+    "falbarp": true,
+    "lmhs": true,
+    "program247365": true,
+    "mano.rajesh": true,
+    "norman784": true,
+    "nlukyanchuk": true,
+    "adamkdean": true,
+    "mohankethees": true,
+    "mattms": true,
+    "mezeitamas": true,
+    "tamer1an": true,
+    "gabrielscindian": true,
+    "pcac": true,
+    "yxqme": true,
+    "buzzalderaan": true,
+    "walkerbe": true,
+    "nicastelo": true,
+    "saquibofficial": true,
+    "donvercety": true,
+    "akash_shah": true,
+    "lassevolkmann": true,
+    "leoyzy": true,
+    "stretchgz": true,
+    "keanodejs": true,
+    "fvcproductions": true,
+    "makenova": true,
+    "shaddyhm": true,
+    "gilbarbara": true,
+    "nonoroazoro": true,
+    "kurtz1993": true,
+    "imatveev": true,
+    "amaynut": true,
+    "jshaw3": true,
+    "tomekf": true,
+    "chillcapped": true,
+    "sandinmyjoints": true,
+    "temoto-kun": true,
+    "matmancini": true,
+    "m412c0": true,
+    "smirking-ninja": true,
+    "fmoliveira": true,
+    "yyscamper": true,
+    "galenandrew": true,
+    "daviddraughn": true,
+    "zumanex": true,
+    "fabian.moron.zirfas": true,
+    "xingjianpan": true,
+    "grantgeorge": true,
+    "enriquecaballero": true,
+    "pjb3": true,
+    "svgkrishnamurthy": true,
+    "mngaw20": true,
+    "dani.raja": true,
+    "jeffb_incontact": true,
+    "chicho": true,
+    "rackyrose": true,
+    "markbroadhead": true,
+    "enricllagostera": true,
+    "jorycn": true,
+    "bernardhamann": true,
+    "danmcc": true,
+    "decoded": true,
+    "tim545": true,
+    "aolu11": true,
+    "camilohe": true,
+    "iliyat": true,
+    "leandro.maioral": true,
+    "mariod3w": true,
+    "thejaydox": true,
+    "isik": true,
+    "roxnz": true,
+    "donkino": true,
+    "maninbucket": true,
+    "ibourgeois": true,
+    "tekguy": true,
+    "soluzionisubito": true,
+    "hughker": true,
+    "eazel7": true,
+    "eli_f": true,
+    "tetra": true,
+    "monkeymonk": true,
+    "mavenrix": true,
+    "justincann": true,
+    "ndfool": true,
+    "kurt.pattyn": true,
+    "thelfensdrfer": true,
+    "xucl": true,
+    "0x4c3p": true,
+    "tujiaw": true,
+    "matiasmarani": true,
+    "codebruder": true,
+    "vishwasc": true,
+    "sixertoy": true,
+    "martinlancer": true,
+    "kontrax": true,
+    "belbola": true,
+    "westyler": true,
+    "alagodich": true,
+    "arielabreu": true,
+    "arielfr": true,
+    "adampie": true,
+    "edusig": true,
+    "nickeltobias": true,
+    "decoda": true,
+    "starknode": true,
+    "thenpmfather": true,
+    "matthewbauer": true,
+    "arnoldstoba": true,
+    "wzbg": true,
+    "romelperez": true,
+    "trquoccuong": true,
+    "danielmacho72": true,
+    "nicwaller": true,
+    "lgvo": true,
+    "tm65": true,
+    "pdedkov": true,
+    "edwin_estrada": true,
+    "hanmnaing": true,
+    "mjurczyk": true,
+    "shakakira": true,
+    "ssh0702": true,
+    "nketchum": true,
+    "tbotv63": true,
+    "vqoph": true,
+    "sammyteahan": true,
+    "sky3r": true,
+    "lova": true,
+    "bsonntag": true,
+    "jonatasnona": true,
+    "antoinebou": true,
+    "nicholaslp": true,
+    "dskecse": true,
+    "demoive": true,
+    "yanvalue": true,
+    "esundahl": true,
+    "gollojs": true,
+    "mjurincic": true,
+    "ruyadorno": true,
+    "grantcarthew": true,
+    "quality520": true,
+    "jerkovicl": true,
+    "knoja4": true,
+    "paulrichards19": true,
+    "liesju": true,
+    "ral.amgstromg": true,
+    "nonemoticoner": true,
+    "tcrowe": true,
+    "davidrapin": true,
+    "viktorivanov": true,
+    "windhamdavid": true,
+    "flozz": true,
+    "zava": true,
+    "kparkov": true,
+    "lbebber": true,
+    "thegman": true,
+    "chris-morse-sebrell": true,
+    "tjfwalker": true,
+    "lezyeoh": true,
+    "andrew.medvedev": true,
+    "chrisbrocklesby": true,
+    "ramzesucr": true,
+    "acollins-ts": true,
+    "linuxwizard": true,
+    "componentfactory": true,
+    "xgqfrms": true,
+    "bhill": true,
+    "jkrenge": true,
+    "jasonevrtt": true,
+    "4ster": true,
+    "monadic.coffee": true,
+    "davincho": true,
+    "gtskk": true,
+    "macmladen": true,
+    "hpherzog": true,
+    "alectic": true,
+    "gamr": true,
+    "shiva127": true,
+    "chadyred": true,
+    "xeoneux": true,
+    "adammcarth": true,
+    "ericnelson": true,
+    "n1kkou": true,
+    "panoptican": true,
+    "superjudge": true,
+    "srbdev": true,
+    "lekkas": true,
+    "perrymitchell": true,
+    "chesstrian": true,
+    "jdacosta": true,
+    "aman26": true,
+    "dereklakin": true,
+    "onheiron": true,
+    "urbancvek": true,
+    "artjacob": true,
+    "mkany": true,
+    "larnera": true,
+    "mattevigo": true,
+    "bitkomponist": true,
+    "icor": true,
+    "leoribeiro": true,
+    "jamesmgreene": true,
+    "favasconcelos": true,
+    "skl.2015": true,
+    "mikepol": true,
+    "dbsweets": true,
+    "vb078": true,
+    "marlongrape": true,
+    "sigkill(9)": true,
+    "jordansrowles": true,
+    "adonai": true,
+    "snowdream": true,
+    "diegoprates": true,
+    "superpaintman": true,
+    "silva23": true,
+    "daveatdog": true,
+    "mikewink": true,
+    "preco21": true,
+    "kaperstone": true,
+    "meetravi": true,
+    "f.egerer": true,
+    "liushoukai": true,
+    "blueqnx": true,
+    "wisecolt": true,
+    "digimiles": true,
+    "acolchado": true,
+    "nystul": true,
+    "cascadejs": true,
+    "gustavomeloweb": true,
+    "iambmelt": true,
+    "yeluoqiuzhi": true,
+    "wfcookie": true,
+    "stroem!": true,
+    "josejaguirre": true,
+    "urbantumbleweed": true,
+    "stany": true,
+    "liulei224": true,
+    "mkstix6": true,
+    "jclo": true,
+    "raskawa": true,
+    "jonashavers": true,
+    "becxer": true,
+    "f3r": true,
+    "veritasx": true,
+    "wangnan0610": true,
+    "kleintobe": true,
+    "juk": true,
+    "clisun": true,
+    "dacosta": true,
+    "jerous": true,
+    "raisiqueira": true,
+    "erikj": true,
+    "hyde2able": true,
+    "crisleiria": true,
+    "lcdss": true,
+    "bracketdash": true,
+    "undertuga": true,
+    "drj": true,
+    "mling": true,
+    "ozshimon21": true,
+    "itskdk": true,
+    "kerimdzhanov": true,
+    "vixxd": true,
+    "richardcfelix": true,
+    "fistynuts": true,
+    "leahcimic": true,
+    "machineee": true,
+    "ovrmrw": true,
+    "faelcorreia": true,
+    "craql": true,
+    "tonyleen": true,
+    "artemigos": true,
+    "iroc": true,
+    "loadaverage": true,
+    "traveltechymatt": true,
+    "vmarkevich": true,
+    "kmfnj": true,
+    "toryburgett": true,
+    "ncfoco": true,
+    "quanack": true,
+    "moueza": true,
+    "sparkrico": true,
+    "valentinbrclz": true,
+    "cruzrovira": true,
+    "potnox": true,
+    "thiagoh": true,
+    "efosao": true,
+    "makay": true,
+    "michaeldegroot": true,
+    "geese98": true,
+    "vladkozlovski": true,
+    "amenadiel": true,
+    "algonzo": true,
+    "stuart.shi": true,
+    "abdihaikal": true,
+    "demiurgosoft": true,
+    "tobiasnickel": true,
+    "arttse": true,
+    "livfwds": true,
+    "evan2x": true,
+    "cfleschhut": true,
+    "piixiiees": true,
+    "alexg53090": true,
+    "ajaykp": true,
+    "jtsky": true,
+    "djamseed": true,
+    "buru1020": true,
+    "pnhung177": true,
+    "usedf295": true,
+    "cshutchinson": true,
+    "sternelee": true,
+    "lekosfmi": true,
+    "aditcmarix": true,
+    "garrickcheung": true,
+    "andriecool": true,
+    "corca": true,
+    "ryandu": true,
+    "daniele_cammarata": true,
+    "lucadev15": true,
+    "dosevader": true,
+    "stephenway": true,
+    "barbarosh": true,
+    "jamesbedont": true,
+    "jrnail23": true,
+    "empurium": true,
+    "dyaa": true,
+    "thomasfoster96": true,
+    "heitorschueroff": true,
+    "hugojosefson": true,
+    "msjcaetano": true,
+    "gleox": true,
+    "animustechnology": true,
+    "sneakysnakeman": true,
+    "davidbraun": true,
+    "neomadara": true,
+    "arover": true,
+    "nauwep": true,
+    "vleesbrood": true,
+    "eserozvataf": true,
+    "aldur": true,
+    "treeofnations": true,
+    "powellmedia": true,
+    "lesterzone": true,
+    "zgrolink": true,
+    "piotr-mroczek": true,
+    "mistkafka": true,
+    "jabbalaci": true,
+    "mark12433": true,
+    "flamewow": true,
+    "bhenav": true,
+    "jovaage": true,
+    "jun01ito": true,
+    "txredking": true,
+    "paragi": true,
+    "aurium": true,
+    "sariss": true,
+    "arbazsiddiqui": true,
+    "maxsliw": true,
+    "wombatworks": true,
+    "tschellenbach2": true,
+    "craigklem": true,
+    "justdomepaul": true,
+    "bruinebeer": true,
+    "paulequilibrio": true,
+    "squalrus": true,
+    "evanyeung": true,
+    "richardpringle": true,
+    "demod": true,
+    "ismaelvsqz": true,
+    "zaephor": true,
+    "ansuman": true,
+    "crusaderltd": true,
+    "oikewll": true,
+    "yetithefoot": true,
+    "nikhilkumar80": true,
+    "tedhoryczun": true,
+    "dennykuo": true,
+    "justinanastos": true,
+    "highlanderkev": true,
+    "mazimuhlari": true,
+    "martijndevalk": true,
+    "benjaminaaron": true,
+    "hughescr": true,
+    "qddegtya": true,
+    "golendukhin": true,
+    "onbjerg": true,
+    "lionet": true,
+    "pirmax": true,
+    "gooer": true,
+    "bwade231": true,
+    "stuartmvg": true,
+    "cmdaniels": true,
+    "reema": true,
+    "wander_lp": true,
+    "yabasha": true,
+    "psmorrow": true,
+    "demopark": true,
+    "vutran": true,
+    "chris-me": true,
+    "garenyondem": true,
+    "mrvincenzo": true,
+    "geooogle": true,
+    "s950329": true,
+    "haeresis": true,
+    "ryanlee": true,
+    "lucachaves": true,
+    "same": true,
+    "kevinrwing": true,
+    "weshigbee": true,
+    "lucaskatayama": true,
+    "antoniordo": true,
+    "designbymind": true,
+    "thomas.miele": true,
+    "bemace": true,
+    "hardball": true,
+    "southpawlife": true,
+    "membersheep": true,
+    "giovanni.bruno": true,
+    "ristostevcev": true,
+    "genediazjr": true,
+    "joannerpena": true,
+    "xxsnake28": true,
+    "rlihm": true,
+    "philiiiiiipp": true,
+    "hngrhorace": true,
+    "figroc": true,
+    "wisdom": true,
+    "gx": true,
+    "sebinbenjamin": true,
+    "poppowerlb2": true,
+    "zapo": true,
+    "arleytriana": true,
+    "yokubee": true,
+    "modao": true,
+    "rsmccloskey": true,
+    "a3.ivanenko": true,
+    "fgarrido": true,
+    "bhaveshrpatel": true,
+    "feyzee": true,
+    "nanosekund": true,
+    "spencermathews": true,
+    "yuanlin_dev": true,
+    "abdul": true,
+    "goodnighthsu": true,
+    "royling": true,
+    "telco2011": true,
+    "gvr37leo": true,
+    "supersephy": true,
+    "adritek": true,
+    "jalfcolombia": true,
+    "franz899": true,
+    "dangerdave": true,
+    "lex_nel": true,
+    "alexc1212": true,
+    "roman-io": true,
+    "battlemidget": true,
+    "peteb": true,
+    "xufz": true,
+    "alvajc": true,
+    "krocon": true,
+    "koskokos": true,
+    "mzheng": true,
+    "hyungdookil": true,
+    "ghe1219": true,
+    "muralibala": true,
+    "toby_reynold": true,
+    "gracheff": true,
+    "dimonfox": true,
+    "ryanoasis": true,
+    "lisafrench": true,
+    "pruettti": true,
+    "mauriciolauffer": true,
+    "jedateach": true,
+    "lakipatel": true,
+    "bryanwood": true,
+    "thumkus": true,
+    "fernandopasik": true,
+    "troels.trvo.dk": true,
+    "werninator": true,
+    "mate2": true,
+    "zackharley": true,
+    "zbreakstone": true,
+    "peddi": true,
+    "miguelpalazzo": true,
+    "jensnilsson": true,
+    "bob.cody": true,
+    "guidoschmidt": true,
+    "yassinesania": true,
+    "codekraft-studio": true,
+    "rwnet": true,
+    "tuomastolppi": true,
+    "chris.ch86": true,
+    "runjinz": true,
+    "peacebaro": true,
+    "cnlopes": true,
+    "net-burst": true,
+    "cmudrick": true,
+    "chrisx": true,
+    "apita-cc": true,
+    "gvhinks": true,
+    "sbvonline": true,
+    "zagonine": true,
+    "emarcs": true,
+    "khinenw": true,
+    "houser": true,
+    "kevteljeur": true,
+    "hireton": true,
+    "trtrojo": true,
+    "unijad": true,
+    "mseminatore": true,
+    "kimkee": true,
+    "diegorbaquero": true,
+    "asm2hex": true,
+    "katy": true,
+    "natarajanmca11": true,
+    "smedegaard": true,
+    "bruno.m": true,
+    "ferchoriverar": true,
+    "amdsouza92": true,
+    "landy2014": true,
+    "mkoc": true,
+    "benpptung": true,
+    "zhouanbo": true,
+    "sammffl": true,
+    "nomedescargues": true,
+    "mcfarljw": true,
+    "nitinbansal": true,
+    "pablo.tavarez": true,
+    "clarenceho": true,
+    "dahnielson": true,
+    "0711levski": true,
+    "gspanoae": true,
+    "joel-ericsson": true,
+    "slavqa": true,
+    "rolldance": true,
+    "acoustics": true,
+    "segen": true,
+    "rectar2": true,
+    "hypersprite": true,
+    "ninjs": true,
+    "skgtouch": true,
+    "dainov": true,
+    "elviopita": true,
+    "droha": true,
+    "palelion": true,
+    "snarky": true,
+    "huxiaolei": true,
+    "grreenzz": true,
+    "phlp": true,
+    "garustar": true,
+    "nescio": true,
+    "princetoad": true,
+    "guoer": true,
+    "whatsamoorefor": true,
+    "jfernandezgersol": true,
+    "chemdrew": true,
+    "thomascarvalho": true,
+    "cstanard": true,
+    "chentel": true,
+    "alex_toudic": true,
+    "leejefon": true,
+    "janggomgeun": true,
+    "aaronfurtado93": true,
+    "tanhauhau": true,
+    "kevinlaunay": true,
+    "benjamin_hesse": true,
+    "jotadeveloper": true,
+    "eruditecat": true,
+    "raff": true,
+    "coolhanddev": true,
+    "cperezabo": true,
+    "ibio": true,
+    "mooshe": true,
+    "geekwen": true,
+    "isman_usoh": true,
+    "jtrh": true,
+    "plachy.jozef": true,
+    "ngrenwalt": true,
+    "usama.ashraf": true,
+    "ions": true,
+    "andrew.oxenburgh": true,
+    "scippio": true,
+    "heyimeugene": true,
+    "dmsanchez86": true,
+    "piyo": true,
+    "mrbgit": true,
+    "james3299": true,
+    "tacoc0815": true,
+    "sroveda": true,
+    "eliaslfox": true,
+    "htemizyurek": true,
+    "sylvain261": true,
+    "weiffert": true,
+    "danielsunami": true,
+    "syaning": true,
+    "sboyd": true,
+    "flomader": true,
+    "leowoods": true,
+    "matthewh": true,
+    "binq": true,
+    "grahamjpark": true,
+    "hugovila": true,
+    "djeck": true,
+    "mugifly": true,
+    "zafix": true,
+    "jacobmischka": true,
+    "sunkeyhub": true,
+    "geralex": true,
+    "siirial": true,
+    "leogoncha": true,
+    "cilerler": true,
+    "mhetrerajat": true,
+    "fasdgoc": true,
+    "errhunter": true,
+    "pmasa": true,
+    "sbskl": true,
+    "eb.coder": true,
+    "tonethar": true,
+    "udeste": true,
+    "julienrbrt": true,
+    "maykonlf": true,
+    "sesamechee": true,
+    "vitali.doudko": true,
+    "programmer.severson": true,
+    "carbonspike": true,
+    "mllee": true,
+    "janapriya": true,
+    "aquafadas": true,
+    "duskalbatross": true,
+    "sergfedo": true,
+    "rrpf": true,
+    "danielsimonjr": true,
+    "apwn": true,
+    "theoryofnekomata": true,
+    "merrickp": true,
+    "sethfork": true,
+    "tbear79": true,
+    "justinmchase": true,
+    "yoking": true,
+    "phocks": true,
+    "cyusim": true,
+    "edwardburns": true,
+    "laconty": true,
+    "ssasthan": true,
+    "taqrow": true,
+    "x0000ff": true,
+    "hoibatpham": true,
+    "daniel_mantei": true,
+    "kimmohintikka": true,
+    "crutchfix": true,
+    "ischiavon": true,
+    "ameenkhan07": true,
+    "djviolin": true,
+    "stephensauceda": true,
+    "pusing": true,
+    "mychyl": true,
+    "clarsen": true,
+    "kufii": true,
+    "kurtisnpm": true,
+    "ianyuen": true,
+    "robba.jt": true,
+    "carlhong": true,
+    "terminaltraces": true,
+    "brpaz": true,
+    "marcobiedermann": true,
+    "cpe89": true,
+    "anhurtado": true,
+    "alin.alexa": true,
+    "goatandsheep": true,
+    "csarkosh": true,
+    "angrykoala": true,
+    "xhonker": true,
+    "creativ073": true,
+    "serhatcan": true,
+    "makknife": true,
+    "jmsherry": true,
+    "shekharreddy": true,
+    "lhard": true,
+    "a_dent": true,
+    "bad-coder": true,
+    "sopov": true,
+    "mluberry": true,
+    "i.vispyanskiy": true,
+    "davidlanger": true,
+    "ibartholomew": true,
+    "jsds": true,
+    "samersm": true,
+    "luhalvesbr": true,
+    "maxkoryukov": true,
+    "volebonet": true,
+    "szymex73": true,
+    "rocket0191": true,
+    "lihsai0": true,
+    "ivnovi": true,
+    "scotchulous": true,
+    "dcavalcante": true,
+    "ryansalvador": true,
+    "volebo": true,
+    "mryeol": true,
+    "itsmeara": true,
+    "evegreen": true,
+    "artbels": true,
+    "razr9": true,
+    "ymk": true,
+    "faraoman": true,
+    "alochious": true,
+    "mickaelb": true,
+    "yasinaydin": true,
+    "john-goldsmith": true,
+    "akarem": true,
+    "azevedo": true,
+    "apopek": true,
+    "twilkerson": true,
+    "leetwelve": true,
+    "ealen": true,
+    "repeale": true,
+    "steve3d3d": true,
+    "miga": true,
+    "jcarlos": true,
+    "mobeicaoyuan": true,
+    "dralc": true,
+    "yscnysj": true,
+    "simon-yukuan": true,
+    "vpal": true,
+    "katsos": true,
+    "rsaa": true,
+    "billysharp": true,
+    "albizures": true,
+    "chengfubei": true,
+    "cisc": true,
+    "kwhitley": true,
+    "youngmo": true,
+    "largepuma": true,
+    "adrian110288": true,
+    "ikhrome": true,
+    "lmanukyan": true,
+    "scottfreecode": true,
+    "vifird": true,
+    "chiraggarg": true,
+    "aman2609": true,
+    "jaredpalmer": true,
+    "sumit270": true,
+    "infantito": true,
+    "serioga": true,
+    "vipergtsrz": true,
+    "pddivine": true,
+    "tteogi": true,
+    "ivibe": true,
+    "duck102017": true,
+    "jrperdomoz": true,
+    "shadowless": true,
+    "nyzm": true,
+    "jez9999": true,
+    "tainanreis": true,
+    "saisatik": true,
+    "varinliali": true,
+    "xsdc": true,
+    "avanthikameenakshi": true,
+    "phoenixsoul": true,
+    "caeyna": true,
+    "arvraepe": true,
+    "aurieh": true,
+    "easimonenko": true,
+    "quzhi78": true,
+    "boogy": true,
+    "jamchill": true,
+    "dabin": true,
+    "alessandraurso": true,
+    "degouville": true,
+    "husayt": true,
+    "slmcassio": true,
+    "ramhejazi": true,
+    "johnend": true,
+    "kistoryg": true,
+    "fizzvr": true,
+    "bboulahdid": true,
+    "cetincem": true,
+    "hueby": true,
+    "meb": true,
+    "deadcoder0904": true,
+    "post72": true,
+    "kudakv": true,
+    "tiggerhyun": true,
+    "z1c0": true,
+    "jonabasque": true,
+    "suhaib.affan": true,
+    "gilson004": true,
+    "monomon": true,
+    "adapter": true,
+    "nohomey": true,
+    "quafoo": true,
+    "ognjen.jevremovic": true,
+    "blasterun": true,
+    "niksudan": true,
+    "ushervani": true,
+    "13lank.null": true,
+    "chunxchun": true,
+    "monjer": true,
+    "simioni": true,
+    "eijs": true,
+    "morogasper": true,
+    "jeanpsv": true,
+    "prbsas": true,
+    "aikaramba": true,
+    "hodd": true,
+    "tin-lek": true,
+    "podlebar": true,
+    "luiscauro": true,
+    "mahmoodramzani": true,
+    "kunalgaurav18": true,
+    "laudeon": true,
+    "danielbankhead": true,
+    "sunggun": true,
+    "fenrir": true,
+    "geduardcatalin": true,
+    "muroc": true,
+    "hanwf": true,
+    "saa": true,
+    "ahvonenj": true,
+    "mojaray2k": true,
+    "dmandola11": true,
+    "jstinm": true,
+    "gaelabc": true,
+    "fahadjadoon": true,
+    "mahdi.ehsanifar": true,
+    "willyelm": true,
+    "dzhou777": true,
+    "sonance207": true,
+    "dawn_scroll": true,
+    "nikches": true,
+    "ww522413622": true,
+    "lmussio": true,
+    "jetbug123": true,
+    "jpshankle": true,
+    "spad": true,
+    "langri-sha": true,
+    "rickdesantis": true,
+    "zorak": true,
+    "huunam82": true,
+    "bizu": true,
+    "mwehlou": true,
+    "chirag8642": true,
+    "soulevans07": true,
+    "joechow": true,
+    "erynellbe32": true,
+    "a.sanchez": true,
+    "fgmnts": true,
+    "techyone": true,
+    "matiasherranz": true,
+    "zhengyaing": true,
+    "mrwanashraf": true,
+    "pl0x": true,
+    "ifahrentholz": true,
+    "leondacosta": true,
+    "anxing": true,
+    "nelreina": true,
+    "shanewholloway": true,
+    "axelniklasson": true,
+    "itesic": true,
+    "adamdreszer": true,
+    "albertofdzm": true,
+    "tunjos": true,
+    "jmtcsngr": true,
+    "ma-ha": true,
+    "jmkim9": true,
+    "pp253": true,
+    "proxy": true,
+    "youmoo": true,
+    "mattbodman": true,
+    "carusog": true,
+    "matt-jensen": true,
+    "xpr": true,
+    "raphaelgmelo": true,
+    "parkwookyun": true,
+    "mwebsolutions": true,
+    "jirwong": true,
+    "rylan_yan": true,
+    "jonathas": true,
+    "filipesoccol": true,
+    "pengyu": true,
+    "code-curious": true,
+    "nate-river": true,
+    "bradleybossard": true,
+    "trendoid": true,
+    "austinbillings": true,
+    "kabugyei": true,
+    "super-cache-money": true,
+    "joshberg": true,
+    "cliffyan": true,
+    "thedayman": true,
+    "orenschwartz": true,
+    "ektx": true,
+    "wearevilla": true,
+    "nicohe": true,
+    "izzy": true,
+    "hafizahmedattari": true,
+    "amazingandyyy": true,
+    "rogeriera": true,
+    "haowu": true,
+    "chrisindark": true,
+    "nesffer": true,
+    "mattboyd": true,
+    "rich-97": true,
+    "norlando": true,
+    "jeffbyrnes": true,
+    "boyander": true,
+    "ahmetertem": true,
+    "dyyz993": true,
+    "ulongx": true,
+    "sako73": true,
+    "kuzmicheff": true,
+    "vladimir.shushkov": true,
+    "pixelcraft": true,
+    "postnuclearmorning": true,
+    "dallin_r": true,
+    "igorsetsfire": true,
+    "guywicks": true,
+    "vmleon": true,
+    "stonenik": true,
+    "zoluzo": true,
+    "yuhb": true,
+    "lorenzoi": true,
+    "yavarnia": true,
+    "atulmy": true,
+    "manparvesh": true,
+    "anoubis": true,
+    "miroklarin": true,
+    "lech-u": true,
+    "kog-7": true,
+    "da5atar": true,
+    "raschdiaz": true,
+    "seangenabe": true,
+    "jordan-carney": true,
+    "avernon2": true,
+    "geekish": true,
+    "mafikes": true,
+    "railites": true,
+    "hurerera": true,
+    "audstanley": true,
+    "champz": true,
+    "potentii": true,
+    "aidenzou": true,
+    "adeelp": true,
+    "tonstwo": true,
+    "yaphtes.ks": true,
+    "harrydu": true,
+    "isenricho": true,
+    "boopathisakthivel.in": true,
+    "i3fox": true,
+    "jasonleewilson": true,
+    "nwservices": true,
+    "chrisco": true,
+    "yabeswirawan": true,
+    "zach.d.yang": true,
+    "mahdi-se": true,
+    "serge-nikitin": true,
+    "ukrbublik": true,
+    "franksansc": true,
+    "evanfreeman": true,
+    "guihgo": true,
+    "pr-anoop": true,
+    "marcelagotta": true,
+    "awesomename": true,
+    "ariesmoo": true,
+    "themadjoker": true,
+    "doc.gunthrop": true,
+    "dnero": true,
+    "yuch4n": true,
+    "nysingh": true,
+    "arobert93": true,
+    "moonnoire": true,
+    "evdokimovm": true,
+    "charlietango592": true,
+    "esummers": true,
+    "luck7": true,
+    "arvindrsingh": true,
+    "sgvinci": true,
+    "gesf": true,
+    "fintanak": true,
+    "ptrevethan": true,
+    "satoru": true,
+    "cwooz": true,
+    "goldentk": true,
+    "giussa_dan": true,
+    "ilyinilyas": true,
+    "salomaosnff": true,
+    "xcoda": true,
+    "ukuli": true,
+    "xmalinov": true,
+    "awynter": true,
+    "futerzak": true,
+    "devnka": true,
+    "boulakar": true,
+    "aj888907": true,
+    "cvc": true,
+    "artmadiar": true,
+    "hehaiyang": true,
+    "steeljuice": true,
+    "longbuxu03": true,
+    "jetze": true,
+    "spences10": true,
+    "rramona2": true,
+    "psicodead": true,
+    "fattypanda": true,
+    "magic5": true,
+    "rebooter": true,
+    "gwilison": true,
+    "phillycheese": true,
+    "zavrakv": true,
+    "cocorax": true,
+    "rdonmez": true,
+    "madalozzo": true,
+    "qizai": true,
+    "hmatijev": true,
+    "jarilehtinen": true,
+    "pmbenjamin": true,
+    "bengi": true,
+    "mbovbjerg": true,
+    "luiko": true,
+    "changlee": true,
+    "vanelizarov": true,
+    "rlafferty": true,
+    "igasho": true,
+    "pintux": true,
+    "lcsisy": true,
+    "masterofweb": true,
+    "pepedders": true,
+    "timothywei": true,
+    "gberto": true,
+    "mparaiso": true,
+    "thgsilva": true,
+    "intrwins": true,
+    "aquiandres": true,
+    "axelrindle": true,
+    "shentengtu": true,
+    "kconner": true,
+    "s.well": true,
+    "hpauwelyn": true,
+    "nickchow": true,
+    "fedeghe": true,
+    "sprybear": true,
+    "thomas.li": true,
+    "chinawolf_wyp": true,
+    "beenorgone": true,
+    "wesleylhandy": true,
+    "derflatulator": true,
+    "jhonkaman": true,
+    "kaemiin": true,
+    "mrzmmr": true,
+    "gabestevy": true,
+    "mattlk13": true,
+    "abernier": true,
+    "neofaucheur": true,
+    "agon": true,
+    "pablaber": true,
+    "vinnyfonseca": true,
+    "qafir": true,
+    "junos": true,
+    "abpeinado": true,
+    "chrisakakay": true,
+    "dahdoul": true,
+    "xx1196": true,
+    "qjawe": true,
+    "blackrocky": true,
+    "trippyhank": true,
+    "icodeforcookies": true,
+    "alexcabaang": true,
+    "keithpepin": true,
+    "tomchao": true,
+    "milan322": true,
+    "tuncerbasdag": true,
+    "npmmurali": true,
+    "jaguarj": true,
+    "cfernandomaciel": true,
+    "htc2ubusiness": true,
+    "madcoded": true,
+    "haihepeng": true,
+    "fxkraus": true,
+    "u.turkoz": true,
+    "comandan": true,
+    "chrisguoado": true,
+    "jerrywu12": true,
+    "ilia.ivanov": true,
+    "beatwinthewave": true,
+    "krugarmatt": true,
+    "juliocj360": true,
+    "josokinas": true,
+    "cyberhollow": true,
+    "miadzadfallah": true,
+    "in-the-box": true,
+    "vicsandoli": true,
+    "rob.mcfarlane": true,
+    "jws": true,
+    "musikele": true,
+    "filipve": true,
+    "speedazerty": true,
+    "n0f3": true,
+    "lavysh": true,
+    "nazhmik": true,
+    "cubiio": true,
+    "n.sanitate": true,
+    "kurniawanchan": true,
+    "nerov": true,
+    "d0ughtyj": true,
+    "hechuan": true,
+    "meph": true,
+    "kodekracker": true,
+    "vuntsova": true,
+    "taita": true,
+    "alaska": true,
+    "jarvis211": true,
+    "ericteng177": true,
+    "chiaychang": true,
+    "enjoyharddrink": true,
+    "zaks": true,
+    "hallako": true,
+    "apollo89": true,
+    "gpuente": true,
+    "zvikyb": true,
+    "qingqingcao": true,
+    "psibal": true,
+    "berkshireescorts": true,
+    "kevinhassan": true,
+    "kingfeast": true,
+    "bykirby": true,
+    "terre": true,
+    "splode": true,
+    "guioconnor": true,
+    "dunstontc": true,
+    "jlopvi": true,
+    "vinyguedess": true,
+    "iceriver2": true,
+    "rxmth": true,
+    "heartnett": true,
+    "blakeredwolf": true,
+    "forecast": true,
+    "shadyshrif": true,
+    "maxwelldu": true,
+    "ntl88": true,
+    "ikhsaan": true,
+    "sommardnaiel": true,
+    "adam8690": true,
+    "alshamiri2": true,
+    "adrian.arroyocalle": true,
+    "guven.aslan": true,
+    "evanshortiss": true,
+    "andy65007": true,
+    "walexstevens": true,
+    "sammy_winchester": true,
+    "ys_sidson_aidson": true,
+    "karbunkul": true,
+    "valenwave": true,
+    "rbcorrea": true,
+    "davidalves1": true,
+    "chainn": true,
+    "bprogyan": true,
+    "lusai": true,
+    "trygganomics": true,
+    "allendale": true,
+    "sibawite": true,
+    "kakaman": true,
+    "dhanya-kr": true,
+    "binginsist": true,
+    "hektve87": true,
+    "alexpearly": true,
+    "cpowmatt": true,
+    "imaginary": true,
+    "xaview": true,
+    "hengshengchen": true,
+    "fabioper": true,
+    "waiwaiku": true,
+    "bdfu": true,
+    "windyh": true,
+    "hawai": true,
+    "umo": true,
+    "qinyuhang": true,
+    "vinceucla": true,
+    "karzanosman984": true,
+    "alaeddine17": true,
+    "ctyloading": true,
+    "giovannism20": true,
+    "hodaraadam": true,
+    "xiaoyiyu": true,
+    "alexxnica": true,
+    "grabantot": true,
+    "scottbailey": true,
+    "viperchin": true,
+    "thetwosents": true,
+    "maycon_ribeiro": true,
+    "dongyukang": true,
+    "atakane": true,
+    "bertof": true,
+    "grahm": true,
+    "krettis": true,
+    "freech": true,
+    "legion44": true,
+    "alexis-nava": true,
+    "bezoslee": true,
+    "cqkd6381": true,
+    "cantuga": true,
+    "fabioricali": true,
+    "kulyk404": true,
+    "andysw": true,
+    "borasta": true,
+    "elehas": true,
+    "geyokoyama": true,
+    "solzimer": true,
+    "andygreenegrass": true,
+    "lijq123": true,
+    "manojkhannakm": true,
+    "gregjohnson": true,
+    "hakhagmon": true,
+    "mayurmakhija": true,
+    "maciej.litwiniec": true,
+    "xmwx38": true,
+    "mo30qari": true,
+    "erictreacy": true,
+    "cygik": true,
+    "buzzpsych": true,
+    "thivieira": true,
+    "lbeff": true,
+    "nayuki": true,
+    "sakib15": true,
+    "penzin": true,
+    "codeinfront": true,
+    "brainmaxz": true,
+    "behnameghorbani": true,
+    "tewarid": true,
+    "arnoldask": true,
+    "kremr": true,
+    "a.jumping425": true,
+    "z33": true,
+    "ambition101": true,
+    "drdoof": true,
+    "livarion": true,
+    "albertico88": true,
+    "johnaleman": true,
+    "hoho721": true,
+    "dna2go": true,
+    "denwilliams": true,
+    "greganswer": true,
+    "leonel-ai": true,
+    "felegz": true,
+    "vmcreative": true,
+    "xdays": true,
+    "gavatron": true,
+    "kakrot": true,
+    "jamesczekaj": true,
+    "mohamedmousa": true,
+    "julianomontini": true,
+    "krzych93": true,
+    "sahlzen": true,
+    "abhijitkalta": true,
+    "wayn": true,
+    "zombieleet": true,
+    "stellarnode": true,
+    "zzz1233210731": true,
+    "bcoe": true,
+    "sidkb": true,
+    "mlcdf": true,
+    "dryliketoast": true,
+    "raizu": true,
+    "piotrposzytek": true,
+    "fabioppalumbo": true,
+    "asj1992": true,
+    "zerouikit": true,
+    "javadtyb": true,
+    "rahsaanbasek": true,
+    "jakedemonaco": true,
+    "hndev": true,
+    "ndxbn": true,
+    "treatkor": true,
+    "3ddario": true,
+    "mouaad": true,
+    "spinbit": true,
+    "cooboor": true,
+    "leelandmiller": true,
+    "colin-harrison": true,
+    "malek": true,
+    "anemone.js": true,
+    "gruebes": true,
+    "swift2728": true,
+    "madarche": true,
+    "paulin": true,
+    "rupertong": true,
+    "neo1": true,
+    "luffy84217": true,
+    "eagleflo": true,
+    "jhillacre": true,
+    "diangelium": true,
+    "shreyawhiz": true,
+    "andrewlam": true,
+    "starlord40k": true,
+    "postcrafter": true,
+    "dimaroxx": true,
+    "bellyy": true,
+    "x_venux": true,
+    "kiaratto": true,
+    "majkel": true,
+    "ricardogobbosouza": true,
+    "michaelprflores": true,
+    "allenmoore": true,
+    "chenphoenix": true,
+    "alanson": true,
+    "scalz": true,
+    "emircanok": true,
+    "paulkolesnyk": true,
+    "marinear212": true,
+    "mr_panda": true,
+    "sayansaha": true,
+    "legiao": true,
+    "npm-packages": true,
+    "rayjshin": true,
+    "tonerbarato": true,
+    "daniel-lewis-bsc-hons": true,
+    "gatesmart": true,
+    "vision_tecnologica": true,
+    "tiggem1993": true,
+    "fejku": true,
+    "gresite_piscinas": true,
+    "alexmeooow": true,
+    "denu5": true,
+    "helderam": true,
+    "granhermandadblanca": true,
+    "portilha": true,
+    "suryasaripalli": true,
+    "oliverkascha": true,
+    "itcorp": true,
+    "kwcjr": true,
+    "svoss24": true,
+    "colageno": true,
+    "johanlindberg": true,
+    "hitalos": true,
+    "itsmyth": true,
+    "dwqs": true,
+    "dodoss": true,
+    "omar84": true,
+    "liupengbo": true,
+    "deivbid": true,
+    "waldrupm": true,
+    "mimizq": true,
+    "zwwggg": true,
+    "ssmhan4": true,
+    "robinblomberg": true,
+    "leogiese": true,
+    "mtclark518": true,
+    "kmathmann": true,
+    "nazy": true,
+    "bradleymackey": true,
+    "xwh123807": true,
+    "haroxy": true,
+    "alquilerargentina": true,
+    "jream": true,
+    "enzoaliatis": true,
+    "wvlvik": true,
+    "guiyuzhao": true,
+    "vapeadores": true,
+    "processbrain": true,
+    "dangmin": true,
+    "iamninad": true,
+    "sebrofjr": true,
+    "theyeshu": true,
+    "yeming": true,
+    "zalithka": true,
+    "diegonobre": true,
+    "ehrig": true,
+    "bab": true,
+    "ashifatb": true,
+    "guogai": true,
+    "awareness481": true,
+    "trbula": true,
+    "maddas": true,
+    "varunm": true,
+    "nimtronican": true,
+    "ipasha": true,
+    "itsqrhq": true,
+    "fakefarm": true,
+    "bloep": true,
+    "yangzw": true,
+    "annarpack": true,
+    "sayrilamar": true,
+    "junyeong": true,
+    "rshaw": true,
+    "tztz": true,
+    "artamonovdev": true,
+    "chiroc": true,
+    "msq": true,
+    "vladimi": true,
+    "oeduardoal": true,
+    "joey.dossche": true,
+    "sarnsdev": true,
+    "xanderlewis": true,
+    "thetimmaeh": true,
+    "pajamasam": true,
+    "wallenberg12": true,
+    "nicksnell": true,
+    "lander-xiong": true,
+    "yancq": true,
+    "hashito": true,
+    "moharram82": true,
+    "rudchyk": true,
+    "cmonster": true,
+    "avenida14": true,
+    "kwabenaberko": true,
+    "professorcoal": true,
+    "chenyingxuan1996": true,
+    "dh19911021": true,
+    "krostyslav": true,
+    "tpkn": true,
+    "pedromclamas": true,
+    "laserblue": true,
+    "matthiasgrune": true,
+    "phil1929": true,
+    "stormcrows": true,
+    "pauljacobson": true,
+    "schm-dt": true,
+    "renz0": true,
+    "gamersdelight": true,
+    "akshay.vs9543": true,
+    "sdove1": true,
+    "rubenjose75": true,
+    "henriesteves": true,
+    "yakumat": true,
+    "owillo": true,
+    "testuserjanedoe": true,
+    "leor": true,
+    "neaker15668": true,
+    "kaybeard": true,
+    "danielheene": true,
+    "bauhuynh2020": true,
+    "marcovossen": true,
+    "jkirchartz": true,
+    "michaelsosin": true,
+    "j.chutinut": true,
+    "keybouh": true,
+    "ddaversa": true,
+    "tomitoivio": true,
+    "jackie-his": true,
+    "touskar": true,
+    "drewgg": true,
+    "danday74": true,
+    "hanhq": true,
+    "ostoh": true,
+    "michellespice": true,
+    "jthobbs": true,
+    "emilien.jegou": true,
+    "azulejosmetrosubway": true,
+    "plogbilen": true,
+    "double1000": true,
+    "tangshingkwan": true,
+    "instazapas": true,
+    "tnacious": true,
+    "zapastore": true,
+    "jaxomofruatha": true,
+    "govindaraja91": true,
+    "edgardoalz": true,
+    "lioth": true,
+    "bursalia-gestion": true,
+    "71emj1": true,
+    "greenbud-seeds": true,
+    "adaliszk": true,
+    "rockash93": true,
+    "lotspecter": true,
+    "jasperdm": true,
+    "nicknaso": true,
+    "manavsaxena": true,
+    "assiduous": true,
+    "logos": true,
+    "gw-zj": true,
+    "ciro.spaciari": true,
+    "rainrivas": true,
+    "ggan": true,
+    "oakleg": true,
+    "laoshaw": true,
+    "helcat": true,
+    "rascalquan": true,
+    "nguyenvanhoang26041994": true,
+    "fredtma": true,
+    "nicolehli": true,
+    "omkar.sheral.1989": true,
+    "hridoyryan": true,
+    "ricardweii": true,
+    "daskepon": true,
+    "shivayl": true,
+    "dewsalot": true,
+    "crismvp3200": true,
+    "undre4m": true,
+    "jeffhawkins": true,
+    "jeppesigaard": true,
+    "tranceyos2419": true,
+    "avivharuzi": true,
+    "unruhschuh": true,
+    "thomashzhu": true,
+    "midascreed": true,
+    "brocier": true,
+    "paulohsilvapinto": true,
+    "botdevel": true,
+    "franceskynov": true,
+    "nilaeus": true,
+    "mdedirudianto": true,
+    "gabriel_hansson": true,
+    "thekuzia": true,
+    "cisco_lai": true,
+    "z3mil": true,
+    "cyberboy": true,
+    "l8niteowl": true,
+    "codyschindler": true,
+    "ryaned": true,
+    "nrrb": true,
+    "imaginegenesis": true,
+    "madeo": true,
+    "yjhmelody": true,
+    "alirezavalizade": true,
+    "isaacdagel": true,
+    "renchiliu": true,
+    "ashco": true,
+    "christopheredrian": true,
+    "udaygowda": true,
+    "salvationz": true,
+    "thiagowittmann": true,
+    "michaeljwilliams": true,
+    "tblazemoro": true,
+    "barbaraackles": true,
+    "wolfram77": true,
+    "mdecker": true,
+    "txmcy1993": true,
+    "obsessiveprogrammer": true,
+    "qinshixixing": true,
+    "dandingxiong": true,
+    "sfpharmaplus": true,
+    "alexdreptu": true,
+    "jameskrill": true,
+    "ephigenia": true,
+    "rickkky": true,
+    "vla": true,
+    "jimknopf": true,
+    "nunogee": true,
+    "trocafone": true,
+    "ming371": true,
+    "lonespear": true,
+    "sandrinio": true,
+    "hutleus": true,
+    "piotrj87": true,
+    "dadoumda": true,
+    "jal": true,
+    "cab1729": true,
+    "hu3shui": true,
+    "zenfeder": true,
+    "coton_chen": true,
+    "etoxin": true,
+    "kodeo": true,
+    "aereobarato": true,
+    "ohom": true,
+    "karnavpargi": true,
+    "liuhuoliunian": true,
+    "migkjy": true,
+    "collado": true,
+    "kainos90": true,
+    "ambroseus": true,
+    "undisclosed": true,
+    "mrky007": true,
+    "gpmetheny": true,
+    "nliz77": true,
+    "edmondnow": true,
+    "forican": true,
+    "shedule": true,
+    "rparris": true,
+    "dgavilez": true,
+    "mgthomas99": true,
+    "olexandr17": true,
+    "gestoria-madrid": true,
+    "lqblovezh": true,
+    "johndorian": true,
+    "diogocapela": true,
+    "rgt": true,
+    "huiyifyj": true,
+    "cmangos": true,
+    "jussipekka": true,
+    "genbuhase": true,
+    "lfrichter": true,
+    "vivek.kumar": true,
+    "instriker": true,
+    "kazimierz.jawor": true,
+    "serdarb": true,
+    "thefox": true,
+    "jordanrw": true,
+    "scottgroves": true,
+    "codetilldrop": true,
+    "aminnazarie": true,
+    "andreaslacza": true,
+    "shashankpallerla": true,
+    "igorxp5": true,
+    "endsoul": true,
+    "kogakure": true,
+    "stormynight8": true,
+    "mspanagel": true,
+    "sfran96": true,
+    "mohokh67": true,
+    "calvinmuthig": true,
+    "zlklalala": true,
+    "shovan1995": true,
+    "takonyc": true,
+    "eduarte78": true,
+    "rajatlnwebworks": true,
+    "peterbaraka": true,
+    "mohsinnadeem": true,
+    "limintu": true,
+    "hidori": true,
+    "shajanjp": true,
+    "amiziara": true,
+    "felipeferreirasilva": true,
+    "waterswv": true,
+    "allanwxm": true,
+    "plasticut": true,
+    "drafael": true,
+    "jwv": true,
+    "kaycee": true,
+    "huyz": true,
+    "smrr723": true,
+    "maremarismaria": true,
+    "deepsky-io": true,
+    "romedu": true,
+    "oussoulessou": true,
+    "jashsayani": true,
+    "gabrielneuer": true,
+    "destemidosistemas": true,
+    "fpenno": true,
+    "kagerjay": true,
+    "maxblock": true,
+    "mateussampsouza": true,
+    "vittorio.adamo": true,
+    "bengsfort": true,
+    "konamacona": true,
+    "tombenke": true,
+    "philosec": true,
+    "evang": true,
+    "fearnbuster": true,
+    "mrgabo": true,
+    "sanjeevbelagali": true,
+    "joelishere21": true,
+    "jeremy-j-ackso": true,
+    "prabhu25.1975": true,
+    "raciat": true,
+    "kazem1": true,
+    "danhodkinson": true,
+    "dgmike": true,
+    "wandyezj": true,
+    "devqx": true,
+    "jcanes": true,
+    "benwyse11": true,
+    "mutantspew": true,
+    "mestar": true,
+    "leota": true,
+    "juanf03": true,
+    "ahillier": true,
+    "payaamemami": true,
+    "pvoronin": true,
+    "spaceface777": true,
+    "cambro93": true,
+    "habiiev": true,
+    "staatsanwalt": true,
+    "vivekrp": true,
+    "miguelsolans": true,
+    "innf107": true,
+    "ghoulfriend": true,
+    "metaa": true,
+    "papb": true,
+    "gakis41": true,
+    "sudhasrinivas": true,
+    "darrenluo1993": true,
+    "warraichtasawar": true,
+    "xerullian": true
+  },
+  "readme": "",
+  "readmeFilename": "",
+  "homepage": "http://expressjs.com/",
+  "keywords": [
+    "express",
+    "framework",
+    "sinatra",
+    "web",
+    "rest",
+    "restful",
+    "router",
+    "app",
+    "api"
+  ],
+  "contributors": [
+    {
+      "name": "Aaron Heckmann",
+      "email": "aaron.heckmann+github@gmail.com"
+    },
+    {
+      "name": "Ciaran Jessup",
+      "email": "ciaranj@gmail.com"
+    },
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Guillermo Rauch",
+      "email": "rauchg@gmail.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com"
+    },
+    {
+      "name": "Roman Shtylman",
+      "email": "shtylman+expressjs@gmail.com"
+    },
+    {
+      "name": "Young Jae Sim",
+      "email": "hanul@hanul.me"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/expressjs/express/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/express.min.json
+++ b/test/fixtures/registry-mocks/content/express.min.json
@@ -1,0 +1,11281 @@
+{
+  "name": "express",
+  "dist-tags": {
+    "latest": "4.17.1",
+    "next": "5.0.0-alpha.8"
+  },
+  "versions": {
+    "0.14.0": {
+      "name": "express",
+      "version": "0.14.0",
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-0.14.0.tgz",
+        "shasum": "7b33a9fb54c605a3be46c1d3dbbc821acf1d2efb"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      },
+      "deprecated": "express 0.x series is deprecated"
+    },
+    "0.14.1": {
+      "name": "express",
+      "version": "0.14.1",
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-0.14.1.tgz",
+        "shasum": "40b0119ea0549892b03b5bb56c79cdff468d04b4"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      },
+      "deprecated": "express 0.x series is deprecated"
+    },
+    "1.0.0": {
+      "name": "express",
+      "version": "1.0.0",
+      "dependencies": {
+        "connect": ">= 0.3.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0.tgz",
+        "shasum": "48a43d78a96eb9232f631d23cc8de8f854d8e0e9"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.1": {
+      "name": "express",
+      "version": "1.0.1",
+      "dependencies": {
+        "connect": ">= 0.3.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "shasum": "53ad8442c3feb46588f08698f1872c4dbf24137f",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.2": {
+      "name": "express",
+      "version": "1.0.2",
+      "dependencies": {
+        "connect": ">= 0.3.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "shasum": "5985fd1986b2275d8e96976a8b8de011dc823e0d",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.3": {
+      "name": "express",
+      "version": "1.0.3",
+      "dependencies": {
+        "connect": ">= 0.3.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "shasum": "e07fd860c4af7ffddc77653fd1fd930fce26cb61",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.4": {
+      "name": "express",
+      "version": "1.0.4",
+      "dependencies": {
+        "connect": ">= 0.5.x",
+        "qs": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "fab80c530d40b04f4f558f7f03b2cbf0f9040b14",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.5": {
+      "name": "express",
+      "version": "1.0.5",
+      "dependencies": {
+        "connect": ">= 0.5.0",
+        "qs": ">= 0.0.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "2d32dff93a8c454e9a717c43b856c5369efc2856",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.6": {
+      "name": "express",
+      "version": "1.0.6",
+      "dependencies": {
+        "connect": ">= 0.5.0",
+        "qs": ">= 0.0.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "9aee1508f0e9ce4cc2eabdda94ec8793898306f9",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.7": {
+      "name": "express",
+      "version": "1.0.7",
+      "dependencies": {
+        "connect": ">= 0.5.0",
+        "qs": ">= 0.0.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "ccb14eee039e4177ce410fe5f074e96f68629e6c",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "1.0.8": {
+      "name": "express",
+      "version": "1.0.8",
+      "dependencies": {
+        "connect": ">= 0.5.0 < 1.0.0",
+        "qs": ">= 0.0.5"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "fe254667ad612c23dd87d61180dc194cda1f7d38",
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0 < 0.4.0"
+      },
+      "deprecated": "express 1.x series is deprecated"
+    },
+    "2.0.0": {
+      "name": "express",
+      "version": "2.0.0",
+      "dependencies": {
+        "connect": ">= 1.1.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "f9f715cf54e9b6f3f00115fe7e1188964d0a74b2",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.1.0": {
+      "name": "express",
+      "version": "2.1.0",
+      "dependencies": {
+        "connect": ">= 1.1.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "34542d68cf298d5a89d74dc1c8f96b5c4e1b00a7",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.1.1": {
+      "name": "express",
+      "version": "2.1.1",
+      "dependencies": {
+        "connect": ">= 1.1.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "4ab83c3509050ef917532cdb174bc23d8a007af4",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.2.0": {
+      "name": "express",
+      "version": "2.2.0",
+      "dependencies": {
+        "connect": ">= 1.2.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "ab38a7eaad67a1c28495021a798d234086d73dea",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.2.1": {
+      "name": "express",
+      "version": "2.2.1",
+      "dependencies": {
+        "connect": ">= 1.2.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "a4937f9d5e661282cd62d88e227132f79ccbe25f",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.2.2": {
+      "name": "express",
+      "version": "2.2.2",
+      "dependencies": {
+        "connect": ">= 1.3.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "19c26d4cd36018896fc90a9eef3300052b3e01d2",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.0": {
+      "name": "express",
+      "version": "2.3.0",
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "c32ae9a32a364077976352349eac54820cf21e3e",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.1": {
+      "name": "express",
+      "version": "2.3.1",
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "15a9459c9b9e785d52d14a62595a29d7cbab4882",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.2": {
+      "name": "express",
+      "version": "2.3.2",
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "ad6a3071d59a3bf1a4ed0b1b2942d9f0e510a028",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.3": {
+      "name": "express",
+      "version": "2.3.3",
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "936507d26e0433598679a645a87e403b3292547c",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.4": {
+      "name": "express",
+      "version": "2.3.4",
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "8db976504b3f7f1da32abc845c45c20610a1ffd0",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.5": {
+      "name": "express",
+      "version": "2.3.5",
+      "dependencies": {
+        "connect": ">= 1.4.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "a3113d0d9db4ea118e2c12b044a04c16741e799b",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.6": {
+      "name": "express",
+      "version": "2.3.6",
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "8598e2995fc7c7427b7c3aed53837be652e873c7",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.7": {
+      "name": "express",
+      "version": "2.3.7",
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "6d008ca32c4a23110032e67f4c40843c068e13b7",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.8": {
+      "name": "express",
+      "version": "2.3.8",
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "fac5808b93b5abf84906c886fe314a0d4f44fa89",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.9": {
+      "name": "express",
+      "version": "2.3.9",
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "e5b6a5dc5452e9bcaf8936297f9f0e111b71a2a7",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.10": {
+      "name": "express",
+      "version": "2.3.10",
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "09b5e939b28af0705d1ac46265c703db1016310c",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.11": {
+      "name": "express",
+      "version": "2.3.11",
+      "dependencies": {
+        "connect": ">= 1.4.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "1dcd3a404332565a64c8290797e183707612f25a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.11.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.3.12": {
+      "name": "express",
+      "version": "2.3.12",
+      "dependencies": {
+        "connect": ">= 1.5.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "9e750c8e50ff976f89b4ed9e1ca6d534bad23014",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.3.12.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.0": {
+      "name": "express",
+      "version": "2.4.0",
+      "dependencies": {
+        "connect": ">= 1.5.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "c6cad05e9ec481a91e3817ca25cfd55ea37c00ce",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.1": {
+      "name": "express",
+      "version": "2.4.1",
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "006d435d5ca4332e51cc56ec3a69c707e40d62b4",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.2": {
+      "name": "express",
+      "version": "2.4.2",
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "bfdd3dfd9c387e3196ac9dc8c7ff8d3a930d4d1a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.3": {
+      "name": "express",
+      "version": "2.4.3",
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "5f52dd1e2cddbb83b3483cfb4c8c5c24d3975450",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.4": {
+      "name": "express",
+      "version": "2.4.4",
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "ae677e39c6f489e328cb7994b88ebee7db19b6d9",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.5": {
+      "name": "express",
+      "version": "2.4.5",
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "b042984190df1ea06cc6e89c3eb4dfa848376322",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.6": {
+      "name": "express",
+      "version": "2.4.6",
+      "dependencies": {
+        "connect": ">= 1.5.2 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "df8152c5a40bd89ad74ab07e5ef999fac5a00916",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.4.7": {
+      "name": "express",
+      "version": "2.4.7",
+      "dependencies": {
+        "connect": "1.7.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.7.2",
+        "hamljs": "0.5.1",
+        "jade": "0.11.0",
+        "stylus": "0.13.0",
+        "should": "0.2.1",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "872bbf5427e062100901ade6e80ff577ac24de3f",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.4.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.0": {
+      "name": "express",
+      "version": "2.5.0",
+      "dependencies": {
+        "connect": "1.7.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "3f9716eaa0e7380025fbb2c6c9942e3d9c9ed3b9",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.1": {
+      "name": "express",
+      "version": "2.5.1",
+      "dependencies": {
+        "connect": "1.8.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "0644284c2c219264e2955fe94717ce7b462cd5d6",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.2": {
+      "name": "express",
+      "version": "2.5.2",
+      "dependencies": {
+        "connect": "1.8.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d58c41f7dff9a69696cffcc8e9bde4e81cbbcbef",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.3": {
+      "name": "express",
+      "version": "2.5.3",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "65c909b778715753797129b9ea39bca6a248d6f1",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.4": {
+      "name": "express",
+      "version": "2.5.4",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "3090710723a13acfe000817b0fbeea13d8faee4b",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.5": {
+      "name": "express",
+      "version": "2.5.5",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.5.1",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d15d4ffe5c420adda0645680361bb21c836b6e7c",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.6": {
+      "name": "express",
+      "version": "2.5.6",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "1f2a96d01e1285797dae715d9ac93d9c60dd772a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.7": {
+      "name": "express",
+      "version": "2.5.7",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.3.1",
+        "mkdirp": "0.0.7"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "9f8fa92be38cb3c11959e99e18806cda19fd359f",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.8": {
+      "name": "express",
+      "version": "2.5.8",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": "1.2.4",
+        "qs": "0.4.x",
+        "mkdirp": "0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f166b55d4e8c6d2307ef88ad1768209613f7452a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.9": {
+      "name": "express",
+      "version": "2.5.9",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": "1.2.4",
+        "qs": "0.4.x",
+        "mkdirp": "0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "62d111ccaccf425182e1f30e541f84b551a72f2c",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.7.0"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.10": {
+      "name": "express",
+      "version": "2.5.10",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": "1.2.4",
+        "qs": "0.4.x",
+        "mkdirp": "0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "b1cdaf0c7e98e33125e6f8476800bdeb7f7efc8a",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.10.tgz"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "2.5.11": {
+      "name": "express",
+      "version": "2.5.11",
+      "dependencies": {
+        "connect": "1.x",
+        "mime": "1.2.4",
+        "qs": "0.4.x",
+        "mkdirp": "0.3.0"
+      },
+      "devDependencies": {
+        "connect-form": "0.2.1",
+        "ejs": "0.4.2",
+        "expresso": "0.9.2",
+        "hamljs": "0.6.x",
+        "jade": "0.16.2",
+        "stylus": "0.13.0",
+        "should": "0.3.2",
+        "express-messages": "0.0.2",
+        "node-markdown": ">= 0.0.1",
+        "connect-redis": ">= 0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "4ce8ea1f3635e69e49f0ebb497b6a4b0a51ce6f0",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.5.11.tgz"
+      },
+      "deprecated": "express 2.x series is deprecated"
+    },
+    "3.0.0": {
+      "name": "express",
+      "version": "3.0.0",
+      "dependencies": {
+        "connect": "2.6.0",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "41e202f3627ea442be9e86d5ec51246ad72339ed",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.1": {
+      "name": "express",
+      "version": "3.0.1",
+      "dependencies": {
+        "connect": "2.6.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "36a5008d158a97e82817f45b89561633b61a1be8",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.2": {
+      "name": "express",
+      "version": "3.0.2",
+      "dependencies": {
+        "connect": "2.6.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "fd93ed32f9a938cf79b7c4df95a2458d412f09b9",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.3": {
+      "name": "express",
+      "version": "3.0.3",
+      "dependencies": {
+        "connect": "2.7.0",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "007c7590b1ab31219e6d8d71f86ad5086204868c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.4": {
+      "name": "express",
+      "version": "3.0.4",
+      "dependencies": {
+        "connect": "2.7.1",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.1.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "04a8e939145940a6bb3b215d736ec2c1584ee0a8",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.5": {
+      "name": "express",
+      "version": "3.0.5",
+      "dependencies": {
+        "connect": "2.7.1",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.1.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "4c6e5850e6b5e8ca2af57f21ed7097de50948b73",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.6": {
+      "name": "express",
+      "version": "3.0.6",
+      "dependencies": {
+        "connect": "2.7.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.1.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d274fcb868b95788bf4af62168d75d13fd77d8b4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.1.0": {
+      "name": "express",
+      "version": "3.1.0",
+      "dependencies": {
+        "connect": "2.7.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.1.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f869b2d92320f5c3dd496c172e06f02b6ad43310",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.1.1": {
+      "name": "express",
+      "version": "3.1.1",
+      "dependencies": {
+        "connect": "2.7.4",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "~0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "~0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "2cc065f642856be506686399aadeff375a701468",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.1.2": {
+      "name": "express",
+      "version": "3.1.2",
+      "dependencies": {
+        "connect": "2.7.5",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "~0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "~0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "52a02c8db8f22bbfa0d7478d847cd45161f985f7",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.0": {
+      "name": "express",
+      "version": "3.2.0",
+      "dependencies": {
+        "connect": "2.7.6",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "~0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "~0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "7b66d6c66b038038eedf452804222b3077374ae0",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.1": {
+      "name": "express",
+      "version": "3.2.1",
+      "dependencies": {
+        "connect": "2.7.7",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "qs": "0.6.1"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "fd9ce6c0b8e4fda80772cef9af6e756434628d84",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.2": {
+      "name": "express",
+      "version": "3.2.2",
+      "dependencies": {
+        "connect": "2.7.8",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "qs": "0.6.3"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "22c6cb2e0efc20833670425cd820c5f4bb119f8b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.3": {
+      "name": "express",
+      "version": "3.2.3",
+      "dependencies": {
+        "connect": "2.7.9",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*",
+        "qs": "0.6.4"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "9952eb764953ad40e4caa1f0b8715f7ba667f477",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.4": {
+      "name": "express",
+      "version": "3.2.4",
+      "dependencies": {
+        "connect": "2.7.9",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.0.5",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f39fcba9a224011058fb581647688b12df94f585",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.5": {
+      "name": "express",
+      "version": "3.2.5",
+      "dependencies": {
+        "connect": "2.7.10",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d2c86134d9fa1573b8004d23c6dc0d50bc8efe20",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.2.6": {
+      "name": "express",
+      "version": "3.2.6",
+      "dependencies": {
+        "connect": "2.7.11",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d8a9fe065adc23c5b41ec2c689c672b261430ffc",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.2.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.0": {
+      "name": "express",
+      "version": "3.3.0",
+      "dependencies": {
+        "connect": "2.8.0",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.1",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f89f8fc1ddfb7ffdfc9db3103a75881cd64dce7f",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.1": {
+      "name": "express",
+      "version": "3.3.1",
+      "dependencies": {
+        "connect": "2.8.1",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.1",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "4bb79fb3548313d9e1a49ffdc5aa369a936127d7",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.2": {
+      "name": "express",
+      "version": "3.3.2",
+      "dependencies": {
+        "connect": "2.8.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.4",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.2",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d70c4888da2f35c9fa80e6747323ec6afeb6f947",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.3": {
+      "name": "express",
+      "version": "3.3.3",
+      "dependencies": {
+        "connect": "2.8.3",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.2",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "c9b5244edad7c6b85dae94e5cf1b29162470c933",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.4": {
+      "name": "express",
+      "version": "3.3.4",
+      "dependencies": {
+        "connect": "2.8.4",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.3",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "9abf22017213a8f6f54a421ce22b8ec27b7def62",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.5": {
+      "name": "express",
+      "version": "3.3.5",
+      "dependencies": {
+        "connect": "2.8.5",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "3fd077660c9ccae4710fcfb326290a01d1e72566",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.6": {
+      "name": "express",
+      "version": "3.3.6",
+      "dependencies": {
+        "connect": "2.8.5",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "c1082fdb55b9de2ce399252eb4e048da2ed9918d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.0-beta": {
+      "name": "express",
+      "version": "1.0.0-beta",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0beta.tgz",
+        "shasum": "f8c485ec1aa2d8612c667a0fca08603abdb27246"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      }
+    },
+    "1.0.0-beta2": {
+      "name": "express",
+      "version": "1.0.0-beta2",
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0beta2.tgz",
+        "shasum": "4e9f6f94405c969173e09a20ba3f0d27020ec9e9"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      }
+    },
+    "1.0.0-rc": {
+      "name": "express",
+      "version": "1.0.0-rc",
+      "dependencies": {
+        "connect": ">= 0.2.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0rc.tgz",
+        "shasum": "cc9545ae107dac12821f997e3dd43c5df223ba13"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      }
+    },
+    "1.0.0-rc2": {
+      "name": "express",
+      "version": "1.0.0-rc2",
+      "dependencies": {
+        "connect": ">= 0.2.4"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0rc2.tgz",
+        "shasum": "040b7790e1ab041e8218835376c5d21bba634bac"
+      },
+      "engines": {
+        "node": ">= 0.1.98"
+      }
+    },
+    "1.0.0-rc3": {
+      "name": "express",
+      "version": "1.0.0-rc3",
+      "dependencies": {
+        "connect": ">= 0.2.5"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0rc3.tgz",
+        "shasum": "ae5ee7dfbe436192adad65c7817c5ae78a8b4f93"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "1.0.0-rc4": {
+      "name": "express",
+      "version": "1.0.0-rc4",
+      "dependencies": {
+        "connect": ">= 0.2.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib/express"
+      },
+      "dist": {
+        "tarball": "https://registry.npmjs.org/express/-/express-1.0.0rc4.tgz",
+        "shasum": "c5363c021717c02728c692fedc632cac9a869160"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "2.0.0-beta": {
+      "name": "express",
+      "version": "2.0.0-beta",
+      "dependencies": {
+        "connect": ">= 1.0.1",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "c2095479887128f161ee13211e7b886edb4d9f98",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0beta.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      }
+    },
+    "2.0.0-beta2": {
+      "name": "express",
+      "version": "2.0.0-beta2",
+      "dependencies": {
+        "connect": ">= 1.0.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "274e49af300145688e87ed2f5c5e59f6e26af135",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0beta2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      }
+    },
+    "2.0.0-beta3": {
+      "name": "express",
+      "version": "2.0.0-beta3",
+      "dependencies": {
+        "connect": ">= 1.0.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "f9c1324023729c4eb96688023e989fe2f8565c61",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0beta3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      }
+    },
+    "2.0.0-rc": {
+      "name": "express",
+      "version": "2.0.0-rc",
+      "dependencies": {
+        "connect": ">= 1.0.1 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "6d3da0301b6cdce94ee437ae40ae6c8c7f5d7ccf",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0rc.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      }
+    },
+    "2.0.0-rc2": {
+      "name": "express",
+      "version": "2.0.0-rc2",
+      "dependencies": {
+        "connect": ">= 1.1.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "381e1388bcd56d0449dbbf2272975f907488f710",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0rc2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      }
+    },
+    "2.0.0-rc3": {
+      "name": "express",
+      "version": "2.0.0-rc3",
+      "dependencies": {
+        "connect": ">= 1.1.0 < 2.0.0",
+        "mime": ">= 0.0.1",
+        "qs": ">= 0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "directories": {
+        "lib": "./lib",
+        "bin": "./bin"
+      },
+      "dist": {
+        "shasum": "538a35c8b0e2b08c455a20528b8d6a5568e901c1",
+        "tarball": "https://registry.npmjs.org/express/-/express-2.0.0rc3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.1 < 0.5.0"
+      }
+    },
+    "3.0.0-alpha1": {
+      "name": "express",
+      "version": "3.0.0-alpha1",
+      "dependencies": {
+        "connect": "2.1.2",
+        "commander": "0.5.2",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "252902b7ed3a4b18a9163c51bdab519282cf2401",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.5.0 < 0.7.0"
+      }
+    },
+    "3.0.0-alpha2": {
+      "name": "express",
+      "version": "3.0.0-alpha2",
+      "dependencies": {
+        "connect": "2.2.1",
+        "commander": "0.5.2",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "crc": "0.1.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "e82f7ba6b2c3e678c44343d0ba4fe339ca928e6c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.5.0 < 0.7.0"
+      }
+    },
+    "3.0.0-alpha3": {
+      "name": "express",
+      "version": "3.0.0-alpha3",
+      "dependencies": {
+        "connect": "2.2.2",
+        "commander": "0.5.2",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "a65af40b696d39310c434d810adc9c4942fc2f9c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-alpha4": {
+      "name": "express",
+      "version": "3.0.0-alpha4",
+      "dependencies": {
+        "connect": "2.2.2",
+        "commander": "0.5.2",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "9bc6be2bcfbbd74dba66063808d3a75ad4bd7edb",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-alpha5": {
+      "name": "express",
+      "version": "3.0.0-alpha5",
+      "dependencies": {
+        "connect": "2.2.2",
+        "commander": "0.6.0",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.1",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d01ff9c2ebd769744ee90cc89561a1c8ca5340ac",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0alpha5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-beta1": {
+      "name": "express",
+      "version": "3.0.0-beta1",
+      "dependencies": {
+        "connect": "2.3.0",
+        "commander": "0.6.1",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.2",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "557dda7815bffb84dea4cd3c09e1fe6538b2262f",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-beta2": {
+      "name": "express",
+      "version": "3.0.0-beta2",
+      "dependencies": {
+        "connect": "2.3.1",
+        "commander": "0.6.1",
+        "mime": "1.2.5",
+        "mkdirp": "0.3.2",
+        "cookie": "0.0.3",
+        "crc": "0.2.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "2755a16a2f7054c06d93f3a17dd6cbd0d5aa8698",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-beta3": {
+      "name": "express",
+      "version": "3.0.0-beta3",
+      "dependencies": {
+        "connect": "2.3.3",
+        "commander": "0.6.1",
+        "mkdirp": "0.3.2",
+        "cookie": "0.0.3",
+        "crc": "0.2.0",
+        "fresh": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "e8425ee5f1d1c649c2e0627f437a331e9b9da867",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-beta4": {
+      "name": "express",
+      "version": "3.0.0-beta4",
+      "dependencies": {
+        "connect": "2.3.4",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.3",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "0f7e5bb2db67e81b4d1c752300954133df276063",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-beta6": {
+      "name": "express",
+      "version": "3.0.0-beta6",
+      "dependencies": {
+        "connect": "2.3.8",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "response-send": "0.0.1",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.3",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.2",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "3eef2ed7ce7511170df4d15f4d2dade10dbc6614",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-beta7": {
+      "name": "express",
+      "version": "3.0.0-beta7",
+      "dependencies": {
+        "connect": "2.3.9",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "response-send": "0.0.1",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.3",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.3",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "92e854f2814e05a333d2acfde43585cfda21d9aa",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0beta7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-rc1": {
+      "name": "express",
+      "version": "3.0.0-rc1",
+      "dependencies": {
+        "connect": "2.4.1",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.3",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "b96bc45e19a0fece6b4c26c297db2f958a50643a",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-rc2": {
+      "name": "express",
+      "version": "3.0.0-rc2",
+      "dependencies": {
+        "connect": "2.4.2",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.3",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "ffa79ccee41abc97f2c57576cc433339200fcd33",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-rc3": {
+      "name": "express",
+      "version": "3.0.0-rc3",
+      "dependencies": {
+        "connect": "2.4.3",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.3",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "740d4e14335a1e92a19493930def0c747a0367b4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-rc4": {
+      "name": "express",
+      "version": "3.0.0-rc4",
+      "dependencies": {
+        "connect": "2.4.4",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.0.4",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f07490f3578a87e06d4244d58c18d6f6e2c5fc33",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.0.0-rc5": {
+      "name": "express",
+      "version": "3.0.0-rc5",
+      "dependencies": {
+        "connect": "2.5.0",
+        "commander": "0.6.1",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.3",
+        "cookie": "0.0.4",
+        "crc": "0.2.0",
+        "fresh": "0.1.0",
+        "methods": "0.0.1",
+        "send": "0.1.0",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "*",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "github-flavored-markdown": "*",
+        "supertest": "0.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "c63b56257f33a74498dbc0ba8986a3d5b627fc9d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.0.0rc5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.7": {
+      "name": "express",
+      "version": "3.3.7",
+      "dependencies": {
+        "connect": "2.8.7",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "de0b67ae1b04999fe7141940c2749f5b435a8fcd",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.3.8": {
+      "name": "express",
+      "version": "3.3.8",
+      "dependencies": {
+        "connect": "2.8.8",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "8e98ac30d81f4c95b85d71d2af6cf84f62ef19bd",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.3.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.0": {
+      "name": "express",
+      "version": "3.4.0",
+      "dependencies": {
+        "connect": "2.9.0",
+        "commander": "1.2.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "*",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "6ed289da0d5f55ac30997cf832e5fc36f784071e",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.1": {
+      "name": "express",
+      "version": "3.4.1",
+      "dependencies": {
+        "connect": "2.9.1",
+        "commander": "2.0.0",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "2",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "3b4fb8862b6a1dfce3dc760629833d0cfef9314c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.2": {
+      "name": "express",
+      "version": "3.4.2",
+      "dependencies": {
+        "connect": "2.9.2",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "2",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "3cfaa66fb1e1fac5012129b473f0e2143544aa07",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.3": {
+      "name": "express",
+      "version": "3.4.3",
+      "dependencies": {
+        "connect": "2.10.1",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.0.1",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "2",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.6.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d0d237d60cd9c741b50da88379527e2a1d804627",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.4": {
+      "name": "express",
+      "version": "3.4.4",
+      "dependencies": {
+        "connect": "2.11.0",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": "*"
+      },
+      "devDependencies": {
+        "ejs": "*",
+        "mocha": "*",
+        "jade": "0.30.0",
+        "hjs": "*",
+        "stylus": "*",
+        "should": "2",
+        "connect-redis": "*",
+        "marked": "*",
+        "supertest": "0.8.1 - 1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "0b63ae626c96b71b78d13dfce079c10351635a86",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "3.4.5": {
+      "name": "express",
+      "version": "3.4.5",
+      "dependencies": {
+        "connect": "2.11.1",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.14.0",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.0.2",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "dc82aa4d932f0d0ee93e8e7ee9824d73bb00d47a",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.4.6": {
+      "name": "express",
+      "version": "3.4.6",
+      "dependencies": {
+        "connect": "2.11.2",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.14.0",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.0.2",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "85b6004076f9004f806e9f49c90487d1f6f89c43",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.4.7": {
+      "name": "express",
+      "version": "3.4.7",
+      "dependencies": {
+        "connect": "2.12.0",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "merge-descriptors": "0.0.1",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "3b939c47d2aa44dfecf77d50da2123c5bd313366",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.4.8": {
+      "name": "express",
+      "version": "3.4.8",
+      "dependencies": {
+        "connect": "2.12.0",
+        "commander": "1.3.2",
+        "range-parser": "0.0.4",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.0",
+        "methods": "0.1.0",
+        "send": "0.1.4",
+        "cookie-signature": "1.0.1",
+        "merge-descriptors": "0.0.1",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "aa7a8986de07053337f4bc5ed9a6453d9cc8e2e1",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.4.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.0.0-rc1": {
+      "name": "express",
+      "version": "4.0.0-rc1",
+      "dependencies": {
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0"
+      },
+      "dist": {
+        "shasum": "a9f3f89e4726e2ff60f62ab625c960eaa2cba3a6",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0-rc1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.0.0-rc2": {
+      "name": "express",
+      "version": "4.0.0-rc2",
+      "dependencies": {
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0"
+      },
+      "dist": {
+        "shasum": "0b3fc3b853b393cdb5042dc9960498015ed06b96",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0-rc2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.5.0": {
+      "name": "express",
+      "version": "3.5.0",
+      "dependencies": {
+        "connect": "2.14.1",
+        "commander": "1.3.2",
+        "range-parser": "1.0.0",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.1",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.17.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.9.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "703f299aa2a7fce122025b61a2e170d536b35019",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.0.0-rc3": {
+      "name": "express",
+      "version": "4.0.0-rc3",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.0.1",
+        "path-to-regexp": "0.1.0",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "da0113235684e89d36bd7796440809e889ee8692",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0-rc3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.0.0-rc4": {
+      "name": "express",
+      "version": "4.0.0-rc4",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "1cedc8790f47b776b9d100f5388e5fb652ea4388",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0-rc4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.5.1": {
+      "name": "express",
+      "version": "3.5.1",
+      "dependencies": {
+        "connect": "2.14.1",
+        "commander": "1.3.2",
+        "range-parser": "1.0.0",
+        "mkdirp": "0.3.5",
+        "cookie": "0.1.1",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.17.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.9.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "4b333e1117faca336a538f4c724140b9ce1a87e7",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.0.0": {
+      "name": "express",
+      "version": "4.0.0",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.0",
+        "type-is": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.0",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.2.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.0.1",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.15.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.8.1",
+        "body-parser": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "static-favicon": "1.0.0",
+        "express-session": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "274dc82933c9f574cc38a0ce5ea8172be9c6b094",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.5.2": {
+      "name": "express",
+      "version": "3.5.2",
+      "dependencies": {
+        "connect": "2.14.5",
+        "commander": "1.3.2",
+        "range-parser": "1.0.0",
+        "mkdirp": "0.4.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.18.2",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.11.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "aab0d2b31ef21259eac24dc45c43378fcf144b6d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.1.0": {
+      "name": "express",
+      "version": "4.1.0",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.1",
+        "type-is": "1.1.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "body-parser": "1.0.2",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "express-session": "1.0.3",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "static-favicon": "1.0.2",
+        "hjs": "~0.0.6",
+        "should": "~3.3.1",
+        "supertest": "~0.11.0",
+        "method-override": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "a822be824cf88e8ad67ec5df75d02887de6058b4",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.1.1": {
+      "name": "express",
+      "version": "4.1.1",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.1",
+        "type-is": "1.1.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "body-parser": "1.0.2",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "express-session": "1.0.3",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "static-favicon": "1.0.2",
+        "hjs": "~0.0.6",
+        "should": "~3.3.1",
+        "supertest": "~0.11.0",
+        "method-override": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "266f08c3cbc21fc1831e954073dda8cf3cae002f",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.5.3": {
+      "name": "express",
+      "version": "3.5.3",
+      "dependencies": {
+        "connect": "2.14.5",
+        "commander": "1.3.2",
+        "range-parser": "1.0.0",
+        "mkdirp": "0.4.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.18.2",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.11.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "af440e1ddad078934ec78241420b40bbc56dc2ad",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.5.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.1.2": {
+      "name": "express",
+      "version": "4.1.2",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.1",
+        "type-is": "1.1.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "0.1.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": ">= 0.7.3 < 1"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "body-parser": "1.0.2",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "express-session": "1.0.3",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "static-favicon": "1.0.2",
+        "hjs": "~0.0.6",
+        "should": "~3.3.1",
+        "supertest": "~0.11.0",
+        "method-override": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "morgan": "1.0.0",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "cb1d114255718a65a1bcd6958036ef720c529487",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.6.0": {
+      "name": "express",
+      "version": "3.6.0",
+      "dependencies": {
+        "connect": "2.15.0",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "mocha": "~1.18.2",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "should": "~2.1.1",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.12.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "94c7b0f8f506b046d4d9770b40992f224026e5d5",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.2.0": {
+      "name": "express",
+      "version": "4.2.0",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "accepts": "1.0.1",
+        "type-is": "1.1.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "body-parser": "~1.1.2",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "should": "~3.3.1",
+        "supertest": "~0.12.0",
+        "method-override": "1.0.0",
+        "cookie-parser": "1.0.1",
+        "express-session": "1.0.4",
+        "morgan": "1.0.1",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "3121993a45126693e8bf897aefb4dd783762dc60",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.7.0": {
+      "name": "express",
+      "version": "3.7.0",
+      "dependencies": {
+        "connect": "2.16.2",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "coveralls": "2.10.0",
+        "ejs": "~0.8.4",
+        "istanbul": "0.2.10",
+        "mocha": "~1.18.2",
+        "should": "~3.3.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.12.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "74f62f00ab2d7d49f19a9b6c81fb80b00e495868",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.8.0": {
+      "name": "express",
+      "version": "3.8.0",
+      "dependencies": {
+        "connect": "2.17.1",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.12.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f243c1752630b21b5e898cc586d1d39690422876",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.3.0": {
+      "name": "express",
+      "version": "4.3.0",
+      "dependencies": {
+        "accepts": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "supertest": "~0.12.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.2.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.0",
+        "method-override": "1.0.1",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "3a65f18e40be9ea124f11c435b88b07430ef6fea",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.3.1": {
+      "name": "express",
+      "version": "4.3.1",
+      "dependencies": {
+        "accepts": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "supertest": "~0.12.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.2.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.0",
+        "method-override": "1.0.1",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "656b2c148d1db3e2ac53727b799f0e34ecc7d713",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.8.1": {
+      "name": "express",
+      "version": "3.8.1",
+      "dependencies": {
+        "connect": "2.17.3",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "ejs": "~0.8.4",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "jade": "~0.30.0",
+        "hjs": "~0.0.6",
+        "stylus": "~0.40.0",
+        "connect-redis": "~1.4.5",
+        "marked": "0.2.10",
+        "supertest": "~0.12.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "884148c879c5ae88243c635dee4d91956b750143",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.8.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.3.2": {
+      "name": "express",
+      "version": "4.3.2",
+      "dependencies": {
+        "accepts": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "buffer-crc32": "0.2.1",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "send": "0.3.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.1.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.1",
+        "supertest": "~0.12.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~0.35.0",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.2.2",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "1.0.2",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "b8332c55d7b2f69f2d90e14c0958431e3a1a25dc",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.9.0": {
+      "name": "express",
+      "version": "3.9.0",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.18.0",
+        "commander": "1.3.2",
+        "methods": "1.0.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "send": "0.4.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "da991c3ff90bb5b9f26842e3e3f70c8caa4797c8",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.9.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.4.0": {
+      "name": "express",
+      "version": "4.4.0",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "buffer-crc32": "0.2.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "send": "0.4.0",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "methods": "1.0.0",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "serve-static": "1.2.0",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.2.2",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "1.0.2",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "1ffd7dbe7a24fb2940ad0570611a3312b76d8f37",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.4.1": {
+      "name": "express",
+      "version": "4.4.1",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "buffer-crc32": "0.2.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "serve-static": "1.2.1",
+        "type-is": "1.2.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "escape-html": "1.0.1",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2",
+        "debug": "0.8.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.3.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "2.0.1",
+        "morgan": "1.1.1",
+        "vhost": "1.0.0"
+      },
+      "dist": {
+        "shasum": "9e0364d1c74e076d7409d302429a384b10dfbd42",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.10.0": {
+      "name": "express",
+      "version": "3.10.0",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.1",
+        "commander": "1.3.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.0",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "508aebb75685a84fe5873b080a2f759c5e0f4a97",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.10.1": {
+      "name": "express",
+      "version": "3.10.1",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.2",
+        "commander": "1.3.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "259578cd1238731560460e833bc8b2a10b031b4d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.10.2": {
+      "name": "express",
+      "version": "3.10.2",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.3",
+        "commander": "1.3.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "debug": ">= 0.8.0 < 1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "4fa0df0a6dd3956255cc23ade6c6576911d8e467",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.10.3": {
+      "name": "express",
+      "version": "3.10.3",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.4",
+        "commander": "1.3.2",
+        "debug": "1.0.0",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d669d5fa2d79fa6349af5fa6338d646bc346ada5",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.10.4": {
+      "name": "express",
+      "version": "3.10.4",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.5",
+        "commander": "1.3.2",
+        "debug": "1.0.1",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "527bd28b0e17cd41722617ab88cb4a41b15f497d",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.4.2": {
+      "name": "express",
+      "version": "4.4.2",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "buffer-crc32": "0.2.1",
+        "debug": "1.0.1",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.2",
+        "serve-static": "1.2.2",
+        "type-is": "1.2.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.3.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "2.0.2",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "ff6c8a513d31cc60cabe0f71848dea3cb4f56df6",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.10.5": {
+      "name": "express",
+      "version": "3.10.5",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "connect": "2.19.6",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "842c0bcb4f6b7fc6323fa3030f24d0e9f82c5501",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.10.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.4.3": {
+      "name": "express",
+      "version": "4.4.3",
+      "dependencies": {
+        "accepts": "1.0.3",
+        "buffer-crc32": "0.2.1",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "serve-static": "1.2.3",
+        "type-is": "1.2.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "1.3.0",
+        "cookie-parser": "1.1.0",
+        "express-session": "1.2.1",
+        "method-override": "2.0.2",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "c52525743153f00452fe8b13fee1e94330a208a0",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.11.0": {
+      "name": "express",
+      "version": "3.11.0",
+      "dependencies": {
+        "buffer-crc32": "0.2.3",
+        "connect": "2.20.2",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f1c8e1c991a444dd7ae331bfb7f1a4557fcfd2ee",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.11.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.4.4": {
+      "name": "express",
+      "version": "4.4.4",
+      "dependencies": {
+        "accepts": "~1.0.5",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "serve-static": "1.2.3",
+        "type-is": "1.2.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.5.0",
+        "method-override": "2.0.2",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "198bfd931c16ce869e54af5fb0515064fb8ea431",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.12.0": {
+      "name": "express",
+      "version": "3.12.0",
+      "dependencies": {
+        "buffer-crc32": "0.2.3",
+        "connect": "2.21.0",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.3",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "8f00c9bef6f4d186f4a481ad831844dd7d73336e",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.12.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.12.1": {
+      "name": "express",
+      "version": "3.12.1",
+      "dependencies": {
+        "buffer-crc32": "0.2.3",
+        "connect": "2.21.1",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.12",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f13d260d1ac6ebc4913a42dfee913cdc65dd96d4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.12.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.4.5": {
+      "name": "express",
+      "version": "4.4.5",
+      "dependencies": {
+        "accepts": "~1.0.5",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.4.3",
+        "serve-static": "1.2.3",
+        "type-is": "1.2.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "multiparty": "~3.2.4",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.5.0",
+        "method-override": "2.0.2",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "5f2f302f277187abd721c3a36e44d86c5e3f03eb",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.4.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.13.0": {
+      "name": "express",
+      "version": "3.13.0",
+      "dependencies": {
+        "basic-auth": "0.0.1",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.22.0",
+        "commander": "1.3.2",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.12",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "69ac1d62732992e9529dc3b21eb40f23cc64438b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.13.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.5.0": {
+      "name": "express",
+      "version": "4.5.0",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.2",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "serve-static": "~1.3.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.14",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.6.1",
+        "method-override": "2.0.2",
+        "multiparty": "~3.3.0",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "64c68b9e41f66339c95a462f37f94ff436724bd7",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.5.1": {
+      "name": "express",
+      "version": "4.5.1",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.2",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.2",
+        "media-typer": "0.2.0",
+        "methods": "1.0.1",
+        "parseurl": "1.0.1",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "serve-static": "~1.3.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0",
+        "qs": "0.6.6",
+        "path-to-regexp": "0.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.2.14",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.6.1",
+        "method-override": "2.0.2",
+        "multiparty": "~3.3.0",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "4bc3e6ec9db28e575fe591c36fbb781ffef6fe7c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.14.0": {
+      "name": "express",
+      "version": "3.14.0",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.23.0",
+        "commander": "1.3.2",
+        "debug": "1.0.3",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.5.0",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "91f28701eedbce71ddca15b0fb92cfeff1401afb",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.14.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.6.0": {
+      "name": "express",
+      "version": "4.6.0",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.3",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.3",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.1.3",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.6.0",
+        "serve-static": "~1.3.2",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.6.5",
+        "method-override": "~2.1.1",
+        "multiparty": "~3.3.0",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "abaf229003006ada5a4dc5d99abbc7095570af7d",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.6.1": {
+      "name": "express",
+      "version": "4.6.1",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.3",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.0.3",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.1.3",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.6.0",
+        "serve-static": "~1.3.2",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.4.3",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.6.5",
+        "method-override": "~2.1.1",
+        "multiparty": "~3.3.0",
+        "morgan": "1.1.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "c806e51755cb453ba17fac2f343caff6af885df4",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.15.0": {
+      "name": "express",
+      "version": "3.15.0",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.24.0",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.2",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.0",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "c9ac9eb2c38c34a650597300a06848d2e7001aa4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.15.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.7.0": {
+      "name": "express",
+      "version": "4.7.0",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.2",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.0",
+        "serve-static": "~1.4.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.0",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.0",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.0",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "9b38ca8eb3bf75fdcd9fad39ad85d02f5ef80b4b",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.15.1": {
+      "name": "express",
+      "version": "3.15.1",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.24.1",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.3",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "ce6800e0fa51c1c9700f246fc90eb8bcde8172e1",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.15.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.7.1": {
+      "name": "express",
+      "version": "4.7.1",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.3",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.1",
+        "serve-static": "~1.4.1",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.0",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.0",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.0",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "06c0aa7d03d5ea5565bb0249b2da3671a24062d3",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.15.2": {
+      "name": "express",
+      "version": "3.15.2",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.24.2",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "a45f213bcfc5022914223d5d67747661cc7515a1",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.15.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.7.2": {
+      "name": "express",
+      "version": "4.7.2",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.2",
+        "serve-static": "~1.4.2",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.2",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "2cbae61efab6c2db72a547ff3bf380e637c08590",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.7.3": {
+      "name": "express",
+      "version": "4.7.3",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.3",
+        "serve-static": "~1.4.3",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.2",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "9fde138763113224c8204a48209511d0c2d27284",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.15.3": {
+      "name": "express",
+      "version": "3.15.3",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.24.3",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.4",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.3.1",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "connect-redis": "~1.4.5",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "993a9ef1c2d67f2525d086a67dc187edeab6f025",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.15.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.7.4": {
+      "name": "express",
+      "version": "4.7.4",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.7.4",
+        "serve-static": "~1.4.4",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "qs": "0.6.6",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.5.2",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "caf59389cf0b31b1314bf44d3355c2a80cfa217c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.7.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.0": {
+      "name": "express",
+      "version": "3.16.0",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.0",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "289dc292da617d06ac21bc1f4b2ee0e9a09a9c38",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.0": {
+      "name": "express",
+      "version": "4.8.0",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.0.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "serve-static": "~1.5.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.0",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "a6079da464ec502ecaef4e11faa7e127f5593d85",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.1": {
+      "name": "express",
+      "version": "3.16.1",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.1",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "fc5cc9627c8c2837da21119b8d909247b0b40ba0",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.1": {
+      "name": "express",
+      "version": "4.8.1",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.1.0",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "serve-static": "~1.5.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.1",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "24cf5a613156d5d95bc8c2fa843cf12e2a1be6c9",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.2": {
+      "name": "express",
+      "version": "3.16.2",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.2",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "5ed1411187b64e05fef8b70671d3bf9fdf9bc7eb",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.2": {
+      "name": "express",
+      "version": "4.8.2",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.2.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.2.0",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "serve-static": "~1.5.0",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.1",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "99fd5c03a8d885ba83981599619d71d088e46d3c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.3": {
+      "name": "express",
+      "version": "3.16.3",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.3",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.2.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "89157f5e6a84365036ed93ae1e413ab1bd6ce1a5",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.16.4": {
+      "name": "express",
+      "version": "3.16.4",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.4",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "d0dae63fc0d5a24ef48901d6b31d5e5791226033",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.3": {
+      "name": "express",
+      "version": "4.8.3",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.2.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "serve-static": "~1.5.1",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.1",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.2",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.1",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "a2c95b9079cda0473a04448f6b6c1e7fc20bf200",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.5": {
+      "name": "express",
+      "version": "3.16.5",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.5",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.1",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "70dc7fd31be9d7bea32312ce0e461dd4ca5bb58b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.16.6": {
+      "name": "express",
+      "version": "3.16.6",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.6",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "585104615f0b857750856424bcfaa4c16b3cce1c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.4": {
+      "name": "express",
+      "version": "4.8.4",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.2.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.2",
+        "serve-static": "~1.5.2",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.4",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.5",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.1",
+        "morgan": "~1.2.2",
+        "multiparty": "~3.3.2",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "b14d432cc1897e10b1915cf9b648f8930deadb0e",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.7": {
+      "name": "express",
+      "version": "3.16.7",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.7",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "788aab5d66e85060211d6fea08eb2986f2f2631c",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.5": {
+      "name": "express",
+      "version": "4.8.5",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "1.2.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "serve-static": "~1.5.3",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.5",
+        "cookie-parser": "~1.3.1",
+        "express-session": "~1.7.6",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.3",
+        "morgan": "~1.2.3",
+        "multiparty": "~3.3.2",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "59cf7666c29bf7cb8545a1acd43dd81a52cb26d9",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.8": {
+      "name": "express",
+      "version": "3.16.8",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.8",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "46307b9e35a52e523b9d58a16e4c128cd21f43f4",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.6": {
+      "name": "express",
+      "version": "4.8.6",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.0",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "serve-static": "~1.5.3",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.6",
+        "cookie-parser": "~1.3.2",
+        "express-session": "~1.7.6",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.3",
+        "morgan": "~1.2.3",
+        "multiparty": "~3.3.2",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "703b2aa835dafab9840bb890bc55557d96516acd",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.9": {
+      "name": "express",
+      "version": "3.16.9",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.9",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "993747be5669700280d9682cb61ad138939847fc",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.7": {
+      "name": "express",
+      "version": "4.8.7",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.3",
+        "serve-static": "~1.5.3",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.6.7",
+        "cookie-parser": "~1.3.2",
+        "express-session": "~1.7.6",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.3",
+        "morgan": "~1.2.3",
+        "multiparty": "~3.3.2",
+        "vhost": "2.0.0"
+      },
+      "dist": {
+        "shasum": "e4290dd5ff9c5a1a1af6f7a1c0c53021adf8564d",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.16.10": {
+      "name": "express",
+      "version": "3.16.10",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.25.10",
+        "commander": "1.3.2",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "1.0.0",
+        "send": "0.8.5",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.5.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "c68c5ac30e9e890b812c11408dcde183c411bb56",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.16.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.8.8": {
+      "name": "express",
+      "version": "4.8.8",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "buffer-crc32": "0.2.3",
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finalhandler": "0.1.0",
+        "media-typer": "0.2.0",
+        "methods": "1.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.2",
+        "range-parser": "1.0.0",
+        "send": "0.8.5",
+        "serve-static": "~1.5.4",
+        "type-is": "~1.3.2",
+        "vary": "0.1.0",
+        "cookie": "0.1.2",
+        "fresh": "0.2.2",
+        "cookie-signature": "1.0.4",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "connect-redis": "~2.0.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.7.0",
+        "cookie-parser": "~1.3.2",
+        "express-session": "~1.7.6",
+        "jade": "~1.5.0",
+        "method-override": "~2.1.3",
+        "morgan": "~1.2.3",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "6aba348ccdfa87608040b12ca0010107a0aac28e",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.8.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.17.0": {
+      "name": "express",
+      "version": "3.17.0",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.26.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "~1.0.2",
+        "send": "0.9.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "e882e8921dbd193042559b52f7d0250f749ec7ac",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.17.1": {
+      "name": "express",
+      "version": "3.17.1",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "buffer-crc32": "0.2.3",
+        "connect": "2.26.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "~1.0.2",
+        "send": "0.9.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "82b357f0bc78733b1ac1070224f89a37dea76a74",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.9.0": {
+      "name": "express",
+      "version": "4.9.0",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "buffer-crc32": "0.2.3",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.1",
+        "serve-static": "~1.6.1",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.2",
+        "express-session": "~1.8.1",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.0",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "9b2ea4ebce57c7ac710604c74f6c303ab344a7f3",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.17.2": {
+      "name": "express",
+      "version": "3.17.2",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.1",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "1.0.1",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "9593dd94af5d4776ea2b6dbff8c4d850a3381353",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.9.1": {
+      "name": "express",
+      "version": "4.9.1",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "serve-static": "~1.6.2",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "70536ee2a8f2c302c4df45e23f4fcc7e4c2c9603",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.9.2": {
+      "name": "express",
+      "version": "4.9.2",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "1.0.1",
+        "qs": "2.2.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "serve-static": "~1.6.2",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "988fbe666dfb1ba7f13edf7f27fea2a8bd101439",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.17.3": {
+      "name": "express",
+      "version": "3.17.3",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.1",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.2",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "cc25ea448a0f23225385948511f0bedb2dfa92c2",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.9.3": {
+      "name": "express",
+      "version": "4.9.3",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.2",
+        "qs": "2.2.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "serve-static": "~1.6.2",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "6aadd470fbb0fdd2550536ab33b63c3fcb7f1028",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.17.4": {
+      "name": "express",
+      "version": "3.17.4",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.2",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.2",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "38d2749198f4d2d6b19433bd1105d065eb975a14",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.9.4": {
+      "name": "express",
+      "version": "4.9.4",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.2",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.2",
+        "serve-static": "~1.6.2",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "008e18c92add61fcb534968e04c7e0102a66690b",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.17.5": {
+      "name": "express",
+      "version": "3.17.5",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.3",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "859f4f7bd8d4b8656982592d432f6a0ee06afd30",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.9.5": {
+      "name": "express",
+      "version": "4.9.5",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "serve-static": "~1.6.3",
+        "type-is": "~1.5.1",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "7f62aa84ac8f5e96acfb98e2944dde0bf1cf8688",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.17.6": {
+      "name": "express",
+      "version": "3.17.6",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.4",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2",
+        "supertest": "~0.13.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "e2f9a6a48b85233afc4f7b6c5cd6799c53f5f46f",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.17.7": {
+      "name": "express",
+      "version": "3.17.7",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.5",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "4261113907252e0b4b8346a342d321fe7fd11d75",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.9.6": {
+      "name": "express",
+      "version": "4.9.6",
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "serve-static": "~1.6.4",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "0b3e3970784d9133c4335c299539e6d895dbb208",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.9.7": {
+      "name": "express",
+      "version": "4.9.7",
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "serve-static": "~1.6.4",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "ae3e0bdf0095749467fde125afd77e7988ff0fbb",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.17.8": {
+      "name": "express",
+      "version": "3.17.8",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.26.6",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "crc": "3.0.0",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.6.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "f0a451865f31938ea518a924c6f521df2d474d4b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.17.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.9.8": {
+      "name": "express",
+      "version": "4.9.8",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "finalhandler": "0.2.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.2.4",
+        "range-parser": "~1.0.2",
+        "send": "0.9.3",
+        "serve-static": "~1.6.4",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.4",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.8.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.8.2",
+        "jade": "~1.6.0",
+        "method-override": "~2.2.0",
+        "morgan": "~1.3.1",
+        "multiparty": "~3.3.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "f360f596baeabbd0e5223b603d6eb578d9d2d10d",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.9.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.18.0": {
+      "name": "express",
+      "version": "3.18.0",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.0",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "ff1f4ee689ba6e622a087e397994f7c2115c5c57",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.18.1": {
+      "name": "express",
+      "version": "3.18.1",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.1",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "0bbd6269abbdb53482166b0b5a9a04e311be9977",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.10.0": {
+      "name": "express",
+      "version": "4.10.0",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.3.0",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.1",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.4.1",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "52719d5a1cde4edd47b87da43b1a7c337d761a12",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.18.2": {
+      "name": "express",
+      "version": "3.18.2",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.2",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "7f92bce77e4f606a8defcf6aed54f8cfa0e044ca",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.10.1": {
+      "name": "express",
+      "version": "4.10.1",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.3.2",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.1",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.4.1",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "a291c812bc8b0ed6ab877366fe0e68a2368fde7e",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "5.0.0-alpha.1": {
+      "name": "express",
+      "version": "5.0.0-alpha.1",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.3.2",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.2",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.1",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.4.1",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "415df02c51ae01c221362fca59b03591d956b2d7",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.18.3": {
+      "name": "express",
+      "version": "3.18.3",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.3",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.2.1",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "4020829da766557f308161b3d0ea01c838b2aff6",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.10.2": {
+      "name": "express",
+      "version": "4.10.2",
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.3",
+        "qs": "2.3.2",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.2.1",
+        "supertest": "~0.14.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.1",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.4.1",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "df06dde94d968932829d440a2004c5efe64495b0",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.18.4": {
+      "name": "express",
+      "version": "3.18.4",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.4",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.4",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.3.0",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "jade": "~1.7.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "7b40ad2c10a987692ee97a387c21593011f03712",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.10.3": {
+      "name": "express",
+      "version": "4.10.3",
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.3.0",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "08006c11d0c519339963bf643c3d76c2765f9349",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.10.4": {
+      "name": "express",
+      "version": "4.10.4",
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.3",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.3.0",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "31aa70acdad6b6093945c30523df8537336deb58",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.10.5": {
+      "name": "express",
+      "version": "4.10.5",
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.4",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.3.0",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "cdcff3ea56f9cd8017043356553661cbae161f4f",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.18.5": {
+      "name": "express",
+      "version": "3.18.5",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.6",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.4",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "bf0feb8562f82419ffdacf7c2315755758bfd7ec",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "3.18.6": {
+      "name": "express",
+      "version": "3.18.6",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.27.6",
+        "content-disposition": "0.5.0",
+        "commander": "1.3.2",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.4",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "cbcc7cb610d061ac619e5d090a5539353a3e870b",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.18.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.10.6": {
+      "name": "express",
+      "version": "4.10.6",
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.2",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.0",
+        "on-finished": "~2.1.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.1",
+        "type-is": "~1.5.4",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "a9015979ccf38b11a39c0f726dcf6c4b85a4e758",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.10.7": {
+      "name": "express",
+      "version": "4.10.7",
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.4",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.2",
+        "type-is": "~1.5.5",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.9.3",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.7.0",
+        "method-override": "~2.3.0",
+        "morgan": "~1.5.0",
+        "multiparty": "~4.0.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "0652f8cd5d0e2949d77b7dea7c5208161ec81ac6",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.19.0": {
+      "name": "express",
+      "version": "3.19.0",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.28.1",
+        "content-disposition": "0.5.0",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.5",
+        "range-parser": "~1.0.2",
+        "send": "0.11.0",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.0.8",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "should": "~4.4.4",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "cdac51029ccd012840d74c8c9a05834ac3a23a25",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.19.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.10.8": {
+      "name": "express",
+      "version": "4.10.8",
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.5",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.10.1",
+        "serve-static": "~1.7.2",
+        "type-is": "~1.5.5",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.0",
+        "should": "~4.3.1",
+        "supertest": "~0.15.0",
+        "ejs": "~1.0.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.10.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.9.2",
+        "jade": "~1.8.2",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "2d83571e065c0efb2679c0a5f9ae66aeaa47024a",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.10.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.11.0": {
+      "name": "express",
+      "version": "4.11.0",
+      "dependencies": {
+        "accepts": "~1.2.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.5",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.11.0",
+        "serve-static": "~1.8.0",
+        "type-is": "~1.5.5",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.0.8",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "should": "~4.4.4",
+        "supertest": "~0.15.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.10.1",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.10.1",
+        "jade": "~1.9.0",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.0",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "ad5b5157b74a95fc5c59442efad0306e7b1aeb99",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.11.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.19.1": {
+      "name": "express",
+      "version": "3.19.1",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.28.2",
+        "content-disposition": "0.5.0",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.5",
+        "range-parser": "~1.0.2",
+        "send": "0.11.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "should": "~4.6.1",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6",
+        "marked": "0.3.2"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "2b65f584a4c9856ff656595680f522a106b81693",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.19.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.11.1": {
+      "name": "express",
+      "version": "4.11.1",
+      "dependencies": {
+        "accepts": "~1.2.2",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.5",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.11.1",
+        "serve-static": "~1.8.1",
+        "type-is": "~1.5.5",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "should": "~4.6.1",
+        "supertest": "~0.15.0",
+        "marked": "0.3.2",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.10.2",
+        "connect-redis": "~2.1.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.10.1",
+        "jade": "~1.9.1",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "36d04dd27aa1667634e987529767f9c99de7903f",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.11.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.19.2": {
+      "name": "express",
+      "version": "3.19.2",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.28.3",
+        "content-disposition": "0.5.0",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.6",
+        "range-parser": "~1.0.2",
+        "send": "0.11.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~4.6.2",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "7f9b3ad8ae0f29d2df98cb3d8649dec8bcc47bf6",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.19.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.11.2": {
+      "name": "express",
+      "version": "4.11.2",
+      "dependencies": {
+        "accepts": "~1.2.3",
+        "content-disposition": "0.5.0",
+        "cookie-signature": "1.0.5",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "media-typer": "0.3.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.6",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.11.1",
+        "serve-static": "~1.8.1",
+        "type-is": "~1.5.6",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~4.6.2",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.11.0",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.3",
+        "express-session": "~1.10.2",
+        "jade": "~1.9.1",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "8df3d5a9ac848585f00a0777601823faecd3b148",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.11.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.20.0": {
+      "name": "express",
+      "version": "3.20.0",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.29.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.6",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.1.4",
+        "istanbul": "0.3.5",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.0",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "9dac561e31a08e7d2852790d86d17c7b70bdd9ac",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.20.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.12.0": {
+      "name": "express",
+      "version": "4.12.0",
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.6",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "serve-static": "~1.9.1",
+        "type-is": "~1.6.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.6",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.1",
+        "supertest": "~0.15.0",
+        "hjs": "~0.0.6",
+        "body-parser": "~1.12.0",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.4",
+        "express-session": "~1.10.3",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "739660fce86acbc11ba9c37dc96ff009dc9975e8",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.20.1": {
+      "name": "express",
+      "version": "3.20.1",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.29.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.6",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "merge-descriptors": "0.0.2"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.6",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.0",
+        "supertest": "~0.15.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "982701ba766a67a8bcc6f6d92366a1d0794e2c55",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.20.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.12.1": {
+      "name": "express",
+      "version": "4.12.1",
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.6",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "serve-static": "~1.9.1",
+        "type-is": "~1.6.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.6",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.1",
+        "supertest": "~0.15.0",
+        "body-parser": "~1.12.0",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.4",
+        "express-session": "~1.10.3",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "bb784ce513d39f2b283fa2736303f89ba7951aeb",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.12.2": {
+      "name": "express",
+      "version": "4.12.2",
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.3",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.6",
+        "qs": "2.3.3",
+        "range-parser": "~1.0.2",
+        "send": "0.12.1",
+        "serve-static": "~1.9.1",
+        "type-is": "~1.6.0",
+        "vary": "~1.0.0",
+        "cookie": "0.1.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.6",
+        "marked": "0.3.3",
+        "mocha": "~2.1.0",
+        "should": "~5.0.1",
+        "supertest": "~0.15.0",
+        "body-parser": "~1.12.0",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.4",
+        "express-session": "~1.10.3",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.1",
+        "morgan": "~1.5.1",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "7e72ad4c1b4edf07536a6d1e2acec0161d8564bd",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.20.2": {
+      "name": "express",
+      "version": "3.20.2",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.29.1",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.7",
+        "range-parser": "~1.0.2",
+        "send": "0.12.2",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.8",
+        "marked": "0.3.3",
+        "mocha": "~2.2.1",
+        "should": "~5.2.0",
+        "supertest": "~0.15.0"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "c604027746e60f3da0a4b43063375d21c3235858",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.20.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.12.3": {
+      "name": "express",
+      "version": "4.12.3",
+      "dependencies": {
+        "accepts": "~1.2.5",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "finalhandler": "0.3.4",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.7",
+        "qs": "2.4.1",
+        "range-parser": "~1.0.2",
+        "send": "0.12.2",
+        "serve-static": "~1.9.2",
+        "type-is": "~1.6.1",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.8",
+        "marked": "0.3.3",
+        "mocha": "~2.2.1",
+        "should": "~5.2.0",
+        "supertest": "~0.15.0",
+        "body-parser": "~1.12.2",
+        "connect-redis": "~2.2.0",
+        "cookie-parser": "~1.3.4",
+        "cookie-session": "~1.1.0",
+        "express-session": "~1.10.4",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.2",
+        "morgan": "~1.5.2",
+        "multiparty": "~4.1.1",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "6b9d94aec5ae03270d86d390c277a8c5a5ad0ee2",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.20.3": {
+      "name": "express",
+      "version": "3.20.3",
+      "dependencies": {
+        "basic-auth": "1.0.0",
+        "connect": "2.29.2",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.0",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
+        "send": "0.12.3",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "6.0.1",
+        "supertest": "1.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "5085ab3f5ff761cf7e1597e9b9df156f1094aded",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.20.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.12.4": {
+      "name": "express",
+      "version": "4.12.4",
+      "dependencies": {
+        "accepts": "~1.2.7",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.2",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.1",
+        "etag": "~1.6.0",
+        "finalhandler": "0.3.6",
+        "fresh": "0.2.4",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.2.1",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.3",
+        "proxy-addr": "~1.0.8",
+        "qs": "2.4.2",
+        "range-parser": "~1.0.2",
+        "send": "0.12.3",
+        "serve-static": "~1.9.3",
+        "type-is": "~1.6.2",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "6.0.1",
+        "supertest": "1.0.1",
+        "body-parser": "~1.12.4",
+        "connect-redis": "~2.3.0",
+        "cookie-parser": "~1.3.4",
+        "cookie-session": "~1.1.0",
+        "express-session": "~1.11.2",
+        "jade": "~1.9.2",
+        "method-override": "~2.3.3",
+        "morgan": "~1.5.3",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "8fec2510255bc6b2e58107c48239c0fa307c1aa2",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.12.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.21.0": {
+      "name": "express",
+      "version": "3.21.0",
+      "dependencies": {
+        "basic-auth": "1.0.2",
+        "connect": "2.30.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.1",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "8ff7c424a92d15ee1a27c4bc8425ddba2c14aa38",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.21.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.13.0": {
+      "name": "express",
+      "version": "4.13.0",
+      "dependencies": {
+        "accepts": "~1.2.9",
+        "array-flatten": "1.1.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.6",
+        "proxy-addr": "~1.0.8",
+        "qs": "2.4.2",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.3",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.1",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.1",
+        "connect-redis": "~2.3.0",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.1.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.3",
+        "morgan": "~1.6.0",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "0678bdbc72715170b3fcc917052f046cb9689add",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.21.1": {
+      "name": "express",
+      "version": "3.21.1",
+      "dependencies": {
+        "basic-auth": "~1.0.3",
+        "connect": "2.30.1",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.1",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.0"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.2",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "427b1f4e68dcfd5da6809892fe19219d52ce6b55",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.21.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.13.1": {
+      "name": "express",
+      "version": "4.13.1",
+      "dependencies": {
+        "accepts": "~1.2.10",
+        "array-flatten": "1.1.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.6",
+        "proxy-addr": "~1.0.8",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.4",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.2",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.2",
+        "connect-redis": "~2.3.0",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.3",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "f117aa1d1f6bedbc8de5b6d71fc31a5acd0f63df",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "5.0.0-alpha.2": {
+      "name": "express",
+      "version": "5.0.0-alpha.2",
+      "dependencies": {
+        "accepts": "~1.2.10",
+        "array-flatten": "1.1.0",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-is-absolute": "1.0.0",
+        "path-to-regexp": "0.1.6",
+        "proxy-addr": "~1.0.8",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.2",
+        "router": "~1.1.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.4",
+        "vary": "~1.0.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.2",
+        "istanbul": "0.3.9",
+        "marked": "0.3.3",
+        "mocha": "2.2.5",
+        "should": "7.0.1",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.2",
+        "connect-redis": "~2.3.0",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.3",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.0"
+      },
+      "dist": {
+        "shasum": "fd54177f657b6a4c4540727702edd1cbaa3a6ac5",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "3.21.2": {
+      "name": "express",
+      "version": "3.21.2",
+      "dependencies": {
+        "basic-auth": "~1.0.3",
+        "connect": "2.30.2",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "commander": "2.6.0",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "mkdirp": "0.5.1",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "connect-redis": "~1.5.0",
+        "ejs": "2.3.3",
+        "istanbul": "0.3.9",
+        "marked": "0.3.5",
+        "mocha": "2.2.5",
+        "should": "7.0.2",
+        "supertest": "1.0.1"
+      },
+      "bin": {
+        "express": "./bin/express"
+      },
+      "dist": {
+        "shasum": "0c2903ee5c54e63d65a96170764703550665a3de",
+        "tarball": "https://registry.npmjs.org/express/-/express-3.21.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "4.13.2": {
+      "name": "express",
+      "version": "4.13.2",
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.0.8",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.6",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.3",
+        "istanbul": "0.3.17",
+        "marked": "0.3.5",
+        "mocha": "2.2.5",
+        "should": "7.0.2",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.3",
+        "connect-redis": "~2.4.1",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.5",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.1"
+      },
+      "dist": {
+        "shasum": "e4259f58d8ca85f54b820d7057b02ef90b471f1d",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.13.3": {
+      "name": "express",
+      "version": "4.13.3",
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.0",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.3",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.0",
+        "methods": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.0",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.0.8",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.2",
+        "send": "0.13.0",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.6",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.3",
+        "istanbul": "0.3.17",
+        "marked": "0.3.5",
+        "mocha": "2.2.5",
+        "should": "7.0.2",
+        "supertest": "1.0.1",
+        "body-parser": "~1.13.3",
+        "connect-redis": "~2.4.1",
+        "cookie-parser": "~1.3.5",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.11.3",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.5",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.1"
+      },
+      "dist": {
+        "shasum": "ddb2f1fb4502bf33598d2b032b037960ca6c80a3",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.13.4": {
+      "name": "express",
+      "version": "4.13.4",
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.1",
+        "content-type": "~1.0.1",
+        "cookie": "0.1.5",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.4.1",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.0.10",
+        "qs": "4.0.0",
+        "range-parser": "~1.0.3",
+        "send": "0.13.1",
+        "serve-static": "~1.10.2",
+        "type-is": "~1.6.6",
+        "utils-merge": "1.0.0",
+        "vary": "~1.0.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "ejs": "2.3.4",
+        "istanbul": "0.4.2",
+        "marked": "0.3.5",
+        "mocha": "2.3.4",
+        "should": "7.1.1",
+        "supertest": "1.1.0",
+        "body-parser": "~1.14.2",
+        "connect-redis": "~2.4.1",
+        "cookie-parser": "~1.4.1",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.13.0",
+        "jade": "~1.11.0",
+        "method-override": "~2.3.5",
+        "morgan": "~1.6.1",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.1"
+      },
+      "dist": {
+        "shasum": "3c0b76f3c77590c8345739061ec0bd3ba067ec24",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.13.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.14.0": {
+      "name": "express",
+      "version": "4.14.0",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.1",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.5.0",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.2",
+        "qs": "6.2.0",
+        "range-parser": "~1.2.0",
+        "send": "0.14.1",
+        "serve-static": "~1.11.1",
+        "type-is": "~1.6.13",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "body-parser": "~1.15.1",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.4.2",
+        "istanbul": "0.4.3",
+        "marked": "0.3.5",
+        "method-override": "~2.3.6",
+        "mocha": "2.5.3",
+        "morgan": "~1.7.0",
+        "should": "9.0.2",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "express-session": "~1.13.0",
+        "jade": "~1.11.0",
+        "multiparty": "~4.1.2",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "c1ee3f42cdc891fb3dc650a8922d51ec847d0d66",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.14.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.14.1": {
+      "name": "express",
+      "version": "4.14.1",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.5.1",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.2.0",
+        "range-parser": "~1.2.0",
+        "send": "0.14.2",
+        "serve-static": "~1.11.2",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.16.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.5",
+        "express-session": "1.15.0",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "~2.3.6",
+        "mocha": "3.2.0",
+        "morgan": "~1.7.0",
+        "multiparty": "4.1.3",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "646c237f766f148c2120aff073817b9e4d7e0d33",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.14.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "5.0.0-alpha.3": {
+      "name": "express",
+      "version": "5.0.0-alpha.3",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "2.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "finalhandler": "0.5.1",
+        "fresh": "0.3.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.2.0",
+        "range-parser": "~1.2.0",
+        "router": "~1.1.5",
+        "send": "0.14.2",
+        "serve-static": "~1.11.2",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.16.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.5",
+        "express-session": "1.15.0",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "~2.3.6",
+        "mocha": "3.2.0",
+        "morgan": "~1.7.0",
+        "multiparty": "4.1.3",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "19d63b931bf0f64c42725952ef0602c381fe64db",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.15.0": {
+      "name": "express",
+      "version": "4.15.0",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.3.1",
+        "range-parser": "~1.2.0",
+        "send": "0.15.0",
+        "serve-static": "1.12.0",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "8fb125829f70a04a59e1c40ceb8dea19cf5c879c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "5.0.0-alpha.4": {
+      "name": "express",
+      "version": "5.0.0-alpha.4",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "2.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.3.1",
+        "range-parser": "~1.2.0",
+        "router": "~1.3.0",
+        "send": "0.15.0",
+        "serve-static": "1.12.0",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "cd96a23fa9e3fce471f9637376b1c7b9d70b865e",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.15.1": {
+      "name": "express",
+      "version": "4.15.1",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.3.1",
+        "range-parser": "~1.2.0",
+        "send": "0.15.1",
+        "serve-static": "1.12.1",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.0",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "e32897816d94cc477e45f0149a8966bc938a329b",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.15.2": {
+      "name": "express",
+      "version": "4.15.2",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.4.0",
+        "range-parser": "~1.2.0",
+        "send": "0.15.1",
+        "serve-static": "1.12.1",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.1",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "af107fc148504457f2dca9a6f2571d7129b97b35",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "5.0.0-alpha.5": {
+      "name": "express",
+      "version": "5.0.0-alpha.5",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "2.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.0",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.3",
+        "qs": "6.4.0",
+        "range-parser": "~1.2.0",
+        "router": "~1.3.0",
+        "send": "0.15.1",
+        "serve-static": "1.12.1",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.14",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.1",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.7",
+        "mocha": "3.2.0",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "jade": "~1.11.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "e37423a8d82826fb915c7dd166e2900bfa3552e6",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.15.3": {
+      "name": "express",
+      "version": "4.15.3",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.7",
+        "depd": "~1.1.0",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.3",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.4",
+        "qs": "6.4.0",
+        "range-parser": "~1.2.0",
+        "send": "0.15.3",
+        "serve-static": "1.12.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.1",
+        "cookie-parser": "~1.4.3",
+        "ejs": "2.5.6",
+        "express-session": "1.15.2",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.8",
+        "mocha": "3.4.1",
+        "morgan": "1.8.1",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.1",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "cookie-session": "~1.2.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "bab65d0f03aa80c358408972fc700f916944b662",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.15.4": {
+      "name": "express",
+      "version": "4.15.4",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.4",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.5",
+        "qs": "6.5.0",
+        "range-parser": "~1.2.0",
+        "send": "0.15.4",
+        "serve-static": "1.12.4",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.17.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.0",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.5",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.9",
+        "mocha": "3.5.0",
+        "morgan": "1.8.2",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "11.2.1",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "032e2253489cf8fce02666beca3d11ed7a2daed1",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.15.5": {
+      "name": "express",
+      "version": "4.15.5",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.6",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.5",
+        "qs": "6.5.0",
+        "range-parser": "~1.2.0",
+        "send": "0.15.6",
+        "serve-static": "1.12.6",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.18.1",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.1",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.5",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.9",
+        "mocha": "3.5.3",
+        "morgan": "1.8.2",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "670235ca9598890a5ae8170b83db722b842ed927",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.15.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "5.0.0-alpha.6": {
+      "name": "express",
+      "version": "5.0.0-alpha.6",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "array-flatten": "2.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "finalhandler": "~1.0.6",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "path-is-absolute": "1.0.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~1.1.5",
+        "qs": "6.5.0",
+        "range-parser": "~1.2.0",
+        "router": "~1.3.1",
+        "send": "0.15.6",
+        "serve-static": "1.12.6",
+        "setprototypeof": "1.0.3",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "~1.1.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "body-parser": "1.18.1",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.1",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.5",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.9",
+        "mocha": "3.5.3",
+        "morgan": "1.8.2",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "85dc44d7e90d4809041407f388f239b5bd2f681e",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.16.0": {
+      "name": "express",
+      "version": "4.16.0",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.0",
+        "serve-static": "1.13.0",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.10",
+        "mocha": "3.5.3",
+        "morgan": "1.9.0",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "b519638e4eb58e7178c81b498ef22f798cb2e255",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.16.1": {
+      "name": "express",
+      "version": "4.16.1",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.10",
+        "mocha": "3.5.3",
+        "morgan": "1.9.0",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-STB7LZ4N0L+81FJHGla2oboUHTk4PaN1RsOkoRh9OSeEKylvF5hwKYVX1xCLFaCT7MD0BNG/gX2WFMLqY6EMBw==",
+        "shasum": "6b33b560183c9b253b7b62144df33a4654ac9ed0",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.16.2": {
+      "name": "express",
+      "version": "4.16.2",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.2",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.6",
+        "method-override": "2.3.10",
+        "mocha": "3.5.3",
+        "morgan": "1.9.0",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.1.0",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "e35c6dfe2d64b7dca0a5cd4f21781be3299e076c",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.16.3": {
+      "name": "express",
+      "version": "4.16.3",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.5.7",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.3.17",
+        "method-override": "2.3.10",
+        "mocha": "3.5.3",
+        "morgan": "1.9.0",
+        "multiparty": "4.1.3",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.1",
+        "supertest": "1.2.0",
+        "connect-redis": "~2.4.1",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "shasum": "6af8a502350db3246ecc4becf6b5a34d22f7ed53",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+        "fileCount": 16,
+        "unpackedSize": 205577
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.16.4": {
+      "name": "express",
+      "version": "4.16.4",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.0",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.5.1",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+        "shasum": "fddef61926109e24c515ea97fd2f1bdbf62df12e",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+        "fileCount": 16,
+        "unpackedSize": 206123,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbvsqSCRA9TVsSAnZWagAAPFwP/iCvznxNrmvgY9ox7w2k\ncS/ej9HZJ5NGjBEWtae1F2bjJ2V7rOxVTGTlqiPMSNIzTgw3fpFkIXp9kCA4\nY03NOsYUjYscGjXR6f2fvOVJ/Si5FKlqr7Ow6WMBClrdo/CMCc8kH9fxtPja\nHla58xiU7ftlzUHIjGmmnHFzAjAeGj+3e3v1omuoeP6mPuxlwYoQ0MuD0sFa\n9qJAFZ0MBrfvoQBI8G++GZZhxalhefuibWi1ErRw3F5cLfvhjKi4HGPh+sDu\nc63D99wQIJIq4HumwX0JNW7OywuL28wgxgtvKyg0iCVR/BnAYiEA0UZUVI4h\nsX1Kuht1oHEp1iGOvGALYotPiovnDCAra+2zPM1p8oZKdXHEpkAygG3mCiD5\nyWlWrFo5jJudULWzMtHp6F0RwQJjpSavnkbusKWZvO717/1Ku5FIM4cnTWVK\nELGmb011jRPMvwFqv1C04SvhBT+UrXe4kd0qwJWQEDT1aWzbjbaroPmVQ+l1\nxzUkHRHm7vYCBE0RxQ4FImNWlYYQVVyBSroYwxvJnP6H8m/DR7oxDPDoJcBn\nXXETuH8Ca+q8KjwdrstVXCwKfB+zs0Z41/oOWKrhsDY2B9HwmyOOA8EtG4QO\np2waBrigD8L4T/Y3II4T144z2MclVid7DulrzKCMiE6yoTqvrH64FfWkLQqG\n11u8\r\n=ZruB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "5.0.0-alpha.7": {
+      "name": "express",
+      "version": "5.0.0-alpha.7",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "array-flatten": "2.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "3.1.0",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-is-absolute": "1.0.1",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "router": "2.0.0-alpha.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.0",
+        "cookie-parser": "~1.4.3",
+        "cookie-session": "1.3.2",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.15.6",
+        "hbs": "4.0.1",
+        "istanbul": "0.4.5",
+        "marked": "0.5.1",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-3FW+yXzYCViXf6Ty9TN9IKLW+rC8qok3ktS4hS1FILAEnMnfnDpQ+23rZVvWC0Ul1alYpJXx7xSBSBp073970g==",
+        "shasum": "879bfb1bd52834646a9d8c3a773863c36e4d494c",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.7.tgz",
+        "fileCount": 11,
+        "unpackedSize": 179029,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb09eLCRA9TVsSAnZWagAA/1AP/269JF2vhXEO9n3MaQLu\nSs95oz9PfsYyucun0Qgjjd5OyERY7IwtkbYoMn60M18w8ni1JR9kjqQ8m07t\nUIpgUBnfnytj9L7qlnmPMF2Uzrh6YwX5gg1jzx0Tri8EwehllZg3f5o2nxPX\nduG87uxNzxUszo52FXRR98Vz6vVup0/0smLa8jtq+VxXRhW3zGcU+zTAIoyy\nP7bvI4Zg5RKWzABTIfBsqW9sxJ6yT0Xa/otiO/IJ3YjJb2f76FdAN1RwrEnA\nvherLVx1V6EooqhkrS0W45Ong2KEytpHWTKj5APDpggffflfJyiON2BqvrPI\nmSDESQzyArpgwckBaSofLcydD7aaGtYP/NpATT3khrWw3UkFeeG0LGGulz7e\nbPN8PFuSXiZ5dfcBXNQsViSF6jkghg0y8bffC3h4VewsKKfgLKehwOjn+Mp4\n7dyZ0KcCJn/xcCCJJFAkJJB9j4Pfqxj1D2hlUMXfSj6L7unmbOnwsFtL0m32\nb0w+WkUxy8DR+UFGUUHGK5bNE9OsX5tYSWm9RH8Z8cco5rgLBkk3Lxq1rSjY\nzLrM5FsakMWgSlI1BTN5gXX9TYumCzke4vI8emkxe8lR3l+XPz2wP/+HB1wg\nfxSecAWnJKwkDAtBifHB8eiOWNLoSnJiOkWk0VnkSXa9Aw95yED1B/sAv/i5\nk5y/\r\n=n8Sg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.17.0": {
+      "name": "express",
+      "version": "4.17.0",
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.1",
+        "cookie-parser": "~1.4.4",
+        "cookie-session": "1.3.3",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.16.1",
+        "hbs": "4.0.4",
+        "istanbul": "0.4.5",
+        "marked": "0.6.2",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-1Z7/t3Z5ZnBG252gKUPyItc4xdeaA0X934ca2ewckAsVsw9EG71i++ZHZPYnus8g/s5Bty8IMpSVEuRkmwwPRQ==",
+        "shasum": "288af62228a73f4c8ea2990ba3b791bb87cd4438",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.17.0.tgz",
+        "fileCount": 16,
+        "unpackedSize": 208134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3hUVCRA9TVsSAnZWagAA3oUP/3V7aiaEhUSyQ9lyDnPF\nxiRwGy0XNIoNRyZbw8gMN2/7V/jjV+H/vWdo9gSr3NJAGsGlS8AtT0uNvKv/\nrssr3WA65/J9QNdCixePj/LHilRzOSMKxnIhk20bVh186vEx7fwehqXbifcS\nNIoSieQRnllJCVH0JudVim4AMWdy3Y2vOLV1kE6UpDs41c3eXzUfFEVxI+WD\nXjUrfHsRCK/IZ5No2Hw8uwF2Y2pnuRHFC0ehIWn+Foijy87doiFidxdn2ybg\nFjdo+AFH3LX2RBR4o7UugtDV1wB0ymRVRNSIk6xoKmMGi5RNE5dhPxNkEvk7\nX5nK18AhRzRFIIZDhHtOZE9wWvlf/25p0y8CmzKrXkpmiuzcby4EneyV0Muk\n8WmbnEO1ah7SATsVf0d/AnR1tCXE+0wLXvVrq9Z1BAkeW1rsR9OHqzpLGCc3\njmYqyrN+2iyPeqy/cemnU52fmUC/Kfj8q8Uv2RCxJo9cAKKp+ljaMXCiJMcP\nrYPu4X0n0ijSLVF1dAQkDs05MVbZeCl5RM0GhPndFwcdCBc1JdJSYK/6ylHK\nFDoB5YBzxglMPL8iMwbDhS2+N25vRDAWr52GKTwJFmcfW04/EXrFEgm2gk1/\nmRLojES3L7P5L96c9P2SVzp7YjWFw71OkQctzlDrNC28VOU3ie95pYQyHV5/\n64mY\r\n=ZTgO\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "4.17.1": {
+      "name": "express",
+      "version": "4.17.1",
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.1",
+        "cookie-parser": "~1.4.4",
+        "cookie-session": "1.3.3",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.16.1",
+        "hbs": "4.0.4",
+        "istanbul": "0.4.5",
+        "marked": "0.6.2",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+        "shasum": "4491fc38605cf51f8629d39c2b5d026f98a4c134",
+        "tarball": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+        "fileCount": 16,
+        "unpackedSize": 208133,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc6hU/CRA9TVsSAnZWagAAFc4QAJzqxI1sgdfreUHk+NIa\n38jYea65Xg8N9JgZVF67j7aXqPT6VXhGu2j54oveGIkr+RL2Xm58RrRWn+Sg\nVWOOSZzotLKtx1qCYS4ozPRYvujKMLYDeiLxePDCSrrLYt48+IJwkHF04Un1\nJ0ZUmtlEqgLL85gvaCrKa9qF8TfwbQhhIzQ914vum11tJ506ePpffN2xFY0M\nsHf0CiuV1OFOD7Wne/RR7DVsxQwZ/FXomkxLJm8+T+T9ZYm3WQxWVD7BRQpA\nN08+zkPd1XMEZiVZkR9Ie4+7ydZomJE8PNCOt5SzvEW6ekDW10QuuF0521Wj\n5lHp4AflVFq1LTJB0WDR6VIPJRp0H5aYTh1tBRxWHUx/EP2LfFS/XEz1bUvm\nBDVj2e1iA4ZWz8aeu9p/2N8Zp05WGINF3/E4YG9smxxs5EDJZGA9k1DAj6US\nzKWTOemaqypRshFWThvfA70a1Rcwdj+0XGboscg/S20XTT0FvG2GLkEY0OO/\niHBy5fKYplUQsths48V8I9P9Gx6U534iaFJlxlzzVEsDleBkH+NBSP8OB7dx\n8N/0ZQDBY6JWL5ZSW9yVY2FzrTEmUOPC1Rts5Uj4m7SBmu8yK154ylnPQ4T6\nMr0jG8XQPYhTLc5pYNTFZNV1Ydu4d01xIrLhGy/3dc7kRlwy3FN5ceNVsB88\njyN+\r\n=QYw2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "5.0.0-alpha.8": {
+      "name": "express",
+      "version": "5.0.0-alpha.8",
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "2.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "3.1.0",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-is-absolute": "1.0.1",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "router": "2.0.0-alpha.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "connect-redis": "3.4.1",
+        "cookie-parser": "~1.4.4",
+        "cookie-session": "1.3.3",
+        "ejs": "2.6.1",
+        "eslint": "2.13.1",
+        "express-session": "1.16.1",
+        "hbs": "4.0.4",
+        "istanbul": "0.4.5",
+        "marked": "0.6.2",
+        "method-override": "3.0.0",
+        "mocha": "5.2.0",
+        "morgan": "1.9.1",
+        "multiparty": "4.2.1",
+        "pbkdf2-password": "1.2.1",
+        "should": "13.2.3",
+        "supertest": "3.3.0",
+        "vhost": "~3.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-PL8wTLgaNOiq7GpXt187/yWHkrNSfbr4H0yy+V0fpqJt5wpUzBi9DprAkwGKBFOqWHylJ8EyPy34V5u9YArfng==",
+        "shasum": "b9dd3a568eab791e3391db47f9e6ab91e61b13fe",
+        "tarball": "https://registry.npmjs.org/express/-/express-5.0.0-alpha.8.tgz",
+        "fileCount": 11,
+        "unpackedSize": 181194,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJee/3fCRA9TVsSAnZWagAAzf8P/2dMh5PO1SR+CZLuGvPE\nOcR9dd4+epUcIgK6antdYjzMm+HHHMTnObyS523wd9Xm2nWLNDI70nSNHUbn\nxIjlGp9o+NMtvv0RnKKkG+xnlidfrkt7SVvlVzr5D65m6UNxp8bP01KElCNh\nqkAO7ipVYFhzEWFbFJWljN9kR1mCSp4qpL+vTn1wn8xSryYH/+ZRc8rBBlCA\nzBUfx3cQAaH8fy6Cij/bzTdcGWqucBrTP6wgRZca3EDKaOhC8JSf072ISqZM\nAwIUANiYZKPGDv5AUh2T1C8jG4tKdoROr9iqIrsHn9iW8Ppk5R4odblZtDNW\nhROzSfS7i5lFZFxhMZCnrV5aN/zbBiRtMIpFGns0EYWd07l5fMRA817ItntM\nbBZB4MJBH91SoTonBg8Elo5oE9428kdHDKiNi+eK6C3ndqAE0KzgeOIBmol4\n4V3Q4/v6MxSAjGWO9Kw3wKjpCJ4B3LV3F4NwKGHDQlWidkCKQOFg5ylCmDcw\n+7z8/GeahapeWRtkifAhavX0rNYiRUjrgY0yeR98YFOg1K4yvYSXxbY4Xv2B\nWqxikjXqPXk6PavumvJizunzxGVKfOpiQ6XFcIkpfIEJ3JRfU8LUgx+EhAIq\nB35/nbzY8E3f3RCINhqV3y+rBsHhPmnElCASaL5iO5A9CaltyfyZPA+ciMS4\neKlV\r\n=P2Q8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    }
+  },
+  "modified": "2020-11-06T02:46:30.572Z"
+}

--- a/test/fixtures/registry-mocks/content/extend-shallow.json
+++ b/test/fixtures/registry-mocks/content/extend-shallow.json
@@ -1,0 +1,1234 @@
+{
+  "_id": "extend-shallow",
+  "_rev": "22-36cf0c922ae7784ea57b1604d8fb3ea6",
+  "name": "extend-shallow",
+  "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+  "dist-tags": {
+    "latest": "3.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "extend-shallow",
+      "description": "Extend javascript object A with the properties of object B.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/extend-shallow/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6"
+      },
+      "keywords": [
+        "extend",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props"
+      ],
+      "_id": "extend-shallow@0.1.0",
+      "_shasum": "3992b6a016e9562db4cbe3ac55977e09b2ff3415",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3992b6a016e9562db4cbe3ac55977e09b2ff3415",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "extend-shallow",
+      "description": "Extend javascript object A with the properties of object B.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/extend-shallow/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6"
+      },
+      "keywords": [
+        "extend",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props"
+      ],
+      "dependencies": {
+        "array-slice": "^0.2.2"
+      },
+      "_id": "extend-shallow@0.1.1",
+      "_shasum": "913c08db4887d3297dc762df8b5815757f56ddf3",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "913c08db4887d3297dc762df8b5815757f56ddf3",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "licenses": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/extend-shallow/blob/master/LICENSE-MIT"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "dependencies": {
+        "array-slice": "^0.2.2"
+      },
+      "devDependencies": {
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "glob": "^4.3.1",
+        "mocha": "*",
+        "should": "^4.3.0"
+      },
+      "keywords": [
+        "extend",
+        "javascript",
+        "js",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "_id": "extend-shallow@0.2.0",
+      "_shasum": "0c98a09f27d83cb43efafcedac8c9d149deb599c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0c98a09f27d83cb43efafcedac8c9d149deb599c",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/extend-shallow/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-plain-object": "^1.0.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "keywords": [
+        "extend",
+        "javascript",
+        "js",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "gitHead": "d1cb5302360c1590b649102010c266404874d860",
+      "_id": "extend-shallow@1.0.0",
+      "_shasum": "3c8406b1484d6c50c14bc0fa2af16c56924f90e1",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3c8406b1484d6c50c14bc0fa2af16c56924f90e1",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/extend-shallow/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-plain-object": "^1.0.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "keywords": [
+        "extend",
+        "javascript",
+        "js",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "gitHead": "cb7b2d726bd030740c8a4a97dae5d7d2b29b5268",
+      "_id": "extend-shallow@1.0.1",
+      "_shasum": "e40197917b39b175850083b7dd725c7e9732f99b",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e40197917b39b175850083b7dd725c7e9732f99b",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "1.1.1",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/extend-shallow/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^1.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "helper-related": "^0.1.0",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "keywords": [
+        "extend",
+        "javascript",
+        "js",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "gitHead": "cb7b2d726bd030740c8a4a97dae5d7d2b29b5268",
+      "_id": "extend-shallow@1.1.1",
+      "_shasum": "a934b62da72ac6978dd248f0d37da1d2c8ed61ef",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a934b62da72ac6978dd248f0d37da1d2c8ed61ef",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "1.1.2",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/extend-shallow/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^1.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "helper-related": "^0.1.0",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "keywords": [
+        "extend",
+        "javascript",
+        "js",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "gitHead": "9ff9fb16d3e6e436db95dfe7f502bfa603c105ca",
+      "_id": "extend-shallow@1.1.2",
+      "_shasum": "25d3b690988adbeddebcc6ef113bdac083c55ef0",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "25d3b690988adbeddebcc6ef113bdac083c55ef0",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "1.1.4",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^1.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "is-plain-object": "^2.0.0",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "keywords": [
+        "extend",
+        "javascript",
+        "js",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "gitHead": "1b97f0c177ce152d85b6f6e69c6154232665bf7a",
+      "_id": "extend-shallow@1.1.4",
+      "_shasum": "19d6bf94dfc09d76ba711f39b872d21ff4dd9071",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "19d6bf94dfc09d76ba711f39b872d21ff4dd9071",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.3",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "for-own": "^0.1.3",
+        "glob": "^5.0.12",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^2.0.0",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.5",
+        "should": "^7.0.1"
+      },
+      "keywords": [
+        "extend",
+        "javascript",
+        "js",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "gitHead": "1b97f0c177ce152d85b6f6e69c6154232665bf7a",
+      "_id": "extend-shallow@2.0.0",
+      "_shasum": "47da017bd07e4763e7546fca0a829da59a6ddc4d",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "47da017bd07e4763e7546fca0a829da59a6ddc4d",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.3",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "for-own": "^0.1.3",
+        "glob": "^5.0.12",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^2.0.0",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.5",
+        "should": "^7.0.1"
+      },
+      "keywords": [
+        "assign",
+        "extend",
+        "javascript",
+        "js",
+        "keys",
+        "merge",
+        "obj",
+        "object",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "gitHead": "e9b1f1d2ff9d2990ec4a127afa7c14732d1eec8a",
+      "_id": "extend-shallow@2.0.1",
+      "_shasum": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "3.0.0",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Peter deHaan",
+          "url": "http://about.me/peterdehaan"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-extendable": "^1.0.1"
+      },
+      "devDependencies": {
+        "array-slice": "^1.0.0",
+        "benchmarked": "^2.0.0",
+        "for-own": "^1.0.0",
+        "gulp-format-md": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.1",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "object-assign": "^4.1.1"
+      },
+      "keywords": [
+        "assign",
+        "clone",
+        "extend",
+        "merge",
+        "obj",
+        "object",
+        "object-assign",
+        "object.assign",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "related": {
+          "list": [
+            "extend-shallow",
+            "for-in",
+            "for-own",
+            "is-plain-object",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "1b211ea8183dfec923702179a7131ca1c5828abd",
+      "_id": "extend-shallow@3.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-2DwaMfw1xjy1kxz1ZzvQJt6klvkYW/tNPXAZgE8iHsQtkiQoOxrJevsTmWF01SRra++QgjxXGApWqBktbzmAvw==",
+        "shasum": "34d45c2bb1f4ea804fe9c35d40d798a7b869c087",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/extend-shallow-3.0.0.tgz_1511106716802_0.30916304350830615"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "3.0.1",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Peter deHaan",
+          "url": "http://about.me/peterdehaan"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-extendable": "^1.0.1"
+      },
+      "devDependencies": {
+        "array-slice": "^1.0.0",
+        "benchmarked": "^2.0.0",
+        "for-own": "^1.0.0",
+        "gulp-format-md": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.1",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "object-assign": "^4.1.1"
+      },
+      "keywords": [
+        "assign",
+        "clone",
+        "extend",
+        "merge",
+        "obj",
+        "object",
+        "object-assign",
+        "object.assign",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "related": {
+          "list": [
+            "extend-shallow",
+            "for-in",
+            "for-own",
+            "is-plain-object",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "468316f009781e90197c6a1fe3134c2c6cdccfe8",
+      "_id": "extend-shallow@3.0.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-Fg1xXAv+qXKdwHiJFMcZSqsMcbPlkzsZtf8KkLJ2fqnP+lqg2RjEKgDcSfO9CO1+p4LZKgApDBUUUqKaaRhwZQ==",
+        "shasum": "4b6d8c49b147fee029dc9eb9484adb770f689844",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/extend-shallow-3.0.1.tgz_1511241367476_0.9273872210178524"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "extend-shallow",
+      "description": "Extend an object with the properties of additional objects. node.js/javascript util.",
+      "version": "3.0.2",
+      "homepage": "https://github.com/jonschlinkert/extend-shallow",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Peter deHaan",
+          "url": "http://about.me/peterdehaan"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/extend-shallow.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "devDependencies": {
+        "array-slice": "^1.0.0",
+        "benchmarked": "^2.0.0",
+        "for-own": "^1.0.0",
+        "gulp-format-md": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.1",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "object-assign": "^4.1.1"
+      },
+      "keywords": [
+        "assign",
+        "clone",
+        "extend",
+        "merge",
+        "obj",
+        "object",
+        "object-assign",
+        "object.assign",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "shallow",
+        "util",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "related": {
+          "list": [
+            "extend-shallow",
+            "for-in",
+            "for-own",
+            "is-plain-object",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "33698c3df7804f0d0e3ea98caa64d53f09c37bd4",
+      "_id": "extend-shallow@3.0.2",
+      "_shasum": "26a71aaf073b39fb2127172746131c2704028db8",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "0.10.48",
+      "_npmUser": {
+        "name": "phated",
+        "email": "blaine.bublitz@gmail.com"
+      },
+      "maintainers": [
+        {
+          "email": "blaine.bublitz@gmail.com",
+          "name": "phated"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "dist": {
+        "shasum": "26a71aaf073b39fb2127172746131c2704028db8",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/extend-shallow-3.0.2.tgz_1513797098024_0.23954258323647082"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# extend-shallow [![NPM version](https://img.shields.io/npm/v/extend-shallow.svg?style=flat)](https://www.npmjs.com/package/extend-shallow) [![NPM monthly downloads](https://img.shields.io/npm/dm/extend-shallow.svg?style=flat)](https://npmjs.org/package/extend-shallow) [![NPM total downloads](https://img.shields.io/npm/dt/extend-shallow.svg?style=flat)](https://npmjs.org/package/extend-shallow) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/extend-shallow.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/extend-shallow)\n\n> Extend an object with the properties of additional objects. node.js/javascript util.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save extend-shallow\n```\n\n## Usage\n\n```js\nvar extend = require('extend-shallow');\n\nextend({a: 'b'}, {c: 'd'})\n//=> {a: 'b', c: 'd'}\n```\n\nPass an empty object to shallow clone:\n\n```js\nvar obj = {};\nextend(obj, {a: 'b'}, {c: 'd'})\n//=> {a: 'b', c: 'd'}\n```\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [extend-shallow](https://www.npmjs.com/package/extend-shallow): Extend an object with the properties of additional objects. node.js/javascript util. | [homepage](https://github.com/jonschlinkert/extend-shallow \"Extend an object with the properties of additional objects. node.js/javascript util.\")\n* [for-in](https://www.npmjs.com/package/for-in): Iterate over the own and inherited enumerable properties of an object, and return an object… [more](https://github.com/jonschlinkert/for-in) | [homepage](https://github.com/jonschlinkert/for-in \"Iterate over the own and inherited enumerable properties of an object, and return an object with properties that evaluate to true from the callback. Exit early by returning `false`. JavaScript/Node.js\")\n* [for-own](https://www.npmjs.com/package/for-own): Iterate over the own enumerable properties of an object, and return an object with properties… [more](https://github.com/jonschlinkert/for-own) | [homepage](https://github.com/jonschlinkert/for-own \"Iterate over the own enumerable properties of an object, and return an object with properties that evaluate to true from the callback. Exit early by returning `false`. JavaScript/Node.js.\")\n* [is-plain-object](https://www.npmjs.com/package/is-plain-object): Returns true if an object was created by the `Object` constructor. | [homepage](https://github.com/jonschlinkert/is-plain-object \"Returns true if an object was created by the `Object` constructor.\")\n* [isobject](https://www.npmjs.com/package/isobject): Returns true if the value is an object and not an array or null. | [homepage](https://github.com/jonschlinkert/isobject \"Returns true if the value is an object and not an array or null.\")\n* [kind-of](https://www.npmjs.com/package/kind-of): Get the native type of a value. | [homepage](https://github.com/jonschlinkert/kind-of \"Get the native type of a value.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 33 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 1 | [pdehaan](https://github.com/pdehaan) |\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2017, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on November 19, 2017._",
+  "maintainers": [
+    {
+      "email": "blaine.bublitz@gmail.com",
+      "name": "phated"
+    },
+    {
+      "email": "github@sellside.com",
+      "name": "jonschlinkert"
+    }
+  ],
+  "time": {
+    "modified": "2017-12-20T19:11:38.344Z",
+    "created": "2014-10-06T08:44:08.862Z",
+    "0.1.0": "2014-10-06T08:44:08.862Z",
+    "0.1.1": "2014-10-28T11:46:35.182Z",
+    "0.2.0": "2014-12-05T13:49:53.276Z",
+    "1.0.0": "2015-02-25T08:24:54.761Z",
+    "1.0.1": "2015-02-25T23:21:09.029Z",
+    "1.1.1": "2015-02-27T19:04:46.305Z",
+    "1.1.2": "2015-03-01T09:58:53.828Z",
+    "1.1.4": "2015-05-21T21:56:11.056Z",
+    "2.0.0": "2015-06-29T07:55:51.264Z",
+    "2.0.1": "2015-07-16T23:28:36.775Z",
+    "3.0.0": "2017-11-19T15:51:56.871Z",
+    "3.0.1": "2017-11-21T05:16:07.718Z",
+    "3.0.2": "2017-12-20T19:11:38.344Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/extend-shallow",
+  "keywords": [
+    "assign",
+    "clone",
+    "extend",
+    "merge",
+    "obj",
+    "object",
+    "object-assign",
+    "object.assign",
+    "prop",
+    "properties",
+    "property",
+    "props",
+    "shallow",
+    "util",
+    "utility",
+    "utils",
+    "value"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/extend-shallow.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/extend-shallow/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "users": {
+    "vlazar": true
+  },
+  "contributors": [
+    {
+      "name": "Jon Schlinkert",
+      "url": "http://twitter.com/jonschlinkert"
+    },
+    {
+      "name": "Peter deHaan",
+      "url": "http://about.me/peterdehaan"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/extend-shallow.min.json
+++ b/test/fixtures/registry-mocks/content/extend-shallow.min.json
@@ -1,0 +1,318 @@
+{
+  "name": "extend-shallow",
+  "dist-tags": {
+    "latest": "3.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "extend-shallow",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6"
+      },
+      "dist": {
+        "shasum": "3992b6a016e9562db4cbe3ac55977e09b2ff3415",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "extend-shallow",
+      "version": "0.1.1",
+      "dependencies": {
+        "array-slice": "^0.2.2"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6"
+      },
+      "dist": {
+        "shasum": "913c08db4887d3297dc762df8b5815757f56ddf3",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "extend-shallow",
+      "version": "0.2.0",
+      "dependencies": {
+        "array-slice": "^0.2.2"
+      },
+      "devDependencies": {
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "glob": "^4.3.1",
+        "mocha": "*",
+        "should": "^4.3.0"
+      },
+      "dist": {
+        "shasum": "0c98a09f27d83cb43efafcedac8c9d149deb599c",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "extend-shallow",
+      "version": "1.0.0",
+      "dependencies": {
+        "is-plain-object": "^1.0.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "dist": {
+        "shasum": "3c8406b1484d6c50c14bc0fa2af16c56924f90e1",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "extend-shallow",
+      "version": "1.0.1",
+      "dependencies": {
+        "is-plain-object": "^1.0.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "dist": {
+        "shasum": "e40197917b39b175850083b7dd725c7e9732f99b",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.1": {
+      "name": "extend-shallow",
+      "version": "1.1.1",
+      "dependencies": {
+        "kind-of": "^1.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "helper-related": "^0.1.0",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "dist": {
+        "shasum": "a934b62da72ac6978dd248f0d37da1d2c8ed61ef",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.2": {
+      "name": "extend-shallow",
+      "version": "1.1.2",
+      "dependencies": {
+        "kind-of": "^1.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "helper-related": "^0.1.0",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "dist": {
+        "shasum": "25d3b690988adbeddebcc6ef113bdac083c55ef0",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.4": {
+      "name": "extend-shallow",
+      "version": "1.1.4",
+      "dependencies": {
+        "kind-of": "^1.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.2",
+        "benchmarked": "^0.1.3",
+        "chalk": "^0.5.1",
+        "for-own": "^0.1.2",
+        "glob": "^4.3.1",
+        "is-plain-object": "^2.0.0",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^5.0.1"
+      },
+      "dist": {
+        "shasum": "19d6bf94dfc09d76ba711f39b872d21ff4dd9071",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "extend-shallow",
+      "version": "2.0.0",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.3",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "for-own": "^0.1.3",
+        "glob": "^5.0.12",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^2.0.0",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.5",
+        "should": "^7.0.1"
+      },
+      "dist": {
+        "shasum": "47da017bd07e4763e7546fca0a829da59a6ddc4d",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.1": {
+      "name": "extend-shallow",
+      "version": "2.0.1",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "devDependencies": {
+        "array-slice": "^0.2.3",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "for-own": "^0.1.3",
+        "glob": "^5.0.12",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^2.0.0",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.5",
+        "should": "^7.0.1"
+      },
+      "dist": {
+        "shasum": "51af7d614ad9a9f610ea1bafbb989d6b1c56890f",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "extend-shallow",
+      "version": "3.0.0",
+      "dependencies": {
+        "is-extendable": "^1.0.1"
+      },
+      "devDependencies": {
+        "array-slice": "^1.0.0",
+        "benchmarked": "^2.0.0",
+        "for-own": "^1.0.0",
+        "gulp-format-md": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.1",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "object-assign": "^4.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-2DwaMfw1xjy1kxz1ZzvQJt6klvkYW/tNPXAZgE8iHsQtkiQoOxrJevsTmWF01SRra++QgjxXGApWqBktbzmAvw==",
+        "shasum": "34d45c2bb1f4ea804fe9c35d40d798a7b869c087",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.1": {
+      "name": "extend-shallow",
+      "version": "3.0.1",
+      "dependencies": {
+        "is-extendable": "^1.0.1"
+      },
+      "devDependencies": {
+        "array-slice": "^1.0.0",
+        "benchmarked": "^2.0.0",
+        "for-own": "^1.0.0",
+        "gulp-format-md": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.1",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "object-assign": "^4.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-Fg1xXAv+qXKdwHiJFMcZSqsMcbPlkzsZtf8KkLJ2fqnP+lqg2RjEKgDcSfO9CO1+p4LZKgApDBUUUqKaaRhwZQ==",
+        "shasum": "4b6d8c49b147fee029dc9eb9484adb770f689844",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.2": {
+      "name": "extend-shallow",
+      "version": "3.0.2",
+      "dependencies": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "devDependencies": {
+        "array-slice": "^1.0.0",
+        "benchmarked": "^2.0.0",
+        "for-own": "^1.0.0",
+        "gulp-format-md": "^1.0.0",
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.1",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "object-assign": "^4.1.1"
+      },
+      "dist": {
+        "shasum": "26a71aaf073b39fb2127172746131c2704028db8",
+        "tarball": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-12-20T19:11:38.344Z"
+}

--- a/test/fixtures/registry-mocks/content/faye-websocket.json
+++ b/test/fixtures/registry-mocks/content/faye-websocket.json
@@ -1,0 +1,1762 @@
+{
+  "_id": "faye-websocket",
+  "_rev": "80-ff7bacf86586ef4185c606af95ea4f62",
+  "name": "faye-websocket",
+  "description": "Standards-compliant WebSocket server and client",
+  "dist-tags": {
+    "latest": "0.11.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "faye-websocket",
+      "description": "Robust general-purpose WebSocket server and client",
+      "homepage": "http://github.com/jcoglan/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ">=3.0.4"
+      },
+      "bugs": {
+        "name": "http://github.com/jcoglan/faye-websocket-node/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/jcoglan/faye-websocket-node.git"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "_id": "faye-websocket@0.1.0",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.2",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "696de95fac9ac2bc818f7d4f9f4f39b3bf1dad43",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "faye-websocket",
+      "description": "Robust general-purpose WebSocket server and client",
+      "homepage": "http://github.com/jcoglan/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "version": "0.1.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ">=3.0.4"
+      },
+      "bugs": {
+        "name": "http://github.com/jcoglan/faye-websocket-node/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/jcoglan/faye-websocket-node.git"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "_id": "faye-websocket@0.1.1",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-alpha-2",
+      "_nodeVersion": "v0.6.3",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "aa35191903be46f35a83417f83659f2ab6c23f47",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "faye-websocket",
+      "description": "Robust general-purpose WebSocket server and client",
+      "homepage": "http://github.com/jcoglan/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "version": "0.1.2",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ">=3.0.4"
+      },
+      "bugs": {
+        "name": "http://github.com/jcoglan/faye-websocket-node/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/jcoglan/faye-websocket-node.git"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "_id": "faye-websocket@0.1.2",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-alpha-6",
+      "_nodeVersion": "v0.6.5",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "763e4e7432b5f23b235d879c1a49a7bc91892797",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/jcoglan/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "version": "0.2.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "bugs": {
+        "name": "http://github.com/jcoglan/faye-websocket-node/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/jcoglan/faye-websocket-node.git"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "_id": "faye-websocket@0.2.0",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "05a3f9c21b41fde1facb43a556d906707d6548c9",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.3.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "bugs": {
+        "name": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "_id": "faye-websocket@0.3.0",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "cfd147e54da489a372f9a8af591b8f3037f4edcd",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.3.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "bugs": {
+        "name": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "_id": "faye-websocket@0.3.1",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "ad3dd5a1674c21c52d7664194589a3abd1ec32f0",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.4.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": {
+        "name": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "_id": "faye-websocket@0.4.0",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e9a8fc6b3e5a610f3308e8b9782876a01a745799",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.4.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": {
+        "name": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "_id": "faye-websocket@0.4.1",
+      "dependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-3",
+      "_nodeVersion": "v0.7.3",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "d234387dfa2117d0db98a5dc3ec456161494e333",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.4.2",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": "http://github.com/faye/faye-websocket-node/issues",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_id": "faye-websocket@0.4.2",
+      "dist": {
+        "shasum": "fef4f9f2caadcfd92f3c4c8319c147c0b7dbbaeb",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.3": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.4.3",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": "http://github.com/faye/faye-websocket-node/issues",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_id": "faye-websocket@0.4.3",
+      "dist": {
+        "shasum": "8a881b7976b3f19fcd0abff26377c610e95778de",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.4": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.4.4",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "devDependencies": {
+        "jsclass": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": "http://github.com/faye/faye-websocket-node/issues",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_id": "faye-websocket@0.4.4",
+      "dist": {
+        "shasum": "c14c5b3bf14d7417ffbfd990c0a7495cd9f337bc",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.10",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.5.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ""
+      },
+      "devDependencies": {
+        "jsclass": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": "http://github.com/faye/faye-websocket-node/issues",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_id": "faye-websocket@0.5.0",
+      "dist": {
+        "shasum": "4fb370c03b806ffe6cde19063cf9f8c31cc37846",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "version": "0.6.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.2.0"
+      },
+      "devDependencies": {
+        "jsclass": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": "http://github.com/faye/faye-websocket-node/issues",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/faye-websocket-node.git"
+        }
+      ],
+      "_id": "faye-websocket@0.6.0",
+      "dist": {
+        "shasum": "4d0b0e8ed35880f6a81d2bd1eae643c5e48d5da7",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.6.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.2.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "_id": "faye-websocket@0.6.1",
+      "dist": {
+        "shasum": "43a54b2ab807761d7ec335d12f48eb69ec4ab61c",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.6.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.7.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.3.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "_id": "faye-websocket@0.7.0",
+      "dist": {
+        "shasum": "c16c50ec0d483357a8eafd1ec6fcc313d027f5be",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.7.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.3.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "_id": "faye-websocket@0.7.1",
+      "dist": {
+        "shasum": "72fe630d122333e0f36ac453f593ed70e1cb6baa",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.2": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.7.2",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.3.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "_id": "faye-websocket@0.7.2",
+      "dist": {
+        "shasum": "799970386f87105592397434b02abfa4f07bdf70",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.3": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.7.3",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.3.6"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "4db640660d63db1cf208c27e41df62dd5a10f6d6",
+      "_id": "faye-websocket@0.7.3",
+      "_shasum": "cc4074c7f4a4dfd03af54dd65c354b135132ce11",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cc4074c7f4a4dfd03af54dd65c354b135132ce11",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.8.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.4.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "89a9b0d9b8898218616117fee9474b7209debc47",
+      "_id": "faye-websocket@0.8.0",
+      "_shasum": "94e94f24963a9ff2757d1a75c7f2d010df89b51d",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "94e94f24963a9ff2757d1a75c7f2d010df89b51d",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.8.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.4.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "112082800350b61653e1f0dfa878e52e31f2395f",
+      "_id": "faye-websocket@0.8.1",
+      "_shasum": "c1eb3f3aad85f0eb505057332690163297b0ea26",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c1eb3f3aad85f0eb505057332690163297b0ea26",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.9.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "4f1eced5e0e6093f0c1e10ab749376472dad53dc",
+      "_id": "faye-websocket@0.9.0",
+      "_shasum": "175258b5cf1745f5258d67bcbec2672d287670d8",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "175258b5cf1745f5258d67bcbec2672d287670d8",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.1": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.9.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "73284c858c6c63631bd6b8fb1cf938cc5bdcea14",
+      "_id": "faye-websocket@0.9.1",
+      "_shasum": "01a206fbf2aae351f1ef6e7d3adf6069dd7ccc13",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "01a206fbf2aae351f1ef6e7d3adf6069dd7ccc13",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.2": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.9.2",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "cd8f337278954d89709788ca3e63473597e372b2",
+      "_id": "faye-websocket@0.9.2",
+      "_shasum": "872e633049fa10c3a55381f9ecac80bfb3053405",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "872e633049fa10c3a55381f9ecac80bfb3053405",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.3": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.9.3",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "39eeb1b884bab3ea995bb8d0aa982a9fd9fdc15e",
+      "_id": "faye-websocket@0.9.3",
+      "_shasum": "482a505b0df0ae626b969866d3bd740cdb962e83",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "482a505b0df0ae626b969866d3bd740cdb962e83",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.4": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.9.4",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "6c1689a73d5936a69e58ca2f046fe472cf1e62bd",
+      "_id": "faye-websocket@0.9.4",
+      "_shasum": "885934c79effb0409549e0c0a3801ed17a40cdad",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "885934c79effb0409549e0c0a3801ed17a40cdad",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "http://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.10.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "854c0a96581d95d0f07db01ce48431a4098e7c60",
+      "_id": "faye-websocket@0.10.0",
+      "_shasum": "4e492f8d04dfb6f89003507f6edbf2d501e7c6f4",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.6",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4e492f8d04dfb6f89003507f6edbf2d501e7c6f4",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "https://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.11.0",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "dc392490a8e84b9735aab0e306a2b477a6e84ce5",
+      "_id": "faye-websocket@0.11.0",
+      "_shasum": "d9ccf0e789e7db725d74bc4877d23aa42972ac50",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d9ccf0e789e7db725d74bc4877d23aa42972ac50",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/faye-websocket-0.11.0.tgz_1456302881552_0.75253253034316"
+      },
+      "directories": {}
+    },
+    "0.11.1": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "https://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "MIT",
+      "version": "0.11.1",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "49eab191cc2946e40bdee650e9bd0bb2384562a2",
+      "_id": "faye-websocket@0.11.1",
+      "_shasum": "f0efe18c4f56e4f40afc7e06c719fd5ee6188f38",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.2",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "dist": {
+        "shasum": "f0efe18c4f56e4f40afc7e06c719fd5ee6188f38",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/faye-websocket-0.11.1.tgz_1485114699910_0.504224339267239"
+      },
+      "directories": {}
+    },
+    "0.11.3": {
+      "name": "faye-websocket",
+      "description": "Standards-compliant WebSocket server and client",
+      "homepage": "https://github.com/faye/faye-websocket-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket",
+        "eventsource"
+      ],
+      "license": "Apache-2.0",
+      "version": "0.11.3",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "main": "./lib/faye/websocket",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "pace": "*",
+        "permessage-deflate": "*"
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js",
+        "start": "node server.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/faye-websocket-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/faye-websocket-node/issues"
+      },
+      "gitHead": "a2d1fa84e4262a4a1f06700b188ad365d25fab03",
+      "_id": "faye-websocket@0.11.3",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+        "shasum": "5c0e9a8968e8912c286639fde977a8b209f2508e",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+        "fileCount": 10,
+        "unpackedSize": 30705,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/j/ACRA9TVsSAnZWagAAI4oP/RitbbyDqlGh7/Prbrj6\nL/NWcFcS0wb+3vqXyEdeTRqUTzyZBdGmPvTdJl6P7GIsKXhgZoUpHz0thmWB\nnBr0HY/ThTzeKYIQ7hVD04rQwHAPtbYtOC0HXqRRK0Jm8FcjLjikKZBL+Y4V\nCpG45lbPd5D2B3AjXFD7Wf5h0tOcejT4lCJEyLvx21ScUmMnwnCjl2WynYg/\nN8EHAFedCvfGd0M+5syFTQ5Bk+ggJmX5gGyaMAJ3BCw6n4k4OTO7iBG5/Bzb\nkdkjeEykBZTxZQAKn0I/Wx/FW63r767mF8yJ4u29bzTWEy9uw2liqlW+NnfG\nRfpwlwmxcCGTm23SlCKma32yOOYKE+DdRlfcc06wGbEqlzJ3ajU44UW9ycHl\nLGJwCzl2AVD8ZxJCuB20GzMFMaafwUJ0PgKcb6XNaepU7WW+0LLoFCK5sY+R\nRfyL2cScj/cZk5SVPNLfPHiA3xt+wix4PPznCOGan8nKEOrOSlFQ+oHU04C5\n7matWy3WG8yhhvAUEtyBk/G3O5TFFR+tgvaICS0f7TF1ou67Fh/oc0Xky7b0\nrLn84PSCBqjrVePUlDZh13XFN2JJBY42oNyIYAC8EWeEL9XWlWJvp0l8jZ/S\nJqa1g8XVp+I+uSAn8OXOq4c3C/9k1Vuoof+GbPsssKdY+OgZWUfVuge15qn/\n8N6x\r\n=qFQi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/faye-websocket_0.11.3_1560166335655_0.05438899040824596"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# faye-websocket [![Build status](https://secure.travis-ci.org/faye/faye-websocket-node.svg)](http://travis-ci.org/faye/faye-websocket-node)\n\nThis is a general-purpose WebSocket implementation extracted from the\n[Faye](http://faye.jcoglan.com) project. It provides classes for easily building\nWebSocket servers and clients in Node. It does not provide a server itself, but\nrather makes it easy to handle WebSocket connections within an existing\n[Node](https://nodejs.org/) application. It does not provide any abstraction\nother than the standard [WebSocket\nAPI](https://html.spec.whatwg.org/multipage/comms.html#network).\n\nIt also provides an abstraction for handling\n[EventSource](https://html.spec.whatwg.org/multipage/comms.html#server-sent-events)\nconnections, which are one-way connections that allow the server to push data to\nthe client. They are based on streaming HTTP responses and can be easier to access\nvia proxies than WebSockets.\n\n\n## Installation\n\n```\n$ npm install faye-websocket\n```\n\n\n## Handling WebSocket connections in Node\n\nYou can handle WebSockets on the server side by listening for HTTP Upgrade\nrequests, and creating a new socket for the request. This socket object exposes\nthe usual WebSocket methods for receiving and sending messages. For example this\nis how you'd implement an echo server:\n\n```js\nvar WebSocket = require('faye-websocket'),\n    http      = require('http');\n\nvar server = http.createServer();\n\nserver.on('upgrade', function(request, socket, body) {\n  if (WebSocket.isWebSocket(request)) {\n    var ws = new WebSocket(request, socket, body);\n    \n    ws.on('message', function(event) {\n      ws.send(event.data);\n    });\n    \n    ws.on('close', function(event) {\n      console.log('close', event.code, event.reason);\n      ws = null;\n    });\n  }\n});\n\nserver.listen(8000);\n```\n\n`WebSocket` objects are also duplex streams, so you could replace the\n`ws.on('message', ...)` line with:\n\n```js\n    ws.pipe(ws);\n```\n\nNote that under certain circumstances (notably a draft-76 client connecting\nthrough an HTTP proxy), the WebSocket handshake will not be complete after you\ncall `new WebSocket()` because the server will not have received the entire\nhandshake from the client yet. In this case, calls to `ws.send()` will buffer\nthe message in memory until the handshake is complete, at which point any\nbuffered messages will be sent to the client.\n\nIf you need to detect when the WebSocket handshake is complete, you can use the\n`onopen` event.\n\nIf the connection's protocol version supports it, you can call `ws.ping()` to\nsend a ping message and wait for the client's response. This method takes a\nmessage string, and an optional callback that fires when a matching pong message\nis received. It returns `true` if and only if a ping message was sent. If the\nclient does not support ping/pong, this method sends no data and returns\n`false`.\n\n```js\nws.ping('Mic check, one, two', function() {\n  // fires when pong is received\n});\n```\n\n\n## Using the WebSocket client\n\nThe client supports both the plain-text `ws` protocol and the encrypted `wss`\nprotocol, and has exactly the same interface as a socket you would use in a web\nbrowser. On the wire it identifies itself as `hybi-13`.\n\n```js\nvar WebSocket = require('faye-websocket'),\n    ws        = new WebSocket.Client('ws://www.example.com/');\n\nws.on('open', function(event) {\n  console.log('open');\n  ws.send('Hello, world!');\n});\n\nws.on('message', function(event) {\n  console.log('message', event.data);\n});\n\nws.on('close', function(event) {\n  console.log('close', event.code, event.reason);\n  ws = null;\n});\n```\n\nThe WebSocket client also lets you inspect the status and headers of the\nhandshake response via its `statusCode` and `headers` properties.\n\nTo connect via a proxy, set the `proxy` option to the HTTP origin of the proxy,\nincluding any authorization information, custom headers and TLS config you\nrequire. Only the `origin` setting is required.\n\n```js\nvar ws = new WebSocket.Client('ws://www.example.com/', [], {\n  proxy: {\n    origin:  'http://username:password@proxy.example.com',\n    headers: {'User-Agent': 'node'},\n    tls:     {cert: fs.readFileSync('client.crt')}\n  }\n});\n```\n\nThe `tls` value is an object that will be passed to\n[`tls.connect()`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).\n\n\n## Subprotocol negotiation\n\nThe WebSocket protocol allows peers to select and identify the application\nprotocol to use over the connection. On the client side, you can set which\nprotocols the client accepts by passing a list of protocol names when you\nconstruct the socket:\n\n```js\nvar ws = new WebSocket.Client('ws://www.example.com/', ['irc', 'amqp']);\n```\n\nOn the server side, you can likewise pass in the list of protocols the server\nsupports after the other constructor arguments:\n\n```js\nvar ws = new WebSocket(request, socket, body, ['irc', 'amqp']);\n```\n\nIf the client and server agree on a protocol, both the client- and server-side\nsocket objects expose the selected protocol through the `ws.protocol` property.\n\n\n## Protocol extensions\n\nfaye-websocket is based on the\n[websocket-extensions](https://github.com/faye/websocket-extensions-node)\nframework that allows extensions to be negotiated via the\n`Sec-WebSocket-Extensions` header. To add extensions to a connection, pass an\narray of extensions to the `:extensions` option. For example, to add\n[permessage-deflate](https://github.com/faye/permessage-deflate-node):\n\n```js\nvar deflate = require('permessage-deflate');\n\nvar ws = new WebSocket(request, socket, body, [], {extensions: [deflate]});\n```\n\n\n## Initialization options\n\nBoth the server- and client-side classes allow an options object to be passed in\nat initialization time, for example:\n\n```js\nvar ws = new WebSocket(request, socket, body, protocols, options);\nvar ws = new WebSocket.Client(url, protocols, options);\n```\n\n`protocols` is an array of subprotocols as described above, or `null`.\n`options` is an optional object containing any of these fields:\n\n- `extensions` - an array of\n  [websocket-extensions](https://github.com/faye/websocket-extensions-node)\n  compatible extensions, as described above\n- `headers` - an object containing key-value pairs representing HTTP headers to\n  be sent during the handshake process\n- `maxLength` - the maximum allowed size of incoming message frames, in bytes.\n  The default value is `2^26 - 1`, or 1 byte short of 64 MiB.\n- `ping` - an integer that sets how often the WebSocket should send ping frames,\n  measured in seconds\n\nThe client accepts some additional options:\n\n- `proxy` - settings for a proxy as described above\n- `net` - an object containing settings for the origin server that will be\n  passed to\n  [`net.connect()`](https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener)\n- `tls` - an object containing TLS settings for the origin server, this will be\n  passed to\n  [`tls.connect()`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback)\n- `ca` - (legacy) a shorthand for passing `{tls: {ca: value}}`\n\n\n## WebSocket API\n\nBoth server- and client-side `WebSocket` objects support the following API.\n\n- **`on('open', function(event) {})`** fires when the socket connection is\n  established. Event has no attributes.\n- **`on('message', function(event) {})`** fires when the socket receives a\n  message. Event has one attribute, **`data`**, which is either a `String` (for\n  text frames) or a `Buffer` (for binary frames).\n- **`on('error', function(event) {})`** fires when there is a protocol error due\n  to bad data sent by the other peer. This event is purely informational, you do\n  not need to implement error recover.\n- **`on('close', function(event) {})`** fires when either the client or the\n  server closes the connection. Event has two optional attributes, **`code`**\n  and **`reason`**, that expose the status code and message sent by the peer\n  that closed the connection.\n- **`send(message)`** accepts either a `String` or a `Buffer` and sends a text\n  or binary message over the connection to the other peer.\n- **`ping(message, function() {})`** sends a ping frame with an optional message\n  and fires the callback when a matching pong is received.\n- **`close(code, reason)`** closes the connection, sending the given status code\n  and reason text, both of which are optional.\n- **`version`** is a string containing the version of the `WebSocket` protocol\n  the connection is using.\n- **`protocol`** is a string (which may be empty) identifying the subprotocol\n  the socket is using.\n\n\n## Handling EventSource connections in Node\n\nEventSource connections provide a very similar interface, although because they\nonly allow the server to send data to the client, there is no `onmessage` API.\nEventSource allows the server to push text messages to the client, where each\nmessage has an optional event-type and ID.\n\n```js\nvar WebSocket   = require('faye-websocket'),\n    EventSource = WebSocket.EventSource,\n    http        = require('http');\n\nvar server = http.createServer();\n\nserver.on('request', function(request, response) {\n  if (EventSource.isEventSource(request)) {\n    var es = new EventSource(request, response);\n    console.log('open', es.url, es.lastEventId);\n    \n    // Periodically send messages\n    var loop = setInterval(function() { es.send('Hello') }, 1000);\n    \n    es.on('close', function() {\n      clearInterval(loop);\n      es = null;\n    });\n  \n  } else {\n    // Normal HTTP request\n    response.writeHead(200, {'Content-Type': 'text/plain'});\n    response.end('Hello');\n  }\n});\n\nserver.listen(8000);\n```\n\nThe `send` method takes two optional parameters, `event` and `id`. The default\nevent-type is `'message'` with no ID. For example, to send a `notification`\nevent with ID `99`:\n\n```js\nes.send('Breaking News!', {event: 'notification', id: '99'});\n```\n\nThe `EventSource` object exposes the following properties:\n\n- **`url`** is a string containing the URL the client used to create the\n  EventSource.\n- **`lastEventId`** is a string containing the last event ID received by the\n  client. You can use this when the client reconnects after a dropped connection\n  to determine which messages need resending.\n\nWhen you initialize an EventSource with ` new EventSource()`, you can pass\nconfiguration options after the `response` parameter. Available options are:\n\n- **`headers`** is an object containing custom headers to be set on the\n  EventSource response.\n- **`retry`** is a number that tells the client how long (in seconds) it should\n  wait after a dropped connection before attempting to reconnect.\n- **`ping`** is a number that tells the server how often (in seconds) to send\n  'ping' packets to the client to keep the connection open, to defeat timeouts\n  set by proxies. The client will ignore these messages.\n\nFor example, this creates a connection that allows access from any origin, pings\nevery 15 seconds and is retryable every 10 seconds if the connection is broken:\n\n```js\nvar es = new EventSource(request, response, {\n  headers: {'Access-Control-Allow-Origin': '*'},\n  ping:    15,\n  retry:   10\n});\n```\n\nYou can send a ping message at any time by calling `es.ping()`. Unlike\nWebSocket, the client does not send a response to this; it is merely to send\nsome data over the wire to keep the connection alive.\n",
+  "maintainers": [
+    {
+      "name": "jcoglan",
+      "email": "jcoglan@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-06-10T11:32:21.489Z",
+    "created": "2011-11-28T09:14:29.219Z",
+    "0.1.0": "2011-11-28T09:14:30.572Z",
+    "0.1.1": "2011-11-30T00:57:50.689Z",
+    "0.1.2": "2011-12-05T09:59:27.990Z",
+    "0.2.0": "2011-12-21T01:32:48.433Z",
+    "0.3.0": "2012-01-13T21:47:51.142Z",
+    "0.3.1": "2012-01-16T20:37:57.952Z",
+    "0.4.0": "2012-02-13T13:55:51.397Z",
+    "0.4.1": "2012-02-26T19:00:56.585Z",
+    "0.4.2": "2012-08-23T12:55:40.507Z",
+    "0.4.3": "2012-08-23T12:56:31.937Z",
+    "0.4.4": "2013-02-15T01:40:58.615Z",
+    "0.5.0": "2013-05-05T00:52:21.933Z",
+    "0.6.0": "2013-05-12T16:42:22.738Z",
+    "0.6.1": "2013-07-05T14:19:18.633Z",
+    "0.7.0": "2013-09-09T21:23:12.135Z",
+    "0.7.1": "2013-12-03T00:49:59.632Z",
+    "0.7.2": "2013-12-29T12:31:14.993Z",
+    "0.7.3": "2014-10-04T07:36:24.348Z",
+    "0.8.0": "2014-11-08T19:50:49.115Z",
+    "0.8.1": "2014-11-12T19:45:59.943Z",
+    "0.9.0": "2014-12-13T14:30:23.501Z",
+    "0.9.1": "2014-12-18T02:27:06.965Z",
+    "0.9.2": "2014-12-21T22:40:55.749Z",
+    "0.9.3": "2015-02-19T21:08:33.395Z",
+    "0.9.4": "2015-03-08T17:18:00.799Z",
+    "0.10.0": "2015-07-08T20:18:58.386Z",
+    "0.11.0": "2016-02-24T08:34:42.626Z",
+    "0.11.1": "2017-01-22T19:51:41.863Z",
+    "0.11.2": "2019-06-10T11:28:10.515Z",
+    "0.11.3": "2019-06-10T11:32:15.751Z"
+  },
+  "author": {
+    "name": "James Coglan",
+    "email": "jcoglan@gmail.com",
+    "url": "http://jcoglan.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/faye/faye-websocket-node.git"
+  },
+  "users": {
+    "285858315": true,
+    "codevia": true,
+    "huangjia86": true,
+    "hollobit": true,
+    "io2work": true,
+    "wenhsiaoyi": true,
+    "staydan": true,
+    "xuhong": true,
+    "oleg_tsyba": true,
+    "shanewholloway": true
+  },
+  "homepage": "https://github.com/faye/faye-websocket-node",
+  "keywords": [
+    "websocket",
+    "eventsource"
+  ],
+  "bugs": {
+    "url": "https://github.com/faye/faye-websocket-node/issues"
+  },
+  "license": "Apache-2.0",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/faye-websocket.min.json
+++ b/test/fixtures/registry-mocks/content/faye-websocket.min.json
@@ -1,0 +1,501 @@
+{
+  "name": "faye-websocket",
+  "dist-tags": {
+    "latest": "0.11.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "faye-websocket",
+      "version": "0.1.0",
+      "devDependencies": {
+        "jsclass": ">=3.0.4"
+      },
+      "dist": {
+        "shasum": "696de95fac9ac2bc818f7d4f9f4f39b3bf1dad43",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.1.1": {
+      "name": "faye-websocket",
+      "version": "0.1.1",
+      "devDependencies": {
+        "jsclass": ">=3.0.4"
+      },
+      "dist": {
+        "shasum": "aa35191903be46f35a83417f83659f2ab6c23f47",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.1.2": {
+      "name": "faye-websocket",
+      "version": "0.1.2",
+      "devDependencies": {
+        "jsclass": ">=3.0.4"
+      },
+      "dist": {
+        "shasum": "763e4e7432b5f23b235d879c1a49a7bc91892797",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.2.0": {
+      "name": "faye-websocket",
+      "version": "0.2.0",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "05a3f9c21b41fde1facb43a556d906707d6548c9",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.0": {
+      "name": "faye-websocket",
+      "version": "0.3.0",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "cfd147e54da489a372f9a8af591b8f3037f4edcd",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.1": {
+      "name": "faye-websocket",
+      "version": "0.3.1",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "ad3dd5a1674c21c52d7664194589a3abd1ec32f0",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.4.0": {
+      "name": "faye-websocket",
+      "version": "0.4.0",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "e9a8fc6b3e5a610f3308e8b9782876a01a745799",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.4.1": {
+      "name": "faye-websocket",
+      "version": "0.4.1",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "d234387dfa2117d0db98a5dc3ec456161494e333",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.4.2": {
+      "name": "faye-websocket",
+      "version": "0.4.2",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "fef4f9f2caadcfd92f3c4c8319c147c0b7dbbaeb",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.4.3": {
+      "name": "faye-websocket",
+      "version": "0.4.3",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "8a881b7976b3f19fcd0abff26377c610e95778de",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.4.4": {
+      "name": "faye-websocket",
+      "version": "0.4.4",
+      "devDependencies": {
+        "jsclass": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "c14c5b3bf14d7417ffbfd990c0a7495cd9f337bc",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.5.0": {
+      "name": "faye-websocket",
+      "version": "0.5.0",
+      "dependencies": {
+        "websocket-driver": ""
+      },
+      "devDependencies": {
+        "jsclass": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "4fb370c03b806ffe6cde19063cf9f8c31cc37846",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.6.0": {
+      "name": "faye-websocket",
+      "version": "0.6.0",
+      "dependencies": {
+        "websocket-driver": ">=0.2.0"
+      },
+      "devDependencies": {
+        "jsclass": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "4d0b0e8ed35880f6a81d2bd1eae643c5e48d5da7",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.6.1": {
+      "name": "faye-websocket",
+      "version": "0.6.1",
+      "dependencies": {
+        "websocket-driver": ">=0.2.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "43a54b2ab807761d7ec335d12f48eb69ec4ab61c",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.6.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.7.0": {
+      "name": "faye-websocket",
+      "version": "0.7.0",
+      "dependencies": {
+        "websocket-driver": ">=0.3.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "c16c50ec0d483357a8eafd1ec6fcc313d027f5be",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.7.1": {
+      "name": "faye-websocket",
+      "version": "0.7.1",
+      "dependencies": {
+        "websocket-driver": ">=0.3.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "72fe630d122333e0f36ac453f593ed70e1cb6baa",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.7.2": {
+      "name": "faye-websocket",
+      "version": "0.7.2",
+      "dependencies": {
+        "websocket-driver": ">=0.3.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "799970386f87105592397434b02abfa4f07bdf70",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.7.3": {
+      "name": "faye-websocket",
+      "version": "0.7.3",
+      "dependencies": {
+        "websocket-driver": ">=0.3.6"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "cc4074c7f4a4dfd03af54dd65c354b135132ce11",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.8.0": {
+      "name": "faye-websocket",
+      "version": "0.8.0",
+      "dependencies": {
+        "websocket-driver": ">=0.4.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "94e94f24963a9ff2757d1a75c7f2d010df89b51d",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.8.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.8.1": {
+      "name": "faye-websocket",
+      "version": "0.8.1",
+      "dependencies": {
+        "websocket-driver": ">=0.4.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": ""
+      },
+      "dist": {
+        "shasum": "c1eb3f3aad85f0eb505057332690163297b0ea26",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.8.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.9.0": {
+      "name": "faye-websocket",
+      "version": "0.9.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "175258b5cf1745f5258d67bcbec2672d287670d8",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.9.1": {
+      "name": "faye-websocket",
+      "version": "0.9.1",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "01a206fbf2aae351f1ef6e7d3adf6069dd7ccc13",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.9.2": {
+      "name": "faye-websocket",
+      "version": "0.9.2",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "872e633049fa10c3a55381f9ecac80bfb3053405",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.9.3": {
+      "name": "faye-websocket",
+      "version": "0.9.3",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "482a505b0df0ae626b969866d3bd740cdb962e83",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.9.4": {
+      "name": "faye-websocket",
+      "version": "0.9.4",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "885934c79effb0409549e0c0a3801ed17a40cdad",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.10.0": {
+      "name": "faye-websocket",
+      "version": "0.10.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "4e492f8d04dfb6f89003507f6edbf2d501e7c6f4",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.11.0": {
+      "name": "faye-websocket",
+      "version": "0.11.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "d9ccf0e789e7db725d74bc4877d23aa42972ac50",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.11.1": {
+      "name": "faye-websocket",
+      "version": "0.11.1",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "pace": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "f0efe18c4f56e4f40afc7e06c719fd5ee6188f38",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.11.3": {
+      "name": "faye-websocket",
+      "version": "0.11.3",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "pace": "*",
+        "permessage-deflate": "*"
+      },
+      "dist": {
+        "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+        "shasum": "5c0e9a8968e8912c286639fde977a8b209f2508e",
+        "tarball": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+        "fileCount": 10,
+        "unpackedSize": 30705,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/j/ACRA9TVsSAnZWagAAI4oP/RitbbyDqlGh7/Prbrj6\nL/NWcFcS0wb+3vqXyEdeTRqUTzyZBdGmPvTdJl6P7GIsKXhgZoUpHz0thmWB\nnBr0HY/ThTzeKYIQ7hVD04rQwHAPtbYtOC0HXqRRK0Jm8FcjLjikKZBL+Y4V\nCpG45lbPd5D2B3AjXFD7Wf5h0tOcejT4lCJEyLvx21ScUmMnwnCjl2WynYg/\nN8EHAFedCvfGd0M+5syFTQ5Bk+ggJmX5gGyaMAJ3BCw6n4k4OTO7iBG5/Bzb\nkdkjeEykBZTxZQAKn0I/Wx/FW63r767mF8yJ4u29bzTWEy9uw2liqlW+NnfG\nRfpwlwmxcCGTm23SlCKma32yOOYKE+DdRlfcc06wGbEqlzJ3ajU44UW9ycHl\nLGJwCzl2AVD8ZxJCuB20GzMFMaafwUJ0PgKcb6XNaepU7WW+0LLoFCK5sY+R\nRfyL2cScj/cZk5SVPNLfPHiA3xt+wix4PPznCOGan8nKEOrOSlFQ+oHU04C5\n7matWy3WG8yhhvAUEtyBk/G3O5TFFR+tgvaICS0f7TF1ou67Fh/oc0Xky7b0\nrLn84PSCBqjrVePUlDZh13XFN2JJBY42oNyIYAC8EWeEL9XWlWJvp0l8jZ/S\nJqa1g8XVp+I+uSAn8OXOq4c3C/9k1Vuoof+GbPsssKdY+OgZWUfVuge15qn/\n8N6x\r\n=qFQi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    }
+  },
+  "modified": "2019-06-10T11:32:21.489Z"
+}

--- a/test/fixtures/registry-mocks/content/figgy-pudding.json
+++ b/test/fixtures/registry-mocks/content/figgy-pudding.json
@@ -1,0 +1,1117 @@
+{
+  "_id": "figgy-pudding",
+  "_rev": "36-a9e2d2b210f10fc866bd6ce3e314a1a9",
+  "name": "figgy-pudding",
+  "description": "Delicious, festive, cascading config/opts definitions",
+  "dist-tags": {
+    "latest": "3.5.2"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "figgy-pudding",
+      "version": "0.0.1",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap -j8 test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "gitHead": "153be98d1cbee45fb39dc4297241d7182baba975",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@0.0.1",
+      "_shasum": "5be4d211c872bb267225346381957c435b7c7c4c",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "5be4d211c872bb267225346381957c435b7c7c4c",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/figgy-pudding-0.0.1.tgz_1486434433688_0.060132883256301284"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "figgy-pudding",
+      "version": "1.0.0",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "preversion": "npm t",
+        "postversion": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "test": "nyc -- tap -j8 test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "gitHead": "4bd8c1323046019a7fe947d8230956fb5c9f36ef",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@1.0.0",
+      "_shasum": "00ae832d49ee2373590f1a06416b194936afb627",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "00ae832d49ee2373590f1a06416b194936afb627",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/figgy-pudding-1.0.0.tgz_1486504629065_0.16432326822541654"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "figgy-pudding",
+      "version": "2.0.0",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "49388fd6049fb0707e1c5580371bab45ff75b134",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@2.0.0",
+      "_npmVersion": "5.8.0-next.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-h67cT0L1BpsDITtxWfgsCAH5BBI3tk9VBnRdTYltSyUMWZF7lqBYgQfaLwRhd6AAIu8Aft0JsneId1dVwKBH6Q==",
+        "shasum": "0079daad9855d2a2585acc6f49d5e4e8b7bd291a",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7283
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_2.0.0_1521177895432_0.26953869904274996"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "figgy-pudding",
+      "version": "2.0.1",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "1b2d18b188e50c7e9b71b36163fa9593efa40a41",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@2.0.1",
+      "_npmVersion": "5.8.0-next.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-yIJPhIBi/oFdU/P+GSXjmk/rmGjuZkm7A5LTXZxNrEprXJXRK012FiI1BR1Pga+0d/d6taWWD+B5d2ozqaxHig==",
+        "shasum": "56c8fc878e06e1090799b9bcc91cbd85c2c92278",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-2.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7589
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_2.0.1_1521179306148_0.810228600565964"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "figgy-pudding",
+      "version": "3.0.0",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "018039231b94ea37318e476afa40afa32bf1c6e4",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.0.0",
+      "_npmVersion": "6.0.0-next.0",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-V5i5eQecLl6rfChOBqAVV9OleahLe6pCXOSG3hWAoYSkDyp28xjhsWh0xRPz1PHFARMP6rp9bOiLXipwF9iObA==",
+        "shasum": "b27194ad339c61b6f492bcc52852b5f107af9a16",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9288
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.0.0_1523051828836_0.7858626678194904"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "figgy-pudding",
+      "version": "3.1.0",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "ab7f0aad103c806dafb134343ae9f21f67435d00",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.1.0",
+      "_npmVersion": "6.0.0-next.0",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-Gi2vIue0ec6P/7LNpueGhLuvfF2ztuterl8YFBQn1yKgIS46noGxCbi+vviPdObNYtgUSh5FpHy5q0Cw9XhxKQ==",
+        "shasum": "a77ed2284175976c424b390b298569e9df86dd1e",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10188
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.1.0_1523230922576_0.9253852187715028"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.2.0": {
+      "name": "figgy-pudding",
+      "version": "3.2.0",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "f8f11564ce090eb272472ffe6b128c098a557993",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.2.0",
+      "_npmVersion": "6.3.0-next.0",
+      "_nodeVersion": "10.5.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-S2gSvqcqkI4sk+dI3ykKllfEg88dL5cXM0QPT4z9UbOkNygqec8/99d0VB3ikZ7u1/QC5l4e1YJPWvoUFuRVkg==",
+        "shasum": "464626b73d7b0fc045a99753d191b0785957ff73",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10593,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbWkQRCRA9TVsSAnZWagAAkpkQAKAwhXoxByiLiPG4Eyzj\nbs0AXPb3cjBji48wuK6AYYMQ9mvOyH/bNtpBtoooY/H361HjhbIvwLNxWpoT\n0M4bqAAvV1e6a2lGgtCekODinGzL85h3/CsO2V7SdRVB3ywz4dTwxpi8UVds\nhKiJENp36IBAFaUT2Ozekz4lyjwYg4Rpf119lMPT62k9/r3bCP0QIUeRC2kk\n9PBzWgWYkcSZHJrVdcFWiOXVVOZ4tGNh/cBqyQyOF0OXbwrUlXLUi1zxPdM/\nu2tshokpz/eqhPV2wj/6j+ny2csZJVWaiKAy/7iaqAjaZd5fa8OTiH8vfLuw\n1ebi7+Gx+PtnNcZeVS3WtQOkp+D6Z1aPADct1H+WmOLap3bR08J8penAoP8u\n8qBe2RfLadrpzb4OfDntfe17WTv1H/WOp8ze8/B8A+lJq2Yvb2PiRxHy/SJr\noLuLBMQPTudxNofUwVsQQSMKUn83qMSRpLZ2JRUoGkDdh9P5ZNPIItfX1yS+\naxhIbffODboo3LlXm/7eOYwauVznC2vCpOa8X44R7nKAXiGSdOetmOJq8VaF\nSDi1q47T70RKjne5NI8dT33hyk83z0TFllW6zGc/VxPK2m3G+ya/tMX8luNx\nTIR+5VbXO/y/OJf9/naCYZ89khIdpHjJWfseY6l4jn3/c/gGqW7mezkxjPjn\nWIx+\r\n=Rzzu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.2.0_1532642321850_0.076595614169785"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.2.1": {
+      "name": "figgy-pudding",
+      "version": "3.2.1",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "bc6f9edb82baceb2e70a79a8c5fbc6c8751e0459",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.2.1",
+      "_npmVersion": "6.4.0-next.0",
+      "_nodeVersion": "10.6.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-1kWvzhClfNh9NhhUaT9D9H7knbQ4kW+SOa7TRYHZshd0YsBWQpffjx9T++Psx5XpXJV6utRSP70sm2Ivb7If3w==",
+        "shasum": "946bdc2515abad5190027113778595462b668eb3",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.2.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 11588,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbc4KSCRA9TVsSAnZWagAAL3QP/iUY+zaOP8x8wTmeH2rV\ny8f8RupnpMYwVmVzhQlWjUq5QMvhuuvZSljZ9vRAtJxwTwJWjf05L7TTorYo\negEwByqzdSVB7/rNrteyc175fU7jRkM5Yb58OewDsH0zNVo/WjrV0el0INBf\nBKvE7ZlGTbS591EZsTLMfUxM6XEhry8NfKmE4dQ3zW0S/frRxhxo6XQBf3Su\nz6sG+e/tFEWxVgBKuA6dhObH83oYNnYYk8wVsHv+eK5WF+tpGtv0PBTGD/HY\nPt5NfTR01Q4IzobeWpTMZulxHfGSlUVR40FSUSoHJQA5uvEN/EAUkInLtJ30\nFMtu6fsQSGuJjmvK5xH8uvGgTId/bCp3kb+W04zc9eO5/uHpPb9IqeKZPnXP\n6cTVT64GyL0on4Y+IaTXWVDib8wRUdUbkabAlTgx+Qxxkr/KzX9tB5OYAP+D\nPl+Y7BzVvZVVDLF1YRhajLMLDntKq2mOA5HQXmJwWW1HBO+Lapu367bana2s\njWn9DShUamfuv36Luq2Zz6biERugR6IePqW58GESu+09gGGrSWRl86RQpMv7\naXEaTrok1tfUMqPjn2/wjevboPqM/KB9CJJBQ6ASZgkMucn4wv8f8e1hv9ie\nATfhdIr+oGTuuXdlMlnI7UwZp/RCyx8Lc07RZjR9bT30yKtKWJ7BrOB5FFBL\n4QyI\r\n=HRKN\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.2.1_1534296722898_0.3241029239706352"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.3.0": {
+      "name": "figgy-pudding",
+      "version": "3.3.0",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "3a3e029abb88973819e10fe92f317881c5e9a851",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.3.0",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.6.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-M+rtA1ExfVeoGM+BIXhyhamlc9tptJ0PI5tzy8EEzj4KM0r6uFdthIEU3zwWt3WmmIT/5bExGL4vr5xlqa1ehA==",
+        "shasum": "dd6df760ce955b785ebc7d28a1555ee7e2e40d21",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 12996,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbdNQoCRA9TVsSAnZWagAAYiMP/3YBWYxqVmjZ7dVKnQM5\n3c8RBE0dizd/RAG7wlc0F+WlT+9UgjKERXjU4N1Haa4rmWF53yoAsUcUof/B\n4urk5bj2PAZ0d7LXXc7c5XAlR/Wm0oJpR5PGlyJFTQ0DVxz/5K7zQ6jIBEmj\n9izHSQwoTEUWFmQSUWpcDAYOTP1q3QJmObndJftRRC8QnxDxfWVLFzY+JlyX\nIPLPkS1nKCC+PEM3SwMEQgSoE1TMyjwk9ISledWSDjCdND4DxFPNrBrz9UxS\n3k/lBmGq3XfWq227SgW2jVtFdwfLRVNASE2CXbzLxXfucZqwtcKPkx+4lq8W\n8wQo78p2hDh+dIQg1Nibm2PkJxiyIinxh41vFFIPKYHNFaFWdUVtLQb0dpuU\nIkYsyl50i+uI09Pp4i/c/IyHRiEIcz4A4ZNKUa3SXNjf12xbyz/m6QcvlAC2\nUTxaDxKYFBeOZdYvJUHs0CzcWZdq3qHWRCRYaeMjf2Mmlu16u/jCzLfQ2IIy\nFw1vUG+4+8UwR45OuD2fXHvUs9jDcmL1ODI8VlRPlIa2OZitnLikU5y9Qhrw\nxshwTccU9jK49YsDi40ddZ3ltA7bnct+gnj91zNbGbZ3wNVjYL+lW37hlDWr\nDbXFeqVmmHHfzs+1+q274NrmjN09cric1c7eJdtbj0wXyBKdVYP5A2w2hgEj\naBrS\r\n=BDox\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.3.0_1534383143468_0.3393609820350276"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.4.0": {
+      "name": "figgy-pudding",
+      "version": "3.4.0",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "526571ae8179d774fe7d142fe286daf427d616c7",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.4.0",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.6.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-HC2Jfmr7yxnvCKLwimbztpbC8pdIvKykk6iPOk1wq/nY7S9L12Trq2w0t6LPqpARBaFAoO0hkkFTjKlYjyMxcQ==",
+        "shasum": "683ad8c51b5d443d85c129e66cae9f2714926eea",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.4.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 13632,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbdOOHCRA9TVsSAnZWagAAczYP/2ngv4eri01XT5V5/aqM\nw55nC/TmH9Q227eYy1VE3Ikk+I2KY3aIJQSWUNHU6D+TFD42yPG0R1mYVBXW\nQ1MBQpAuSHbKbnevTodf5QTKe/q3KTdTitWOcGnaJ4YB9hGuyYThoV1BXLkC\n7F98Tn8uiQmjDb2YgQ+KCBIXVqmV/cMiZt7y9ICe0Tpx/Q9+27fjGPCa0P0y\nfTohcOcjixEf7Zm5yWf06PNPzJQO71DrOPMFhUw3om+zHH0V6OY6CPGrPAzO\nvut74OP9IDeWJxz+OdiBkLzX+XiGUlZ9K/Io9KOrj/7DgNuO9vfYmEQ0GY/O\nLIfZll29aRAMgKj1k00s/jHs1c4znYTX8EoKBIOkxSGt0XsfMvuep2ROr7in\nAES2sphsvRjwtiWGkw72QHLaLCbxzyaelB7r7E269UC7jKDVp8sfLUDu5s6R\nUISH5JY1KSGq1nkewd6B/dtM8isUCV6PAoaQ3rRFjNl65URus21z/nIcb/xd\nWCAOkun3rnwLKSHCrNgoxbzeRW198bk+eDMBAxLLLfDonaO5aB2B2QyGMA+Y\nnLNGIl4GkrSr9b7AubosB001A2i1PLgZsEB3gAA448iRegIrthG+xKT8kS7g\nmZwBZojhrzWjNv8GbsUnplAWZiKYmS/vlw3nvACw0QInzMdp8U0Jl3t+CVZg\nhuYB\r\n=DckI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.4.0_1534387078790_0.15201654260381847"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.4.1": {
+      "name": "figgy-pudding",
+      "version": "3.4.1",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --100 --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "c306571e40ee96022c93c06511a5dac0f0e1ab01",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.4.1",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.6.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-j1SAT641cerGuOvoSBoaE9LbSzh1N/E5ufk9oMpOKuyK8MyW3sGg4rh+4qhLmVTEAzipO5XTHYT4gjb6JYLE8g==",
+        "shasum": "af66da1991fa2f94ff7f33b545a38ea4b3869696",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.4.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 14597,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbddpMCRA9TVsSAnZWagAAr1EQAJcWddlhC6GIgzLyauRI\n56jat4zljMsWRE/ujgd44LVEhQTRrBzibMmSl//2TWdL2RFxUNw549WpWJYz\naFfSOp1oiCsnhZuluaGZt+FRCFSHz6mVHX7aBVmuKL1QDCLzB7PPgouhSVSu\nxHFR1C6/yKCwe9ktQRa7IoC3Xa/oh0EFmJJG/tcPPjMB73dYxZ0nzZYhJStj\nOck869ai1XRKcCLbAplyVY19nX7gzy71eiGNoXaA4BwiLHrxPoSIkFi+GZSz\nxF3Yj4Q9oAr0K7Y/II4Cz4aCD4T/GfEUfJmaCynh/Dmxcub1VrKsXZEOzYXI\nuMaAy/yCOAQzCtrmX2unHo/czQKQQmJQlOz4v6qFvOjLtOlglpGXoxq34Rqh\niQc6LUL3cMcooQQou9LifMZpB3MeGYA4+sfL2MlOc+NKkrpRhBHrLVOVp7vE\neI7JPnpZR8Zdkem7BD29Ie6g/w9K45eOXJyc8v/cGwrgepZKRMabxsajyvW4\nho3S7Ps4ksNEn5d5nTZjuRjTmSdMCndFltk1ma5TV6Q2qqRg8gF3sfsBRVQx\n133KCbSAEnhvpW9+HtotLv7opfatC5YdOgceiE6hI7GOL9sXtVavZLuLDB90\n2+4/7oC6Ccd4AdFHzTjKIvUBh5TFF15qIW2FgIXkd7fKjMDtW9/I8hjnK/s3\nLQfg\r\n=7Apo\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.4.1_1534450251778_0.2721734825118596"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.0": {
+      "name": "figgy-pudding",
+      "version": "3.5.0",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --100 --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "cbff4729987d1bce00d89f0c31d74718252dc8c8",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.5.0",
+      "_npmVersion": "6.4.1-next.0",
+      "_nodeVersion": "10.6.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-3ictE+JYpOWuDoTWQW99aw0xIR0MTKFQnJcsIeDvVt08aoaS/8w8jx6TmXz58r0tnrAwSbaHGa14dK1c1c528g==",
+        "shasum": "50f18167ffb8d6ff199463f2c25e8875753d79bb",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15042,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgM96CRA9TVsSAnZWagAATt4P/0abVn+MiF1gyLd9TdZI\nX8Y7Pje5M1xwct3Ar4RgIoJfmDccQLfIpzu21i/Zi7F5KZ5FJVfEaTwGHxTO\n+Wlg1Vfg3byjvZNcGA/iDPL4yseP/CoUYRFFfjeI0AqXez530gpVBImSxnGK\n6eF2/YCQhd4GLk4Aw+7AMWh6iey/BcUvOdxrU1xPCisgzGWQAtsq162X2XPo\nc5A30Qeu7h3IwzgNq6D5mzyj0MmVgf2bFwtOmH+XY1WdiUWthL4GLW/I5AQu\nCRPCLbTngiJNxUn8rfzZoNGEB4Gm+t01t63M9m65PflOV1dHZ0UJXVrCk2u2\nHIvVL+qdBn4iDo5JFhs0lujSxkdtOL4cvjtkb32hBiYXnomnHOaPZ6w/AWmn\nDvXKUyKuZTixQHTuaZFOsWENrmnDWIU04qhR6WTG2ZFWkUlB1sPVcUoNGRWZ\nZclAQR9qhsDINqHOf2lnUqqueOy6IlakoGTVO61ilRf2JAqKMMEE8wOxP8Nv\nPssFXhuL+/+fDcPBV/RnJg6GNl07evSuLWLbuFZQpfBXfSlcdP+F4PtR/jSK\nxER8u+JBXJVDilusLAlS9IR1tsGa8fhqgM8ga6nlww01s0lT4crao3BKFgoZ\nH2Xi3Oo9eVZSmnUnEIqOC9SxzeyIuvT0VmacNhAMB2F9FhshJZYwr+emGxyz\nY0+8\r\n=LIth\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.5.0_1535168377402_0.38911617295835943"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.1": {
+      "name": "figgy-pudding",
+      "version": "3.5.1",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --100 --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "gitHead": "7d68bd3b8bba8d6343aa56c33e95986573d17adf",
+      "bugs": {
+        "url": "https://github.com/zkat/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/zkat/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.5.1",
+      "_npmVersion": "6.4.1-next.0",
+      "_nodeVersion": "10.6.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+        "shasum": "862470112901c727a0e495a80744bd5baa1d6790",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18589,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgbNPCRA9TVsSAnZWagAAd6oQAKAGIrveXRiPm14qfabm\nnimhLk6KXlqLH9C9CyDHq8S+qbsUCK217D8H3jjlOlr+JrZnyfmV8/S0tR8L\ncP5ZsIxiPC3aFn8b7bviVoGraba+/pQ+ZHxrupTrXlaDlaYhIb+u1Nr/cj8c\nSNB7MV+nhu5qdzfecLDCWg4lyas80yUB6BI1S2so694WbFxDsZKQp9SXN7Le\nKGVSJdaz60hqYZF3KRDcR4DiV9yLIgO2dKXaijNYC2J0bvCguoiMD/8eKTBO\ni5UGw5lF7hR0ggMAWECKTgVY2EybePTmtWZ/nLQ/LjPFcPrfOHOnkn1oQp8V\nQJXao3MdQ4YFOezdSUR+Sj9F3ITo0CoztDyCE7p1EkE/s7yh3zKupt/HD7AM\nnFgqR+YnaGedjH8wQ2j12XPMgywv9dRYMyuMrPYp9y5KLgHZTjXbwVN2v8zN\n7V2UfBBta/MsG6p9pDCektV1yI1lpoCf/F5umdZIiwamWsN1S95MdNY/nALX\nXsDQxC9yva+GULLlcLuFRALvXXwP97iqHKYZ6c4thGHVqSh6Cu5wgatbXegr\n1n+09ZWKdmFdsqUfJYwym6/KFHXIJq1D6M39+Y67NZnQ/YQIotHdjPXr6jWJ\nWIHnxSBHvDpY7hl54oFUg6IJhtCnuJokBYyg3fUqnaexTxn0o389vQ1hppq6\nM+Xu\r\n=B/oi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kzm@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.5.1_1535226702466_0.7038187525511241"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.2": {
+      "name": "figgy-pudding",
+      "version": "3.5.2",
+      "description": "Delicious, festive, cascading config/opts definitions",
+      "main": "index.js",
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --100 --coverage test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/figgy-pudding.git"
+      },
+      "keywords": [
+        "config",
+        "options",
+        "yummy"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1"
+      },
+      "gitHead": "757175df2b06e89cdc1550deb86acaf45fac6b21",
+      "bugs": {
+        "url": "https://github.com/npm/figgy-pudding/issues"
+      },
+      "homepage": "https://github.com/npm/figgy-pudding#readme",
+      "_id": "figgy-pudding@3.5.2",
+      "_nodeVersion": "13.10.1",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+        "shasum": "b4eee8148abb01dcf1d1ac34367d59e12fa61d6e",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18434,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeejnFCRA9TVsSAnZWagAA9CgQAJ7iGyn+McTQAEKqjUtC\n2qJsGdCBZmz9MfYTx3VUxHBdSgBkNjcRhmKGzWcY+2KxI7CHS5gAuF9Y/oPJ\nxHHtRMiHeksc0LW0qhPcZiOAsdRml3IQJf02gKUyTR/uvRo6KelAvGuyg+k6\nfjwLI9zq6Hqal2RYILCvH59ysQj+lTvKS5SdNThkLt+tg4dNFzSkmOLn6Y6T\nbCzgf+wb9973BqwwF3floLWhkVPbmjair0+TdL5RnmMXQgNzMRNI7gOFC5fq\nlTSILFyVZzRJ31n+Nr0s12mvBcf8Ete4IUxcQjQcDDOzxMLJpM9v4ij7yZEp\nLcfSVkfQFZZYyQ1OWxAKtDMFK09NEdmYGSlQXq4rumxnrQZC5xsjkybi+Xv7\n+JACxR5YtdK2RVW34T7TbkxIDXaYSwvwMGmDzmJvG2Q1r7yRVcnx36OcZ8On\ntnklwrKPBzJH3WC/6c9BHWIvre8n/Li6+WlrxfRDQxsalcd9x6sMJ92r8vJs\n13gsHTPprS9RTeu/uRKV44N5eb+MyZTx+XHI9ar1hwWg41GqVYWnWyWquONA\nZqlv1cKC5MRIpc+bXNAq1cX7EPCgLBD12ez7uVV2YapO5zV9vAfDNFqccduT\nP4ynpTu1/uKS3KAq+k78uIbVIq1o4BvlbyjReGavQ7FfcoiPRQtbZwL8P6AE\n/jlo\r\n=UMNn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/figgy-pudding_3.5.2_1585068485271_0.8348682273445724"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Note: pending imminent deprecation\n\n**This module will be deprecated once npm v7 is released.  Please do not rely\non it more than absolutely necessary (ie, only if you are depending on\nit for use with npm v6 internal dependencies).**\n\n----\n\n# figgy-pudding [![npm version](https://img.shields.io/npm/v/figgy-pudding.svg)](https://npm.im/figgy-pudding) [![license](https://img.shields.io/npm/l/figgy-pudding.svg)](https://npm.im/figgy-pudding) [![Travis](https://img.shields.io/travis/npm/figgy-pudding.svg)](https://travis-ci.org/npm/figgy-pudding) [![Coverage Status](https://coveralls.io/repos/github/npm/figgy-pudding/badge.svg?branch=latest)](https://coveralls.io/github/npm/figgy-pudding?branch=latest)\n\n[`figgy-pudding`](https://github.com/npm/figgy-pudding) is a small JavaScript\nlibrary for managing and composing cascading options objects -- hiding what\nneeds to be hidden from each layer, without having to do a lot of manual munging\nand passing of options.\n\n### The God Object is Dead!\n### Now Bring Us Some Figgy Pudding!\n\n## Install\n\n`$ npm install figgy-pudding`\n\n## Table of Contents\n\n* [Example](#example)\n* [Features](#features)\n* [API](#api)\n  * [`figgyPudding(spec)`](#figgy-pudding)\n  * [`PuddingFactory(values)`](#pudding-factory)\n    * [`opts.get()`](#opts-get)\n    * [`opts.concat()`](#opts-concat)\n    * [`opts.toJSON()`](#opts-to-json)\n    * [`opts.forEach()`](#opts-for-each)\n    * [`opts[Symbol.iterator]()`](#opts-symbol-iterator)\n    * [`opts.entries()`](#opts-entries)\n    * [`opts.keys()`](#opts-keys)\n    * [`opts.value()`](#opts-values)\n\n### Example\n\n```javascript\n// print-package.js\nconst fetch = require('./fetch.js')\nconst puddin = require('figgy-pudding')\n\nconst PrintOpts = puddin({\n  json: { default: false }\n})\n\nasync function printPkg (name, opts) {\n  // Expected pattern is to call this in every interface function. If `opts` is\n  // not passed in, it will automatically create an (empty) object for it.\n  opts = PrintOpts(opts)\n  const uri = `https://registry.npmjs.com/${name}`\n  const res = await fetch(uri, opts.concat({\n    // Add or override any passed-in configs and pass them down.\n    log: customLogger\n  }))\n  // The following would throw an error, because it's not in PrintOpts:\n  // console.log(opts.log)\n  if (opts.json) {\n    return res.json()\n  } else {\n    return res.text()\n  }\n}\n\nconsole.log(await printPkg('figgy', {\n  // Pass in *all* configs at the toplevel, as a regular object.\n  json: true,\n  cache: './tmp-cache'\n}))\n```\n\n```javascript\n// fetch.js\nconst puddin = require('figgy-pudding')\n\nconst FetchOpts = puddin({\n  log: { default: require('npmlog') },\n  cache: {}\n})\n\nmodule.exports = async function (..., opts) {\n  opts = FetchOpts(opts)\n}\n```\n\n### Features\n\n* hide options from layer that didn't ask for it\n* shared multi-layer options\n* make sure `opts` argument is available\n* transparent key access like normal keys, through a Proxy. No need for`.get()`!\n* default values\n* key aliases\n* arbitrary key filter functions\n* key/value iteration\n* serialization\n* 100% test coverage using `tap --100`\n\n### API\n\n#### <a name=\"figgy-pudding\"></a> `> figgyPudding({ key: { default: val } | String }, [opts]) -> PuddingFactory`\n\nDefines an Options constructor that can be used to collect only the needed\noptions.\n\nAn optional `default` property for specs can be used to specify default values\nif nothing was passed in.\n\nIf the value for a spec is a string, it will be treated as an alias to that\nother key.\n\n##### Example\n\n```javascript\nconst MyAppOpts = figgyPudding({\n  lg: 'log',\n  log: {\n    default: () => require('npmlog')\n  },\n  cache: {}\n})\n```\n\n#### <a name=\"pudding-factory\"></a> `> PuddingFactory(...providers) -> FiggyPudding{}`\n\nInstantiates an options object defined by `figgyPudding()`, which uses\n`providers`, in order, to find requested properties.\n\nEach provider can be either a plain object, a `Map`-like object (that is, one\nwith a `.get()` method) or another figgyPudding `Opts` object.\n\nWhen nesting `Opts` objects, their properties will not become available to the\nnew object, but any further nested `Opts` that reference that property _will_ be\nable to read from their grandparent, as long as they define that key. Default\nvalues for nested `Opts` parents will be used, if found.\n\n##### Example\n\n```javascript\nconst ReqOpts = figgyPudding({\n  follow: {}\n})\n\nconst opts = ReqOpts({\n  follow: true,\n  log: require('npmlog')\n})\n\nopts.follow // => true\nopts.log // => Error: ReqOpts does not define `log`\n\nconst MoreOpts = figgyPudding({\n  log: {}\n})\nMoreOpts(opts).log // => npmlog object (passed in from original plain obj)\nMoreOpts(opts).follow // => Error: MoreOpts does not define `follow`\n```\n\n#### <a name=\"opts-get\"></a> `> opts.get(key) -> Value`\n\nGets a value from the options object.\n\n##### Example\n\n```js\nconst opts = MyOpts(config)\nopts.get('foo') // value of `foo`\nopts.foo // Proxy-based access through `.get()`\n```\n\n#### <a name=\"opts-concat\"></a> `> opts.concat(...moreProviders) -> FiggyPudding{}`\n\nCreates a new opts object of the same type as `opts` with additional providers.\nProviders further to the right shadow providers to the left, with properties in\nthe original `opts` being shadows by the new providers.\n\n##### Example\n\n```js\nconst opts = MyOpts({x: 1})\nopts.get('x') // 1\nopts.concat({x: 2}).get('x') // 2\nopts.get('x') // 1 (original opts object left intact)\n```\n\n#### <a name=\"opts-to-json\"></a> `> opts.toJSON() -> Value`\n\nConverts `opts` to a plain, JSON-stringifiable JavaScript value. Used internally\nby JavaScript to get `JSON.stringify()` working.\n\nOnly keys that are readable by the current pudding type will be serialized.\n\n##### Example\n\n```js\nconst opts = MyOpts({x: 1})\nopts.toJSON() // {x: 1}\nJSON.stringify(opts) // '{\"x\":1}'\n```\n\n#### <a name=\"opts-for-each\"></a> `> opts.forEach((value, key, opts) => {}, thisArg) -> undefined`\n\nIterates over the values of `opts`, limited to the keys readable by the current\npudding type. `thisArg` will be used to set the `this` argument when calling the\n`fn`.\n\n##### Example\n\n```js\nconst opts = MyOpts({x: 1, y: 2})\nopts.forEach((value, key) => console.log(key, '=', value))\n```\n\n#### <a name=\"opts-entries\"></a> `> opts.entries() -> Iterator<[[key, value], ...]>`\n\nReturns an iterator that iterates over the keys and values in `opts`, limited to\nthe keys readable by the current pudding type. Each iteration returns an array\nof `[key, value]`.\n\n##### Example\n\n```js\nconst opts = MyOpts({x: 1, y: 2})\n[...opts({x: 1, y: 2}).entries()] // [['x', 1], ['y', 2]]\n```\n\n#### <a name=\"opts-symbol-iterator\"></a> `> opts[Symbol.iterator]() -> Iterator<[[key, value], ...]>`\n\nReturns an iterator that iterates over the keys and values in `opts`, limited to\nthe keys readable by the current pudding type. Each iteration returns an array\nof `[key, value]`. Makes puddings work natively with JS iteration mechanisms.\n\n##### Example\n\n```js\nconst opts = MyOpts({x: 1, y: 2})\n[...opts({x: 1, y: 2})] // [['x', 1], ['y', 2]]\nfor (let [key, value] of opts({x: 1, y: 2})) {\n  console.log(key, '=', value)\n}\n```\n\n#### <a name=\"opts-keys\"></a> `> opts.keys() -> Iterator<[key, ...]>`\n\nReturns an iterator that iterates over the keys in `opts`, limited to the keys\nreadable by the current pudding type.\n\n##### Example\n\n```js\nconst opts = MyOpts({x: 1, y: 2})\n[...opts({x: 1, y: 2}).keys()] // ['x', 'y']\n```\n\n#### <a name=\"opts-values\"></a> `> opts.values() -> Iterator<[value, ...]>`\n\nReturns an iterator that iterates over the values in `opts`, limited to the keys\nreadable by the current pudding type.\n\n##### Example\n'\n```js\nconst opts = MyOpts({x: 1, y: 2})\n[...opts({x: 1, y: 2}).values()] // [1, 2]\n```\n",
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-19T13:50:01.046Z",
+    "created": "2017-02-07T02:27:13.915Z",
+    "0.0.1": "2017-02-07T02:27:13.915Z",
+    "1.0.0": "2017-02-07T21:57:10.872Z",
+    "2.0.0": "2018-03-16T05:24:55.508Z",
+    "2.0.1": "2018-03-16T05:48:26.275Z",
+    "3.0.0": "2018-04-06T21:57:08.888Z",
+    "3.1.0": "2018-04-08T23:42:02.688Z",
+    "3.2.0": "2018-07-26T21:58:41.911Z",
+    "3.2.1": "2018-08-15T01:32:02.956Z",
+    "3.3.0": "2018-08-16T01:32:23.593Z",
+    "3.4.0": "2018-08-16T02:37:59.067Z",
+    "3.4.1": "2018-08-16T20:10:51.860Z",
+    "3.5.0": "2018-08-25T03:39:37.470Z",
+    "3.5.1": "2018-08-25T19:51:42.627Z",
+    "3.5.2": "2020-03-24T16:48:05.394Z"
+  },
+  "homepage": "https://github.com/npm/figgy-pudding#readme",
+  "keywords": [
+    "config",
+    "options",
+    "yummy"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/figgy-pudding.git"
+  },
+  "author": {
+    "name": "Kat Marchán",
+    "email": "kzm@sykosomatic.org"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/figgy-pudding/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "charlotteis": true,
+    "evocateur": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/figgy-pudding.min.json
+++ b/test/fixtures/registry-mocks/content/figgy-pudding.min.json
@@ -1,0 +1,257 @@
+{
+  "name": "figgy-pudding",
+  "dist-tags": {
+    "latest": "3.5.2"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "figgy-pudding",
+      "version": "0.0.1",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "dist": {
+        "shasum": "5be4d211c872bb267225346381957c435b7c7c4c",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-0.0.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "figgy-pudding",
+      "version": "1.0.0",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^8.6.0",
+        "tap": "^10.0.2"
+      },
+      "dist": {
+        "shasum": "00ae832d49ee2373590f1a06416b194936afb627",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "figgy-pudding",
+      "version": "2.0.0",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-h67cT0L1BpsDITtxWfgsCAH5BBI3tk9VBnRdTYltSyUMWZF7lqBYgQfaLwRhd6AAIu8Aft0JsneId1dVwKBH6Q==",
+        "shasum": "0079daad9855d2a2585acc6f49d5e4e8b7bd291a",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7283
+      }
+    },
+    "2.0.1": {
+      "name": "figgy-pudding",
+      "version": "2.0.1",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-yIJPhIBi/oFdU/P+GSXjmk/rmGjuZkm7A5LTXZxNrEprXJXRK012FiI1BR1Pga+0d/d6taWWD+B5d2ozqaxHig==",
+        "shasum": "56c8fc878e06e1090799b9bcc91cbd85c2c92278",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-2.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7589
+      }
+    },
+    "3.0.0": {
+      "name": "figgy-pudding",
+      "version": "3.0.0",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-V5i5eQecLl6rfChOBqAVV9OleahLe6pCXOSG3hWAoYSkDyp28xjhsWh0xRPz1PHFARMP6rp9bOiLXipwF9iObA==",
+        "shasum": "b27194ad339c61b6f492bcc52852b5f107af9a16",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9288
+      }
+    },
+    "3.1.0": {
+      "name": "figgy-pudding",
+      "version": "3.1.0",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-Gi2vIue0ec6P/7LNpueGhLuvfF2ztuterl8YFBQn1yKgIS46noGxCbi+vviPdObNYtgUSh5FpHy5q0Cw9XhxKQ==",
+        "shasum": "a77ed2284175976c424b390b298569e9df86dd1e",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10188
+      }
+    },
+    "3.2.0": {
+      "name": "figgy-pudding",
+      "version": "3.2.0",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-S2gSvqcqkI4sk+dI3ykKllfEg88dL5cXM0QPT4z9UbOkNygqec8/99d0VB3ikZ7u1/QC5l4e1YJPWvoUFuRVkg==",
+        "shasum": "464626b73d7b0fc045a99753d191b0785957ff73",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10593,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbWkQRCRA9TVsSAnZWagAAkpkQAKAwhXoxByiLiPG4Eyzj\nbs0AXPb3cjBji48wuK6AYYMQ9mvOyH/bNtpBtoooY/H361HjhbIvwLNxWpoT\n0M4bqAAvV1e6a2lGgtCekODinGzL85h3/CsO2V7SdRVB3ywz4dTwxpi8UVds\nhKiJENp36IBAFaUT2Ozekz4lyjwYg4Rpf119lMPT62k9/r3bCP0QIUeRC2kk\n9PBzWgWYkcSZHJrVdcFWiOXVVOZ4tGNh/cBqyQyOF0OXbwrUlXLUi1zxPdM/\nu2tshokpz/eqhPV2wj/6j+ny2csZJVWaiKAy/7iaqAjaZd5fa8OTiH8vfLuw\n1ebi7+Gx+PtnNcZeVS3WtQOkp+D6Z1aPADct1H+WmOLap3bR08J8penAoP8u\n8qBe2RfLadrpzb4OfDntfe17WTv1H/WOp8ze8/B8A+lJq2Yvb2PiRxHy/SJr\noLuLBMQPTudxNofUwVsQQSMKUn83qMSRpLZ2JRUoGkDdh9P5ZNPIItfX1yS+\naxhIbffODboo3LlXm/7eOYwauVznC2vCpOa8X44R7nKAXiGSdOetmOJq8VaF\nSDi1q47T70RKjne5NI8dT33hyk83z0TFllW6zGc/VxPK2m3G+ya/tMX8luNx\nTIR+5VbXO/y/OJf9/naCYZ89khIdpHjJWfseY6l4jn3/c/gGqW7mezkxjPjn\nWIx+\r\n=Rzzu\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.2.1": {
+      "name": "figgy-pudding",
+      "version": "3.2.1",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-1kWvzhClfNh9NhhUaT9D9H7knbQ4kW+SOa7TRYHZshd0YsBWQpffjx9T++Psx5XpXJV6utRSP70sm2Ivb7If3w==",
+        "shasum": "946bdc2515abad5190027113778595462b668eb3",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.2.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 11588,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbc4KSCRA9TVsSAnZWagAAL3QP/iUY+zaOP8x8wTmeH2rV\ny8f8RupnpMYwVmVzhQlWjUq5QMvhuuvZSljZ9vRAtJxwTwJWjf05L7TTorYo\negEwByqzdSVB7/rNrteyc175fU7jRkM5Yb58OewDsH0zNVo/WjrV0el0INBf\nBKvE7ZlGTbS591EZsTLMfUxM6XEhry8NfKmE4dQ3zW0S/frRxhxo6XQBf3Su\nz6sG+e/tFEWxVgBKuA6dhObH83oYNnYYk8wVsHv+eK5WF+tpGtv0PBTGD/HY\nPt5NfTR01Q4IzobeWpTMZulxHfGSlUVR40FSUSoHJQA5uvEN/EAUkInLtJ30\nFMtu6fsQSGuJjmvK5xH8uvGgTId/bCp3kb+W04zc9eO5/uHpPb9IqeKZPnXP\n6cTVT64GyL0on4Y+IaTXWVDib8wRUdUbkabAlTgx+Qxxkr/KzX9tB5OYAP+D\nPl+Y7BzVvZVVDLF1YRhajLMLDntKq2mOA5HQXmJwWW1HBO+Lapu367bana2s\njWn9DShUamfuv36Luq2Zz6biERugR6IePqW58GESu+09gGGrSWRl86RQpMv7\naXEaTrok1tfUMqPjn2/wjevboPqM/KB9CJJBQ6ASZgkMucn4wv8f8e1hv9ie\nATfhdIr+oGTuuXdlMlnI7UwZp/RCyx8Lc07RZjR9bT30yKtKWJ7BrOB5FFBL\n4QyI\r\n=HRKN\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.3.0": {
+      "name": "figgy-pudding",
+      "version": "3.3.0",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-M+rtA1ExfVeoGM+BIXhyhamlc9tptJ0PI5tzy8EEzj4KM0r6uFdthIEU3zwWt3WmmIT/5bExGL4vr5xlqa1ehA==",
+        "shasum": "dd6df760ce955b785ebc7d28a1555ee7e2e40d21",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 12996,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbdNQoCRA9TVsSAnZWagAAYiMP/3YBWYxqVmjZ7dVKnQM5\n3c8RBE0dizd/RAG7wlc0F+WlT+9UgjKERXjU4N1Haa4rmWF53yoAsUcUof/B\n4urk5bj2PAZ0d7LXXc7c5XAlR/Wm0oJpR5PGlyJFTQ0DVxz/5K7zQ6jIBEmj\n9izHSQwoTEUWFmQSUWpcDAYOTP1q3QJmObndJftRRC8QnxDxfWVLFzY+JlyX\nIPLPkS1nKCC+PEM3SwMEQgSoE1TMyjwk9ISledWSDjCdND4DxFPNrBrz9UxS\n3k/lBmGq3XfWq227SgW2jVtFdwfLRVNASE2CXbzLxXfucZqwtcKPkx+4lq8W\n8wQo78p2hDh+dIQg1Nibm2PkJxiyIinxh41vFFIPKYHNFaFWdUVtLQb0dpuU\nIkYsyl50i+uI09Pp4i/c/IyHRiEIcz4A4ZNKUa3SXNjf12xbyz/m6QcvlAC2\nUTxaDxKYFBeOZdYvJUHs0CzcWZdq3qHWRCRYaeMjf2Mmlu16u/jCzLfQ2IIy\nFw1vUG+4+8UwR45OuD2fXHvUs9jDcmL1ODI8VlRPlIa2OZitnLikU5y9Qhrw\nxshwTccU9jK49YsDi40ddZ3ltA7bnct+gnj91zNbGbZ3wNVjYL+lW37hlDWr\nDbXFeqVmmHHfzs+1+q274NrmjN09cric1c7eJdtbj0wXyBKdVYP5A2w2hgEj\naBrS\r\n=BDox\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.4.0": {
+      "name": "figgy-pudding",
+      "version": "3.4.0",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-HC2Jfmr7yxnvCKLwimbztpbC8pdIvKykk6iPOk1wq/nY7S9L12Trq2w0t6LPqpARBaFAoO0hkkFTjKlYjyMxcQ==",
+        "shasum": "683ad8c51b5d443d85c129e66cae9f2714926eea",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.4.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 13632,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbdOOHCRA9TVsSAnZWagAAczYP/2ngv4eri01XT5V5/aqM\nw55nC/TmH9Q227eYy1VE3Ikk+I2KY3aIJQSWUNHU6D+TFD42yPG0R1mYVBXW\nQ1MBQpAuSHbKbnevTodf5QTKe/q3KTdTitWOcGnaJ4YB9hGuyYThoV1BXLkC\n7F98Tn8uiQmjDb2YgQ+KCBIXVqmV/cMiZt7y9ICe0Tpx/Q9+27fjGPCa0P0y\nfTohcOcjixEf7Zm5yWf06PNPzJQO71DrOPMFhUw3om+zHH0V6OY6CPGrPAzO\nvut74OP9IDeWJxz+OdiBkLzX+XiGUlZ9K/Io9KOrj/7DgNuO9vfYmEQ0GY/O\nLIfZll29aRAMgKj1k00s/jHs1c4znYTX8EoKBIOkxSGt0XsfMvuep2ROr7in\nAES2sphsvRjwtiWGkw72QHLaLCbxzyaelB7r7E269UC7jKDVp8sfLUDu5s6R\nUISH5JY1KSGq1nkewd6B/dtM8isUCV6PAoaQ3rRFjNl65URus21z/nIcb/xd\nWCAOkun3rnwLKSHCrNgoxbzeRW198bk+eDMBAxLLLfDonaO5aB2B2QyGMA+Y\nnLNGIl4GkrSr9b7AubosB001A2i1PLgZsEB3gAA448iRegIrthG+xKT8kS7g\nmZwBZojhrzWjNv8GbsUnplAWZiKYmS/vlw3nvACw0QInzMdp8U0Jl3t+CVZg\nhuYB\r\n=DckI\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.4.1": {
+      "name": "figgy-pudding",
+      "version": "3.4.1",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-j1SAT641cerGuOvoSBoaE9LbSzh1N/E5ufk9oMpOKuyK8MyW3sGg4rh+4qhLmVTEAzipO5XTHYT4gjb6JYLE8g==",
+        "shasum": "af66da1991fa2f94ff7f33b545a38ea4b3869696",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.4.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 14597,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbddpMCRA9TVsSAnZWagAAr1EQAJcWddlhC6GIgzLyauRI\n56jat4zljMsWRE/ujgd44LVEhQTRrBzibMmSl//2TWdL2RFxUNw549WpWJYz\naFfSOp1oiCsnhZuluaGZt+FRCFSHz6mVHX7aBVmuKL1QDCLzB7PPgouhSVSu\nxHFR1C6/yKCwe9ktQRa7IoC3Xa/oh0EFmJJG/tcPPjMB73dYxZ0nzZYhJStj\nOck869ai1XRKcCLbAplyVY19nX7gzy71eiGNoXaA4BwiLHrxPoSIkFi+GZSz\nxF3Yj4Q9oAr0K7Y/II4Cz4aCD4T/GfEUfJmaCynh/Dmxcub1VrKsXZEOzYXI\nuMaAy/yCOAQzCtrmX2unHo/czQKQQmJQlOz4v6qFvOjLtOlglpGXoxq34Rqh\niQc6LUL3cMcooQQou9LifMZpB3MeGYA4+sfL2MlOc+NKkrpRhBHrLVOVp7vE\neI7JPnpZR8Zdkem7BD29Ie6g/w9K45eOXJyc8v/cGwrgepZKRMabxsajyvW4\nho3S7Ps4ksNEn5d5nTZjuRjTmSdMCndFltk1ma5TV6Q2qqRg8gF3sfsBRVQx\n133KCbSAEnhvpW9+HtotLv7opfatC5YdOgceiE6hI7GOL9sXtVavZLuLDB90\n2+4/7oC6Ccd4AdFHzTjKIvUBh5TFF15qIW2FgIXkd7fKjMDtW9/I8hjnK/s3\nLQfg\r\n=7Apo\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.5.0": {
+      "name": "figgy-pudding",
+      "version": "3.5.0",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-3ictE+JYpOWuDoTWQW99aw0xIR0MTKFQnJcsIeDvVt08aoaS/8w8jx6TmXz58r0tnrAwSbaHGa14dK1c1c528g==",
+        "shasum": "50f18167ffb8d6ff199463f2c25e8875753d79bb",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15042,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgM96CRA9TVsSAnZWagAATt4P/0abVn+MiF1gyLd9TdZI\nX8Y7Pje5M1xwct3Ar4RgIoJfmDccQLfIpzu21i/Zi7F5KZ5FJVfEaTwGHxTO\n+Wlg1Vfg3byjvZNcGA/iDPL4yseP/CoUYRFFfjeI0AqXez530gpVBImSxnGK\n6eF2/YCQhd4GLk4Aw+7AMWh6iey/BcUvOdxrU1xPCisgzGWQAtsq162X2XPo\nc5A30Qeu7h3IwzgNq6D5mzyj0MmVgf2bFwtOmH+XY1WdiUWthL4GLW/I5AQu\nCRPCLbTngiJNxUn8rfzZoNGEB4Gm+t01t63M9m65PflOV1dHZ0UJXVrCk2u2\nHIvVL+qdBn4iDo5JFhs0lujSxkdtOL4cvjtkb32hBiYXnomnHOaPZ6w/AWmn\nDvXKUyKuZTixQHTuaZFOsWENrmnDWIU04qhR6WTG2ZFWkUlB1sPVcUoNGRWZ\nZclAQR9qhsDINqHOf2lnUqqueOy6IlakoGTVO61ilRf2JAqKMMEE8wOxP8Nv\nPssFXhuL+/+fDcPBV/RnJg6GNl07evSuLWLbuFZQpfBXfSlcdP+F4PtR/jSK\nxER8u+JBXJVDilusLAlS9IR1tsGa8fhqgM8ga6nlww01s0lT4crao3BKFgoZ\nH2Xi3Oo9eVZSmnUnEIqOC9SxzeyIuvT0VmacNhAMB2F9FhshJZYwr+emGxyz\nY0+8\r\n=LIth\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.5.1": {
+      "name": "figgy-pudding",
+      "version": "3.5.1",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
+        "shasum": "862470112901c727a0e495a80744bd5baa1d6790",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18589,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgbNPCRA9TVsSAnZWagAAd6oQAKAGIrveXRiPm14qfabm\nnimhLk6KXlqLH9C9CyDHq8S+qbsUCK217D8H3jjlOlr+JrZnyfmV8/S0tR8L\ncP5ZsIxiPC3aFn8b7bviVoGraba+/pQ+ZHxrupTrXlaDlaYhIb+u1Nr/cj8c\nSNB7MV+nhu5qdzfecLDCWg4lyas80yUB6BI1S2so694WbFxDsZKQp9SXN7Le\nKGVSJdaz60hqYZF3KRDcR4DiV9yLIgO2dKXaijNYC2J0bvCguoiMD/8eKTBO\ni5UGw5lF7hR0ggMAWECKTgVY2EybePTmtWZ/nLQ/LjPFcPrfOHOnkn1oQp8V\nQJXao3MdQ4YFOezdSUR+Sj9F3ITo0CoztDyCE7p1EkE/s7yh3zKupt/HD7AM\nnFgqR+YnaGedjH8wQ2j12XPMgywv9dRYMyuMrPYp9y5KLgHZTjXbwVN2v8zN\n7V2UfBBta/MsG6p9pDCektV1yI1lpoCf/F5umdZIiwamWsN1S95MdNY/nALX\nXsDQxC9yva+GULLlcLuFRALvXXwP97iqHKYZ6c4thGHVqSh6Cu5wgatbXegr\n1n+09ZWKdmFdsqUfJYwym6/KFHXIJq1D6M39+Y67NZnQ/YQIotHdjPXr6jWJ\nWIHnxSBHvDpY7hl54oFUg6IJhtCnuJokBYyg3fUqnaexTxn0o389vQ1hppq6\nM+Xu\r\n=B/oi\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.5.2": {
+      "name": "figgy-pudding",
+      "version": "3.5.2",
+      "devDependencies": {
+        "standard": "^11.0.1",
+        "standard-version": "^4.4.0",
+        "tap": "^12.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
+        "shasum": "b4eee8148abb01dcf1d1ac34367d59e12fa61d6e",
+        "tarball": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18434,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeejnFCRA9TVsSAnZWagAA9CgQAJ7iGyn+McTQAEKqjUtC\n2qJsGdCBZmz9MfYTx3VUxHBdSgBkNjcRhmKGzWcY+2KxI7CHS5gAuF9Y/oPJ\nxHHtRMiHeksc0LW0qhPcZiOAsdRml3IQJf02gKUyTR/uvRo6KelAvGuyg+k6\nfjwLI9zq6Hqal2RYILCvH59ysQj+lTvKS5SdNThkLt+tg4dNFzSkmOLn6Y6T\nbCzgf+wb9973BqwwF3floLWhkVPbmjair0+TdL5RnmMXQgNzMRNI7gOFC5fq\nlTSILFyVZzRJ31n+Nr0s12mvBcf8Ete4IUxcQjQcDDOzxMLJpM9v4ij7yZEp\nLcfSVkfQFZZYyQ1OWxAKtDMFK09NEdmYGSlQXq4rumxnrQZC5xsjkybi+Xv7\n+JACxR5YtdK2RVW34T7TbkxIDXaYSwvwMGmDzmJvG2Q1r7yRVcnx36OcZ8On\ntnklwrKPBzJH3WC/6c9BHWIvre8n/Li6+WlrxfRDQxsalcd9x6sMJ92r8vJs\n13gsHTPprS9RTeu/uRKV44N5eb+MyZTx+XHI9ar1hwWg41GqVYWnWyWquONA\nZqlv1cKC5MRIpc+bXNAq1cX7EPCgLBD12ez7uVV2YapO5zV9vAfDNFqccduT\nP4ynpTu1/uKS3KAq+k78uIbVIq1o4BvlbyjReGavQ7FfcoiPRQtbZwL8P6AE\n/jlo\r\n=UMNn\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:50:01.046Z"
+}

--- a/test/fixtures/registry-mocks/content/file-uri-to-path.json
+++ b/test/fixtures/registry-mocks/content/file-uri-to-path.json
@@ -1,0 +1,296 @@
+{
+  "_id": "file-uri-to-path",
+  "_rev": "5-e511c37d50d3af8c15e2884f826019bf",
+  "name": "file-uri-to-path",
+  "description": "Convert a file: URI to a file path",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "file-uri-to-path",
+      "version": "0.0.1",
+      "description": "Convert a file: URI to a file path",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/file-uri-to-path.git"
+      },
+      "keywords": [
+        "file",
+        "uri",
+        "convert",
+        "path"
+      ],
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://n8.io/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/file-uri-to-path/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/file-uri-to-path",
+      "devDependencies": {
+        "mocha": "~1.17.1"
+      },
+      "_id": "file-uri-to-path@0.0.1",
+      "dist": {
+        "shasum": "e443f3ace914db5a8053363f8efd14d8aac79ae9",
+        "tarball": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "maintainers": [
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ]
+    },
+    "0.0.2": {
+      "name": "file-uri-to-path",
+      "version": "0.0.2",
+      "description": "Convert a file: URI to a file path",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/file-uri-to-path.git"
+      },
+      "keywords": [
+        "file",
+        "uri",
+        "convert",
+        "path"
+      ],
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://n8.io/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/file-uri-to-path/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/file-uri-to-path",
+      "devDependencies": {
+        "mocha": "~1.17.1"
+      },
+      "_id": "file-uri-to-path@0.0.2",
+      "dist": {
+        "shasum": "37cdd1b5b905404b3f05e1b23645be694ff70f82",
+        "tarball": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "maintainers": [
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ]
+    },
+    "1.0.0": {
+      "name": "file-uri-to-path",
+      "version": "1.0.0",
+      "description": "Convert a file: URI to a file path",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/file-uri-to-path.git"
+      },
+      "keywords": [
+        "file",
+        "uri",
+        "convert",
+        "path"
+      ],
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://n8.io/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/file-uri-to-path/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/file-uri-to-path",
+      "devDependencies": {
+        "mocha": "3"
+      },
+      "gitHead": "db012b4db2c9da9f6eeb5202b4a493450482e0e4",
+      "_id": "file-uri-to-path@1.0.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.1.2",
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "dist": {
+        "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+        "shasum": "553a7b8446ff6f684359c445f1e37a05dacc33dd",
+        "tarball": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/file-uri-to-path-1.0.0.tgz_1499377910342_0.7947268672287464"
+      }
+    },
+    "2.0.0": {
+      "name": "file-uri-to-path",
+      "version": "2.0.0",
+      "description": "Convert a file: URI to a file path",
+      "main": "dist/src/index",
+      "typings": "dist/src/index",
+      "scripts": {
+        "prebuild": "rimraf dist",
+        "build": "tsc",
+        "postbuild": "cpy --parents src test '!**/*.ts' dist",
+        "test": "mocha --reporter spec dist/test/*.js",
+        "test-lint": "eslint src --ext .js,.ts",
+        "prepublishOnly": "npm run build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/TooTallNate/file-uri-to-path.git"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "keywords": [
+        "file",
+        "uri",
+        "convert",
+        "path"
+      ],
+      "author": {
+        "name": "Nathan Rajlich",
+        "email": "nathan@tootallnate.net",
+        "url": "http://n8.io/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/TooTallNate/file-uri-to-path/issues"
+      },
+      "homepage": "https://github.com/TooTallNate/file-uri-to-path",
+      "devDependencies": {
+        "@types/mocha": "^5.2.7",
+        "@types/node": "^10.5.3",
+        "@typescript-eslint/eslint-plugin": "1.6.0",
+        "@typescript-eslint/parser": "1.1.0",
+        "cpy-cli": "^2.0.0",
+        "eslint": "5.16.0",
+        "eslint-config-airbnb": "17.1.0",
+        "eslint-config-prettier": "4.1.0",
+        "eslint-import-resolver-typescript": "1.1.1",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-jsx-a11y": "6.2.1",
+        "eslint-plugin-react": "7.12.4",
+        "mocha": "^6.2.0",
+        "rimraf": "^3.0.0",
+        "typescript": "^3.5.3"
+      },
+      "gitHead": "701a2d8e6927a74b40f605e7f6071ec57cd978f0",
+      "_id": "file-uri-to-path@2.0.0",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
+        "shasum": "7b415aeba227d575851e0a5b0c640d7656403fba",
+        "tarball": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 7880,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdoORhCRA9TVsSAnZWagAAntwQAJZa/7FN144+7M/sKt5m\nBCh2ZDR0HyEuROh+jAjCoXCWI5HY5CZXW0ThM6P8XYv5Y+NsXDjqY9W46S2m\nMPmAJktmvfh2xLaSUV8ww9E8doqcVhBytFzaL9qwckbDQXgaFwmDU6/Byeo9\nrzGI1/z4Co00G2a9ZTR8Jv/15xc2K5Bd+ymnqjCPu6Lru71hi5FPr4kNNa/F\nTnE1PB5uEkakv5xDGjgSTg3I8BFVbXrbCaT5V5RlvIexl5sXQzJ7P+YuCALA\nRF4ocMouqfm8fUbqZ9XmmdXCrVq05i/IRrOP7o5kNq915e0ghbctUwr0KY2w\nPxKpSjiYnNO6f9SrhuP9bKQ5D2nAntzkzsMFZdJj9jMtgzzHCeflpxvBDrlc\n+DgH4ELUpEt5f9E8Pse+oDye2oymtuU/sPBok6CEcsuiTFjSRV8Cjh1GSPis\nV8aWWhhkRlpcg+kIft8ugl2RCIUwuj1bGkZpzNFM6fC3WtAJy7md8kPMNPS+\nb8xyngudxYjU/HPujuVi0Sb90f9yxNpw5tep6tBzC4FKMtmafwII77lI9Md/\nMIfSZkPNAaOpyrrYxcWr2+fjd2LsPw5PP/N2Kiw+t622w/oLdfj7A/y2oOpP\nxlxS64Fq9nIXdSDzNowxSWC/wniA9poNZI4AjrUAkurQ9PV4pFF/woTlGcIg\nH6WX\r\n=JNiM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        }
+      ],
+      "_npmUser": {
+        "name": "tootallnate",
+        "email": "nathan@tootallnate.net"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/file-uri-to-path_2.0.0_1570825313193_0.4774934534232189"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "file-uri-to-path\n================\n### Convert a `file:` URI to a file path\n[![Build Status](https://github.com/TooTallNate/file-uri-to-path/workflows/Node%20CI/badge.svg)](https://github.com/TooTallNate/file-uri-to-path/actions?workflow=Node+CI)\n\nAccepts a `file:` URI and returns a regular file path suitable for use with the\n`fs` module functions.\n\n\nInstallation\n------------\n\nInstall with `npm`:\n\n``` bash\n$ npm install file-uri-to-path\n```\n\n\nExample\n-------\n\n``` js\nvar uri2path = require('file-uri-to-path');\n\nuri2path('file://localhost/c|/WINDOWS/clock.avi');\n// \"c:\\\\WINDOWS\\\\clock.avi\"\n\nuri2path('file:///c|/WINDOWS/clock.avi');\n// \"c:\\\\WINDOWS\\\\clock.avi\"\n\nuri2path('file://localhost/c:/WINDOWS/clock.avi');\n// \"c:\\\\WINDOWS\\\\clock.avi\"\n\nuri2path('file://hostname/path/to/the%20file.txt');\n// \"\\\\\\\\hostname\\\\path\\\\to\\\\the file.txt\"\n\nuri2path('file:///c:/path/to/the%20file.txt');\n// \"c:\\\\path\\\\to\\\\the file.txt\"\n```\n\n\nAPI\n---\n\n### fileUriToPath(String uri) → String\n\n\n\nLicense\n-------\n\n(The MIT License)\n\nCopyright (c) 2014 Nathan Rajlich &lt;nathan@tootallnate.net&gt;\n\nPermission is hereby granted, free of charge, to any person obtaining\na copy of this software and associated documentation files (the\n'Software'), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to\npermit persons to whom the Software is furnished to do so, subject to\nthe following conditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.\nIN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY\nCLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,\nTORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE\nSOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "tootallnate",
+      "email": "nathan@tootallnate.net"
+    }
+  ],
+  "time": {
+    "modified": "2019-10-11T20:21:55.798Z",
+    "created": "2014-01-27T08:05:51.258Z",
+    "0.0.1": "2014-01-27T08:05:51.258Z",
+    "0.0.2": "2014-01-27T08:13:31.848Z",
+    "1.0.0": "2017-07-06T21:51:51.414Z",
+    "2.0.0": "2019-10-11T20:21:53.304Z"
+  },
+  "readmeFilename": "README.md",
+  "users": {
+    "vonthar": true
+  },
+  "homepage": "https://github.com/TooTallNate/file-uri-to-path",
+  "keywords": [
+    "file",
+    "uri",
+    "convert",
+    "path"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/TooTallNate/file-uri-to-path.git"
+  },
+  "author": {
+    "name": "Nathan Rajlich",
+    "email": "nathan@tootallnate.net",
+    "url": "http://n8.io/"
+  },
+  "bugs": {
+    "url": "https://github.com/TooTallNate/file-uri-to-path/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/file-uri-to-path.min.json
+++ b/test/fixtures/registry-mocks/content/file-uri-to-path.min.json
@@ -1,0 +1,84 @@
+{
+  "name": "file-uri-to-path",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "file-uri-to-path",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "~1.17.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "e443f3ace914db5a8053363f8efd14d8aac79ae9",
+        "tarball": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "file-uri-to-path",
+      "version": "0.0.2",
+      "devDependencies": {
+        "mocha": "~1.17.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "37cdd1b5b905404b3f05e1b23645be694ff70f82",
+        "tarball": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-0.0.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "file-uri-to-path",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "3"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+        "shasum": "553a7b8446ff6f684359c445f1e37a05dacc33dd",
+        "tarball": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "file-uri-to-path",
+      "version": "2.0.0",
+      "devDependencies": {
+        "@types/mocha": "^5.2.7",
+        "@types/node": "^10.5.3",
+        "@typescript-eslint/eslint-plugin": "1.6.0",
+        "@typescript-eslint/parser": "1.1.0",
+        "cpy-cli": "^2.0.0",
+        "eslint": "5.16.0",
+        "eslint-config-airbnb": "17.1.0",
+        "eslint-config-prettier": "4.1.0",
+        "eslint-import-resolver-typescript": "1.1.1",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-jsx-a11y": "6.2.1",
+        "eslint-plugin-react": "7.12.4",
+        "mocha": "^6.2.0",
+        "rimraf": "^3.0.0",
+        "typescript": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-hjPFI8oE/2iQPVe4gbrJ73Pp+Xfub2+WI2LlXDbsaJBwT5wuMh35WNWVYYTpnz895shtwfyutMFLFywpQAFdLg==",
+        "shasum": "7b415aeba227d575851e0a5b0c640d7656403fba",
+        "tarball": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 7880,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdoORhCRA9TVsSAnZWagAAntwQAJZa/7FN144+7M/sKt5m\nBCh2ZDR0HyEuROh+jAjCoXCWI5HY5CZXW0ThM6P8XYv5Y+NsXDjqY9W46S2m\nMPmAJktmvfh2xLaSUV8ww9E8doqcVhBytFzaL9qwckbDQXgaFwmDU6/Byeo9\nrzGI1/z4Co00G2a9ZTR8Jv/15xc2K5Bd+ymnqjCPu6Lru71hi5FPr4kNNa/F\nTnE1PB5uEkakv5xDGjgSTg3I8BFVbXrbCaT5V5RlvIexl5sXQzJ7P+YuCALA\nRF4ocMouqfm8fUbqZ9XmmdXCrVq05i/IRrOP7o5kNq915e0ghbctUwr0KY2w\nPxKpSjiYnNO6f9SrhuP9bKQ5D2nAntzkzsMFZdJj9jMtgzzHCeflpxvBDrlc\n+DgH4ELUpEt5f9E8Pse+oDye2oymtuU/sPBok6CEcsuiTFjSRV8Cjh1GSPis\nV8aWWhhkRlpcg+kIft8ugl2RCIUwuj1bGkZpzNFM6fC3WtAJy7md8kPMNPS+\nb8xyngudxYjU/HPujuVi0Sb90f9yxNpw5tep6tBzC4FKMtmafwII77lI9Md/\nMIfSZkPNAaOpyrrYxcWr2+fjd2LsPw5PP/N2Kiw+t622w/oLdfj7A/y2oOpP\nxlxS64Fq9nIXdSDzNowxSWC/wniA9poNZI4AjrUAkurQ9PV4pFF/woTlGcIg\nH6WX\r\n=JNiM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    }
+  },
+  "modified": "2019-10-11T20:21:55.798Z"
+}

--- a/test/fixtures/registry-mocks/content/finalhandler.json
+++ b/test/fixtures/registry-mocks/content/finalhandler.json
@@ -1,0 +1,2145 @@
+{
+  "_id": "finalhandler",
+  "_rev": "75-17e9f920f258539d4444781ccdada312",
+  "name": "finalhandler",
+  "description": "Node.js final http responder",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "1.0.0",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/expressjs/finalhandler",
+      "_id": "finalhandler@0.0.0",
+      "_shasum": "1dcd03de37b283d0593b47a327535c9490d5b246",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1dcd03de37b283d0593b47a327535c9490d5b246",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/expressjs/finalhandler",
+      "_id": "finalhandler@0.0.1",
+      "dist": {
+        "shasum": "624429d98b41ab1538b21b97086a74f23b07fcd6",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/expressjs/finalhandler",
+      "_id": "finalhandler@0.0.2",
+      "dist": {
+        "shasum": "0603d875ee87d567a266692815cc8ad44fcceeda",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.0.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "1.0.3",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/expressjs/finalhandler",
+      "_id": "finalhandler@0.0.3",
+      "dist": {
+        "shasum": "5a86b7bc4dca3d1275eb0532c81ee81d747504df",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "1.0.4",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.27",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/expressjs/finalhandler",
+      "_id": "finalhandler@0.1.0",
+      "dist": {
+        "shasum": "da05bbc4f5f4a30c84ce1d91f3c154007c4e9daa",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.2.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.0.0",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "readable-stream": "~1.0.27",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0e5d26695b1ab248823366018f09c058a4eaf59b",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.2.0",
+      "_shasum": "794082424b17f6a4b2a0eda39f9db6948ee4be8d",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "794082424b17f6a4b2a0eda39f9db6948ee4be8d",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.3.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.0.0",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "readable-stream": "~1.0.27",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "8cc4b0afde5ab1fdb1f42bcdf80fd1d9dd4e1528",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.3.0",
+      "_shasum": "581afe4d28da13491487f1c0ef9c29ef883e6e59",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "581afe4d28da13491487f1c0ef9c29ef883e6e59",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.3.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.1.0",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "readable-stream": "~1.0.33",
+        "should": "~4.0.1",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d7ad6d8d66316d88774171f606b78f386eadce85",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.3.1",
+      "_shasum": "ffda7643228678c6b088c89421a8381663961808",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ffda7643228678c6b088c89421a8381663961808",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.3.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.1.0",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "readable-stream": "~1.0.33",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "1dc292faf576fade3b0218caab39060f4da5fe9c",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.3.2",
+      "_shasum": "7b389b0fd3647a6f90bd564e22624bf8a4a77fb5",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7b389b0fd3647a6f90bd564e22624bf8a4a77fb5",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.3": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.3.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.1.1",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "readable-stream": "~1.0.33",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "dfce5042f996ba93ac85b9282e6d1cae1561acc6",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.3.3",
+      "_shasum": "b1a09aa1e6a607b3541669b09bcb727f460cd426",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b1a09aa1e6a607b3541669b09bcb727f460cd426",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.4": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.3.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.1.3",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.8",
+        "mocha": "~2.2.1",
+        "readable-stream": "~1.0.33",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "63e18603c11effcacc06676f6fefbf270795459a",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.3.4",
+      "_shasum": "4787d3573d079ae8b07536f26b0b911ebaf2a2ac",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4787d3573d079ae8b07536f26b0b911ebaf2a2ac",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.5": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.3.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.1.3",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "618ff86e01ca5b8eb2f204ba1f322f65896c1455",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.3.5",
+      "_shasum": "0d1bf5dfcb5f77d073a402aabe5f7a8a90413721",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0d1bf5dfcb5f77d073a402aabe5f7a8a90413721",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.6": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.3.6",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "10c8b938d00acdd5a2bdc6fbd912fb24ffd9f328",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.3.6",
+      "_shasum": "daf9c4161b1b06e001466b1411dfdb6973be138b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "daf9c4161b1b06e001466b1411dfdb6973be138b",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.4.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "1.0.2",
+        "on-finished": "~2.3.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.15",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.0",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "fe4e4de9ebb0f3831493ad75119ee6ba40542853",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.4.0",
+      "_shasum": "965a52d9e8d05d2b857548541fb89b53a2497d9b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "965a52d9e8d05d2b857548541fb89b53a2497d9b",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.4.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "mocha": "2.3.4",
+        "readable-stream": "2.0.4",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ac2036774059eb93dbac8475580e52433204d4d4",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.4.1",
+      "_shasum": "85a17c6c59a94717d262d61230d4b0ebe3d4a14d",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "85a17c6c59a94717d262d61230d4b0ebe3d4a14d",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.5.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "statuses": "~1.3.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "2.12.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "15cc543eb87dd0e2f29e931d86816a6eb348c573",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.5.0",
+      "_shasum": "e9508abece9b6dba871a6942a1d7911b91911ac7",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e9508abece9b6dba871a6942a1d7911b91911ac7",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/finalhandler-0.5.0.tgz_1466028655505_0.19758180482313037"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "0.5.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/finalhandler"
+      },
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.10.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "ae6137a81049eecb2d57341b1a9c4efed46a25da",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler",
+      "_id": "finalhandler@0.5.1",
+      "_shasum": "2c400d8d4530935bc232549c5fa385ec07de6fcd",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2c400d8d4530935bc232549c5fa385ec07de6fcd",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/finalhandler-0.5.1.tgz_1479018213560_0.8304649770725518"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "6e024b1139202f69a537884ea755a0bf1bb72d69",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.0.0",
+      "_shasum": "b5691c2c0912092f18ac23e9416bde5cd7dc6755",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "b5691c2c0912092f18ac23e9416bde5cd7dc6755",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/finalhandler-1.0.0.tgz_1487228805174_0.0024696807377040386"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.3",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.18.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "7643136085e8c178902a93d6ef43ad42cd3936f1",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.0.1",
+      "_shasum": "bcd15d1689c0e5ed729b6f7f541a6df984117db8",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "bcd15d1689c0e5ed729b6f7f541a6df984117db8",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/finalhandler-1.0.1.tgz_1490162581058_0.40150946634821594"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.2.9",
+        "safe-buffer": "5.0.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "fdc51081ce2747d28855f4d6ac9d418379f509ed",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.0.2",
+      "_shasum": "d0e36f9dbc557f2de14423df6261889e9d60c93a",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d0e36f9dbc557f2de14423df6261889e9d60c93a",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/finalhandler-1.0.2.tgz_1492903233024_0.34017785592004657"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.0.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.7",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.2.9",
+        "safe-buffer": "5.0.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "0425ae63bf44a661354baf6b37eebb01909cd78d",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.0.3",
+      "_shasum": "ef47e77950e999780e86022a560e3217e0d0cc89",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "ef47e77950e999780e86022a560e3217e0d0cc89",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/finalhandler-1.0.3.tgz_1494997503461_0.08480599173344672"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.0.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.8",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "85049f83c5eca2ce6f41700ab3ea7b1bfc64e18f",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.0.4",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+        "shasum": "18574f2e7c4b98b8ae3b230c21f201f31bdb3fb7",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/finalhandler-1.0.4.tgz_1501819287831_0.5680490005761385"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.0.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.8",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "56992d0cb79e0c6575e7ec02bffa244d999d1fd3",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.0.5",
+      "_shasum": "a701303d257a1bc82fea547a33e5ae89531723df",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "a701303d257a1bc82fea547a33e5ae89531723df",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/finalhandler-1.0.5.tgz_1505531025359_0.3480313152540475"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.0.6",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "ed4c24d4d7f78b3136ca7d0e7215541cb921a980",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.0.6",
+      "_shasum": "007aea33d1a4d3e42017f624848ad58d212f814f",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "007aea33d1a4d3e42017f624848ad58d212f814f",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/finalhandler-1.0.6.tgz_1506104827410_0.847819667076692"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "a49efb83a3363d895f8c2a4cad07ccfc9e90b8ef",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.1.0",
+      "_shasum": "ce0b6855b45853e791b2fcc680046d88253dd7f5",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "ce0b6855b45853e791b2fcc680046d88253dd7f5",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/finalhandler-1.1.0.tgz_1506311584388_0.4006447312422097"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.1.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "4.18.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.9.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.4",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "024f493418f62a59592a98f07b23b265092c1006",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.1.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "6.13.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+        "shasum": "eebf4ed840079c83f4249038c9d703008301b105",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16905
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/finalhandler_1.1.1_1520357803698_0.8904166922156158"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.2": {
+      "name": "finalhandler",
+      "description": "Node.js final http responder",
+      "version": "1.1.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/finalhandler.git"
+      },
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "supertest": "4.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "15e78cab32ecbd4993d1575a065963b238336df9",
+      "bugs": {
+        "url": "https://github.com/pillarjs/finalhandler/issues"
+      },
+      "homepage": "https://github.com/pillarjs/finalhandler#readme",
+      "_id": "finalhandler@1.1.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+        "shasum": "b7e7d000ffd11938d0fdb053506f6ebabe9f587d",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17043,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1NxFCRA9TVsSAnZWagAA5lsP/ikRb6COPldBamNBvpJ9\nRhs/yK6Xs0xWScOozeN+eYycCG1ybDJaCZ7Pw1dkjpfSVB6gIuV+o1DxycnA\n3Fp+IPyJ4W3hHgWUL+1KuA5ajYbrH22ezf+DnmU3G04Xj3qpEZeeYI3hQ0IQ\nBXWjiCwmn2CEB8HYyAuvgEgsH8crqkzRlaLMb4I57TAKk0JKwZd+4r4t2WlM\n8sI83C7in0rOWkjUpJWBuR7hwSGqygKf8i0cIrOdA3ilf8EjmjELrA5mIga/\norpYoarZRenzzyyRRfG3H3Sryblavh6lajTwqwh+CxmeQJLv+gJTERLvrUc2\n2Rjmj2Iu3Z2h+D6f9qWdsPRXqE91KU0X0fDtBNjibOMncX8GtpG332SmN0Fd\nXs1E/Fcu2GlOgoJfD5mKA2OJ3GN9YlFfc7uvXuaB491/i9J/Zde548Tdn3im\ncxN8ULRL3GLHHbxONXX9Q49mdQxmHsJDPe6xN7RQwxirLZKlZEXJjl82x1kJ\nJQ0wHcxsuZiJmUTje64W5ETFBI1qN/rJiFN8HQTEkUeXpnI/Kl4ktzefhwPF\njlgPQ8BLiCeHAM4cCweDGUTUVelo6RQaN/ljpPivvd1l8DU+1R4guvjjDWcr\nb2eE7W0pup5R/PAJe61LTA38pRuurq4kR0lLfPWvOQvhPuSZ8WbDP0JNBf/U\noAB7\r\n=2zSq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/finalhandler_1.1.2_1557453893383_0.5703759185655743"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# finalhandler\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-image]][node-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nNode.js function to invoke as the final step to respond to HTTP request.\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install finalhandler\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar finalhandler = require('finalhandler')\n```\n\n### finalhandler(req, res, [options])\n\nReturns function to be invoked as the final step for the given `req` and `res`.\nThis function is to be invoked as `fn(err)`. If `err` is falsy, the handler will\nwrite out a 404 response to the `res`. If it is truthy, an error response will\nbe written out to the `res`.\n\nWhen an error is written, the following information is added to the response:\n\n  * The `res.statusCode` is set from `err.status` (or `err.statusCode`). If\n    this value is outside the 4xx or 5xx range, it will be set to 500.\n  * The `res.statusMessage` is set according to the status code.\n  * The body will be the HTML of the status code message if `env` is\n    `'production'`, otherwise will be `err.stack`.\n  * Any headers specified in an `err.headers` object.\n\nThe final handler will also unpipe anything from `req` when it is invoked.\n\n#### options.env\n\nBy default, the environment is determined by `NODE_ENV` variable, but it can be\noverridden by this option.\n\n#### options.onerror\n\nProvide a function to be called with the `err` when it exists. Can be used for\nwriting errors to a central location without excessive function generation. Called\nas `onerror(err, req, res)`.\n\n## Examples\n\n### always 404\n\n```js\nvar finalhandler = require('finalhandler')\nvar http = require('http')\n\nvar server = http.createServer(function (req, res) {\n  var done = finalhandler(req, res)\n  done()\n})\n\nserver.listen(3000)\n```\n\n### perform simple action\n\n```js\nvar finalhandler = require('finalhandler')\nvar fs = require('fs')\nvar http = require('http')\n\nvar server = http.createServer(function (req, res) {\n  var done = finalhandler(req, res)\n\n  fs.readFile('index.html', function (err, buf) {\n    if (err) return done(err)\n    res.setHeader('Content-Type', 'text/html')\n    res.end(buf)\n  })\n})\n\nserver.listen(3000)\n```\n\n### use with middleware-style functions\n\n```js\nvar finalhandler = require('finalhandler')\nvar http = require('http')\nvar serveStatic = require('serve-static')\n\nvar serve = serveStatic('public')\n\nvar server = http.createServer(function (req, res) {\n  var done = finalhandler(req, res)\n  serve(req, res, done)\n})\n\nserver.listen(3000)\n```\n\n### keep log of all errors\n\n```js\nvar finalhandler = require('finalhandler')\nvar fs = require('fs')\nvar http = require('http')\n\nvar server = http.createServer(function (req, res) {\n  var done = finalhandler(req, res, { onerror: logerror })\n\n  fs.readFile('index.html', function (err, buf) {\n    if (err) return done(err)\n    res.setHeader('Content-Type', 'text/html')\n    res.end(buf)\n  })\n})\n\nserver.listen(3000)\n\nfunction logerror (err) {\n  console.error(err.stack || err.toString())\n}\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/finalhandler.svg\n[npm-url]: https://npmjs.org/package/finalhandler\n[node-image]: https://img.shields.io/node/v/finalhandler.svg\n[node-url]: https://nodejs.org/en/download\n[travis-image]: https://img.shields.io/travis/pillarjs/finalhandler.svg\n[travis-url]: https://travis-ci.org/pillarjs/finalhandler\n[coveralls-image]: https://img.shields.io/coveralls/pillarjs/finalhandler.svg\n[coveralls-url]: https://coveralls.io/r/pillarjs/finalhandler?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/finalhandler.svg\n[downloads-url]: https://npmjs.org/package/finalhandler\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-05-10T02:04:55.863Z",
+    "created": "2014-06-06T02:46:23.972Z",
+    "0.0.0": "2014-06-06T02:46:23.972Z",
+    "0.0.1": "2014-06-17T03:16:02.504Z",
+    "0.0.2": "2014-06-19T22:45:27.016Z",
+    "0.0.3": "2014-07-12T02:55:27.900Z",
+    "0.1.0": "2014-07-17T00:46:33.245Z",
+    "0.2.0": "2014-09-04T02:47:49.096Z",
+    "0.3.0": "2014-09-18T08:05:47.995Z",
+    "0.3.1": "2014-10-17T03:04:23.148Z",
+    "0.3.2": "2014-10-23T03:43:37.882Z",
+    "0.3.3": "2015-01-02T03:41:17.238Z",
+    "0.3.4": "2015-03-16T01:50:44.350Z",
+    "0.3.5": "2015-04-23T02:25:52.619Z",
+    "0.3.6": "2015-05-12T03:53:24.990Z",
+    "0.4.0": "2015-06-14T21:15:57.149Z",
+    "0.4.1": "2015-12-02T18:07:45.449Z",
+    "0.5.0": "2016-06-15T22:10:57.784Z",
+    "0.5.1": "2016-11-13T06:23:35.753Z",
+    "1.0.0": "2017-02-16T07:06:45.834Z",
+    "1.0.1": "2017-03-22T06:03:01.761Z",
+    "1.0.2": "2017-04-22T23:20:33.617Z",
+    "1.0.3": "2017-05-17T05:05:05.352Z",
+    "1.0.4": "2017-08-04T04:01:28.872Z",
+    "1.0.5": "2017-09-16T03:03:46.811Z",
+    "1.0.6": "2017-09-22T18:27:08.637Z",
+    "1.1.0": "2017-09-25T03:53:05.677Z",
+    "1.1.1": "2018-03-06T17:36:44.075Z",
+    "1.1.2": "2019-05-10T02:04:53.493Z"
+  },
+  "homepage": "https://github.com/pillarjs/finalhandler#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pillarjs/finalhandler.git"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/pillarjs/finalhandler/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "akiva": true,
+    "simplyianm": true,
+    "qqqppp9998": true,
+    "nex": true,
+    "princetoad": true,
+    "wangnan0610": true,
+    "kistoryg": true,
+    "monjer": true,
+    "mojaray2k": true,
+    "jetthiago": true,
+    "ziflex": true,
+    "tampham47": true,
+    "leonzhao": true,
+    "quafoo": true,
+    "ridermansb": true,
+    "chaoliu": true,
+    "larrychen": true,
+    "eyson": true,
+    "daizch": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/finalhandler.min.json
+++ b/test/fixtures/registry-mocks/content/finalhandler.min.json
@@ -1,0 +1,739 @@
+{
+  "name": "finalhandler",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "finalhandler",
+      "version": "0.0.0",
+      "dependencies": {
+        "debug": "1.0.0",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "1dcd03de37b283d0593b47a327535c9490d5b246",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.0.1": {
+      "name": "finalhandler",
+      "version": "0.0.1",
+      "dependencies": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "624429d98b41ab1538b21b97086a74f23b07fcd6",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.0.2": {
+      "name": "finalhandler",
+      "version": "0.0.2",
+      "dependencies": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "0603d875ee87d567a266692815cc8ad44fcceeda",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.0.3": {
+      "name": "finalhandler",
+      "version": "0.0.3",
+      "dependencies": {
+        "debug": "1.0.3",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "5a86b7bc4dca3d1275eb0532c81ee81d747504df",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.1.0": {
+      "name": "finalhandler",
+      "version": "0.1.0",
+      "dependencies": {
+        "debug": "1.0.4",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.27",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "da05bbc4f5f4a30c84ce1d91f3c154007c4e9daa",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.2.0": {
+      "name": "finalhandler",
+      "version": "0.2.0",
+      "dependencies": {
+        "debug": "~2.0.0",
+        "escape-html": "1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "readable-stream": "~1.0.27",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "794082424b17f6a4b2a0eda39f9db6948ee4be8d",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.3.0": {
+      "name": "finalhandler",
+      "version": "0.3.0",
+      "dependencies": {
+        "debug": "~2.0.0",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "readable-stream": "~1.0.27",
+        "should": "~4.0.1",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "581afe4d28da13491487f1c0ef9c29ef883e6e59",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.3.1": {
+      "name": "finalhandler",
+      "version": "0.3.1",
+      "dependencies": {
+        "debug": "~2.1.0",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "readable-stream": "~1.0.33",
+        "should": "~4.0.1",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "ffda7643228678c6b088c89421a8381663961808",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.3.2": {
+      "name": "finalhandler",
+      "version": "0.3.2",
+      "dependencies": {
+        "debug": "~2.1.0",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "readable-stream": "~1.0.33",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "7b389b0fd3647a6f90bd564e22624bf8a4a77fb5",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.3.3": {
+      "name": "finalhandler",
+      "version": "0.3.3",
+      "dependencies": {
+        "debug": "~2.1.1",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "readable-stream": "~1.0.33",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "b1a09aa1e6a607b3541669b09bcb727f460cd426",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.3.4": {
+      "name": "finalhandler",
+      "version": "0.3.4",
+      "dependencies": {
+        "debug": "~2.1.3",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.8",
+        "mocha": "~2.2.1",
+        "readable-stream": "~1.0.33",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "4787d3573d079ae8b07536f26b0b911ebaf2a2ac",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.3.5": {
+      "name": "finalhandler",
+      "version": "0.3.5",
+      "dependencies": {
+        "debug": "~2.1.3",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "0d1bf5dfcb5f77d073a402aabe5f7a8a90413721",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.3.6": {
+      "name": "finalhandler",
+      "version": "0.3.6",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "1.0.1",
+        "on-finished": "~2.2.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "daf9c4161b1b06e001466b1411dfdb6973be138b",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.4.0": {
+      "name": "finalhandler",
+      "version": "0.4.0",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "1.0.2",
+        "on-finished": "~2.3.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.15",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.0",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "965a52d9e8d05d2b857548541fb89b53a2497d9b",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.4.1": {
+      "name": "finalhandler",
+      "version": "0.4.1",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "mocha": "2.3.4",
+        "readable-stream": "2.0.4",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "85a17c6c59a94717d262d61230d4b0ebe3d4a14d",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.5.0": {
+      "name": "finalhandler",
+      "version": "0.5.0",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "statuses": "~1.3.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "2.12.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "e9508abece9b6dba871a6942a1d7911b91911ac7",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "0.5.1": {
+      "name": "finalhandler",
+      "version": "0.5.1",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.10.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "2c400d8d4530935bc232549c5fa385ec07de6fcd",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.0": {
+      "name": "finalhandler",
+      "version": "1.0.0",
+      "dependencies": {
+        "debug": "2.6.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "b5691c2c0912092f18ac23e9416bde5cd7dc6755",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.1": {
+      "name": "finalhandler",
+      "version": "1.0.1",
+      "dependencies": {
+        "debug": "2.6.3",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.18.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "bcd15d1689c0e5ed729b6f7f541a6df984117db8",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.2": {
+      "name": "finalhandler",
+      "version": "1.0.2",
+      "dependencies": {
+        "debug": "2.6.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.2.9",
+        "safe-buffer": "5.0.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "d0e36f9dbc557f2de14423df6261889e9d60c93a",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.3": {
+      "name": "finalhandler",
+      "version": "1.0.3",
+      "dependencies": {
+        "debug": "2.6.7",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.2.9",
+        "safe-buffer": "5.0.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "ef47e77950e999780e86022a560e3217e0d0cc89",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.4": {
+      "name": "finalhandler",
+      "version": "1.0.4",
+      "dependencies": {
+        "debug": "2.6.8",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.1",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+        "shasum": "18574f2e7c4b98b8ae3b230c21f201f31bdb3fb7",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.5": {
+      "name": "finalhandler",
+      "version": "1.0.5",
+      "dependencies": {
+        "debug": "2.6.8",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "a701303d257a1bc82fea547a33e5ae89531723df",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.6": {
+      "name": "finalhandler",
+      "version": "1.0.6",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "007aea33d1a4d3e42017f624848ad58d212f814f",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.0": {
+      "name": "finalhandler",
+      "version": "1.1.0",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "ce0b6855b45853e791b2fcc680046d88253dd7f5",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.1": {
+      "name": "finalhandler",
+      "version": "1.1.1",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "4.18.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.9.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.4",
+        "safe-buffer": "5.1.1",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+        "shasum": "eebf4ed840079c83f4249038c9d703008301b105",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16905
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.2": {
+      "name": "finalhandler",
+      "version": "1.1.2",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "supertest": "4.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+        "shasum": "b7e7d000ffd11938d0fdb053506f6ebabe9f587d",
+        "tarball": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17043,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1NxFCRA9TVsSAnZWagAA5lsP/ikRb6COPldBamNBvpJ9\nRhs/yK6Xs0xWScOozeN+eYycCG1ybDJaCZ7Pw1dkjpfSVB6gIuV+o1DxycnA\n3Fp+IPyJ4W3hHgWUL+1KuA5ajYbrH22ezf+DnmU3G04Xj3qpEZeeYI3hQ0IQ\nBXWjiCwmn2CEB8HYyAuvgEgsH8crqkzRlaLMb4I57TAKk0JKwZd+4r4t2WlM\n8sI83C7in0rOWkjUpJWBuR7hwSGqygKf8i0cIrOdA3ilf8EjmjELrA5mIga/\norpYoarZRenzzyyRRfG3H3Sryblavh6lajTwqwh+CxmeQJLv+gJTERLvrUc2\n2Rjmj2Iu3Z2h+D6f9qWdsPRXqE91KU0X0fDtBNjibOMncX8GtpG332SmN0Fd\nXs1E/Fcu2GlOgoJfD5mKA2OJ3GN9YlFfc7uvXuaB491/i9J/Zde548Tdn3im\ncxN8ULRL3GLHHbxONXX9Q49mdQxmHsJDPe6xN7RQwxirLZKlZEXJjl82x1kJ\nJQ0wHcxsuZiJmUTje64W5ETFBI1qN/rJiFN8HQTEkUeXpnI/Kl4ktzefhwPF\njlgPQ8BLiCeHAM4cCweDGUTUVelo6RQaN/ljpPivvd1l8DU+1R4guvjjDWcr\nb2eE7W0pup5R/PAJe61LTA38pRuurq4kR0lLfPWvOQvhPuSZ8WbDP0JNBf/U\noAB7\r\n=2zSq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-05-10T02:04:55.863Z"
+}

--- a/test/fixtures/registry-mocks/content/flush-write-stream.json
+++ b/test/fixtures/registry-mocks/content/flush-write-stream.json
@@ -1,0 +1,429 @@
+{
+  "_id": "flush-write-stream",
+  "_rev": "8-3eca78c97f065586c2d67ad20109dfa1",
+  "name": "flush-write-stream",
+  "description": "A write stream constructor that supports a flush function that is called before finish is emitted",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "flush-write-stream",
+      "version": "1.0.0",
+      "description": "A write stream constructor that supports a flush function that is called before finish is emitted",
+      "main": "index.js",
+      "dependencies": {
+        "readable-stream": "^2.0.4"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/flush-write-stream.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/flush-write-stream/issues"
+      },
+      "homepage": "https://github.com/mafintosh/flush-write-stream",
+      "gitHead": "50e81d8eeee8a9666c7d5105775a6c89b7ae9dfa",
+      "_id": "flush-write-stream@1.0.0",
+      "_shasum": "cc4fc24f4b4c973f80027f27cc095841639965a7",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "cc4fc24f4b4c973f80027f27cc095841639965a7",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "flush-write-stream",
+      "version": "1.0.1",
+      "description": "A write stream constructor that supports a flush function that is called before finish is emitted",
+      "main": "index.js",
+      "dependencies": {
+        "readable-stream": "^2.0.4"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/flush-write-stream.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/flush-write-stream/issues"
+      },
+      "homepage": "https://github.com/mafintosh/flush-write-stream",
+      "gitHead": "7f00179b7018083158fdf58c416aaa77ed2696c3",
+      "_id": "flush-write-stream@1.0.1",
+      "_shasum": "39dd8e6627109b5e833461d1b1eeb25edff3c4ba",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.2.6",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "39dd8e6627109b5e833461d1b1eeb25edff3c4ba",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/flush-write-stream-1.0.1.tgz_1476614551011_0.6873086630366743"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "flush-write-stream",
+      "version": "1.0.2",
+      "description": "A write stream constructor that supports a flush function that is called before finish is emitted",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/flush-write-stream.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/flush-write-stream/issues"
+      },
+      "homepage": "https://github.com/mafintosh/flush-write-stream",
+      "gitHead": "d35a4071dacbcc60fc40d798fa58fc425cba3efc",
+      "_id": "flush-write-stream@1.0.2",
+      "_shasum": "c81b90d8746766f1a609a46809946c45dd8ae417",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.2.6",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "c81b90d8746766f1a609a46809946c45dd8ae417",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/flush-write-stream-1.0.2.tgz_1476614807882_0.22224654001183808"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "flush-write-stream",
+      "version": "1.0.3",
+      "description": "A write stream constructor that supports a flush function that is called before finish is emitted",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/flush-write-stream.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/flush-write-stream/issues"
+      },
+      "homepage": "https://github.com/mafintosh/flush-write-stream",
+      "gitHead": "3a0c6e62c7c9a5c22abf49cd1a06c960487fa2c9",
+      "_id": "flush-write-stream@1.0.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.7.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+        "shasum": "c5d586ef38af6097650b49bc41b55fabb19f35bd",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6512
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/flush-write-stream_1.0.3_1521632961113_0.42985920051576776"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.0": {
+      "name": "flush-write-stream",
+      "version": "1.1.0",
+      "description": "A write stream constructor that supports a flush function that is called before finish is emitted",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/flush-write-stream.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/flush-write-stream/issues"
+      },
+      "homepage": "https://github.com/mafintosh/flush-write-stream",
+      "gitHead": "85d36bb3cde116622da5ac3c966e2cd58d9a75ff",
+      "_id": "flush-write-stream@1.1.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-6MHED/cmsyux1G4/Cek2Z776y9t7WCNd3h2h/HW91vFeU7pzMhA8XvAlDhHcanG5IWuIh/xcC7JASY4WQpG6xg==",
+        "shasum": "2e89a8bd5eee42f8ec97e43aae81e3d5099c2ddc",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6512,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcWANoCRA9TVsSAnZWagAAyzwP/0R/kZ0ApTRQZswgVKZv\nBS1qKpEz4jfTDV/OELjYh88cTPKvAFApDJ9mR6eyH5W/t6MsAe8d/j9miTxz\nWj8/5e37KEKy3qZTz1uUk7Mf9oYROG0qpNpehH/xGNxS1cOzg09uyD3j3QUU\ngNAtVyMGnMFYlq7ibJlhKZOiYu+8enRPOfj2BGXYGkDt+ujvBzOFUUpeSY03\n2wbiJkwVkCsWGPpkUd5MDYjovPK4Q5Mip6TzIfAaQiH0GZUrMgNh3wyCuTob\niC3q7l0MxmZqjovWwqMOXNnTiCE4i+RDVbM7jPd89Gec4rs/95T9n284iCw+\nGVv9MExeVOoMkzZ9fesqrA8ezWcJ/sj6OwH05N1Uz0fmUsXVtxmQjval6eUe\ncaijTikLRabA463njYi7CX/VROOqZzrV4USU/Rl2IBzwJFfAnkSuI0Xa8hWy\nv/xKCVvJb2uZPG0/24WJqfE0Qy+9i0JLq+/8dSm+QFJxpi06i89nmWywmxox\nAbY2N579+Be2eYt32hkBNT/BVvPWtv5EiZtplXV0WeFZECqG1J6qi58GW8j8\ncJ0/0Pkg3SPqqMdD3kLWNsUOKE7AlAbJ2ujC7Prml2WN7l17gsER2oZvhpBo\nYVanzxl0mzA+yosqUbBe1ZXgLlAOsVsCcDZlaY7I4Ow0eoUFlCHLTkp729Xv\n9XBg\r\n=kCSG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/flush-write-stream_1.1.0_1549271911926_0.4645147990967873"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.1": {
+      "name": "flush-write-stream",
+      "version": "1.1.1",
+      "description": "A write stream constructor that supports a flush function that is called before finish is emitted",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/flush-write-stream.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/flush-write-stream/issues"
+      },
+      "homepage": "https://github.com/mafintosh/flush-write-stream",
+      "gitHead": "bab61bb3805d5750cb864aeee387fbddea93c913",
+      "_id": "flush-write-stream@1.1.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+        "shasum": "8dd7d873a1babc207d94ead0c2e0e44276ebf2e8",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6503,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcXWhRCRA9TVsSAnZWagAAO6AP/1PeJON8gEoXFRpQyMvK\nev0cTYLHqU0z52V9dvugJ+RVvrdXfLXf63lSAiOjc3KBONbdhKFavJU+QlrA\nbqIx7pq5X61gvsFzgWfkGVluOCb0sgr2aJ4BcyeYrETrPCUV2QibPz0tqoyu\ntUvTeeIR3wGrksA5HUIHdf3f35E5ZTBMK18sTaA2PkTgj6VuQ4m8NBxgkatL\n1LVNh+n3kQvzH2nBtwsPZKzDFSXHvTpPNgjwIuasewe96f9rJAsPBgA32c1j\nVUs5QVKQyl3fGFCpA5W9fQBS40j89I1yAetgT+6zXMfRz2z9Gvx0C5UTyD3h\njX7vu/ktZb2kmlWPbHcNwRFCSsm53cpZ2LFj0u5Pw9EcC9aBiK2dGdQJeOaS\nd2Vn7IXMUKip7yOZcnMv3N4YGx6+mjHIOweIJKfu1z/S4kjGmZ2nLQKrO2Vz\nzOZCJoRjMpZUbv+ATZ2t2WfKe3YcXLmfJHs3p0fRSe1HjBvkrjHbRE7L0ML+\nksZr0m2fi0bYu3uY08VkJN9pR1c+4iuU5zc1gCUH5EgnkEH0MHfXrcbXskwy\ndk9Qpc2BkWD+wcIHjw/xApktFqPsCTM7SrR+XEHElgyUOyeW7H4gQ741iOHf\nhFmMUl0zin/p2Jstylv+zDI8e2JKfFQ3WsgMSq7Qi1XJ8Ta4Q2xtwbhBpkd+\nQLEn\r\n=Qfkq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/flush-write-stream_1.1.1_1549625425108_0.2525437003881257"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "flush-write-stream",
+      "version": "2.0.0",
+      "description": "A write stream constructor that supports a flush function that is called before finish is emitted",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/flush-write-stream.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/flush-write-stream/issues"
+      },
+      "homepage": "https://github.com/mafintosh/flush-write-stream",
+      "gitHead": "cea3fbb3a3d11fb1e226d8893a1749178627b284",
+      "_id": "flush-write-stream@2.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-uXClqPxT4xW0lcdSBheb2ObVU+kuqUk3Jk64EwieirEXZx9XUrVwp/JuBfKAWaM4T5Td/VL7QLDWPXp/MvGm/g==",
+        "shasum": "6f58e776154f5eefacff92a6e5a681c88ac50f7c",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-2.0.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6503,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcXWh3CRA9TVsSAnZWagAAiHIP/3xb/bnCTbJW9iASegn7\n6NoyhqP7JD28hrwOHRrw2xE12wOsMkGTWcydTVhlOjjLjfYuOtyf197n2gm/\nPI41F+T+y5fXIwe9SCdmlrlcS1KKPNFJMVdNxDHsqYmV5fSwcgtG3xuVLCgg\nA5ap0bw5YBzGPOexBT5tpqrlAnXYFrl7bHOpqjdGPa5EPaxTCTlU7QJMfe2J\nh1jqFxXx3eHWb1cBs/8goxC0ISXCnvqPNUl8LU5GzhJ82xtjXzLS6HGRrKXJ\nnp4Xlb6znV27OsxV/SuFzhq8AZTeHJPJmNEMa8VrBgU9bN4U5fAwZJoBOqt3\nTL/SAkP4layhJb7YVYa2pyNFTKjH1S+N3vq7j/kQNZ4F4b5YYsvBF4kgA9xe\nSwW726sNIIgDl4GxmlTrZletQW74YVCwkuK3oSzugpxXBzVybJH/WAaAhzbL\nbSf5owGfPm0QMxJeEn19um5fspdbCk3lWNOp+9BdtimIVEWPJMGxNhy63pdW\nQcNK3w3hpFEvesAlNrP/Yu/vgx7Cx/JLqJID1vbJMM7GHD6DbItlHrl92BHE\nGsSQCg8i5aTyQBAsRTqAjrAk+WkxF/w6jbxuzvoTsTbFFh46KASGABzNht+x\nei2jxhkWeWrl5JOr61/s0Y/EV6He0bBDXl99WpSH0PL1EjNYR+0CHANxnjzp\nnqL3\r\n=e35e\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/flush-write-stream_2.0.0_1549625462928_0.38196138371240473"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# flush-write-stream\n\nA write stream constructor that supports a flush function that is called before `finish` is emitted\n\n```\nnpm install flush-write-stream\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/flush-write-stream.svg?style=flat)](http://travis-ci.org/mafintosh/flush-write-stream)\n\n## Usage\n\n``` js\nvar writer = require('flush-write-stream')\n\nvar ws = writer(write, flush)\n\nws.on('finish', function () {\n  console.log('finished')\n})\n\nws.write('hello')\nws.write('world')\nws.end()\n\nfunction write (data, enc, cb) {\n  // i am your normal ._write method\n  console.log('writing', data.toString())\n  cb()\n}\n\nfunction flush (cb) {\n  // i am called before finish is emitted\n  setTimeout(cb, 1000) // wait 1 sec\n}\n```\n\nIf you run the above it will produce the following output\n\n```\nwriting hello\nwriting world\n(nothing happens for 1 sec)\nfinished\n```\n\n## API\n\n#### `var ws = writer([options], write, [flush])`\n\nCreate a new writable stream. Options are forwarded to the stream constructor.\n\n#### `var ws = writer.obj([options], write, [flush])`\n\nSame as the above except `objectMode` is set to `true` per default.\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-02-08T11:31:05.545Z",
+    "created": "2015-11-06T21:57:03.152Z",
+    "1.0.0": "2015-11-06T21:57:03.152Z",
+    "1.0.1": "2016-10-16T10:42:32.651Z",
+    "1.0.2": "2016-10-16T10:46:49.463Z",
+    "1.0.3": "2018-03-21T11:49:21.221Z",
+    "1.1.0": "2019-02-04T09:18:32.074Z",
+    "1.1.1": "2019-02-08T11:30:25.188Z",
+    "2.0.0": "2019-02-08T11:31:03.031Z"
+  },
+  "homepage": "https://github.com/mafintosh/flush-write-stream",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mafintosh/flush-write-stream.git"
+  },
+  "author": {
+    "name": "Mathias Buus",
+    "url": "@mafintosh"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/flush-write-stream/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "bret": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/flush-write-stream.min.json
+++ b/test/fixtures/registry-mocks/content/flush-write-stream.min.json
@@ -1,0 +1,127 @@
+{
+  "name": "flush-write-stream",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "flush-write-stream",
+      "version": "1.0.0",
+      "dependencies": {
+        "readable-stream": "^2.0.4"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "dist": {
+        "shasum": "cc4fc24f4b4c973f80027f27cc095841639965a7",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "flush-write-stream",
+      "version": "1.0.1",
+      "dependencies": {
+        "readable-stream": "^2.0.4"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "dist": {
+        "shasum": "39dd8e6627109b5e833461d1b1eeb25edff3c4ba",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "flush-write-stream",
+      "version": "1.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "dist": {
+        "shasum": "c81b90d8746766f1a609a46809946c45dd8ae417",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "flush-write-stream",
+      "version": "1.0.3",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+        "shasum": "c5d586ef38af6097650b49bc41b55fabb19f35bd",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6512
+      }
+    },
+    "1.1.0": {
+      "name": "flush-write-stream",
+      "version": "1.1.0",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-6MHED/cmsyux1G4/Cek2Z776y9t7WCNd3h2h/HW91vFeU7pzMhA8XvAlDhHcanG5IWuIh/xcC7JASY4WQpG6xg==",
+        "shasum": "2e89a8bd5eee42f8ec97e43aae81e3d5099c2ddc",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6512,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcWANoCRA9TVsSAnZWagAAyzwP/0R/kZ0ApTRQZswgVKZv\nBS1qKpEz4jfTDV/OELjYh88cTPKvAFApDJ9mR6eyH5W/t6MsAe8d/j9miTxz\nWj8/5e37KEKy3qZTz1uUk7Mf9oYROG0qpNpehH/xGNxS1cOzg09uyD3j3QUU\ngNAtVyMGnMFYlq7ibJlhKZOiYu+8enRPOfj2BGXYGkDt+ujvBzOFUUpeSY03\n2wbiJkwVkCsWGPpkUd5MDYjovPK4Q5Mip6TzIfAaQiH0GZUrMgNh3wyCuTob\niC3q7l0MxmZqjovWwqMOXNnTiCE4i+RDVbM7jPd89Gec4rs/95T9n284iCw+\nGVv9MExeVOoMkzZ9fesqrA8ezWcJ/sj6OwH05N1Uz0fmUsXVtxmQjval6eUe\ncaijTikLRabA463njYi7CX/VROOqZzrV4USU/Rl2IBzwJFfAnkSuI0Xa8hWy\nv/xKCVvJb2uZPG0/24WJqfE0Qy+9i0JLq+/8dSm+QFJxpi06i89nmWywmxox\nAbY2N579+Be2eYt32hkBNT/BVvPWtv5EiZtplXV0WeFZECqG1J6qi58GW8j8\ncJ0/0Pkg3SPqqMdD3kLWNsUOKE7AlAbJ2ujC7Prml2WN7l17gsER2oZvhpBo\nYVanzxl0mzA+yosqUbBe1ZXgLlAOsVsCcDZlaY7I4Ow0eoUFlCHLTkp729Xv\n9XBg\r\n=kCSG\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.1": {
+      "name": "flush-write-stream",
+      "version": "1.1.1",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
+        "shasum": "8dd7d873a1babc207d94ead0c2e0e44276ebf2e8",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6503,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcXWhRCRA9TVsSAnZWagAAO6AP/1PeJON8gEoXFRpQyMvK\nev0cTYLHqU0z52V9dvugJ+RVvrdXfLXf63lSAiOjc3KBONbdhKFavJU+QlrA\nbqIx7pq5X61gvsFzgWfkGVluOCb0sgr2aJ4BcyeYrETrPCUV2QibPz0tqoyu\ntUvTeeIR3wGrksA5HUIHdf3f35E5ZTBMK18sTaA2PkTgj6VuQ4m8NBxgkatL\n1LVNh+n3kQvzH2nBtwsPZKzDFSXHvTpPNgjwIuasewe96f9rJAsPBgA32c1j\nVUs5QVKQyl3fGFCpA5W9fQBS40j89I1yAetgT+6zXMfRz2z9Gvx0C5UTyD3h\njX7vu/ktZb2kmlWPbHcNwRFCSsm53cpZ2LFj0u5Pw9EcC9aBiK2dGdQJeOaS\nd2Vn7IXMUKip7yOZcnMv3N4YGx6+mjHIOweIJKfu1z/S4kjGmZ2nLQKrO2Vz\nzOZCJoRjMpZUbv+ATZ2t2WfKe3YcXLmfJHs3p0fRSe1HjBvkrjHbRE7L0ML+\nksZr0m2fi0bYu3uY08VkJN9pR1c+4iuU5zc1gCUH5EgnkEH0MHfXrcbXskwy\ndk9Qpc2BkWD+wcIHjw/xApktFqPsCTM7SrR+XEHElgyUOyeW7H4gQ741iOHf\nhFmMUl0zin/p2Jstylv+zDI8e2JKfFQ3WsgMSq7Qi1XJ8Ta4Q2xtwbhBpkd+\nQLEn\r\n=Qfkq\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "flush-write-stream",
+      "version": "2.0.0",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-uXClqPxT4xW0lcdSBheb2ObVU+kuqUk3Jk64EwieirEXZx9XUrVwp/JuBfKAWaM4T5Td/VL7QLDWPXp/MvGm/g==",
+        "shasum": "6f58e776154f5eefacff92a6e5a681c88ac50f7c",
+        "tarball": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-2.0.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6503,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcXWh3CRA9TVsSAnZWagAAiHIP/3xb/bnCTbJW9iASegn7\n6NoyhqP7JD28hrwOHRrw2xE12wOsMkGTWcydTVhlOjjLjfYuOtyf197n2gm/\nPI41F+T+y5fXIwe9SCdmlrlcS1KKPNFJMVdNxDHsqYmV5fSwcgtG3xuVLCgg\nA5ap0bw5YBzGPOexBT5tpqrlAnXYFrl7bHOpqjdGPa5EPaxTCTlU7QJMfe2J\nh1jqFxXx3eHWb1cBs/8goxC0ISXCnvqPNUl8LU5GzhJ82xtjXzLS6HGRrKXJ\nnp4Xlb6znV27OsxV/SuFzhq8AZTeHJPJmNEMa8VrBgU9bN4U5fAwZJoBOqt3\nTL/SAkP4layhJb7YVYa2pyNFTKjH1S+N3vq7j/kQNZ4F4b5YYsvBF4kgA9xe\nSwW726sNIIgDl4GxmlTrZletQW74YVCwkuK3oSzugpxXBzVybJH/WAaAhzbL\nbSf5owGfPm0QMxJeEn19um5fspdbCk3lWNOp+9BdtimIVEWPJMGxNhy63pdW\nQcNK3w3hpFEvesAlNrP/Yu/vgx7Cx/JLqJID1vbJMM7GHD6DbItlHrl92BHE\nGsSQCg8i5aTyQBAsRTqAjrAk+WkxF/w6jbxuzvoTsTbFFh46KASGABzNht+x\nei2jxhkWeWrl5JOr61/s0Y/EV6He0bBDXl99WpSH0PL1EjNYR+0CHANxnjzp\nnqL3\r\n=e35e\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-02-08T11:31:05.545Z"
+}

--- a/test/fixtures/registry-mocks/content/follow-redirects.json
+++ b/test/fixtures/registry-mocks/content/follow-redirects.json
@@ -1,0 +1,4459 @@
+{
+  "_id": "follow-redirects",
+  "_rev": "63-855da6d472f913b3e1dd3c33e858ef06",
+  "name": "follow-redirects",
+  "description": "HTTP and HTTPS modules that follow redirects.",
+  "dist-tags": {
+    "latest": "1.13.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "follow-redirects",
+      "version": "0.0.1",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:olalonde/follow-redirects.git"
+      },
+      "homepage": "",
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "dependencies": {
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "license": "BSD",
+      "_id": "follow-redirects@0.0.1",
+      "dist": {
+        "shasum": "b0b9078dc855b13a7acfebcb099b9f98f2366772",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.1.tgz"
+      },
+      "_npmVersion": "1.1.62",
+      "_npmUser": {
+        "name": "olalonde",
+        "email": "olalonde@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "follow-redirects",
+      "version": "0.0.2",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:olalonde/follow-redirects.git"
+      },
+      "homepage": "",
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "dependencies": {
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "license": "BSD",
+      "_id": "follow-redirects@0.0.2",
+      "dist": {
+        "shasum": "06c81345f422a3bfd93583bd0b6c0daa58cb54b9",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.2.tgz"
+      },
+      "_npmVersion": "1.1.62",
+      "_npmUser": {
+        "name": "olalonde",
+        "email": "olalonde@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "follow-redirects",
+      "version": "0.0.3",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:olalonde/follow-redirects.git"
+      },
+      "homepage": "",
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "dependencies": {
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "license": "BSD",
+      "_id": "follow-redirects@0.0.3",
+      "dist": {
+        "shasum": "6ce67a24db1fe13f226c1171a72a7ef2b17b8f65",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz"
+      },
+      "_npmVersion": "1.1.62",
+      "_npmUser": {
+        "name": "olalonde",
+        "email": "olalonde@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "follow-redirects",
+      "version": "0.0.4",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "dependencies": {
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "license": "MIT",
+      "gitHead": "0eb72aca9f61ffdf0b064b3582a4591756890853",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "_id": "follow-redirects@0.0.4",
+      "_shasum": "78d2faec253da7bbd4bbb6733e05132a6ae9b483",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "olalonde",
+        "email": "olalonde@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "78d2faec253da7bbd4bbb6733e05132a6ae9b483",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "follow-redirects",
+      "version": "0.0.5",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "license": "MIT",
+      "gitHead": "1dd1218dbbcbea595b00c107a7fc04aab17e900d",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "_id": "follow-redirects@0.0.5",
+      "_shasum": "c4d40dddfd8a9349e052c50c00222a5e393bae32",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "olalonde",
+        "email": "olalonde@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c4d40dddfd8a9349e052c50c00222a5e393bae32",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.6": {
+      "name": "follow-redirects",
+      "version": "0.0.6",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run cover && npm run lint && npm run style",
+        "lint": "jshint *.js test/*.js test/**/*.js",
+        "style": "jscs *.js && jscs test/*.js test/**/*.js --config=test/.jscsrc",
+        "cover": "BLUEBIRD_DEBUG=1 istanbul cover ./node_modules/.bin/_mocha",
+        "debug": "BLUEBIRD_DEBUG=1 mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^2.9.30",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "semver": "~4.3.6"
+      },
+      "license": "MIT",
+      "gitHead": "795bae039c7a756dbed9ce7c4a45cf2d2ed7dd83",
+      "_id": "follow-redirects@0.0.6",
+      "_shasum": "a3d57beaea728d96a5dbb6f1e790351d2ee18331",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "olalonde",
+        "email": "olalonde@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a3d57beaea728d96a5dbb6f1e790351d2ee18331",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.7": {
+      "name": "follow-redirects",
+      "version": "0.0.7",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run cover && npm run lint && npm run style",
+        "lint": "jshint *.js test/*.js test/**/*.js",
+        "style": "jscs *.js && jscs test/*.js test/**/*.js --config=test/.jscsrc",
+        "cover": "BLUEBIRD_DEBUG=1 istanbul cover ./node_modules/.bin/_mocha",
+        "debug": "BLUEBIRD_DEBUG=1 mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "stream-consume": "^0.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^2.9.30",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "semver": "~4.3.6"
+      },
+      "license": "MIT",
+      "gitHead": "5137f3958a179f0bf9310886edb77efd3b85a208",
+      "_id": "follow-redirects@0.0.7",
+      "_shasum": "34b90bab2a911aa347571da90f22bd36ecd8a919",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "james.talmage",
+        "email": "james@talmage.io"
+      },
+      "dist": {
+        "shasum": "34b90bab2a911aa347571da90f22bd36ecd8a919",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        },
+        {
+          "name": "james.talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "follow-redirects",
+      "version": "0.1.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run cover && npm run lint && npm run style",
+        "lint": "jshint *.js test/*.js test/**/*.js",
+        "style": "jscs *.js && jscs test/*.js test/**/*.js --config=test/.jscsrc",
+        "cover": "BLUEBIRD_DEBUG=1 istanbul cover ./node_modules/.bin/_mocha",
+        "debug": "BLUEBIRD_DEBUG=1 mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "stream-consume": "^0.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^2.9.30",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "semver": "~4.3.6"
+      },
+      "license": "MIT",
+      "gitHead": "20537d21a1e4eb9371a0c2d74cff5a041ee2e22a",
+      "_id": "follow-redirects@0.1.0",
+      "_shasum": "8333fbee65d2fa8585241ebb1372fc01e5b1f671",
+      "_from": ".",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.9.0",
+      "_npmUser": {
+        "name": "jamestalmage",
+        "email": "james@talmage.io"
+      },
+      "dist": {
+        "shasum": "8333fbee65d2fa8585241ebb1372fc01e5b1f671",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-0.1.0.tgz_1460316696773_0.05581280658952892"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "follow-redirects",
+      "version": "0.2.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "stream-consume": "^0.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^2.2.5",
+        "nyc": "^6.4.4",
+        "semver": "~5.1.0",
+        "xo": "^0.15.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "9a13ff409ce5b05463ee0785cb4c048c21800561",
+      "_id": "follow-redirects@0.2.0",
+      "_shasum": "e0229d7a388bb5ff7b29f44fc1e1b62e921272df",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "jamestalmage",
+        "email": "james@talmage.io"
+      },
+      "dist": {
+        "shasum": "e0229d7a388bb5ff7b29f44fc1e1b62e921272df",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-0.2.0.tgz_1465250402713_0.451352697564289"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "follow-redirects",
+      "version": "0.3.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^3.1.2",
+        "nyc": "^8.3.1",
+        "semver": "^5.3.0",
+        "xo": "^0.17.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "3a3f8b040b32098606630278176e2dc54cf29723",
+      "_id": "follow-redirects@0.3.0",
+      "_shasum": "6d9935db28386943b19730cbc0ae1a3b72ef0bc8",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "shasum": "6d9935db28386943b19730cbc0ae1a3b72ef0bc8",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        },
+        {
+          "name": "rubenverborgh",
+          "email": "ruben.verborgh@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-0.3.0.tgz_1476978547120_0.37060856400057673"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "follow-redirects",
+      "version": "1.0.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^3.1.2",
+        "nyc": "^8.3.1",
+        "xo": "^0.17.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "4010b44f4715c89dd75037f66458b93fd59599a1",
+      "_id": "follow-redirects@1.0.0",
+      "_shasum": "8e34298cbd2e176f254effec75a1c78cc849fd37",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "shasum": "8e34298cbd2e176f254effec75a1c78cc849fd37",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        },
+        {
+          "name": "rubenverborgh",
+          "email": "ruben.verborgh@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-1.0.0.tgz_1477238992406_0.5941755524836481"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "follow-redirects",
+      "version": "1.1.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^3.1.2",
+        "nyc": "^8.3.1",
+        "xo": "^0.17.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "6626d432f0e6a9919dab492bce484e3d9f4657e4",
+      "_id": "follow-redirects@1.1.0",
+      "_shasum": "f0a07e20b96396f096873f16ea2b9638a79e7b0c",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "shasum": "f0a07e20b96396f096873f16ea2b9638a79e7b0c",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        },
+        {
+          "name": "rubenverborgh",
+          "email": "ruben.verborgh@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-1.1.0.tgz_1478450677901_0.6304203481413424"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "follow-redirects",
+      "version": "1.2.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^3.1.2",
+        "nyc": "^8.3.1",
+        "xo": "^0.17.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "7dd0cb2a92cf04c8e95432c341a3ec881abeff41",
+      "_id": "follow-redirects@1.2.0",
+      "_shasum": "e1746cbf9c9c1d5fbff07de315d0c8730ad68172",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "shasum": "e1746cbf9c9c1d5fbff07de315d0c8730ad68172",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        },
+        {
+          "name": "rubenverborgh",
+          "email": "ruben.verborgh@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-1.2.0.tgz_1481147454200_0.2246841248124838"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "follow-redirects",
+      "version": "1.2.1",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.4.5"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "a3cca068fbc3ea7377f8aaf658982f997c1c6dd3",
+      "_id": "follow-redirects@1.2.1",
+      "_shasum": "796c716970df4fb0096165393545040f61b00f59",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "shasum": "796c716970df4fb0096165393545040f61b00f59",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        },
+        {
+          "name": "rubenverborgh",
+          "email": "ruben.verborgh@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-1.2.1.tgz_1482065567827_0.582136373501271"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "follow-redirects",
+      "version": "1.2.2",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.4.5"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "f6e923e03ff734319bb0dbbfe50112ed4518aa7a",
+      "_id": "follow-redirects@1.2.2",
+      "_shasum": "45e4248c741128874f4a4900fd7e14f644b0bc40",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "shasum": "45e4248c741128874f4a4900fd7e14f644b0bc40",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        },
+        {
+          "name": "rubenverborgh",
+          "email": "ruben.verborgh@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-1.2.2.tgz_1489096432046_0.3155715446919203"
+      },
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "follow-redirects",
+      "version": "1.2.3",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.4.5"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "ad35f4c9ab0c3fbf23c8486ba5e241d08d6b39b4",
+      "_id": "follow-redirects@1.2.3",
+      "_shasum": "01abaeca85e3609837d9fcda3167a7e42fdaca21",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "shasum": "01abaeca85e3609837d9fcda3167a7e42fdaca21",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jamestalmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "olalonde",
+          "email": "olalonde@gmail.com"
+        },
+        {
+          "name": "rubenverborgh",
+          "email": "ruben.verborgh@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/follow-redirects-1.2.3.tgz_1489164681760_0.5944589097052813"
+      },
+      "directories": {}
+    },
+    "1.2.4": {
+      "name": "follow-redirects",
+      "version": "1.2.4",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.4.5"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "c3770de92eb2898ccc638f269a1046919329bd81",
+      "_id": "follow-redirects@1.2.4",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
+        "shasum": "355e8f4d16876b43f577b0d5ce2668b9723214ea",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        },
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects-1.2.4.tgz_1498073966897_0.48846928821876645"
+      },
+      "directories": {}
+    },
+    "1.2.5": {
+      "name": "follow-redirects",
+      "version": "1.2.5",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^2.6.9"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "be81edd4dd413bd8f7f12344809b982df888e061",
+      "_id": "follow-redirects@1.2.5",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+        "shasum": "ffd3e14cbdd5eaa72f61b6368c1f68516c2a26cc",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        },
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects-1.2.5.tgz_1507223053004_0.14782698079943657"
+      },
+      "directories": {}
+    },
+    "1.2.6": {
+      "name": "follow-redirects",
+      "version": "1.2.6",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "xo && BLUEBIRD_DEBUG=1 nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^3.0.0",
+        "express": "^4.13.0",
+        "mocha": "^4.0.1",
+        "nyc": "^11.3.0",
+        "xo": "^0.17.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "xo": {
+        "envs": [
+          "mocha"
+        ]
+      },
+      "gitHead": "99bd703a765992a260f07e1a2721005fa8b7501d",
+      "_id": "follow-redirects@1.2.6",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "8.8.1",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
+        "shasum": "4dcdc7e4ab3dd6765a97ff89c3b4c258117c79bf",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        },
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects-1.2.6.tgz_1511346901294_0.8867264720611274"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "follow-redirects",
+      "version": "1.3.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.14.0",
+        "express": "^4.13.0",
+        "mocha": "^4.0.1",
+        "nyc": "^11.3.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "dc709643b367ba1fd8039a83431f844ea8f03b64",
+      "_id": "follow-redirects@1.3.0",
+      "_shasum": "f684871fc116d2e329fda55ef67687f4fabc905c",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.8.7",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "shasum": "f684871fc116d2e329fda55ef67687f4fabc905c",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        },
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects-1.3.0.tgz_1515178643188_0.43387531186454"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "follow-redirects",
+      "version": "1.4.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.14.0",
+        "express": "^4.13.0",
+        "mocha": "^4.0.1",
+        "nyc": "^11.3.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "8faff2e73cf2a760f1e9d87bc193209042ac5364",
+      "_id": "follow-redirects@1.4.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-SLUmsiaGeQa2qgJJzJgHpQ6lARP3uyVr0SkMryJmoE86XvUeM7RkYD5FT0rNyjCV5zHlNUpcp3l/6oUkqMEOqg==",
+        "shasum": "a146a3a5d402201c7a3e6128643f0e336d212b10",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        },
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects-1.4.0.tgz_1516571750943_0.4768338876310736"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "follow-redirects",
+      "version": "1.4.1",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.16.0",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.4.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "1b6340f83ad5596a0a38c16a7113692bd90301f2",
+      "_id": "follow-redirects@1.4.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+        "shasum": "d8120f4518190f55aac65bb6fc7b85fcd666d6aa",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        },
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects-1.4.1.tgz_1516754560314_0.16931934002786875"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "follow-redirects",
+      "version": "1.5.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "23f66feabb9eb22e3b251251b5935725fb1845bf",
+      "_id": "follow-redirects@1.5.0",
+      "_npmVersion": "6.0.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+        "shasum": "234f49cf770b7f35b40e790f636ceba0c3a0ab77",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 18729,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbAE4ZCRA9TVsSAnZWagAAhUEP/R+3IwcS8XgjikEcHeTF\nXGCAZ633ZHqPa3ZsXeCSQ5HtFfOef8nx8jIKsrOzNVTHZYMfiV4LqAZku8+Q\nIJD1sL395TeB9ysOg8iFINaLOC4VtChUcq9mwgwSIlacsKt6RoJ7Z9eZBjCJ\n2/mdTYxr3nXKBqrsg9lSkvkfeR8ysIHSgI3E6UTCVa6Q3E2c9vZqGbYSbTr0\nKTvf+ZWGfeWvc5xGj0epAISiJEhtdp9d+ATRBsJH8LL+gpGtwsM/PDp33TNU\nbAbNfBU73Brhu2XUtOABaKQYCWoDnb2DsuOphFnfZ9MLg0ZfmopR1QohaSPV\no0BBAhmnE73Ksp1xhk5JctTmLTH+zO163eUE9MdZ23i64Rhvk0ozZ4SRy6r6\n6d2Y0lt3E/A88iXTJZIMtlODgWm4M6dXneNJV+0e4SKDxmiJvzCHbMjgUVhj\n3eUMVPJ069yUHYa+vWR6MIeGyrCz6v21ip0Et/uvpql8kmYPLFTzR98SFDc/\n08DUTLBZIHFuBQrQPWfNUzaMLU5ziaE8x1d3HBwKjo/Gz8FV7s1i/3cXMF3u\nP+rBj0aALpynKEqligANpN5R01zcAp1qReyHsMvGjMuwl3KDpX8X8HIeciXi\nYCzGOWIGbC47080rnsJ4ct2hFifL8Ee3pmfYHet+Kn1urcFH91Lyb/oOxj9m\nJ/HX\r\n=oo9R\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.0_1526746647796_0.20553048579519562"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.1": {
+      "name": "follow-redirects",
+      "version": "1.5.1",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "6a74f5480e2bc0f93d03577865e371a4817ceae2",
+      "_id": "follow-redirects@1.5.1",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+        "shasum": "67a8f14f5a1f67f962c2c46469c79eaec0a90291",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 18825,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbPoNFCRA9TVsSAnZWagAAg+4P/0/cIO3/7dHL/bUgTB8X\nhJH/teo2Iy5mv1mtqE9OEltWx2JsrEUPC5ZVZDCCc8ufKsHvobs/84mH7cS/\ndCHG9xDIFQWMifr2MEDEudI0Zh+7z+0jWpVi3siXWJ4Ka/rY88jFV9gjKRH0\nyLL8pc50e6ibuAihzAcDqgu2TxRMcB+9CrG2rBOIIMC7ln1DIlKDhPBjtxeZ\n5dSOHgrk4SgR9nIMWXjXbb+vp8n72VHg07ppqXofLOZopqHvfuMXZdk8+g/b\ntHPVd73uyReXGjdnmZNH+NXptKTGEArL3elRC86L6no8jdtco7aFDG4EOGOl\npDgShyy4KWkl5JNglsHEW0J2C09TdyE5vYM3q0PBo6SC5TczuJsxTbeCM//4\necLAFGrrw0ce8D/WyMAp7MmcYmcu5UtjcrooxJ7xPNKcxMKKzR+t2s3XnrZ2\n0+asUDIotwKU7alW4k3FyeDDEI0gYtZhRXU4auR5nkCZJEashKxN38kDeJXa\nnBvejV/qcyX5zkVg7ZnJ1V9QAkeR9lXlxYSM2v3jwDuCZk0qkQ+Dj21VAyJZ\nUp5xJ1/VPcMPeATGFrOsEkruutDhriV/rYG1cGyyBg1ty3iG0MgELM9BzqAB\n6yT8Iq/1GV4f4drWpyAZbj1cTocw2K/PQ6+t2Ojt6iywQI45JEQCski3qznU\nHqDK\r\n=411h\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.1_1530823492901_0.29396077553661915"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.2": {
+      "name": "follow-redirects",
+      "version": "1.5.2",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "4d328f0ef3e07575b7e5b950f9dcc521906104b2",
+      "_id": "follow-redirects@1.5.2",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
+        "shasum": "5a9d80e0165957e5ef0c1210678fc5c4acb9fb03",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19118,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbYf1SCRA9TVsSAnZWagAAB1kP/ijEe8beBvmA/Pu4iq7K\n9ZsTHYQ5enR+xtzFpcdL7OepgE10ztRak9YTWx9nzQmQkqbBlUpTWSp4x4IE\nKDGGzat1qPSn5nJSgonotfNyuK9fVlE0B58CHRdvV9whb+9X0brs8DuKQcPb\nRQyuszljkz9UVnBhKmGKwLQ9WiFTlgywiMfY0yArqyVtSkyaOlwSczUZUA0+\nMhuAUU2cq8MUrYFDMTurV2258jRLFrkojiMYrwQlrA7Rsssen5R6lKGZURH3\nvePD8L4ORf6HAbkJUckf+gaag1HPKstz27PsoXp2nRKF+Lr7UFxGUMNlAxIP\ntZTAdrn/+026wDSf1MZHOlIx5L87yQfrUz93QmIkF1eqrgnOO1uc2Vfp+Fi5\nGlpgZschXo22v/fXjfM1+qHdlSbc92ZjUBKhu7qWUV00tFhqxkExhFj7i5dr\nzcb8EHMqfHlfrwhCIG3TBjVJBOwpl6SvTE5o8So7AutpJU4dfg4Dp9AGC+mh\n3sp3hMTtwpK3XNAIGHP+/tPn1S0jXCbiitjvsEv+S/kcx0QakSx09YkUkA8Z\nfegWmqthuT8w3N99VVY2H9kK3Ci6TRAzqUPqGR8Q6jDRp5GiOQtqEw1lTxTv\nvT+lpOrpS7ND4lmmkHpILBzMzBrGc7xt5pWVrn/IEQ7cN3TCFgiChJybIJh9\nedJE\r\n=PcuT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.2_1533148497739_0.4948117273541661"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.3": {
+      "name": "follow-redirects",
+      "version": "1.5.3",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "20c5169d1a6dc76ab78c69ccd78d2d884cd16a27",
+      "_id": "follow-redirects@1.5.3",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Q19GwKpz/zVkwVzbEkICtentX0NKcCix7g1l3vNewCLZ6KwGAU7bdJEQEZb9NN0D9kapySzQPMrOuj6rvrLXnQ==",
+        "shasum": "ba150caf15e2f0b30c789993be9b912db553855b",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19146,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbcWhVCRA9TVsSAnZWagAAKNsP/iXcKhxuZgTu7/e1Eozm\nyhhM5uZzrEsiGhv2e8K9ZRjpldwvKJ6kUMn+MMJx7ZtioK378IBSereCBGuu\nHv04XJC42RZjEeBqu8CkP1NBM4wQgap9sm8cmTol1zzx2G7sNY//ekfbJ5mz\n4c8eKqC3De3LmGv/hdC9sdWWDyKET/52nhyGcbQDYAlT9dSpmGOHI8m9MkZJ\nhGUjip1vVqBxndrc47b7AOvcTS+fcyd2yUskxK8wq0nDfT6vJ38pcXOjIj7N\n62etsAg7KE/gfEED+vqU5MCBh/D4NuM4JEJggdVnUUo+gEkyh3R0ii/xvtju\nujU3CPY7sWL0uTIv9I5nkUQijnxwau45qsxGINXuvTiCFc7c9ILS/8DRoW0C\n34Ck2YYhMi9EkDvh60A4CAxvWyOWcIM3vpQchjd6uM7kCtF/4MeWqbDhB9Ok\nPbf3uXNC1t2CbNxPaQAZ/u0DpUXzU/eUKygcxh7i6tK0L0XN4sTTF30fJv8B\nY19O6/KJDqRqqrJYUt7qYLD006THwx3/lnBzt6pdsFNmZT3CgaGe/W2+fCDO\nE5qGr4mKlvyTUUztXbsLXXSn0j1EsFrVZoe4UiocAt3vwkBMfAU040x77xPd\nZVmC6c+txQXcUnx71cnKamp/dEri8Bm9M/iSj9RcUYm4nOWxK0Mik7zD5qMN\nE2kz\r\n=v4+N\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.3_1534158932609_0.26887812892104646"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.4": {
+      "name": "follow-redirects",
+      "version": "1.5.4",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "6dc19f9f17e087c979c44d91215c445dd34d8a20",
+      "_id": "follow-redirects@1.5.4",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-qGsq5ExgV2z6YTV2mkqemjo6sy6BaXWwKlNYSmpvBONGdFDcpML0ieQ7iQDDlu82JrMTmft4zrpSFfS8PIPoHA==",
+        "shasum": "86d1bb946f24cb988d660aaa2ca2478c0772ead1",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.4.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19148,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbcYUPCRA9TVsSAnZWagAAoPMP/ROCKpdJmF1Ml1wQloU1\n/97jDpo+EpL8l6wRZjTbFaGbNT5Wn5dK1wbnhEoWt8lTc19kvCOAWktSf2Hx\njel+Ci1jOfDxavFrOaYadQs8iHLL0jFVeXzKh62V2ocme3474LIhLqIgD4YQ\nJ0qtAIdlhe3AQQf0lRUjDITHjYixd2OUUIAOpk51gt975SRQam37tIUNAC3x\nZkaKm7aiiCpzzS5fR/cI2+Cx7kboExrFqmi7GUY+aPtmpWn9rTdD2kKpFFUU\ng1uSUTza34ytYltu9TvNXiHOH3yFpl1eG/o6XJikf/d3ds0jwr9lV6glvel/\nHqSp1Nlu06YjlddML++i/osnNkPzdHhnvvWQKtMI9ls+bXcYHWpEApO49Wnp\nasCtK4t0HWyNJJnGri8+gr4PVIU3uykAyM1JKAFl4b1qnPkg1KOsxRRbx5VA\nwBLtoN/CZukQGga5co01/OiENJssfp6NS0yUMYMni0Myi5k99B6JSZUaG8fi\n4VtrLR657NnZ/Fcu1D5csqR0fjFFrWaxZT32w6shra58VqWtubgEWnXAdy/R\nwjIJON5aETNTciEAmGzqRxz1bNHMjUCpeNIx+UXbnhAEVvm23GkjRrsRZ0FY\nD0XeX8a0XkxJX+tgfF7X39GqKf2XzRvTgFYejPM2khAL7nWJuMkOtprIc9YQ\nxYFu\r\n=0WBo\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.4_1534166286574_0.17784307842570124"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.5": {
+      "name": "follow-redirects",
+      "version": "1.5.5",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "de80dec9d8e7a1d99a242e357e653039b96bae9e",
+      "_id": "follow-redirects@1.5.5",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-GHjtHDlY/ehslqv0Gr5N0PUJppgg/q0rOBvX0na1s7y1A3LWxPqCYU76s3Z1bM4+UZB4QF0usaXLT5wFpof5PA==",
+        "shasum": "3c143ca599a2e22e62876687d68b23d55bad788b",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19125,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbccemCRA9TVsSAnZWagAAtCEP/A4f3eHwGBSRl6Th3xx1\nwKeTmf6qczJkIWGE7iw9L3DE1B6sGW8ttCn6Qj/AQVWGDcWtYP32az2Kso4z\neJ5Jckbx8hHXVtJLEEHMJk7kymPHXHQenhBoe6u5cpdqcgDzILcHWFQ9mGcl\nVVMqMEzc7uuVvY6akf4vxmLAn+lOGqwlQz/cql8jpOVP0CuIFhFF//VRS0vL\nv3yxF+1CjKv4DX2zapo6H/KmbMMPs//7ofNbg87qR8DGT3BCY9XO6sU8Ze46\nn8/jDcYLmF6vjzMjJwP7qmeoX5PpK/CmGy8KJt+EEfFNi3KF63FGteUBJ7NP\nw8fquRpeDTHTOQRnTDCyvYM4kKqlZK1IrqoFzo5DNh6RBUWLNR/Abie/Vbke\nqvq5njsSghqLvJoTwgvMyxj+Bh54m5FQWw4xvh93uF8SsmFOGukvut21BbuC\nGD5QAWghlv2CcKk3i2UE86z1iCnVuWCTNwmhJHIoX98XKNnDGRbB/iAETe7Q\nYsCoZOLRgCrM9ZR892A5OHSGo8w0PqI7cVPYSGsVALUlc39CVCJXDONJVVvp\nm4Hjp+SEWpwXAA03JO8RLMTnzFs/pyRKx44PrUcCMBziNO495bc68qpGoiAs\npt9LainlBMUzdrqxk9ELIWgeR1ew96AddAcBV0e3tWGlSBq8JPO/mgeAAbhN\n6PVf\r\n=A7dn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.5_1534183334213_0.1548457281029405"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.6": {
+      "name": "follow-redirects",
+      "version": "1.5.6",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "7d4a56aa9d33dc91895f75ada95d725b6ab98083",
+      "_id": "follow-redirects@1.5.6",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-xay/eYZGgdpb3rpugZj1HunNaPcqc6fud/RW7LNEQntvKzuRO4DDLL+MnJIbTHh6t3Kda3v2RvhY2doxUddnig==",
+        "shasum": "44eb4fe1981dff25e2bd86b7d4033abcdb81e965",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.6.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19237,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbe26UCRA9TVsSAnZWagAA/OgQAITs7BjctCy1nPMbBS/a\nekq3MPD9/qd5I7q34MIC7x1ryS1VJRhB5bcUew7xham6tzgX5kb4kzSs7S0T\nOCnydQUxmkHqJ2ArVek0GL1BoAcv1aukzGBUsA0DfM8glWDezF0l2ovBGsSa\nd8VcoxsU3Ez4mxY57bWzJWo25JxhfHsEByFv0Q6NLrRmetA6onzTvUyqmRQw\nhG07wzvjPWTSMEMdQM9OPAYd6Kj3U/AoPw8mnF5gurBCZx+raoC3knbRzW7o\nUzRjyo5x+nTLIK/5VR2UuZACaD4KxZLP+K0x94vZu/pwkQcsqJ0vNHQfTsdX\nu7BweUZrG0tPqtyw6JIBhW7CCxs7GoUlNiBnCP/ssrZEOlVuFCAKPyzQ1+sf\nd93p9eHBxTAd05b59uKqWrWTCIRSwoEt6C3EXKdkfB+LNyVahwsCx3jL+wMN\nMnHtdQ8K0ypa/6AsopMEYNgFNbgYdiknkCtVQW52B+uG71Ej+PTpqJ5e/J8R\nOP0xUoiczr4fP4LxHSJmP4ZmQexSnkv9dmkoMk7dGyWl/RJWT9KfAfGqXNnV\nq0swteE4yEy6LSV64y6thouq5UTSdGboTNxuP1OyFA/8RJDwCmC2zUG5+T7A\nvytO94UmDI15jAT76mppeeTAl0hzOq8LOLJOWk/NZ8e5orhVJA5RVoJyBXnc\nktQI\r\n=u2AQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.6_1534815892063_0.5635425139833941"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.7": {
+      "name": "follow-redirects",
+      "version": "1.5.7",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "files": [
+        "index.js",
+        "create.js",
+        "http.js",
+        "https.js"
+      ],
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "7fd6bf3a56cd1632d2171d7e11d3386e1bccb949",
+      "_id": "follow-redirects@1.5.7",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+        "shasum": "a39e4804dacb90202bca76a9e2ac10433ca6a69a",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19548,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfaVBCRA9TVsSAnZWagAAFGwP+QBVZLosWW0bEwyhgXka\n64JvK0X82Gz218ZTzxYzkXPVYtoCZm+gLAppdaAKS+xemhvw7UFYoYSopVb4\nLF4ZL7JCTz7pyn1sDuWHnqfd/xNqUPYfHF0ylE03tjEfSJREM/9q2tnt9ruJ\nfE1hsFa3GGuUNsjbntMwhJ+o/3kiXr6dZqTStsOg9W2oWd/vzP5cxWCX3RxK\nSVISYcSZrVu8e2vYBhtedEcHjIC2PVUufEmHrcOQ8DPvpliOT/L4HQbXwrfA\nQx6ElABUSyD/U4JvV5799sdV/JTxJ1HKMTqKNqeeO0j3D8HeAB95ykqI1zwD\nUocEz4mSPNDIiKYr1wcP6B0rs7i/pqbSj8v9mlu3385ziMV2sVJJ7zfJj0Q5\ncUE59dbDusFxe6QSaliPbfq3kjwgLiiFI3fVTEXDnwZJ3y9gDgripyHpx9St\n9CrkNTe/vT90tnXb3Ak8C+exNC/yZcfFd1rXz29Akk6uRHQQR4536bEL/kb9\nQ00ozRuZWJDXev8PZRnO0R/PLR+NP4+ZxH4l3nkF+RVtJXOzn9D7IMw0MV1Y\nOoQwyxDdokTbgvNSlnEfJa3jWxJ0aYrJTnCnnIF9dyUpvizFNGFROifuImgH\n6K7dxHQtH4B//2EvWghOB51u66FS7UglRTRArpJ16h9CrTETx+2I7Y3q8yNK\nhY3M\r\n=G3OF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.7_1534960961042_0.010777989922793552"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.8": {
+      "name": "follow-redirects",
+      "version": "1.5.8",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "0a75768c122cf693dddfa85fd218f35c29bfe81e",
+      "_id": "follow-redirects@1.5.8",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben.verborgh@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
+        "shasum": "1dbfe13e45ad969f813e86c00e5296f525c885a1",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19548,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbmBa/CRA9TVsSAnZWagAAuTsP/1UQNUc2CA5UKKrSLI5E\nStiPsQXJI5nmVuNOyTHxFb6bWzRa4rXlLxJ/NkPyGXl6Vc+DMof1h9AU0vRX\nZwpSP4wp/kB49/ZS8+t/0GZ4QSoJlhtOpubL7XyHGsssMjEsMcTBWKQc8MbL\nUobJnJapu3ryyuj2sBh0UwZAaUBL0PsTCtoDWzj5um5sdsU/2wFjKMVUFBl7\n6DQolXWUFcUAnwFC9UnPMxKIPuVIreksVTpx6SW6l26OSEmAm3AWKEmD/mbD\nIHiIUowJ8VSwSRaOCRUKSwfrFp494nIJESDZAU8yMB7m4krN4+l51I80jZeO\no33NpB3NBBWz+Tfj5ST+vIz3U92FaMZop4Q4qSXR3fXXg3iaAB9DsNRvMlIz\nbDQYRCWSBpnvOBzPwDVPZmKexQM6UpQphlLTTXu4qtuVHG8byc3z5oWY8MFw\nlgqh1PGXjXmwhtFSnd2cXd1voUK1Ljrzp4ei356uScjE/8kzNr9shgPz5y7W\nJNqlsmnTaS7LWdVFKcxbbFY53mxxEh6Rx0CuH6v963IDOWWBpyyIOi2PO2em\nbS52oglk/h3NBiP55hdDQ+dsj28h2Dw3Na8LIyDQvO0vhbSiuKEKNxRC40SP\nYCtpuhXluvtYeEvlFzWcQaUNLa1w0wZ1cERWaq5PeilVA3sS57Ib9RXZcd4k\n3pAC\r\n=JSYr\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.8_1536693950574_0.5199163289035582"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.9": {
+      "name": "follow-redirects",
+      "version": "1.5.9",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/olalonde/follow-redirects.git"
+      },
+      "homepage": "https://github.com/olalonde/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/olalonde/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Olivier Lalonde",
+        "email": "olalonde@gmail.com",
+        "url": "http://www.syskall.com"
+      },
+      "contributors": [
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        },
+        {
+          "name": "Ruben Verborgh",
+          "email": "ruben@verborgh.org",
+          "url": "https://ruben.verborgh.org/"
+        }
+      ],
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "90a52f7c9bc084c20ae167d7fcd0ede4770f582e",
+      "_id": "follow-redirects@1.5.9",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "dist": {
+        "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+        "shasum": "c9ed9d748b814a39535716e531b9196a845d89c6",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19522,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbvNDqCRA9TVsSAnZWagAAvKkP/j2g9UU23tkeBbnBBcDU\nfk0cBX6C+0D6Jo4FFXLr6ZBCZ77yHwZLHcbWGcHJzGaBDRG71aQC9DpoEMXq\nPeBGtp1Ag8tS1uC8SgCq1jYKqv3J84NzkpnKpzPA7PWcU6uG9erGjcRKenpB\nyWnF8EUTNLFA52WBhfE+lzn5yNx2nEpdxV55uYAwTyMZkub8edh/l48EwG9U\nH1XsySLz7MsEXr+1zsKl9MwsW6Z/ukFXFSZhiIJVM5ygq56AMiN57644uEbQ\ntXet7FNj+JafBXSuQnqrhatWnqu6oCxuuNYGpYiYjqbE53ExF3UHHRaHFMpY\n/IUbGUg3NsfGxgpBw9NGrai80eFhXr+m48dpWHGD3RjBRRVsbkjM1klxLo00\n7/o/nFGckmmf5w6GO0ev960QNoVJuDhDeM7Z5aDloEmazfUA6SvsoIHSCxEf\njxYh5RfnuNq5f8neqgvxp4TZ4WIzwHt9qL17YYAj4yqFEAZAfceZ3rrL4dcJ\nXmrEistf5DAiChl92vmUMT+hGpFUrUbk8cQ/DM4w0+Gk3Ikkn3J5fPBEHiBl\nE9HQNzkDrPzGTgnH+rRPw+lO5CDBMS6RZ/uoiQI+dDETUKtLg9+uCsfIaGBN\ntXtlW4EvzTLAASofbQheIOmg188y6vg4R4iNB0vDeM576QWpV1Jn9MSw6BEO\npP1Y\r\n=Zxsh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.9_1539100905320_0.008006507326728585"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.10": {
+      "name": "follow-redirects",
+      "version": "1.5.10",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.2",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "91842752013b26ed780f7b04e557c72f02228cde",
+      "_id": "follow-redirects@1.5.10",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "dist": {
+        "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+        "shasum": "7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19800,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb8ypeCRA9TVsSAnZWagAAR7AP/RwuZoZJOzKWB2RcWOk6\n+U2yuf3DRHCEEZuaynkOZTBc5B+xIpYFkDWgO+3lFQ8mTFVRfl9b87vJ4tQ2\npXeYcbWvt79hB+K4jh2VavKxsA3zByh4o0AVOWoaSn5qzull6Z4n9InAe2hN\ned5R3PZpMqY4YXuWMtHCLn+NJePGnFyEY2ESP0Ehs4DKDypj02HO3s9qCuqO\nlhSw9VmpQ+imJMge8o7EyvwfZaWEmb0ERaL1thLUOY2trHDKVO85JXla4h38\nM4oOc1g7o3yc0rVT8vZk9C56lkTQgULBIKc5HXUHjOkTO7wfbR+vq+cuUMaq\nBqyQb2qsy54nPC8EK6C36nIKXIy2F0UvARc1x/302XQkCjNajEIoPtX3vouo\nU3MIg8UKm0jJxjf6/PAgeDN4rtHaDUgK3N3YMzvhcIU/H+Bz00rEyn0GMCTM\npi6zo6aa3VXjyFP2+vQghXax6PYcbyec2/cBuUk9KZOfORvJ5gmvCkbLWWZC\nQUapjl2+4sWA2j1kT+m8JkUo969yiayjmKeI4zP0jLPFwZ0IPcN1+/ekMnD0\nAtwF0k7RPz06GrdleYaKk/+3+88ViuEkfH0tBomMIgSZ7Zui0SsPS6ToQcxK\nPHjOCKAFOcYs10ZFhfhgV/wF8LR16rIRwXnlYREKQE6YuAMvhNN5UyLEqwNE\nqVU1\r\n=Xtc4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.5.10_1542662749815_0.6076235029881887"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.0": {
+      "name": "follow-redirects",
+      "version": "1.6.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.2",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "10476676a84c9f1e44b93e4ca28a1dbf7145e673",
+      "_id": "follow-redirects@1.6.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.14.2",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "dist": {
+        "integrity": "sha512-4Oh4eI3S9OueVV41AgJ1oLjpaJUhbJ7JDGOMhe0AFqoSejl5Q2nn3eGglAzRUKVKZE8jG5MNn66TjCJMAnpsWA==",
+        "shasum": "d12452c031e8c67eb6637d861bfc7a8090167933",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21984,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcIq7WCRA9TVsSAnZWagAAuNEQAJWykCTynA9/C+60/9m/\n60s8Un+AfmRb/EDi0juPUuJZZQ0W1/RQfN3oCBpx8vMMjuztK/zUuLa5wLI/\nsX0Eaa2dG9TEFqEKWoQvhXv5mP33uEoa25yYtku64usRPXV6cw/1oggBKKlA\npsYNr0TZz34baoTN+oT9A0FpsByRA+Tn+HGtzRXY6J55DxZAbWoJAS5jTIOF\nwGvYKFPj+UIG1E0o8QiepgslMM6D2P/Xx4AFN25E8uMcF4mEkIRS979UIyTl\n4oCJch98KgwOqcb4ZiKO/bDXdXig1S8YUwoPAK88unGATIgitLLQtpYNspWN\nx9TJen67V8askFhyDng9a3dWfHtYTi3RDORCx4j216MD9jHGPetArQaYi0aZ\nUTLvuYtVqHvwHPZ8UYzmuMxyPhMTZEPhRTbtpgAkCRBMhrWy+gaz6nkWU2aW\nqp80LHIIdjtCDtR9IWEnRmX+JMJx2s/0N+hMGqXTXpDs0M2HxKkF9n3wPXVI\nlprD0dPuMNY1gR9cunSzbl+AF5AH4xif5QVdHGoSkichuhVFUZNub9O36sTA\nc6Vw7FIVLF6fcAIk0SM/VLMq4G956rWiFcnhChrmvXjMqlEnmZWL9UrP1gwh\n4dMwM0hcd6313x0PgiIWfGCFFP/2gAceHD6rsGpy1nv/VRhBYKHkujNrAoWO\nMaEu\r\n=8Rks\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.6.0_1545776853871_0.9355239754490214"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.1": {
+      "name": "follow-redirects",
+      "version": "1.6.1",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.2",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "0cbcaac65e5c0fdff425af75939d0e92f54cfe73",
+      "_id": "follow-redirects@1.6.1",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.2",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "dist": {
+        "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+        "shasum": "514973c44b5757368bad8bddfe52f81f015c94cb",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20845,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcLeLrCRA9TVsSAnZWagAA7GsQAJGbHWOu1A2HhmqPwWGG\n0xWiMBnggNuxljneb+J4JXp+2gPrC6ZRnWoGijY4yu/d5zv9Z4Yjt1/7MgfA\n7sbJ110OIyinX99qEbB75R9xho4kmm6eLfZX9xjMiK2uNcMCtdUiZMUhE5dy\nRYZDT7SW+/9JAnqWo2FyyR1aC/ypZWSVZ4p6kSLR4tL841urFyk3WmZzsHQT\n9+FAkmSlSkzGHfiDitzh6nHmncztCXZ0abClV2q0/BdYaGkwlJUO0F2uagBF\nhDIyiQnIhiN8/8IRJDozlr/an5PM3RTZs3S29/RoeLnURpTkWw0Hk0XN6ZVH\nf/YvuW5sHGwJU36pz6OnfJeLWUcRcxr8EDQJBqAaGqZURr9f9Rsv4/r/D0l2\nR52pOQSbOxwngYVITDGmXPkYwH/ZEjNtiZZW2RVuJx1joIzNOE7s93Mvu79i\n9WPjcc0KXhK7ANaNE77ZqB5v1fIps050vlaYPVnbr5n+4hNYvaZf1Ib4cTTW\nUJN5p3NfsMxnQOVD26Sgs/QtfV3BVC6xTJDyS398RWDauWXZMv5r+LSLHJYy\noiAw6YKYcjpv8Dk4kl3Z8BAEwHVr4ftKIPfu7fGSGbXqvh+9dKHeFIaUdQGE\nVYJirggQPnUammloIB4cH7ZGKgv2QtfEy5CeunhQk9ZEGVMZDhvpaYb/Ed2e\nTg8m\r\n=2SpE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.6.1_1546511083043_0.9607381997588877"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.0": {
+      "name": "follow-redirects",
+      "version": "1.7.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.2.6"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.2",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "lolex": "^3.0.0",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "301e0b45122faeb8fad8b887b6c73ef36538d628",
+      "_id": "follow-redirects@1.7.0",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.2",
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "dist": {
+        "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+        "shasum": "489ebc198dc0e7f64167bd23b03c4c19b5784c76",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21525,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcZI7aCRA9TVsSAnZWagAA4wYP/i0UEluhn6QsNUW7FsQC\nV6csdzuDsSeSgskqm/CI6rqTxpXxSMUMG4GtFfnynrAEYz2dwa+KNonZOvhc\nP0DRvRJerUwyblF6deVA9cYDNj8WSE1ftOjQp6X7r5LW4jud+vTM+tCYFvIo\nbJW1IaTunyz1HNemveYSwC8W/qeCuDY7UlLOoz7IWypivuLZSwjKfcL7BVjO\nVwn77IivSNNLSbDtcmXIiR6zGVBSkY9JMXPM4bBC5kJytWO5QwE6OzGY0xNq\nTDnBh0hHNRw3RkcIotM/U0YVais8HuaDr2WO7/N3pGfqtLVHT92hxZtIcnSu\nDJFzs8ptzBB5jzx2/uD6wpXq9+fNxc/EcbeH9GFNBxMA9Ks4rT2VdbjJnkFu\npWfAwaYKcCTz0CRffkeN64Py4NDiwQ0MuNYlKlGthTzz08f3c7Z/DssV+ffD\neVrZ8C0Z400+dsMdvGH74DKw+8qYaVXZ++Yaxc8PoG+mKnW49IAa5nN7huL5\nvNNFGES6lVnOtHPSJpdUK9MAJGr8L1PTBqZYr8ALVcUkHeKzb/3Z3Z8NfE/i\nCUdxcsCoP+C52bmESwhJIN3SLSuMb4Nbx+/s3f0zx+gZ2HieGQicYyRybBEj\nkkzparnDuGJ+63+IWc4rbEv0vD7iw8EX5SazL+/DDAH0X9jsU6gkZYIVc6SK\neyjn\r\n=xy7d\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.7.0_1550094042182_0.6861824070554166"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.8.0": {
+      "name": "follow-redirects",
+      "version": "1.8.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "main": "index.js",
+      "engines": {
+        "node": ">=6.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.1.1"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "coveralls": "^3.0.3",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "license": "MIT",
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text"
+        ]
+      },
+      "gitHead": "b7a8216d3014dd82a605bd36e8756cd40936878c",
+      "_id": "follow-redirects@1.8.0",
+      "_nodeVersion": "10.14.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-eYyazyi+vwXZ6LfSQicvqFwaNEF5xTvnB/rpzRLuqwK45u7WbBEnQ/dDic66KD/A8IzTXFlj2ROAcaP0f2v4lg==",
+        "shasum": "dcf34930bcfdb6c1eb22b8eb7c457ec95a3dcf40",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22157,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZQ+vCRA9TVsSAnZWagAAwA4P/iVHFFfoYSdGJ2tiqvXX\njtykXmGCqIgwK1pZ6tjotSJSVDT9VZNFIVZCuIcPIjGB/TbH7kWCF2bpvBnt\nfp3Z3BW9+NGv7/zBSymQWSzYapB881VWf6O1Nuz5t1T8BH9TNb56R9L1ooVO\nZQYUOKB3hw3EyhQRQWl4InUzSpNwh2oLr4l4TotHx6/AUEq29DPp8BxoXe4F\nV9IOWW+ViVphXnDtHSi8zulHKv9ZwnoknbkSnD+8PKFMyEpDYM2VXqb2Oxsn\nYkxp9OSCZioJtafzzOWfow4Fo3R7+E7IWlTBlhXr+QzVOYPS9eg2QXgY/nPr\nwokYdQIMeEYOy906Xe8QoRiOJgcqWutcPivFPeodp6gAzNUsIAKm1qAeNNPM\nMhj7Lml3i5eTa5zuIGAZEIwhHaNqAyPB8seaih140jIarPxhTzSN2vCqCgmN\nmLyMki9CM+v0jiljxrtdBrj1X8DZEMMOYTKk81cdpc/EFhgns1MG315lZm97\nMIYNbPU18IdYTy7T7iSdlTdVOufwUiDmaayZDPQlINb53TgA8+Huck7gaTGs\nPSArjdXVkpVvDDcuo7QEX19tSq18hc/kgVWFndkmZ+v5WZyv/kskh7GA8qZZ\nNlcRxdW2K0CPGHOCSAl1hLaj2gmWXEwejm9wn0zskSq8sbm5T50iLxTjNK6W\negO/\r\n=HCb6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.8.0_1566904239145_0.5933962124783387"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.8.1": {
+      "name": "follow-redirects",
+      "version": "1.8.1",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "gitHead": "5e38b2279e21086952aaa8590e0d83adf9c028f9",
+      "_id": "follow-redirects@1.8.1",
+      "_nodeVersion": "10.14.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
+        "shasum": "24804f9eaab67160b0e840c085885d606371a35b",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22063,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZWpxCRA9TVsSAnZWagAA8CkQAInJyjtAmvR/Jmc2H4m+\n+GLuWGtxQXAh5jAVfLFVBOYAogY5OGqNQvkKLWYuPOp5Q5c5WYQYnXz3uifI\n647JAXSjFOIEIDDHi3qWGvQbA8NlT+XoHRICocGk3/ogir4x7KMx1L0UZ2Yj\nwSw5zdJB9iP4LoGMuOx7/06mgv9Pox9QOruKM4tXqAaraPyTRAAw4qf30kq5\neRAKGujNeaoeOaCqHym9mB2p20dq9VvRWm56QDC/lIzuDip26XjbduQZABjM\nOiyI0NB54FjT9v91q6ZgIqSIwSuU4/MKoBDymvr95/DaQgiEcW3P3IhTHzyv\nGQ0CNEF+ruPBbw6DhiBhWB38Tv7LvAvSIb7d6xOuhrYIFLYPfkIZIfSNsigZ\nZPxILHiPShHQd1rJUZoeu0Ek2PVRuL8znnXsIj/B32ZjN11gRii2NfWZBILq\n5cK8YTBfnCXbUhpiBhAjfr93P/CGZ5oJSBaZCG30XvAn2WU5AUw93jwen7HQ\nyPnvUSR76UYdMQalugCyn9oE6fq150XFQMI9rNNN1GfxeTEPTcefvAG2rrtK\naakpIfkcNIZRPvntKM5KDeB90ah1KhNTVosZ3mPk89mXJC7rXCls4cOh+wxq\ntXQ7G/pLy+qrzkhlCyh0r++UHtM3i5dh+bEcIebnD85GeqL+YI6S+37uAEAY\npOoq\r\n=SrNP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.8.1_1566927473228_0.8108710547104683"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.9.0": {
+      "name": "follow-redirects",
+      "version": "1.9.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "gitHead": "2215c54e527663cf39b2c4e8c6dd862207390824",
+      "_id": "follow-redirects@1.9.0",
+      "_nodeVersion": "10.14.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+        "shasum": "8d5bcdc65b7108fe1508649c79c12d732dcedb4f",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22100,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdclssCRA9TVsSAnZWagAAz9IP/2MzQdIJBkQMV2fMW8eX\nejrm9NKiRDWy5iHHlMNP4Ab5Q/L6EoWQfIey+tsvVXdeKg4yX3CmrGHAD2YU\nRPDD2m/D+9ODwl6DkA1eJgB/CeFqOuPXLdAO996N/HNJraF1D13X7eakNr0X\n46Q2l4fXatrHbFnjCAQXDbn7Xc27wgqBYWz0QPFhllQU025/vnk9p0mpgb3F\noUaSiK0YyHpWTlFHTI9Q4T4JzLn4UOtrWKAII3OcfxDcoKvM7HHaBT+Pm4aF\nQrx8MrC/KWgARmN3b//Na4qdjvVSigiXfG2jyVXx+KrryHCmN987439BsvYP\nwM172NFHOav+GCL5pCvNnrLVmtyO75TKpd5yPS4usNiOlZYl8lVrJGBo7e4W\ng2p60W6ihMfVBNFagXK1B6MXFi8ukgXFk+Y0M8peY2ZpA3PwBuE2RIf+fkYn\n74tghvFa15FZXO7Fm8G7sHHA1TNj4/6eehTXir3+P4TQwMCTt+WHJpbCcxfk\nCryarN58fnkYI6ErmFYZsiPmuqsuFE6ZG3XTXu7xq1oSmIJneByyc8QhZq2V\nGc0THH7minRYYN9QAFYNDPORBdHAgwyFctICpNFt3rqFVK4eryLqbMJKqwSR\nLgVuqL2uWOd4K3zxeLYsqmDp5Ww8SdITJFtVXkyJfK5T4dSwtiMyQwpgJTfk\neWy5\r\n=NYvs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.9.0_1567775532196_0.9615187287965778"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.9.1": {
+      "name": "follow-redirects",
+      "version": "1.9.1",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "gitHead": "9df47ad6d7aa4c54fe293ce5ef9637650ce9c460",
+      "_id": "follow-redirects@1.9.1",
+      "_nodeVersion": "12.14.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-oUNbrdUjHItyCytZQrHxWQ81ebL4xCFLH10sG0poUMgbKWoBnswpICjUBld3PLJ1lF6cCYVUBG7hAdLro0JNvg==",
+        "shasum": "26e329669886f8b3baccbaf352067b0253da6c2d",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22322,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeLNU7CRA9TVsSAnZWagAA9OwP/0q/xlzGdXLvctnmG22L\njYFGGcAzMS04Jve+FmofdtUKQG5YVyQTjJsy1Te8mJkggc0GYHmxcpQFSOEp\n6WxT1jjc0aQd1utL8T0hANlEvtPYcqV2o6vn14GQwOgbbcAc3FhjAeK96+Wl\nsgk51vwTlVXqoI1VUrq8ckxzzs4zGI2LaHINtIeMF5fBvRH/FkHZMdw1eUMs\niJhP5ydEBNBXSj/aD8d5SybbwW3Dsj2/ighXIIjck9ssoWBTVf6UtxeJR9P7\nGF1Np2W0psLbGfMQKE1k3XS+UTOhFAkXrLT70pL9YzcZskvGOlzws6aN6BSB\nVDSitmNmiSav6b2aQvosG0aH0K/PFD+wetCwo42K3AlTP8jIwZUKiHmPenJs\nezE8hpJ8kHra73GAzsAkQ5r5P/2Ic7rrzJxElLkgXOwK3ld4bEK3StsmSJwO\n7gCNGFSGXHk2if7cK5lwA430rRmgAdp23EBIGg1qanko/BaiuhjXvEo1gYnp\n5SSwy7cHdzG1t6AYBhiic0TZADNDifZB+pHd4dCZjxibY9fHHg6Q88acbiKr\nkDzJQWZ4yGkZp1+3Vg1WlnQxRn4BfRu63ux7zm0D24Gk1GkKu6af80uz3/Um\nrbxTIhaObp0FaD8eQsk+uaMAIyeOACqpaKrzngTmeS9utLygkr3DPYYJayXw\np3Ym\r\n=bIRS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.9.1_1579996474755_0.05050984072533149"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.10.0": {
+      "name": "follow-redirects",
+      "version": "1.10.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "gitHead": "670c3a7b38e0707a22d111fa766b4e82d277ec41",
+      "_id": "follow-redirects@1.10.0",
+      "_nodeVersion": "12.14.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
+        "shasum": "01f5263aee921c6a54fb91667f08f4155ce169eb",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23170,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeLiJfCRA9TVsSAnZWagAAMCoQAKUGsAjNMrjM8v1P+Rrq\nCQkexRzO2E3kywImR9837V1NvO/qjrGs3B6fHcP4uvWi237W6pNNpi+9HC2J\nhwUO1AugHjdlGBmZ3xpjZLGgI0oy7Ws9UrHTAyHZcfY7B4YzuF8//P65W6LE\nW9JlqfIPIC8dYX2Y9fR+sqk3urlRSf0SyulYvOMeZYe2+/3PaiKG/JeGHY7T\nsfzi52wk7Y4sQ33VPWa03umgoRWlZ75KTQLcvLKtbR7upBAp1mbc7029PJPB\nPR05STVaOa8di3jvJP89pUs7V7I3yLoSdtKxPatoDPFsAZPWh7seQMJJjzfa\ndo8MdjA1DLNoR7sMUmYsu8dIVd1JHzGHH2HDnDrEZrsIKUQTQC7ovw4MyZ05\niNo/vRg7Pg7xYEqmYq/7YM4TERVWQzf/C2yo4Q2iQsER73FXW3zTglW1uA6g\n4eMgxPKf+6390oxrL8pBAONxM11WeRjJDt7Rrx23nfPCMkVky9vRPTUapsv0\nELVkb+NPTDs4wiEO0t6TQNFdClmSUwfVotSLD6Z79YagB1jrxLJ7zK0Ntz8m\nflaZCpG0SdLC/YFIX7pCc3K9AsZSeNkrt7ejuMTCxFAPXWGfPerSGbEuv/8X\nLBApiH7cvjha+qG1shEA+unjAr6/l5PHX8/bFFDYzI9X3HHxv5UJf/7uXm7K\nKiJk\r\n=0B6u\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.10.0_1580081759334_0.796661405877777"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.11.0": {
+      "name": "follow-redirects",
+      "version": "1.11.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "gitHead": "0de31a8a0afbb859eca1b522fb3306121ba7c0a4",
+      "_id": "follow-redirects@1.11.0",
+      "_nodeVersion": "12.14.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
+        "shasum": "afa14f08ba12a52963140fe43212658897bc0ecb",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23524,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJegH5gCRA9TVsSAnZWagAAnLMP/jR2M97OJB0tx9WA781R\n9n6DD/Ikjyi6coHArH6vMnqW0K4IK1Jsn29rR13M/uc/hZnn+Y/Y9d1lCBuy\n5hPm13ZCtbfNDaCqYMqSd6WGhzj/S/FDjjDHZKyoLlA5JxRpBszwNL6c78SZ\ntYJJMMRAOfZo4apotVG+fvpq1eZ/qw3Vrxsrihzc6v9Xd9RAdLsOh7345RKN\nAJEfm1XcQl54HaRv8jrrLtb1ESHjIeMWcLYS8tI0koCvS8eO1Jf2Hl0Bonrz\n8QDd9YfIS/5qRRXpubKvZ21yKFJ8rWRCJRgjvCSn1DM3fbp66XvjESh61lHN\nLxeIjsMdwv1vGumyJJtcej8DjGfwsBUAcMlrqMo1fpwGJq5u2Zw2TMAGeVK1\nu9myTSynjp/fpv2smZvE7taiYb2Ws01HRadc1CxiRcxHU+UV9SwLKAWaPGIq\n50uF0VfXswFecMY8Mblh5BudCpejf5KBpHKt6Fr3boQFj5jqXlZoGZkSwJea\npZhT14ELTkFqQ4I9EE1wyI8smtXfVVKrpZSoJWuKZDg8TLYf9EHZvu5zcBnT\nHoyhM1SUy6B0AowPDmWBJ92W2d10PcuWFoKFb4bEyzpfYSHaJGoeBiYvboDc\nFBlnbCiamAASn+RzwGu/u+NkxodQUOI1UavxfVCq4qoctRzMK3qU9aJTSVGM\nA+64\r\n=Qy8M\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.11.0_1585479263559_0.7488129880046406"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.12.0": {
+      "name": "follow-redirects",
+      "version": "1.12.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "peerDependencies": {
+        "debug": "^3.0.0 || ^4.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "gitHead": "89fc462674c9a1b88262f1b7d0e828f4ced1b890",
+      "_id": "follow-redirects@1.12.0",
+      "_nodeVersion": "14.2.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+        "shasum": "ff0ccf85cf2c867c481957683b5f91b75b25e240",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 23697,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe6S2GCRA9TVsSAnZWagAAfPgP/1NdDvODI9cnOFEXtzyJ\nRFtpkrpuWSpZWxnv7nyQBuPiXJRLSOqtGaP1CfOJjL2uP9Tbf2ogZLnMA5oA\nz2Ie6pCh/U1p/bvxNNXRBAoSGOgzB1/2IZUTuR0/LK6Gt321uF8i/yQKmyug\nzGUKQjz3GONyheTfyhLrcy5PCZwfSADLyAILsFMuMI1AB4ifm/6Zp0oshQw+\nUuE0SiftQvVG0BVxS2vYS66fAMKktxc6DPvUbn6EKAfaM7Ggj48OqHu77TAD\nJEem8+dYZ9Q2+eY4UyiaZwS3+grO49oymzZ5he6XyRh+6BLclTs8FPlfb+da\nTatRA+ksV9AMVdr3vAoCnxu6I5QxXYnlsNgan1TOzm+edV4zXYwtg6MP+luk\nSD2VQJXi3q/IReADnqWtBfZ9GLHMlAEX9RHubzNsY7bL2F0M6qUSMSIfdHmW\neTTB2YgD5VIVH6HoM4GiI6vwcnupBLrI0wTuBUjswTIIHC3DXsZ+/l5bdKiD\nICcV2MURZ6P7I5HNtdkJVCgydIOY+4vw7y7QNmdyMvq+ALM+tjhAG0N1RvL2\nXaQzfCkG3DaGLEr4h/nfN7yU/NLdi7EDUyYT+vEV0owvoGXrSBoyVEAfVbwe\nGRXRw4RomjGZK5qrnJkOXugSm7zcapK0bz3Do5u96Pp+gLYHCBVy1ka3+vq0\nf8iI\r\n=7ygN\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.12.0_1592339846541_0.940755220987272"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.12.1": {
+      "name": "follow-redirects",
+      "version": "1.12.1",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "gitHead": "aa6ce01c8145b1f968031c663d9aa87a692cfca7",
+      "_id": "follow-redirects@1.12.1",
+      "_nodeVersion": "12.18.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==",
+        "shasum": "de54a6205311b93d60398ebc01cf7015682312b6",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 23900,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe6+ybCRA9TVsSAnZWagAAsAcP/1TfXM557wagSC8+bQ1K\n9rHGMRSLAFf7AI3mc6sWLgNPGnh8KiLph98mCy5u7RZmeHWEwNiN5WYcXKPD\ns/q5GnacO6uRdxbC69YwUvY5VljBpdAGqLn2rg85kRF/MkoWWGIe0OXI+eQm\nHZKTlVrRoYA2nOfMjNkws6/3pRSX1FHdgn/uihauW7Z/yHEMR4tt9hYsHtKt\nl9wLbBF+nEq85zSLesBWGyZnAo4JCSaHhRRuRYVON+YYYgi0JXtMgIw01K3k\nw2/DRCzs1gWBgwp2Xb/lIkfY530MQg6ChaC0V+YwSyLyH9l/KMho1qFoUTeL\n1gFPV9qd0+N/ZsjyFOX11HEcoj2cQNZqAkrUKNX0xPLKcwoKlI5B6zCIRvIm\n/3ETO3sFi4otJIzY86DwNWFku+0r9FNftKEiXLlTskh2omdX5Rm/f8CyAChU\nnXThZKYAS7/+miM8aY15WN/yYuxK0nFfNNCTDwMb5sgqTYWJ6jCoIHchxbIK\n2VHK5XT/aezSLmLEKVvmE4LqaaEONqhqnfBngx6fcCDHhPlo5oDDwWQGId/u\n5MlJI3V/YA8zDFhqR8L445Y6w/bMRFIBI7E2xvUij9AZ5MCN/qzZyUcaiGhW\n81gPvWFXoCP6KmAKKAk/FvRBPibk+YLp1sQNaDZlerVnuHpt9jjcDyB0aPmJ\n40A/\r\n=nX59\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.12.1_1592519834666_0.2575521981101132"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.13.0": {
+      "name": "follow-redirects",
+      "version": "1.13.0",
+      "description": "HTTP and HTTPS modules that follow redirects.",
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "npm run lint && npm run mocha",
+        "lint": "eslint *.js test",
+        "mocha": "nyc mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+      },
+      "homepage": "https://github.com/follow-redirects/follow-redirects",
+      "bugs": {
+        "url": "https://github.com/follow-redirects/follow-redirects/issues"
+      },
+      "keywords": [
+        "http",
+        "https",
+        "url",
+        "redirect",
+        "client",
+        "location",
+        "utility"
+      ],
+      "author": {
+        "name": "Ruben Verborgh",
+        "email": "ruben@verborgh.org",
+        "url": "https://ruben.verborgh.org/"
+      },
+      "contributors": [
+        {
+          "name": "Olivier Lalonde",
+          "email": "olalonde@gmail.com",
+          "url": "http://www.syskall.com"
+        },
+        {
+          "name": "James Talmage",
+          "email": "james@talmage.io"
+        }
+      ],
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "gitHead": "b2f2ea52edb4d5949751e2467d9e6d42ca24c8d0",
+      "_id": "follow-redirects@1.13.0",
+      "_nodeVersion": "12.18.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+        "shasum": "b42e8d93a2a7eea5ed88633676d6597bc8e384db",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 24066,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfMTJXCRA9TVsSAnZWagAAH+QP/RYg/ow5bVtgXIxGYoBT\n/mncbw9r192KpPWj/3C7vn3izLTf/GvWuU6DjETTYenRkpOF1QkjlRFyVDBJ\nEYrDlXmHL5AIdQRPQoRFXIRgdOx+bMjYFdeV4KVTqMq9Yh3vFFqho63oBnTP\nRo8iGZ8KGzF2ZVNXRwEnoGSANERPXKsoLKlvBMA0MAXtjQCgOpdzYlNv5h5j\nSXLwxZobsc/4piJWvRjdrITE45UYR5HnknUM90Pm73kVfg5kNdrPqLWUCJ1+\nO/Nf9lzFXrgO8j3fNLw+VB0i8gsAZZz4MOmn/AUUERx8c2mvU7g0R3c5NM4o\nbL+CSNutmz8Vtlu7wxXA7kCJKTPxHQmpfHlZR3B3pKH8nKqGw3lto6XdjWNn\nYZu+YzzJg7v5WVVp7BY54FnVgS+JHz5qog1YqG95IOeErAlA1JWupA7TZrdG\nmm6H5zVI3+qKMUwMUk8TDwpzrInbYbndEcOfgC5OIn7Fc7qxn48duwqcOCBE\nX3VmJJJWil6GP6QsL2DkMC8fEbFluXPeB8BNzxY1HfWWetTI708oYRBVqEQt\nhBqTgF/Px5EeA6BJ5cVg/swOnRYEQ8jL7Bx867bBsfzhE/hC8bmFu29AWXU5\nIM1yHtvey8jgaPVmbFzoWbW9cObfsqmdwIDNamtjhMGDrPeKEhb9CVDXaB4T\n0n4A\r\n=QqNW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "james@talmage.io",
+          "name": "jamestalmage"
+        },
+        {
+          "email": "olalonde@gmail.com",
+          "name": "olalonde"
+        },
+        {
+          "email": "ruben.verborgh@gmail.com",
+          "name": "rubenverborgh"
+        }
+      ],
+      "_npmUser": {
+        "name": "rubenverborgh",
+        "email": "ruben@verborgh.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/follow-redirects_1.13.0_1597059670652_0.3409890757494629"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "## Follow Redirects\n\nDrop-in replacement for Node's `http` and `https` modules that automatically follows redirects.\n\n[![npm version](https://img.shields.io/npm/v/follow-redirects.svg)](https://www.npmjs.com/package/follow-redirects)\n[![Build Status](https://travis-ci.org/follow-redirects/follow-redirects.svg?branch=master)](https://travis-ci.org/follow-redirects/follow-redirects)\n[![Coverage Status](https://coveralls.io/repos/follow-redirects/follow-redirects/badge.svg?branch=master)](https://coveralls.io/r/follow-redirects/follow-redirects?branch=master)\n[![npm downloads](https://img.shields.io/npm/dm/follow-redirects.svg)](https://www.npmjs.com/package/follow-redirects)\n[![Sponsor on GitHub](https://img.shields.io/static/v1?label=Sponsor&message=%F0%9F%92%96&logo=GitHub)](https://github.com/sponsors/RubenVerborgh)\n\n`follow-redirects` provides [request](https://nodejs.org/api/http.html#http_http_request_options_callback) and [get](https://nodejs.org/api/http.html#http_http_get_options_callback)\n methods that behave identically to those found on the native [http](https://nodejs.org/api/http.html#http_http_request_options_callback) and [https](https://nodejs.org/api/https.html#https_https_request_options_callback)\n modules, with the exception that they will seamlessly follow redirects.\n\n```javascript\nconst { http, https } = require('follow-redirects');\n\nhttp.get('http://bit.ly/900913', response => {\n  response.on('data', chunk => {\n    console.log(chunk);\n  });\n}).on('error', err => {\n  console.error(err);\n});\n```\n\nYou can inspect the final redirected URL through the `responseUrl` property on the `response`.\nIf no redirection happened, `responseUrl` is the original request URL.\n\n```javascript\nconst request = https.request({\n  host: 'bitly.com',\n  path: '/UHfDGO',\n}, response => {\n  console.log(response.responseUrl);\n  // 'http://duckduckgo.com/robots.txt'\n});\nrequest.end();\n```\n\n## Options\n### Global options\nGlobal options are set directly on the `follow-redirects` module:\n\n```javascript\nconst followRedirects = require('follow-redirects');\nfollowRedirects.maxRedirects = 10;\nfollowRedirects.maxBodyLength = 20 * 1024 * 1024; // 20 MB\n```\n\nThe following global options are supported:\n\n- `maxRedirects` (default: `21`) – sets the maximum number of allowed redirects; if exceeded, an error will be emitted.\n\n- `maxBodyLength` (default: 10MB) – sets the maximum size of the request body; if exceeded, an error will be emitted.\n\n### Per-request options\nPer-request options are set by passing an `options` object:\n\n```javascript\nconst url = require('url');\nconst { http, https } = require('follow-redirects');\n\nconst options = url.parse('http://bit.ly/900913');\noptions.maxRedirects = 10;\noptions.beforeRedirect = (options, { headers }) => {\n  // Use this to adjust the request options upon redirecting,\n  // to inspect the latest response headers,\n  // or to cancel the request by throwing an error\n  if (options.hostname === \"example.com\") {\n    options.auth = \"user:password\";\n  }\n};\nhttp.request(options);\n```\n\nIn addition to the [standard HTTP](https://nodejs.org/api/http.html#http_http_request_options_callback) and [HTTPS options](https://nodejs.org/api/https.html#https_https_request_options_callback),\nthe following per-request options are supported:\n- `followRedirects` (default: `true`) – whether redirects should be followed.\n\n- `maxRedirects` (default: `21`) – sets the maximum number of allowed redirects; if exceeded, an error will be emitted.\n\n- `maxBodyLength` (default: 10MB) – sets the maximum size of the request body; if exceeded, an error will be emitted.\n\n- `beforeRedirect` (default: `undefined`) – optionally change the request `options` on redirects, or abort the request by throwing an error.\n\n- `agents` (default: `undefined`) – sets the `agent` option per protocol, since HTTP and HTTPS use different agents. Example value: `{ http: new http.Agent(), https: new https.Agent() }`\n\n- `trackRedirects` (default: `false`) – whether to store the redirected response details into the `redirects` array on the response object.\n\n\n### Advanced usage\nBy default, `follow-redirects` will use the Node.js default implementations\nof [`http`](https://nodejs.org/api/http.html)\nand [`https`](https://nodejs.org/api/https.html).\nTo enable features such as caching and/or intermediate request tracking,\nyou might instead want to wrap `follow-redirects` around custom protocol implementations:\n\n```javascript\nconst { http, https } = require('follow-redirects').wrap({\n  http: require('your-custom-http'),\n  https: require('your-custom-https'),\n});\n```\n\nSuch custom protocols only need an implementation of the `request` method.\n\n## Browser Usage\n\nDue to the way the browser works,\nthe `http` and `https` browser equivalents perform redirects by default.\n\nBy requiring `follow-redirects` this way:\n```javascript\nconst http = require('follow-redirects/http');\nconst https = require('follow-redirects/https');\n```\nyou can easily tell webpack and friends to replace\n`follow-redirect` by the built-in versions:\n\n```json\n{\n  \"follow-redirects/http\"  : \"http\",\n  \"follow-redirects/https\" : \"https\"\n}\n```\n\n## Contributing\n\nPull Requests are always welcome. Please [file an issue](https://github.com/follow-redirects/follow-redirects/issues)\n detailing your proposal before you invest your valuable time. Additional features and bug fixes should be accompanied\n by tests. You can run the test suite locally with a simple `npm test` command.\n\n## Debug Logging\n\n`follow-redirects` uses the excellent [debug](https://www.npmjs.com/package/debug) for logging. To turn on logging\n set the environment variable `DEBUG=follow-redirects` for debug output from just this module. When running the test\n suite it is sometimes advantageous to set `DEBUG=*` to see output from the express server as well.\n\n## Authors\n\n- [Ruben Verborgh](https://ruben.verborgh.org/)\n- [Olivier Lalonde](mailto:olalonde@gmail.com)\n- [James Talmage](mailto:james@talmage.io)\n\n## License\n\n[MIT License](https://github.com/follow-redirects/follow-redirects/blob/master/LICENSE)\n",
+  "maintainers": [
+    {
+      "email": "james@talmage.io",
+      "name": "jamestalmage"
+    },
+    {
+      "email": "olalonde@gmail.com",
+      "name": "olalonde"
+    },
+    {
+      "email": "ruben.verborgh@gmail.com",
+      "name": "rubenverborgh"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-10T11:41:15.992Z",
+    "created": "2012-11-15T22:23:37.885Z",
+    "0.0.1": "2012-11-15T22:23:44.078Z",
+    "0.0.2": "2012-11-21T00:14:20.978Z",
+    "0.0.3": "2012-11-29T08:19:21.319Z",
+    "0.0.4": "2015-07-01T14:43:59.128Z",
+    "0.0.5": "2015-07-01T15:27:15.970Z",
+    "0.0.6": "2015-07-04T13:26:09.166Z",
+    "0.0.7": "2015-09-10T01:41:18.073Z",
+    "0.1.0": "2016-04-10T19:31:39.368Z",
+    "0.2.0": "2016-06-06T22:00:05.075Z",
+    "0.3.0": "2016-10-20T15:49:08.939Z",
+    "1.0.0": "2016-10-23T16:09:54.517Z",
+    "1.1.0": "2016-11-06T16:44:38.542Z",
+    "1.2.0": "2016-12-07T21:50:56.326Z",
+    "1.2.1": "2016-12-18T12:52:48.546Z",
+    "1.2.2": "2017-03-09T21:53:54.031Z",
+    "1.2.3": "2017-03-10T16:51:22.410Z",
+    "1.2.4": "2017-06-21T19:39:27.920Z",
+    "1.2.5": "2017-10-05T17:04:14.010Z",
+    "1.2.6": "2017-11-22T10:35:02.216Z",
+    "1.3.0": "2018-01-05T18:57:24.272Z",
+    "1.4.0": "2018-01-21T21:55:51.028Z",
+    "1.4.1": "2018-01-24T00:42:40.382Z",
+    "1.5.0": "2018-05-19T16:17:27.946Z",
+    "1.5.1": "2018-07-05T20:44:53.010Z",
+    "1.5.2": "2018-08-01T18:34:57.855Z",
+    "1.5.3": "2018-08-13T11:15:32.833Z",
+    "1.5.4": "2018-08-13T13:18:06.652Z",
+    "1.5.5": "2018-08-13T18:02:14.290Z",
+    "1.5.6": "2018-08-21T01:44:52.160Z",
+    "1.5.7": "2018-08-22T18:02:41.148Z",
+    "1.5.8": "2018-09-11T19:25:50.658Z",
+    "1.5.9": "2018-10-09T16:01:45.434Z",
+    "1.5.10": "2018-11-19T21:25:49.948Z",
+    "1.6.0": "2018-12-25T22:27:34.053Z",
+    "1.6.1": "2019-01-03T10:24:43.194Z",
+    "1.7.0": "2019-02-13T21:40:42.432Z",
+    "1.8.0": "2019-08-27T11:10:39.307Z",
+    "1.8.1": "2019-08-27T17:37:53.351Z",
+    "1.9.0": "2019-09-06T13:12:12.301Z",
+    "1.9.1": "2020-01-25T23:54:34.866Z",
+    "1.10.0": "2020-01-26T23:35:59.450Z",
+    "1.11.0": "2020-03-29T10:54:23.756Z",
+    "1.12.0": "2020-06-16T20:37:26.684Z",
+    "1.12.1": "2020-06-18T22:37:14.802Z",
+    "1.13.0": "2020-08-10T11:41:11.024Z"
+  },
+  "author": {
+    "name": "Ruben Verborgh",
+    "email": "ruben@verborgh.org",
+    "url": "https://ruben.verborgh.org/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/follow-redirects/follow-redirects.git"
+  },
+  "users": {
+    "antongorodezkiy": true,
+    "eklem": true,
+    "alejcerro": true,
+    "tarkeshwar": true,
+    "lababygirl": true,
+    "poginni": true,
+    "shentengtu": true,
+    "edwardxyt": true,
+    "g120hbq": true
+  },
+  "homepage": "https://github.com/follow-redirects/follow-redirects",
+  "keywords": [
+    "http",
+    "https",
+    "url",
+    "redirect",
+    "client",
+    "location",
+    "utility"
+  ],
+  "bugs": {
+    "url": "https://github.com/follow-redirects/follow-redirects/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Olivier Lalonde",
+      "email": "olalonde@gmail.com",
+      "url": "http://www.syskall.com"
+    },
+    {
+      "name": "James Talmage",
+      "email": "james@talmage.io"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/follow-redirects.min.json
+++ b/test/fixtures/registry-mocks/content/follow-redirects.min.json
@@ -1,0 +1,1069 @@
+{
+  "name": "follow-redirects",
+  "dist-tags": {
+    "latest": "1.13.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "follow-redirects",
+      "version": "0.0.1",
+      "dependencies": {
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "dist": {
+        "shasum": "b0b9078dc855b13a7acfebcb099b9f98f2366772",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "follow-redirects",
+      "version": "0.0.2",
+      "dependencies": {
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "dist": {
+        "shasum": "06c81345f422a3bfd93583bd0b6c0daa58cb54b9",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "follow-redirects",
+      "version": "0.0.3",
+      "dependencies": {
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "dist": {
+        "shasum": "6ce67a24db1fe13f226c1171a72a7ef2b17b8f65",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "follow-redirects",
+      "version": "0.0.4",
+      "dependencies": {
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "dist": {
+        "shasum": "78d2faec253da7bbd4bbb6733e05132a6ae9b483",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.4.tgz"
+      }
+    },
+    "0.0.5": {
+      "name": "follow-redirects",
+      "version": "0.0.5",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "underscore": ""
+      },
+      "devDependencies": {
+        "colors": ""
+      },
+      "dist": {
+        "shasum": "c4d40dddfd8a9349e052c50c00222a5e393bae32",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.5.tgz"
+      }
+    },
+    "0.0.6": {
+      "name": "follow-redirects",
+      "version": "0.0.6",
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^2.9.30",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "semver": "~4.3.6"
+      },
+      "dist": {
+        "shasum": "a3d57beaea728d96a5dbb6f1e790351d2ee18331",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.6.tgz"
+      }
+    },
+    "0.0.7": {
+      "name": "follow-redirects",
+      "version": "0.0.7",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "stream-consume": "^0.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^2.9.30",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "semver": "~4.3.6"
+      },
+      "dist": {
+        "shasum": "34b90bab2a911aa347571da90f22bd36ecd8a919",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "follow-redirects",
+      "version": "0.1.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "stream-consume": "^0.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^2.9.30",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "istanbul": "^0.3.17",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "semver": "~4.3.6"
+      },
+      "dist": {
+        "shasum": "8333fbee65d2fa8585241ebb1372fc01e5b1f671",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "follow-redirects",
+      "version": "0.2.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "stream-consume": "^0.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^2.2.5",
+        "nyc": "^6.4.4",
+        "semver": "~5.1.0",
+        "xo": "^0.15.1"
+      },
+      "dist": {
+        "shasum": "e0229d7a388bb5ff7b29f44fc1e1b62e921272df",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "follow-redirects",
+      "version": "0.3.0",
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^3.1.2",
+        "nyc": "^8.3.1",
+        "semver": "^5.3.0",
+        "xo": "^0.17.0"
+      },
+      "dist": {
+        "shasum": "6d9935db28386943b19730cbc0ae1a3b72ef0bc8",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.3.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "follow-redirects",
+      "version": "1.0.0",
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^3.1.2",
+        "nyc": "^8.3.1",
+        "xo": "^0.17.0"
+      },
+      "dist": {
+        "shasum": "8e34298cbd2e176f254effec75a1c78cc849fd37",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "follow-redirects",
+      "version": "1.1.0",
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^3.1.2",
+        "nyc": "^8.3.1",
+        "xo": "^0.17.0"
+      },
+      "dist": {
+        "shasum": "f0a07e20b96396f096873f16ea2b9638a79e7b0c",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "follow-redirects",
+      "version": "1.2.0",
+      "dependencies": {
+        "debug": "^2.2.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.0",
+        "mocha": "^3.1.2",
+        "nyc": "^8.3.1",
+        "xo": "^0.17.0"
+      },
+      "dist": {
+        "shasum": "e1746cbf9c9c1d5fbff07de315d0c8730ad68172",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "follow-redirects",
+      "version": "1.2.1",
+      "dependencies": {
+        "debug": "^2.4.5"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "dist": {
+        "shasum": "796c716970df4fb0096165393545040f61b00f59",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "follow-redirects",
+      "version": "1.2.2",
+      "dependencies": {
+        "debug": "^2.4.5"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.0",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "dist": {
+        "shasum": "45e4248c741128874f4a4900fd7e14f644b0bc40",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.2.tgz"
+      }
+    },
+    "1.2.3": {
+      "name": "follow-redirects",
+      "version": "1.2.3",
+      "dependencies": {
+        "debug": "^2.4.5"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "dist": {
+        "shasum": "01abaeca85e3609837d9fcda3167a7e42fdaca21",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.3.tgz"
+      }
+    },
+    "1.2.4": {
+      "name": "follow-redirects",
+      "version": "1.2.4",
+      "dependencies": {
+        "debug": "^2.4.5"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "dist": {
+        "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
+        "shasum": "355e8f4d16876b43f577b0d5ce2668b9723214ea",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.2.5": {
+      "name": "follow-redirects",
+      "version": "1.2.5",
+      "dependencies": {
+        "debug": "^2.6.9"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^2.11.15",
+        "express": "^4.13.0",
+        "mocha": "^3.2.0",
+        "nyc": "^10.0.0",
+        "xo": "^0.17.1"
+      },
+      "dist": {
+        "integrity": "sha512-lMhwQTryFbG+wYsAIEKC1Kf5IGDlVNnONRogIBllh7LLoV7pNIxW0z9fhjRar9NBql+hd2Y49KboVVNxf6GEfg==",
+        "shasum": "ffd3e14cbdd5eaa72f61b6368c1f68516c2a26cc",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.5.tgz"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.2.6": {
+      "name": "follow-redirects",
+      "version": "1.2.6",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^3.0.0",
+        "express": "^4.13.0",
+        "mocha": "^4.0.1",
+        "nyc": "^11.3.0",
+        "xo": "^0.17.1"
+      },
+      "dist": {
+        "integrity": "sha512-FrMqZ/FONtHnbqO651UPpfRUVukIEwJhXMfdr/JWAmrDbeYBu773b1J6gdWDyRIj4hvvzQEHoEOTrdR8o6KLYA==",
+        "shasum": "4dcdc7e4ab3dd6765a97ff89c3b4c258117c79bf",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.6.tgz"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.3.0": {
+      "name": "follow-redirects",
+      "version": "1.3.0",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.14.0",
+        "express": "^4.13.0",
+        "mocha": "^4.0.1",
+        "nyc": "^11.3.0"
+      },
+      "dist": {
+        "shasum": "f684871fc116d2e329fda55ef67687f4fabc905c",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.4.0": {
+      "name": "follow-redirects",
+      "version": "1.4.0",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.4.0",
+        "concat-stream": "^1.5.2",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.14.0",
+        "express": "^4.13.0",
+        "mocha": "^4.0.1",
+        "nyc": "^11.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-SLUmsiaGeQa2qgJJzJgHpQ6lARP3uyVr0SkMryJmoE86XvUeM7RkYD5FT0rNyjCV5zHlNUpcp3l/6oUkqMEOqg==",
+        "shasum": "a146a3a5d402201c7a3e6128643f0e336d212b10",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.4.1": {
+      "name": "follow-redirects",
+      "version": "1.4.1",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.16.0",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+        "shasum": "d8120f4518190f55aac65bb6fc7b85fcd666d6aa",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.0": {
+      "name": "follow-redirects",
+      "version": "1.5.0",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+        "shasum": "234f49cf770b7f35b40e790f636ceba0c3a0ab77",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 18729,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbAE4ZCRA9TVsSAnZWagAAhUEP/R+3IwcS8XgjikEcHeTF\nXGCAZ633ZHqPa3ZsXeCSQ5HtFfOef8nx8jIKsrOzNVTHZYMfiV4LqAZku8+Q\nIJD1sL395TeB9ysOg8iFINaLOC4VtChUcq9mwgwSIlacsKt6RoJ7Z9eZBjCJ\n2/mdTYxr3nXKBqrsg9lSkvkfeR8ysIHSgI3E6UTCVa6Q3E2c9vZqGbYSbTr0\nKTvf+ZWGfeWvc5xGj0epAISiJEhtdp9d+ATRBsJH8LL+gpGtwsM/PDp33TNU\nbAbNfBU73Brhu2XUtOABaKQYCWoDnb2DsuOphFnfZ9MLg0ZfmopR1QohaSPV\no0BBAhmnE73Ksp1xhk5JctTmLTH+zO163eUE9MdZ23i64Rhvk0ozZ4SRy6r6\n6d2Y0lt3E/A88iXTJZIMtlODgWm4M6dXneNJV+0e4SKDxmiJvzCHbMjgUVhj\n3eUMVPJ069yUHYa+vWR6MIeGyrCz6v21ip0Et/uvpql8kmYPLFTzR98SFDc/\n08DUTLBZIHFuBQrQPWfNUzaMLU5ziaE8x1d3HBwKjo/Gz8FV7s1i/3cXMF3u\nP+rBj0aALpynKEqligANpN5R01zcAp1qReyHsMvGjMuwl3KDpX8X8HIeciXi\nYCzGOWIGbC47080rnsJ4ct2hFifL8Ee3pmfYHet+Kn1urcFH91Lyb/oOxj9m\nJ/HX\r\n=oo9R\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.1": {
+      "name": "follow-redirects",
+      "version": "1.5.1",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+        "shasum": "67a8f14f5a1f67f962c2c46469c79eaec0a90291",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 18825,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbPoNFCRA9TVsSAnZWagAAg+4P/0/cIO3/7dHL/bUgTB8X\nhJH/teo2Iy5mv1mtqE9OEltWx2JsrEUPC5ZVZDCCc8ufKsHvobs/84mH7cS/\ndCHG9xDIFQWMifr2MEDEudI0Zh+7z+0jWpVi3siXWJ4Ka/rY88jFV9gjKRH0\nyLL8pc50e6ibuAihzAcDqgu2TxRMcB+9CrG2rBOIIMC7ln1DIlKDhPBjtxeZ\n5dSOHgrk4SgR9nIMWXjXbb+vp8n72VHg07ppqXofLOZopqHvfuMXZdk8+g/b\ntHPVd73uyReXGjdnmZNH+NXptKTGEArL3elRC86L6no8jdtco7aFDG4EOGOl\npDgShyy4KWkl5JNglsHEW0J2C09TdyE5vYM3q0PBo6SC5TczuJsxTbeCM//4\necLAFGrrw0ce8D/WyMAp7MmcYmcu5UtjcrooxJ7xPNKcxMKKzR+t2s3XnrZ2\n0+asUDIotwKU7alW4k3FyeDDEI0gYtZhRXU4auR5nkCZJEashKxN38kDeJXa\nnBvejV/qcyX5zkVg7ZnJ1V9QAkeR9lXlxYSM2v3jwDuCZk0qkQ+Dj21VAyJZ\nUp5xJ1/VPcMPeATGFrOsEkruutDhriV/rYG1cGyyBg1ty3iG0MgELM9BzqAB\n6yT8Iq/1GV4f4drWpyAZbj1cTocw2K/PQ6+t2Ojt6iywQI45JEQCski3qznU\nHqDK\r\n=411h\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.2": {
+      "name": "follow-redirects",
+      "version": "1.5.2",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
+        "shasum": "5a9d80e0165957e5ef0c1210678fc5c4acb9fb03",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19118,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbYf1SCRA9TVsSAnZWagAAB1kP/ijEe8beBvmA/Pu4iq7K\n9ZsTHYQ5enR+xtzFpcdL7OepgE10ztRak9YTWx9nzQmQkqbBlUpTWSp4x4IE\nKDGGzat1qPSn5nJSgonotfNyuK9fVlE0B58CHRdvV9whb+9X0brs8DuKQcPb\nRQyuszljkz9UVnBhKmGKwLQ9WiFTlgywiMfY0yArqyVtSkyaOlwSczUZUA0+\nMhuAUU2cq8MUrYFDMTurV2258jRLFrkojiMYrwQlrA7Rsssen5R6lKGZURH3\nvePD8L4ORf6HAbkJUckf+gaag1HPKstz27PsoXp2nRKF+Lr7UFxGUMNlAxIP\ntZTAdrn/+026wDSf1MZHOlIx5L87yQfrUz93QmIkF1eqrgnOO1uc2Vfp+Fi5\nGlpgZschXo22v/fXjfM1+qHdlSbc92ZjUBKhu7qWUV00tFhqxkExhFj7i5dr\nzcb8EHMqfHlfrwhCIG3TBjVJBOwpl6SvTE5o8So7AutpJU4dfg4Dp9AGC+mh\n3sp3hMTtwpK3XNAIGHP+/tPn1S0jXCbiitjvsEv+S/kcx0QakSx09YkUkA8Z\nfegWmqthuT8w3N99VVY2H9kK3Ci6TRAzqUPqGR8Q6jDRp5GiOQtqEw1lTxTv\nvT+lpOrpS7ND4lmmkHpILBzMzBrGc7xt5pWVrn/IEQ7cN3TCFgiChJybIJh9\nedJE\r\n=PcuT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.3": {
+      "name": "follow-redirects",
+      "version": "1.5.3",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-Q19GwKpz/zVkwVzbEkICtentX0NKcCix7g1l3vNewCLZ6KwGAU7bdJEQEZb9NN0D9kapySzQPMrOuj6rvrLXnQ==",
+        "shasum": "ba150caf15e2f0b30c789993be9b912db553855b",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19146,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbcWhVCRA9TVsSAnZWagAAKNsP/iXcKhxuZgTu7/e1Eozm\nyhhM5uZzrEsiGhv2e8K9ZRjpldwvKJ6kUMn+MMJx7ZtioK378IBSereCBGuu\nHv04XJC42RZjEeBqu8CkP1NBM4wQgap9sm8cmTol1zzx2G7sNY//ekfbJ5mz\n4c8eKqC3De3LmGv/hdC9sdWWDyKET/52nhyGcbQDYAlT9dSpmGOHI8m9MkZJ\nhGUjip1vVqBxndrc47b7AOvcTS+fcyd2yUskxK8wq0nDfT6vJ38pcXOjIj7N\n62etsAg7KE/gfEED+vqU5MCBh/D4NuM4JEJggdVnUUo+gEkyh3R0ii/xvtju\nujU3CPY7sWL0uTIv9I5nkUQijnxwau45qsxGINXuvTiCFc7c9ILS/8DRoW0C\n34Ck2YYhMi9EkDvh60A4CAxvWyOWcIM3vpQchjd6uM7kCtF/4MeWqbDhB9Ok\nPbf3uXNC1t2CbNxPaQAZ/u0DpUXzU/eUKygcxh7i6tK0L0XN4sTTF30fJv8B\nY19O6/KJDqRqqrJYUt7qYLD006THwx3/lnBzt6pdsFNmZT3CgaGe/W2+fCDO\nE5qGr4mKlvyTUUztXbsLXXSn0j1EsFrVZoe4UiocAt3vwkBMfAU040x77xPd\nZVmC6c+txQXcUnx71cnKamp/dEri8Bm9M/iSj9RcUYm4nOWxK0Mik7zD5qMN\nE2kz\r\n=v4+N\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.4": {
+      "name": "follow-redirects",
+      "version": "1.5.4",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-qGsq5ExgV2z6YTV2mkqemjo6sy6BaXWwKlNYSmpvBONGdFDcpML0ieQ7iQDDlu82JrMTmft4zrpSFfS8PIPoHA==",
+        "shasum": "86d1bb946f24cb988d660aaa2ca2478c0772ead1",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.4.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19148,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbcYUPCRA9TVsSAnZWagAAoPMP/ROCKpdJmF1Ml1wQloU1\n/97jDpo+EpL8l6wRZjTbFaGbNT5Wn5dK1wbnhEoWt8lTc19kvCOAWktSf2Hx\njel+Ci1jOfDxavFrOaYadQs8iHLL0jFVeXzKh62V2ocme3474LIhLqIgD4YQ\nJ0qtAIdlhe3AQQf0lRUjDITHjYixd2OUUIAOpk51gt975SRQam37tIUNAC3x\nZkaKm7aiiCpzzS5fR/cI2+Cx7kboExrFqmi7GUY+aPtmpWn9rTdD2kKpFFUU\ng1uSUTza34ytYltu9TvNXiHOH3yFpl1eG/o6XJikf/d3ds0jwr9lV6glvel/\nHqSp1Nlu06YjlddML++i/osnNkPzdHhnvvWQKtMI9ls+bXcYHWpEApO49Wnp\nasCtK4t0HWyNJJnGri8+gr4PVIU3uykAyM1JKAFl4b1qnPkg1KOsxRRbx5VA\nwBLtoN/CZukQGga5co01/OiENJssfp6NS0yUMYMni0Myi5k99B6JSZUaG8fi\n4VtrLR657NnZ/Fcu1D5csqR0fjFFrWaxZT32w6shra58VqWtubgEWnXAdy/R\nwjIJON5aETNTciEAmGzqRxz1bNHMjUCpeNIx+UXbnhAEVvm23GkjRrsRZ0FY\nD0XeX8a0XkxJX+tgfF7X39GqKf2XzRvTgFYejPM2khAL7nWJuMkOtprIc9YQ\nxYFu\r\n=0WBo\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.5": {
+      "name": "follow-redirects",
+      "version": "1.5.5",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-GHjtHDlY/ehslqv0Gr5N0PUJppgg/q0rOBvX0na1s7y1A3LWxPqCYU76s3Z1bM4+UZB4QF0usaXLT5wFpof5PA==",
+        "shasum": "3c143ca599a2e22e62876687d68b23d55bad788b",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19125,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbccemCRA9TVsSAnZWagAAtCEP/A4f3eHwGBSRl6Th3xx1\nwKeTmf6qczJkIWGE7iw9L3DE1B6sGW8ttCn6Qj/AQVWGDcWtYP32az2Kso4z\neJ5Jckbx8hHXVtJLEEHMJk7kymPHXHQenhBoe6u5cpdqcgDzILcHWFQ9mGcl\nVVMqMEzc7uuVvY6akf4vxmLAn+lOGqwlQz/cql8jpOVP0CuIFhFF//VRS0vL\nv3yxF+1CjKv4DX2zapo6H/KmbMMPs//7ofNbg87qR8DGT3BCY9XO6sU8Ze46\nn8/jDcYLmF6vjzMjJwP7qmeoX5PpK/CmGy8KJt+EEfFNi3KF63FGteUBJ7NP\nw8fquRpeDTHTOQRnTDCyvYM4kKqlZK1IrqoFzo5DNh6RBUWLNR/Abie/Vbke\nqvq5njsSghqLvJoTwgvMyxj+Bh54m5FQWw4xvh93uF8SsmFOGukvut21BbuC\nGD5QAWghlv2CcKk3i2UE86z1iCnVuWCTNwmhJHIoX98XKNnDGRbB/iAETe7Q\nYsCoZOLRgCrM9ZR892A5OHSGo8w0PqI7cVPYSGsVALUlc39CVCJXDONJVVvp\nm4Hjp+SEWpwXAA03JO8RLMTnzFs/pyRKx44PrUcCMBziNO495bc68qpGoiAs\npt9LainlBMUzdrqxk9ELIWgeR1ew96AddAcBV0e3tWGlSBq8JPO/mgeAAbhN\n6PVf\r\n=A7dn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.6": {
+      "name": "follow-redirects",
+      "version": "1.5.6",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-xay/eYZGgdpb3rpugZj1HunNaPcqc6fud/RW7LNEQntvKzuRO4DDLL+MnJIbTHh6t3Kda3v2RvhY2doxUddnig==",
+        "shasum": "44eb4fe1981dff25e2bd86b7d4033abcdb81e965",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.6.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19237,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbe26UCRA9TVsSAnZWagAA/OgQAITs7BjctCy1nPMbBS/a\nekq3MPD9/qd5I7q34MIC7x1ryS1VJRhB5bcUew7xham6tzgX5kb4kzSs7S0T\nOCnydQUxmkHqJ2ArVek0GL1BoAcv1aukzGBUsA0DfM8glWDezF0l2ovBGsSa\nd8VcoxsU3Ez4mxY57bWzJWo25JxhfHsEByFv0Q6NLrRmetA6onzTvUyqmRQw\nhG07wzvjPWTSMEMdQM9OPAYd6Kj3U/AoPw8mnF5gurBCZx+raoC3knbRzW7o\nUzRjyo5x+nTLIK/5VR2UuZACaD4KxZLP+K0x94vZu/pwkQcsqJ0vNHQfTsdX\nu7BweUZrG0tPqtyw6JIBhW7CCxs7GoUlNiBnCP/ssrZEOlVuFCAKPyzQ1+sf\nd93p9eHBxTAd05b59uKqWrWTCIRSwoEt6C3EXKdkfB+LNyVahwsCx3jL+wMN\nMnHtdQ8K0ypa/6AsopMEYNgFNbgYdiknkCtVQW52B+uG71Ej+PTpqJ5e/J8R\nOP0xUoiczr4fP4LxHSJmP4ZmQexSnkv9dmkoMk7dGyWl/RJWT9KfAfGqXNnV\nq0swteE4yEy6LSV64y6thouq5UTSdGboTNxuP1OyFA/8RJDwCmC2zUG5+T7A\nvytO94UmDI15jAT76mppeeTAl0hzOq8LOLJOWk/NZ8e5orhVJA5RVoJyBXnc\nktQI\r\n=u2AQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.7": {
+      "name": "follow-redirects",
+      "version": "1.5.7",
+      "dependencies": {
+        "debug": "^3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
+        "shasum": "a39e4804dacb90202bca76a9e2ac10433ca6a69a",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19548,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfaVBCRA9TVsSAnZWagAAFGwP+QBVZLosWW0bEwyhgXka\n64JvK0X82Gz218ZTzxYzkXPVYtoCZm+gLAppdaAKS+xemhvw7UFYoYSopVb4\nLF4ZL7JCTz7pyn1sDuWHnqfd/xNqUPYfHF0ylE03tjEfSJREM/9q2tnt9ruJ\nfE1hsFa3GGuUNsjbntMwhJ+o/3kiXr6dZqTStsOg9W2oWd/vzP5cxWCX3RxK\nSVISYcSZrVu8e2vYBhtedEcHjIC2PVUufEmHrcOQ8DPvpliOT/L4HQbXwrfA\nQx6ElABUSyD/U4JvV5799sdV/JTxJ1HKMTqKNqeeO0j3D8HeAB95ykqI1zwD\nUocEz4mSPNDIiKYr1wcP6B0rs7i/pqbSj8v9mlu3385ziMV2sVJJ7zfJj0Q5\ncUE59dbDusFxe6QSaliPbfq3kjwgLiiFI3fVTEXDnwZJ3y9gDgripyHpx9St\n9CrkNTe/vT90tnXb3Ak8C+exNC/yZcfFd1rXz29Akk6uRHQQR4536bEL/kb9\nQ00ozRuZWJDXev8PZRnO0R/PLR+NP4+ZxH4l3nkF+RVtJXOzn9D7IMw0MV1Y\nOoQwyxDdokTbgvNSlnEfJa3jWxJ0aYrJTnCnnIF9dyUpvizFNGFROifuImgH\n6K7dxHQtH4B//2EvWghOB51u66FS7UglRTRArpJ16h9CrTETx+2I7Y3q8yNK\nhY3M\r\n=G3OF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.8": {
+      "name": "follow-redirects",
+      "version": "1.5.8",
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "bluebird": "^3.5.1",
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
+        "shasum": "1dbfe13e45ad969f813e86c00e5296f525c885a1",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19548,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbmBa/CRA9TVsSAnZWagAAuTsP/1UQNUc2CA5UKKrSLI5E\nStiPsQXJI5nmVuNOyTHxFb6bWzRa4rXlLxJ/NkPyGXl6Vc+DMof1h9AU0vRX\nZwpSP4wp/kB49/ZS8+t/0GZ4QSoJlhtOpubL7XyHGsssMjEsMcTBWKQc8MbL\nUobJnJapu3ryyuj2sBh0UwZAaUBL0PsTCtoDWzj5um5sdsU/2wFjKMVUFBl7\n6DQolXWUFcUAnwFC9UnPMxKIPuVIreksVTpx6SW6l26OSEmAm3AWKEmD/mbD\nIHiIUowJ8VSwSRaOCRUKSwfrFp494nIJESDZAU8yMB7m4krN4+l51I80jZeO\no33NpB3NBBWz+Tfj5ST+vIz3U92FaMZop4Q4qSXR3fXXg3iaAB9DsNRvMlIz\nbDQYRCWSBpnvOBzPwDVPZmKexQM6UpQphlLTTXu4qtuVHG8byc3z5oWY8MFw\nlgqh1PGXjXmwhtFSnd2cXd1voUK1Ljrzp4ei356uScjE/8kzNr9shgPz5y7W\nJNqlsmnTaS7LWdVFKcxbbFY53mxxEh6Rx0CuH6v963IDOWWBpyyIOi2PO2em\nbS52oglk/h3NBiP55hdDQ+dsj28h2Dw3Na8LIyDQvO0vhbSiuKEKNxRC40SP\nYCtpuhXluvtYeEvlFzWcQaUNLa1w0wZ1cERWaq5PeilVA3sS57Ib9RXZcd4k\n3pAC\r\n=JSYr\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.9": {
+      "name": "follow-redirects",
+      "version": "1.5.9",
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.0",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
+        "shasum": "c9ed9d748b814a39535716e531b9196a845d89c6",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19522,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbvNDqCRA9TVsSAnZWagAAvKkP/j2g9UU23tkeBbnBBcDU\nfk0cBX6C+0D6Jo4FFXLr6ZBCZ77yHwZLHcbWGcHJzGaBDRG71aQC9DpoEMXq\nPeBGtp1Ag8tS1uC8SgCq1jYKqv3J84NzkpnKpzPA7PWcU6uG9erGjcRKenpB\nyWnF8EUTNLFA52WBhfE+lzn5yNx2nEpdxV55uYAwTyMZkub8edh/l48EwG9U\nH1XsySLz7MsEXr+1zsKl9MwsW6Z/ukFXFSZhiIJVM5ygq56AMiN57644uEbQ\ntXet7FNj+JafBXSuQnqrhatWnqu6oCxuuNYGpYiYjqbE53ExF3UHHRaHFMpY\n/IUbGUg3NsfGxgpBw9NGrai80eFhXr+m48dpWHGD3RjBRRVsbkjM1klxLo00\n7/o/nFGckmmf5w6GO0ev960QNoVJuDhDeM7Z5aDloEmazfUA6SvsoIHSCxEf\njxYh5RfnuNq5f8neqgvxp4TZ4WIzwHt9qL17YYAj4yqFEAZAfceZ3rrL4dcJ\nXmrEistf5DAiChl92vmUMT+hGpFUrUbk8cQ/DM4w0+Gk3Ikkn3J5fPBEHiBl\nE9HQNzkDrPzGTgnH+rRPw+lO5CDBMS6RZ/uoiQI+dDETUKtLg9+uCsfIaGBN\ntXtlW4EvzTLAASofbQheIOmg188y6vg4R4iNB0vDeM576QWpV1Jn9MSw6BEO\npP1Y\r\n=Zxsh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.5.10": {
+      "name": "follow-redirects",
+      "version": "1.5.10",
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.2",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+        "shasum": "7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19800,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb8ypeCRA9TVsSAnZWagAAR7AP/RwuZoZJOzKWB2RcWOk6\n+U2yuf3DRHCEEZuaynkOZTBc5B+xIpYFkDWgO+3lFQ8mTFVRfl9b87vJ4tQ2\npXeYcbWvt79hB+K4jh2VavKxsA3zByh4o0AVOWoaSn5qzull6Z4n9InAe2hN\ned5R3PZpMqY4YXuWMtHCLn+NJePGnFyEY2ESP0Ehs4DKDypj02HO3s9qCuqO\nlhSw9VmpQ+imJMge8o7EyvwfZaWEmb0ERaL1thLUOY2trHDKVO85JXla4h38\nM4oOc1g7o3yc0rVT8vZk9C56lkTQgULBIKc5HXUHjOkTO7wfbR+vq+cuUMaq\nBqyQb2qsy54nPC8EK6C36nIKXIy2F0UvARc1x/302XQkCjNajEIoPtX3vouo\nU3MIg8UKm0jJxjf6/PAgeDN4rtHaDUgK3N3YMzvhcIU/H+Bz00rEyn0GMCTM\npi6zo6aa3VXjyFP2+vQghXax6PYcbyec2/cBuUk9KZOfORvJ5gmvCkbLWWZC\nQUapjl2+4sWA2j1kT+m8JkUo969yiayjmKeI4zP0jLPFwZ0IPcN1+/ekMnD0\nAtwF0k7RPz06GrdleYaKk/+3+88ViuEkfH0tBomMIgSZ7Zui0SsPS6ToQcxK\nPHjOCKAFOcYs10ZFhfhgV/wF8LR16rIRwXnlYREKQE6YuAMvhNN5UyLEqwNE\nqVU1\r\n=Xtc4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.6.0": {
+      "name": "follow-redirects",
+      "version": "1.6.0",
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.2",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-4Oh4eI3S9OueVV41AgJ1oLjpaJUhbJ7JDGOMhe0AFqoSejl5Q2nn3eGglAzRUKVKZE8jG5MNn66TjCJMAnpsWA==",
+        "shasum": "d12452c031e8c67eb6637d861bfc7a8090167933",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21984,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcIq7WCRA9TVsSAnZWagAAuNEQAJWykCTynA9/C+60/9m/\n60s8Un+AfmRb/EDi0juPUuJZZQ0W1/RQfN3oCBpx8vMMjuztK/zUuLa5wLI/\nsX0Eaa2dG9TEFqEKWoQvhXv5mP33uEoa25yYtku64usRPXV6cw/1oggBKKlA\npsYNr0TZz34baoTN+oT9A0FpsByRA+Tn+HGtzRXY6J55DxZAbWoJAS5jTIOF\nwGvYKFPj+UIG1E0o8QiepgslMM6D2P/Xx4AFN25E8uMcF4mEkIRS979UIyTl\n4oCJch98KgwOqcb4ZiKO/bDXdXig1S8YUwoPAK88unGATIgitLLQtpYNspWN\nx9TJen67V8askFhyDng9a3dWfHtYTi3RDORCx4j216MD9jHGPetArQaYi0aZ\nUTLvuYtVqHvwHPZ8UYzmuMxyPhMTZEPhRTbtpgAkCRBMhrWy+gaz6nkWU2aW\nqp80LHIIdjtCDtR9IWEnRmX+JMJx2s/0N+hMGqXTXpDs0M2HxKkF9n3wPXVI\nlprD0dPuMNY1gR9cunSzbl+AF5AH4xif5QVdHGoSkichuhVFUZNub9O36sTA\nc6Vw7FIVLF6fcAIk0SM/VLMq4G956rWiFcnhChrmvXjMqlEnmZWL9UrP1gwh\n4dMwM0hcd6313x0PgiIWfGCFFP/2gAceHD6rsGpy1nv/VRhBYKHkujNrAoWO\nMaEu\r\n=8Rks\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.6.1": {
+      "name": "follow-redirects",
+      "version": "1.6.1",
+      "dependencies": {
+        "debug": "=3.1.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.2",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+        "shasum": "514973c44b5757368bad8bddfe52f81f015c94cb",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 20845,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcLeLrCRA9TVsSAnZWagAA7GsQAJGbHWOu1A2HhmqPwWGG\n0xWiMBnggNuxljneb+J4JXp+2gPrC6ZRnWoGijY4yu/d5zv9Z4Yjt1/7MgfA\n7sbJ110OIyinX99qEbB75R9xho4kmm6eLfZX9xjMiK2uNcMCtdUiZMUhE5dy\nRYZDT7SW+/9JAnqWo2FyyR1aC/ypZWSVZ4p6kSLR4tL841urFyk3WmZzsHQT\n9+FAkmSlSkzGHfiDitzh6nHmncztCXZ0abClV2q0/BdYaGkwlJUO0F2uagBF\nhDIyiQnIhiN8/8IRJDozlr/an5PM3RTZs3S29/RoeLnURpTkWw0Hk0XN6ZVH\nf/YvuW5sHGwJU36pz6OnfJeLWUcRcxr8EDQJBqAaGqZURr9f9Rsv4/r/D0l2\nR52pOQSbOxwngYVITDGmXPkYwH/ZEjNtiZZW2RVuJx1joIzNOE7s93Mvu79i\n9WPjcc0KXhK7ANaNE77ZqB5v1fIps050vlaYPVnbr5n+4hNYvaZf1Ib4cTTW\nUJN5p3NfsMxnQOVD26Sgs/QtfV3BVC6xTJDyS398RWDauWXZMv5r+LSLHJYy\noiAw6YKYcjpv8Dk4kl3Z8BAEwHVr4ftKIPfu7fGSGbXqvh+9dKHeFIaUdQGE\nVYJirggQPnUammloIB4cH7ZGKgv2QtfEy5CeunhQk9ZEGVMZDhvpaYb/Ed2e\nTg8m\r\n=2SpE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.7.0": {
+      "name": "follow-redirects",
+      "version": "1.7.0",
+      "dependencies": {
+        "debug": "^3.2.6"
+      },
+      "devDependencies": {
+        "concat-stream": "^1.6.0",
+        "coveralls": "^3.0.2",
+        "eslint": "^4.19.1",
+        "express": "^4.16.2",
+        "lolex": "^3.0.0",
+        "mocha": "^5.0.0",
+        "nyc": "^11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+        "shasum": "489ebc198dc0e7f64167bd23b03c4c19b5784c76",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21525,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcZI7aCRA9TVsSAnZWagAA4wYP/i0UEluhn6QsNUW7FsQC\nV6csdzuDsSeSgskqm/CI6rqTxpXxSMUMG4GtFfnynrAEYz2dwa+KNonZOvhc\nP0DRvRJerUwyblF6deVA9cYDNj8WSE1ftOjQp6X7r5LW4jud+vTM+tCYFvIo\nbJW1IaTunyz1HNemveYSwC8W/qeCuDY7UlLOoz7IWypivuLZSwjKfcL7BVjO\nVwn77IivSNNLSbDtcmXIiR6zGVBSkY9JMXPM4bBC5kJytWO5QwE6OzGY0xNq\nTDnBh0hHNRw3RkcIotM/U0YVais8HuaDr2WO7/N3pGfqtLVHT92hxZtIcnSu\nDJFzs8ptzBB5jzx2/uD6wpXq9+fNxc/EcbeH9GFNBxMA9Ks4rT2VdbjJnkFu\npWfAwaYKcCTz0CRffkeN64Py4NDiwQ0MuNYlKlGthTzz08f3c7Z/DssV+ffD\neVrZ8C0Z400+dsMdvGH74DKw+8qYaVXZ++Yaxc8PoG+mKnW49IAa5nN7huL5\nvNNFGES6lVnOtHPSJpdUK9MAJGr8L1PTBqZYr8ALVcUkHeKzb/3Z3Z8NfE/i\nCUdxcsCoP+C52bmESwhJIN3SLSuMb4Nbx+/s3f0zx+gZ2HieGQicYyRybBEj\nkkzparnDuGJ+63+IWc4rbEv0vD7iw8EX5SazL+/DDAH0X9jsU6gkZYIVc6SK\neyjn\r\n=xy7d\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.8.0": {
+      "name": "follow-redirects",
+      "version": "1.8.0",
+      "dependencies": {
+        "debug": "^4.1.1"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "coveralls": "^3.0.3",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-eYyazyi+vwXZ6LfSQicvqFwaNEF5xTvnB/rpzRLuqwK45u7WbBEnQ/dDic66KD/A8IzTXFlj2ROAcaP0f2v4lg==",
+        "shasum": "dcf34930bcfdb6c1eb22b8eb7c457ec95a3dcf40",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22157,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZQ+vCRA9TVsSAnZWagAAwA4P/iVHFFfoYSdGJ2tiqvXX\njtykXmGCqIgwK1pZ6tjotSJSVDT9VZNFIVZCuIcPIjGB/TbH7kWCF2bpvBnt\nfp3Z3BW9+NGv7/zBSymQWSzYapB881VWf6O1Nuz5t1T8BH9TNb56R9L1ooVO\nZQYUOKB3hw3EyhQRQWl4InUzSpNwh2oLr4l4TotHx6/AUEq29DPp8BxoXe4F\nV9IOWW+ViVphXnDtHSi8zulHKv9ZwnoknbkSnD+8PKFMyEpDYM2VXqb2Oxsn\nYkxp9OSCZioJtafzzOWfow4Fo3R7+E7IWlTBlhXr+QzVOYPS9eg2QXgY/nPr\nwokYdQIMeEYOy906Xe8QoRiOJgcqWutcPivFPeodp6gAzNUsIAKm1qAeNNPM\nMhj7Lml3i5eTa5zuIGAZEIwhHaNqAyPB8seaih140jIarPxhTzSN2vCqCgmN\nmLyMki9CM+v0jiljxrtdBrj1X8DZEMMOYTKk81cdpc/EFhgns1MG315lZm97\nMIYNbPU18IdYTy7T7iSdlTdVOufwUiDmaayZDPQlINb53TgA8+Huck7gaTGs\nPSArjdXVkpVvDDcuo7QEX19tSq18hc/kgVWFndkmZ+v5WZyv/kskh7GA8qZZ\nNlcRxdW2K0CPGHOCSAl1hLaj2gmWXEwejm9wn0zskSq8sbm5T50iLxTjNK6W\negO/\r\n=HCb6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "1.8.1": {
+      "name": "follow-redirects",
+      "version": "1.8.1",
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
+        "shasum": "24804f9eaab67160b0e840c085885d606371a35b",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22063,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdZWpxCRA9TVsSAnZWagAA8CkQAInJyjtAmvR/Jmc2H4m+\n+GLuWGtxQXAh5jAVfLFVBOYAogY5OGqNQvkKLWYuPOp5Q5c5WYQYnXz3uifI\n647JAXSjFOIEIDDHi3qWGvQbA8NlT+XoHRICocGk3/ogir4x7KMx1L0UZ2Yj\nwSw5zdJB9iP4LoGMuOx7/06mgv9Pox9QOruKM4tXqAaraPyTRAAw4qf30kq5\neRAKGujNeaoeOaCqHym9mB2p20dq9VvRWm56QDC/lIzuDip26XjbduQZABjM\nOiyI0NB54FjT9v91q6ZgIqSIwSuU4/MKoBDymvr95/DaQgiEcW3P3IhTHzyv\nGQ0CNEF+ruPBbw6DhiBhWB38Tv7LvAvSIb7d6xOuhrYIFLYPfkIZIfSNsigZ\nZPxILHiPShHQd1rJUZoeu0Ek2PVRuL8znnXsIj/B32ZjN11gRii2NfWZBILq\n5cK8YTBfnCXbUhpiBhAjfr93P/CGZ5oJSBaZCG30XvAn2WU5AUw93jwen7HQ\nyPnvUSR76UYdMQalugCyn9oE6fq150XFQMI9rNNN1GfxeTEPTcefvAG2rrtK\naakpIfkcNIZRPvntKM5KDeB90ah1KhNTVosZ3mPk89mXJC7rXCls4cOh+wxq\ntXQ7G/pLy+qrzkhlCyh0r++UHtM3i5dh+bEcIebnD85GeqL+YI6S+37uAEAY\npOoq\r\n=SrNP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.9.0": {
+      "name": "follow-redirects",
+      "version": "1.9.0",
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+        "shasum": "8d5bcdc65b7108fe1508649c79c12d732dcedb4f",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22100,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdclssCRA9TVsSAnZWagAAz9IP/2MzQdIJBkQMV2fMW8eX\nejrm9NKiRDWy5iHHlMNP4Ab5Q/L6EoWQfIey+tsvVXdeKg4yX3CmrGHAD2YU\nRPDD2m/D+9ODwl6DkA1eJgB/CeFqOuPXLdAO996N/HNJraF1D13X7eakNr0X\n46Q2l4fXatrHbFnjCAQXDbn7Xc27wgqBYWz0QPFhllQU025/vnk9p0mpgb3F\noUaSiK0YyHpWTlFHTI9Q4T4JzLn4UOtrWKAII3OcfxDcoKvM7HHaBT+Pm4aF\nQrx8MrC/KWgARmN3b//Na4qdjvVSigiXfG2jyVXx+KrryHCmN987439BsvYP\nwM172NFHOav+GCL5pCvNnrLVmtyO75TKpd5yPS4usNiOlZYl8lVrJGBo7e4W\ng2p60W6ihMfVBNFagXK1B6MXFi8ukgXFk+Y0M8peY2ZpA3PwBuE2RIf+fkYn\n74tghvFa15FZXO7Fm8G7sHHA1TNj4/6eehTXir3+P4TQwMCTt+WHJpbCcxfk\nCryarN58fnkYI6ErmFYZsiPmuqsuFE6ZG3XTXu7xq1oSmIJneByyc8QhZq2V\nGc0THH7minRYYN9QAFYNDPORBdHAgwyFctICpNFt3rqFVK4eryLqbMJKqwSR\nLgVuqL2uWOd4K3zxeLYsqmDp5Ww8SdITJFtVXkyJfK5T4dSwtiMyQwpgJTfk\neWy5\r\n=NYvs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.9.1": {
+      "name": "follow-redirects",
+      "version": "1.9.1",
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-oUNbrdUjHItyCytZQrHxWQ81ebL4xCFLH10sG0poUMgbKWoBnswpICjUBld3PLJ1lF6cCYVUBG7hAdLro0JNvg==",
+        "shasum": "26e329669886f8b3baccbaf352067b0253da6c2d",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22322,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeLNU7CRA9TVsSAnZWagAA9OwP/0q/xlzGdXLvctnmG22L\njYFGGcAzMS04Jve+FmofdtUKQG5YVyQTjJsy1Te8mJkggc0GYHmxcpQFSOEp\n6WxT1jjc0aQd1utL8T0hANlEvtPYcqV2o6vn14GQwOgbbcAc3FhjAeK96+Wl\nsgk51vwTlVXqoI1VUrq8ckxzzs4zGI2LaHINtIeMF5fBvRH/FkHZMdw1eUMs\niJhP5ydEBNBXSj/aD8d5SybbwW3Dsj2/ighXIIjck9ssoWBTVf6UtxeJR9P7\nGF1Np2W0psLbGfMQKE1k3XS+UTOhFAkXrLT70pL9YzcZskvGOlzws6aN6BSB\nVDSitmNmiSav6b2aQvosG0aH0K/PFD+wetCwo42K3AlTP8jIwZUKiHmPenJs\nezE8hpJ8kHra73GAzsAkQ5r5P/2Ic7rrzJxElLkgXOwK3ld4bEK3StsmSJwO\n7gCNGFSGXHk2if7cK5lwA430rRmgAdp23EBIGg1qanko/BaiuhjXvEo1gYnp\n5SSwy7cHdzG1t6AYBhiic0TZADNDifZB+pHd4dCZjxibY9fHHg6Q88acbiKr\nkDzJQWZ4yGkZp1+3Vg1WlnQxRn4BfRu63ux7zm0D24Gk1GkKu6af80uz3/Um\nrbxTIhaObp0FaD8eQsk+uaMAIyeOACqpaKrzngTmeS9utLygkr3DPYYJayXw\np3Ym\r\n=bIRS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.10.0": {
+      "name": "follow-redirects",
+      "version": "1.10.0",
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
+        "shasum": "01f5263aee921c6a54fb91667f08f4155ce169eb",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23170,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeLiJfCRA9TVsSAnZWagAAMCoQAKUGsAjNMrjM8v1P+Rrq\nCQkexRzO2E3kywImR9837V1NvO/qjrGs3B6fHcP4uvWi237W6pNNpi+9HC2J\nhwUO1AugHjdlGBmZ3xpjZLGgI0oy7Ws9UrHTAyHZcfY7B4YzuF8//P65W6LE\nW9JlqfIPIC8dYX2Y9fR+sqk3urlRSf0SyulYvOMeZYe2+/3PaiKG/JeGHY7T\nsfzi52wk7Y4sQ33VPWa03umgoRWlZ75KTQLcvLKtbR7upBAp1mbc7029PJPB\nPR05STVaOa8di3jvJP89pUs7V7I3yLoSdtKxPatoDPFsAZPWh7seQMJJjzfa\ndo8MdjA1DLNoR7sMUmYsu8dIVd1JHzGHH2HDnDrEZrsIKUQTQC7ovw4MyZ05\niNo/vRg7Pg7xYEqmYq/7YM4TERVWQzf/C2yo4Q2iQsER73FXW3zTglW1uA6g\n4eMgxPKf+6390oxrL8pBAONxM11WeRjJDt7Rrx23nfPCMkVky9vRPTUapsv0\nELVkb+NPTDs4wiEO0t6TQNFdClmSUwfVotSLD6Z79YagB1jrxLJ7zK0Ntz8m\nflaZCpG0SdLC/YFIX7pCc3K9AsZSeNkrt7ejuMTCxFAPXWGfPerSGbEuv/8X\nLBApiH7cvjha+qG1shEA+unjAr6/l5PHX8/bFFDYzI9X3HHxv5UJf/7uXm7K\nKiJk\r\n=0B6u\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.11.0": {
+      "name": "follow-redirects",
+      "version": "1.11.0",
+      "dependencies": {
+        "debug": "^3.0.0"
+      },
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
+        "shasum": "afa14f08ba12a52963140fe43212658897bc0ecb",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 23524,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJegH5gCRA9TVsSAnZWagAAnLMP/jR2M97OJB0tx9WA781R\n9n6DD/Ikjyi6coHArH6vMnqW0K4IK1Jsn29rR13M/uc/hZnn+Y/Y9d1lCBuy\n5hPm13ZCtbfNDaCqYMqSd6WGhzj/S/FDjjDHZKyoLlA5JxRpBszwNL6c78SZ\ntYJJMMRAOfZo4apotVG+fvpq1eZ/qw3Vrxsrihzc6v9Xd9RAdLsOh7345RKN\nAJEfm1XcQl54HaRv8jrrLtb1ESHjIeMWcLYS8tI0koCvS8eO1Jf2Hl0Bonrz\n8QDd9YfIS/5qRRXpubKvZ21yKFJ8rWRCJRgjvCSn1DM3fbp66XvjESh61lHN\nLxeIjsMdwv1vGumyJJtcej8DjGfwsBUAcMlrqMo1fpwGJq5u2Zw2TMAGeVK1\nu9myTSynjp/fpv2smZvE7taiYb2Ws01HRadc1CxiRcxHU+UV9SwLKAWaPGIq\n50uF0VfXswFecMY8Mblh5BudCpejf5KBpHKt6Fr3boQFj5jqXlZoGZkSwJea\npZhT14ELTkFqQ4I9EE1wyI8smtXfVVKrpZSoJWuKZDg8TLYf9EHZvu5zcBnT\nHoyhM1SUy6B0AowPDmWBJ92W2d10PcuWFoKFb4bEyzpfYSHaJGoeBiYvboDc\nFBlnbCiamAASn+RzwGu/u+NkxodQUOI1UavxfVCq4qoctRzMK3qU9aJTSVGM\nA+64\r\n=Qy8M\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.12.0": {
+      "name": "follow-redirects",
+      "version": "1.12.0",
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "peerDependencies": {
+        "debug": "^3.0.0 || ^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-JgawlbfBQKjbKegPn8vUsvJqplE7KHJuhGO4yPcb+ZOIYKSr+xobMVlfRBToZwZUUxy7lFiKBdFNloz9ui368Q==",
+        "shasum": "ff0ccf85cf2c867c481957683b5f91b75b25e240",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 23697,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe6S2GCRA9TVsSAnZWagAAfPgP/1NdDvODI9cnOFEXtzyJ\nRFtpkrpuWSpZWxnv7nyQBuPiXJRLSOqtGaP1CfOJjL2uP9Tbf2ogZLnMA5oA\nz2Ie6pCh/U1p/bvxNNXRBAoSGOgzB1/2IZUTuR0/LK6Gt321uF8i/yQKmyug\nzGUKQjz3GONyheTfyhLrcy5PCZwfSADLyAILsFMuMI1AB4ifm/6Zp0oshQw+\nUuE0SiftQvVG0BVxS2vYS66fAMKktxc6DPvUbn6EKAfaM7Ggj48OqHu77TAD\nJEem8+dYZ9Q2+eY4UyiaZwS3+grO49oymzZ5he6XyRh+6BLclTs8FPlfb+da\nTatRA+ksV9AMVdr3vAoCnxu6I5QxXYnlsNgan1TOzm+edV4zXYwtg6MP+luk\nSD2VQJXi3q/IReADnqWtBfZ9GLHMlAEX9RHubzNsY7bL2F0M6qUSMSIfdHmW\neTTB2YgD5VIVH6HoM4GiI6vwcnupBLrI0wTuBUjswTIIHC3DXsZ+/l5bdKiD\nICcV2MURZ6P7I5HNtdkJVCgydIOY+4vw7y7QNmdyMvq+ALM+tjhAG0N1RvL2\nXaQzfCkG3DaGLEr4h/nfN7yU/NLdi7EDUyYT+vEV0owvoGXrSBoyVEAfVbwe\nGRXRw4RomjGZK5qrnJkOXugSm7zcapK0bz3Do5u96Pp+gLYHCBVy1ka3+vq0\nf8iI\r\n=7ygN\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "1.12.1": {
+      "name": "follow-redirects",
+      "version": "1.12.1",
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg==",
+        "shasum": "de54a6205311b93d60398ebc01cf7015682312b6",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 23900,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe6+ybCRA9TVsSAnZWagAAsAcP/1TfXM557wagSC8+bQ1K\n9rHGMRSLAFf7AI3mc6sWLgNPGnh8KiLph98mCy5u7RZmeHWEwNiN5WYcXKPD\ns/q5GnacO6uRdxbC69YwUvY5VljBpdAGqLn2rg85kRF/MkoWWGIe0OXI+eQm\nHZKTlVrRoYA2nOfMjNkws6/3pRSX1FHdgn/uihauW7Z/yHEMR4tt9hYsHtKt\nl9wLbBF+nEq85zSLesBWGyZnAo4JCSaHhRRuRYVON+YYYgi0JXtMgIw01K3k\nw2/DRCzs1gWBgwp2Xb/lIkfY530MQg6ChaC0V+YwSyLyH9l/KMho1qFoUTeL\n1gFPV9qd0+N/ZsjyFOX11HEcoj2cQNZqAkrUKNX0xPLKcwoKlI5B6zCIRvIm\n/3ETO3sFi4otJIzY86DwNWFku+0r9FNftKEiXLlTskh2omdX5Rm/f8CyAChU\nnXThZKYAS7/+miM8aY15WN/yYuxK0nFfNNCTDwMb5sgqTYWJ6jCoIHchxbIK\n2VHK5XT/aezSLmLEKVvmE4LqaaEONqhqnfBngx6fcCDHhPlo5oDDwWQGId/u\n5MlJI3V/YA8zDFhqR8L445Y6w/bMRFIBI7E2xvUij9AZ5MCN/qzZyUcaiGhW\n81gPvWFXoCP6KmAKKAk/FvRBPibk+YLp1sQNaDZlerVnuHpt9jjcDyB0aPmJ\n40A/\r\n=nX59\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ]
+    },
+    "1.13.0": {
+      "name": "follow-redirects",
+      "version": "1.13.0",
+      "devDependencies": {
+        "concat-stream": "^2.0.0",
+        "eslint": "^5.16.0",
+        "express": "^4.16.4",
+        "lolex": "^3.1.0",
+        "mocha": "^6.0.2",
+        "nyc": "^14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
+        "shasum": "b42e8d93a2a7eea5ed88633676d6597bc8e384db",
+        "tarball": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 24066,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfMTJXCRA9TVsSAnZWagAAH+QP/RYg/ow5bVtgXIxGYoBT\n/mncbw9r192KpPWj/3C7vn3izLTf/GvWuU6DjETTYenRkpOF1QkjlRFyVDBJ\nEYrDlXmHL5AIdQRPQoRFXIRgdOx+bMjYFdeV4KVTqMq9Yh3vFFqho63oBnTP\nRo8iGZ8KGzF2ZVNXRwEnoGSANERPXKsoLKlvBMA0MAXtjQCgOpdzYlNv5h5j\nSXLwxZobsc/4piJWvRjdrITE45UYR5HnknUM90Pm73kVfg5kNdrPqLWUCJ1+\nO/Nf9lzFXrgO8j3fNLw+VB0i8gsAZZz4MOmn/AUUERx8c2mvU7g0R3c5NM4o\nbL+CSNutmz8Vtlu7wxXA7kCJKTPxHQmpfHlZR3B3pKH8nKqGw3lto6XdjWNn\nYZu+YzzJg7v5WVVp7BY54FnVgS+JHz5qog1YqG95IOeErAlA1JWupA7TZrdG\nmm6H5zVI3+qKMUwMUk8TDwpzrInbYbndEcOfgC5OIn7Fc7qxn48duwqcOCBE\nX3VmJJJWil6GP6QsL2DkMC8fEbFluXPeB8BNzxY1HfWWetTI708oYRBVqEQt\nhBqTgF/Px5EeA6BJ5cVg/swOnRYEQ8jL7Bx867bBsfzhE/hC8bmFu29AWXU5\nIM1yHtvey8jgaPVmbFzoWbW9cObfsqmdwIDNamtjhMGDrPeKEhb9CVDXaB4T\n0n4A\r\n=QqNW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ]
+    }
+  },
+  "modified": "2020-08-10T11:41:15.992Z"
+}

--- a/test/fixtures/registry-mocks/content/forwarded.json
+++ b/test/fixtures/registry-mocks/content/forwarded.json
@@ -1,0 +1,268 @@
+{
+  "_id": "forwarded",
+  "_rev": "12-36dd9543e195d9d55d3e1f82f3cc0fdf",
+  "name": "forwarded",
+  "time": {
+    "modified": "2017-09-15T02:17:54.232Z",
+    "created": "2014-08-19T08:43:29.230Z",
+    "0.0.0": "2014-08-19T08:43:29.230Z",
+    "0.1.0": "2014-09-21T19:23:28.870Z",
+    "0.1.1": "2017-09-10T23:15:48.834Z",
+    "0.1.2": "2017-09-15T02:17:54.232Z"
+  },
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "dist-tags": {
+    "latest": "0.1.2"
+  },
+  "description": "Parse HTTP X-Forwarded-For header",
+  "readme": "# forwarded\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nParse HTTP X-Forwarded-For header\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install forwarded\n```\n\n## API\n\n```js\nvar forwarded = require('forwarded')\n```\n\n### forwarded(req)\n\n```js\nvar addresses = forwarded(req)\n```\n\nParse the `X-Forwarded-For` header from the request. Returns an array\nof the addresses, including the socket address for the `req`, in reverse\norder (i.e. index `0` is the socket address and the last index is the\nfurthest address, typically the end-user).\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/forwarded.svg\n[npm-url]: https://npmjs.org/package/forwarded\n[node-version-image]: https://img.shields.io/node/v/forwarded.svg\n[node-version-url]: https://nodejs.org/en/download/\n[travis-image]: https://img.shields.io/travis/jshttp/forwarded/master.svg\n[travis-url]: https://travis-ci.org/jshttp/forwarded\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/forwarded/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/forwarded?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/forwarded.svg\n[downloads-url]: https://npmjs.org/package/forwarded\n",
+  "versions": {
+    "0.1.0": {
+      "name": "forwarded",
+      "description": "Parse HTTP X-Forwarded-For header",
+      "version": "0.1.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "x-forwarded-for",
+        "http",
+        "req"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/forwarded"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "e9a9faeb3cfaadf40eb57d144fff26bca9b818e8",
+      "bugs": {
+        "url": "https://github.com/jshttp/forwarded/issues"
+      },
+      "homepage": "https://github.com/jshttp/forwarded",
+      "_id": "forwarded@0.1.0",
+      "_shasum": "19ef9874c4ae1c297bcf078fde63a09b66a84363",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "19ef9874c4ae1c297bcf078fde63a09b66a84363",
+        "tarball": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "forwarded",
+      "description": "Parse HTTP X-Forwarded-For header",
+      "version": "0.1.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "x-forwarded-for",
+        "http",
+        "req"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/forwarded.git"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "45e46e2a56348b62ebe679e263550624e6a02d70",
+      "bugs": {
+        "url": "https://github.com/jshttp/forwarded/issues"
+      },
+      "homepage": "https://github.com/jshttp/forwarded#readme",
+      "_id": "forwarded@0.1.1",
+      "_shasum": "8a4e30c640b05395399a3549c730257728048961",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "8a4e30c640b05395399a3549c730257728048961",
+        "tarball": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/forwarded-0.1.1.tgz_1505085347950_0.7802835658658296"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "forwarded",
+      "description": "Parse HTTP X-Forwarded-For header",
+      "version": "0.1.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "x-forwarded-for",
+        "http",
+        "req"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/forwarded.git"
+      },
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "2fc094b49781b62acb0e2b00f83abd641d604a7c",
+      "bugs": {
+        "url": "https://github.com/jshttp/forwarded/issues"
+      },
+      "homepage": "https://github.com/jshttp/forwarded#readme",
+      "_id": "forwarded@0.1.2",
+      "_shasum": "98c23dab1175657b8c0573e8ceccd91b0ff18c84",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "98c23dab1175657b8c0573e8ceccd91b0ff18c84",
+        "tarball": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/forwarded-0.1.2.tgz_1505441873168_0.0936233215034008"
+      },
+      "directories": {}
+    }
+  },
+  "homepage": "https://github.com/jshttp/forwarded#readme",
+  "keywords": [
+    "x-forwarded-for",
+    "http",
+    "req"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/forwarded.git"
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/jshttp/forwarded/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "mojaray2k": true,
+    "rocket0191": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/forwarded.min.json
+++ b/test/fixtures/registry-mocks/content/forwarded.min.json
@@ -1,0 +1,68 @@
+{
+  "name": "forwarded",
+  "dist-tags": {
+    "latest": "0.1.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "forwarded",
+      "version": "0.1.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "19ef9874c4ae1c297bcf078fde63a09b66a84363",
+        "tarball": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.1.1": {
+      "name": "forwarded",
+      "version": "0.1.1",
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "8a4e30c640b05395399a3549c730257728048961",
+        "tarball": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.1.2": {
+      "name": "forwarded",
+      "version": "0.1.2",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "98c23dab1175657b8c0573e8ceccd91b0ff18c84",
+        "tarball": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2017-09-15T02:17:54.232Z"
+}

--- a/test/fixtures/registry-mocks/content/fragment-cache.json
+++ b/test/fixtures/registry-mocks/content/fragment-cache.json
@@ -1,0 +1,316 @@
+{
+  "_id": "fragment-cache",
+  "_rev": "3-5dc42d53a72f036b5f9ed23e7278cdef",
+  "name": "fragment-cache",
+  "description": "A cache for managing namespaced sub-caches",
+  "dist-tags": {
+    "latest": "0.2.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "fragment-cache",
+      "description": "A cache for managing namespaced sub-caches",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/fragment-cache",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/fragment-cache.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/fragment-cache/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "map-cache": "^0.2.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.9",
+        "gulp-istanbul": "^0.10.4",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5"
+      },
+      "keywords": [
+        "cache",
+        "fragment"
+      ],
+      "verb": {
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "reflinks": [
+          "verb",
+          "map-cache"
+        ],
+        "related": {
+          "list": [
+            "base",
+            "map-cache"
+          ]
+        },
+        "layout": "default",
+        "toc": false,
+        "tasks": [
+          "readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "_id": "fragment-cache@0.1.0",
+      "_shasum": "8f8d04a94eec9510a22b3d1c6a2b46b1144988c9",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8f8d04a94eec9510a22b3d1c6a2b46b1144988c9",
+        "tarball": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/fragment-cache-0.1.0.tgz_1462276976394_0.7934316475875676"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "fragment-cache",
+      "description": "A cache for managing namespaced sub-caches",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/fragment-cache",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/fragment-cache.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/fragment-cache/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.1.2"
+      },
+      "keywords": [
+        "cache",
+        "fragment"
+      ],
+      "verb": {
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "reflinks": [
+          "map-cache",
+          "verb"
+        ],
+        "related": {
+          "list": [
+            "base",
+            "map-cache"
+          ]
+        },
+        "layout": "default",
+        "toc": false,
+        "tasks": [
+          "readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "b2e876bc60f09bff7017f7c08211d098de27622c",
+      "_id": "fragment-cache@0.2.0",
+      "_shasum": "783dd290444ac80f87d9022d2eccc67f6e4f7fe4",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "783dd290444ac80f87d9022d2eccc67f6e4f7fe4",
+        "tarball": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/fragment-cache-0.2.0.tgz_1476743803652_0.9261136949062347"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "fragment-cache",
+      "description": "A cache for managing namespaced sub-caches",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/fragment-cache",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/fragment-cache.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/fragment-cache/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "cache",
+        "fragment"
+      ],
+      "verb": {
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "reflinks": [
+          "map-cache",
+          "verb"
+        ],
+        "related": {
+          "list": [
+            "base",
+            "map-cache"
+          ]
+        },
+        "layout": "default",
+        "toc": false,
+        "tasks": [
+          "readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "33583b03f505c67479ddbc66f825b0e653704207",
+      "_id": "fragment-cache@0.2.1",
+      "_shasum": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+        "tarball": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/fragment-cache-0.2.1.tgz_1489523817961_0.01654543890617788"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# fragment-cache [![NPM version](https://img.shields.io/npm/v/fragment-cache.svg?style=flat)](https://www.npmjs.com/package/fragment-cache) [![NPM downloads](https://img.shields.io/npm/dm/fragment-cache.svg?style=flat)](https://npmjs.org/package/fragment-cache) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/fragment-cache.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/fragment-cache)\n\n> A cache for managing namespaced sub-caches\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save fragment-cache\n```\n\n## Usage\n\n```js\nvar Fragment = require('fragment-cache');\nvar fragment = new Fragment();\n```\n\n## API\n\n### [FragmentCache](index.js#L24)\n\nCreate a new `FragmentCache` with an optional object to use for `caches`.\n\n**Example**\n\n```js\nvar fragment = new FragmentCache();\n```\n\n**Params**\n\n* `cacheName` **{String}**\n* `returns` **{Object}**: Returns the [map-cache](https://github.com/jonschlinkert/map-cache) instance.\n\n### [.cache](index.js#L49)\n\nGet cache `name` from the `fragment.caches` object. Creates a new `MapCache` if it doesn't already exist.\n\n**Example**\n\n```js\nvar cache = fragment.cache('files');\nconsole.log(fragment.caches.hasOwnProperty('files'));\n//=> true\n```\n\n**Params**\n\n* `cacheName` **{String}**\n* `returns` **{Object}**: Returns the [map-cache](https://github.com/jonschlinkert/map-cache) instance.\n\n### [.set](index.js#L67)\n\nSet a value for property `key` on cache `name`\n\n**Example**\n\n```js\nfragment.set('files', 'somefile.js', new File({path: 'somefile.js'}));\n```\n\n**Params**\n\n* `name` **{String}**\n* `key` **{String}**: Property name to set\n* `val` **{any}**: The value of `key`\n* `returns` **{Object}**: The cache instance for chaining\n\n### [.has](index.js#L93)\n\nReturns true if a non-undefined value is set for `key` on fragment cache `name`.\n\n**Example**\n\n```js\nvar cache = fragment.cache('files');\ncache.set('somefile.js');\n\nconsole.log(cache.has('somefile.js'));\n//=> true\n\nconsole.log(cache.has('some-other-file.js'));\n//=> false\n```\n\n**Params**\n\n* `name` **{String}**: Cache name\n* `key` **{String}**: Optionally specify a property to check for on cache `name`\n* `returns` **{Boolean}**\n\n### [.get](index.js#L115)\n\nGet `name`, or if specified, the value of `key`. Invokes the [cache](#cache) method, so that cache `name` will be created it doesn't already exist. If `key` is not passed, the entire cache (`name`) is returned.\n\n**Example**\n\n```js\nvar Vinyl = require('vinyl');\nvar cache = fragment.cache('files');\ncache.set('somefile.js', new Vinyl({path: 'somefile.js'}));\nconsole.log(cache.get('somefile.js'));\n//=> <File \"somefile.js\">\n```\n\n**Params**\n\n* `name` **{String}**\n* `returns` **{Object}**: Returns cache `name`, or the value of `key` if specified\n\n## About\n\n### Related projects\n\n* [base](https://www.npmjs.com/package/base): base is the foundation for creating modular, unit testable and highly pluggable node.js applications, starting… [more](https://github.com/node-base/base) | [homepage](https://github.com/node-base/base \"base is the foundation for creating modular, unit testable and highly pluggable node.js applications, starting with a handful of common methods, like `set`, `get`, `del` and `use`.\")\n* [map-cache](https://www.npmjs.com/package/map-cache): Basic cache object for storing key-value pairs. | [homepage](https://github.com/jonschlinkert/map-cache \"Basic cache object for storing key-value pairs.\")\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Building docs\n\n_(This document was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme) (a [verb](https://github.com/verbose/verb) generator), please don't edit the readme directly. Any changes to the readme must be made in [.verb.md](.verb.md).)_\n\nTo generate the readme and API documentation with [verb](https://github.com/verbose/verb):\n\n```sh\n$ npm install -g verb verb-generate-readme && verb\n```\n\n### Running tests\n\nInstall dev dependencies:\n\n```sh\n$ npm install -d && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](http://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2016, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT license](https://github.com/jonschlinkert/fragment-cache/blob/master/LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.2.0, on October 17, 2016._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-03-14T20:36:58.556Z",
+    "created": "2016-05-03T12:02:57.546Z",
+    "0.1.0": "2016-05-03T12:02:57.546Z",
+    "0.2.0": "2016-10-17T22:36:45.438Z",
+    "0.2.1": "2017-03-14T20:36:58.556Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/fragment-cache",
+  "keywords": [
+    "cache",
+    "fragment"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/fragment-cache.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/fragment-cache/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/fragment-cache.min.json
+++ b/test/fixtures/registry-mocks/content/fragment-cache.min.json
@@ -1,0 +1,75 @@
+{
+  "name": "fragment-cache",
+  "dist-tags": {
+    "latest": "0.2.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "fragment-cache",
+      "version": "0.1.0",
+      "dependencies": {
+        "map-cache": "^0.2.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.9",
+        "gulp-istanbul": "^0.10.4",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5"
+      },
+      "dist": {
+        "shasum": "8f8d04a94eec9510a22b3d1c6a2b46b1144988c9",
+        "tarball": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "0.2.0": {
+      "name": "fragment-cache",
+      "version": "0.2.0",
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.1.2"
+      },
+      "dist": {
+        "shasum": "783dd290444ac80f87d9022d2eccc67f6e4f7fe4",
+        "tarball": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "0.2.1": {
+      "name": "fragment-cache",
+      "version": "0.2.1",
+      "dependencies": {
+        "map-cache": "^0.2.2"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "4290fad27f13e89be7f33799c6bc5a0abfff0d19",
+        "tarball": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-03-14T20:36:58.556Z"
+}

--- a/test/fixtures/registry-mocks/content/fresh.json
+++ b/test/fixtures/registry-mocks/content/fresh.json
@@ -1,0 +1,874 @@
+{
+  "_id": "fresh",
+  "_rev": "45-2ea2e347c7b1853450c8fc132432c64a",
+  "name": "fresh",
+  "description": "HTTP response freshness testing",
+  "dist-tags": {
+    "latest": "0.5.2"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "fresh",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "HTTP response freshness testing",
+      "version": "0.0.1",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "fresh@0.0.1",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.24",
+      "_nodeVersion": "v0.6.19",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f98a0a1b9001b6e227fb9c65ff3927bdb7b404fa",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "fresh",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "HTTP response freshness testing",
+      "version": "0.1.0",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "fresh@0.1.0",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.24",
+      "_nodeVersion": "v0.6.19",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "03e4b0178424e4c2d5d19a54d8814cdc97934850",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "fresh",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "HTTP response freshness testing",
+      "version": "0.2.0",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-fresh.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-fresh/issues"
+      },
+      "_id": "fresh@0.2.0",
+      "dist": {
+        "shasum": "bfd9402cf3df12c4a4c310c79f99a3dde13d34a7",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.4",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "fresh",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "HTTP response freshness testing",
+      "version": "0.2.1",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-fresh.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/visionmedia/node-fresh/blob/master/Readme.md#license"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-fresh/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-fresh",
+      "_id": "fresh@0.2.1",
+      "dist": {
+        "shasum": "13cc0b1f53fe0e6fa6a70c18d52ce3c5c56be066",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "fresh",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "HTTP response freshness testing",
+      "version": "0.2.2",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-fresh.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/visionmedia/node-fresh/blob/master/Readme.md#license"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-fresh/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-fresh",
+      "_id": "fresh@0.2.2",
+      "dist": {
+        "shasum": "9731dcf5678c7faeb44fb903c4f72df55187fa77",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "fresh",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "HTTP response freshness testing",
+      "version": "0.2.3",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/fresh"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1",
+        "should": "3"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "mocha --reporter spec --require should",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --require should"
+      },
+      "keywords": [
+        "fresh",
+        "http",
+        "conditional",
+        "cache"
+      ],
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "a94cacdf94f85bd6a1e1210c5928e4b0d8518043",
+      "bugs": {
+        "url": "https://github.com/jshttp/fresh/issues"
+      },
+      "homepage": "https://github.com/jshttp/fresh",
+      "_id": "fresh@0.2.3",
+      "_shasum": "2db40d43bc63830f418519380879d6bedde2e845",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2db40d43bc63830f418519380879d6bedde2e845",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.4": {
+      "name": "fresh",
+      "description": "HTTP response freshness testing",
+      "version": "0.2.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "fresh",
+        "http",
+        "conditional",
+        "cache"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/fresh"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1",
+        "should": "3"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --require should"
+      },
+      "gitHead": "8440a4ca75fb091dec06e88654b3b1c31d7e7164",
+      "bugs": {
+        "url": "https://github.com/jshttp/fresh/issues"
+      },
+      "homepage": "https://github.com/jshttp/fresh",
+      "_id": "fresh@0.2.4",
+      "_shasum": "3582499206c9723714190edd74b4604feb4a614c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3582499206c9723714190edd74b4604feb4a614c",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "fresh",
+      "description": "HTTP response freshness testing",
+      "version": "0.3.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "fresh",
+        "http",
+        "conditional",
+        "cache"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/fresh"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "14616c9748368ca08cd6a955dd88ab659b778634",
+      "bugs": {
+        "url": "https://github.com/jshttp/fresh/issues"
+      },
+      "homepage": "https://github.com/jshttp/fresh",
+      "_id": "fresh@0.3.0",
+      "_shasum": "651f838e22424e7566de161d8358caa199f83d4f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "651f838e22424e7566de161d8358caa199f83d4f",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "fresh",
+      "description": "HTTP response freshness testing",
+      "version": "0.4.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "fresh",
+        "http",
+        "conditional",
+        "cache"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/fresh.git"
+      },
+      "devDependencies": {
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "c0af4deba75d95d1f5d56906b7dc45b849cbaa21",
+      "bugs": {
+        "url": "https://github.com/jshttp/fresh/issues"
+      },
+      "homepage": "https://github.com/jshttp/fresh#readme",
+      "_id": "fresh@0.4.0",
+      "_shasum": "475626a934a8d3480b2101a1d6ecef7dafd7c553",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "475626a934a8d3480b2101a1d6ecef7dafd7c553",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/fresh-0.4.0.tgz_1486346746830_0.760833503678441"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "fresh",
+      "description": "HTTP response freshness testing",
+      "version": "0.5.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "fresh",
+        "http",
+        "conditional",
+        "cache"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/fresh.git"
+      },
+      "devDependencies": {
+        "eslint": "3.16.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "b1d26abb390d5dd1d9b82f0a5b890ab0ef1fee5c",
+      "bugs": {
+        "url": "https://github.com/jshttp/fresh/issues"
+      },
+      "homepage": "https://github.com/jshttp/fresh#readme",
+      "_id": "fresh@0.5.0",
+      "_shasum": "f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/fresh-0.5.0.tgz_1487738798128_0.4817247486207634"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "fresh",
+      "description": "HTTP response freshness testing",
+      "version": "0.5.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "fresh",
+        "http",
+        "conditional",
+        "cache"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/fresh.git"
+      },
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "e8a4aaffc75b6169a6f57168ac79dee7a7f02c92",
+      "bugs": {
+        "url": "https://github.com/jshttp/fresh/issues"
+      },
+      "homepage": "https://github.com/jshttp/fresh#readme",
+      "_id": "fresh@0.5.1",
+      "_shasum": "c3a08bcec0fcdcc223edf3b23eb327f1f9fcbf5c",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "c3a08bcec0fcdcc223edf3b23eb327f1f9fcbf5c",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/fresh-0.5.1.tgz_1505187168525_0.3156159908976406"
+      },
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "fresh",
+      "description": "HTTP response freshness testing",
+      "version": "0.5.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "fresh",
+        "http",
+        "conditional",
+        "cache"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/fresh.git"
+      },
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "02df6303ff260b6b7da0b479f3e42222e8157b47",
+      "bugs": {
+        "url": "https://github.com/jshttp/fresh/issues"
+      },
+      "homepage": "https://github.com/jshttp/fresh#readme",
+      "_id": "fresh@0.5.2",
+      "_shasum": "3d8cadd90d976569fa835ab1f8e4b23a105605a7",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "3d8cadd90d976569fa835ab1f8e4b23a105605a7",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/fresh-0.5.2.tgz_1505365391149_0.7952043106779456"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# fresh\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nHTTP response freshness testing\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```\n$ npm install fresh\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar fresh = require('fresh')\n```\n\n### fresh(reqHeaders, resHeaders)\n\nCheck freshness of the response using request and response headers.\n\nWhen the response is still \"fresh\" in the client's cache `true` is\nreturned, otherwise `false` is returned to indicate that the client\ncache is now stale and the full response should be sent.\n\nWhen a client sends the `Cache-Control: no-cache` request header to\nindicate an end-to-end reload request, this module will return `false`\nto make handling these requests transparent.\n\n## Known Issues\n\nThis module is designed to only follow the HTTP specifications, not\nto work-around all kinda of client bugs (especially since this module\ntypically does not recieve enough information to understand what the\nclient actually is).\n\nThere is a known issue that in certain versions of Safari, Safari\nwill incorrectly make a request that allows this module to validate\nfreshness of the resource even when Safari does not have a\nrepresentation of the resource in the cache. The module\n[jumanji](https://www.npmjs.com/package/jumanji) can be used in\nan Express application to work-around this issue and also provides\nlinks to further reading on this Safari bug.\n\n## Example\n\n### API usage\n\n<!-- eslint-disable no-redeclare, no-undef -->\n\n```js\nvar reqHeaders = { 'if-none-match': '\"foo\"' }\nvar resHeaders = { 'etag': '\"bar\"' }\nfresh(reqHeaders, resHeaders)\n// => false\n\nvar reqHeaders = { 'if-none-match': '\"foo\"' }\nvar resHeaders = { 'etag': '\"foo\"' }\nfresh(reqHeaders, resHeaders)\n// => true\n```\n\n### Using with Node.js http server\n\n```js\nvar fresh = require('fresh')\nvar http = require('http')\n\nvar server = http.createServer(function (req, res) {\n  // perform server logic\n  // ... including adding ETag / Last-Modified response headers\n\n  if (isFresh(req, res)) {\n    // client has a fresh copy of resource\n    res.statusCode = 304\n    res.end()\n    return\n  }\n\n  // send the resource\n  res.statusCode = 200\n  res.end('hello, world!')\n})\n\nfunction isFresh (req, res) {\n  return fresh(req.headers, {\n    'etag': res.getHeader('ETag'),\n    'last-modified': res.getHeader('Last-Modified')\n  })\n}\n\nserver.listen(3000)\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/fresh.svg\n[npm-url]: https://npmjs.org/package/fresh\n[node-version-image]: https://img.shields.io/node/v/fresh.svg\n[node-version-url]: https://nodejs.org/en/\n[travis-image]: https://img.shields.io/travis/jshttp/fresh/master.svg\n[travis-url]: https://travis-ci.org/jshttp/fresh\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/fresh/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/fresh?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/fresh.svg\n[downloads-url]: https://npmjs.org/package/fresh\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-12-04T10:08:50.043Z",
+    "created": "2012-06-10T19:09:34.892Z",
+    "0.0.1": "2012-06-10T19:09:36.227Z",
+    "0.1.0": "2012-06-15T23:07:11.778Z",
+    "0.2.0": "2013-08-10T21:44:55.387Z",
+    "0.2.1": "2014-01-29T20:16:08.494Z",
+    "0.2.2": "2014-02-19T23:28:15.565Z",
+    "0.2.3": "2014-09-08T01:09:11.214Z",
+    "0.2.4": "2014-09-08T02:50:40.194Z",
+    "0.3.0": "2015-05-12T15:10:38.713Z",
+    "0.4.0": "2017-02-06T02:05:48.973Z",
+    "0.5.0": "2017-02-22T04:46:40.181Z",
+    "0.5.1": "2017-09-12T03:32:49.448Z",
+    "0.5.2": "2017-09-14T05:03:12.205Z"
+  },
+  "author": {
+    "name": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "url": "http://tjholowaychuk.com"
+  },
+  "users": {
+    "m42am": true,
+    "goodseller": true,
+    "simplyianm": true,
+    "ninozhang": true,
+    "moimikey": true,
+    "nickeltobias": true,
+    "tobiasnickel": true,
+    "wangnan0610": true,
+    "jovinbm": true,
+    "mojaray2k": true,
+    "ckaatz": true,
+    "oldfish": true,
+    "wxttxw125": true,
+    "eyson": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/fresh.git"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jshttp/fresh#readme",
+  "bugs": {
+    "url": "https://github.com/jshttp/fresh/issues"
+  },
+  "keywords": [
+    "fresh",
+    "http",
+    "conditional",
+    "cache"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/fresh.min.json
+++ b/test/fixtures/registry-mocks/content/fresh.min.json
@@ -1,0 +1,205 @@
+{
+  "name": "fresh",
+  "dist-tags": {
+    "latest": "0.5.2"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "fresh",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "f98a0a1b9001b6e227fb9c65ff3927bdb7b404fa",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "fresh",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "03e4b0178424e4c2d5d19a54d8814cdc97934850",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.0": {
+      "name": "fresh",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "bfd9402cf3df12c4a4c310c79f99a3dde13d34a7",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "fresh",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "13cc0b1f53fe0e6fa6a70c18d52ce3c5c56be066",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "fresh",
+      "version": "0.2.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "9731dcf5678c7faeb44fb903c4f72df55187fa77",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+      }
+    },
+    "0.2.3": {
+      "name": "fresh",
+      "version": "0.2.3",
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1",
+        "should": "3"
+      },
+      "dist": {
+        "shasum": "2db40d43bc63830f418519380879d6bedde2e845",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.3.tgz"
+      }
+    },
+    "0.2.4": {
+      "name": "fresh",
+      "version": "0.2.4",
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1",
+        "should": "3"
+      },
+      "dist": {
+        "shasum": "3582499206c9723714190edd74b4604feb4a614c",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.3.0": {
+      "name": "fresh",
+      "version": "0.3.0",
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "651f838e22424e7566de161d8358caa199f83d4f",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.4.0": {
+      "name": "fresh",
+      "version": "0.4.0",
+      "devDependencies": {
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "475626a934a8d3480b2101a1d6ecef7dafd7c553",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.0": {
+      "name": "fresh",
+      "version": "0.5.0",
+      "devDependencies": {
+        "eslint": "3.16.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.1": {
+      "name": "fresh",
+      "version": "0.5.1",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "c3a08bcec0fcdcc223edf3b23eb327f1f9fcbf5c",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.2": {
+      "name": "fresh",
+      "version": "0.5.2",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "3d8cadd90d976569fa835ab1f8e4b23a105605a7",
+        "tarball": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2017-12-04T10:08:50.043Z"
+}

--- a/test/fixtures/registry-mocks/content/from2.json
+++ b/test/fixtures/registry-mocks/content/from2.json
@@ -1,0 +1,1095 @@
+{
+  "_id": "from2",
+  "_rev": "32-7e5fec715ce04d5ae17740d082c921c9",
+  "name": "from2",
+  "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+  "dist-tags": {
+    "latest": "2.3.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "0.0.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "_id": "from2@0.0.0",
+      "dist": {
+        "shasum": "66d98a665a59a6cd5dd29bc9b11d6e48343cbd71",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "hughsk",
+        "email": "hughskennedy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "1.0.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "d0914ee2a5c1b2fb233d984c1b6687e6fa9f3081",
+      "_id": "from2@1.0.0",
+      "_shasum": "ee0974ca65e5fdbe6f151c30f10cce380d4466d6",
+      "_from": ".",
+      "_npmVersion": "1.4.13",
+      "_npmUser": {
+        "name": "hughsk",
+        "email": "hughskennedy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ee0974ca65e5fdbe6f151c30f10cce380d4466d6",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "1.0.1",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "066e9c3f010a0d67c5a0025d33e5d8ae082ed627",
+      "_id": "from2@1.0.1",
+      "_shasum": "c9d33f6a16c62493f4814d3626e4cd4288040e14",
+      "_from": ".",
+      "_npmVersion": "1.4.13",
+      "_npmUser": {
+        "name": "hughsk",
+        "email": "hughskennedy@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c9d33f6a16c62493f4814d3626e4cd4288040e14",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "1.1.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "_id": "from2@1.1.0",
+      "_shasum": "bead16cd3b49ecee186008fc9d8573c7e322b852",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bead16cd3b49ecee186008fc9d8573c7e322b852",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "1.1.1",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "_id": "from2@1.1.1",
+      "_shasum": "100a7cb5e8479baddc54ba90a3a6b080231dfc88",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "100a7cb5e8479baddc54ba90a3a6b080231dfc88",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "1.2.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "8c5efc9ca4e254208f01609f490bd4ae67c3d9b6",
+      "_id": "from2@1.2.0",
+      "_shasum": "90576dff6fe01b5d0b4e6933cf97bbd78cc95f83",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "90576dff6fe01b5d0b4e6933cf97bbd78cc95f83",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "1.3.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "96118ea0d8aff6fb28cb8b7d8bc63ab1adb946a9",
+      "_id": "from2@1.3.0",
+      "_shasum": "88413baaa5f9a597cfde9221d86986cd3c061dfd",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "88413baaa5f9a597cfde9221d86986cd3c061dfd",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "2.0.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2.git"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "8fa9bb234bd99d6bfb074156db80db80d94d81c7",
+      "_id": "from2@2.0.0",
+      "_shasum": "1f3b7b3507a493ba5fc05259d30f25a08c6648ea",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "1f3b7b3507a493ba5fc05259d30f25a08c6648ea",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "2.0.1",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2.git"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "321cf5ad8be7dc8f5bca04a8cd904b25a144c319",
+      "_id": "from2@2.0.1",
+      "_shasum": "d11c3d98df002f7f22aa86be26fdf8abc49458a5",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "d11c3d98df002f7f22aa86be26fdf8abc49458a5",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "2.0.2",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2.git"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "1f9ad64c753ccf64f6afe3ab603cd63990f4c5bb",
+      "_id": "from2@2.0.2",
+      "_shasum": "6225505c3171302b6c4c122069be50f932aee5f6",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "6225505c3171302b6c4c122069be50f932aee5f6",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "2.0.3",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2.git"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "08b671ee713c45064dec6de59da5f79f11e0b053",
+      "_id": "from2@2.0.3",
+      "_shasum": "ba8cab86f25e2083f909eb9798d58bc28abd819f",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "ba8cab86f25e2083f909eb9798d58bc28abd819f",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "2.1.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2.git"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "32b7efb53c92c8abde09291b06e1f8a009c60b63",
+      "_id": "from2@2.1.0",
+      "_shasum": "2a223b6593903735064a7445afa4dcc59544bf53",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "2a223b6593903735064a7445afa4dcc59544bf53",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "2.1.1",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "c95b2b94e0610a739757ced5c2fabb44c76f9532",
+      "_id": "from2@2.1.1",
+      "_shasum": "0b0e068bdf409ab734f1b15a6a779a217ede5724",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "0b0e068bdf409ab734f1b15a6a779a217ede5724",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "2.2.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2.git"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "ca5d76e86cf527871edf214848637a3cf6981802",
+      "_id": "from2@2.2.0",
+      "_shasum": "afe200e83933610a415723c367a68bf8df637b5e",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "afe200e83933610a415723c367a68bf8df637b5e",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/from2-2.2.0.tgz_1471195530446_0.8108480179216713"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "from2",
+      "description": "Convenience wrapper for ReadableStream, with an API lifted from \"from\" and \"through2\"",
+      "version": "2.3.0",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "author": {
+        "name": "Hugh Kennedy",
+        "email": "hughskennedy@gmail.com",
+        "url": "http://hughsk.io/"
+      },
+      "contributors": [
+        {
+          "name": "Mathias Buus",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/hughsk/from2.git"
+      },
+      "bugs": {
+        "url": "https://github.com/hughsk/from2/issues"
+      },
+      "homepage": "https://github.com/hughsk/from2",
+      "keywords": [
+        "from",
+        "stream",
+        "readable",
+        "pull",
+        "convenience",
+        "wrapper"
+      ],
+      "gitHead": "09243c8b8354420059c9bc935875e1896aa58c10",
+      "_id": "from2@2.3.0",
+      "_shasum": "8bfb5502bde4a4d36cfdeea007fcca21d7e382af",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "8bfb5502bde4a4d36cfdeea007fcca21d7e382af",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/from2-2.3.0.tgz_1471281357716_0.0004089232534170151"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# from2 [![Flattr this!](https://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=hughskennedy&url=http://github.com/hughsk/from2&title=from2&description=hughsk/from2%20on%20GitHub&language=en_GB&tags=flattr,github,javascript&category=software)[![experimental](http://hughsk.github.io/stability-badges/dist/experimental.svg)](http://github.com/hughsk/stability-badges) #\n\n`from2` is a high-level module for creating readable streams that properly handle backpressure.\n\nConvience wrapper for\n[readable-stream](http://github.com/isaacs/readable-stream)'s `ReadableStream`\nbase class, with an API lifted from\n[from](http://github.com/dominictarr/from) and\n[through2](http://github.com/rvagg/through2).\n\n## Usage ##\n\n[![from2](https://nodei.co/npm/from2.png?mini=true)](https://nodei.co/npm/from2)\n\n### `stream = from2([opts], read)` ###\n\nWhere `opts` are the options to pass on to the `ReadableStream` constructor,\nand `read(size, next)` is called when data is requested from the stream.\n\n* `size` is the recommended amount of data (in bytes) to retrieve.\n* `next(err)` should be called when you're ready to emit more data.\n\nFor example, here's a readable stream that emits the contents of a given\nstring:\n\n``` javascript\nvar from = require('from2')\n\nfunction fromString(string) {\n  return from(function(size, next) {\n    // if there's no more content\n    // left in the string, close the stream.\n    if (string.length <= 0) return next(null, null)\n\n    // Pull in a new chunk of text,\n    // removing it from the string.\n    var chunk = string.slice(0, size)\n    string = string.slice(size)\n\n    // Emit \"chunk\" from the stream.\n    next(null, chunk)\n  })\n}\n\n// pipe \"hello world\" out\n// to stdout.\nfromString('hello world').pipe(process.stdout)\n```\n\n### `stream = from2.obj([opts], read)` ###\n\nShorthand for `from2({ objectMode: true }, read)`.\n\n### `createStream = from2.ctor([opts], read)` ###\n\nIf you're creating similar streams in quick succession you can improve\nperformance by generating a stream **constructor** that you can reuse instead\nof creating one-off streams on each call.\n\nTakes the same options as `from2`, instead returning a constructor which you\ncan use to create new streams.\n\n### See Also\n\n- [from2-array](https://github.com/binocarlos/from2-array) - Create a from2 stream based on an array of source values.\n- [from2-string](https://github.com/yoshuawuyts/from2-string) - Create a stream from a string. Sugary wrapper around from2.\n\n## License ##\n\nMIT. See [LICENSE.md](http://github.com/hughsk/from2/blob/master/LICENSE.md) for details.\n",
+  "maintainers": [
+    {
+      "name": "hughsk",
+      "email": "hughskennedy@gmail.com"
+    },
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-07-19T10:52:04.866Z",
+    "created": "2014-02-10T10:03:36.170Z",
+    "0.0.0": "2014-02-10T10:03:36.170Z",
+    "1.0.0": "2014-07-18T12:00:01.486Z",
+    "1.0.1": "2014-07-18T12:03:25.410Z",
+    "1.1.0": "2014-07-19T10:02:18.699Z",
+    "1.1.1": "2014-07-20T08:35:13.241Z",
+    "1.2.0": "2014-08-07T20:22:42.339Z",
+    "1.3.0": "2015-01-11T22:42:21.511Z",
+    "2.0.0": "2015-06-16T20:32:45.396Z",
+    "2.0.1": "2015-06-16T20:37:19.288Z",
+    "2.0.2": "2015-06-16T21:16:12.733Z",
+    "2.0.3": "2015-06-17T04:32:13.320Z",
+    "2.1.0": "2015-07-15T16:35:14.616Z",
+    "2.1.1": "2016-01-27T10:20:00.083Z",
+    "2.2.0": "2016-08-14T17:25:32.081Z",
+    "2.3.0": "2016-08-15T17:15:59.624Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/hughsk/from2",
+  "keywords": [
+    "from",
+    "stream",
+    "readable",
+    "pull",
+    "convenience",
+    "wrapper"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/hughsk/from2.git"
+  },
+  "author": {
+    "name": "Hugh Kennedy",
+    "email": "hughskennedy@gmail.com",
+    "url": "http://hughsk.io/"
+  },
+  "bugs": {
+    "url": "https://github.com/hughsk/from2/issues"
+  },
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Mathias Buus",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "users": {
+    "tclay": true,
+    "mohankethees": true,
+    "incendiary": true,
+    "sirrah": true,
+    "nichoth": true,
+    "shiningray": true,
+    "jekrb": true,
+    "knksmith57": true,
+    "quocnguyen": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/from2.min.json
+++ b/test/fixtures/registry-mocks/content/from2.min.json
@@ -1,0 +1,234 @@
+{
+  "name": "from2",
+  "dist-tags": {
+    "latest": "2.3.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "from2",
+      "version": "0.0.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "dist": {
+        "shasum": "66d98a665a59a6cd5dd29bc9b11d6e48343cbd71",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-0.0.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "from2",
+      "version": "1.0.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "dist": {
+        "shasum": "ee0974ca65e5fdbe6f151c30f10cce380d4466d6",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "from2",
+      "version": "1.0.1",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "dist": {
+        "shasum": "c9d33f6a16c62493f4814d3626e4cd4288040e14",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "from2",
+      "version": "1.1.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "dist": {
+        "shasum": "bead16cd3b49ecee186008fc9d8573c7e322b852",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "from2",
+      "version": "1.1.1",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "dist": {
+        "shasum": "100a7cb5e8479baddc54ba90a3a6b080231dfc88",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "from2",
+      "version": "1.2.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "dist": {
+        "shasum": "90576dff6fe01b5d0b4e6933cf97bbd78cc95f83",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "from2",
+      "version": "1.3.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "~1.1.10"
+      },
+      "devDependencies": {
+        "tape": "~2.4.2"
+      },
+      "dist": {
+        "shasum": "88413baaa5f9a597cfde9221d86986cd3c061dfd",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "from2",
+      "version": "2.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "1f3b7b3507a493ba5fc05259d30f25a08c6648ea",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "from2",
+      "version": "2.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "d11c3d98df002f7f22aa86be26fdf8abc49458a5",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "from2",
+      "version": "2.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "6225505c3171302b6c4c122069be50f932aee5f6",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "from2",
+      "version": "2.0.3",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "ba8cab86f25e2083f909eb9798d58bc28abd819f",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.0.3.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "from2",
+      "version": "2.1.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "2a223b6593903735064a7445afa4dcc59544bf53",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.1.0.tgz"
+      }
+    },
+    "2.1.1": {
+      "name": "from2",
+      "version": "2.1.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "0b0e068bdf409ab734f1b15a6a779a217ede5724",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.1.1.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "from2",
+      "version": "2.2.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "afe200e83933610a415723c367a68bf8df637b5e",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.2.0.tgz"
+      }
+    },
+    "2.3.0": {
+      "name": "from2",
+      "version": "2.3.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "8bfb5502bde4a4d36cfdeea007fcca21d7e382af",
+        "tarball": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz"
+      }
+    }
+  },
+  "modified": "2017-07-19T10:52:04.866Z"
+}

--- a/test/fixtures/registry-mocks/content/fs-write-stream-atomic.json
+++ b/test/fixtures/registry-mocks/content/fs-write-stream-atomic.json
@@ -1,0 +1,757 @@
+{
+  "_id": "fs-write-stream-atomic",
+  "_rev": "43-fa6ef079614577a1000db303dd3638d5",
+  "name": "fs-write-stream-atomic",
+  "description": "Like `fs.createWriteStream(...)`, but atomic.",
+  "dist-tags": {
+    "latest": "1.0.10"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.0",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^3.0.2"
+      },
+      "devDependencies": {
+        "tap": "^0.4.12"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/npm/fs-write-stream-atomic"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "81a7c1e0f9dbcfc6e7a2e004389f362c7997566c",
+      "_id": "fs-write-stream-atomic@1.0.0",
+      "_shasum": "df22968876ac5163dce116790792cb3592d16930",
+      "_from": ".",
+      "_npmVersion": "2.0.1",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "dist": {
+        "shasum": "df22968876ac5163dce116790792cb3592d16930",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.1",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^3.0.2"
+      },
+      "devDependencies": {
+        "tap": "^0.4.12"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/npm/fs-write-stream-atomic"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "7db0e8159270278b097789bcefb061b5c5fa7161",
+      "_id": "fs-write-stream-atomic@1.0.1",
+      "_shasum": "5e424a143d9d29a700bb409729d6612b678f05ac",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "dist": {
+        "shasum": "5e424a143d9d29a700bb409729d6612b678f05ac",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.2",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^3.0.2"
+      },
+      "devDependencies": {
+        "tap": "^0.4.12"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/npm/fs-write-stream-atomic"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "86b111ed1d5db84e8a9680986ef7917036b9c97b",
+      "_id": "fs-write-stream-atomic@1.0.2",
+      "_shasum": "fe0c6cec75256072b2fef8180d97e309fe3f5efb",
+      "_from": ".",
+      "_npmVersion": "2.1.0",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "dist": {
+        "shasum": "fe0c6cec75256072b2fef8180d97e309fe3f5efb",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.3",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^3.0.2"
+      },
+      "devDependencies": {
+        "tap": "^0.4.12"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/npm/fs-write-stream-atomic"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "78573c09271f3ec672740862dad80be3d75e1963",
+      "_id": "fs-write-stream-atomic@1.0.3",
+      "_shasum": "c8fe17f66d7d3f50e9aee59195c358e7710372cc",
+      "_from": ".",
+      "_npmVersion": "2.7.6",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "c8fe17f66d7d3f50e9aee59195c358e7710372cc",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        },
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ]
+    },
+    "1.0.4": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.4",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      },
+      "devDependencies": {
+        "tap": "^1.2.0"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/fs-write-stream-atomic.git"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "6ca2651b913149543c5390c6c4f7d370bdca42b5",
+      "_id": "fs-write-stream-atomic@1.0.4",
+      "_shasum": "c1ea55889f036ceebdead7d1055edbad998fe5e9",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "2.2.2",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "c1ea55889f036ceebdead7d1055edbad998fe5e9",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "isaacs",
+          "email": "isaacs@npmjs.com"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ]
+    },
+    "1.0.5": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.5",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "imurmurhash": "^0.1.4"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "scripts": {
+        "test": "standard && tap --coverage test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/fs-write-stream-atomic.git"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "1bc752bf0e0d5b7aaaad7be696dbc0e4ea64258c",
+      "_id": "fs-write-stream-atomic@1.0.5",
+      "_shasum": "862a4dabdffcafabfc16499458e37310c39925f6",
+      "_from": ".",
+      "_npmVersion": "3.5.1",
+      "_nodeVersion": "5.1.0",
+      "_npmUser": {
+        "name": "othiym23",
+        "email": "ogd@aoaioxxysz.net"
+      },
+      "dist": {
+        "shasum": "862a4dabdffcafabfc16499458e37310c39925f6",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        },
+        {
+          "name": "othiym23",
+          "email": "ogd@aoaioxxysz.net"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ]
+    },
+    "1.0.6": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.6",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "scripts": {
+        "test": "standard && tap --coverage test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/fs-write-stream-atomic.git"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "ba90fb2caf2a4d75691fdc84cff1c0448848832e",
+      "_id": "fs-write-stream-atomic@1.0.6",
+      "_shasum": "3b4d4b4c76ba8173107faab8659dacae04dc5a62",
+      "_from": ".",
+      "_npmVersion": "3.5.2",
+      "_nodeVersion": "0.8.28",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "3b4d4b4c76ba8173107faab8659dacae04dc5a62",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        },
+        {
+          "name": "othiym23",
+          "email": "ogd@aoaioxxysz.net"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "deprecated": "This version is known to be broken, please use 1.0.8"
+    },
+    "1.0.7": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.7",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "scripts": {
+        "test": "standard && tap --coverage test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/fs-write-stream-atomic.git"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "81bcae2ca1afde451461cd3750874dc32b067959",
+      "_id": "fs-write-stream-atomic@1.0.7",
+      "_shasum": "6b9ea43780268835f2ec6a8f2ee5aca42c5f6130",
+      "_from": ".",
+      "_npmVersion": "3.5.1",
+      "_nodeVersion": "5.1.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "6b9ea43780268835f2ec6a8f2ee5aca42c5f6130",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        },
+        {
+          "name": "othiym23",
+          "email": "ogd@aoaioxxysz.net"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "deprecated": "This version is known to be broken, please use 1.0.8"
+    },
+    "1.0.8": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.8",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "scripts": {
+        "test": "standard && tap --coverage test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/fs-write-stream-atomic.git"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "b55824ee4de7f1ca23784929d68b1b8f5edbf4a4",
+      "_id": "fs-write-stream-atomic@1.0.8",
+      "_shasum": "e49aaddf288f87d46ff9e882f216a13abc40778b",
+      "_from": ".",
+      "_npmVersion": "3.5.2",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "e49aaddf288f87d46ff9e882f216a13abc40778b",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        },
+        {
+          "name": "othiym23",
+          "email": "ogd@aoaioxxysz.net"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ]
+    },
+    "1.0.9": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.9",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "scripts": {
+        "test": "standard && tap --coverage test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/fs-write-stream-atomic.git"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "20be0cd6dce7531ea7e73b464a1abf8d521438c2",
+      "_id": "fs-write-stream-atomic@1.0.9",
+      "_shasum": "e9fe396640fb22b03919bea30e267f927918bf01",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "e9fe396640fb22b03919bea30e267f927918bf01",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        },
+        {
+          "name": "othiym23",
+          "email": "ogd@aoaioxxysz.net"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/fs-write-stream-atomic-1.0.9.tgz_1488922728902_0.3049999396316707"
+      }
+    },
+    "1.0.10": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.10",
+      "description": "Like `fs.createWriteStream(...)`, but atomic.",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "scripts": {
+        "test": "standard && tap --coverage test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/fs-write-stream-atomic.git"
+      },
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "http://blog.izs.me/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+      },
+      "homepage": "https://github.com/npm/fs-write-stream-atomic",
+      "gitHead": "de157c0373a40fb5539640923cab9671cef08b12",
+      "_id": "fs-write-stream-atomic@1.0.10",
+      "_shasum": "b47df53493ef911df75731e70a9ded0189db40c9",
+      "_from": ".",
+      "_npmVersion": "4.4.1",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "b47df53493ef911df75731e70a9ded0189db40c9",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        },
+        {
+          "name": "othiym23",
+          "email": "ogd@aoaioxxysz.net"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/fs-write-stream-atomic-1.0.10.tgz_1488925398888_0.6416559314820915"
+      }
+    }
+  },
+  "readme": "# fs-write-stream-atomic\n\nLike `fs.createWriteStream(...)`, but atomic.\n\nWrites to a tmp file and does an atomic `fs.rename` to move it into\nplace when it's done.\n\nFirst rule of debugging: **It's always a race condition.**\n\n## USAGE\n\n```javascript\nvar fsWriteStreamAtomic = require('fs-write-stream-atomic')\n// options are optional.\nvar write = fsWriteStreamAtomic('output.txt', options)\nvar read = fs.createReadStream('input.txt')\nread.pipe(write)\n\n// When the write stream emits a 'finish' or 'close' event,\n// you can be sure that it is moved into place, and contains\n// all the bytes that were written to it, even if something else\n// was writing to `output.txt` at the same time.\n```\n\n### `fsWriteStreamAtomic(filename, [options])`\n\n* `filename` {String} The file we want to write to\n* `options` {Object}\n  * `chown` {Object} User and group to set ownership after write\n    * `uid` {Number}\n    * `gid` {Number}\n  * `encoding` {String} default = 'utf8'\n  * `mode` {Number} default = `0666`\n  * `flags` {String} default = `'w'`\n\n",
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-19T13:50:05.778Z",
+    "created": "2014-09-19T23:13:20.734Z",
+    "1.0.0": "2014-09-19T23:13:20.734Z",
+    "1.0.1": "2014-09-22T22:27:01.540Z",
+    "1.0.2": "2014-09-29T21:23:51.108Z",
+    "1.0.3": "2015-05-21T20:44:34.797Z",
+    "1.0.4": "2015-09-09T23:21:57.637Z",
+    "1.0.5": "2015-12-02T04:30:39.101Z",
+    "1.0.6": "2015-12-10T00:28:40.297Z",
+    "1.0.7": "2015-12-10T02:16:03.249Z",
+    "1.0.8": "2015-12-12T06:55:11.674Z",
+    "1.0.9": "2017-03-07T21:38:49.136Z",
+    "1.0.10": "2017-03-07T22:23:19.124Z"
+  },
+  "homepage": "https://github.com/npm/fs-write-stream-atomic",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/fs-write-stream-atomic.git"
+  },
+  "author": {
+    "name": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "http://blog.izs.me/"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/fs-write-stream-atomic/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "rcramu": true,
+    "nathan7": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/fs-write-stream-atomic.min.json
+++ b/test/fixtures/registry-mocks/content/fs-write-stream-atomic.min.json
@@ -1,0 +1,225 @@
+{
+  "name": "fs-write-stream-atomic",
+  "dist-tags": {
+    "latest": "1.0.10"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.0",
+      "dependencies": {
+        "graceful-fs": "^3.0.2"
+      },
+      "devDependencies": {
+        "tap": "^0.4.12"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "df22968876ac5163dce116790792cb3592d16930",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.1",
+      "dependencies": {
+        "graceful-fs": "^3.0.2"
+      },
+      "devDependencies": {
+        "tap": "^0.4.12"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "5e424a143d9d29a700bb409729d6612b678f05ac",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.2",
+      "dependencies": {
+        "graceful-fs": "^3.0.2"
+      },
+      "devDependencies": {
+        "tap": "^0.4.12"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "fe0c6cec75256072b2fef8180d97e309fe3f5efb",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.3",
+      "dependencies": {
+        "graceful-fs": "^3.0.2"
+      },
+      "devDependencies": {
+        "tap": "^0.4.12"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "c8fe17f66d7d3f50e9aee59195c358e7710372cc",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.4",
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      },
+      "devDependencies": {
+        "tap": "^1.2.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "c1ea55889f036ceebdead7d1055edbad998fe5e9",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.5",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "imurmurhash": "^0.1.4"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "862a4dabdffcafabfc16499458e37310c39925f6",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.5.tgz"
+      }
+    },
+    "1.0.6": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.6",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "3b4d4b4c76ba8173107faab8659dacae04dc5a62",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.6.tgz"
+      },
+      "deprecated": "This version is known to be broken, please use 1.0.8"
+    },
+    "1.0.7": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.7",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "6b9ea43780268835f2ec6a8f2ee5aca42c5f6130",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.7.tgz"
+      },
+      "deprecated": "This version is known to be broken, please use 1.0.8"
+    },
+    "1.0.8": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.8",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "e49aaddf288f87d46ff9e882f216a13abc40778b",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz"
+      }
+    },
+    "1.0.9": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.9",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "e9fe396640fb22b03919bea30e267f927918bf01",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.9.tgz"
+      }
+    },
+    "1.0.10": {
+      "name": "fs-write-stream-atomic",
+      "version": "1.0.10",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "devDependencies": {
+        "rimraf": "^2.4.4",
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "b47df53493ef911df75731e70a9ded0189db40c9",
+        "tarball": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:50:05.778Z"
+}

--- a/test/fixtures/registry-mocks/content/get-value.json
+++ b/test/fixtures/registry-mocks/content/get-value.json
@@ -1,0 +1,2816 @@
+{
+  "_id": "get-value",
+  "_rev": "60-ff7c7c5cda4f51c285e913781575cd17",
+  "name": "get-value",
+  "time": {
+    "modified": "2018-03-17T08:34:37.620Z",
+    "created": "2014-10-06T16:49:43.142Z",
+    "0.1.1": "2014-10-06T16:49:43.142Z",
+    "0.1.0": "2014-10-07T20:49:47.984Z",
+    "0.1.2": "2014-10-07T20:50:53.592Z",
+    "0.2.0": "2014-10-08T06:33:47.548Z",
+    "0.2.1": "2014-10-08T06:44:25.198Z",
+    "0.2.2": "2014-10-08T14:47:42.044Z",
+    "0.3.0": "2014-10-18T20:37:49.687Z",
+    "0.3.1": "2014-10-26T12:19:53.648Z",
+    "0.3.2": "2014-11-02T01:54:55.176Z",
+    "1.0.0": "2015-01-26T12:31:14.445Z",
+    "1.1.0": "2015-02-13T08:39:54.029Z",
+    "1.0.1": "2015-02-13T08:40:41.452Z",
+    "1.0.2": "2015-02-13T09:26:45.295Z",
+    "1.0.3": "2015-02-23T03:07:50.256Z",
+    "1.0.4": "2015-02-23T03:54:44.779Z",
+    "1.1.1": "2015-03-12T02:06:09.041Z",
+    "1.1.2": "2015-03-25T09:55:54.883Z",
+    "1.1.3": "2015-03-29T00:23:50.138Z",
+    "1.1.4": "2015-05-03T18:48:09.629Z",
+    "1.1.5": "2015-06-02T21:19:16.614Z",
+    "1.2.0": "2015-09-02T10:50:26.319Z",
+    "1.2.1": "2015-09-02T10:56:13.066Z",
+    "1.3.0": "2015-10-29T03:28:50.244Z",
+    "1.3.1": "2015-10-29T03:46:15.492Z",
+    "2.0.0": "2015-10-29T07:30:40.184Z",
+    "2.0.1": "2015-12-11T00:50:19.996Z",
+    "2.0.2": "2015-12-11T01:36:17.515Z",
+    "2.0.3": "2016-01-19T13:31:00.895Z",
+    "2.0.4": "2016-03-27T15:22:57.068Z",
+    "2.0.5": "2016-03-27T15:24:12.030Z",
+    "2.0.6": "2016-06-18T08:27:49.973Z",
+    "3.0.0": "2018-01-30T19:06:46.294Z",
+    "3.0.1": "2018-03-07T05:27:53.926Z"
+  },
+  "maintainers": [
+    {
+      "name": "doowb",
+      "email": "brian.woodward@gmail.com"
+    },
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "dist-tags": {
+    "latest": "3.0.1"
+  },
+  "description": "Use property paths like 'a.b.c' to get a nested value from an object. Even works when keys have dots in them (no other dot-prop library can do this!).",
+  "readme": "# get-value [![NPM version](https://img.shields.io/npm/v/get-value.svg?style=flat)](https://www.npmjs.com/package/get-value) [![NPM monthly downloads](https://img.shields.io/npm/dm/get-value.svg?style=flat)](https://npmjs.org/package/get-value) [![NPM total downloads](https://img.shields.io/npm/dt/get-value.svg?style=flat)](https://npmjs.org/package/get-value) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/get-value.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/get-value)\n\n> Use property paths like 'a.b.c' to get a nested value from an object. Even works when keys have dots in them (no other dot-prop library can do this!).\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Table of Contents\n\n<details>\n<summary><strong>Details</strong></summary>\n\n- [Install](#install)\n- [Usage](#usage)\n  * [Supports keys with dots](#supports-keys-with-dots)\n  * [Supports arrays](#supports-arrays)\n  * [Supports functions](#supports-functions)\n  * [Supports passing object path as an array](#supports-passing-object-path-as-an-array)\n- [Options](#options)\n  * [options.default](#optionsdefault)\n  * [options.isValid](#optionsisvalid)\n  * [options.split](#optionssplit)\n  * [options.separator](#optionsseparator)\n  * [options.join](#optionsjoin)\n  * [options.joinChar](#optionsjoinchar)\n- [Benchmarks](#benchmarks)\n  * [Running the benchmarks](#running-the-benchmarks)\n- [Release history](#release-history)\n  * [v3.0.0](#v300)\n- [About](#about)\n\n</details>\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save get-value\n```\n\n## Usage\n\nSee the [unit tests](test/test.js) for many more examples.\n\n```js\nconst get = require('foo');\nconst obj = { a: { b: { c: { d: 'foo' } } } };\n\nconsole.log(get(obj));            //=> { a: { b: { c: { d: 'foo' } } } };\nconsole.log(get(obj, 'a'));       //=> { b: { c: { d: 'foo' } } }\nconsole.log(get(obj, 'a.b'));     //=> { c: { d: 'foo' } }\nconsole.log(get(obj, 'a.b.c'));   //=> { d: 'foo' }\nconsole.log(get(obj, 'a.b.c.d')); //=> 'foo'\n```\n\n### Supports keys with dots\n\nUnlike other dot-prop libraries, get-value works when keys have dots in them:\n\n```js\nconsole.log(get({ 'a.b': { c: 'd' } }, 'a.b.c'));\n//=> 'd'\n\nconsole.log(get({ 'a.b': { c: { 'd.e': 'f' } } }, 'a.b.c.d.e'));\n//=> 'f'\n```\n\n### Supports arrays\n\n```js\nconsole.log(get({ a: { b: { c: { d: 'foo' } } }, e: [{ f: 'g' }, { f: 'h' }] }, 'e.1.f'));   \n//=> 'h'\n\nconsole.log(get({ a: { b: [{ c: 'd' }] } }, 'a.b.0.c')); \n//=> 'f'\n\nconsole.log(get({ a: { b: [{ c: 'd' }, { e: 'f' }] } }, 'a.b.1.e'));\n//=> 'f'\n```\n\n### Supports functions\n\n```js\nfunction foo() {}\nfoo.bar = { baz: 'qux' };\n\nconsole.log(get(foo));            \n//=> { [Function: foo] bar: { baz: 'qux' } }\n\nconsole.log(get(foo, 'bar'));     \n//=> { baz: 'qux' }\n\nconsole.log(get(foo, 'bar.baz')); \n//=> qux\n```\n\n### Supports passing object path as an array\n\nSlighly improve performance by passing an array of strings to use as object path segments (this is also useful when you need to dynamically build up the path segments):\n\n```js\nconsole.log(get({ a: { b: 'c' } }, ['a', 'b']));\n//=> 'c'\n```\n\n## Options\n\n### options.default\n\n**Type**: `any`\n\n**Default**: `undefined`\n\nThe default value to return when get-value cannot resolve a value from the given object.\n\n```js\nconst obj = { foo: { a: { b: { c: { d: 'e' } } } } };\nconsole.log(get(obj, 'foo.a.b.c.d', { default: true }));  //=> 'e'\nconsole.log(get(obj, 'foo.bar.baz', { default: true }));  //=> true\nconsole.log(get(obj, 'foo.bar.baz', { default: false })); //=> false\nconsole.log(get(obj, 'foo.bar.baz', { default: null }));  //=> null\n\n// you can also pass the default value as the last argument\n// (this is necessary if the default value is an object)\nconsole.log(get(obj, 'foo.a.b.c.d', true));  //=> 'e'\nconsole.log(get(obj, 'foo.bar.baz', true));  //=> true\nconsole.log(get(obj, 'foo.bar.baz', false)); //=> false\nconsole.log(get(obj, 'foo.bar.baz', null));  //=> null\n```\n\n### options.isValid\n\n**Type**: `function`\n\n**Default**: `true`\n\nIf defined, this function is called on each resolved value. Useful if you want to do `.hasOwnProperty` or `Object.prototype.propertyIsEnumerable`.\n\n```js\nconst isEnumerable = Object.prototype.propertyIsEnumerable;\nconst options = {\n  isValid: (key, obj) => isEnumerable.call(obj, key)\n};\n\nconst obj = {};\nObject.defineProperty(obj, 'foo', { value: 'bar', enumerable: false });\n\nconsole.log(get(obj, 'foo', options));           //=> undefined\nconsole.log(get({}, 'hasOwnProperty', options)); //=> undefined\nconsole.log(get({}, 'constructor', options));    //=> undefined\n\n// without \"isValid\" check\nconsole.log(get(obj, 'foo', options));           //=> bar\nconsole.log(get({}, 'hasOwnProperty', options)); //=> [Function: hasOwnProperty]\nconsole.log(get({}, 'constructor', options));    //=> [Function: Object]\n```\n\n### options.split\n\n**Type**: `function`\n\n**Default**: `String.split()`\n\nCustom function to use for splitting the string into object path segments.\n\n```js\nconst obj = { 'a.b': { c: { d: 'e' } } };\n\n// example of using a string to split the object path\nconst options = { split: path => path.split('/') };\nconsole.log(get(obj, 'a.b/c/d', options)); //=> 'e'\n\n// example of using a regex to split the object path\n// (removing escaped dots is unnecessary, this is just an example)\nconst options = { split: path => path.split(/\\\\?\\./) };\nconsole.log(get(obj, 'a\\\\.b.c.d', options)); //=> 'e'\n```\n\n### options.separator\n\n**Type**: `string|regex`\n\n**Default**: `.`\n\nThe separator to use for spliting the string (this is probably not needed when `options.split` is used).\n\n```js\nconst obj = { 'a.b': { c: { d: 'e' } } };\n\nconsole.log(get(obj, 'a.b/c/d', { separator: '/' }));       \n//=> 'e'\n\nconsole.log(get(obj, 'a\\\\.b.c.d', { separator: /\\\\?\\./ })); \n//=> 'e'\n```\n\n### options.join\n\n**Type**: `function`\n\n**Default**: `Array.join()`\n\nCustomize how the object path is created when iterating over path segments.\n\n```js\nconst obj = { 'a/b': { c: { d: 'e' } } };\nconst options = {\n  // when segs === ['a', 'b'] use a \"/\" to join, otherwise use a \".\"\n  join: segs => segs.join(segs[0] === 'a' ? '/' : '.')\n};\n\nconsole.log(get(obj, 'a.b.c.d', options));\n//=> 'e'\n```\n\n### options.joinChar\n\n**Type**: `string`\n\n**Default**: `.`\n\nThe character to use when re-joining the string to check for keys with dots in them (this is probably not needed when `options.join` is used). This can be a different value than the separator, since the separator can be a string or regex.\n\n```js\nconst target = { 'a-b': { c: { d: 'e' } } };\nconst options = { joinChar: '-' };\nconsole.log(get(target, 'a.b.c.d', options)); \n//=> 'e'\n```\n\n## Benchmarks\n\n_(benchmarks were run on a MacBook Pro 2.5 GHz Intel Core i7, 16 GB 1600 MHz DDR3)_.\n\nget-value is more reliable and has more features than dot-prop, without sacrificing performance.\n\n```\n# deep (175 bytes)\n  dot-prop x 883,166 ops/sec ±0.93% (86 runs sampled)\n  get-value x 1,448,928 ops/sec ±1.53% (87 runs sampled)\n  getobject x 213,797 ops/sec ±0.85% (90 runs sampled)\n  object-path x 184,347 ops/sec ±2.48% (85 runs sampled)\n\n  fastest is get-value (by 339% avg)\n\n# root (210 bytes)\n  dot-prop x 3,905,828 ops/sec ±1.36% (87 runs sampled)\n  get-value x 16,391,934 ops/sec ±1.43% (83 runs sampled)\n  getobject x 1,200,021 ops/sec ±1.81% (88 runs sampled)\n  object-path x 2,788,494 ops/sec ±1.81% (86 runs sampled)\n\n  fastest is get-value (by 623% avg)\n\n# shallow (84 bytes)\n  dot-prop x 2,553,558 ops/sec ±0.89% (89 runs sampled)\n  get-value x 3,070,159 ops/sec ±0.88% (90 runs sampled)\n  getobject x 726,670 ops/sec ±0.81% (86 runs sampled)\n  object-path x 922,351 ops/sec ±2.05% (86 runs sampled)\n\n  fastest is get-value (by 219% avg)\n\n```\n\n### Running the benchmarks\n\nClone this library into a local directory:\n\n```sh\n$ git clone https://github.com/jonschlinkert/get-value.git\n```\n\nThen install devDependencies and run benchmarks:\n\n```sh\n$ npm install && node benchmark\n```\n\n## Release history\n\n### v3.0.0\n\n* Improved support for escaping. It's no longer necessary to use backslashes to escape keys.\n* Adds `options.default` for defining a default value to return when no value is resolved.\n* Adds `options.isValid` to allow the user to check the object after each iteration.\n* Adds `options.separator` for customizing character to split on.\n* Adds `options.split` for customizing how the object path is split.\n* Adds `options.join` for customizing how the object path is joined when iterating over path segments.\n* Adds `options.joinChar` for customizing the join character.\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [has-any-deep](https://www.npmjs.com/package/has-any-deep): Return true if `key` exists deeply on the given object.  | [homepage](https://github.com/jonschlinkert/has-any-deep \"Return true if `key` exists deeply on the given object. \")\n* [has-any](https://www.npmjs.com/package/has-any): Returns true if an object has any of the specified keys. | [homepage](https://github.com/jonschlinkert/has-any \"Returns true if an object has any of the specified keys.\")\n* [has-value](https://www.npmjs.com/package/has-value): Returns true if a value exists, false if empty. Works with deeply nested values using… [more](https://github.com/jonschlinkert/has-value) | [homepage](https://github.com/jonschlinkert/has-value \"Returns true if a value exists, false if empty. Works with deeply nested values using object paths.\")\n* [set-value](https://www.npmjs.com/package/set-value): Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths. | [homepage](https://github.com/jonschlinkert/set-value \"Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths.\")\n* [unset-value](https://www.npmjs.com/package/unset-value): Delete nested properties from an object using dot notation. | [homepage](https://github.com/jonschlinkert/unset-value \"Delete nested properties from an object using dot notation.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 81 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 2 | [ianwalter](https://github.com/ianwalter) |\n| 1 | [doowb](https://github.com/doowb) |\n\n### Author\n\n**Jon Schlinkert**\n\n* [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)\n* [GitHub Profile](https://github.com/jonschlinkert)\n* [Twitter Profile](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on March 07, 2018._",
+  "versions": {
+    "0.1.0": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "keywords": [
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "_id": "get-value@0.1.0",
+      "_shasum": "a07411896d764f45082483114368787883adcc32",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a07411896d764f45082483114368787883adcc32",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "keywords": [
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "_id": "get-value@0.1.2",
+      "_shasum": "66c81f361bc99e14be549b24174596d0c68dd305",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "66c81f361bc99e14be549b24174596d0c68dd305",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "keywords": [
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "_id": "get-value@0.2.0",
+      "_shasum": "6d4e3be73979a4732c78a980c4501bf1b1fc29fd",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6d4e3be73979a4732c78a980c4501bf1b1fc29fd",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "keywords": [
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "_id": "get-value@0.2.1",
+      "_shasum": "0279ca54122126dafbbe1fad13b05063ae40d969",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0279ca54122126dafbbe1fad13b05063ae40d969",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "0.2.2",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "keywords": [
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "_id": "get-value@0.2.2",
+      "_shasum": "dd4b70f7f5a85e972059a99a181aef4de32b169f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dd4b70f7f5a85e972059a99a181aef4de32b169f",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "_id": "get-value@0.3.0",
+      "_shasum": "02a571ec9c89d1be5d6f9299af55ee0f9d680964",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "02a571ec9c89d1be5d6f9299af55ee0f9d680964",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "0.3.1",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "benchmarked": "^0.1.1",
+        "getobject": "^0.1.0",
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "_id": "get-value@0.3.1",
+      "_shasum": "75f4c5561ac0f880ebb586b4fbd178d40ed936a0",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "75f4c5561ac0f880ebb586b4fbd178d40ed936a0",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "0.3.2",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "benchmarked": "^0.1.1",
+        "getobject": "^0.1.0",
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "_id": "get-value@0.3.2",
+      "_shasum": "d52e793355ee75e4b8b04decbe2a330942ccc845",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d52e793355ee75e4b8b04decbe2a330942ccc845",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "files": [
+        "index.js"
+      ],
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "gitHead": "47d14599797900aaf01828ba9a8f95374ab81a02",
+      "_id": "get-value@1.0.0",
+      "_shasum": "009e1d6e404926d3ab315ae785314b2e944311d5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "009e1d6e404926d3ab315ae785314b2e944311d5",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "files": [
+        "index.js"
+      ],
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value",
+        "values"
+      ],
+      "gitHead": "c76fc1af9c8943abe6f42b51acdfd4f497c7e1fb",
+      "_id": "get-value@1.0.1",
+      "_shasum": "e16357e6fcbc6ecec022f5f87e8db7682b65d14c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e16357e6fcbc6ecec022f5f87e8db7682b65d14c",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.0.2",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "gitHead": "f0cdb46a2898f455991540de031317788e9125e4",
+      "_id": "get-value@1.0.2",
+      "_shasum": "6df09e3bfce55b44fbb1ceac5b35e3801cf26a69",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6df09e3bfce55b44fbb1ceac5b35e3801cf26a69",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.0.3",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "gitHead": "acaecc3c34b8d06f6a7366e8487a74637a7344de",
+      "_id": "get-value@1.0.3",
+      "_shasum": "8746cf0e20b1dd5eb4e760b61ea56b485dcb2d8a",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8746cf0e20b1dd5eb4e760b61ea56b485dcb2d8a",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.0.4",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0",
+        "noncharacters": "^1.0.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "gitHead": "c0e7bffc585a09400a00250c16f7897461e82201",
+      "_id": "get-value@1.0.4",
+      "_shasum": "4f2d51c1fd393ab83b267138a84a189b1846c105",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4f2d51c1fd393ab83b267138a84a189b1846c105",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.1.1",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0",
+        "noncharacters": "^1.0.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "gitHead": "6fd670b1d48cd72a48fc3c27179e2ed3b39be5df",
+      "_id": "get-value@1.1.1",
+      "_shasum": "370f92421db312410dd7c6253a63a869099f85dd",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "370f92421db312410dd7c6253a63a869099f85dd",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.1.2",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0",
+        "noncharacters": "^1.0.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "gitHead": "8c0bdc2bf341cc67f898e921e6e4c6abfa819358",
+      "_id": "get-value@1.1.2",
+      "_shasum": "bafe82b38ade9ebce7dbf41e93e7bf18a5611679",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bafe82b38ade9ebce7dbf41e93e7bf18a5611679",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.1.3",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.3",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.1",
+        "should": "^5.2.0"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "gitHead": "4d237f003fd744694b293cc936083d424c1abe5b",
+      "_id": "get-value@1.1.3",
+      "_shasum": "6894a37f833b75acb3be02b811f00cae699d9f14",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6894a37f833b75acb3be02b811f00cae699d9f14",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) get a nested value from an object.",
+      "version": "1.1.4",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/get-value/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.5",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.4",
+        "should": "^6.0.1"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "gitHead": "183afbc4ebef07bbba66d2263f42c3f1be7c1d7d",
+      "_id": "get-value@1.1.4",
+      "_shasum": "514801d69a62c741d9d15deafeb603e3ac38c564",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "514801d69a62c741d9d15deafeb603e3ac38c564",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "1.1.5",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.5",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.4",
+        "should": "^6.0.1"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "gitHead": "183afbc4ebef07bbba66d2263f42c3f1be7c1d7d",
+      "_id": "get-value@1.1.5",
+      "_shasum": "59ad9bf9004b2a900761ead3b72dc42ee161a6a6",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "59ad9bf9004b2a900761ead3b72dc42ee161a6a6",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "1.2.0",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.5",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.4",
+        "should": "^6.0.1"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "unset-value",
+            "has-value",
+            "set-value",
+            "has-any",
+            "has-any-deep"
+          ]
+        }
+      },
+      "gitHead": "1948c93122235f7e14a5f55c7bfde64728bdb692",
+      "_id": "get-value@1.2.0",
+      "_shasum": "731f451320e1428bdccaa0e510223e25f62bfe49",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "731f451320e1428bdccaa0e510223e25f62bfe49",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "1.2.1",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.5",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.4",
+        "should": "^6.0.1"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "unset-value",
+            "has-value",
+            "set-value",
+            "has-any",
+            "has-any-deep"
+          ]
+        }
+      },
+      "gitHead": "1948c93122235f7e14a5f55c7bfde64728bdb692",
+      "_id": "get-value@1.2.1",
+      "_shasum": "b309beebce2f4ae0945b77767c611a5a6af3ff6f",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b309beebce2f4ae0945b77767c611a5a6af3ff6f",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "1.3.0",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "arr-flatten": "^1.0.1",
+        "is-extendable": "^0.1.1",
+        "lazy-cache": "^0.2.4",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "getobject": "^0.1.0",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "^2.3.3",
+        "should": "^7.1.1"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "unset-value",
+            "has-value",
+            "set-value",
+            "has-any",
+            "has-any-deep"
+          ]
+        }
+      },
+      "gitHead": "72eacd9f6fb5aa4dd1eed500832f479be875d116",
+      "_id": "get-value@1.3.0",
+      "_shasum": "0cb41d0bc435559b482a629d0192529ce02aff8b",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0cb41d0bc435559b482a629d0192529ce02aff8b",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "1.3.1",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "arr-flatten": "^1.0.1",
+        "is-extendable": "^0.1.1",
+        "lazy-cache": "^0.2.4",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "getobject": "^0.1.0",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "^2.3.3",
+        "should": "^7.1.1"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "unset-value",
+            "has-value",
+            "set-value",
+            "has-any",
+            "has-any-deep"
+          ]
+        }
+      },
+      "gitHead": "72eacd9f6fb5aa4dd1eed500832f479be875d116",
+      "_id": "get-value@1.3.1",
+      "_shasum": "8ac7ef4f20382392b2646548f9b9ad2dc6c89642",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8ac7ef4f20382392b2646548f9b9ad2dc6c89642",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "jshint-stylish": "^2.0.1",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "^2.3.3",
+        "should": "^7.1.1"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "unset-value",
+            "has-value",
+            "set-value",
+            "has-any",
+            "has-any-deep"
+          ]
+        }
+      },
+      "gitHead": "df1e88cf5ddb5353f12fbc11ed63243585376445",
+      "_id": "get-value@2.0.0",
+      "_shasum": "de1d3ba0714ebce2d807977e48a616187fd94809",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "de1d3ba0714ebce2d807977e48a616187fd94809",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "unset-value",
+            "has-value",
+            "set-value",
+            "has-any",
+            "has-any-deep"
+          ]
+        }
+      },
+      "gitHead": "e7eb881af2d58224f36f4f1974f360d5c3a87018",
+      "_id": "get-value@2.0.1",
+      "_shasum": "b6daee9249910c1d14fdbb7468906a775f43439a",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b6daee9249910c1d14fdbb7468906a775f43439a",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "2.0.2",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "unset-value",
+            "has-value",
+            "set-value",
+            "has-any",
+            "has-any-deep"
+          ]
+        }
+      },
+      "gitHead": "87c35de815c35ee151d06397472ad0fb65938466",
+      "_id": "get-value@2.0.2",
+      "_shasum": "1cdcafe16cd02ac4a44b58a155adf227b83b150d",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1cdcafe16cd02ac4a44b58a155adf227b83b150d",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "2.0.3",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-format-md": "^0.1.5",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "unset-value",
+            "has-value",
+            "set-value",
+            "has-any",
+            "has-any-deep"
+          ]
+        },
+        "plugins": [
+          "gulp-format-md"
+        ]
+      },
+      "gitHead": "85507d3fc907c37dcdb84619766e5655407c542a",
+      "_id": "get-value@2.0.3",
+      "_shasum": "13a50f0faf69a201c1f0aabdb52c21edd48f105d",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "13a50f0faf69a201c1f0aabdb52c21edd48f105d",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "2.0.4",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-format-md": "^0.1.5",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-any",
+            "has-any-deep",
+            "has-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "d96b39593d3eecfa4a56cec0220d5e8640db8f10",
+      "_id": "get-value@2.0.4",
+      "_shasum": "d73104aba3f6413610eded22113379cfdf8247d0",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d73104aba3f6413610eded22113379cfdf8247d0",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/get-value-2.0.4.tgz_1459092174622_0.320156384492293"
+      },
+      "directories": {}
+    },
+    "2.0.5": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "2.0.5",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-format-md": "^0.1.5",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-any",
+            "has-any-deep",
+            "has-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "14c43971784c0ef94f20a2be2edd9fa9e44a35a1",
+      "_id": "get-value@2.0.5",
+      "_shasum": "af917a37935e88aa548f5fd0e1a8745d914046db",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "af917a37935e88aa548f5fd0e1a8745d914046db",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/get-value-2.0.5.tgz_1459092249587_0.9073094315826893"
+      },
+      "directories": {}
+    },
+    "2.0.6": {
+      "name": "get-value",
+      "description": "Use property paths (`a.b.c`) to get a nested value from an object.",
+      "version": "2.0.6",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-format-md": "^0.1.5",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-any",
+            "has-any-deep",
+            "has-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-readme-generator"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "5dc7466a65eec37e3b9e3d94f274b7aba193ea60",
+      "_id": "get-value@2.0.6",
+      "_shasum": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/get-value-2.0.6.tgz_1466238467647_0.5326845925301313"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "get-value",
+      "description": "Use property paths like 'a.b.c' to get a nested value from an object. Even works when keys have dots in them (no other dot-prop library can do this!).",
+      "version": "3.0.0",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6.0"
+      },
+      "scripts": {
+        "test": "nyc --reporter=text --reporter=html mocha"
+      },
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^2.0.0",
+        "dot-prop": "^4.2.0",
+        "getobject": "^0.1.0",
+        "gulp-format-md": "^1.0.0",
+        "micromatch": "^3.1.5",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "nyc": "^11.4.1"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "run": true,
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-any",
+            "has-any-deep",
+            "has-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "61143e59a1553ef703d15a27f5f1397e743dbee0",
+      "_id": "get-value@3.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-AvQx2mGq9phwebBJBScxxEXlPBVwi7Fz8Pt0wcvtGv7cun4Roipt6FwQkN7lMSg6Wcavw0+3GC1zSe+XaroJJg==",
+        "shasum": "dd1442206a3bd100109ebbbb79c3b2425b2a7bcb",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/get-value-3.0.0.tgz_1517339205284_0.6575652312021703"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "get-value",
+      "description": "Use property paths like 'a.b.c' to get a nested value from an object. Even works when keys have dots in them (no other dot-prop library can do this!).",
+      "version": "3.0.1",
+      "homepage": "https://github.com/jonschlinkert/get-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/get-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/get-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6.0"
+      },
+      "scripts": {
+        "test": "nyc --reporter=text --reporter=html mocha"
+      },
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^2.0.0",
+        "dot-prop": "^4.2.0",
+        "getobject": "^0.1.0",
+        "glob": "^7.1.2",
+        "gulp-format-md": "^1.0.0",
+        "micromatch": "^3.1.5",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "nyc": "^11.4.1",
+        "object-path": "^0.11.4",
+        "write": "^1.0.3"
+      },
+      "keywords": [
+        "get",
+        "key",
+        "nested",
+        "object",
+        "path",
+        "paths",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "segment",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "run": true,
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-any",
+            "has-any-deep",
+            "has-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "f703b744ac60592ca5a8d3dee8cb7de6fbb88a9c",
+      "_id": "get-value@3.0.1",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.7.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+        "shasum": "5efd2a157f1d6a516d7524e124ac52d0a39ef5a8",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 16889
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/get-value_3.0.1_1520400473888_0.8710185921842548"
+      }
+    }
+  },
+  "homepage": "https://github.com/jonschlinkert/get-value",
+  "keywords": [
+    "get",
+    "key",
+    "nested",
+    "object",
+    "path",
+    "paths",
+    "prop",
+    "properties",
+    "property",
+    "props",
+    "segment",
+    "value",
+    "values"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/get-value.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/get-value/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "users": {
+    "knownasilya": true,
+    "den-dp": true,
+    "ninozhang": true,
+    "rocket0191": true,
+    "rbecheras": true,
+    "cr8tiv": true,
+    "isayme": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/get-value.min.json
+++ b/test/fixtures/registry-mocks/content/get-value.min.json
@@ -1,0 +1,783 @@
+{
+  "name": "get-value",
+  "dist-tags": {
+    "latest": "3.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "get-value",
+      "version": "0.1.0",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "dist": {
+        "shasum": "a07411896d764f45082483114368787883adcc32",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "get-value",
+      "version": "0.1.2",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "dist": {
+        "shasum": "66c81f361bc99e14be549b24174596d0c68dd305",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "get-value",
+      "version": "0.2.0",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "dist": {
+        "shasum": "6d4e3be73979a4732c78a980c4501bf1b1fc29fd",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.1": {
+      "name": "get-value",
+      "version": "0.2.1",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "dist": {
+        "shasum": "0279ca54122126dafbbe1fad13b05063ae40d969",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.2": {
+      "name": "get-value",
+      "version": "0.2.2",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "dist": {
+        "shasum": "dd4b70f7f5a85e972059a99a181aef4de32b169f",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.2.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.0": {
+      "name": "get-value",
+      "version": "0.3.0",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "dist": {
+        "shasum": "02a571ec9c89d1be5d6f9299af55ee0f9d680964",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.1": {
+      "name": "get-value",
+      "version": "0.3.1",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "benchmarked": "^0.1.1",
+        "getobject": "^0.1.0",
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "dist": {
+        "shasum": "75f4c5561ac0f880ebb586b4fbd178d40ed936a0",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.2": {
+      "name": "get-value",
+      "version": "0.3.2",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "benchmarked": "^0.1.1",
+        "getobject": "^0.1.0",
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6",
+        "verb-tag-jscomments": ">= 0.2.0"
+      },
+      "dist": {
+        "shasum": "d52e793355ee75e4b8b04decbe2a330942ccc845",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-0.3.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "get-value",
+      "version": "1.0.0",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "009e1d6e404926d3ab315ae785314b2e944311d5",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "get-value",
+      "version": "1.0.1",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "e16357e6fcbc6ecec022f5f87e8db7682b65d14c",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.2": {
+      "name": "get-value",
+      "version": "1.0.2",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "6df09e3bfce55b44fbb1ceac5b35e3801cf26a69",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.3": {
+      "name": "get-value",
+      "version": "1.0.3",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "8746cf0e20b1dd5eb4e760b61ea56b485dcb2d8a",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.4": {
+      "name": "get-value",
+      "version": "1.0.4",
+      "dependencies": {
+        "isobject": "^0.2.0",
+        "noncharacters": "^1.0.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "4f2d51c1fd393ab83b267138a84a189b1846c105",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.1": {
+      "name": "get-value",
+      "version": "1.1.1",
+      "dependencies": {
+        "isobject": "^0.2.0",
+        "noncharacters": "^1.0.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "370f92421db312410dd7c6253a63a869099f85dd",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.2": {
+      "name": "get-value",
+      "version": "1.1.2",
+      "dependencies": {
+        "isobject": "^0.2.0",
+        "noncharacters": "^1.0.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.0",
+        "benchmarked": "^0.1.1",
+        "chalk": "^0.5.1",
+        "dot-prop": "^1.0.1",
+        "getobject": "^0.1.0",
+        "glob": "^4.3.5",
+        "minimist": "^1.1.0",
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "bafe82b38ade9ebce7dbf41e93e7bf18a5611679",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.3": {
+      "name": "get-value",
+      "version": "1.1.3",
+      "dependencies": {
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.3",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.1",
+        "should": "^5.2.0"
+      },
+      "dist": {
+        "shasum": "6894a37f833b75acb3be02b811f00cae699d9f14",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.4": {
+      "name": "get-value",
+      "version": "1.1.4",
+      "dependencies": {
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.5",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.4",
+        "should": "^6.0.1"
+      },
+      "dist": {
+        "shasum": "514801d69a62c741d9d15deafeb603e3ac38c564",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.5": {
+      "name": "get-value",
+      "version": "1.1.5",
+      "dependencies": {
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.5",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.4",
+        "should": "^6.0.1"
+      },
+      "dist": {
+        "shasum": "59ad9bf9004b2a900761ead3b72dc42ee161a6a6",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.1.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.2.0": {
+      "name": "get-value",
+      "version": "1.2.0",
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.5",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.4",
+        "should": "^6.0.1"
+      },
+      "dist": {
+        "shasum": "731f451320e1428bdccaa0e510223e25f62bfe49",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.2.1": {
+      "name": "get-value",
+      "version": "1.2.1",
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "isobject": "^1.0.0",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "chalk": "^1.0.0",
+        "getobject": "^0.1.0",
+        "glob": "^5.0.5",
+        "minimist": "^1.1.1",
+        "mocha": "^2.2.4",
+        "should": "^6.0.1"
+      },
+      "dist": {
+        "shasum": "b309beebce2f4ae0945b77767c611a5a6af3ff6f",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.3.0": {
+      "name": "get-value",
+      "version": "1.3.0",
+      "dependencies": {
+        "arr-flatten": "^1.0.1",
+        "is-extendable": "^0.1.1",
+        "lazy-cache": "^0.2.4",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "getobject": "^0.1.0",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "^2.3.3",
+        "should": "^7.1.1"
+      },
+      "dist": {
+        "shasum": "0cb41d0bc435559b482a629d0192529ce02aff8b",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.3.1": {
+      "name": "get-value",
+      "version": "1.3.1",
+      "dependencies": {
+        "arr-flatten": "^1.0.1",
+        "is-extendable": "^0.1.1",
+        "lazy-cache": "^0.2.4",
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "getobject": "^0.1.0",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "^2.3.3",
+        "should": "^7.1.1"
+      },
+      "dist": {
+        "shasum": "8ac7ef4f20382392b2646548f9b9ad2dc6c89642",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "get-value",
+      "version": "2.0.0",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "jshint-stylish": "^2.0.1",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "^2.3.3",
+        "should": "^7.1.1"
+      },
+      "dist": {
+        "shasum": "de1d3ba0714ebce2d807977e48a616187fd94809",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.1": {
+      "name": "get-value",
+      "version": "2.0.1",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "b6daee9249910c1d14fdbb7468906a775f43439a",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.2": {
+      "name": "get-value",
+      "version": "2.0.2",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "1cdcafe16cd02ac4a44b58a155adf227b83b150d",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.3": {
+      "name": "get-value",
+      "version": "2.0.3",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-format-md": "^0.1.5",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "13a50f0faf69a201c1f0aabdb52c21edd48f105d",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.4": {
+      "name": "get-value",
+      "version": "2.0.4",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-format-md": "^0.1.5",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "d73104aba3f6413610eded22113379cfdf8247d0",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.5": {
+      "name": "get-value",
+      "version": "2.0.5",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-format-md": "^0.1.5",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "af917a37935e88aa548f5fd0e1a8745d914046db",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.6": {
+      "name": "get-value",
+      "version": "2.0.6",
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^0.1.4",
+        "dot-prop": "^2.2.0",
+        "getobject": "^0.1.0",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-format-md": "^0.1.5",
+        "gulp-istanbul": "^0.10.2",
+        "gulp-mocha": "^2.1.3",
+        "isobject": "^2.0.0",
+        "matched": "^0.3.2",
+        "minimist": "^1.2.0"
+      },
+      "dist": {
+        "shasum": "dc15ca1c672387ca76bd37ac0a395ba2042a2c28",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "get-value",
+      "version": "3.0.0",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^2.0.0",
+        "dot-prop": "^4.2.0",
+        "getobject": "^0.1.0",
+        "gulp-format-md": "^1.0.0",
+        "micromatch": "^3.1.5",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "nyc": "^11.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-AvQx2mGq9phwebBJBScxxEXlPBVwi7Fz8Pt0wcvtGv7cun4Roipt6FwQkN7lMSg6Wcavw0+3GC1zSe+XaroJJg==",
+        "shasum": "dd1442206a3bd100109ebbbb79c3b2425b2a7bcb",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "3.0.1": {
+      "name": "get-value",
+      "version": "3.0.1",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "arr-reduce": "^1.0.1",
+        "benchmarked": "^2.0.0",
+        "dot-prop": "^4.2.0",
+        "getobject": "^0.1.0",
+        "glob": "^7.1.2",
+        "gulp-format-md": "^1.0.0",
+        "micromatch": "^3.1.5",
+        "minimist": "^1.2.0",
+        "mocha": "^3.5.3",
+        "nyc": "^11.4.1",
+        "object-path": "^0.11.4",
+        "write": "^1.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-mKZj9JLQrwMBtj5wxi6MH8Z5eSKaERpAwjg43dPtlGI1ZVEgH/qC7T8/6R2OBSUA+zzHBZgICsVJaEIV2tKTDA==",
+        "shasum": "5efd2a157f1d6a516d7524e124ac52d0a39ef5a8",
+        "tarball": "https://registry.npmjs.org/get-value/-/get-value-3.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 16889
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    }
+  },
+  "modified": "2018-03-17T08:34:37.620Z"
+}

--- a/test/fixtures/registry-mocks/content/handle-thing.json
+++ b/test/fixtures/registry-mocks/content/handle-thing.json
@@ -1,0 +1,683 @@
+{
+  "_id": "handle-thing",
+  "_rev": "12-0385b5d40bcacd4bcbe3d6bf245d95b2",
+  "name": "handle-thing",
+  "description": "Wrap Streams2 instance into a HandleWrap",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "handle-thing",
+      "version": "1.0.1",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "cfe9b47e2120ff34fa2abad906f6d66e7ad1d4d5",
+      "_id": "handle-thing@1.0.1",
+      "_shasum": "8d2699e00830315f2f4df976ec78e13edc138376",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8d2699e00830315f2f4df976ec78e13edc138376",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "handle-thing",
+      "version": "1.1.0",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "e10bf84ef6c805fafbbfd51f45a9bb99b691c9f7",
+      "_id": "handle-thing@1.1.0",
+      "_shasum": "3396fa569f84a72bc514b6ae8f8b59d536755776",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3396fa569f84a72bc514b6ae8f8b59d536755776",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "handle-thing",
+      "version": "1.1.1",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "d71668176561ea0e94d22fd2a9994bf5426e3af2",
+      "_id": "handle-thing@1.1.1",
+      "_shasum": "2548f79bf1a9d9b8afd2a204df555e97a48667a0",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2548f79bf1a9d9b8afd2a204df555e97a48667a0",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "handle-thing",
+      "version": "1.2.0",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "0a248f009a80c6bd3d0a72a9b93169d8935d96fb",
+      "_id": "handle-thing@1.2.0",
+      "_shasum": "83dca5730101278b7eadcbdcb77ebbe3c9118e99",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "83dca5730101278b7eadcbdcb77ebbe3c9118e99",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "handle-thing",
+      "version": "1.2.1",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "23be78e16c30e1c1f24c8c438825dce933075718",
+      "_id": "handle-thing@1.2.1",
+      "_shasum": "bc4481875c25058ebed3bef0b14584502b012e3a",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bc4481875c25058ebed3bef0b14584502b012e3a",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "handle-thing",
+      "version": "1.2.2",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "39be7a6108eae277106986859b27fb1cdaab0aa7",
+      "_id": "handle-thing@1.2.2",
+      "_shasum": "b70a18da0d65c5c9aefd92ed1b659a7763d58f0a",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b70a18da0d65c5c9aefd92ed1b659a7763d58f0a",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "handle-thing",
+      "version": "1.2.3",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "2385a9fc298b3248296ffb9799a4f25d0d9e2b8a",
+      "_id": "handle-thing@1.2.3",
+      "_shasum": "6f5feda35992bf0a0168fd50fa246e43a7b11565",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6f5feda35992bf0a0168fd50fa246e43a7b11565",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.4": {
+      "name": "handle-thing",
+      "version": "1.2.4",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "d6859d96df339ada550386672c17ea21251d08fc",
+      "_id": "handle-thing@1.2.4",
+      "_shasum": "b41a5a3ff11a15e80312964ef6da7b45041c8a1e",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b41a5a3ff11a15e80312964ef6da7b45041c8a1e",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.5": {
+      "name": "handle-thing",
+      "version": "1.2.5",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/handle-thing/issues"
+      },
+      "homepage": "https://github.com/indutny/handle-thing#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "6faac3994e329a6736cdd5f8866d5fb3c994a3a3",
+      "_id": "handle-thing@1.2.5",
+      "_shasum": "fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/handle-thing-1.2.5.tgz_1471506800120_0.3210516825783998"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "handle-thing",
+      "version": "2.0.0",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/handle-thing/issues"
+      },
+      "homepage": "https://github.com/spdy-http2/handle-thing#readme",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2",
+        "readable-stream": "^3.0.6",
+        "standard": "^12.0.1",
+        "stream-pair": "^1.0.3"
+      },
+      "gitHead": "219d451c77b496e9dfc6b63ba37787a84a60fc1b",
+      "_id": "handle-thing@2.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "mail@daviddias.me"
+      },
+      "dist": {
+        "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
+        "shasum": "0e039695ff50c93fc288557d696f3c1dc6776754",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 11608,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4+CYCRA9TVsSAnZWagAAZeUP/05FTpmigS1MMtg5209t\n0EQAB8pYF+J9cUk/0p4GOVsE6/DN+Y9yMVFZWTl4r23Nug2CjHs/iJdXc2z1\nGT5q1VfGzRRp/0b1+V1ZBcCAOuClPtQ01bG48FjhqRvdk5xNk0Qbsbc5fMiy\noh8pwt6FjSoIMs2geJKM+2hjoIqbsCa1zao5lTgWx7Rf9vqG7y1J/GuLJhYv\nRFv87AVwJEUWIHha/wezXKB2cguW6aPPiwgw2SyikeGG68eN4KI+GMzJ0EJ0\nGQYmWL569knDS5SoobxlKsmTqigdb7PEeeX1pUbe0SgsFGFx6bcBfRakiV1a\nznBDaebbhDinZtYYZQuo4sNkCdEoj8TZnbd5dWIaUii1yCHB7akNwzo+9ptv\nlQjDnUBudIGtHQV4HwbmVA/IgIBtxMyOGDI0P2yEohMYeeDRGIXjN9ucrlBq\niAm3S60UjfWBOwlcPatfcBfQyrZohDigfpT9C8A5GnVakkW2U5k+KY5HH/gx\nB5xu3pJ7U+uaWg4Ay72pLaDVJUtBA6N87WjHX3TcI8dBP2m6gv7+mdjTq2Wj\n8B7KtoPGAOpRiJBmSM6MRnUYO5PSD4s4HN0/piH4u3stQzxSPyWoDyneDKGN\nFUXL3JVYoGeSOf9vFdwPlvg3lIq2uaxQw4LBKOTkcAlJ18xDL3mKRUECshnh\n4J9W\r\n=JfNi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "daviddias",
+          "email": "daviddias.p@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/handle-thing_2.0.0_1541660823785_0.2980331579099351"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "handle-thing",
+      "version": "2.0.1",
+      "description": "Wrap Streams2 instance into a HandleWrap",
+      "main": "lib/handle.js",
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+      },
+      "keywords": [
+        "handle",
+        "net",
+        "streams2"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/handle-thing/issues"
+      },
+      "homepage": "https://github.com/spdy-http2/handle-thing#readme",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2",
+        "readable-stream": "^3.0.6",
+        "standard": "^12.0.1",
+        "stream-pair": "^1.0.3"
+      },
+      "gitHead": "cc8c5c99189a9edfb7a3456eb97573c3741b79ec",
+      "_id": "handle-thing@2.0.1",
+      "_nodeVersion": "13.9.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+        "shasum": "857f79ce359580c340d43081cc648970d0bb234e",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 12147,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJee4gmCRA9TVsSAnZWagAANVAP/2StYI+jGXer4C8cp2NJ\nmSOsiPnY8OLltFFEpE4rbuufXs0g9ig+WjIgIaxgft1F+Uz2Gi1sHnuxdRst\n7DULmz6j4aHRUo24yrkPQueZMaSyPppWYNWfLvBNyChrQFdngTcfVsze8TgS\nisKJxx3Gg9/KWBrQ85Lp5WFXPgTvXQ9JC7/PQanJV30rXX1SaLAOxrjkj3CS\nEjD66UfWaGWRSmnr8sHHvgiXlXQ60HvNeS7sSn6dKWgGn2Dqrltvh27aGMQF\nEfasSPn9pkJWTVfdn8LE0e5vfS5nI0yXEJ8OELhBsUGx2wGH62AtZpDQ14rJ\n9eCp4dmCZ7K5i2muNdvYnUDOPgg2hcY5eDbOsVYujo1IRvVz3F7+qwv3+Ekt\ni7p2lU5Sg2WZiWU2DNorWHfP8+nLeTf+hfFW8TOG3iypa1kmPU4bqj2CjGj3\nqKQAkv4PA2/N7+TVpcrnlczZTS1r1AG+O4E7KMsMwzhFi2eL8S+vHldU5xye\nDWYijHdjIhEgVYbbNMtyOFPyu7bGmQDG/S4pHsM2mEYiWxULBPO/W84SsDmB\nyl4VXCI3Aflq1mH5AcSlXD8lBNuhJC1/QD+h5c9vHH9gE+vakyyCnTm9mIPD\n3XyKnKIk+OQpzTVykNCXOceuYdyKZgT0cmlQDXigL+OoQmhjpUhs8bM39dbh\nxT66\r\n=Gwnr\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "daviddias",
+          "email": "daviddias.p@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/handle-thing_2.0.1_1585154085964_0.0654420205612285"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Handle Thing\n\n[![Build Status](https://travis-ci.org/spdy-http2/handle-thing.svg?branch=master)](http://travis-ci.org/spdy-http2/handle-thing)\n[![NPM version](https://badge.fury.io/js/handle-thing.svg)](http://badge.fury.io/js/handle-thing)\n[![dependencies Status](https://david-dm.org/spdy-http2/handle-thing/status.svg?style=flat-square)](https://david-dm.org/spdy-http2/handle-thing)\n[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)\n[![Waffle](https://img.shields.io/badge/track-waffle-blue.svg?style=flat-square)](https://waffle.io/spdy-http2/node-spdy)\n\n> Wrap Streams2 instance into a HandleWrap. The right thing when you need it\n\n## Usage\n\n### Examples\n\n`soon™`\n\n### API\n\n`soon™`\n\n## LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2015.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "daviddias",
+      "email": "daviddias.p@gmail.com"
+    },
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-03-25T16:34:48.499Z",
+    "created": "2015-07-08T21:02:24.418Z",
+    "1.0.1": "2015-07-08T21:02:24.418Z",
+    "1.1.0": "2015-07-11T02:23:33.646Z",
+    "1.1.1": "2015-07-11T02:37:21.079Z",
+    "1.2.0": "2015-07-11T03:02:53.814Z",
+    "1.2.1": "2015-07-14T17:40:37.609Z",
+    "1.2.2": "2015-08-10T05:21:56.851Z",
+    "1.2.3": "2015-08-10T05:23:52.100Z",
+    "1.2.4": "2015-08-10T23:47:40.881Z",
+    "1.2.5": "2016-08-18T07:53:22.147Z",
+    "2.0.0": "2018-11-08T07:07:03.940Z",
+    "2.0.1": "2020-03-25T16:34:46.090Z"
+  },
+  "homepage": "https://github.com/spdy-http2/handle-thing#readme",
+  "keywords": [
+    "handle",
+    "net",
+    "streams2"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/handle-thing.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/spdy-http2/handle-thing/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/handle-thing.min.json
+++ b/test/fixtures/registry-mocks/content/handle-thing.min.json
@@ -1,0 +1,166 @@
+{
+  "name": "handle-thing",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "handle-thing",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "8d2699e00830315f2f4df976ec78e13edc138376",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "handle-thing",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "3396fa569f84a72bc514b6ae8f8b59d536755776",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "handle-thing",
+      "version": "1.1.1",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "2548f79bf1a9d9b8afd2a204df555e97a48667a0",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "handle-thing",
+      "version": "1.2.0",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "83dca5730101278b7eadcbdcb77ebbe3c9118e99",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "handle-thing",
+      "version": "1.2.1",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "bc4481875c25058ebed3bef0b14584502b012e3a",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "handle-thing",
+      "version": "1.2.2",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "b70a18da0d65c5c9aefd92ed1b659a7763d58f0a",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.2.tgz"
+      }
+    },
+    "1.2.3": {
+      "name": "handle-thing",
+      "version": "1.2.3",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "6f5feda35992bf0a0168fd50fa246e43a7b11565",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.3.tgz"
+      }
+    },
+    "1.2.4": {
+      "name": "handle-thing",
+      "version": "1.2.4",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "b41a5a3ff11a15e80312964ef6da7b45041c8a1e",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.4.tgz"
+      }
+    },
+    "1.2.5": {
+      "name": "handle-thing",
+      "version": "1.2.5",
+      "devDependencies": {
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "handle-thing",
+      "version": "2.0.0",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2",
+        "readable-stream": "^3.0.6",
+        "standard": "^12.0.1",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
+        "shasum": "0e039695ff50c93fc288557d696f3c1dc6776754",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 11608,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4+CYCRA9TVsSAnZWagAAZeUP/05FTpmigS1MMtg5209t\n0EQAB8pYF+J9cUk/0p4GOVsE6/DN+Y9yMVFZWTl4r23Nug2CjHs/iJdXc2z1\nGT5q1VfGzRRp/0b1+V1ZBcCAOuClPtQ01bG48FjhqRvdk5xNk0Qbsbc5fMiy\noh8pwt6FjSoIMs2geJKM+2hjoIqbsCa1zao5lTgWx7Rf9vqG7y1J/GuLJhYv\nRFv87AVwJEUWIHha/wezXKB2cguW6aPPiwgw2SyikeGG68eN4KI+GMzJ0EJ0\nGQYmWL569knDS5SoobxlKsmTqigdb7PEeeX1pUbe0SgsFGFx6bcBfRakiV1a\nznBDaebbhDinZtYYZQuo4sNkCdEoj8TZnbd5dWIaUii1yCHB7akNwzo+9ptv\nlQjDnUBudIGtHQV4HwbmVA/IgIBtxMyOGDI0P2yEohMYeeDRGIXjN9ucrlBq\niAm3S60UjfWBOwlcPatfcBfQyrZohDigfpT9C8A5GnVakkW2U5k+KY5HH/gx\nB5xu3pJ7U+uaWg4Ay72pLaDVJUtBA6N87WjHX3TcI8dBP2m6gv7+mdjTq2Wj\n8B7KtoPGAOpRiJBmSM6MRnUYO5PSD4s4HN0/piH4u3stQzxSPyWoDyneDKGN\nFUXL3JVYoGeSOf9vFdwPlvg3lIq2uaxQw4LBKOTkcAlJ18xDL3mKRUECshnh\n4J9W\r\n=JfNi\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.1": {
+      "name": "handle-thing",
+      "version": "2.0.1",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2",
+        "readable-stream": "^3.0.6",
+        "standard": "^12.0.1",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+        "shasum": "857f79ce359580c340d43081cc648970d0bb234e",
+        "tarball": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 12147,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJee4gmCRA9TVsSAnZWagAANVAP/2StYI+jGXer4C8cp2NJ\nmSOsiPnY8OLltFFEpE4rbuufXs0g9ig+WjIgIaxgft1F+Uz2Gi1sHnuxdRst\n7DULmz6j4aHRUo24yrkPQueZMaSyPppWYNWfLvBNyChrQFdngTcfVsze8TgS\nisKJxx3Gg9/KWBrQ85Lp5WFXPgTvXQ9JC7/PQanJV30rXX1SaLAOxrjkj3CS\nEjD66UfWaGWRSmnr8sHHvgiXlXQ60HvNeS7sSn6dKWgGn2Dqrltvh27aGMQF\nEfasSPn9pkJWTVfdn8LE0e5vfS5nI0yXEJ8OELhBsUGx2wGH62AtZpDQ14rJ\n9eCp4dmCZ7K5i2muNdvYnUDOPgg2hcY5eDbOsVYujo1IRvVz3F7+qwv3+Ekt\ni7p2lU5Sg2WZiWU2DNorWHfP8+nLeTf+hfFW8TOG3iypa1kmPU4bqj2CjGj3\nqKQAkv4PA2/N7+TVpcrnlczZTS1r1AG+O4E7KMsMwzhFi2eL8S+vHldU5xye\nDWYijHdjIhEgVYbbNMtyOFPyu7bGmQDG/S4pHsM2mEYiWxULBPO/W84SsDmB\nyl4VXCI3Aflq1mH5AcSlXD8lBNuhJC1/QD+h5c9vHH9gE+vakyyCnTm9mIPD\n3XyKnKIk+OQpzTVykNCXOceuYdyKZgT0cmlQDXigL+OoQmhjpUhs8bM39dbh\nxT66\r\n=Gwnr\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-03-25T16:34:48.499Z"
+}

--- a/test/fixtures/registry-mocks/content/has-value.json
+++ b/test/fixtures/registry-mocks/content/has-value.json
@@ -1,0 +1,1019 @@
+{
+  "_id": "has-value",
+  "_rev": "15-52d84b3bf86abf1d6622b87eea937ccf",
+  "name": "has-value",
+  "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "has-value",
+      "description": "Returns true if a value exists, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. Other libs do this, but I needed one that would optionally _not_ treat zero as empty. Also, this works with booleans and other valu",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/has-value/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "_id": "has-value@0.1.0",
+      "_shasum": "43d36b0019fce4f0106f77ced58fcbd9c82988c3",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43d36b0019fce4f0106f77ced58fcbd9c82988c3",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "has-value",
+      "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/has-value/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "get-value": "^1.1.1",
+        "has-values": "^0.1.2"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "gitHead": "0e50bd07b986ac899a5f72e1428f1641f7bf6030",
+      "_id": "has-value@0.2.0",
+      "_shasum": "e4b036874a791eb6b80ab36d8ba5427c7319eac2",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e4b036874a791eb6b80ab36d8ba5427c7319eac2",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "has-value",
+      "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "get-value": "^2.0.0",
+        "has-values": "^0.1.3"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "description": "",
+          "list": [
+            "get-value",
+            "set-value",
+            "get-property",
+            "get-object"
+          ]
+        }
+      },
+      "gitHead": "0e50bd07b986ac899a5f72e1428f1641f7bf6030",
+      "_id": "has-value@0.2.1",
+      "_shasum": "dbb14da140d429a8bcd4f089bc190f7db30bef70",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dbb14da140d429a8bcd4f089bc190f7db30bef70",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "has-value",
+      "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "get-value": "^2.0.0",
+        "has-values": "^0.1.3",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "get-value",
+            "set-value",
+            "get-property",
+            "get-object"
+          ],
+          "description": ""
+        }
+      },
+      "gitHead": "7db732eb679e22fd058b64f70755389ed3b1cbb4",
+      "_id": "has-value@0.3.0",
+      "_shasum": "e63297a4d45ca7c8647337e1ba7be9f18e27ee3c",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e63297a4d45ca7c8647337e1ba7be9f18e27ee3c",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "has-value",
+      "version": "0.3.1",
+      "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "get-object",
+            "get-property",
+            "get-value",
+            "set-value"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "adecb27b13b7e99688694e228a946e6e635fcc64",
+      "_id": "has-value@0.3.1",
+      "_shasum": "7b1f58bada62ca827ec0a2078025654845995e1f",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7b1f58bada62ca827ec0a2078025654845995e1f",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/has-value-0.3.1.tgz_1459091935592_0.006853065919131041"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "has-value",
+      "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Ryan M Harrison",
+          "url": "https://linkedin.com/in/harrisonrm"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.1"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "get-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "reflinks": [],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "61b5671a48ac40206eb33b4ea75dc2507168d687",
+      "_id": "has-value@1.0.0",
+      "_shasum": "18b281da585b1c5c51def24c930ed29a0be6b177",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "18b281da585b1c5c51def24c930ed29a0be6b177",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/has-value-1.0.0.tgz_1495221082986_0.06325704883784056"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "has-value",
+      "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Ryan M Harrison",
+          "url": "https://linkedin.com/in/harrisonrm"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "get-value": "^3.0.0",
+        "has-values": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "check",
+        "deep",
+        "empty",
+        "function",
+        "has",
+        "hasOwn",
+        "is-empty",
+        "nested",
+        "null",
+        "number",
+        "object",
+        "object path",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "value"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "get-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "b7f8d300f40fb4d5502a2b9b9663d6149f061f35",
+      "_id": "has-value@2.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-xtebC5A+YFrlfEIQHYBflcgECx375VotcuNjT8+U0zQDNSFiUe/zA3FX9gSdx9CwoNBFeSL9icj2V4Ps0oNvHg==",
+        "shasum": "aae2c3f2c1001313c382948a9baa77f3b28ef9be",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/has-value-2.0.0.tgz_1517360751813_0.23941618809476495"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "has-value",
+      "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Ryan M Harrison",
+          "url": "https://linkedin.com/in/harrisonrm"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "get-value": "^3.0.0",
+        "has-values": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "check",
+        "deep",
+        "empty",
+        "function",
+        "has",
+        "hasOwn",
+        "is-empty",
+        "nested",
+        "null",
+        "number",
+        "object",
+        "object path",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "value"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "get-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "b2385563add4bfd7d0ebf4496adb23ec5459175a",
+      "_id": "has-value@2.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-oCDVCcqagvg7sJFMuzwZjLaWPey4yF1NjSZ3Ch+ONuxDL+tdmTSIsNZZyTjZxPzef3FIB0YDeLqn7XUyzwcg2g==",
+        "shasum": "749e1e53104af6b73554e079c1871991be1a7895",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/has-value-2.0.1.tgz_1517360804545_0.8370905774645507"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "has-value",
+      "description": "Returns true if a value exists, false if empty. Works with deeply nested values using object paths.",
+      "version": "2.0.2",
+      "homepage": "https://github.com/jonschlinkert/has-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Ryan M Harrison",
+          "url": "https://linkedin.com/in/harrisonrm"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "get-value": "^3.0.0",
+        "has-values": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "check",
+        "deep",
+        "empty",
+        "function",
+        "has",
+        "hasOwn",
+        "is-empty",
+        "nested",
+        "null",
+        "number",
+        "object",
+        "object path",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "value"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "define-property",
+            "get-value",
+            "set-value",
+            "unset-value"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "db042177595bde65af9286566190ce10f86b1edf",
+      "_id": "has-value@2.0.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.7.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-ybKOlcRsK2MqrM3Hmz/lQxXHZ6ejzSPzpNabKB45jb5qDgJvKPa3SdapTsTLwEb9WltgWpOmNax7i+DzNOk4TA==",
+        "shasum": "d0f12e8780ba8e90e66ad1a21c707fdb67c25658",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-2.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 10680
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/has-value_2.0.2_1520110149506_0.9471665906446345"
+      }
+    }
+  },
+  "readme": "# has-value [![NPM version](https://img.shields.io/npm/v/has-value.svg?style=flat)](https://www.npmjs.com/package/has-value) [![NPM monthly downloads](https://img.shields.io/npm/dm/has-value.svg?style=flat)](https://npmjs.org/package/has-value) [![NPM total downloads](https://img.shields.io/npm/dt/has-value.svg?style=flat)](https://npmjs.org/package/has-value) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/has-value.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/has-value)\n\n> Returns true if a value exists, false if empty. Works with deeply nested values using object paths.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save has-value\n```\n\n## Heads up!\n\nBreaking changes in v2.0! See the [release history](#release-history) for details.\n\n## Usage\n\n```js\nconst has = require('has-value');\n\nconsole.log(has()) //=> true\nconsole.log(has('foo')) //=> true\n```\n\n**Works for:**\n\n* booleans\n* functions\n* numbers\n* strings\n* nulls\n* object\n* arrays\n\n**isEmpty**\n\nTo do the opposite and test for empty values, do:\n\n```js\nconst isEmpty = (...args) => !has(...args);\n```\n\n## Supported types\n\n### Arrays\n\n```js\nconsole.log(has({ foo: { bar: ['a'] } }, 'foo.bar'));    //=> true\nconsole.log(has({ foo: { bar: [0] } }, 'foo.bar'));      //=> true\nconsole.log(has({ foo: { bar: [[[]]] } }, 'foo.bar'));   //=> false\nconsole.log(has({ foo: { bar: [[], []] } }, 'foo.bar')); //=> false\nconsole.log(has({ foo: { bar: [] } }, 'foo.bar'));       //=> false\n```\n\n### Booleans\n\n```js\nconsole.log(has({ foo: { bar: true } }, 'foo.bar'));  //=> true\nconsole.log(has({ foo: { bar: false } }, 'foo.bar')); //=> true\n```\n\n### Buffers\n\n```js\nconsole.log(has({ foo: { bar: new Buffer() } }, 'foo.bar'));      //=> false\nconsole.log(has({ foo: { bar: new Buffer('foo') } }, 'foo.bar')); //=> true\n```\n\n### Dates\n\nDates are always true.\n\n```js\nconsole.log(has({ foo: { bar: new Date() } }, 'foo.bar')); //=> true\n```\n\n### Errors\n\nReturns `false` if `err.message` is an empty string.\n\n```js\nconsole.log(has({ foo: { bar: new Error() } }, 'foo.bar'));      //=> false\nconsole.log(has({ foo: { bar: new Error('foo') } }, 'foo.bar')); //=> true\n```\n\n### Functions\n\nFunctions are always true.\n\n```js\nconsole.log(has({ foo: { bar: function(foo) {} } }, 'foo.bar')); //=> true\nconsole.log(has({ foo: { bar: function() {} } }, 'foo.bar'));    //=> true\n```\n\n### Maps\n\n```js\nconsole.log(has({ foo: { bar: new Map() } }, 'foo.bar'));                 //=> false\nconsole.log(has({ foo: { bar: new Map([['foo', 'bar']]) } }, 'foo.bar')); //=> true\n```\n\n### Null\n\n`null` is always true, as it's assumed that this is a user-defined value, versus `undefined` which is not.\n\n```js\nconsole.log(has({ foo: { bar: null } }, 'foo.bar')); //=> true\n```\n\n### Objects\n\n```js\nconsole.log(has({ foo: { bar: {} } }, 'foo.bar')); //=> false\nconsole.log(has({ foo: { bar: { a: 'a' }} } }, 'foo.bar'));        //=> true\nconsole.log(has({ foo: { bar: { foo: undefined } } }, 'foo.bar')); //=> false\nconsole.log(has({ foo: { bar: { foo: null } } }, 'foo.bar'));      //=> true\n```\n\n### Numbers\n\n```js\nconsole.log(has({ foo: { bar: 1 } }, 'foo.bar')); //=> true\nconsole.log(has({ foo: { bar: 0 } }, 'foo.bar')); //=> true\n```\n\n### Regular expressions\n\n```js\nconsole.log(has({ foo: { bar: new RegExp() } }, 'foo.bar'));      //=> false\nconsole.log(has({ foo: { bar: new RegExp('foo') } }, 'foo.bar')); //=> true\n```\n\n### Sets\n\n```js\nconsole.log(has({ foo: { bar: new Set() } }, 'foo.bar'));               //=> false\nconsole.log(has({ foo: { bar: new Set(['foo', 'bar']) } }, 'foo.bar')); //=> true\n```\n\n### Strings\n\n```js\nconsole.log(has({ foo: { bar: 'a' } }, 'foo.bar')); //=> true\nconsole.log(has({ foo: { bar: '' } }, 'foo.bar'));  //=> false\n```\n\n## Undefined\n\n```js\nconsole.log(has({ foo: { bar:  } }, 'foo.bar'));          //=> false\nconsole.log(has({ foo: { bar: void 0 } }, 'foo.bar'));    //=> false\nconsole.log(has({ foo: { bar: undefined } }, 'foo.bar')); //=> false\n```\n\n## Release history\n\n### v2.0.0\n\n**Breaking changes**\n\n* Now returns false if the first argument is not an object, function or array, and the second argument is not a string or array.\n\n### v1.0.0\n\n* `zero` always returns true\n* `array` now recurses, so that an array of empty arrays will return `false`\n* `null` now returns true\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [define-property](https://www.npmjs.com/package/define-property): Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty. | [homepage](https://github.com/jonschlinkert/define-property \"Define a non-enumerable property on an object. Uses Reflect.defineProperty when available, otherwise Object.defineProperty.\")\n* [get-value](https://www.npmjs.com/package/get-value): Use property paths like 'a.b.c' to get a nested value from an object. Even works… [more](https://github.com/jonschlinkert/get-value) | [homepage](https://github.com/jonschlinkert/get-value \"Use property paths like 'a.b.c' to get a nested value from an object. Even works when keys have dots in them (no other dot-prop library can do this!).\")\n* [set-value](https://www.npmjs.com/package/set-value): Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths. | [homepage](https://github.com/jonschlinkert/set-value \"Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths.\")\n* [unset-value](https://www.npmjs.com/package/unset-value): Delete nested properties from an object using dot notation. | [homepage](https://github.com/jonschlinkert/unset-value \"Delete nested properties from an object using dot notation.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 32 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 2 | [rmharrison](https://github.com/rmharrison) |\n| 1 | [wtgtybhertgeghgtwtg](https://github.com/wtgtybhertgeghgtwtg) |\n\n### Author\n\n**Jon Schlinkert**\n\n* [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)\n* [GitHub Profile](https://github.com/jonschlinkert)\n* [Twitter Profile](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on March 03, 2018._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-03-03T20:49:10.735Z",
+    "created": "2014-09-22T01:44:49.852Z",
+    "0.1.0": "2014-09-22T01:44:49.852Z",
+    "0.2.0": "2015-03-25T19:47:23.519Z",
+    "0.2.1": "2015-10-30T19:53:26.993Z",
+    "0.3.0": "2015-11-24T02:22:33.282Z",
+    "0.3.1": "2016-03-27T15:18:56.829Z",
+    "1.0.0": "2017-05-19T19:11:24.026Z",
+    "2.0.0": "2018-01-31T01:05:52.860Z",
+    "2.0.1": "2018-01-31T01:06:45.561Z",
+    "2.0.2": "2018-03-03T20:49:09.585Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/has-value",
+  "keywords": [
+    "array",
+    "boolean",
+    "check",
+    "deep",
+    "empty",
+    "function",
+    "has",
+    "hasOwn",
+    "is-empty",
+    "nested",
+    "null",
+    "number",
+    "object",
+    "object path",
+    "properties",
+    "property",
+    "string",
+    "type",
+    "value"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/has-value.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/has-value/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "users": {
+    "ninozhang": true,
+    "456wyc": true,
+    "rocket0191": true,
+    "bsara": true,
+    "rahulraghavankklm": true
+  },
+  "contributors": [
+    {
+      "name": "Jon Schlinkert",
+      "url": "http://twitter.com/jonschlinkert"
+    },
+    {
+      "name": "Ryan M Harrison",
+      "url": "https://linkedin.com/in/harrisonrm"
+    },
+    {
+      "url": "https://github.com/wtgtybhertgeghgtwtg"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/has-value.min.json
+++ b/test/fixtures/registry-mocks/content/has-value.min.json
@@ -1,0 +1,184 @@
+{
+  "name": "has-value",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "has-value",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6"
+      },
+      "dist": {
+        "shasum": "43d36b0019fce4f0106f77ced58fcbd9c82988c3",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "has-value",
+      "version": "0.2.0",
+      "dependencies": {
+        "get-value": "^1.1.1",
+        "has-values": "^0.1.2"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "e4b036874a791eb6b80ab36d8ba5427c7319eac2",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.1": {
+      "name": "has-value",
+      "version": "0.2.1",
+      "dependencies": {
+        "get-value": "^2.0.0",
+        "has-values": "^0.1.3"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "dbb14da140d429a8bcd4f089bc190f7db30bef70",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.0": {
+      "name": "has-value",
+      "version": "0.3.0",
+      "dependencies": {
+        "get-value": "^2.0.0",
+        "has-values": "^0.1.3",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "e63297a4d45ca7c8647337e1ba7be9f18e27ee3c",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.1": {
+      "name": "has-value",
+      "version": "0.3.1",
+      "dependencies": {
+        "get-value": "^2.0.3",
+        "has-values": "^0.1.4",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5"
+      },
+      "dist": {
+        "shasum": "7b1f58bada62ca827ec0a2078025654845995e1f",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "has-value",
+      "version": "1.0.0",
+      "dependencies": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.1"
+      },
+      "dist": {
+        "shasum": "18b281da585b1c5c51def24c930ed29a0be6b177",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "has-value",
+      "version": "2.0.0",
+      "dependencies": {
+        "get-value": "^3.0.0",
+        "has-values": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-xtebC5A+YFrlfEIQHYBflcgECx375VotcuNjT8+U0zQDNSFiUe/zA3FX9gSdx9CwoNBFeSL9icj2V4Ps0oNvHg==",
+        "shasum": "aae2c3f2c1001313c382948a9baa77f3b28ef9be",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.1": {
+      "name": "has-value",
+      "version": "2.0.1",
+      "dependencies": {
+        "get-value": "^3.0.0",
+        "has-values": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-oCDVCcqagvg7sJFMuzwZjLaWPey4yF1NjSZ3Ch+ONuxDL+tdmTSIsNZZyTjZxPzef3FIB0YDeLqn7XUyzwcg2g==",
+        "shasum": "749e1e53104af6b73554e079c1871991be1a7895",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.2": {
+      "name": "has-value",
+      "version": "2.0.2",
+      "dependencies": {
+        "get-value": "^3.0.0",
+        "has-values": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-ybKOlcRsK2MqrM3Hmz/lQxXHZ6ejzSPzpNabKB45jb5qDgJvKPa3SdapTsTLwEb9WltgWpOmNax7i+DzNOk4TA==",
+        "shasum": "d0f12e8780ba8e90e66ad1a21c707fdb67c25658",
+        "tarball": "https://registry.npmjs.org/has-value/-/has-value-2.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 10680
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "modified": "2018-03-03T20:49:10.735Z"
+}

--- a/test/fixtures/registry-mocks/content/has-values.json
+++ b/test/fixtures/registry-mocks/content/has-values.json
@@ -1,0 +1,758 @@
+{
+  "_id": "has-values",
+  "_rev": "9-ca902d5f2f64e49c12d883f49c12d9d1",
+  "name": "has-values",
+  "description": "Returns true if any values exist, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. ",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "0.1.1": {
+      "name": "has-values",
+      "description": "Returns true if a value exists, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. Other libs do this, but I needed one that would optionally _not_ treat zero as empty. Also, this works with booleans and other valu",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/has-values",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/has-values.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-values/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/has-values/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "gitHead": "9e6e72d2d2d41c67131051eaa5c940d67f5b965f",
+      "_id": "has-values@0.1.1",
+      "_shasum": "af131afe61081fa8bcefecc608e3bcc8e556619f",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "af131afe61081fa8bcefecc608e3bcc8e556619f",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "has-values",
+      "description": "Returns true if a value exists, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. Other libs do this, but I needed one that would optionally _not_ treat zero as empty. Also, this works with booleans and other valu",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/has-values",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/has-values.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-values/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/has-values/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "gitHead": "9e6e72d2d2d41c67131051eaa5c940d67f5b965f",
+      "_id": "has-values@0.1.2",
+      "_shasum": "804a721f892a31ee86ae118109fdacaafae6bcf3",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "804a721f892a31ee86ae118109fdacaafae6bcf3",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "has-values",
+      "description": "Returns true if any values exist, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. ",
+      "version": "0.1.3",
+      "homepage": "https://github.com/jonschlinkert/has-values",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/has-values.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-values/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/has-values/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "gitHead": "d47866d2a5e7af8803bf0af69f71b161eaba50b4",
+      "_id": "has-values@0.1.3",
+      "_shasum": "f0fb706128d3516bc8713cd14aaf2370598ee797",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f0fb706128d3516bc8713cd14aaf2370598ee797",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "has-values",
+      "version": "0.1.4",
+      "description": "Returns true if any values exist, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. ",
+      "homepage": "https://github.com/jonschlinkert/has-values",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-values.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-values/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-value",
+            "isobject",
+            "is-plain-object"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "199a3eacd663b4ae4b00aef5ef5541aa2c7c8089",
+      "_id": "has-values@0.1.4",
+      "_shasum": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/has-values-0.1.4.tgz_1459080711641_0.050919414730742574"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "has-values",
+      "description": "Returns true if any values exist, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. ",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/has-values",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-values.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-values/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.1"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-value",
+            "kind-of",
+            "is-number",
+            "is-plain-object",
+            "isobject"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "fead695044aafcfb337c7125af5479c7eaf1c92c",
+      "_id": "has-values@1.0.0",
+      "_shasum": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/has-values-1.0.0.tgz_1495219418678_0.2592258816584945"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "has-values",
+      "description": "Returns true if any values exist, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. ",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/has-values",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-values.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-values/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-value",
+            "is-number",
+            "is-plain-object",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "71702a05ea6c03deb18a8a56061f18a9f206a74f",
+      "_id": "has-values@2.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-MLMpI3eJVuEWhTg98GFObcPtvcn+CUe9wqpNNvMS48IBVz6dS0Wb4ERkPgVMeeirGfkmQ/Vjnx+TQ4A5pLIGMQ==",
+        "shasum": "885d9fc5f6bb619c9cfca28775feb7c22bbb82ad",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/has-values-2.0.0.tgz_1517354355906_0.20138088054955006"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "has-values",
+      "description": "Returns true if any values exist, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays. ",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/has-values",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/has-values.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/has-values/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "array",
+        "boolean",
+        "empty",
+        "find",
+        "function",
+        "has",
+        "hasOwn",
+        "javascript",
+        "js",
+        "key",
+        "keys",
+        "node.js",
+        "null",
+        "number",
+        "object",
+        "properties",
+        "property",
+        "string",
+        "type",
+        "util",
+        "utilities",
+        "utility",
+        "value",
+        "values"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-value",
+            "is-number",
+            "is-plain-object",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "7bb2ba66535f9cc849c292841a8af73d83f79331",
+      "_id": "has-values@2.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-+QdH3jOmq9P8GfdjFg0eJudqx1FqU62NQJ4P16rOEHeRdl7ckgwn6uqQjzYE0ZoHVV/e5E2esuJ5Gl5+HUW19w==",
+        "shasum": "3876200ff86d8a8546a9264a952c17d5fc17579d",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/has-values-2.0.1.tgz_1517360589346_0.17850913107395172"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# has-values [![NPM version](https://img.shields.io/npm/v/has-values.svg?style=flat)](https://www.npmjs.com/package/has-values) [![NPM monthly downloads](https://img.shields.io/npm/dm/has-values.svg?style=flat)](https://npmjs.org/package/has-values) [![NPM total downloads](https://img.shields.io/npm/dt/has-values.svg?style=flat)](https://npmjs.org/package/has-values) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/has-values.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/has-values)\n\n> Returns true if any values exist, false if empty. Works for booleans, functions, numbers, strings, nulls, objects and arrays.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save has-values\n```\n\n## Usage\n\n```js\nconst has = require('has-values');\n```\n\nCreate an `isEmpty` function by returning the inverse of the result from has-values:\n\n```js\nconst isEmpty = val => !has(val);\n```\n\n## Supported types\n\n### Arrays\n\n```js\nconsole.log(has(['a']));      //=> true\nconsole.log(has([0]));        //=> true\nconsole.log(has([[[]]]));     //=> false\nconsole.log(has([[], []]));   //=> false\nconsole.log(has([]));         //=> false\n```\n\n### Booleans\n\n```js\nconsole.log(has(true));  //=> true\nconsole.log(has(false)); //=> true\n```\n\n### Buffers\n\n```js\nconsole.log(has(new Buffer()));      //=> false\nconsole.log(has(new Buffer('foo'))); //=> true\n```\n\n### Dates\n\nDates are always true.\n\n```js\nconsole.log(has(new Date())); //=> true\n```\n\n### Errors\n\nReturns `false` if `err.message` is an empty string.\n\n```js\nconsole.log(has(new Error()));      //=> false\nconsole.log(has(new Error('foo'))); //=> true\n```\n\n### Functions\n\nFunctions are always true.\n\n```js\nconsole.log(has(function(foo) {})); //=> true\nconsole.log(has(function() {}));    //=> true\n```\n\n### Maps\n\n```js\nconsole.log(has(new Map()));                 //=> false\nconsole.log(has(new Map([['foo', 'bar']]))); //=> true\n```\n\n### Null\n\n`null` is always true, as it's assumed that this is a user-defined value, versus `undefined` which is not.\n\n```js\nconsole.log(has(null)); //=> true\n```\n\n### Objects\n\n```js\nconsole.log(has({})); //=> false\nconsole.log(has({ a: 'a' }}));        //=> true\nconsole.log(has({ foo: undefined })); //=> false\nconsole.log(has({ foo: null }));      //=> true\n```\n\n### Numbers\n\n```js\nconsole.log(has(1)); //=> true\nconsole.log(has(0)); //=> true\n```\n\n### Regular expressions\n\n```js\nconsole.log(has(new RegExp()));      //=> false\nconsole.log(has(new RegExp('foo'))); //=> true\n```\n\n### Sets\n\n```js\nconsole.log(has(new Set()));               //=> false\nconsole.log(has(new Set(['foo', 'bar']))); //=> true\n```\n\n### Strings\n\n```js\nconsole.log(has('a')); //=> true\nconsole.log(has(''));  //=> false\n```\n\n## Undefined\n\n```js\nconsole.log(has());          //=> false\nconsole.log(has(void 0));    //=> false\nconsole.log(has(undefined)); //=> false\n```\n\n## Release history\n\n### v2.0.0\n\n* no longer supports numbers as a string\n* optimizations\n* adds support for `regex` and `buffer`\n\n### v1.0.0\n\n* adds support for `Map` and `Set`\n* `zero` always returns true\n* `array` now recurses, so that an array of empty arrays will return `false`\n* `null` now returns true\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [has-value](https://www.npmjs.com/package/has-value): Returns true if a value exists, false if empty. Works with deeply nested values using… [more](https://github.com/jonschlinkert/has-value) | [homepage](https://github.com/jonschlinkert/has-value \"Returns true if a value exists, false if empty. Works with deeply nested values using object paths.\")\n* [is-number](https://www.npmjs.com/package/is-number): Returns true if the value is a number. comprehensive tests. | [homepage](https://github.com/jonschlinkert/is-number \"Returns true if the value is a number. comprehensive tests.\")\n* [is-plain-object](https://www.npmjs.com/package/is-plain-object): Returns true if an object was created by the `Object` constructor. | [homepage](https://github.com/jonschlinkert/is-plain-object \"Returns true if an object was created by the `Object` constructor.\")\n* [isobject](https://www.npmjs.com/package/isobject): Returns true if the value is an object and not an array or null. | [homepage](https://github.com/jonschlinkert/isobject \"Returns true if the value is an object and not an array or null.\")\n* [kind-of](https://www.npmjs.com/package/kind-of): Get the native type of a value. | [homepage](https://github.com/jonschlinkert/kind-of \"Get the native type of a value.\")\n\n### Author\n\n**Jon Schlinkert**\n\n* [linkedin/in/jonschlinkert](https://linkedin.com/in/jonschlinkert)\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on January 30, 2018._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-01-31T01:03:10.470Z",
+    "created": "2015-03-25T02:12:55.847Z",
+    "0.1.1": "2015-03-25T02:12:55.847Z",
+    "0.1.2": "2015-03-25T02:13:20.984Z",
+    "0.1.3": "2015-03-27T21:09:00.648Z",
+    "0.1.4": "2016-03-27T12:11:52.568Z",
+    "1.0.0": "2017-05-19T18:43:39.654Z",
+    "2.0.0": "2018-01-30T23:19:16.894Z",
+    "2.0.1": "2018-01-31T01:03:10.470Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/has-values",
+  "keywords": [
+    "array",
+    "boolean",
+    "empty",
+    "find",
+    "function",
+    "has",
+    "hasOwn",
+    "javascript",
+    "js",
+    "key",
+    "keys",
+    "node.js",
+    "null",
+    "number",
+    "object",
+    "properties",
+    "property",
+    "string",
+    "type",
+    "util",
+    "utilities",
+    "utility",
+    "value",
+    "values"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/has-values.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/has-values/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "rocket0191": true,
+    "bsara": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/has-values.min.json
+++ b/test/fixtures/registry-mocks/content/has-values.min.json
@@ -1,0 +1,126 @@
+{
+  "name": "has-values",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "0.1.1": {
+      "name": "has-values",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "af131afe61081fa8bcefecc608e3bcc8e556619f",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "has-values",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "804a721f892a31ee86ae118109fdacaafae6bcf3",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.3": {
+      "name": "has-values",
+      "version": "0.1.3",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "f0fb706128d3516bc8713cd14aaf2370598ee797",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-0.1.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.4": {
+      "name": "has-values",
+      "version": "0.1.4",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5"
+      },
+      "dist": {
+        "shasum": "6d61de95d91dfca9b9a02089ad384bff8f62b771",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "has-values",
+      "version": "1.0.0",
+      "dependencies": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.1"
+      },
+      "dist": {
+        "shasum": "95b0b63fec2146619a6fe57fe75628d5a39efe4f",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "has-values",
+      "version": "2.0.0",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-MLMpI3eJVuEWhTg98GFObcPtvcn+CUe9wqpNNvMS48IBVz6dS0Wb4ERkPgVMeeirGfkmQ/Vjnx+TQ4A5pLIGMQ==",
+        "shasum": "885d9fc5f6bb619c9cfca28775feb7c22bbb82ad",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.1": {
+      "name": "has-values",
+      "version": "2.0.1",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-+QdH3jOmq9P8GfdjFg0eJudqx1FqU62NQJ4P16rOEHeRdl7ckgwn6uqQjzYE0ZoHVV/e5E2esuJ5Gl5+HUW19w==",
+        "shasum": "3876200ff86d8a8546a9264a952c17d5fc17579d",
+        "tarball": "https://registry.npmjs.org/has-values/-/has-values-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "modified": "2018-01-31T01:03:10.470Z"
+}

--- a/test/fixtures/registry-mocks/content/hash-base.json
+++ b/test/fixtures/registry-mocks/content/hash-base.json
@@ -1,0 +1,933 @@
+{
+  "_id": "hash-base",
+  "_rev": "15-934f10af44f4fb0776454710d52afbeb",
+  "name": "hash-base",
+  "description": "abstract base class for hash-streams",
+  "dist-tags": {
+    "latest": "3.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "hash-base",
+      "version": "1.0.0",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "e315bd2c5c9e98ecac9a45bb5af1c38d87c3bc47",
+      "_id": "hash-base@1.0.0",
+      "_shasum": "72e2cc98c2ba5d6667034376afecdc9383b0bded",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "72e2cc98c2ba5d6667034376afecdc9383b0bded",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/hash-base-1.0.0.tgz_1459711075584_0.6947719715535641"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "hash-base",
+      "version": "1.0.1",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "e31f5acb15a16bcc9475308a07949836f38d3daf",
+      "_id": "hash-base@1.0.1",
+      "_shasum": "472384fb22358c460af6b270f15a24e67cf60a1e",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "472384fb22358c460af6b270f15a24e67cf60a1e",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-1.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/hash-base-1.0.1.tgz_1459765278491_0.9590846872888505"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "hash-base",
+      "version": "1.0.2",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "b10031234ba760da754b2f8fa3a4c20d76336e5b",
+      "_id": "hash-base@1.0.2",
+      "_shasum": "f5d93455e8b5778b855ec6531eb87853a2295688",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "f5d93455e8b5778b855ec6531eb87853a2295688",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-1.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/hash-base-1.0.2.tgz_1459768485871_0.13139901007525623"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "hash-base",
+      "version": "2.0.0",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "aafd2ed37cde65cd0d5969e1a3f45a7ba6a99197",
+      "_id": "hash-base@2.0.0",
+      "_shasum": "582af12ab8c6d9d218aea9dc849b4582d495d4c6",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "582af12ab8c6d9d218aea9dc849b4582d495d4c6",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/hash-base-2.0.0.tgz_1460011600955_0.857208457775414"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "hash-base",
+      "version": "2.0.1",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "3cb689188cfd5aaf4e537316ff0b48669a8acb4c",
+      "_id": "hash-base@2.0.1",
+      "_shasum": "e05d166102b12265782b938f7ba18246222db6d7",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "e05d166102b12265782b938f7ba18246222db6d7",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/hash-base-2.0.1.tgz_1460639157385_0.5800484092906117"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "hash-base",
+      "version": "2.0.2",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "dff2ded0a9e5d0e5e604dd785213fa991d1af4a5",
+      "_id": "hash-base@2.0.2",
+      "_shasum": "66ea1d856db4e8a5470cadf6fce23ae5244ef2e1",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "66ea1d856db4e8a5470cadf6fce23ae5244ef2e1",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/hash-base-2.0.2.tgz_1460889681740_0.6923118229024112"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "hash-base",
+      "version": "3.0.0",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "1d905bb490a45987037c78d499971d9b4772217c",
+      "_id": "hash-base@3.0.0",
+      "_shasum": "fab7a974e1522bbcc0e38b9a3b8d625190518769",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "fab7a974e1522bbcc0e38b9a3b8d625190518769",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/hash-base-3.0.0.tgz_1462358197141_0.928217556560412"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "hash-base",
+      "version": "3.0.1",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^7.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "1625296a72c2f93f5f7e52839996cee67e565d0f",
+      "_id": "hash-base@3.0.1",
+      "_shasum": "e151fac39ceae63b6129ad857922e113fa66eb3d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "e151fac39ceae63b6129ad857922e113fa66eb3d",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/hash-base-3.0.1.tgz_1470750706567_0.5660293367691338"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "hash-base",
+      "version": "3.0.2",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^7.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "78f5c19b5c532d10d31dadae27e126453c174bea",
+      "_id": "hash-base@3.0.2",
+      "_shasum": "7f5964fd83b0034830dc94874336f03b5b9352f8",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.4.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "7f5964fd83b0034830dc94874336f03b5b9352f8",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/hash-base-3.0.2.tgz_1472129291617_0.33186267665587366"
+      },
+      "directories": {}
+    },
+    "3.0.3": {
+      "name": "hash-base",
+      "version": "3.0.3",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^7.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "b967951707050670429e55d21659e6af9ad2f9f0",
+      "_id": "hash-base@3.0.3",
+      "_shasum": "87ec48734bfe354275535150b14821566b083807",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.4.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "87ec48734bfe354275535150b14821566b083807",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/hash-base-3.0.3.tgz_1472409725983_0.894441373180598"
+      },
+      "directories": {}
+    },
+    "3.0.4": {
+      "name": "hash-base",
+      "version": "3.0.4",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^8.3.2",
+        "standard": "*",
+        "tape": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "d36440ed0448a654734ae05464d55d34b189a17a",
+      "_id": "hash-base@3.0.4",
+      "_shasum": "5fc8686847ecd73499403319a6b0a3f3f6ae4918",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "5fc8686847ecd73499403319a6b0a3f3f6ae4918",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash-base-3.0.4.tgz_1495616777218_0.30660409457050264"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "hash-base",
+      "version": "3.1.0",
+      "description": "abstract base class for hash-streams",
+      "keywords": [
+        "hash",
+        "stream"
+      ],
+      "homepage": "https://github.com/crypto-browserify/hash-base",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/hash-base/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/hash-base.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "devDependencies": {
+        "nyc": "^15.0.1",
+        "standard": "^14.3.3",
+        "tape": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "gitHead": "e0e5732e3d5cdf1bca71bc092d36a9e8f475c271",
+      "_id": "hash-base@3.1.0",
+      "_nodeVersion": "14.0.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+        "shasum": "55c381d9e06e1d2997a883b4a3fddfe7f0d3af33",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6077,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeq84KCRA9TVsSAnZWagAA0UAQAKMCAKPKYhsmpHWWPTlH\nX4ZJNh3J+teUIQohGNAPW4aTAQFyJlbF9bD92wJVrkbWyJI7GzGfRH5lCsnd\ndydUZ2V3dnT1lUzmoeA+j6zJzPuYZmn3yxEfUFbhY59qNjRqXU8OpZbyFBDA\n6dRkn3O3mW87FJflu68FRU64i10Lt24Da7T2OsH4v9+5IzSsYQlHKf3FgONn\n3pSvfX37sCmWFLJeijoXALRVwnvjYaqXmZi0+8PB4S2VsKekfZCbxCQDTkmz\nmjpf9vvcllFfgB9bah81k3JBS7JmLidC7JnS/lPBy0QMDjoe5O5cDsY7rLko\nbLhqSpgg4EwfAuLbkvpXrhYT1diUvrVxOMG+UjxfYS1Et9r65Ne2nC8HAGmp\nI99NRpRx94YxlcpEUJHDvXs5TRTDxdQ3uYEZUHxjOU6xcm5EMoIvKMs9JfUH\n7lxzyCOpMFgzMKxjfUAcgRVRLKqlq+Au7WwLh1F3NyhVHk8vcmmK0ZlqhnYZ\nezteC8p948bLd/rI6i5XV6srFIuGgt3LLh5XVB6ZXa74EGXbjS3Ly7Vnqfrx\njSrdrsS/vR4dc8KNh0JTxXFi5dBPdioed7paJ8AVncTUstYHgWS6LjxMQ88Q\nnduFVBSp3vMF76lJLANdtpPzSZWMIToKphfjc5boNp3MBdTttRH1+ZlkbhCl\nM0D/\r\n=bRNI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash-base_3.1.0_1588317706470_0.7933367604914434"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# hash-base\n\n[![NPM Package](https://img.shields.io/npm/v/hash-base.svg?style=flat-square)](https://www.npmjs.org/package/hash-base)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/hash-base.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/hash-base)\n[![Dependency status](https://img.shields.io/david/crypto-browserify/hash-base.svg?style=flat-square)](https://david-dm.org/crypto-browserify/hash-base#info=dependencies)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nAbstract base class to inherit from if you want to create streams implementing the same API as node crypto [Hash][1] (for [Cipher][2] / [Decipher][3] check [crypto-browserify/cipher-base][4]).\n\n## Example\n\n```js\nconst HashBase = require('hash-base')\nconst inherits = require('inherits')\n\n// our hash function is XOR sum of all bytes\nfunction MyHash () {\n  HashBase.call(this, 1) // in bytes\n\n  this._sum = 0x00\n}\n\ninherits(MyHash, HashBase)\n\nMyHash.prototype._update = function () {\n  for (let i = 0; i < this._block.length; ++i) this._sum ^= this._block[i]\n}\n\nMyHash.prototype._digest = function () {\n  return this._sum\n}\n\nconst data = Buffer.from([ 0x00, 0x42, 0x01 ])\nconst hash = new MyHash().update(data).digest()\nconsole.log(hash) // => 67\n```\nYou also can check [source code](index.js) or [crypto-browserify/md5.js][5]\n\n## LICENSE\n\nMIT\n\n[1]: https://nodejs.org/api/crypto.html#crypto_class_hash\n[2]: https://nodejs.org/api/crypto.html#crypto_class_cipher\n[3]: https://nodejs.org/api/crypto.html#crypto_class_decipher\n[4]: https://github.com/crypto-browserify/cipher-base\n[5]: https://github.com/crypto-browserify/md5.js\n",
+  "maintainers": [
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    },
+    {
+      "name": "dcousens",
+      "email": "email@dcousens.com"
+    },
+    {
+      "name": "fanatid",
+      "email": "fanatid@ya.ru"
+    }
+  ],
+  "time": {
+    "modified": "2020-05-01T07:21:48.921Z",
+    "created": "2016-04-03T19:17:57.853Z",
+    "1.0.0": "2016-04-03T19:17:57.853Z",
+    "1.0.1": "2016-04-04T10:21:20.754Z",
+    "1.0.2": "2016-04-04T11:14:48.156Z",
+    "2.0.0": "2016-04-07T06:46:43.395Z",
+    "2.0.1": "2016-04-14T13:05:59.246Z",
+    "2.0.2": "2016-04-17T10:41:22.907Z",
+    "3.0.0": "2016-05-04T10:36:38.422Z",
+    "3.0.1": "2016-08-09T13:51:49.308Z",
+    "3.0.2": "2016-08-25T12:48:14.540Z",
+    "3.0.3": "2016-08-28T18:42:07.708Z",
+    "3.0.4": "2017-05-24T09:06:17.348Z",
+    "3.1.0": "2020-05-01T07:21:46.608Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/hash-base",
+  "keywords": [
+    "hash",
+    "stream"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/hash-base.git"
+  },
+  "author": {
+    "name": "Kirill Fomichev",
+    "email": "fanatid@ya.ru",
+    "url": "https://github.com/fanatid"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/hash-base/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "fanatid": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/hash-base.min.json
+++ b/test/fixtures/registry-mocks/content/hash-base.min.json
@@ -1,0 +1,214 @@
+{
+  "name": "hash-base",
+  "dist-tags": {
+    "latest": "3.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "hash-base",
+      "version": "1.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "72e2cc98c2ba5d6667034376afecdc9383b0bded",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "hash-base",
+      "version": "1.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "472384fb22358c460af6b270f15a24e67cf60a1e",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "hash-base",
+      "version": "1.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "f5d93455e8b5778b855ec6531eb87853a2295688",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-1.0.2.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "hash-base",
+      "version": "2.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "582af12ab8c6d9d218aea9dc849b4582d495d4c6",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "hash-base",
+      "version": "2.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "e05d166102b12265782b938f7ba18246222db6d7",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "hash-base",
+      "version": "2.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "66ea1d856db4e8a5470cadf6fce23ae5244ef2e1",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "hash-base",
+      "version": "3.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^6.1.1",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "fab7a974e1522bbcc0e38b9a3b8d625190518769",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "hash-base",
+      "version": "3.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^7.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "e151fac39ceae63b6129ad857922e113fa66eb3d",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.1.tgz"
+      }
+    },
+    "3.0.2": {
+      "name": "hash-base",
+      "version": "3.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^7.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "7f5964fd83b0034830dc94874336f03b5b9352f8",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.2.tgz"
+      }
+    },
+    "3.0.3": {
+      "name": "hash-base",
+      "version": "3.0.3",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^7.0.0",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "87ec48734bfe354275535150b14821566b083807",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.3.tgz"
+      }
+    },
+    "3.0.4": {
+      "name": "hash-base",
+      "version": "3.0.4",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^8.3.2",
+        "standard": "*",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "5fc8686847ecd73499403319a6b0a3f3f6ae4918",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "3.1.0": {
+      "name": "hash-base",
+      "version": "3.1.0",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "devDependencies": {
+        "nyc": "^15.0.1",
+        "standard": "^14.3.3",
+        "tape": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+        "shasum": "55c381d9e06e1d2997a883b4a3fddfe7f0d3af33",
+        "tarball": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6077,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeq84KCRA9TVsSAnZWagAA0UAQAKMCAKPKYhsmpHWWPTlH\nX4ZJNh3J+teUIQohGNAPW4aTAQFyJlbF9bD92wJVrkbWyJI7GzGfRH5lCsnd\ndydUZ2V3dnT1lUzmoeA+j6zJzPuYZmn3yxEfUFbhY59qNjRqXU8OpZbyFBDA\n6dRkn3O3mW87FJflu68FRU64i10Lt24Da7T2OsH4v9+5IzSsYQlHKf3FgONn\n3pSvfX37sCmWFLJeijoXALRVwnvjYaqXmZi0+8PB4S2VsKekfZCbxCQDTkmz\nmjpf9vvcllFfgB9bah81k3JBS7JmLidC7JnS/lPBy0QMDjoe5O5cDsY7rLko\nbLhqSpgg4EwfAuLbkvpXrhYT1diUvrVxOMG+UjxfYS1Et9r65Ne2nC8HAGmp\nI99NRpRx94YxlcpEUJHDvXs5TRTDxdQ3uYEZUHxjOU6xcm5EMoIvKMs9JfUH\n7lxzyCOpMFgzMKxjfUAcgRVRLKqlq+Au7WwLh1F3NyhVHk8vcmmK0ZlqhnYZ\nezteC8p948bLd/rI6i5XV6srFIuGgt3LLh5XVB6ZXa74EGXbjS3Ly7Vnqfrx\njSrdrsS/vR4dc8KNh0JTxXFi5dBPdioed7paJ8AVncTUstYHgWS6LjxMQ88Q\nnduFVBSp3vMF76lJLANdtpPzSZWMIToKphfjc5boNp3MBdTttRH1+ZlkbhCl\nM0D/\r\n=bRNI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
+  "modified": "2020-05-01T07:21:48.921Z"
+}

--- a/test/fixtures/registry-mocks/content/hash.js.json
+++ b/test/fixtures/registry-mocks/content/hash.js.json
@@ -1,0 +1,1058 @@
+{
+  "_id": "hash.js",
+  "_rev": "47-44a0cea30cd6ec6f76d35d71076c57f1",
+  "name": "hash.js",
+  "description": "Various hash functions that could be run by both browser and node",
+  "dist-tags": {
+    "latest": "1.1.7"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "hash.js",
+      "version": "0.1.0",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/hash.js"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "hash.js@0.1.0",
+      "_shasum": "88ee2ca98ab25399b592cb935d77419bf948fd25",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "88ee2ca98ab25399b592cb935d77419bf948fd25",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "hash.js",
+      "version": "0.2.0",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/hash.js"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "hash.js@0.2.0",
+      "_shasum": "be3729680fd5541fbce74b70a5514bd0d3afdd81",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "be3729680fd5541fbce74b70a5514bd0d3afdd81",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "hash.js",
+      "version": "0.2.1",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/hash.js"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "hash.js@0.2.1",
+      "_shasum": "30a06810932478e53c0c4509fe7f1db62e38c6ff",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "30a06810932478e53c0c4509fe7f1db62e38c6ff",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "hash.js",
+      "version": "0.3.1",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/hash.js"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "_id": "hash.js@0.3.1",
+      "_shasum": "36db4f82c22b2862713f7b53457ff55cf8d01827",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "36db4f82c22b2862713f7b53457ff55cf8d01827",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "hash.js",
+      "version": "0.3.2",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/hash.js"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "fcca8374d368b728da4ade9d9d2719180bae9a2a",
+      "_id": "hash.js@0.3.2",
+      "_shasum": "6a945434ba8dbbadebb4e5065f9287b02529b93c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6a945434ba8dbbadebb4e5065f9287b02529b93c",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "hash.js",
+      "version": "1.0.0",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/hash.js"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "39826eb20cb5e6a220a85daa689810ded095545a",
+      "_id": "hash.js@1.0.0",
+      "_shasum": "b2b534d73aa44273728ac4ac5c3f7058b65e52ac",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b2b534d73aa44273728ac4ac5c3f7058b65e52ac",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "hash.js",
+      "version": "1.0.1",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/hash.js"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "69d670274daacea8ab688369aa05e485089b596c",
+      "_id": "hash.js@1.0.1",
+      "_shasum": "6f18adbfe43efe34d6f0f02be8d55126c7519d2d",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6f18adbfe43efe34d6f0f02be8d55126c7519d2d",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "hash.js",
+      "version": "1.0.2",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/hash.js"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "9a85e099dbf05531e1c3956c7f205405f6bfc13c",
+      "_id": "hash.js@1.0.2",
+      "_shasum": "bc7d601f4e0d05a32f3526d11fe39f7a5eb8c187",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bc7d601f4e0d05a32f3526d11fe39f7a5eb8c187",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "hash.js",
+      "version": "1.0.3",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "gitHead": "9c2ec8f5cdcdc255d5f6951427c5c803c097f7c6",
+      "_id": "hash.js@1.0.3",
+      "_shasum": "1332ff00156c0a0ffdd8236013d07b77a0451573",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1332ff00156c0a0ffdd8236013d07b77a0451573",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "hash.js",
+      "version": "1.1.0",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && npm run lint",
+        "lint": "eslint lib/*.js lib/**/*.js lib/**/**/*.js test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "mocha": "^3.4.2"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0"
+      },
+      "gitHead": "224838e0f0d67db3cbe3e2be0920ffe2a7fbfbac",
+      "_id": "hash.js@1.1.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-UpPhT4r7U+SZlbz8W4c9ka7SpEINzenNH9NunpzFAEB9BOVHSNGn560p004huBamjTX/nUyPjdo5n8WSo5Nfug==",
+        "shasum": "67da897b1ced6f42a70dae5b3650ca3742e9ae91",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash.js-1.1.0.tgz_1497934355515_0.33835372352041304"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "hash.js",
+      "version": "1.1.1",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && npm run lint",
+        "lint": "eslint lib/*.js lib/**/*.js lib/**/**/*.js test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0",
+        "mocha": "^3.4.2"
+      },
+      "gitHead": "78fa691ee8ea2f3ffd43472ecae8c87823c7c84e",
+      "_id": "hash.js@1.1.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-I2TYCUjYQMmqmRMCp6jKMC5bvdXxGIZ/heITRR/0F1u0OP920ImEj/cXt3WgcTKBnNYGn7enxUzdai3db829JA==",
+        "shasum": "5cb2e796499224e69fd0b00ed01d2d4a16e7a323",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash.js-1.1.1.tgz_1497948343086_0.251419770764187"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "hash.js",
+      "version": "1.1.2",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && npm run lint",
+        "lint": "eslint lib/*.js lib/**/*.js lib/**/**/*.js test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0",
+        "mocha": "^3.4.2"
+      },
+      "gitHead": "cf43ff09e5b38de85f98829a72438a01390ffa8d",
+      "_id": "hash.js@1.1.2",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-SsNl8Ro2uz5xUTRYq8ysWzX8B7jCj7pLvX3opktaI6ZrTT2YElqjFVJXHJZe+5Aby20c9UC7elCjJDe1dhTaAw==",
+        "shasum": "bf5c887825cfe40b9efde7bf11bd2db26e6bf01b",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash.js-1.1.2.tgz_1498538308655_0.3117987022269517"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "hash.js",
+      "version": "1.1.3",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "typings": "lib/hash.d.ts",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && npm run lint",
+        "lint": "eslint lib/*.js lib/**/*.js lib/**/**/*.js test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0",
+        "mocha": "^3.4.2"
+      },
+      "gitHead": "99b093196d0104b54192d31169a9041c3a588411",
+      "_id": "hash.js@1.1.3",
+      "_npmVersion": "5.0.4",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+        "shasum": "340dedbe6290187151c1ea1d777a3448935df846",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash.js-1.1.3.tgz_1498923085485_0.6784083768725395"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "hash.js",
+      "version": "1.1.4",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "typings": "lib/hash.d.ts",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && npm run lint",
+        "lint": "eslint lib/*.js lib/**/*.js lib/**/**/*.js test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0",
+        "mocha": "^3.4.2"
+      },
+      "gitHead": "65e82132bb12c55c7c03c652fcc85d9e7acbb99e",
+      "_id": "hash.js@1.1.4",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+        "shasum": "8b50e1f35d51bd01e5ed9ece4dbe3549ccfa0a3c",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
+        "fileCount": 19,
+        "unpackedSize": 40147,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbHw9MCRA9TVsSAnZWagAASYYP/AhjGGyo7z9Gcgkz5PKw\nZ+rTOppS3ilGD8oFayP+CbwlQE7TyWPXzrGFBfGkCJNot1BFdsMiABY2oy7L\nRAxhUgPvI2mH9iyMzkJfMZLfvBrXdbI40TXxQStMk6I5lf69g15r82rqRn5M\n+9k75mWPAOyX1FC18f9eyI1vcPF5qsmMZCWhILdPsi4UnE7M54uy+C3NUZgM\nbZfRcpP0TetwrMuiimdte1q1e27Ysu0O/RMG9wdCX/bAulVfCfsQeLox4Oiw\nQREFh1moJf7Tz4IzaqpA1yTjJomskW5R5pGTAgnrPFLxeFwChRhfusDAybZB\nCC2ERltsUmw6HbRqmYmE+UC6/kwR1j3+ylyXJofnkkgAMVWsjAyFitxoSiLN\nUJcY/8WJh9Vc1ljPw6mukgKwBnvgbTWVjBqFWH1NylGuLhjE7vvBlfQFK5jT\nFn5o5FrQu9I0wk0anGpFEj+4qS/5HLYbj2UhvKY4oP6e8Vvq0nHUnwMG5w+o\nA7EFMrOKkdFcZ/qFaczThiL/p9tzfp1LZvDwOJOCTBhspYhds8rlg9Zx0TKj\nFZ4RuxHA0wwYR7ng7cqvozsLRNgNI7a/4VuRUPIUlxKG2sqgWfiFkFZ9/i+w\nLUZdlFh2PgPiDWS1oudIEKsZQtS7nQnCc8jjrEGRkKGb3SWP60D2/gAUWLmi\nAt+u\r\n=YZGD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash.js_1.1.4_1528762188030_0.7123934148661004"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.5": {
+      "name": "hash.js",
+      "version": "1.1.5",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "typings": "lib/hash.d.ts",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && npm run lint",
+        "lint": "eslint lib/*.js lib/**/*.js lib/**/**/*.js test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "mocha": "^5.2.0"
+      },
+      "gitHead": "07aeaf2769bc0b07bb62d4af113e6ab4975855a7",
+      "_id": "hash.js@1.1.5",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+        "shasum": "e38ab4b85dfb1e0c40fe9265c0e9b54854c23812",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+        "fileCount": 19,
+        "unpackedSize": 40175,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbQ4nmCRA9TVsSAnZWagAAaGEP/1MfRjHUe1LlhnNHtL3X\n4rSNIs1kV9+Hw3+kF2gGcOtNP4n+Y5xeoZ5//Fp97hgwO4V1amEjHpqfGnsk\nMNpZmnXLfeybj4Tx0ZsPWwDRU9Je16ggehDy1etK3CaRcl6H7Jsqrz5IVCS5\nZUOflL2rWFCfPwDAYkwVp/Z/97KrlFB9+M4wFDuTAPOsQinsKzo0+vVB84BB\nhlmtlod7l/X+tkDCAV+rT8uKRfP+qZvcHTLKCCV6edgn7Xd+gY75IbFDqWfn\nZ9sSAo6ffBbz/bRsoARG/nDJ3CcWD2MxqiuQ/6fc505QHroXI0N7Q8HHySsa\neGZHSLXvwdP/M+0J9fiqQQFSjWhDqPxKXhDielhdvesw5UpCdD+q5W0CsC9Q\nx6/MNhDrqpx31WYcrMo0aj1Z6XQjVBg3c1EL5isnzimg6usObpN0IAG8ezHz\n2kYLKF8JFjXAFhSAdDqZAfZvIAF5RcPC659RRNuGzZRczeFBPOgBWl+t+4wg\nYIH7hXX6yEeQuhVtPCLoWEIY99jK1wma719IESH8X+/BMuEOFaO74PyYEsxh\nBlrrPQ8UV5vaQ1EnWvfWvuvgq4bopZVMVgCM290O/9o+jc2aveQA5w4F3q5z\nCPA+uwHEfGVJap5FDas5CSsEbI/eevhgUXO0nX0n6kSfeB5tmF3P7LNXh1sF\nVuj2\r\n=IY11\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash.js_1.1.5_1531152870113_0.14399955072989146"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.6": {
+      "name": "hash.js",
+      "version": "1.1.6",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "typings": "lib/hash.d.ts",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && npm run lint",
+        "lint": "eslint lib/*.js lib/**/*.js lib/**/**/*.js test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "mocha": "^5.2.0"
+      },
+      "gitHead": "4758e9a9fa808bbe0b5f05e9e3fe692f13e2e6ca",
+      "_id": "hash.js@1.1.6",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "11.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-fj4u34pebbF6PKHDfVsQtIJGwr1M0goQyiqJE8OXCjiAgInFfKb/BGjD2ht6K9gCXeG6k1ZIR7mQ+KZSsxXK3A==",
+        "shasum": "6d22881dd6aff23c5333033c7d418f5ee366bfc8",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.6.tgz",
+        "fileCount": 19,
+        "unpackedSize": 41697,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcAW0sCRA9TVsSAnZWagAAW/IP/0c51U+cjejkcMduYcHj\n6fwic3ifAVefX6zHYAWM+yN7pvnssAhSlfaeFiz3Nj1Rwgb2owb/VWe7jJ+I\n87crBfZKPOKlVsOF0p8YbLSUHfK953Ll517+57rNl2HwNa18BcU5T6wFGr5N\n/kzqnFlDv6sJTvJ7R03t/CdlBcRS0Te0g+9zHyi7uBWIw41mYeCcf2CoOi+g\n+osPoQQOJJWL/pq9zRfyRhrnxDAmhE/M3h955t2e+pOXfwnt95Jsfr8aHwlR\noJnjDrMAGSNucnz25lfQpzKJTZoyUe+MK0enKSbTxP8umI93jBWizbjSmq4m\nQltLxK7BQ0RPKsqnjd/+7etG8AEdBIUmFPEobk8GbgPlMWfqwCN/nkPekGds\nFhjmW8uSjkFysfK+7J9ruW5TGHp5U9/M4w7pCtCp2N/JKBULhvAydApaM/aj\nmJPDTXBmz21zSbOZRJ1pQGBxaNeTFsg8KDuiEXrcV89AZvTs4b2AZQdOjxar\nGQ2BUo/KOS1lCE5tIdMYsSVfjgDguK35nFORvWNQh9uVPsrpJaSlLZu4sCHz\ncm9wDSSzoUeJGO47Ywvo5HgLDd9NtB5jXNeL9lC61mYNi7+W1bdvR8MTRriI\nr6V3TEzbMTNHbZHOiHb9hEm98JOp77OyD92hN0f5NCqS0f8stcNvGWiePt6q\nTZev\r\n=qhGm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash.js_1.1.6_1543597355459_0.42108067159887663"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.7": {
+      "name": "hash.js",
+      "version": "1.1.7",
+      "description": "Various hash functions that could be run by both browser and node",
+      "main": "lib/hash.js",
+      "typings": "lib/hash.d.ts",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js && npm run lint",
+        "lint": "eslint lib/*.js lib/**/*.js lib/**/**/*.js test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hash.js.git"
+      },
+      "keywords": [
+        "hash",
+        "sha256",
+        "sha224",
+        "hmac"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hash.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hash.js",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "mocha": "^5.2.0"
+      },
+      "gitHead": "fcd35edcc4e30145be4b7a737477ad54e83afc25",
+      "_id": "hash.js@1.1.7",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "11.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+        "shasum": "0babca538e8d4ee4a0f8988d68866537a003cf42",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+        "fileCount": 19,
+        "unpackedSize": 41697,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcAZRsCRA9TVsSAnZWagAAK24P/j0OaTdXWUfwNTqMarCv\nEUzPS0oN71Rz19aDW94FXXguHW2jhfYbK/CUb3tXOIZgdNz7L9QubXbB2PZ+\nkVE0p99Oha+ESYS+LKKwIzcYBA59XtuRBQGlhg2QeWoJOwJzIsey1O74GPGl\nYXh/FlMaFA/OPBEfmLzSrlzIggCdPKYEU+Obtl9b+oTRRawyE/acH9gaK1/t\n21pi7zwku3xWsioArFqSGVSIy3ZIRqTrCkT1XvkhYqtZ81BUdXPh6zXmMsS6\nK/77qHNCUdDImvYUK2h65aNXc4pkYPuqP14cB9SJ/4HjnIj6z9KVt6GLC+kP\n728fUzRIwj+fA6U1YovuZnhfqGK5mDvJ4xaH6STnaOW29m9HScoFyTW/51ZW\n18gOpCndZOv90UKTfwkm6YpryczG8Asn1Jck8fC7gcNP1WyJRIzD15XPFEXI\nQOGOs7SHcxusmLztMSJfpCDfkQHVnPQ5IeLZCHJatCWNZwHsSL6chAcNFTUJ\nF2qA8mFx0YkK88Yvmt9QK5jcC42n90ni+wU+qlG7kviiXCO7M6hJB3ZNR7pl\nYCSHcBSvX2pAWx7GOTRO+kHQ7r5Y/vTNf6Dk0QusrYeEgeJcTlrrgipo//J5\nEP4kyHJh+QNHvUQxxJxMQGHrpCVw5DcOyBTRgtluysLFzmwuBKjo9rKWWj9e\nx7An\r\n=d0k+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/hash.js_1.1.7_1543607403183_0.5084942256681579"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# hash.js [![Build Status](https://secure.travis-ci.org/indutny/hash.js.svg)](http://travis-ci.org/indutny/hash.js)\n\nJust a bike-shed.\n\n## Install\n\n```sh\nnpm install hash.js\n```\n\n## Usage\n\n```js\nvar hash = require('hash.js')\nhash.sha256().update('abc').digest('hex')\n```\n\n## Selective hash usage\n\n```js\nvar sha512 = require('hash.js/lib/hash/sha/512');\nsha512().update('abc').digest('hex');\n```\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2014.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-04T02:40:35.190Z",
+    "created": "2014-04-25T21:12:00.996Z",
+    "0.1.0": "2014-04-25T21:12:00.996Z",
+    "0.2.0": "2014-04-26T11:55:07.892Z",
+    "0.2.1": "2014-05-06T09:38:56.886Z",
+    "0.3.0": "2014-05-10T20:37:09.709Z",
+    "0.3.1": "2014-05-10T20:38:14.606Z",
+    "0.3.2": "2014-08-31T10:48:35.490Z",
+    "1.0.0": "2015-01-05T20:50:34.271Z",
+    "1.0.1": "2015-01-06T00:53:52.794Z",
+    "1.0.2": "2015-01-06T00:56:33.448Z",
+    "1.0.3": "2015-05-21T12:29:07.098Z",
+    "1.1.0": "2017-06-20T04:52:36.503Z",
+    "1.1.1": "2017-06-20T08:45:44.087Z",
+    "1.1.2": "2017-06-27T04:38:29.648Z",
+    "1.1.3": "2017-07-01T15:31:26.446Z",
+    "1.1.4": "2018-06-12T00:09:48.080Z",
+    "1.1.5": "2018-07-09T16:14:30.207Z",
+    "1.1.6": "2018-11-30T17:02:35.608Z",
+    "1.1.7": "2018-11-30T19:50:03.326Z"
+  },
+  "homepage": "https://github.com/indutny/hash.js",
+  "keywords": [
+    "hash",
+    "sha256",
+    "sha224",
+    "hmac"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/hash.js.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/hash.js/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "fonologico": true,
+    "guywicks": true,
+    "asaupup": true,
+    "thejeshgn.com": true,
+    "aswinkolli": true,
+    "cedx": true,
+    "faraoman": true,
+    "thejeshgn": true,
+    "nuwaio": true,
+    "psychollama": true,
+    "anasyusuf": true,
+    "monkeymonk": true,
+    "rokeyzki": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/hash.js.min.json
+++ b/test/fixtures/registry-mocks/content/hash.js.min.json
@@ -1,0 +1,274 @@
+{
+  "name": "hash.js",
+  "dist-tags": {
+    "latest": "1.1.7"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "hash.js",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "88ee2ca98ab25399b592cb935d77419bf948fd25",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "hash.js",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "be3729680fd5541fbce74b70a5514bd0d3afdd81",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "hash.js",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "30a06810932478e53c0c4509fe7f1db62e38c6ff",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.2.1.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "hash.js",
+      "version": "0.3.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "36db4f82c22b2862713f7b53457ff55cf8d01827",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.3.1.tgz"
+      }
+    },
+    "0.3.2": {
+      "name": "hash.js",
+      "version": "0.3.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "6a945434ba8dbbadebb4e5065f9287b02529b93c",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-0.3.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "hash.js",
+      "version": "1.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "b2b534d73aa44273728ac4ac5c3f7058b65e52ac",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "hash.js",
+      "version": "1.0.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "6f18adbfe43efe34d6f0f02be8d55126c7519d2d",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "hash.js",
+      "version": "1.0.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "bc7d601f4e0d05a32f3526d11fe39f7a5eb8c187",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "hash.js",
+      "version": "1.0.3",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "1332ff00156c0a0ffdd8236013d07b77a0451573",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "hash.js",
+      "version": "1.1.0",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "mocha": "^3.4.2"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-UpPhT4r7U+SZlbz8W4c9ka7SpEINzenNH9NunpzFAEB9BOVHSNGn560p004huBamjTX/nUyPjdo5n8WSo5Nfug==",
+        "shasum": "67da897b1ced6f42a70dae5b3650ca3742e9ae91",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "hash.js",
+      "version": "1.1.1",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0",
+        "mocha": "^3.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-I2TYCUjYQMmqmRMCp6jKMC5bvdXxGIZ/heITRR/0F1u0OP920ImEj/cXt3WgcTKBnNYGn7enxUzdai3db829JA==",
+        "shasum": "5cb2e796499224e69fd0b00ed01d2d4a16e7a323",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "hash.js",
+      "version": "1.1.2",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0",
+        "mocha": "^3.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-SsNl8Ro2uz5xUTRYq8ysWzX8B7jCj7pLvX3opktaI6ZrTT2YElqjFVJXHJZe+5Aby20c9UC7elCjJDe1dhTaAw==",
+        "shasum": "bf5c887825cfe40b9efde7bf11bd2db26e6bf01b",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "hash.js",
+      "version": "1.1.3",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0",
+        "mocha": "^3.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+        "shasum": "340dedbe6290187151c1ea1d777a3448935df846",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz"
+      }
+    },
+    "1.1.4": {
+      "name": "hash.js",
+      "version": "1.1.4",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "^4.0.0",
+        "mocha": "^3.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
+        "shasum": "8b50e1f35d51bd01e5ed9ece4dbe3549ccfa0a3c",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
+        "fileCount": 19,
+        "unpackedSize": 40147,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbHw9MCRA9TVsSAnZWagAASYYP/AhjGGyo7z9Gcgkz5PKw\nZ+rTOppS3ilGD8oFayP+CbwlQE7TyWPXzrGFBfGkCJNot1BFdsMiABY2oy7L\nRAxhUgPvI2mH9iyMzkJfMZLfvBrXdbI40TXxQStMk6I5lf69g15r82rqRn5M\n+9k75mWPAOyX1FC18f9eyI1vcPF5qsmMZCWhILdPsi4UnE7M54uy+C3NUZgM\nbZfRcpP0TetwrMuiimdte1q1e27Ysu0O/RMG9wdCX/bAulVfCfsQeLox4Oiw\nQREFh1moJf7Tz4IzaqpA1yTjJomskW5R5pGTAgnrPFLxeFwChRhfusDAybZB\nCC2ERltsUmw6HbRqmYmE+UC6/kwR1j3+ylyXJofnkkgAMVWsjAyFitxoSiLN\nUJcY/8WJh9Vc1ljPw6mukgKwBnvgbTWVjBqFWH1NylGuLhjE7vvBlfQFK5jT\nFn5o5FrQu9I0wk0anGpFEj+4qS/5HLYbj2UhvKY4oP6e8Vvq0nHUnwMG5w+o\nA7EFMrOKkdFcZ/qFaczThiL/p9tzfp1LZvDwOJOCTBhspYhds8rlg9Zx0TKj\nFZ4RuxHA0wwYR7ng7cqvozsLRNgNI7a/4VuRUPIUlxKG2sqgWfiFkFZ9/i+w\nLUZdlFh2PgPiDWS1oudIEKsZQtS7nQnCc8jjrEGRkKGb3SWP60D2/gAUWLmi\nAt+u\r\n=YZGD\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.5": {
+      "name": "hash.js",
+      "version": "1.1.5",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "mocha": "^5.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+        "shasum": "e38ab4b85dfb1e0c40fe9265c0e9b54854c23812",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+        "fileCount": 19,
+        "unpackedSize": 40175,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbQ4nmCRA9TVsSAnZWagAAaGEP/1MfRjHUe1LlhnNHtL3X\n4rSNIs1kV9+Hw3+kF2gGcOtNP4n+Y5xeoZ5//Fp97hgwO4V1amEjHpqfGnsk\nMNpZmnXLfeybj4Tx0ZsPWwDRU9Je16ggehDy1etK3CaRcl6H7Jsqrz5IVCS5\nZUOflL2rWFCfPwDAYkwVp/Z/97KrlFB9+M4wFDuTAPOsQinsKzo0+vVB84BB\nhlmtlod7l/X+tkDCAV+rT8uKRfP+qZvcHTLKCCV6edgn7Xd+gY75IbFDqWfn\nZ9sSAo6ffBbz/bRsoARG/nDJ3CcWD2MxqiuQ/6fc505QHroXI0N7Q8HHySsa\neGZHSLXvwdP/M+0J9fiqQQFSjWhDqPxKXhDielhdvesw5UpCdD+q5W0CsC9Q\nx6/MNhDrqpx31WYcrMo0aj1Z6XQjVBg3c1EL5isnzimg6usObpN0IAG8ezHz\n2kYLKF8JFjXAFhSAdDqZAfZvIAF5RcPC659RRNuGzZRczeFBPOgBWl+t+4wg\nYIH7hXX6yEeQuhVtPCLoWEIY99jK1wma719IESH8X+/BMuEOFaO74PyYEsxh\nBlrrPQ8UV5vaQ1EnWvfWvuvgq4bopZVMVgCM290O/9o+jc2aveQA5w4F3q5z\nCPA+uwHEfGVJap5FDas5CSsEbI/eevhgUXO0nX0n6kSfeB5tmF3P7LNXh1sF\nVuj2\r\n=IY11\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.6": {
+      "name": "hash.js",
+      "version": "1.1.6",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "mocha": "^5.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-fj4u34pebbF6PKHDfVsQtIJGwr1M0goQyiqJE8OXCjiAgInFfKb/BGjD2ht6K9gCXeG6k1ZIR7mQ+KZSsxXK3A==",
+        "shasum": "6d22881dd6aff23c5333033c7d418f5ee366bfc8",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.6.tgz",
+        "fileCount": 19,
+        "unpackedSize": 41697,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcAW0sCRA9TVsSAnZWagAAW/IP/0c51U+cjejkcMduYcHj\n6fwic3ifAVefX6zHYAWM+yN7pvnssAhSlfaeFiz3Nj1Rwgb2owb/VWe7jJ+I\n87crBfZKPOKlVsOF0p8YbLSUHfK953Ll517+57rNl2HwNa18BcU5T6wFGr5N\n/kzqnFlDv6sJTvJ7R03t/CdlBcRS0Te0g+9zHyi7uBWIw41mYeCcf2CoOi+g\n+osPoQQOJJWL/pq9zRfyRhrnxDAmhE/M3h955t2e+pOXfwnt95Jsfr8aHwlR\noJnjDrMAGSNucnz25lfQpzKJTZoyUe+MK0enKSbTxP8umI93jBWizbjSmq4m\nQltLxK7BQ0RPKsqnjd/+7etG8AEdBIUmFPEobk8GbgPlMWfqwCN/nkPekGds\nFhjmW8uSjkFysfK+7J9ruW5TGHp5U9/M4w7pCtCp2N/JKBULhvAydApaM/aj\nmJPDTXBmz21zSbOZRJ1pQGBxaNeTFsg8KDuiEXrcV89AZvTs4b2AZQdOjxar\nGQ2BUo/KOS1lCE5tIdMYsSVfjgDguK35nFORvWNQh9uVPsrpJaSlLZu4sCHz\ncm9wDSSzoUeJGO47Ywvo5HgLDd9NtB5jXNeL9lC61mYNi7+W1bdvR8MTRriI\nr6V3TEzbMTNHbZHOiHb9hEm98JOp77OyD92hN0f5NCqS0f8stcNvGWiePt6q\nTZev\r\n=qhGm\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.7": {
+      "name": "hash.js",
+      "version": "1.1.7",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "mocha": "^5.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+        "shasum": "0babca538e8d4ee4a0f8988d68866537a003cf42",
+        "tarball": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+        "fileCount": 19,
+        "unpackedSize": 41697,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcAZRsCRA9TVsSAnZWagAAK24P/j0OaTdXWUfwNTqMarCv\nEUzPS0oN71Rz19aDW94FXXguHW2jhfYbK/CUb3tXOIZgdNz7L9QubXbB2PZ+\nkVE0p99Oha+ESYS+LKKwIzcYBA59XtuRBQGlhg2QeWoJOwJzIsey1O74GPGl\nYXh/FlMaFA/OPBEfmLzSrlzIggCdPKYEU+Obtl9b+oTRRawyE/acH9gaK1/t\n21pi7zwku3xWsioArFqSGVSIy3ZIRqTrCkT1XvkhYqtZ81BUdXPh6zXmMsS6\nK/77qHNCUdDImvYUK2h65aNXc4pkYPuqP14cB9SJ/4HjnIj6z9KVt6GLC+kP\n728fUzRIwj+fA6U1YovuZnhfqGK5mDvJ4xaH6STnaOW29m9HScoFyTW/51ZW\n18gOpCndZOv90UKTfwkm6YpryczG8Asn1Jck8fC7gcNP1WyJRIzD15XPFEXI\nQOGOs7SHcxusmLztMSJfpCDfkQHVnPQ5IeLZCHJatCWNZwHsSL6chAcNFTUJ\nF2qA8mFx0YkK88Yvmt9QK5jcC42n90ni+wU+qlG7kviiXCO7M6hJB3ZNR7pl\nYCSHcBSvX2pAWx7GOTRO+kHQ7r5Y/vTNf6Dk0QusrYeEgeJcTlrrgipo//J5\nEP4kyHJh+QNHvUQxxJxMQGHrpCVw5DcOyBTRgtluysLFzmwuBKjo9rKWWj9e\nx7An\r\n=d0k+\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-01-04T02:40:35.190Z"
+}

--- a/test/fixtures/registry-mocks/content/hmac-drbg.json
+++ b/test/fixtures/registry-mocks/content/hmac-drbg.json
@@ -1,0 +1,164 @@
+{
+  "_id": "hmac-drbg",
+  "_rev": "2-1dd6cd048d08b0fd164407c14ed38998",
+  "name": "hmac-drbg",
+  "description": "Deterministic random bit generator (hmac)",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "hmac-drbg",
+      "version": "1.0.0",
+      "description": "Deterministic random bit generator (hmac)",
+      "main": "lib/hmac-drbg.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hmac-drbg.git"
+      },
+      "keywords": [
+        "hmac",
+        "drbg",
+        "prng"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hmac-drbg/issues"
+      },
+      "homepage": "https://github.com/indutny/hmac-drbg#readme",
+      "devDependencies": {
+        "mocha": "^3.2.0"
+      },
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "gitHead": "af2f557313531718571515cf6603a0fd8989b197",
+      "_id": "hmac-drbg@1.0.0",
+      "_shasum": "3db471f45aae4a994a0688322171f51b8b91bee5",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "3db471f45aae4a994a0688322171f51b8b91bee5",
+        "tarball": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/hmac-drbg-1.0.0.tgz_1487798629888_0.6923701653722674"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "hmac-drbg",
+      "version": "1.0.1",
+      "description": "Deterministic random bit generator (hmac)",
+      "main": "lib/hmac-drbg.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hmac-drbg.git"
+      },
+      "keywords": [
+        "hmac",
+        "drbg",
+        "prng"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hmac-drbg/issues"
+      },
+      "homepage": "https://github.com/indutny/hmac-drbg#readme",
+      "devDependencies": {
+        "mocha": "^3.2.0"
+      },
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "gitHead": "2592375270a7a689d3752a6ba7235a47eb234d15",
+      "_id": "hmac-drbg@1.0.1",
+      "_shasum": "d2745701025a6c775a6c545793ed502fc0c649a1",
+      "_from": ".",
+      "_npmVersion": "4.5.0",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "d2745701025a6c775a6c545793ed502fc0c649a1",
+        "tarball": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/hmac-drbg-1.0.1.tgz_1491777209966_0.4443417629227042"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# hmac-drbg\n[![Build Status](https://secure.travis-ci.org/indutny/hmac-drbg.svg)](http://travis-ci.org/indutny/hmac-drbg)\n[![NPM version](https://badge.fury.io/js/hmac-drbg.svg)](http://badge.fury.io/js/hmac-drbg)\n\nJS-only implementation of [HMAC DRBG][0].\n\n## Usage\n\n```js\nconst DRBG = require('hmac-drbg');\nconst hash = require('hash.js');\n\nconst d = new DRBG({\n  hash: hash.sha256,\n  entropy: '0123456789abcdef',\n  nonce: '0123456789abcdef',\n  pers: '0123456789abcdef' /* or `null` */\n});\n\nd.generate(32, 'hex');\n```\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2017.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n\n[0]: http://csrc.nist.gov/groups/ST/toolkit/documents/rng/HashBlockCipherDRBG.pdf\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-04-09T22:33:31.828Z",
+    "created": "2017-02-22T21:23:50.501Z",
+    "1.0.0": "2017-02-22T21:23:50.501Z",
+    "1.0.1": "2017-04-09T22:33:31.828Z"
+  },
+  "homepage": "https://github.com/indutny/hmac-drbg#readme",
+  "keywords": [
+    "hmac",
+    "drbg",
+    "prng"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/hmac-drbg.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/hmac-drbg/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/hmac-drbg.min.json
+++ b/test/fixtures/registry-mocks/content/hmac-drbg.min.json
@@ -1,0 +1,41 @@
+{
+  "name": "hmac-drbg",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "hmac-drbg",
+      "version": "1.0.0",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "3db471f45aae4a994a0688322171f51b8b91bee5",
+        "tarball": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "hmac-drbg",
+      "version": "1.0.1",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "d2745701025a6c775a6c545793ed502fc0c649a1",
+        "tarball": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2017-04-09T22:33:31.828Z"
+}

--- a/test/fixtures/registry-mocks/content/hpack.js.json
+++ b/test/fixtures/registry-mocks/content/hpack.js.json
@@ -1,0 +1,592 @@
+{
+  "_id": "hpack.js",
+  "_rev": "11-7f1e76f7169877fc24a27da7799a18a4",
+  "name": "hpack.js",
+  "description": "HPACK implementation",
+  "dist-tags": {
+    "latest": "2.1.6"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "hpack.js",
+      "version": "1.0.0",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "e1cd7302451566af074d815b1008c7d9cdcec3da",
+      "_id": "hpack.js@1.0.0",
+      "_shasum": "999c64d067c9970188d5aba7c3106ecbbb737729",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "999c64d067c9970188d5aba7c3106ecbbb737729",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "hpack.js",
+      "version": "1.1.0",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "ba8da8de1207fa70a97ab5d187214769f83ddc01",
+      "_id": "hpack.js@1.1.0",
+      "_shasum": "e6da660a4b220984a2b5b102623a498d36d07eb9",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e6da660a4b220984a2b5b102623a498d36d07eb9",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "hpack.js",
+      "version": "2.0.0",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "c2aa342839da4e7d6887cdde1ed232122e1cb888",
+      "_id": "hpack.js@2.0.0",
+      "_shasum": "59afdcd2e8d952170a39264208422e9a46882a07",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "59afdcd2e8d952170a39264208422e9a46882a07",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "hpack.js",
+      "version": "2.1.0",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "e2c5e443997d382185e6162a3235ebe57e1d1ace",
+      "_id": "hpack.js@2.1.0",
+      "_shasum": "9c340390806c06b6d9087655c30c932f73c4cbfd",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9c340390806c06b6d9087655c30c932f73c4cbfd",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.2": {
+      "name": "hpack.js",
+      "version": "2.1.2",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "6d457ea08a7e8805685abc3543e5e752ca57a9a1",
+      "_id": "hpack.js@2.1.2",
+      "_shasum": "ffceab8cb343062e4e6bbc40c67254731023240d",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ffceab8cb343062e4e6bbc40c67254731023240d",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.3": {
+      "name": "hpack.js",
+      "version": "2.1.3",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "a4f78d07e4ce45266df2ba14ab7d48ae45aa85f6",
+      "_id": "hpack.js@2.1.3",
+      "_shasum": "fdafb3514690353bf00bfa393469f53aaee227ef",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fdafb3514690353bf00bfa393469f53aaee227ef",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.4": {
+      "name": "hpack.js",
+      "version": "2.1.4",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "7338b7ec5c2fc3c234bbf56d1e570925c15d32a1",
+      "_id": "hpack.js@2.1.4",
+      "_shasum": "87a2d494b0d5df235f34ab5593337f9f97d706d0",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "87a2d494b0d5df235f34ab5593337f9f97d706d0",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.5": {
+      "name": "hpack.js",
+      "version": "2.1.5",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "e127ff3221add58fe24f68df2f720610cb902cea",
+      "_id": "hpack.js@2.1.5",
+      "_shasum": "209e9bd3e2c83cbed6f162205fee6e767d8f9d17",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "209e9bd3e2c83cbed6f162205fee6e767d8f9d17",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/hpack.js-2.1.5.tgz_1474221222672_0.06208904832601547"
+      },
+      "directories": {}
+    },
+    "2.1.6": {
+      "name": "hpack.js",
+      "version": "2.1.6",
+      "description": "HPACK implementation",
+      "main": "lib/hpack.js",
+      "scripts": {
+        "test": "mocha test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+      },
+      "keywords": [
+        "HPACK",
+        "HTTP2",
+        "compress",
+        "decompress",
+        "headers"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/hpack.js/issues"
+      },
+      "homepage": "https://github.com/indutny/hpack.js#readme",
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "gitHead": "c23a03a4ef7fed112e57998911d7ae8df8925616",
+      "_id": "hpack.js@2.1.6",
+      "_shasum": "87774c0949e513f42e84575b3c45681fade2a0b2",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "87774c0949e513f42e84575b3c45681fade2a0b2",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/hpack.js-2.1.6.tgz_1474221634241_0.9987347291316837"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# HPACK.js\n\n[![Build Status](https://secure.travis-ci.org/indutny/hpack.js.png)](http://travis-ci.org/indutny/hpack.js)\n[![NPM version](https://badge.fury.io/js/hpack.js.svg)](http://badge.fury.io/js/hpack.js)\n\nPlain-JS implementation of [HPACK][0].\n\n## Usage\n\n```javascript\nvar hpack = require('hpack.js');\n\nvar comp = hpack.compressor.create({ table: { size: 256 } });\nvar decomp = hpack.decompressor.create({ table: { size: 256 } });\n\ncomp.write([ { name: 'host', value: 'localhost' } ]);\nvar raw = comp.read();\nconsole.log(raw);\n// <Buffer 66 86 a0 e4 1d 13 9d 09>\n\ndecomp.write(raw);\ndecomp.execute();\nconsole.log(decomp.read());\n// { name: 'host', value: 'localhost', neverIndex: false }\n```\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2015.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n\n[0]: https://tools.ietf.org/html/rfc7541\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2016-09-18T18:00:36.108Z",
+    "created": "2015-06-13T17:28:16.079Z",
+    "1.0.0": "2015-06-13T17:28:16.079Z",
+    "1.1.0": "2015-06-15T22:09:15.721Z",
+    "2.0.0": "2015-06-16T18:29:31.603Z",
+    "2.1.0": "2015-06-16T20:57:15.216Z",
+    "2.1.1": "2015-06-16T21:31:14.619Z",
+    "2.1.2": "2015-06-16T21:33:46.460Z",
+    "2.1.3": "2015-07-13T22:32:20.307Z",
+    "2.1.4": "2015-08-11T07:59:49.528Z",
+    "2.1.5": "2016-09-18T17:53:44.624Z",
+    "2.1.6": "2016-09-18T18:00:36.108Z"
+  },
+  "homepage": "https://github.com/indutny/hpack.js#readme",
+  "keywords": [
+    "HPACK",
+    "HTTP2",
+    "compress",
+    "decompress",
+    "headers"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/hpack.js.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/hpack.js/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/hpack.js.min.json
+++ b/test/fixtures/registry-mocks/content/hpack.js.min.json
@@ -1,0 +1,161 @@
+{
+  "name": "hpack.js",
+  "dist-tags": {
+    "latest": "2.1.6"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "hpack.js",
+      "version": "1.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "999c64d067c9970188d5aba7c3106ecbbb737729",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "hpack.js",
+      "version": "1.1.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "e6da660a4b220984a2b5b102623a498d36d07eb9",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-1.1.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "hpack.js",
+      "version": "2.0.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "59afdcd2e8d952170a39264208422e9a46882a07",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.0.0.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "hpack.js",
+      "version": "2.1.0",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "9c340390806c06b6d9087655c30c932f73c4cbfd",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.0.tgz"
+      }
+    },
+    "2.1.2": {
+      "name": "hpack.js",
+      "version": "2.1.2",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "ffceab8cb343062e4e6bbc40c67254731023240d",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.2.tgz"
+      }
+    },
+    "2.1.3": {
+      "name": "hpack.js",
+      "version": "2.1.3",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "fdafb3514690353bf00bfa393469f53aaee227ef",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.3.tgz"
+      }
+    },
+    "2.1.4": {
+      "name": "hpack.js",
+      "version": "2.1.4",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "87a2d494b0d5df235f34ab5593337f9f97d706d0",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.4.tgz"
+      }
+    },
+    "2.1.5": {
+      "name": "hpack.js",
+      "version": "2.1.5",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "209e9bd3e2c83cbed6f162205fee6e767d8f9d17",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.5.tgz"
+      }
+    },
+    "2.1.6": {
+      "name": "hpack.js",
+      "version": "2.1.6",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.5"
+      },
+      "dist": {
+        "shasum": "87774c0949e513f42e84575b3c45681fade2a0b2",
+        "tarball": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz"
+      }
+    }
+  },
+  "modified": "2016-09-18T18:00:36.108Z"
+}

--- a/test/fixtures/registry-mocks/content/http-deceiver.json
+++ b/test/fixtures/registry-mocks/content/http-deceiver.json
@@ -1,0 +1,610 @@
+{
+  "_id": "http-deceiver",
+  "_rev": "15-43bcb3f96b513afcff5c1e813bae900b",
+  "name": "http-deceiver",
+  "description": "Deceive HTTP parser",
+  "dist-tags": {
+    "latest": "1.2.7"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "http-deceiver",
+      "version": "1.0.1",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "896003698071ebb390839f568f7dd5179aa3ddcb",
+      "_id": "http-deceiver@1.0.1",
+      "_shasum": "9ec7f00d90a7f9b3adb8facfcd30fe6594959446",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9ec7f00d90a7f9b3adb8facfcd30fe6594959446",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "http-deceiver",
+      "version": "1.1.0",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "50cdf6c98642ff92949e41a5e2e7a5b4098eee21",
+      "_id": "http-deceiver@1.1.0",
+      "_shasum": "61c2e56c1d3bbfdc74d005b70b08d9f0a75b35bd",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "61c2e56c1d3bbfdc74d005b70b08d9f0a75b35bd",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "http-deceiver",
+      "version": "1.2.0",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "096df237e9954e73cd780073bae70d4a62d2b18b",
+      "_id": "http-deceiver@1.2.0",
+      "_shasum": "b955208dbad9d527feae110377c6332a95d9d9fd",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b955208dbad9d527feae110377c6332a95d9d9fd",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "http-deceiver",
+      "version": "1.2.1",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "e8d307cbad24900ad4108f8e0e2c584542772712",
+      "_id": "http-deceiver@1.2.1",
+      "_shasum": "79538b3c4613e505410aaeb6d42932330f5440ae",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "79538b3c4613e505410aaeb6d42932330f5440ae",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "http-deceiver",
+      "version": "1.2.2",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "dad0b742b8f587d198459358f73a13db540a610c",
+      "_id": "http-deceiver@1.2.2",
+      "_shasum": "a531191c1e3c4ad383887d18ec1439da6343d170",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a531191c1e3c4ad383887d18ec1439da6343d170",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "http-deceiver",
+      "version": "1.2.3",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "cc46e9d4bf271fe55c0c29c6fee2730b807f1bfe",
+      "_id": "http-deceiver@1.2.3",
+      "_shasum": "8e692f841d14a344eb9de2031a2cab6386d06919",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8e692f841d14a344eb9de2031a2cab6386d06919",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.4": {
+      "name": "http-deceiver",
+      "version": "1.2.4",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "11b8e5f1e4d02920a0f2f5414b8e31fa4f018900",
+      "_id": "http-deceiver@1.2.4",
+      "_shasum": "d95d6401fa307da703480bcd80c18a773642803c",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d95d6401fa307da703480bcd80c18a773642803c",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.5": {
+      "name": "http-deceiver",
+      "version": "1.2.5",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "8396690c86100d1333ad324b008c7c34d4c76973",
+      "_id": "http-deceiver@1.2.5",
+      "_shasum": "5ebf51baf822ec0b1497fb2482b7e88401202dac",
+      "_from": ".",
+      "_npmVersion": "3.8.5",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "5ebf51baf822ec0b1497fb2482b7e88401202dac",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-deceiver-1.2.5.tgz_1461187391862_0.8377333206590265"
+      },
+      "directories": {}
+    },
+    "1.2.6": {
+      "name": "http-deceiver",
+      "version": "1.2.6",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "8e1b9704c1c139eccb8b012249ee96e6cac579e9",
+      "_id": "http-deceiver@1.2.6",
+      "_shasum": "328f69040ec2a5efa14567ce291fe1f2cb4d238a",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0-pre",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "328f69040ec2a5efa14567ce291fe1f2cb4d238a",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-deceiver-1.2.6.tgz_1461187696855_0.16383522702381015"
+      },
+      "directories": {}
+    },
+    "1.2.7": {
+      "name": "http-deceiver",
+      "version": "1.2.7",
+      "description": "Deceive HTTP parser",
+      "main": "lib/deceiver.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+      },
+      "keywords": [
+        "http",
+        "net",
+        "deceive"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/http-deceiver/issues"
+      },
+      "homepage": "https://github.com/indutny/http-deceiver#readme",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "gitHead": "8ace40ad41c0e1cfb0d2f130fcf60b63fcb3ecf1",
+      "_id": "http-deceiver@1.2.7",
+      "_shasum": "fa7168944ab9a519d337cb0bec7284dc3e723d87",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "fa7168944ab9a519d337cb0bec7284dc3e723d87",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-deceiver-1.2.7.tgz_1463498902333_0.5118395255412906"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# HTTP Deceiver\n\n[![Build Status](https://secure.travis-ci.org/indutny/http-deceiver.png)](http://travis-ci.org/indutny/http-deceiver)\n[![NPM version](https://badge.fury.io/js/http-deceiver.svg)](http://badge.fury.io/js/http-deceiver)\n\nDeceive!\n\n## LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2015.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "daviddias",
+      "email": "daviddias.p@gmail.com"
+    },
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-01-28T22:19:50.787Z",
+    "created": "2015-07-10T05:10:30.245Z",
+    "1.0.1": "2015-07-10T05:10:30.245Z",
+    "1.0.2": "2015-07-12T06:44:52.793Z",
+    "1.1.0": "2015-07-12T06:45:29.174Z",
+    "1.1.1": "2015-07-13T00:01:40.469Z",
+    "1.2.0": "2015-07-13T00:01:56.887Z",
+    "1.2.1": "2015-07-14T19:06:29.358Z",
+    "1.2.2": "2015-07-14T19:30:17.590Z",
+    "1.2.3": "2015-07-15T05:13:41.162Z",
+    "1.2.4": "2015-07-18T05:33:33.011Z",
+    "1.2.5": "2016-04-20T21:23:12.929Z",
+    "1.2.6": "2016-04-20T21:28:17.279Z",
+    "1.2.7": "2016-05-17T15:28:25.119Z"
+  },
+  "homepage": "https://github.com/indutny/http-deceiver#readme",
+  "keywords": [
+    "http",
+    "net",
+    "deceive"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/http-deceiver.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/http-deceiver/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/http-deceiver.min.json
+++ b/test/fixtures/registry-mocks/content/http-deceiver.min.json
@@ -1,0 +1,149 @@
+{
+  "name": "http-deceiver",
+  "dist-tags": {
+    "latest": "1.2.7"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "http-deceiver",
+      "version": "1.0.1",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "9ec7f00d90a7f9b3adb8facfcd30fe6594959446",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "http-deceiver",
+      "version": "1.1.0",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "61c2e56c1d3bbfdc74d005b70b08d9f0a75b35bd",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "http-deceiver",
+      "version": "1.2.0",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "b955208dbad9d527feae110377c6332a95d9d9fd",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "http-deceiver",
+      "version": "1.2.1",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "79538b3c4613e505410aaeb6d42932330f5440ae",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "http-deceiver",
+      "version": "1.2.2",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "a531191c1e3c4ad383887d18ec1439da6343d170",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.2.tgz"
+      }
+    },
+    "1.2.3": {
+      "name": "http-deceiver",
+      "version": "1.2.3",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "8e692f841d14a344eb9de2031a2cab6386d06919",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.3.tgz"
+      }
+    },
+    "1.2.4": {
+      "name": "http-deceiver",
+      "version": "1.2.4",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "d95d6401fa307da703480bcd80c18a773642803c",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.4.tgz"
+      }
+    },
+    "1.2.5": {
+      "name": "http-deceiver",
+      "version": "1.2.5",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "5ebf51baf822ec0b1497fb2482b7e88401202dac",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.5.tgz"
+      }
+    },
+    "1.2.6": {
+      "name": "http-deceiver",
+      "version": "1.2.6",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "328f69040ec2a5efa14567ce291fe1f2cb4d238a",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.6.tgz"
+      }
+    },
+    "1.2.7": {
+      "name": "http-deceiver",
+      "version": "1.2.7",
+      "devDependencies": {
+        "handle-thing": "^1.0.1",
+        "mocha": "^2.2.5",
+        "readable-stream": "^2.0.1",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "fa7168944ab9a519d337cb0bec7284dc3e723d87",
+        "tarball": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz"
+      }
+    }
+  },
+  "modified": "2017-01-28T22:19:50.787Z"
+}

--- a/test/fixtures/registry-mocks/content/http-errors.json
+++ b/test/fixtures/registry-mocks/content/http-errors.json
@@ -1,0 +1,2285 @@
+{
+  "_id": "http-errors",
+  "_rev": "90-119bd59685bed026e6e7a2d77b08053c",
+  "name": "http-errors",
+  "description": "Create HTTP error objects",
+  "dist-tags": {
+    "latest": "1.8.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "http-errors",
+      "description": "A node module that returns a hash of Error classes representing HTTP errors indexed by error code.",
+      "url": "https://github.com/egeste/http-errors",
+      "keywords": [
+        "util",
+        "errors",
+        "http"
+      ],
+      "author": {
+        "name": "Steve",
+        "email": "npm@egeste.net",
+        "url": "Egesté"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/egeste/http-errors.git"
+      },
+      "main": "http-errors.js",
+      "version": "0.0.1",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmUser": {
+        "name": "egeste",
+        "email": "npm@egeste.net"
+      },
+      "_id": "http-errors@0.0.1",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "_npmVersion": "1.1.12",
+      "_nodeVersion": "v0.6.14",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "caa1ff00ef680ee6cef845d4dd5e23aecc2617e0",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "afcbd1aab20d555acca14efb75263bcabee25482",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.0.0",
+      "_shasum": "bd58a089bfec699480300e472e0d552211bce27c",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bd58a089bfec699480300e472e0d552211bce27c",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "7d68ca1b35ec91be127ecc178c1155ef7f7f3e74",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.0.1",
+      "_shasum": "6b770d23b04759f166b0904200aa50775ce2b4a8",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6b770d23b04759f166b0904200aa50775ce2b4a8",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "7b59d5f38857d25e881276c17b4775c7925c611f",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.1.0",
+      "_shasum": "fc2efe9e9ddead125e6b82023eee7eb3e7785dc1",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fc2efe9e9ddead125e6b82023eee7eb3e7785dc1",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "355036ba35cb1bc79a11a720e83c76ef8596fcde",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.0",
+      "_shasum": "936739e42c3e9b778d84b30bce32802fd5eb9c75",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "936739e42c3e9b778d84b30bce32802fd5eb9c75",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "5ec45187d58c85bb83fed7e7583437977b249688",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.1",
+      "_shasum": "ad25618756c76137f6f28d6aac76224559daf7bf",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.11.13",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ad25618756c76137f6f28d6aac76224559daf7bf",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "84fa640675339c5c5dd915837b4932a19c2c839a",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.2",
+      "_shasum": "ee6fac5b7711f7d5c74c8d8e9ac3d9bb68697540",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.11.13",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ee6fac5b7711f7d5c74c8d8e9ac3d9bb68697540",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "statuses": "~1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "1c4dd0def7803585e64f152418864b551a0191dd",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.3",
+      "_shasum": "1e08daccbebfb175edfb1a11409f9d687fee488c",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.11.13",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1e08daccbebfb175edfb1a11409f9d687fee488c",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.4": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "~1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "b20af52f8ef4fc975ce5c3b628e6cd4a68089c85",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.4",
+      "_shasum": "5d7d6d2d27b1917777ad1869bab742b6c53699d2",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.11.13",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5d7d6d2d27b1917777ad1869bab742b6c53699d2",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.5": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.5",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "61c0b37666a71942edac4c6bebb87ea8bc8b7fb9",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.5",
+      "_shasum": "61da92170b47c12bd11083653e9ed44a9b7abe92",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "61da92170b47c12bd11083653e9ed44a9b7abe92",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.6": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.6",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "fab86d5ed56a2046fd9a8aa066283a63d211a5ea",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.6",
+      "_shasum": "7dc790939e6dc6fb90917b12456a11ad8cf05af0",
+      "_from": ".",
+      "_npmVersion": "2.1.2",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7dc790939e6dc6fb90917b12456a11ad8cf05af0",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.7": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.7",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "gitHead": "42172e6b334c873d54ced516ba12db5a461e3878",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.7",
+      "_shasum": "b881fa12c59b0079fd4ced456bf8dbc9610d3b78",
+      "_from": ".",
+      "_npmVersion": "2.1.2",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b881fa12c59b0079fd4ced456bf8dbc9610d3b78",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.8": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.2.8",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "c6654476fe3f02013259920cc04d9ae6c3b1ba16",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.2.8",
+      "_shasum": "8ee5fe0b51982221d796c0c4712d76f72097a4d0",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8ee5fe0b51982221d796c0c4712d76f72097a4d0",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.3.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "420a333a3c216cd532cbc46aeaeb0d1879c3e602",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.3.0",
+      "_shasum": "239d3bf15d98ea5b3ef553020d60314a2beb2288",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "239d3bf15d98ea5b3ef553020d60314a2beb2288",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.3.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "89a8502b40d5dd42da2908f265275e2eeb8d0699",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.3.1",
+      "_shasum": "197e22cdebd4198585e8694ef6786197b91ed942",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "197e22cdebd4198585e8694ef6786197b91ed942",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.4.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "inherits": "2.0.1",
+        "statuses": ">= 1.2.1 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "3d49066ba40bd7f512bc4cf367bbe650c5f2191f",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.4.0",
+      "_shasum": "6c0242dea6b3df7afda153c71089b31c6e82aabf",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "6c0242dea6b3df7afda153c71089b31c6e82aabf",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.5.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "inherits": "2.0.1",
+        "setprototypeof": "1.0.1",
+        "statuses": ">= 1.3.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "2.10.2",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "1a826d7ac31dde16931b9c566041697939ebd0e0",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.5.0",
+      "_shasum": "b1cb3d8260fd8e2386cad3189045943372d48211",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "b1cb3d8260fd8e2386cad3189045943372d48211",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-errors-1.5.0.tgz_1463621678183_0.44013352948240936"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.5.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/http-errors"
+      },
+      "dependencies": {
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.2",
+        "statuses": ">= 1.3.1 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.10.2",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "a55db90c7a2c0bafedb4bfa35a85eee5f53a37e9",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors",
+      "_id": "http-errors@1.5.1",
+      "_shasum": "788c0d2c1de2c81b9e6e8c01843b6b97eb920750",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "788c0d2c1de2c81b9e6e8c01843b6b97eb920750",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/http-errors-1.5.1.tgz_1479361411507_0.47469806275330484"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.6.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.2",
+        "statuses": ">= 1.3.1 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "2855ff9de28a08a660c48cdfe95cb55574f97cbb",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.6.0",
+      "_shasum": "113314b3973edd0984a1166e530abf5d5785f75c",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "113314b3973edd0984a1166e530abf5d5785f75c",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/http-errors-1.6.0.tgz_1487125936374_0.6465415093116462"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.6.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": ">= 1.3.1 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.16.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "d8d95dbc84c913a594b7fca07096697412af7edd",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.6.1",
+      "_shasum": "5f8b8ed98aca545656bf572997387f904a722257",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "5f8b8ed98aca545656bf572997387f904a722257",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "egeste",
+          "email": "npm@egeste.net"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-errors-1.6.1.tgz_1487647400122_0.1305304525885731"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.6.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": ">= 1.3.1 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "7e534cb45fc06e8c3ad782cde89a7462851b27d1",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.6.2",
+      "_shasum": "0a002cc85707192a7e7946ceedc11155f60ec736",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "0a002cc85707192a7e7946ceedc11155f60ec736",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "npm@egeste.net",
+          "name": "egeste"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-errors-1.6.2.tgz_1501906124983_0.24086778541095555"
+      },
+      "directories": {}
+    },
+    "1.6.3": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.6.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "4.18.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.9.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "5f53811a1a1756997a73ce7660eb55037f43b9dc",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.6.3",
+      "_shasum": "8b55680bb4be283a0b5bf4ea2e38580be1d9320d",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.13.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "8b55680bb4be283a0b5bf4ea2e38580be1d9320d",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15829
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "npm@egeste.net",
+          "name": "egeste"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-errors_1.6.3_1522355346646_0.04474382722688719"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.7.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.13.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.8.0",
+        "eslint-plugin-standard": "3.1.0",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE",
+        "README.md"
+      ],
+      "gitHead": "e2bdd75b81b2b7b168f066c61d1f0083d84daae2",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.7.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-hz3BtSHB7Z6dNWzYc+gUbWqG4dIpJedwwOhe1cvGUq5tGmcTTIRkPiAbyh/JlZx+ksSJyGJlgcHo5jGahiXnKw==",
+        "shasum": "b6d36492a201c7888bdcb5dd0471140423c4ad2a",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16955,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbX0gUCRA9TVsSAnZWagAAEfYP/i1jvg9LMStbGgVRvHX/\nKCmUlRm/7/qHjTWab9+78OKfSc58omNZcLThSY9qjTn6Ac9eVxUMwwcoTfnG\nPMNrz7utKjn8WAyaJDeFKHKdFwOW9CJjRhnp5cSgCgchl5a+KER0XsPyA2FH\n2mzoiWImToSE+2yjFgRuSYWiAs36qJHuDz9w/w4ina1AoGK16s1xHG2dfPm1\nm9vVRRMEY4R0wXaVboNvLa0CIMmgNRvjA2NOJhYg5/5zgTnDGyf7LdfSamQn\naU4prOmZw0e4xG/AVL+A81dkVURmpmwXckIPfg3BQXUWLQdcpJ4K++AjLiTU\nDljWxRsbExveGYSWiJ9D/LgXI6CGDmpnqyWUVH2eywFYBi40TxAnhDoKwZoe\nTmLFTQpFDXN+y/YA1YnWJxMy2/o6Cx3veGsPEKUVM+DPGccADg+KhDoK4u3Z\nWvh6+zQCn+g93SMhmWabJiXqdPQzgvyvF1gmqhf+EYtV15ODwBWa1dVc40hz\nSaRH62lu82aIT+zg4NADTCFggjzuhvMsyoHSEiml9J+dZs9gap1figWLtw68\nFxcc8PnE6o5ScPlu4NjmocvmbtUOn3ruX8PWU2d+cqyYmoOgDHxf58gOy8i5\ncu32x/mGqTL8MgKN5zbb107hV9Cs/yewBcq+V1FmyZbtx01k4ry6lQ9Mjk6/\nnyJ6\r\n=e9ve\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "npm@egeste.net",
+          "name": "egeste"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-errors_1.7.0_1532971028236_0.4059577779248733"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.1": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.7.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "5.5.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "gitHead": "e2d0c45500c62c81e319070aa840bb72132d8de4",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.7.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
+        "shasum": "6a4ffe5d35188e1c39f872534690585852e1f027",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17054,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJblEpBCRA9TVsSAnZWagAArHkQAIG9Rs9Uo3u3p9nJTVYY\nNziZEMW5gOnu7oCxvSO+1iZZlgiQnhtiHWrTbnCOh3yKhBtENyDxdJ95Lnm6\nXkld0fnCntbysQCODV7eGf6qSkSLSieVFiyl6wHOxx7YIYY0n5JOr8o1NlM4\nSQh6U19IOdnz2Vjyhd4nSaszRhLwfiM2zqObqxTl9wd6S3sXP9pmAMY7EkDA\no228jIJGzYrCJyR1wDUAbKCCvwKsKCRaJobCFyqSzjF0agcy8RihbjAIMOQ+\nnhSjrM/nT+JjzpYHCUceprcx+fi31bO7V579RT4tU2FwHungVISL6KOYYyZ7\n0sr1pZ047ExXz6iy+4O5VdpUcnPmKgl2lnXJaumCS9+0j5bSiQ/cRGFPbRyd\nDu8nX6WPI4i3OMnVUYnxy8Hbw63XxgxGEwAMG1mOEIadKQdm/pyuFTYtO+Ri\nDje6i8p1BZ3SPjN3bxQgzY4xuxOS99zKUeojKNcuxwEqGEekfTe797gstYm/\ng2ePtRL+V2IuzXTISdwIJyjt3MdPBNhJ1dXf7dOCGU6JMWYyog/T/iyHVUt3\nZFfTPR+0PIU6V0ZYIRlZYeiP/RWzEvAAmk5eHwyCdSey1wErVmjS4g1k4KbB\nm5mh9e6In/IR/crze1xUQ6zACMt26W0MwOjh4IHAoa+5jimBMgTxUs+SfnWb\nMVyw\r\n=Y6c2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "npm@egeste.net",
+          "name": "egeste"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-errors_1.7.1_1536444992650_0.44494595833851713"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.2": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.7.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "5.13.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "5.2.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md . && node ./scripts/lint-readme-list.js",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "gitHead": "5a61a5b225463a890610b50888b14f16f518ac61",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.7.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+        "shasum": "4f5029cf13239f31036e5b2e55292bcfbcc85c8f",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17086,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcaw02CRA9TVsSAnZWagAAM20P/RYOFi+Y8YJaNae4ZdMA\nx1cD68fmYF8nt8GgOx6MopK9YbsAxJUfpYYdIrg3IaRw7aqHwQGPmaDCa8fL\nUoDVy7ZcqlJLOBGkaJ4YaW4ZX4NFLsSBPhj7KLbmDVBhtQfHPisboMDT+LPk\nou5F2X6QqvQVq4VDlX+zI+Zm0FJmsMabdBJTadofNRoQnJrP70UxyqdoOQNT\nfs96MjO6+FQBE31ln8ZncEsI7MRlq46VnKznbsQ5ghg19MKl5+9czs/jaoaK\nWKf/pfChqFqxvibhmEU/9a09hFqWJLYQ7P6GJENBieWOpPybsOl/JcmPzaUH\nW66tvwTUJFGY3nI89Rqb8s47vj4ToUadzWuz0sZc/VVBahF4Que7riQKzDlw\nb4W92jDyILs8UOlTeHy28CVbA/fm1huLTNtDwjM4iZ9SutZMj/DoxjArGLpR\nOcdLmjlv7nL3p5Sieqsvx5pc06pgGpJH6MCE5XGd11NM5ukkocVi2Kwuu986\nuTKRcXVOXETUYcK/BlkLDwWTsgCcE9pPl4Dy6WOb0ibvcRlJWKwLVBFL40Y0\nMl4//MJidrAl4cTWXBP1e7ILNFS2MSJwSjCUF2eHBvYLvnKo6vS3uPfW35ag\nQdo0pRBwKHczPRzi7gwJSgPCQ/Oi6RQZfxyGe/oYArCQfr4SMSJVjN9LA2Br\nMXTr\r\n=XLau\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "npm@egeste.net",
+          "name": "egeste"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-errors_1.7.2_1550519605679_0.17142404315170912"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.3": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.7.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.18.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md . && node ./scripts/lint-readme-list.js",
+        "test": "mocha --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "gitHead": "a91d0ad87925a791d12fccdd6622ed3fc10fdafd",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.7.3",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+        "shasum": "6c619e4f9c60308c38519498c14fbb10aacebb06",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17151,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdEVruCRA9TVsSAnZWagAA8wUP/Repl5BiN8sPmq7Iy7Yt\nOe1hCpAJE64L+uYRPZm8hV+Wkli7J4/4UyLf9k20JWiU89axyTQzFT/XpLYc\nsw+knAnUwzVDUQvlyNDUllLkLkdhw07VhM7TeL8yym9tem9ghsg8UJZZS3H8\nPXWIqDgVbVqVcWomSiq543tXO+5NG3sqX2pVoGKGISGn/rJhiJvDcBvjYT5i\nv5hwFDK/av11koTioT9As1FR+Pdltj2KetA/SZ7IeIzRc0FPulj2k53c4zjQ\nzazKmL6dnEf2afZuN6clQd+clO8fz1+S58DP+EJj7Cvom2ANvpOlQs3hZchB\nvQOrInn8kcebNzgkTh1n4HdIwHeMEjOgS8c0TxEd2WiQvLRyvPPeTPzEglTx\nmpEhUAWo9xs1nkqQ7/RZZHTni2jRkCUM6saG4hC/kXdx79fiiu7q6BLhF5Wi\nAqb6egAxgmHsaBbDajk/pJk8nsaq+el16Aq69M+heSDCQXV1uzsxCzdimljL\nO+dRFBLKhgSOulIjwM6OraKXh8uIKABPqgAUDMsctFI5gru9ZeXqTNvzNj0g\neFm2elBXn8yjrAOShsx/HUDysNsZ3Y8W1sx6tjFREYmWppAIYjtMOocVIwo6\n7BxMAq9+fl7mSlTBZmrFj0oCfFrGGL3ZzO8vKv1hGeKpslHohoePMiwgiDmE\n2lpi\r\n=LjKs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "npm@egeste.net",
+          "name": "egeste"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-errors_1.7.3_1561418478074_0.7698818220827124"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.8.0": {
+      "name": "http-errors",
+      "description": "Create HTTP error objects",
+      "version": "1.8.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Alan Plum",
+          "email": "me@pluma.io"
+        },
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/http-errors.git"
+      },
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "6.8.0",
+        "eslint-config-standard": "14.1.1",
+        "eslint-plugin-import": "2.22.0",
+        "eslint-plugin-markdown": "1.0.2",
+        "eslint-plugin-node": "11.1.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.1",
+        "mocha": "8.0.1",
+        "nyc": "15.1.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md . && node ./scripts/lint-readme-list.js",
+        "test": "mocha --reporter spec --bail",
+        "test-ci": "nyc --reporter=text npm test",
+        "test-cov": "nyc --reporter=html --reporter=text npm test"
+      },
+      "keywords": [
+        "http",
+        "error"
+      ],
+      "gitHead": "6e4f655ec3a0cedf2e3ce868daa11b9210d1f103",
+      "bugs": {
+        "url": "https://github.com/jshttp/http-errors/issues"
+      },
+      "homepage": "https://github.com/jshttp/http-errors#readme",
+      "_id": "http-errors@1.8.0",
+      "_nodeVersion": "12.16.3",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+        "shasum": "75d1bbe497e1044f51e4ee9e704a62f28d336507",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18238,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe+X79CRA9TVsSAnZWagAAv6wP/RjIshvYJXVRbRP0mb4a\nOvN2mK7/B2nqnD8O2FzgEQ0p1Llb1K9j6TlWdq/cJInioDoR42yQgfyj4FEL\nonR3TgUlE8EjQFhH/ecYF6eaLVNaCTerd3CwdOXAXorzPcCE3g8sx46aB+9p\na/QIvOnNxt9UuDsJDDkpWvVGksr0JwWW0ZEjx0Gw8b4j1GOLXjPzFd4WqOKr\nVXG8KcAs76ZCX4eGIczwRuTpOe8mXITrtqkgyzdM98+PONQsIWEWwjt0tzm0\nMNn9cUfgB0A2UXrHQK0OFuP3TV/Ms3kTvLkvFBkiaxcpuGBlwJXSdK2/j6wA\n88Xqqxx2g70mlCgHfeHOt8GHOnYiCrsCLO5wyhJXkeSipeJM9r/8coZfZEV8\ntGXkLBxAKPInBMzGaIPT9PNsOrTy2JV1Qz2MV1OQU//LokWLLbwxsB54vXVh\nuuQSjjwUYDzA5V52/uBgfPThcM8yC0nYvU7qXV9eb3f2j3f5UJdcVkV/Cr1Z\nHtOqzHPPzY/dDubMfCoufMc3SnFV6fK5IFRmzjlRWLoKy1BZ1bLbmWxhBFeK\n88wD4p0vvSNuPNmXK4ObgxCH6NSUft+4IaHRnpBjPShoV0uyuTktOG1oLxyk\nHgG01wBJcVsUE76idV2fc4VLAMs3l1IiX4kb9+qgEYecsHA5LTuEAHl2aGPr\ngTBl\r\n=OG/P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "npm@egeste.net",
+          "name": "egeste"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-errors_1.8.0_1593409277161_0.44050373643256746"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# http-errors\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][node-url]\n[![Node.js Version][node-image]][node-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nCreate HTTP errors for Express, Koa, Connect, etc. with ease.\n\n## Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```bash\n$ npm install http-errors\n```\n\n## Example\n\n```js\nvar createError = require('http-errors')\nvar express = require('express')\nvar app = express()\n\napp.use(function (req, res, next) {\n  if (!req.user) return next(createError(401, 'Please login to view this page.'))\n  next()\n})\n```\n\n## API\n\nThis is the current API, currently extracted from Koa and subject to change.\n\n### Error Properties\n\n- `expose` - can be used to signal if `message` should be sent to the client,\n  defaulting to `false` when `status` >= 500\n- `headers` - can be an object of header names to values to be sent to the\n  client, defaulting to `undefined`. When defined, the key names should all\n  be lower-cased\n- `message` - the traditional error message, which should be kept short and all\n  single line\n- `status` - the status code of the error, mirroring `statusCode` for general\n  compatibility\n- `statusCode` - the status code of the error, defaulting to `500`\n\n### createError([status], [message], [properties])\n\nCreate a new error object with the given message `msg`.\nThe error object inherits from `createError.HttpError`.\n\n<!-- eslint-disable no-undef, no-unused-vars -->\n\n```js\nvar err = createError(404, 'This video does not exist!')\n```\n\n- `status: 500` - the status code as a number\n- `message` - the message of the error, defaulting to node's text for that status code.\n- `properties` - custom properties to attach to the object\n\n### createError([status], [error], [properties])\n\nExtend the given `error` object with `createError.HttpError`\nproperties. This will not alter the inheritance of the given\n`error` object, and the modified `error` object is the\nreturn value.\n\n<!-- eslint-disable no-redeclare, no-undef, no-unused-vars -->\n\n```js\nfs.readFile('foo.txt', function (err, buf) {\n  if (err) {\n    if (err.code === 'ENOENT') {\n      var httpError = createError(404, err, { expose: false })\n    } else {\n      var httpError = createError(500, err)\n    }\n  }\n})\n```\n\n- `status` - the status code as a number\n- `error` - the error object to extend\n- `properties` - custom properties to attach to the object\n\n### createError.isHttpError(val)\n\nDetermine if the provided `val` is an `HttpError`. This will return `true`\nif the error inherits from the `HttpError` constructor of this module or\nmatches the \"duck type\" for an error this module creates. All outputs from\nthe `createError` factory will return `true` for this function, including\nif an non-`HttpError` was passed into the factory.\n\n### new createError\\[code || name\\](\\[msg]\\))\n\nCreate a new error object with the given message `msg`.\nThe error object inherits from `createError.HttpError`.\n\n<!-- eslint-disable no-undef, no-unused-vars -->\n\n```js\nvar err = new createError.NotFound()\n```\n\n- `code` - the status code as a number\n- `name` - the name of the error as a \"bumpy case\", i.e. `NotFound` or `InternalServerError`.\n\n#### List of all constructors\n\n|Status Code|Constructor Name             |\n|-----------|-----------------------------|\n|400        |BadRequest                   |\n|401        |Unauthorized                 |\n|402        |PaymentRequired              |\n|403        |Forbidden                    |\n|404        |NotFound                     |\n|405        |MethodNotAllowed             |\n|406        |NotAcceptable                |\n|407        |ProxyAuthenticationRequired  |\n|408        |RequestTimeout               |\n|409        |Conflict                     |\n|410        |Gone                         |\n|411        |LengthRequired               |\n|412        |PreconditionFailed           |\n|413        |PayloadTooLarge              |\n|414        |URITooLong                   |\n|415        |UnsupportedMediaType         |\n|416        |RangeNotSatisfiable          |\n|417        |ExpectationFailed            |\n|418        |ImATeapot                    |\n|421        |MisdirectedRequest           |\n|422        |UnprocessableEntity          |\n|423        |Locked                       |\n|424        |FailedDependency             |\n|425        |UnorderedCollection          |\n|426        |UpgradeRequired              |\n|428        |PreconditionRequired         |\n|429        |TooManyRequests              |\n|431        |RequestHeaderFieldsTooLarge  |\n|451        |UnavailableForLegalReasons   |\n|500        |InternalServerError          |\n|501        |NotImplemented               |\n|502        |BadGateway                   |\n|503        |ServiceUnavailable           |\n|504        |GatewayTimeout               |\n|505        |HTTPVersionNotSupported      |\n|506        |VariantAlsoNegotiates        |\n|507        |InsufficientStorage          |\n|508        |LoopDetected                 |\n|509        |BandwidthLimitExceeded       |\n|510        |NotExtended                  |\n|511        |NetworkAuthenticationRequired|\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/http-errors/master\n[coveralls-url]: https://coveralls.io/r/jshttp/http-errors?branch=master\n[node-image]: https://badgen.net/npm/node/http-errors\n[node-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/http-errors\n[npm-url]: https://npmjs.org/package/http-errors\n[npm-version-image]: https://badgen.net/npm/v/http-errors\n[travis-image]: https://badgen.net/travis/jshttp/http-errors/master\n[travis-url]: https://travis-ci.org/jshttp/http-errors\n",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "npm@egeste.net",
+      "name": "egeste"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    }
+  ],
+  "time": {
+    "modified": "2020-06-29T05:41:19.475Z",
+    "created": "2012-11-18T05:58:21.693Z",
+    "0.0.1": "2012-11-18T05:58:24.328Z",
+    "1.0.0": "2014-09-08T20:04:47.893Z",
+    "1.0.1": "2014-09-08T20:20:32.230Z",
+    "1.1.0": "2014-09-09T05:00:38.695Z",
+    "1.2.0": "2014-09-09T18:10:07.228Z",
+    "1.2.1": "2014-09-22T00:44:17.769Z",
+    "1.2.2": "2014-09-22T00:44:44.079Z",
+    "1.2.3": "2014-09-22T00:55:10.961Z",
+    "1.2.4": "2014-09-22T01:02:14.380Z",
+    "1.2.5": "2014-09-29T04:22:37.194Z",
+    "1.2.6": "2014-10-03T07:59:29.863Z",
+    "1.2.7": "2014-10-15T04:16:16.798Z",
+    "1.2.8": "2014-12-09T20:41:08.043Z",
+    "1.3.0": "2015-02-02T01:09:28.350Z",
+    "1.3.1": "2015-02-03T02:06:48.009Z",
+    "1.4.0": "2016-01-29T05:29:34.421Z",
+    "1.5.0": "2016-05-19T01:34:41.193Z",
+    "1.5.1": "2016-11-17T05:43:32.057Z",
+    "1.6.0": "2017-02-15T02:32:16.946Z",
+    "1.6.1": "2017-02-21T03:23:22.251Z",
+    "1.6.2": "2017-08-05T04:08:45.938Z",
+    "1.6.3": "2018-03-29T20:29:06.751Z",
+    "1.7.0": "2018-07-30T17:17:08.342Z",
+    "1.7.1": "2018-09-08T22:16:32.820Z",
+    "1.7.2": "2019-02-18T19:53:25.820Z",
+    "1.7.3": "2019-06-24T23:21:18.236Z",
+    "1.8.0": "2020-06-29T05:41:17.267Z"
+  },
+  "author": {
+    "name": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/http-errors.git"
+  },
+  "users": {
+    "goodseller": true,
+    "tchcxp": true,
+    "maximilianschmitt": true,
+    "h0ward": true,
+    "antanst": true,
+    "h4t0n": true,
+    "igorissen": true,
+    "octetstream": true,
+    "zafaransari": true,
+    "zhanghaili": true,
+    "qqqppp9998": true,
+    "scottfreecode": true,
+    "simonfan": true,
+    "mojaray2k": true,
+    "azevedo": true,
+    "frankl83": true,
+    "progmer": true,
+    "alizurchik": true,
+    "jota": true,
+    "antixrist": true,
+    "leonzhao": true,
+    "shanewholloway": true,
+    "kankungyip": true,
+    "susuaung": true,
+    "fredcorn": true,
+    "ngpvnk": true,
+    "fabioper": true,
+    "bumsuk": true,
+    "zeroth007": true,
+    "buddh!ka": true,
+    "tiendq": true,
+    "azusa0127": true,
+    "isayme": true,
+    "tedyhy": true,
+    "anhulife": true,
+    "astesio": true,
+    "robsoer": true
+  },
+  "keywords": [
+    "http",
+    "error"
+  ],
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jshttp/http-errors#readme",
+  "bugs": {
+    "url": "https://github.com/jshttp/http-errors/issues"
+  },
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Alan Plum",
+      "email": "me@pluma.io"
+    },
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/http-errors.min.json
+++ b/test/fixtures/registry-mocks/content/http-errors.min.json
@@ -1,0 +1,610 @@
+{
+  "name": "http-errors",
+  "dist-tags": {
+    "latest": "1.8.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "http-errors",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "caa1ff00ef680ee6cef845d4dd5e23aecc2617e0",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.0": {
+      "name": "http-errors",
+      "version": "1.0.0",
+      "dependencies": {
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "bd58a089bfec699480300e472e0d552211bce27c",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "http-errors",
+      "version": "1.0.1",
+      "dependencies": {
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "6b770d23b04759f166b0904200aa50775ce2b4a8",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "http-errors",
+      "version": "1.1.0",
+      "dependencies": {
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "fc2efe9e9ddead125e6b82023eee7eb3e7785dc1",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "http-errors",
+      "version": "1.2.0",
+      "dependencies": {
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "936739e42c3e9b778d84b30bce32802fd5eb9c75",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "http-errors",
+      "version": "1.2.1",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "ad25618756c76137f6f28d6aac76224559daf7bf",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "http-errors",
+      "version": "1.2.2",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "statuses": "~1.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "ee6fac5b7711f7d5c74c8d8e9ac3d9bb68697540",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.3": {
+      "name": "http-errors",
+      "version": "1.2.3",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "statuses": "~1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "1e08daccbebfb175edfb1a11409f9d687fee488c",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.4": {
+      "name": "http-errors",
+      "version": "1.2.4",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "~1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "5d7d6d2d27b1917777ad1869bab742b6c53699d2",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.5": {
+      "name": "http-errors",
+      "version": "1.2.5",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "61da92170b47c12bd11083653e9ed44a9b7abe92",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.6": {
+      "name": "http-errors",
+      "version": "1.2.6",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "7dc790939e6dc6fb90917b12456a11ad8cf05af0",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.7": {
+      "name": "http-errors",
+      "version": "1.2.7",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "b881fa12c59b0079fd4ced456bf8dbc9610d3b78",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.8": {
+      "name": "http-errors",
+      "version": "1.2.8",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "8ee5fe0b51982221d796c0c4712d76f72097a4d0",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.0": {
+      "name": "http-errors",
+      "version": "1.3.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "239d3bf15d98ea5b3ef553020d60314a2beb2288",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.1": {
+      "name": "http-errors",
+      "version": "1.3.1",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "statuses": "1"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "197e22cdebd4198585e8694ef6786197b91ed942",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.4.0": {
+      "name": "http-errors",
+      "version": "1.4.0",
+      "dependencies": {
+        "inherits": "2.0.1",
+        "statuses": ">= 1.2.1 < 2"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "6c0242dea6b3df7afda153c71089b31c6e82aabf",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.0": {
+      "name": "http-errors",
+      "version": "1.5.0",
+      "dependencies": {
+        "inherits": "2.0.1",
+        "setprototypeof": "1.0.1",
+        "statuses": ">= 1.3.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "2.10.2",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "b1cb3d8260fd8e2386cad3189045943372d48211",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.1": {
+      "name": "http-errors",
+      "version": "1.5.1",
+      "dependencies": {
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.2",
+        "statuses": ">= 1.3.1 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.10.2",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "788c0d2c1de2c81b9e6e8c01843b6b97eb920750",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.0": {
+      "name": "http-errors",
+      "version": "1.6.0",
+      "dependencies": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.2",
+        "statuses": ">= 1.3.1 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.15.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "113314b3973edd0984a1166e530abf5d5785f75c",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.1": {
+      "name": "http-errors",
+      "version": "1.6.1",
+      "dependencies": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": ">= 1.3.1 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.16.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "5f8b8ed98aca545656bf572997387f904a722257",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.2": {
+      "name": "http-errors",
+      "version": "1.6.2",
+      "dependencies": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": ">= 1.3.1 < 2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "0a002cc85707192a7e7946ceedc11155f60ec736",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.3": {
+      "name": "http-errors",
+      "version": "1.6.3",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "devDependencies": {
+        "eslint": "4.18.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.9.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "8b55680bb4be283a0b5bf4ea2e38580be1d9320d",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15829
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.7.0": {
+      "name": "http-errors",
+      "version": "1.7.0",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.13.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.8.0",
+        "eslint-plugin-standard": "3.1.0",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "integrity": "sha512-hz3BtSHB7Z6dNWzYc+gUbWqG4dIpJedwwOhe1cvGUq5tGmcTTIRkPiAbyh/JlZx+ksSJyGJlgcHo5jGahiXnKw==",
+        "shasum": "b6d36492a201c7888bdcb5dd0471140423c4ad2a",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16955,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbX0gUCRA9TVsSAnZWagAAEfYP/i1jvg9LMStbGgVRvHX/\nKCmUlRm/7/qHjTWab9+78OKfSc58omNZcLThSY9qjTn6Ac9eVxUMwwcoTfnG\nPMNrz7utKjn8WAyaJDeFKHKdFwOW9CJjRhnp5cSgCgchl5a+KER0XsPyA2FH\n2mzoiWImToSE+2yjFgRuSYWiAs36qJHuDz9w/w4ina1AoGK16s1xHG2dfPm1\nm9vVRRMEY4R0wXaVboNvLa0CIMmgNRvjA2NOJhYg5/5zgTnDGyf7LdfSamQn\naU4prOmZw0e4xG/AVL+A81dkVURmpmwXckIPfg3BQXUWLQdcpJ4K++AjLiTU\nDljWxRsbExveGYSWiJ9D/LgXI6CGDmpnqyWUVH2eywFYBi40TxAnhDoKwZoe\nTmLFTQpFDXN+y/YA1YnWJxMy2/o6Cx3veGsPEKUVM+DPGccADg+KhDoK4u3Z\nWvh6+zQCn+g93SMhmWabJiXqdPQzgvyvF1gmqhf+EYtV15ODwBWa1dVc40hz\nSaRH62lu82aIT+zg4NADTCFggjzuhvMsyoHSEiml9J+dZs9gap1figWLtw68\nFxcc8PnE6o5ScPlu4NjmocvmbtUOn3ruX8PWU2d+cqyYmoOgDHxf58gOy8i5\ncu32x/mGqTL8MgKN5zbb107hV9Cs/yewBcq+V1FmyZbtx01k4ry6lQ9Mjk6/\nnyJ6\r\n=e9ve\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.7.1": {
+      "name": "http-errors",
+      "version": "1.7.1",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "5.5.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "integrity": "sha512-jWEUgtZWGSMba9I1N3gc1HmvpBUaNC9vDdA46yScAdp+C5rdEuKWUBLWTQpW9FwSWSbYYs++b6SDCxf9UEJzfw==",
+        "shasum": "6a4ffe5d35188e1c39f872534690585852e1f027",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17054,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJblEpBCRA9TVsSAnZWagAArHkQAIG9Rs9Uo3u3p9nJTVYY\nNziZEMW5gOnu7oCxvSO+1iZZlgiQnhtiHWrTbnCOh3yKhBtENyDxdJ95Lnm6\nXkld0fnCntbysQCODV7eGf6qSkSLSieVFiyl6wHOxx7YIYY0n5JOr8o1NlM4\nSQh6U19IOdnz2Vjyhd4nSaszRhLwfiM2zqObqxTl9wd6S3sXP9pmAMY7EkDA\no228jIJGzYrCJyR1wDUAbKCCvwKsKCRaJobCFyqSzjF0agcy8RihbjAIMOQ+\nnhSjrM/nT+JjzpYHCUceprcx+fi31bO7V579RT4tU2FwHungVISL6KOYYyZ7\n0sr1pZ047ExXz6iy+4O5VdpUcnPmKgl2lnXJaumCS9+0j5bSiQ/cRGFPbRyd\nDu8nX6WPI4i3OMnVUYnxy8Hbw63XxgxGEwAMG1mOEIadKQdm/pyuFTYtO+Ri\nDje6i8p1BZ3SPjN3bxQgzY4xuxOS99zKUeojKNcuxwEqGEekfTe797gstYm/\ng2ePtRL+V2IuzXTISdwIJyjt3MdPBNhJ1dXf7dOCGU6JMWYyog/T/iyHVUt3\nZFfTPR+0PIU6V0ZYIRlZYeiP/RWzEvAAmk5eHwyCdSey1wErVmjS4g1k4KbB\nm5mh9e6In/IR/crze1xUQ6zACMt26W0MwOjh4IHAoa+5jimBMgTxUs+SfnWb\nMVyw\r\n=Y6c2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.7.2": {
+      "name": "http-errors",
+      "version": "1.7.2",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "5.13.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "5.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+        "shasum": "4f5029cf13239f31036e5b2e55292bcfbcc85c8f",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17086,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcaw02CRA9TVsSAnZWagAAM20P/RYOFi+Y8YJaNae4ZdMA\nx1cD68fmYF8nt8GgOx6MopK9YbsAxJUfpYYdIrg3IaRw7aqHwQGPmaDCa8fL\nUoDVy7ZcqlJLOBGkaJ4YaW4ZX4NFLsSBPhj7KLbmDVBhtQfHPisboMDT+LPk\nou5F2X6QqvQVq4VDlX+zI+Zm0FJmsMabdBJTadofNRoQnJrP70UxyqdoOQNT\nfs96MjO6+FQBE31ln8ZncEsI7MRlq46VnKznbsQ5ghg19MKl5+9czs/jaoaK\nWKf/pfChqFqxvibhmEU/9a09hFqWJLYQ7P6GJENBieWOpPybsOl/JcmPzaUH\nW66tvwTUJFGY3nI89Rqb8s47vj4ToUadzWuz0sZc/VVBahF4Que7riQKzDlw\nb4W92jDyILs8UOlTeHy28CVbA/fm1huLTNtDwjM4iZ9SutZMj/DoxjArGLpR\nOcdLmjlv7nL3p5Sieqsvx5pc06pgGpJH6MCE5XGd11NM5ukkocVi2Kwuu986\nuTKRcXVOXETUYcK/BlkLDwWTsgCcE9pPl4Dy6WOb0ibvcRlJWKwLVBFL40Y0\nMl4//MJidrAl4cTWXBP1e7ILNFS2MSJwSjCUF2eHBvYLvnKo6vS3uPfW35ag\nQdo0pRBwKHczPRzi7gwJSgPCQ/Oi6RQZfxyGe/oYArCQfr4SMSJVjN9LA2Br\nMXTr\r\n=XLau\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.7.3": {
+      "name": "http-errors",
+      "version": "1.7.3",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.18.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4"
+      },
+      "dist": {
+        "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+        "shasum": "6c619e4f9c60308c38519498c14fbb10aacebb06",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17151,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdEVruCRA9TVsSAnZWagAA8wUP/Repl5BiN8sPmq7Iy7Yt\nOe1hCpAJE64L+uYRPZm8hV+Wkli7J4/4UyLf9k20JWiU89axyTQzFT/XpLYc\nsw+knAnUwzVDUQvlyNDUllLkLkdhw07VhM7TeL8yym9tem9ghsg8UJZZS3H8\nPXWIqDgVbVqVcWomSiq543tXO+5NG3sqX2pVoGKGISGn/rJhiJvDcBvjYT5i\nv5hwFDK/av11koTioT9As1FR+Pdltj2KetA/SZ7IeIzRc0FPulj2k53c4zjQ\nzazKmL6dnEf2afZuN6clQd+clO8fz1+S58DP+EJj7Cvom2ANvpOlQs3hZchB\nvQOrInn8kcebNzgkTh1n4HdIwHeMEjOgS8c0TxEd2WiQvLRyvPPeTPzEglTx\nmpEhUAWo9xs1nkqQ7/RZZHTni2jRkCUM6saG4hC/kXdx79fiiu7q6BLhF5Wi\nAqb6egAxgmHsaBbDajk/pJk8nsaq+el16Aq69M+heSDCQXV1uzsxCzdimljL\nO+dRFBLKhgSOulIjwM6OraKXh8uIKABPqgAUDMsctFI5gru9ZeXqTNvzNj0g\neFm2elBXn8yjrAOShsx/HUDysNsZ3Y8W1sx6tjFREYmWppAIYjtMOocVIwo6\n7BxMAq9+fl7mSlTBZmrFj0oCfFrGGL3ZzO8vKv1hGeKpslHohoePMiwgiDmE\n2lpi\r\n=LjKs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.8.0": {
+      "name": "http-errors",
+      "version": "1.8.0",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "devDependencies": {
+        "eslint": "6.8.0",
+        "eslint-config-standard": "14.1.1",
+        "eslint-plugin-import": "2.22.0",
+        "eslint-plugin-markdown": "1.0.2",
+        "eslint-plugin-node": "11.1.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.1",
+        "mocha": "8.0.1",
+        "nyc": "15.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+        "shasum": "75d1bbe497e1044f51e4ee9e704a62f28d336507",
+        "tarball": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18238,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe+X79CRA9TVsSAnZWagAAv6wP/RjIshvYJXVRbRP0mb4a\nOvN2mK7/B2nqnD8O2FzgEQ0p1Llb1K9j6TlWdq/cJInioDoR42yQgfyj4FEL\nonR3TgUlE8EjQFhH/ecYF6eaLVNaCTerd3CwdOXAXorzPcCE3g8sx46aB+9p\na/QIvOnNxt9UuDsJDDkpWvVGksr0JwWW0ZEjx0Gw8b4j1GOLXjPzFd4WqOKr\nVXG8KcAs76ZCX4eGIczwRuTpOe8mXITrtqkgyzdM98+PONQsIWEWwjt0tzm0\nMNn9cUfgB0A2UXrHQK0OFuP3TV/Ms3kTvLkvFBkiaxcpuGBlwJXSdK2/j6wA\n88Xqqxx2g70mlCgHfeHOt8GHOnYiCrsCLO5wyhJXkeSipeJM9r/8coZfZEV8\ntGXkLBxAKPInBMzGaIPT9PNsOrTy2JV1Qz2MV1OQU//LokWLLbwxsB54vXVh\nuuQSjjwUYDzA5V52/uBgfPThcM8yC0nYvU7qXV9eb3f2j3f5UJdcVkV/Cr1Z\nHtOqzHPPzY/dDubMfCoufMc3SnFV6fK5IFRmzjlRWLoKy1BZ1bLbmWxhBFeK\n88wD4p0vvSNuPNmXK4ObgxCH6NSUft+4IaHRnpBjPShoV0uyuTktOG1oLxyk\nHgG01wBJcVsUE76idV2fc4VLAMs3l1IiX4kb9+qgEYecsHA5LTuEAHl2aGPr\ngTBl\r\n=OG/P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2020-06-29T05:41:19.475Z"
+}

--- a/test/fixtures/registry-mocks/content/http-proxy-middleware.json
+++ b/test/fixtures/registry-mocks/content/http-proxy-middleware.json
@@ -1,0 +1,5394 @@
+{
+  "_id": "http-proxy-middleware",
+  "_rev": "162-b84ed5a82dd9b780f7a4185bdb498cef",
+  "name": "http-proxy-middleware",
+  "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+  "dist-tags": {
+    "latest": "1.0.6",
+    "beta": "0.21.0-beta.3",
+    "alpha": "0.22.0-alpha"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.1",
+      "description": "http-proxy middleware for connect",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "browser-sync",
+        "gulp-connect"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "http-proxy": "^1.9.0",
+        "mocha": "^2.2.1",
+        "should": "^5.2.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "9003d4cc622be6fc8cd0bbba3fab18af9db0361e",
+      "_id": "http-proxy-middleware@0.0.1",
+      "_shasum": "2b9feaec5fb582db09cf3693f5a5a09a5c1beee6",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2b9feaec5fb582db09cf3693f5a5a09a5c1beee6",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.2",
+      "description": "http-proxy middleware for connect",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "browser-sync",
+        "gulp-connect"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "mocha": "^2.2.1",
+        "should": "^5.2.0",
+        "url": "^0.10.3"
+      },
+      "dependencies": {
+        "http-proxy": "^1.9.0"
+      },
+      "gitHead": "83ace6648fadc0f0b2e2151a7c6f65a91898c3b8",
+      "_id": "http-proxy-middleware@0.0.2",
+      "_shasum": "6e9fde5ec41fb46fd0e3e3885cd4aa7c2e4b2d6f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6e9fde5ec41fb46fd0e3e3885cd4aa7c2e4b2d6f",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.3",
+      "description": "http-proxy middleware for connect",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "browser-sync",
+        "gulp-connect"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "mocha": "^2.2.1",
+        "should": "^5.2.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.9.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "c4963a92594d7d25f0a22ba4e27e6f220ea669a8",
+      "_id": "http-proxy-middleware@0.0.3",
+      "_shasum": "fb97acc26f49a1449eb8112b4711b1bd0723e62c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fb97acc26f49a1449eb8112b4711b1bd0723e62c",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.4",
+      "description": "http-proxy middleware for connect",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && rm -rf coverage",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "browser-sync",
+        "gulp-connect"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "chai": "^2.1.1",
+        "coveralls": "^2.11.2",
+        "mocha": "^2.2.1",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.9.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "537aed2198d02c988d11466970c5d96ff876d417",
+      "_id": "http-proxy-middleware@0.0.4",
+      "_shasum": "1cc89b5e4ecc1a1c023594306cf79ae3d4321ea9",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1cc89b5e4ecc1a1c023594306cf79ae3d4321ea9",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.5",
+      "description": "http-proxy middleware for connect",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && rm -rf coverage",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "browser-sync",
+        "gulp-connect"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "chai": "^2.1.1",
+        "coveralls": "^2.11.2",
+        "mocha": "^2.2.1",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.9.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "9a16ea7ed310db2a2c40a4a8f4bdc136c02f502d",
+      "_id": "http-proxy-middleware@0.0.5",
+      "_shasum": "6ae35180fdaabc5e69c6112e7d4d1919656a6bfa",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6ae35180fdaabc5e69c6112e7d4d1919656a6bfa",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.1.0",
+      "description": "The one-liner http-proxy middleware",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "url": "^0.10.3"
+      },
+      "gitHead": "abcf4a81366dde1d8fa0057c519d79765c54ef46",
+      "_id": "http-proxy-middleware@0.1.0",
+      "_shasum": "7f189e2a56c026eb41cdf1837e58ac6a0155e0b1",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7f189e2a56c026eb41cdf1837e58ac6a0155e0b1",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.2.0",
+      "description": "The one-liner proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "url": "^0.10.3"
+      },
+      "gitHead": "afd3536ba67185b3f082c7a4bdb7cfa7534b7403",
+      "_id": "http-proxy-middleware@0.2.0",
+      "_shasum": "b17921ebef893b9d8e85a7809c979bc626f16320",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "dist": {
+        "shasum": "b17921ebef893b9d8e85a7809c979bc626f16320",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.3.0",
+      "description": "The one-liner proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "^2.1.6",
+        "url": "^0.10.3"
+      },
+      "gitHead": "b596677e0fe4b6c4d974a21949c5e1361b4cbb33",
+      "_id": "http-proxy-middleware@0.3.0",
+      "_shasum": "6122fb3e1ac0e63c1f063f34f1344a5eecafcb55",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6122fb3e1ac0e63c1f063f34f1344a5eecafcb55",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.3.1",
+      "description": "The one-liner proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "~2.1.6",
+        "url": "^0.10.3"
+      },
+      "gitHead": "bcb949b051fa46810fcce7defb8d0f927214db62",
+      "_id": "http-proxy-middleware@0.3.1",
+      "_shasum": "578855ae2b602dc0dc1ce9e6e16f72d60eae5cd0",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "dist": {
+        "shasum": "578855ae2b602dc0dc1ce9e6e16f72d60eae5cd0",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.3.2",
+      "description": "The one-liner proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "e6ef751eb707e2898bed65e23e88fa570123e87c",
+      "_id": "http-proxy-middleware@0.3.2",
+      "_shasum": "159cf6e50f712b50a25582f43b2672869bcd5a4d",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "159cf6e50f712b50a25582f43b2672869bcd5a4d",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.4.0",
+      "description": "The one-liner proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "websocket"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.7.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "b10d7301fcde3be94b8fe4708ec1e0ad17b0bf4a",
+      "_id": "http-proxy-middleware@0.4.0",
+      "_shasum": "82fc0fa2602ad8cd5adb35e0e4e15f9a612e26d6",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "82fc0fa2602ad8cd5adb35e0e4e15f9a612e26d6",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.5.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "websocket"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.7.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "a025f336746df150c58f2851595b8073b3f96e42",
+      "_id": "http-proxy-middleware@0.5.0",
+      "_shasum": "404e8e8104f2bd000fa6946c9624214a8ba19e3a",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "404e8e8104f2bd000fa6946c9624214a8ba19e3a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.6.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "websocket"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.7.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "bb473ad7c20de225fdaed6a7e74e29f3f948fce6",
+      "_id": "http-proxy-middleware@0.6.0",
+      "_shasum": "d5ac345ddb60fb9902c0c82c4754ec243e52018c",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "dist": {
+        "shasum": "d5ac345ddb60fb9902c0c82c4754ec243e52018c",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.7.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "websocket"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.18",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "gitHead": "75a062515001910ce803b1147ee8310a102c82b8",
+      "_id": "http-proxy-middleware@0.7.0",
+      "_shasum": "350d6c2c849dd322535e1b042a01fde386d1f308",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "350d6c2c849dd322535e1b042a01fde386d1f308",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.8.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "websocket"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.19",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.0",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.2",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0"
+      },
+      "gitHead": "f1559c909f0ed3239a970c73f15755d65de86a53",
+      "_id": "http-proxy-middleware@0.8.0",
+      "_shasum": "47698ccccee8fd6ff35013ff3dbe70150dae628c",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "dist": {
+        "shasum": "47698ccccee8fd6ff35013ff3dbe70150dae628c",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.8.1",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "websocket"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.19",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.0",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.2",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0"
+      },
+      "gitHead": "13f949160afd7ef754d5a27af9514d76099817f7",
+      "_id": "http-proxy-middleware@0.8.1",
+      "_shasum": "081b8251f40997ea94f3d7909ffa853cdfc86455",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "dist": {
+        "shasum": "081b8251f40997ea94f3d7909ffa853cdfc86455",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.8.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.8.2",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "websocket"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.19",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.0",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.2",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0"
+      },
+      "gitHead": "5f343b95eac318156e4475d80ec9b9c56437c273",
+      "_id": "http-proxy-middleware@0.8.2",
+      "_shasum": "8ea108c0e2c5b06a889fdec11328782a420e87c6",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "4.1.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8ea108c0e2c5b06a889fdec11328782a420e87c6",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.8.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.9.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "websocket"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.19",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.0",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.11.2",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0"
+      },
+      "gitHead": "57094e506e92bd7a3f5e6cf94dbbad7632cdfcad",
+      "_id": "http-proxy-middleware@0.9.0",
+      "_shasum": "017be05797de74548653e02453b42ba42b7b0326",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "017be05797de74548653e02453b42ba42b7b0326",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.9.1",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "gitHead": "fe24b979cf7a55b757092203a5c7832233ff67ea",
+      "_id": "http-proxy-middleware@0.9.1",
+      "_shasum": "f068d8f4b6faf96cf57712f16a5e6eb50731549a",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f068d8f4b6faf96cf57712f16a5e6eb50731549a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.0-beta": {
+      "name": "http-proxy-middleware",
+      "version": "0.10.0-beta",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "gitHead": "8ce646fe7c7736e9d90bc5d02682bc3fcc649da1",
+      "_id": "http-proxy-middleware@0.10.0-beta",
+      "_shasum": "5573a0d75182da174488a44d56d3427081a1fc61",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5573a0d75182da174488a44d56d3427081a1fc61",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.10.0-beta.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.10.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "gitHead": "5bed3c630c00c0d301fcdda4e4ea20ab31a95bfd",
+      "_id": "http-proxy-middleware@0.10.0",
+      "_shasum": "6060a8bf03c8443a5de7d5f279e95fa0ac0b1cfa",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6060a8bf03c8443a5de7d5f279e95fa0ac0b1cfa",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.10.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.10.0.tgz_1454699998631_0.40408703149296343"
+      },
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.11.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "gitHead": "1f21feda49e57806d82be94ba3f3e46a70e7f868",
+      "_id": "http-proxy-middleware@0.11.0",
+      "_shasum": "0d279b6791b1d1620dca09b657f186e63c84763e",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0d279b6791b1d1620dca09b657f186e63c84763e",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.11.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.11.0.tgz_1456344044565_0.8594308719038963"
+      },
+      "directories": {}
+    },
+    "0.12.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.12.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "gitHead": "951d9bf3fe81d83935bdcb8dfb51643a2775f251",
+      "_id": "http-proxy-middleware@0.12.0",
+      "_shasum": "014849335422dcd28e6eeddb5af1d9d2917fcb36",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "014849335422dcd28e6eeddb5af1d9d2917fcb36",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.12.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.12.0.tgz_1457891496060_0.7292140051722527"
+      },
+      "directories": {}
+    },
+    "0.13.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.13.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.2.0",
+        "ws": "^1.0.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.6.1",
+        "micromatch": "^2.3.7"
+      },
+      "gitHead": "6606489c35a06ded05694d33a15cf02917ca1173",
+      "_id": "http-proxy-middleware@0.13.0",
+      "_shasum": "9c765abb4027b3a95b9e8da8e4f4fa65b1ecca39",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9c765abb4027b3a95b9e8da8e4f4fa65b1ecca39",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.13.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.13.0.tgz_1458764570225_0.37139365426264703"
+      },
+      "directories": {}
+    },
+    "0.14.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.14.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.2.0",
+        "open": "0.0.5",
+        "ws": "^1.0.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.6.1",
+        "micromatch": "^2.3.7"
+      },
+      "gitHead": "28f17062174987e80bdb3ff60478d746a17cb43f",
+      "_id": "http-proxy-middleware@0.14.0",
+      "_shasum": "4bf97e2794201c5cd0ba07ca401c267f9d014444",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4bf97e2794201c5cd0ba07ca401c267f9d014444",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.14.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.14.0.tgz_1461011862294_0.11940710246562958"
+      },
+      "directories": {}
+    },
+    "0.15.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.15.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.12.5",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.4.5",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.1",
+        "ws": "^1.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      },
+      "gitHead": "b33b96978506ce00b7833f94514523a696e6cb13",
+      "_id": "http-proxy-middleware@0.15.0",
+      "_shasum": "59b8c391b2b838763388b0fad48b5bd36b3c0152",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "59b8c391b2b838763388b0fad48b5bd36b3c0152",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.15.0.tgz_1462309355357_0.6974488440901041"
+      },
+      "directories": {}
+    },
+    "0.15.1-beta": {
+      "name": "http-proxy-middleware",
+      "version": "0.15.1-beta",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.12.5",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.4.5",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.1",
+        "ws": "^1.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      },
+      "gitHead": "9bf680f5b6ccef0440b86672c8bd1088b760ee64",
+      "_id": "http-proxy-middleware@0.15.1-beta",
+      "_shasum": "ff501cb51a82d6ec3209c1f8c4345806a4fdaad8",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ff501cb51a82d6ec3209c1f8c4345806a4fdaad8",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.1-beta.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.15.1-beta.tgz_1463590456172_0.49187433044426143"
+      },
+      "directories": {}
+    },
+    "0.15.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.15.1",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.12.5",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.4.5",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.1",
+        "ws": "^1.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      },
+      "gitHead": "9e542faa39fd9e8caa9785088fb99511b24f41f3",
+      "_id": "http-proxy-middleware@0.15.1",
+      "_shasum": "bf455c567f6f411e66dce082d90c9049bfc391d2",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bf455c567f6f411e66dce082d90c9049bfc391d2",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.15.1.tgz_1464300122470_0.43105378933250904"
+      },
+      "directories": {}
+    },
+    "0.15.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.15.2",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "rm -rf coverage && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && rm -rf coverage"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.12.5",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.4.5",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.1",
+        "ws": "^1.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      },
+      "gitHead": "679526ef1f3a61e4b68c26d9f644195e93727b72",
+      "_id": "http-proxy-middleware@0.15.2",
+      "_shasum": "e1c69b8948fb04e2846ee22f38b650e4f09c027f",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e1c69b8948fb04e2846ee22f38b650e4f09c027f",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.15.2.tgz_1464526274174_0.0279650641605258"
+      },
+      "directories": {}
+    },
+    "0.16.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.16.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.13.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.5.3",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.13.3",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.13.1",
+        "micromatch": "^2.3.8"
+      },
+      "gitHead": "09926cdd29573e2966993a743d8b68e415f9c6b5",
+      "_id": "http-proxy-middleware@0.16.0",
+      "_shasum": "6879b8f1151a3289dd301372b81d8dd026e3162b",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6879b8f1151a3289dd301372b81d8dd026e3162b",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.16.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.16.0.tgz_1465843953253_0.4956787379924208"
+      },
+      "directories": {}
+    },
+    "0.17.0-beta": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.0-beta",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.13.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.5.3",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.13.3",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.13.1",
+        "micromatch": "^2.3.8"
+      },
+      "gitHead": "0ec0e6f906c8c41f1a73ecaa1ccc699d20fa7144",
+      "_id": "http-proxy-middleware@0.17.0-beta",
+      "_shasum": "847e594412dccab5f20c1330bd1234de6612eda1",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "847e594412dccab5f20c1330bd1234de6612eda1",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.0-beta.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.17.0-beta.tgz_1466090685347_0.03170943818986416"
+      },
+      "directories": {}
+    },
+    "0.17.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.13.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.5.3",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.13.3",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.13.1",
+        "micromatch": "^2.3.8"
+      },
+      "gitHead": "306fdd4162af41a5ced5ba17be80cbb861204f5f",
+      "_id": "http-proxy-middleware@0.17.0",
+      "_shasum": "65770b0bb5d2b17792984e595afb082599bf81e7",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "65770b0bb5d2b17792984e595afb082599bf81e7",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.17.0.tgz_1467560119815_0.34178488166071475"
+      },
+      "directories": {}
+    },
+    "0.17.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.1",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.14.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.12",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.4",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.0.2",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.14.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.14.2",
+        "micromatch": "^2.3.11"
+      },
+      "gitHead": "8a0ff1f0da2496b517ba02ccb30b1a9a17926dc7",
+      "_id": "http-proxy-middleware@0.17.1",
+      "_shasum": "e2b847aa9962d8ce312cc82a3f443d5039cf197a",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e2b847aa9962d8ce312cc82a3f443d5039cf197a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.17.1.tgz_1470951029603_0.6751409117132425"
+      },
+      "directories": {}
+    },
+    "0.17.2-beta": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.2-beta",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.14.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.12",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.4",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.0.2",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.14.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.14.2",
+        "micromatch": "^2.3.11"
+      },
+      "gitHead": "7d1865c84f4339ced230b0292db42c4d45376f1a",
+      "_id": "http-proxy-middleware@0.17.2-beta",
+      "_shasum": "a232f70909dd9848ab2b2da7d59068b83a9ff9a8",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a232f70909dd9848ab2b2da7d59068b83a9ff9a8",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.2-beta.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.17.2-beta.tgz_1473513288951_0.5517864497378469"
+      },
+      "directories": {}
+    },
+    "0.17.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.2",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.14.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.12",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.4",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.0.2",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.15.1",
+        "is-glob": "^3.0.0",
+        "lodash": "^4.16.2",
+        "micromatch": "^2.3.11"
+      },
+      "gitHead": "f03aecf755a0a645a83646131548754638b2e994",
+      "_id": "http-proxy-middleware@0.17.2",
+      "_shasum": "572d517a6d2fb1063a469de294eed96066352007",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "572d517a6d2fb1063a469de294eed96066352007",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.17.2.tgz_1475101693149_0.3973892144858837"
+      },
+      "directories": {}
+    },
+    "0.17.3": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.3",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.18.2",
+        "chai": "^3.5.0",
+        "connect": "^3.5.0",
+        "coveralls": "^2.11.15",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.2.0",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
+      },
+      "gitHead": "8689cb429577a7722b9334e702535cb752191c43",
+      "_id": "http-proxy-middleware@0.17.3",
+      "_shasum": "940382147149b856084f5534752d5b5a8168cd1d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "940382147149b856084f5534752d5b5a8168cd1d",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.17.3.tgz_1481145720041_0.3982126035261899"
+      },
+      "directories": {}
+    },
+    "0.17.4": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.4",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "browser-sync": "^2.18.2",
+        "chai": "^3.5.0",
+        "connect": "^3.5.0",
+        "coveralls": "^2.11.15",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.2.0",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dependencies": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
+      },
+      "gitHead": "cb5e084e71bc3202fe4f711f2f5edf4e29355d99",
+      "_id": "http-proxy-middleware@0.17.4",
+      "_shasum": "642e8848851d66f09d4f124912846dbaeb41b833",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "642e8848851d66f09d4f124912846dbaeb41b833",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-middleware-0.17.4.tgz_1488496050141_0.13289726292714477"
+      },
+      "directories": {}
+    },
+    "0.18.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.18.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "lint": "standard --verbose | snazzy --colors",
+        "test": "npm run lint && mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean",
+        "commitmsg": "commitlint -e $GIT_PARAMS"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^6.1.3",
+        "@commitlint/config-conventional": "^6.1.3",
+        "browser-sync": "^2.23.6",
+        "chai": "^4.1.2",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.0",
+        "express": "^4.16.3",
+        "husky": "^0.14.3",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^5.0.4",
+        "mocha-lcov-reporter": "1.3.0",
+        "opn": "^5.2.0",
+        "snazzy": "^7.1.1",
+        "standard": "^11.0.0",
+        "ws": "^5.0.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.5",
+        "micromatch": "^3.1.9"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "standard": {
+        "env": [
+          "mocha"
+        ]
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "_id": "http-proxy-middleware@0.18.0",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
+        "shasum": "0987e6bb5a5606e5a69168d8f967a87f15dd8aab",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 45653
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.18.0_1520894840221_0.4597555666447708"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.19.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.19.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "lint": "standard --verbose | snazzy --colors",
+        "lint:fix": "standard --fix",
+        "test": "npm run lint && mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean",
+        "commitmsg": "commitlint -e $GIT_PARAMS"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^7.1.1",
+        "@commitlint/config-conventional": "^7.1.1",
+        "browser-sync": "^2.24.7",
+        "chai": "^4.1.2",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.2",
+        "express": "^4.16.3",
+        "husky": "^0.14.3",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "1.3.0",
+        "opn": "^5.3.0",
+        "snazzy": "^8.0.0",
+        "standard": "^12.0.0",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.10",
+        "micromatch": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "standard": {
+        "env": [
+          "mocha"
+        ]
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "bb59c666dbb65cc0ef422bbf5332b67cbd6fb0e3",
+      "_id": "http-proxy-middleware@0.19.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.1.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Ab/zKDy2B0404mz83bgki0HHv/xqpYKAyFXhopAiJaVAUSJfLYrpBYynTl4ZSUJ7TqrAgjarTsxdX5yBb4unRQ==",
+        "shasum": "40992b5901dc44bc7bc3795da81b0b248eca02d8",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 47638,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbhw0DCRA9TVsSAnZWagAAUPcP/1A2WhkhsxkmhjldBC0L\n2g7MExS6bgGFP9gMvsCGXxGG4b6VlxM2oaQovWICSLrgkSJM+KdtNEw+jGjV\nBVlYMtBy25g3QYnYn9UIdmSC2mhZPg/4Th9K3GM8RFapxnzXCaB6IW9aXrrO\nWxIm2kwcHtg30j6EXdZP2dN8QXIA1hiP3cZUvnayP6knfGZmigtN53oL0aya\njK43LJnvLmGrsn8caBrCYKn/iJg/OS5vQ+efwDV9O6IKXdKDqN4FS/wwZ73B\nvgcR2avQP1ltRKxOhxczDSKB2zkSOPUBwYvsICU0HUC8YnkV54JxBFKXd9vZ\nElFjbUZu1VBYmLu2GpY13ohs6Fp6f+0rD31YWf9927pFfu/4bHcAE2TyGMF+\na7oeE6CfsKkKwwcnQAIGEpP2dJqF1B+HQ6PSVxXZu7Aul/coMNVFDrDclN3O\nRGMPZY1zruZd/rxN8EtkRfw8/3/7/kJ4xZLX9iT14CJMjyhSyAuNUrVEKMwa\nBxf2fIXMMPm8ixJDaoV1YAaguDuI175emLeYJQEIO4QRt26qwiFfNzNtncAD\nGfMvcK1iIPmmmqehBqAnykmY7X8vBwKibiqAqzcDIFvYRVBI6XuitpUtzAcj\nTxSPqbK1LK418yU9kyZTQmvIspJM208WSQg8god9nhZEsH6zuVznuJsDxElj\ncYoN\r\n=tNgg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.19.0_1535577347082_0.9788730101740601"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.19.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.19.1",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "lint": "prettier \"**/*.{js,md}\" --list-different",
+        "lint:fix": "prettier \"**/*.{js,md}\" --write",
+        "test": "npm run lint && mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "browser-sync": "^2.26.3",
+        "chai": "^4.2.0",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.2",
+        "express": "^4.16.4",
+        "husky": "^1.2.0",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "1.3.0",
+        "opn": "^5.4.0",
+        "precise-commits": "^1.0.2",
+        "prettier": "^1.15.2",
+        "ws": "^6.1.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+          "pre-commit": "precise-commits"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "6422977cebde7ba6b2a506f47db97aa58ccbd44c",
+      "_id": "http-proxy-middleware@0.19.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.1.0",
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+        "shasum": "183c7dc4aa1479150306498c210cdaf96080a43a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 47749,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb+wOjCRA9TVsSAnZWagAAF4wP/iFtdy3Uih6MOUfLwFse\n8CQE+LjzM+VtuI9/7Kgzq22OoLSk9HG4f2X0yOwochMFtzyoXpJiQHbx2VQd\nMV5PMDLfoDAU/U9aLzH/HEJY4cS5/+Aq5tcZJQAEEj2BFh2/HazJ9mor7iF/\n5tnSqANMytw4Ns5s481DQ7kWslmfv6tz1sJfUhu3WZ1KRdum4UNkElwdMDo1\nP1KNOmL6fKewy5gaBvagu79Tn7nbW7JJY9LE5FNlWcb3/CamHI/goiYYfOGB\n+voQbrqRKFkoCEsWQM7jsLaAh9ThaZAOLF2qDqdZOy2TC8JQ/eenxhiLUSxy\n7bDH7KAuRr68UrHXNru/SWFXd0UtOk2RgY26/crlJOCyez/wGrVZ879gen8b\npcJRqFmUOZylMrRLCytnfD6q4WDxFXh7Y8SNPBr6YW6MNS11mgiN2Nf2SD23\nrtU4WgtdD7W/ZazW3Nr3OOhF4rXDnsOZkffZq15Kkx7Au9+VkfIu184WdjN0\nELca91oKH4NtOXSXL+2btOwoxQZK9Cil87brxlJWqBp3oEQZkkapeB6hT+xF\nJmSAnUQHthlLr6Nqh9d+s6Atha/m1dlNNhYE/DlDHIBAPSXamhwi1EB2fO4z\noNl+CkmaNXFRG4i2xazaMDnIiWzwbcpS/X+1yVR3apUTRuqc/uaxe0BjhPwe\n/2D0\r\n=nSVz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.19.1_1543177122633_0.17284658095161887"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.20.0-beta.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.20.0-beta.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && npm run build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && npm run build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "@types/express": "^4.16.1",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.11",
+        "@types/lodash": "^4.14.123",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.0.4",
+        "browser-sync": "^2.26.3",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.3",
+        "express": "^4.16.4",
+        "husky": "^2.3.0",
+        "jest": "^24.5.0",
+        "open": "^6.3.0",
+        "prettier": "^1.15.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.14.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.4.1",
+        "ws": "^7.0.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.11",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "readme": "# http-proxy-middleware\n\n[![Build Status](https://img.shields.io/travis/chimurai/http-proxy-middleware/master.svg?style=flat-square)](https://travis-ci.org/chimurai/http-proxy-middleware)\n[![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square)](https://coveralls.io/r/chimurai/http-proxy-middleware)\n[![dependency Status](https://img.shields.io/david/chimurai/http-proxy-middleware.svg?style=flat-square)](https://david-dm.org/chimurai/http-proxy-middleware#info=dependencies)\n[![dependency Status](https://snyk.io/test/npm/http-proxy-middleware/badge.svg?style=flat-square)](https://snyk.io/test/npm/http-proxy-middleware)\n[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)\n\nNode.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/strongloop/express), [browser-sync](https://github.com/BrowserSync/browser-sync) and [many more](#compatible-servers).\n\nPowered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)\n\n## TL;DR\n\nProxy `/api` requests to `http://www.example.org`\n\n```javascript\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\nvar app = express();\n\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n_All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#options) can be used, along with some extra `http-proxy-middleware` [options](#options).\n\n:bulb: **Tip:** Set the option `changeOrigin` to `true` for [name-based virtual hosted sites](http://en.wikipedia.org/wiki/Virtual_hosting#Name-based).\n\n## Table of Contents\n\n<!-- MarkdownTOC autolink=true bracket=round depth=2 -->\n\n- [Install](#install)\n- [Core concept](#core-concept)\n- [Example](#example)\n- [Context matching](#context-matching)\n- [Options](#options)\n  - [http-proxy-middleware options](#http-proxy-middleware-options)\n  - [http-proxy events](#http-proxy-events)\n  - [http-proxy options](#http-proxy-options)\n- [Shorthand](#shorthand)\n  - [app.use\\(path, proxy\\)](#appusepath-proxy)\n- [WebSocket](#websocket)\n  - [External WebSocket upgrade](#external-websocket-upgrade)\n- [Working examples](#working-examples)\n- [Recipes](#recipes)\n- [Compatible servers](#compatible-servers)\n- [Tests](#tests)\n- [Changelog](#changelog)\n- [License](#license)\n\n<!-- /MarkdownTOC -->\n\n## Install\n\n```javascript\n$ npm install --save-dev http-proxy-middleware\n```\n\n## Core concept\n\nProxy middleware configuration.\n\n#### proxy([context,] config)\n\n```javascript\nvar proxy = require('http-proxy-middleware');\n\nvar apiProxy = proxy('/api', { target: 'http://www.example.org' });\n//                   \\____/   \\_____________________________/\n//                     |                    |\n//                   context             options\n\n// 'apiProxy' is now ready to be used as middleware in a server.\n```\n\n- **context**: Determine which requests should be proxied to the target host.\n  (more on [context matching](#context-matching))\n- **options.target**: target host to proxy to. _(protocol + host)_\n\n(full list of [`http-proxy-middleware` configuration options](#options))\n\n#### proxy(uri [, config])\n\n```javascript\n// shorthand syntax for the example above:\nvar apiProxy = proxy('http://www.example.org/api');\n```\n\nMore about the [shorthand configuration](#shorthand).\n\n## Example\n\nAn example with `express` server.\n\n```javascript\n// include dependencies\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\n// proxy middleware options\nvar options = {\n  target: 'http://www.example.org', // target host\n  changeOrigin: true, // needed for virtual hosted sites\n  ws: true, // proxy websockets\n  pathRewrite: {\n    '^/api/old-path': '/api/new-path', // rewrite path\n    '^/api/remove/path': '/path' // remove base path\n  },\n  router: {\n    // when request.headers.host == 'dev.localhost:3000',\n    // override target 'http://www.example.org' to 'http://localhost:8000'\n    'dev.localhost:3000': 'http://localhost:8000'\n  }\n};\n\n// create the proxy (without context)\nvar exampleProxy = proxy(options);\n\n// mount `exampleProxy` in web server\nvar app = express();\napp.use('/api', exampleProxy);\napp.listen(3000);\n```\n\n## Context matching\n\nProviding an alternative way to decide which requests should be proxied; In case you are not able to use the server's [`path` parameter](http://expressjs.com/en/4x/api.html#app.use) to mount the proxy or when you need more flexibility.\n\n[RFC 3986 `path`](https://tools.ietf.org/html/rfc3986#section-3.3) is used for context matching.\n\n```\n         foo://example.com:8042/over/there?name=ferret#nose\n         \\_/   \\______________/\\_________/ \\_________/ \\__/\n          |           |            |            |        |\n       scheme     authority       path        query   fragment\n```\n\n- **path matching**\n\n  - `proxy({...})` - matches any path, all requests will be proxied.\n  - `proxy('/', {...})` - matches any path, all requests will be proxied.\n  - `proxy('/api', {...})` - matches paths starting with `/api`\n\n- **multiple path matching**\n\n  - `proxy(['/api', '/ajax', '/someotherpath'], {...})`\n\n- **wildcard path matching**\n\n  For fine-grained control you can use wildcard matching. Glob pattern matching is done by _micromatch_. Visit [micromatch](https://www.npmjs.com/package/micromatch) or [glob](https://www.npmjs.com/package/glob) for more globbing examples.\n\n  - `proxy('**', {...})` matches any path, all requests will be proxied.\n  - `proxy('**/*.html', {...})` matches any path which ends with `.html`\n  - `proxy('/*.html', {...})` matches paths directly under path-absolute\n  - `proxy('/api/**/*.html', {...})` matches requests ending with `.html` in the path of `/api`\n  - `proxy(['/api/**', '/ajax/**'], {...})` combine multiple patterns\n  - `proxy(['/api/**', '!**/bad.json'], {...})` exclusion\n\n  **Note**: In multiple path matching, you cannot use string paths and wildcard paths together.\n\n- **custom matching**\n\n  For full control you can provide a custom function to determine which requests should be proxied or not.\n\n  ```javascript\n  /**\n   * @return {Boolean}\n   */\n  var filter = function(pathname, req) {\n    return pathname.match('^/api') && req.method === 'GET';\n  };\n\n  var apiProxy = proxy(filter, { target: 'http://www.example.org' });\n  ```\n\n## Options\n\n### http-proxy-middleware options\n\n- **option.pathRewrite**: object/function, rewrite target's url path. Object-keys will be used as _RegExp_ to match paths.\n\n  ```javascript\n  // rewrite path\n  pathRewrite: {'^/old/api' : '/new/api'}\n\n  // remove path\n  pathRewrite: {'^/remove/api' : ''}\n\n  // add base path\n  pathRewrite: {'^/' : '/basepath/'}\n\n  // custom rewriting\n  pathRewrite: function (path, req) { return path.replace('/api', '/base/api') }\n  ```\n\n- **option.router**: object/function, re-target `option.target` for specific requests.\n\n  ```javascript\n  // Use `host` and/or `path` to match requests. First match will be used.\n  // The order of the configuration matters.\n  router: {\n      'integration.localhost:3000' : 'http://localhost:8001',  // host only\n      'staging.localhost:3000'     : 'http://localhost:8002',  // host only\n      'localhost:3000/api'         : 'http://localhost:8003',  // host + path\n      '/rest'                      : 'http://localhost:8004'   // path only\n  }\n\n  // Custom router function\n  router: function(req) {\n      return 'http://localhost:8004';\n  }\n  ```\n\n- **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`\n\n- **option.logProvider**: function, modify or replace log provider. Default: `console`.\n\n  ```javascript\n  // simple replace\n  function logProvider(provider) {\n    // replace the default console log provider.\n    return require('winston');\n  }\n  ```\n\n  ```javascript\n  // verbose replacement\n  function logProvider(provider) {\n    var logger = new (require('winston')).Logger();\n\n    var myCustomProvider = {\n      log: logger.log,\n      debug: logger.debug,\n      info: logger.info,\n      warn: logger.warn,\n      error: logger.error\n    };\n    return myCustomProvider;\n  }\n  ```\n\n### http-proxy events\n\nSubscribe to [http-proxy events](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events):\n\n- **option.onError**: function, subscribe to http-proxy's `error` event for custom error handling.\n\n  ```javascript\n  function onError(err, req, res) {\n    res.writeHead(500, {\n      'Content-Type': 'text/plain'\n    });\n    res.end(\n      'Something went wrong. And we are reporting a custom error message.'\n    );\n  }\n  ```\n\n- **option.onProxyRes**: function, subscribe to http-proxy's `proxyRes` event.\n\n  ```javascript\n  function onProxyRes(proxyRes, req, res) {\n    proxyRes.headers['x-added'] = 'foobar'; // add new header to response\n    delete proxyRes.headers['x-removed']; // remove header from response\n  }\n  ```\n\n- **option.onProxyReq**: function, subscribe to http-proxy's `proxyReq` event.\n\n  ```javascript\n  function onProxyReq(proxyReq, req, res) {\n    // add custom header to request\n    proxyReq.setHeader('x-added', 'foobar');\n    // or log the req\n  }\n  ```\n\n- **option.onProxyReqWs**: function, subscribe to http-proxy's `proxyReqWs` event.\n\n  ```javascript\n  function onProxyReqWs(proxyReq, req, socket, options, head) {\n    // add custom header\n    proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n  }\n  ```\n\n- **option.onOpen**: function, subscribe to http-proxy's `open` event.\n\n  ```javascript\n  function onOpen(proxySocket) {\n    // listen for messages coming FROM the target here\n    proxySocket.on('data', hybiParseAndLogMessage);\n  }\n  ```\n\n- **option.onClose**: function, subscribe to http-proxy's `close` event.\n  ```javascript\n  function onClose(res, socket, head) {\n    // view disconnected websocket connections\n    console.log('Client disconnected');\n  }\n  ```\n\n### http-proxy options\n\nThe following options are provided by the underlying [http-proxy](https://github.com/nodejitsu/node-http-proxy#options) library.\n\n- **option.target**: url string to be parsed with the url module\n- **option.forward**: url string to be parsed with the url module\n- **option.agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n- **option.ssl**: object to be passed to https.createServer()\n- **option.ws**: true/false: if you want to proxy websockets\n- **option.xfwd**: true/false, adds x-forward headers\n- **option.secure**: true/false, if you want to verify the SSL Certs\n- **option.toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n- **option.prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n- **option.ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n- **option.localAddress** : Local interface string to bind for outgoing connections\n- **option.changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n- **option.preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n- **option.auth** : Basic authentication i.e. 'user:password' to compute an Authorization header.\n- **option.hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.\n- **option.autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.\n- **option.protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.\n- **option.cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n  - Object: mapping of domains to new domains, use `\"*\"` to match all domains.  \n    For example keep one domain unchanged, rewrite one domain and remove other domains:\n    ```\n    cookieDomainRewrite: {\n      \"unchanged.domain\": \"unchanged.domain\",\n      \"old.domain\": \"new.domain\",\n      \"*\": \"\"\n    }\n    ```\n- **option.cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n  - Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n    For example, to keep one path unchanged, rewrite one path and remove other paths:\n    ```\n    cookiePathRewrite: {\n      \"/unchanged.path/\": \"/unchanged.path/\",\n      \"/old.path/\": \"/new.path/\",\n      \"*\": \"\"\n    }\n    ```\n- **option.headers**: object, adds [request headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields). (Example: `{host:'www.example.org'}`)\n- **option.proxyTimeout**: timeout (in millis) when proxy receives no response from target\n- **option.timeout**: timeout (in millis) for incoming requests\n- **option.followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n- **option.selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n- **option.buffer**: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on e.g. If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n  ```\n  'use strict';\n\n  const streamify = require('stream-array');\n  const HttpProxy = require('http-proxy');\n  const proxy = new HttpProxy();\n\n  module.exports = (req, res, next) => {\n\n    proxy.web(req, res, {\n      target: 'http://localhost:4003/',\n      buffer: streamify(req.rawBody)\n    }, next);\n\n  };\n  ```\n\n## Shorthand\n\nUse the shorthand syntax when verbose configuration is not needed. The `context` and `option.target` will be automatically configured when shorthand is used. Options can still be used if needed.\n\n```javascript\nproxy('http://www.example.org:8000/api');\n// proxy('/api', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api/books/*/**.json');\n// proxy('/api/books/*/**.json', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api', { changeOrigin: true });\n// proxy('/api', {target: 'http://www.example.org:8000', changeOrigin: true});\n```\n\n### app.use(path, proxy)\n\nIf you want to use the server's `app.use` `path` parameter to match requests;\nCreate and mount the proxy without the http-proxy-middleware `context` parameter:\n\n```javascript\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\n```\n\n`app.use` documentation:\n\n- express: http://expressjs.com/en/4x/api.html#app.use\n- connect: https://github.com/senchalabs/connect#mount-middleware\n\n## WebSocket\n\n```javascript\n// verbose api\nproxy('/', { target: 'http://echo.websocket.org', ws: true });\n\n// shorthand\nproxy('http://echo.websocket.org', { ws: true });\n\n// shorter shorthand\nproxy('ws://echo.websocket.org');\n```\n\n### External WebSocket upgrade\n\nIn the previous WebSocket examples, http-proxy-middleware relies on a initial http request in order to listen to the http `upgrade` event. If you need to proxy WebSockets without the initial http request, you can subscribe to the server's http `upgrade` event manually.\n\n```javascript\nvar wsProxy = proxy('ws://echo.websocket.org', { changeOrigin: true });\n\nvar app = express();\napp.use(wsProxy);\n\nvar server = app.listen(3000);\nserver.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'\n```\n\n## Working examples\n\nView and play around with [working examples](https://github.com/chimurai/http-proxy-middleware/tree/master/examples).\n\n- Browser-Sync ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/browser-sync/index.js))\n- express ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/express/index.js))\n- connect ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/connect/index.js))\n- WebSocket ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/websocket/index.js))\n\n## Recipes\n\nView the [recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes) for common use cases.\n\n## Compatible servers\n\n`http-proxy-middleware` is compatible with the following servers:\n\n- [connect](https://www.npmjs.com/package/connect)\n- [express](https://www.npmjs.com/package/express)\n- [browser-sync](https://www.npmjs.com/package/browser-sync)\n- [lite-server](https://www.npmjs.com/package/lite-server)\n- [grunt-contrib-connect](https://www.npmjs.com/package/grunt-contrib-connect)\n- [grunt-browser-sync](https://www.npmjs.com/package/grunt-browser-sync)\n- [gulp-connect](https://www.npmjs.com/package/gulp-connect)\n- [gulp-webserver](https://www.npmjs.com/package/gulp-webserver)\n\nSample implementations can be found in the [server recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes/servers.md).\n\n## Tests\n\nRun the test suite:\n\n```bash\n# install dependencies\n$ yarn\n\n# linting\n$ yarn lint\n$ yarn lint:fix\n\n# building (compile typescript to js)\n$ yarn build\n\n# unit tests\n$ yarn test\n\n# code coverage\n$ yarn cover\n```\n\n## Changelog\n\n- [View changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2015-2019 Steven Chim\n",
+      "readmeFilename": "README.md",
+      "gitHead": "021b03f0d805446d21e9e9b0700c75b8eb8f39f6",
+      "_id": "http-proxy-middleware@0.20.0-beta.0",
+      "_nodeVersion": "12.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-rXjfA9c4qCfRPBuEjn4lLinMYmXFSmylBPszJiUBg43tAJx7feHWbbx0VsLMTURe1APw8mSXCuRCMBDhByGT4Q==",
+        "shasum": "8d38afb8ea264b8ea41a7b7b8e69411ba2eed224",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0-beta.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 51162,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc8ZZUCRA9TVsSAnZWagAARsoP/2VE+jurLfwtvCIDDVe4\nT+VKqcgNMPJEacyQ1eJBd2cs283zs75Bf/mzIHYAk8doK+X+LWwie1lW9QcP\nf+Rvr8L9bdITk4n+cGfU8es7evpVAuwB7A+h0vdEu5PPYgPhPGAZDVfT19q2\nGy2ByOUiamnNYqAlpIV1iGbPiL9nHqFXCZuEithRR/CYf/JvzW82UCQho5mk\naMhy/I05CFhRQNP30Se26L68NUofKIZnKQUGPoOUjwH5ez73xXWbV4A+gA8o\nNwvAznB9u3SwEwH3qfY880d2vCL0iZ6/wG/5G6BF4bJ/5JlpKEs8i7pxwCV9\nzlD3k0vxgms2g9g3XhuDDJE+rivLWFJa14dROKJGlfgCg8oQQuXMIl5oZJQh\n8uq10OJ2dVRmo/in0rm1BHKx0tugRGysygJ91Lml+AeavTVv719EX4VKgKpW\noXu6nu9cVktYaJN82iB/FKEjsUd2fq8QUsf0cPGj8wyDz6D1uhV76VmIH6Ml\n8HAKxtzlTR15JN9s3uCXqBYCGaAKDz4p6aA57kboWFbgqj3r1InBYhnDq53P\n+9j3xLkiawBnwb2Ckk9MendRklvbyl3Es9TERkEoIL+W/6V+MlImH0DH+uMB\noElTRggfmooAbh6GDjcS++AxlXo/mowisJpe581ndWcgXxE6j/czFt0KK3a4\nM5PT\r\n=HJp3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.20.0-beta.0_1559336531343_0.4642439713593851"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.20.0-beta.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.20.0-beta.1",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepublish": "yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "@types/express": "^4.16.1",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.11",
+        "@types/lodash": "^4.14.123",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.0.4",
+        "browser-sync": "^2.26.3",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.3",
+        "express": "^4.16.4",
+        "husky": "^2.3.0",
+        "jest": "^24.5.0",
+        "open": "^6.3.0",
+        "prettier": "^1.15.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.14.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.4.1",
+        "ws": "^7.0.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.11",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "readme": "# http-proxy-middleware\n\n[![Build Status](https://img.shields.io/travis/chimurai/http-proxy-middleware/master.svg?style=flat-square)](https://travis-ci.org/chimurai/http-proxy-middleware)\n[![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square)](https://coveralls.io/r/chimurai/http-proxy-middleware)\n[![dependency Status](https://img.shields.io/david/chimurai/http-proxy-middleware.svg?style=flat-square)](https://david-dm.org/chimurai/http-proxy-middleware#info=dependencies)\n[![dependency Status](https://snyk.io/test/npm/http-proxy-middleware/badge.svg?style=flat-square)](https://snyk.io/test/npm/http-proxy-middleware)\n[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)\n\nNode.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/strongloop/express), [browser-sync](https://github.com/BrowserSync/browser-sync) and [many more](#compatible-servers).\n\nPowered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)\n\n## TL;DR\n\nProxy `/api` requests to `http://www.example.org`\n\n```javascript\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\nvar app = express();\n\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n_All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#options) can be used, along with some extra `http-proxy-middleware` [options](#options).\n\n:bulb: **Tip:** Set the option `changeOrigin` to `true` for [name-based virtual hosted sites](http://en.wikipedia.org/wiki/Virtual_hosting#Name-based).\n\n## Table of Contents\n\n<!-- MarkdownTOC autolink=true bracket=round depth=2 -->\n\n- [Install](#install)\n- [Core concept](#core-concept)\n- [Example](#example)\n- [Context matching](#context-matching)\n- [Options](#options)\n  - [http-proxy-middleware options](#http-proxy-middleware-options)\n  - [http-proxy events](#http-proxy-events)\n  - [http-proxy options](#http-proxy-options)\n- [Shorthand](#shorthand)\n  - [app.use\\(path, proxy\\)](#appusepath-proxy)\n- [WebSocket](#websocket)\n  - [External WebSocket upgrade](#external-websocket-upgrade)\n- [Working examples](#working-examples)\n- [Recipes](#recipes)\n- [Compatible servers](#compatible-servers)\n- [Tests](#tests)\n- [Changelog](#changelog)\n- [License](#license)\n\n<!-- /MarkdownTOC -->\n\n## Install\n\n```javascript\n$ npm install --save-dev http-proxy-middleware\n```\n\n## Core concept\n\nProxy middleware configuration.\n\n#### proxy([context,] config)\n\n```javascript\nvar proxy = require('http-proxy-middleware');\n\nvar apiProxy = proxy('/api', { target: 'http://www.example.org' });\n//                   \\____/   \\_____________________________/\n//                     |                    |\n//                   context             options\n\n// 'apiProxy' is now ready to be used as middleware in a server.\n```\n\n- **context**: Determine which requests should be proxied to the target host.\n  (more on [context matching](#context-matching))\n- **options.target**: target host to proxy to. _(protocol + host)_\n\n(full list of [`http-proxy-middleware` configuration options](#options))\n\n#### proxy(uri [, config])\n\n```javascript\n// shorthand syntax for the example above:\nvar apiProxy = proxy('http://www.example.org/api');\n```\n\nMore about the [shorthand configuration](#shorthand).\n\n## Example\n\nAn example with `express` server.\n\n```javascript\n// include dependencies\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\n// proxy middleware options\nvar options = {\n  target: 'http://www.example.org', // target host\n  changeOrigin: true, // needed for virtual hosted sites\n  ws: true, // proxy websockets\n  pathRewrite: {\n    '^/api/old-path': '/api/new-path', // rewrite path\n    '^/api/remove/path': '/path' // remove base path\n  },\n  router: {\n    // when request.headers.host == 'dev.localhost:3000',\n    // override target 'http://www.example.org' to 'http://localhost:8000'\n    'dev.localhost:3000': 'http://localhost:8000'\n  }\n};\n\n// create the proxy (without context)\nvar exampleProxy = proxy(options);\n\n// mount `exampleProxy` in web server\nvar app = express();\napp.use('/api', exampleProxy);\napp.listen(3000);\n```\n\n## Context matching\n\nProviding an alternative way to decide which requests should be proxied; In case you are not able to use the server's [`path` parameter](http://expressjs.com/en/4x/api.html#app.use) to mount the proxy or when you need more flexibility.\n\n[RFC 3986 `path`](https://tools.ietf.org/html/rfc3986#section-3.3) is used for context matching.\n\n```\n         foo://example.com:8042/over/there?name=ferret#nose\n         \\_/   \\______________/\\_________/ \\_________/ \\__/\n          |           |            |            |        |\n       scheme     authority       path        query   fragment\n```\n\n- **path matching**\n\n  - `proxy({...})` - matches any path, all requests will be proxied.\n  - `proxy('/', {...})` - matches any path, all requests will be proxied.\n  - `proxy('/api', {...})` - matches paths starting with `/api`\n\n- **multiple path matching**\n\n  - `proxy(['/api', '/ajax', '/someotherpath'], {...})`\n\n- **wildcard path matching**\n\n  For fine-grained control you can use wildcard matching. Glob pattern matching is done by _micromatch_. Visit [micromatch](https://www.npmjs.com/package/micromatch) or [glob](https://www.npmjs.com/package/glob) for more globbing examples.\n\n  - `proxy('**', {...})` matches any path, all requests will be proxied.\n  - `proxy('**/*.html', {...})` matches any path which ends with `.html`\n  - `proxy('/*.html', {...})` matches paths directly under path-absolute\n  - `proxy('/api/**/*.html', {...})` matches requests ending with `.html` in the path of `/api`\n  - `proxy(['/api/**', '/ajax/**'], {...})` combine multiple patterns\n  - `proxy(['/api/**', '!**/bad.json'], {...})` exclusion\n\n  **Note**: In multiple path matching, you cannot use string paths and wildcard paths together.\n\n- **custom matching**\n\n  For full control you can provide a custom function to determine which requests should be proxied or not.\n\n  ```javascript\n  /**\n   * @return {Boolean}\n   */\n  var filter = function(pathname, req) {\n    return pathname.match('^/api') && req.method === 'GET';\n  };\n\n  var apiProxy = proxy(filter, { target: 'http://www.example.org' });\n  ```\n\n## Options\n\n### http-proxy-middleware options\n\n- **option.pathRewrite**: object/function, rewrite target's url path. Object-keys will be used as _RegExp_ to match paths.\n\n  ```javascript\n  // rewrite path\n  pathRewrite: {'^/old/api' : '/new/api'}\n\n  // remove path\n  pathRewrite: {'^/remove/api' : ''}\n\n  // add base path\n  pathRewrite: {'^/' : '/basepath/'}\n\n  // custom rewriting\n  pathRewrite: function (path, req) { return path.replace('/api', '/base/api') }\n  ```\n\n- **option.router**: object/function, re-target `option.target` for specific requests.\n\n  ```javascript\n  // Use `host` and/or `path` to match requests. First match will be used.\n  // The order of the configuration matters.\n  router: {\n      'integration.localhost:3000' : 'http://localhost:8001',  // host only\n      'staging.localhost:3000'     : 'http://localhost:8002',  // host only\n      'localhost:3000/api'         : 'http://localhost:8003',  // host + path\n      '/rest'                      : 'http://localhost:8004'   // path only\n  }\n\n  // Custom router function\n  router: function(req) {\n      return 'http://localhost:8004';\n  }\n  ```\n\n- **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`\n\n- **option.logProvider**: function, modify or replace log provider. Default: `console`.\n\n  ```javascript\n  // simple replace\n  function logProvider(provider) {\n    // replace the default console log provider.\n    return require('winston');\n  }\n  ```\n\n  ```javascript\n  // verbose replacement\n  function logProvider(provider) {\n    var logger = new (require('winston')).Logger();\n\n    var myCustomProvider = {\n      log: logger.log,\n      debug: logger.debug,\n      info: logger.info,\n      warn: logger.warn,\n      error: logger.error\n    };\n    return myCustomProvider;\n  }\n  ```\n\n### http-proxy events\n\nSubscribe to [http-proxy events](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events):\n\n- **option.onError**: function, subscribe to http-proxy's `error` event for custom error handling.\n\n  ```javascript\n  function onError(err, req, res) {\n    res.writeHead(500, {\n      'Content-Type': 'text/plain'\n    });\n    res.end(\n      'Something went wrong. And we are reporting a custom error message.'\n    );\n  }\n  ```\n\n- **option.onProxyRes**: function, subscribe to http-proxy's `proxyRes` event.\n\n  ```javascript\n  function onProxyRes(proxyRes, req, res) {\n    proxyRes.headers['x-added'] = 'foobar'; // add new header to response\n    delete proxyRes.headers['x-removed']; // remove header from response\n  }\n  ```\n\n- **option.onProxyReq**: function, subscribe to http-proxy's `proxyReq` event.\n\n  ```javascript\n  function onProxyReq(proxyReq, req, res) {\n    // add custom header to request\n    proxyReq.setHeader('x-added', 'foobar');\n    // or log the req\n  }\n  ```\n\n- **option.onProxyReqWs**: function, subscribe to http-proxy's `proxyReqWs` event.\n\n  ```javascript\n  function onProxyReqWs(proxyReq, req, socket, options, head) {\n    // add custom header\n    proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n  }\n  ```\n\n- **option.onOpen**: function, subscribe to http-proxy's `open` event.\n\n  ```javascript\n  function onOpen(proxySocket) {\n    // listen for messages coming FROM the target here\n    proxySocket.on('data', hybiParseAndLogMessage);\n  }\n  ```\n\n- **option.onClose**: function, subscribe to http-proxy's `close` event.\n  ```javascript\n  function onClose(res, socket, head) {\n    // view disconnected websocket connections\n    console.log('Client disconnected');\n  }\n  ```\n\n### http-proxy options\n\nThe following options are provided by the underlying [http-proxy](https://github.com/nodejitsu/node-http-proxy#options) library.\n\n- **option.target**: url string to be parsed with the url module\n- **option.forward**: url string to be parsed with the url module\n- **option.agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n- **option.ssl**: object to be passed to https.createServer()\n- **option.ws**: true/false: if you want to proxy websockets\n- **option.xfwd**: true/false, adds x-forward headers\n- **option.secure**: true/false, if you want to verify the SSL Certs\n- **option.toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n- **option.prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n- **option.ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n- **option.localAddress** : Local interface string to bind for outgoing connections\n- **option.changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n- **option.preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n- **option.auth** : Basic authentication i.e. 'user:password' to compute an Authorization header.\n- **option.hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.\n- **option.autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.\n- **option.protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.\n- **option.cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n  - Object: mapping of domains to new domains, use `\"*\"` to match all domains.  \n    For example keep one domain unchanged, rewrite one domain and remove other domains:\n    ```\n    cookieDomainRewrite: {\n      \"unchanged.domain\": \"unchanged.domain\",\n      \"old.domain\": \"new.domain\",\n      \"*\": \"\"\n    }\n    ```\n- **option.cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n  - Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n    For example, to keep one path unchanged, rewrite one path and remove other paths:\n    ```\n    cookiePathRewrite: {\n      \"/unchanged.path/\": \"/unchanged.path/\",\n      \"/old.path/\": \"/new.path/\",\n      \"*\": \"\"\n    }\n    ```\n- **option.headers**: object, adds [request headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields). (Example: `{host:'www.example.org'}`)\n- **option.proxyTimeout**: timeout (in millis) when proxy receives no response from target\n- **option.timeout**: timeout (in millis) for incoming requests\n- **option.followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n- **option.selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n- **option.buffer**: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on e.g. If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n  ```\n  'use strict';\n\n  const streamify = require('stream-array');\n  const HttpProxy = require('http-proxy');\n  const proxy = new HttpProxy();\n\n  module.exports = (req, res, next) => {\n\n    proxy.web(req, res, {\n      target: 'http://localhost:4003/',\n      buffer: streamify(req.rawBody)\n    }, next);\n\n  };\n  ```\n\n## Shorthand\n\nUse the shorthand syntax when verbose configuration is not needed. The `context` and `option.target` will be automatically configured when shorthand is used. Options can still be used if needed.\n\n```javascript\nproxy('http://www.example.org:8000/api');\n// proxy('/api', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api/books/*/**.json');\n// proxy('/api/books/*/**.json', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api', { changeOrigin: true });\n// proxy('/api', {target: 'http://www.example.org:8000', changeOrigin: true});\n```\n\n### app.use(path, proxy)\n\nIf you want to use the server's `app.use` `path` parameter to match requests;\nCreate and mount the proxy without the http-proxy-middleware `context` parameter:\n\n```javascript\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\n```\n\n`app.use` documentation:\n\n- express: http://expressjs.com/en/4x/api.html#app.use\n- connect: https://github.com/senchalabs/connect#mount-middleware\n\n## WebSocket\n\n```javascript\n// verbose api\nproxy('/', { target: 'http://echo.websocket.org', ws: true });\n\n// shorthand\nproxy('http://echo.websocket.org', { ws: true });\n\n// shorter shorthand\nproxy('ws://echo.websocket.org');\n```\n\n### External WebSocket upgrade\n\nIn the previous WebSocket examples, http-proxy-middleware relies on a initial http request in order to listen to the http `upgrade` event. If you need to proxy WebSockets without the initial http request, you can subscribe to the server's http `upgrade` event manually.\n\n```javascript\nvar wsProxy = proxy('ws://echo.websocket.org', { changeOrigin: true });\n\nvar app = express();\napp.use(wsProxy);\n\nvar server = app.listen(3000);\nserver.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'\n```\n\n## Working examples\n\nView and play around with [working examples](https://github.com/chimurai/http-proxy-middleware/tree/master/examples).\n\n- Browser-Sync ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/browser-sync/index.js))\n- express ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/express/index.js))\n- connect ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/connect/index.js))\n- WebSocket ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/websocket/index.js))\n\n## Recipes\n\nView the [recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes) for common use cases.\n\n## Compatible servers\n\n`http-proxy-middleware` is compatible with the following servers:\n\n- [connect](https://www.npmjs.com/package/connect)\n- [express](https://www.npmjs.com/package/express)\n- [browser-sync](https://www.npmjs.com/package/browser-sync)\n- [lite-server](https://www.npmjs.com/package/lite-server)\n- [grunt-contrib-connect](https://www.npmjs.com/package/grunt-contrib-connect)\n- [grunt-browser-sync](https://www.npmjs.com/package/grunt-browser-sync)\n- [gulp-connect](https://www.npmjs.com/package/gulp-connect)\n- [gulp-webserver](https://www.npmjs.com/package/gulp-webserver)\n\nSample implementations can be found in the [server recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes/servers.md).\n\n## Tests\n\nRun the test suite:\n\n```bash\n# install dependencies\n$ yarn\n\n# linting\n$ yarn lint\n$ yarn lint:fix\n\n# building (compile typescript to js)\n$ yarn build\n\n# unit tests\n$ yarn test\n\n# code coverage\n$ yarn cover\n```\n\n## Changelog\n\n- [View changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2015-2019 Steven Chim\n",
+      "readmeFilename": "README.md",
+      "gitHead": "a530c9e1c92b74445b4afb0af70c6b8a8136b238",
+      "_id": "http-proxy-middleware@0.20.0-beta.1",
+      "_nodeVersion": "12.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-vsJ6+FeSwW6epQMXEKowYHmBN+sLxJ58O03Qf8pTyjZM+8hPSpPPasKfALkD7zEgqKJTKMoDskZH6JCkKTeFjg==",
+        "shasum": "55e021c8240e44f9e7cf2d9ec3e18bba6ccc7553",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0-beta.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 50619,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc9B8CCRA9TVsSAnZWagAA55kP/R/PkcwvAL6okwH1wmMy\nE5nhU9ei3BGIy/Jvd8El8vF6y5qg2Xlx+J9wLdxST9Wb4qxkC/kJR6UjH+ni\nTU88pRl+mpiP2UQrakZ234FFsmFfwj8zyXyBq0aQr2V3FCvwMXG+rsGtEjUD\nGtTcfEPs44uFwDwvlFzQZWxlU8ot+ae2PEEg21fj52bLawnTeP4y6cI0g0Z/\n+lhm85lX/r4tqwj+elxQhCDt7GhHgrG0r0Mv7Gmrw96+GIH5Jino3xjjGoAi\nRwz8e8kX8Ugecy/jOp2GNI74AdREzCmEoYEZ7fqCQYi6TtGgLoOJjpA4jZWI\nYrywi6XLcKoiVcBJkvZ1M+A34NuXR3/SsGZj8J64NZ0U0XHG79BRhL1o0gKb\n5JHm5T2697L32jKwRiHipz6lSYcTSaS0PwBrkV1C3DJKIj1mj3QPCFvh6uwb\nVdV2QP34pgucp4tWBZrJXM2URfQ79+fv3CMDfui2mkhZ/hTw2U0mLeKzyCBC\n1b/jcJ3tLFmOEE4FHoWbxtRFngoyxJ4B36iNRFtQgqAmStZUa+0PLHOaXMve\nX3VoTwF2HPx0Y8uKL4KEHlg5oJLNd8pbgVVBSMeI5xJlhBapq0B9h5tjuCHs\nVQzG5tImxFX3fP+u8LLuLUcUrlIStiLqj8uMdh75Z9XzyCylf6wn0xgQOxdv\nTw/7\r\n=gP+D\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.20.0-beta.1_1559502592209_0.9266043472076857"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.20.0-beta.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.20.0-beta.2",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepublish": "yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "@types/express": "^4.16.1",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.11",
+        "@types/lodash": "^4.14.123",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.0.4",
+        "browser-sync": "^2.26.3",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.3",
+        "express": "^4.16.4",
+        "husky": "^2.3.0",
+        "jest": "^24.5.0",
+        "open": "^6.3.0",
+        "prettier": "^1.15.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.14.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.4.1",
+        "ws": "^7.0.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.11",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "readme": "# http-proxy-middleware\n\n[![Build Status](https://img.shields.io/travis/chimurai/http-proxy-middleware/master.svg?style=flat-square)](https://travis-ci.org/chimurai/http-proxy-middleware)\n[![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square)](https://coveralls.io/r/chimurai/http-proxy-middleware)\n[![dependency Status](https://img.shields.io/david/chimurai/http-proxy-middleware.svg?style=flat-square)](https://david-dm.org/chimurai/http-proxy-middleware#info=dependencies)\n[![dependency Status](https://snyk.io/test/npm/http-proxy-middleware/badge.svg?style=flat-square)](https://snyk.io/test/npm/http-proxy-middleware)\n[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)\n\nNode.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/strongloop/express), [browser-sync](https://github.com/BrowserSync/browser-sync) and [many more](#compatible-servers).\n\nPowered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)\n\n## TL;DR\n\nProxy `/api` requests to `http://www.example.org`\n\n```javascript\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\nvar app = express();\n\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n_All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#options) can be used, along with some extra `http-proxy-middleware` [options](#options).\n\n:bulb: **Tip:** Set the option `changeOrigin` to `true` for [name-based virtual hosted sites](http://en.wikipedia.org/wiki/Virtual_hosting#Name-based).\n\n## Table of Contents\n\n<!-- MarkdownTOC autolink=true bracket=round depth=2 -->\n\n- [Install](#install)\n- [Core concept](#core-concept)\n- [Example](#example)\n- [Context matching](#context-matching)\n- [Options](#options)\n  - [http-proxy-middleware options](#http-proxy-middleware-options)\n  - [http-proxy events](#http-proxy-events)\n  - [http-proxy options](#http-proxy-options)\n- [Shorthand](#shorthand)\n  - [app.use\\(path, proxy\\)](#appusepath-proxy)\n- [WebSocket](#websocket)\n  - [External WebSocket upgrade](#external-websocket-upgrade)\n- [Working examples](#working-examples)\n- [Recipes](#recipes)\n- [Compatible servers](#compatible-servers)\n- [Tests](#tests)\n- [Changelog](#changelog)\n- [License](#license)\n\n<!-- /MarkdownTOC -->\n\n## Install\n\n```javascript\n$ npm install --save-dev http-proxy-middleware\n```\n\n## Core concept\n\nProxy middleware configuration.\n\n#### proxy([context,] config)\n\n```javascript\nvar proxy = require('http-proxy-middleware');\n\nvar apiProxy = proxy('/api', { target: 'http://www.example.org' });\n//                   \\____/   \\_____________________________/\n//                     |                    |\n//                   context             options\n\n// 'apiProxy' is now ready to be used as middleware in a server.\n```\n\n- **context**: Determine which requests should be proxied to the target host.\n  (more on [context matching](#context-matching))\n- **options.target**: target host to proxy to. _(protocol + host)_\n\n(full list of [`http-proxy-middleware` configuration options](#options))\n\n#### proxy(uri [, config])\n\n```javascript\n// shorthand syntax for the example above:\nvar apiProxy = proxy('http://www.example.org/api');\n```\n\nMore about the [shorthand configuration](#shorthand).\n\n## Example\n\nAn example with `express` server.\n\n```javascript\n// include dependencies\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\n// proxy middleware options\nvar options = {\n  target: 'http://www.example.org', // target host\n  changeOrigin: true, // needed for virtual hosted sites\n  ws: true, // proxy websockets\n  pathRewrite: {\n    '^/api/old-path': '/api/new-path', // rewrite path\n    '^/api/remove/path': '/path' // remove base path\n  },\n  router: {\n    // when request.headers.host == 'dev.localhost:3000',\n    // override target 'http://www.example.org' to 'http://localhost:8000'\n    'dev.localhost:3000': 'http://localhost:8000'\n  }\n};\n\n// create the proxy (without context)\nvar exampleProxy = proxy(options);\n\n// mount `exampleProxy` in web server\nvar app = express();\napp.use('/api', exampleProxy);\napp.listen(3000);\n```\n\n## Context matching\n\nProviding an alternative way to decide which requests should be proxied; In case you are not able to use the server's [`path` parameter](http://expressjs.com/en/4x/api.html#app.use) to mount the proxy or when you need more flexibility.\n\n[RFC 3986 `path`](https://tools.ietf.org/html/rfc3986#section-3.3) is used for context matching.\n\n```\n         foo://example.com:8042/over/there?name=ferret#nose\n         \\_/   \\______________/\\_________/ \\_________/ \\__/\n          |           |            |            |        |\n       scheme     authority       path        query   fragment\n```\n\n- **path matching**\n\n  - `proxy({...})` - matches any path, all requests will be proxied.\n  - `proxy('/', {...})` - matches any path, all requests will be proxied.\n  - `proxy('/api', {...})` - matches paths starting with `/api`\n\n- **multiple path matching**\n\n  - `proxy(['/api', '/ajax', '/someotherpath'], {...})`\n\n- **wildcard path matching**\n\n  For fine-grained control you can use wildcard matching. Glob pattern matching is done by _micromatch_. Visit [micromatch](https://www.npmjs.com/package/micromatch) or [glob](https://www.npmjs.com/package/glob) for more globbing examples.\n\n  - `proxy('**', {...})` matches any path, all requests will be proxied.\n  - `proxy('**/*.html', {...})` matches any path which ends with `.html`\n  - `proxy('/*.html', {...})` matches paths directly under path-absolute\n  - `proxy('/api/**/*.html', {...})` matches requests ending with `.html` in the path of `/api`\n  - `proxy(['/api/**', '/ajax/**'], {...})` combine multiple patterns\n  - `proxy(['/api/**', '!**/bad.json'], {...})` exclusion\n\n  **Note**: In multiple path matching, you cannot use string paths and wildcard paths together.\n\n- **custom matching**\n\n  For full control you can provide a custom function to determine which requests should be proxied or not.\n\n  ```javascript\n  /**\n   * @return {Boolean}\n   */\n  var filter = function(pathname, req) {\n    return pathname.match('^/api') && req.method === 'GET';\n  };\n\n  var apiProxy = proxy(filter, { target: 'http://www.example.org' });\n  ```\n\n## Options\n\n### http-proxy-middleware options\n\n- **option.pathRewrite**: object/function, rewrite target's url path. Object-keys will be used as _RegExp_ to match paths.\n\n  ```javascript\n  // rewrite path\n  pathRewrite: {'^/old/api' : '/new/api'}\n\n  // remove path\n  pathRewrite: {'^/remove/api' : ''}\n\n  // add base path\n  pathRewrite: {'^/' : '/basepath/'}\n\n  // custom rewriting\n  pathRewrite: function (path, req) { return path.replace('/api', '/base/api') }\n  ```\n\n- **option.router**: object/function, re-target `option.target` for specific requests.\n\n  ```javascript\n  // Use `host` and/or `path` to match requests. First match will be used.\n  // The order of the configuration matters.\n  router: {\n      'integration.localhost:3000' : 'http://localhost:8001',  // host only\n      'staging.localhost:3000'     : 'http://localhost:8002',  // host only\n      'localhost:3000/api'         : 'http://localhost:8003',  // host + path\n      '/rest'                      : 'http://localhost:8004'   // path only\n  }\n\n  // Custom router function\n  router: function(req) {\n      return 'http://localhost:8004';\n  }\n  ```\n\n- **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`\n\n- **option.logProvider**: function, modify or replace log provider. Default: `console`.\n\n  ```javascript\n  // simple replace\n  function logProvider(provider) {\n    // replace the default console log provider.\n    return require('winston');\n  }\n  ```\n\n  ```javascript\n  // verbose replacement\n  function logProvider(provider) {\n    var logger = new (require('winston')).Logger();\n\n    var myCustomProvider = {\n      log: logger.log,\n      debug: logger.debug,\n      info: logger.info,\n      warn: logger.warn,\n      error: logger.error\n    };\n    return myCustomProvider;\n  }\n  ```\n\n### http-proxy events\n\nSubscribe to [http-proxy events](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events):\n\n- **option.onError**: function, subscribe to http-proxy's `error` event for custom error handling.\n\n  ```javascript\n  function onError(err, req, res) {\n    res.writeHead(500, {\n      'Content-Type': 'text/plain'\n    });\n    res.end(\n      'Something went wrong. And we are reporting a custom error message.'\n    );\n  }\n  ```\n\n- **option.onProxyRes**: function, subscribe to http-proxy's `proxyRes` event.\n\n  ```javascript\n  function onProxyRes(proxyRes, req, res) {\n    proxyRes.headers['x-added'] = 'foobar'; // add new header to response\n    delete proxyRes.headers['x-removed']; // remove header from response\n  }\n  ```\n\n- **option.onProxyReq**: function, subscribe to http-proxy's `proxyReq` event.\n\n  ```javascript\n  function onProxyReq(proxyReq, req, res) {\n    // add custom header to request\n    proxyReq.setHeader('x-added', 'foobar');\n    // or log the req\n  }\n  ```\n\n- **option.onProxyReqWs**: function, subscribe to http-proxy's `proxyReqWs` event.\n\n  ```javascript\n  function onProxyReqWs(proxyReq, req, socket, options, head) {\n    // add custom header\n    proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n  }\n  ```\n\n- **option.onOpen**: function, subscribe to http-proxy's `open` event.\n\n  ```javascript\n  function onOpen(proxySocket) {\n    // listen for messages coming FROM the target here\n    proxySocket.on('data', hybiParseAndLogMessage);\n  }\n  ```\n\n- **option.onClose**: function, subscribe to http-proxy's `close` event.\n  ```javascript\n  function onClose(res, socket, head) {\n    // view disconnected websocket connections\n    console.log('Client disconnected');\n  }\n  ```\n\n### http-proxy options\n\nThe following options are provided by the underlying [http-proxy](https://github.com/nodejitsu/node-http-proxy#options) library.\n\n- **option.target**: url string to be parsed with the url module\n- **option.forward**: url string to be parsed with the url module\n- **option.agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n- **option.ssl**: object to be passed to https.createServer()\n- **option.ws**: true/false: if you want to proxy websockets\n- **option.xfwd**: true/false, adds x-forward headers\n- **option.secure**: true/false, if you want to verify the SSL Certs\n- **option.toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n- **option.prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n- **option.ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n- **option.localAddress** : Local interface string to bind for outgoing connections\n- **option.changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n- **option.preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n- **option.auth** : Basic authentication i.e. 'user:password' to compute an Authorization header.\n- **option.hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.\n- **option.autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.\n- **option.protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.\n- **option.cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n  - Object: mapping of domains to new domains, use `\"*\"` to match all domains.  \n    For example keep one domain unchanged, rewrite one domain and remove other domains:\n    ```\n    cookieDomainRewrite: {\n      \"unchanged.domain\": \"unchanged.domain\",\n      \"old.domain\": \"new.domain\",\n      \"*\": \"\"\n    }\n    ```\n- **option.cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n  - Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n    For example, to keep one path unchanged, rewrite one path and remove other paths:\n    ```\n    cookiePathRewrite: {\n      \"/unchanged.path/\": \"/unchanged.path/\",\n      \"/old.path/\": \"/new.path/\",\n      \"*\": \"\"\n    }\n    ```\n- **option.headers**: object, adds [request headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields). (Example: `{host:'www.example.org'}`)\n- **option.proxyTimeout**: timeout (in millis) when proxy receives no response from target\n- **option.timeout**: timeout (in millis) for incoming requests\n- **option.followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n- **option.selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n- **option.buffer**: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on e.g. If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n  ```\n  'use strict';\n\n  const streamify = require('stream-array');\n  const HttpProxy = require('http-proxy');\n  const proxy = new HttpProxy();\n\n  module.exports = (req, res, next) => {\n\n    proxy.web(req, res, {\n      target: 'http://localhost:4003/',\n      buffer: streamify(req.rawBody)\n    }, next);\n\n  };\n  ```\n\n## Shorthand\n\nUse the shorthand syntax when verbose configuration is not needed. The `context` and `option.target` will be automatically configured when shorthand is used. Options can still be used if needed.\n\n```javascript\nproxy('http://www.example.org:8000/api');\n// proxy('/api', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api/books/*/**.json');\n// proxy('/api/books/*/**.json', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api', { changeOrigin: true });\n// proxy('/api', {target: 'http://www.example.org:8000', changeOrigin: true});\n```\n\n### app.use(path, proxy)\n\nIf you want to use the server's `app.use` `path` parameter to match requests;\nCreate and mount the proxy without the http-proxy-middleware `context` parameter:\n\n```javascript\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\n```\n\n`app.use` documentation:\n\n- express: http://expressjs.com/en/4x/api.html#app.use\n- connect: https://github.com/senchalabs/connect#mount-middleware\n\n## WebSocket\n\n```javascript\n// verbose api\nproxy('/', { target: 'http://echo.websocket.org', ws: true });\n\n// shorthand\nproxy('http://echo.websocket.org', { ws: true });\n\n// shorter shorthand\nproxy('ws://echo.websocket.org');\n```\n\n### External WebSocket upgrade\n\nIn the previous WebSocket examples, http-proxy-middleware relies on a initial http request in order to listen to the http `upgrade` event. If you need to proxy WebSockets without the initial http request, you can subscribe to the server's http `upgrade` event manually.\n\n```javascript\nvar wsProxy = proxy('ws://echo.websocket.org', { changeOrigin: true });\n\nvar app = express();\napp.use(wsProxy);\n\nvar server = app.listen(3000);\nserver.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'\n```\n\n## Working examples\n\nView and play around with [working examples](https://github.com/chimurai/http-proxy-middleware/tree/master/examples).\n\n- Browser-Sync ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/browser-sync/index.js))\n- express ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/express/index.js))\n- connect ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/connect/index.js))\n- WebSocket ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/websocket/index.js))\n\n## Recipes\n\nView the [recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes) for common use cases.\n\n## Compatible servers\n\n`http-proxy-middleware` is compatible with the following servers:\n\n- [connect](https://www.npmjs.com/package/connect)\n- [express](https://www.npmjs.com/package/express)\n- [browser-sync](https://www.npmjs.com/package/browser-sync)\n- [lite-server](https://www.npmjs.com/package/lite-server)\n- [grunt-contrib-connect](https://www.npmjs.com/package/grunt-contrib-connect)\n- [grunt-browser-sync](https://www.npmjs.com/package/grunt-browser-sync)\n- [gulp-connect](https://www.npmjs.com/package/gulp-connect)\n- [gulp-webserver](https://www.npmjs.com/package/gulp-webserver)\n\nSample implementations can be found in the [server recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes/servers.md).\n\n## Tests\n\nRun the test suite:\n\n```bash\n# install dependencies\n$ yarn\n\n# linting\n$ yarn lint\n$ yarn lint:fix\n\n# building (compile typescript to js)\n$ yarn build\n\n# unit tests\n$ yarn test\n\n# code coverage\n$ yarn cover\n```\n\n## Changelog\n\n- [View changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2015-2019 Steven Chim\n",
+      "readmeFilename": "README.md",
+      "gitHead": "bef1d49bfd14a95de3ed8f993cc62161700dc5ef",
+      "_id": "http-proxy-middleware@0.20.0-beta.2",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-OkO4poCBY2pt2Fn4iAte5Vy2vMsLjUzaHX69nxCPRZ8BMjvsv7LZcgyy0xI2fILBQL+D7B6WS+rUI9ugSJh9Ng==",
+        "shasum": "2e1f99591415ea388826f98c065a5fa173ee7d8a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0-beta.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 50947,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdJO3uCRA9TVsSAnZWagAAUfUQAJVf9KYsosvC1oPpHoOu\nqdFXoijnD2S+LD3N5cvYeFG/NvCHOlh+jMuCC2+HPi7Jj2RKM/GmnH6Hvwib\n0wf4yZBU6tKmV/a1KVwZJ8UvahJjgAVjYnK2ri3Gk+4HjrlCtWPpJOm6tmmG\nwzsHQX2T8ZtRUk+bgLlwD84+73xdaYIBDH/eVmxjWFmBiUxOMb/otA5UFxYv\ngIo6+PwyztPMVVkrLsLGJxCH/SdJOEngwPEKwb63DVZmu2urq109v4Yz2U3g\nJmfJg3hbKnvRRejQBm9nOq6IxtVtusTfaIGRwU0p6HFbG9uxjpMWfUGH9yzO\nqXXR05X/bv5xkbI/zLqj5rPnl78BJm4473cWuqpEOW9TFpowuXvEGehLTieK\nnmpBY5qweummrJVLZ1K+N/f12T/MJQv/rmikDEwbiagA17b26r/8J+hINqYn\n9WJXnJn3aDkbY06hlWsw2/cNm22z44nTlD9W00mC7+syavyZFci5bUGzdoPQ\n6LzsFQqGCQHBZ9tZmaVAXbIDnzMQ0zg+9k0EI9fuyGiLRw/3xupP5Js3om4O\nObIVP8JVLajSADARg6HYEcvtiOvs4nFDNktIT9Zr4ex1DFWVcPoIXJJfSnYn\npIMqfC75Qq/FuCDkOAZwbhejlpiN2fWZTEZIsul0e/zZ1y0jPMNr13xpoOpY\n/bbz\r\n=Vg0O\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.20.0-beta.2_1562701294180_0.5240101814223321"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.20.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.20.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.15",
+        "@types/lodash": "^4.14.136",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^24.5.0",
+        "open": "^6.4.0",
+        "prettier": "^1.18.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.18.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.5.3",
+        "ws": "^7.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.14",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "3b9730826187c708fbd16cb0baa588f6aad73a00",
+      "_id": "http-proxy-middleware@0.20.0",
+      "_nodeVersion": "12.8.1",
+      "_npmVersion": "6.10.2",
+      "dist": {
+        "integrity": "sha512-dNJAk71nEJhPiAczQH9hGvE/MT9kEs+zn2Dh+Hi94PGZe1GluQirC7mw5rdREUtWx6qGS1Gu0bZd4qEAg+REgw==",
+        "shasum": "5b128f7207985c4ea91b53fab8ad897a48c690d6",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 51251,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdbsVrCRA9TVsSAnZWagAAouMP/j7gzAb7qpsFw9cwrsJF\nikrihxJpdZHwDmcWeZmo2GsFidAbGfDV6AtL6XDAhSO+XVMb6ALr/tXjWwns\n1I/yrNPWqFEsIJlmKXRZf/cauCPlIWQrPJoGfOVrCo7XunCAxyCT3EmQwjEV\nb40JoPyRUX8UpbmicU2mM0KoKogv2mKhDy85gdLmrpgOMLuk1L3PHSR9xAOB\n69FsAyNuUqNNMfIbKkyQfxLkkAe9AZEgd+1dTf6Qk/GbTIUuMvLBwhoC641q\nFz1VEcABAecS4PkdntwwY1g+Q7nbEFIu8qgJG/o9GQFzod0HORGZhLQy/vOV\nWZCottDnxfGv1p7Nr4IfHjTWn80MYeZbs5VijG0BC539d7DWbobE/qwzUvEA\n4Iu+7WnlqUKwNAh6LEQ/f7OzYuWHp+N2tZPbqr6uJA4Btd0HbpMstVXIGMaK\nzDIsk06Z1JRTva2ws8fMA1rbAZG9YgGN5d8HXTMxf67dmccMZFbnkoP5BlSi\nrmGUYGgwVH1x3v5kzzrbXPZ+6bLB+2s1TOfybcJg6b6hIYkAHq3zX5YzX89w\nmb5MTwUKCevKL/rOzQQRwjm2E6tFI16fXJvXv6OARA+Se/HG5f12ayKppZTD\nQ2okbuuCAasl/K6J0jE35XETiQmfzTGE/lSHS4ihw6lWjW4irXcniRqys0Gg\nXS65\r\n=sGAt\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.20.0_1567540586415_0.9096750997515071"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.21.0-beta.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.21.0-beta.1",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.15",
+        "@types/lodash": "^4.14.136",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^24.5.0",
+        "open": "^6.4.0",
+        "prettier": "^1.18.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.18.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.5.3",
+        "ws": "^7.1.0"
+      },
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.14",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "readme": "# http-proxy-middleware\n\n[![Build Status](https://img.shields.io/travis/chimurai/http-proxy-middleware/master.svg?style=flat-square)](https://travis-ci.org/chimurai/http-proxy-middleware)\n[![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square)](https://coveralls.io/r/chimurai/http-proxy-middleware)\n[![dependency Status](https://img.shields.io/david/chimurai/http-proxy-middleware.svg?style=flat-square)](https://david-dm.org/chimurai/http-proxy-middleware#info=dependencies)\n[![dependency Status](https://snyk.io/test/npm/http-proxy-middleware/badge.svg?style=flat-square)](https://snyk.io/test/npm/http-proxy-middleware)\n[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)\n\nNode.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/strongloop/express), [browser-sync](https://github.com/BrowserSync/browser-sync) and [many more](#compatible-servers).\n\nPowered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)\n\n## TL;DR\n\nProxy `/api` requests to `http://www.example.org`\n\n```javascript\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\nvar app = express();\n\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n_All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#options) can be used, along with some extra `http-proxy-middleware` [options](#options).\n\n:bulb: **Tip:** Set the option `changeOrigin` to `true` for [name-based virtual hosted sites](http://en.wikipedia.org/wiki/Virtual_hosting#Name-based).\n\n## Table of Contents\n\n<!-- MarkdownTOC autolink=true bracket=round depth=2 -->\n\n- [Install](#install)\n- [Core concept](#core-concept)\n- [Example](#example)\n- [Context matching](#context-matching)\n- [Options](#options)\n  - [http-proxy-middleware options](#http-proxy-middleware-options)\n  - [http-proxy events](#http-proxy-events)\n  - [http-proxy options](#http-proxy-options)\n- [Shorthand](#shorthand)\n  - [app.use\\(path, proxy\\)](#appusepath-proxy)\n- [WebSocket](#websocket)\n  - [External WebSocket upgrade](#external-websocket-upgrade)\n- [Working examples](#working-examples)\n- [Recipes](#recipes)\n- [Compatible servers](#compatible-servers)\n- [Tests](#tests)\n- [Changelog](#changelog)\n- [License](#license)\n\n<!-- /MarkdownTOC -->\n\n## Install\n\n```javascript\n$ npm install --save-dev http-proxy-middleware\n```\n\n## Core concept\n\nProxy middleware configuration.\n\n#### proxy([context,] config)\n\n```javascript\nvar proxy = require('http-proxy-middleware');\n\nvar apiProxy = proxy('/api', { target: 'http://www.example.org' });\n//                   \\____/   \\_____________________________/\n//                     |                    |\n//                   context             options\n\n// 'apiProxy' is now ready to be used as middleware in a server.\n```\n\n- **context**: Determine which requests should be proxied to the target host.\n  (more on [context matching](#context-matching))\n- **options.target**: target host to proxy to. _(protocol + host)_\n\n(full list of [`http-proxy-middleware` configuration options](#options))\n\n#### proxy(uri [, config])\n\n```javascript\n// shorthand syntax for the example above:\nvar apiProxy = proxy('http://www.example.org/api');\n```\n\nMore about the [shorthand configuration](#shorthand).\n\n## Example\n\nAn example with `express` server.\n\n```javascript\n// include dependencies\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\n// proxy middleware options\nvar options = {\n  target: 'http://www.example.org', // target host\n  changeOrigin: true, // needed for virtual hosted sites\n  ws: true, // proxy websockets\n  pathRewrite: {\n    '^/api/old-path': '/api/new-path', // rewrite path\n    '^/api/remove/path': '/path' // remove base path\n  },\n  router: {\n    // when request.headers.host == 'dev.localhost:3000',\n    // override target 'http://www.example.org' to 'http://localhost:8000'\n    'dev.localhost:3000': 'http://localhost:8000'\n  }\n};\n\n// create the proxy (without context)\nvar exampleProxy = proxy(options);\n\n// mount `exampleProxy` in web server\nvar app = express();\napp.use('/api', exampleProxy);\napp.listen(3000);\n```\n\n## Context matching\n\nProviding an alternative way to decide which requests should be proxied; In case you are not able to use the server's [`path` parameter](http://expressjs.com/en/4x/api.html#app.use) to mount the proxy or when you need more flexibility.\n\n[RFC 3986 `path`](https://tools.ietf.org/html/rfc3986#section-3.3) is used for context matching.\n\n```\n         foo://example.com:8042/over/there?name=ferret#nose\n         \\_/   \\______________/\\_________/ \\_________/ \\__/\n          |           |            |            |        |\n       scheme     authority       path        query   fragment\n```\n\n- **path matching**\n\n  - `proxy({...})` - matches any path, all requests will be proxied.\n  - `proxy('/', {...})` - matches any path, all requests will be proxied.\n  - `proxy('/api', {...})` - matches paths starting with `/api`\n\n- **multiple path matching**\n\n  - `proxy(['/api', '/ajax', '/someotherpath'], {...})`\n\n- **wildcard path matching**\n\n  For fine-grained control you can use wildcard matching. Glob pattern matching is done by _micromatch_. Visit [micromatch](https://www.npmjs.com/package/micromatch) or [glob](https://www.npmjs.com/package/glob) for more globbing examples.\n\n  - `proxy('**', {...})` matches any path, all requests will be proxied.\n  - `proxy('**/*.html', {...})` matches any path which ends with `.html`\n  - `proxy('/*.html', {...})` matches paths directly under path-absolute\n  - `proxy('/api/**/*.html', {...})` matches requests ending with `.html` in the path of `/api`\n  - `proxy(['/api/**', '/ajax/**'], {...})` combine multiple patterns\n  - `proxy(['/api/**', '!**/bad.json'], {...})` exclusion\n\n  **Note**: In multiple path matching, you cannot use string paths and wildcard paths together.\n\n- **custom matching**\n\n  For full control you can provide a custom function to determine which requests should be proxied or not.\n\n  ```javascript\n  /**\n   * @return {Boolean}\n   */\n  var filter = function(pathname, req) {\n    return pathname.match('^/api') && req.method === 'GET';\n  };\n\n  var apiProxy = proxy(filter, { target: 'http://www.example.org' });\n  ```\n\n## Options\n\n### http-proxy-middleware options\n\n- **option.pathRewrite**: object/function, rewrite target's url path. Object-keys will be used as _RegExp_ to match paths.\n\n  ```javascript\n  // rewrite path\n  pathRewrite: {'^/old/api' : '/new/api'}\n\n  // remove path\n  pathRewrite: {'^/remove/api' : ''}\n\n  // add base path\n  pathRewrite: {'^/' : '/basepath/'}\n\n  // custom rewriting\n  pathRewrite: function (path, req) { return path.replace('/api', '/base/api') }\n  ```\n\n- **option.router**: object/function, re-target `option.target` for specific requests.\n\n  ```javascript\n  // Use `host` and/or `path` to match requests. First match will be used.\n  // The order of the configuration matters.\n  router: {\n      'integration.localhost:3000' : 'http://localhost:8001',  // host only\n      'staging.localhost:3000'     : 'http://localhost:8002',  // host only\n      'localhost:3000/api'         : 'http://localhost:8003',  // host + path\n      '/rest'                      : 'http://localhost:8004'   // path only\n  }\n\n  // Custom router function\n  router: function(req) {\n      return 'http://localhost:8004';\n  }\n\n  // Asynchronous router function which returns promise\n  router: async function(req) {\n      const url = await doSomeIO();\n      return url;\n  }\n  ```\n\n- **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`\n\n- **option.logProvider**: function, modify or replace log provider. Default: `console`.\n\n  ```javascript\n  // simple replace\n  function logProvider(provider) {\n    // replace the default console log provider.\n    return require('winston');\n  }\n  ```\n\n  ```javascript\n  // verbose replacement\n  function logProvider(provider) {\n    var logger = new (require('winston')).Logger();\n\n    var myCustomProvider = {\n      log: logger.log,\n      debug: logger.debug,\n      info: logger.info,\n      warn: logger.warn,\n      error: logger.error\n    };\n    return myCustomProvider;\n  }\n  ```\n\n### http-proxy events\n\nSubscribe to [http-proxy events](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events):\n\n- **option.onError**: function, subscribe to http-proxy's `error` event for custom error handling.\n\n  ```javascript\n  function onError(err, req, res) {\n    res.writeHead(500, {\n      'Content-Type': 'text/plain'\n    });\n    res.end(\n      'Something went wrong. And we are reporting a custom error message.'\n    );\n  }\n  ```\n\n- **option.onProxyRes**: function, subscribe to http-proxy's `proxyRes` event.\n\n  ```javascript\n  function onProxyRes(proxyRes, req, res) {\n    proxyRes.headers['x-added'] = 'foobar'; // add new header to response\n    delete proxyRes.headers['x-removed']; // remove header from response\n  }\n  ```\n\n- **option.onProxyReq**: function, subscribe to http-proxy's `proxyReq` event.\n\n  ```javascript\n  function onProxyReq(proxyReq, req, res) {\n    // add custom header to request\n    proxyReq.setHeader('x-added', 'foobar');\n    // or log the req\n  }\n  ```\n\n- **option.onProxyReqWs**: function, subscribe to http-proxy's `proxyReqWs` event.\n\n  ```javascript\n  function onProxyReqWs(proxyReq, req, socket, options, head) {\n    // add custom header\n    proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n  }\n  ```\n\n- **option.onOpen**: function, subscribe to http-proxy's `open` event.\n\n  ```javascript\n  function onOpen(proxySocket) {\n    // listen for messages coming FROM the target here\n    proxySocket.on('data', hybiParseAndLogMessage);\n  }\n  ```\n\n- **option.onClose**: function, subscribe to http-proxy's `close` event.\n  ```javascript\n  function onClose(res, socket, head) {\n    // view disconnected websocket connections\n    console.log('Client disconnected');\n  }\n  ```\n\n### http-proxy options\n\nThe following options are provided by the underlying [http-proxy](https://github.com/nodejitsu/node-http-proxy#options) library.\n\n- **option.target**: url string to be parsed with the url module\n- **option.forward**: url string to be parsed with the url module\n- **option.agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n- **option.ssl**: object to be passed to https.createServer()\n- **option.ws**: true/false: if you want to proxy websockets\n- **option.xfwd**: true/false, adds x-forward headers\n- **option.secure**: true/false, if you want to verify the SSL Certs\n- **option.toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n- **option.prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n- **option.ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n- **option.localAddress** : Local interface string to bind for outgoing connections\n- **option.changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n- **option.preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n- **option.auth** : Basic authentication i.e. 'user:password' to compute an Authorization header.\n- **option.hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.\n- **option.autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.\n- **option.protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.\n- **option.cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n  - Object: mapping of domains to new domains, use `\"*\"` to match all domains.  \n    For example keep one domain unchanged, rewrite one domain and remove other domains:\n    ```\n    cookieDomainRewrite: {\n      \"unchanged.domain\": \"unchanged.domain\",\n      \"old.domain\": \"new.domain\",\n      \"*\": \"\"\n    }\n    ```\n- **option.cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n  - Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n    For example, to keep one path unchanged, rewrite one path and remove other paths:\n    ```\n    cookiePathRewrite: {\n      \"/unchanged.path/\": \"/unchanged.path/\",\n      \"/old.path/\": \"/new.path/\",\n      \"*\": \"\"\n    }\n    ```\n- **option.headers**: object, adds [request headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields). (Example: `{host:'www.example.org'}`)\n- **option.proxyTimeout**: timeout (in millis) when proxy receives no response from target\n- **option.timeout**: timeout (in millis) for incoming requests\n- **option.followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n- **option.selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n- **option.buffer**: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on e.g. If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n  ```\n  'use strict';\n\n  const streamify = require('stream-array');\n  const HttpProxy = require('http-proxy');\n  const proxy = new HttpProxy();\n\n  module.exports = (req, res, next) => {\n\n    proxy.web(req, res, {\n      target: 'http://localhost:4003/',\n      buffer: streamify(req.rawBody)\n    }, next);\n\n  };\n  ```\n\n## Shorthand\n\nUse the shorthand syntax when verbose configuration is not needed. The `context` and `option.target` will be automatically configured when shorthand is used. Options can still be used if needed.\n\n```javascript\nproxy('http://www.example.org:8000/api');\n// proxy('/api', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api/books/*/**.json');\n// proxy('/api/books/*/**.json', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api', { changeOrigin: true });\n// proxy('/api', {target: 'http://www.example.org:8000', changeOrigin: true});\n```\n\n### app.use(path, proxy)\n\nIf you want to use the server's `app.use` `path` parameter to match requests;\nCreate and mount the proxy without the http-proxy-middleware `context` parameter:\n\n```javascript\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\n```\n\n`app.use` documentation:\n\n- express: http://expressjs.com/en/4x/api.html#app.use\n- connect: https://github.com/senchalabs/connect#mount-middleware\n\n## WebSocket\n\n```javascript\n// verbose api\nproxy('/', { target: 'http://echo.websocket.org', ws: true });\n\n// shorthand\nproxy('http://echo.websocket.org', { ws: true });\n\n// shorter shorthand\nproxy('ws://echo.websocket.org');\n```\n\n### External WebSocket upgrade\n\nIn the previous WebSocket examples, http-proxy-middleware relies on a initial http request in order to listen to the http `upgrade` event. If you need to proxy WebSockets without the initial http request, you can subscribe to the server's http `upgrade` event manually.\n\n```javascript\nvar wsProxy = proxy('ws://echo.websocket.org', { changeOrigin: true });\n\nvar app = express();\napp.use(wsProxy);\n\nvar server = app.listen(3000);\nserver.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'\n```\n\n## Working examples\n\nView and play around with [working examples](https://github.com/chimurai/http-proxy-middleware/tree/master/examples).\n\n- Browser-Sync ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/browser-sync/index.js))\n- express ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/express/index.js))\n- connect ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/connect/index.js))\n- WebSocket ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/websocket/index.js))\n\n## Recipes\n\nView the [recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes) for common use cases.\n\n## Compatible servers\n\n`http-proxy-middleware` is compatible with the following servers:\n\n- [connect](https://www.npmjs.com/package/connect)\n- [express](https://www.npmjs.com/package/express)\n- [browser-sync](https://www.npmjs.com/package/browser-sync)\n- [lite-server](https://www.npmjs.com/package/lite-server)\n- [grunt-contrib-connect](https://www.npmjs.com/package/grunt-contrib-connect)\n- [grunt-browser-sync](https://www.npmjs.com/package/grunt-browser-sync)\n- [gulp-connect](https://www.npmjs.com/package/gulp-connect)\n- [gulp-webserver](https://www.npmjs.com/package/gulp-webserver)\n\nSample implementations can be found in the [server recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes/servers.md).\n\n## Tests\n\nRun the test suite:\n\n```bash\n# install dependencies\n$ yarn\n\n# linting\n$ yarn lint\n$ yarn lint:fix\n\n# building (compile typescript to js)\n$ yarn build\n\n# unit tests\n$ yarn test\n\n# code coverage\n$ yarn cover\n```\n\n## Changelog\n\n- [View changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2015-2019 Steven Chim\n",
+      "readmeFilename": "README.md",
+      "gitHead": "7a738ea2251d1a156267959a202d19b49238f1a6",
+      "_id": "http-proxy-middleware@0.21.0-beta.1",
+      "_nodeVersion": "12.14.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-qiqFG3Ri+aTfQhpeAL1IHKSOdrHTBhiaQoJSKcD5FJwPdm5rxwq6qoVIITcGwHqz0iIZLe3YIkafwRO8FMwt6A==",
+        "shasum": "ddda0025b69f288475926dbe044b90f38278ce32",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.21.0-beta.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 52422,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeA/TqCRA9TVsSAnZWagAACOwP/RVXofcPWn7LTE140UKq\ny4N5PWgXu27qd7twIRWYDF1irH776Qa05DY7RnjbWK6R4+uFZ/Jf+l5ZGdkx\nBOlJVGAEa033Ic3o/BZZh3l3AwO1caR1J47rKRaE9qBWUo+0HD3BNFMbyvSH\n1knyE2af6Q+9HVic3k8ILaSZTbuvFffuR6A9kWgpjTkB22aGaA6ZvfVJCWZP\n/trm8cjUl+oCbF51eQdD38PE4Cmv/UraFDJu7zgeCgjMomH5bbrSN1vpsdvy\n+CD6k2a7j0lLPoXpOG5ehB7u6t07eBOixT0/qfJTntKdV2IOycEGXaSH35j6\n6UKvVJ47FRiV4zxLBiM2/XRhBUyaRzzie61uVDFs2gLV5aKVoS1vjWqzJ1Xl\n/BM9gb9+mWYtbST3/sIZHjzDVyHW0JXG/6KX/ufXm0yKbmqUFEpSIhq1lg24\nOkiHyx+Zmr0Rftj0NpM+2vIDa729+y2g/6DTvAh40cOtxJLSu5KawC0Z7p4L\nV0x/npTRKG49zmrcJz8JdHgTtWOxu3dIhgfCXxV4dqGTDT3dBqLofFbot+71\nwbvE5+lgJWYqAtwk+47HV4HlYm0SjAaHszU5gbdGsQveziKHvOd1wEfcVJ4t\n/aNXDfrbfwXn8OkYi+VlVRDaDhBzL0ZYufKzvhwQF3evGfEr8LfeIRTOJuKP\nhWn0\r\n=MUL+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.21.0-beta.1_1577317609788_0.42476028879033034"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.21.0-beta.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.21.0-beta.2",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.15",
+        "@types/lodash": "^4.14.136",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^24.5.0",
+        "open": "^6.4.0",
+        "prettier": "^1.18.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.18.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.5.3",
+        "ws": "^7.1.0"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.0",
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.14",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "readme": "# http-proxy-middleware\n\n[![Build Status](https://img.shields.io/travis/chimurai/http-proxy-middleware/master.svg?style=flat-square)](https://travis-ci.org/chimurai/http-proxy-middleware)\n[![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square)](https://coveralls.io/r/chimurai/http-proxy-middleware)\n[![dependency Status](https://img.shields.io/david/chimurai/http-proxy-middleware.svg?style=flat-square)](https://david-dm.org/chimurai/http-proxy-middleware#info=dependencies)\n[![dependency Status](https://snyk.io/test/npm/http-proxy-middleware/badge.svg?style=flat-square)](https://snyk.io/test/npm/http-proxy-middleware)\n[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)\n\nNode.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/strongloop/express), [browser-sync](https://github.com/BrowserSync/browser-sync) and [many more](#compatible-servers).\n\nPowered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)\n\n## TL;DR\n\nProxy `/api` requests to `http://www.example.org`\n\n```javascript\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\nvar app = express();\n\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n_All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#options) can be used, along with some extra `http-proxy-middleware` [options](#options).\n\n:bulb: **Tip:** Set the option `changeOrigin` to `true` for [name-based virtual hosted sites](http://en.wikipedia.org/wiki/Virtual_hosting#Name-based).\n\n## Table of Contents\n\n<!-- MarkdownTOC autolink=true bracket=round depth=2 -->\n\n- [Install](#install)\n- [Core concept](#core-concept)\n- [Example](#example)\n- [Context matching](#context-matching)\n- [Options](#options)\n  - [http-proxy-middleware options](#http-proxy-middleware-options)\n  - [http-proxy events](#http-proxy-events)\n  - [http-proxy options](#http-proxy-options)\n- [Shorthand](#shorthand)\n  - [app.use\\(path, proxy\\)](#appusepath-proxy)\n- [WebSocket](#websocket)\n  - [External WebSocket upgrade](#external-websocket-upgrade)\n- [Working examples](#working-examples)\n- [Recipes](#recipes)\n- [Compatible servers](#compatible-servers)\n- [Tests](#tests)\n- [Changelog](#changelog)\n- [License](#license)\n\n<!-- /MarkdownTOC -->\n\n## Install\n\n```javascript\n$ npm install --save-dev http-proxy-middleware\n```\n\n## Core concept\n\nProxy middleware configuration.\n\n#### proxy([context,] config)\n\n```javascript\nvar proxy = require('http-proxy-middleware');\n\nvar apiProxy = proxy('/api', { target: 'http://www.example.org' });\n//                   \\____/   \\_____________________________/\n//                     |                    |\n//                   context             options\n\n// 'apiProxy' is now ready to be used as middleware in a server.\n```\n\n- **context**: Determine which requests should be proxied to the target host.\n  (more on [context matching](#context-matching))\n- **options.target**: target host to proxy to. _(protocol + host)_\n\n(full list of [`http-proxy-middleware` configuration options](#options))\n\n#### proxy(uri [, config])\n\n```javascript\n// shorthand syntax for the example above:\nvar apiProxy = proxy('http://www.example.org/api');\n```\n\nMore about the [shorthand configuration](#shorthand).\n\n## Example\n\nAn example with `express` server.\n\n```javascript\n// include dependencies\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\n// proxy middleware options\nvar options = {\n  target: 'http://www.example.org', // target host\n  changeOrigin: true, // needed for virtual hosted sites\n  ws: true, // proxy websockets\n  pathRewrite: {\n    '^/api/old-path': '/api/new-path', // rewrite path\n    '^/api/remove/path': '/path' // remove base path\n  },\n  router: {\n    // when request.headers.host == 'dev.localhost:3000',\n    // override target 'http://www.example.org' to 'http://localhost:8000'\n    'dev.localhost:3000': 'http://localhost:8000'\n  }\n};\n\n// create the proxy (without context)\nvar exampleProxy = proxy(options);\n\n// mount `exampleProxy` in web server\nvar app = express();\napp.use('/api', exampleProxy);\napp.listen(3000);\n```\n\n## Context matching\n\nProviding an alternative way to decide which requests should be proxied; In case you are not able to use the server's [`path` parameter](http://expressjs.com/en/4x/api.html#app.use) to mount the proxy or when you need more flexibility.\n\n[RFC 3986 `path`](https://tools.ietf.org/html/rfc3986#section-3.3) is used for context matching.\n\n```\n         foo://example.com:8042/over/there?name=ferret#nose\n         \\_/   \\______________/\\_________/ \\_________/ \\__/\n          |           |            |            |        |\n       scheme     authority       path        query   fragment\n```\n\n- **path matching**\n\n  - `proxy({...})` - matches any path, all requests will be proxied.\n  - `proxy('/', {...})` - matches any path, all requests will be proxied.\n  - `proxy('/api', {...})` - matches paths starting with `/api`\n\n- **multiple path matching**\n\n  - `proxy(['/api', '/ajax', '/someotherpath'], {...})`\n\n- **wildcard path matching**\n\n  For fine-grained control you can use wildcard matching. Glob pattern matching is done by _micromatch_. Visit [micromatch](https://www.npmjs.com/package/micromatch) or [glob](https://www.npmjs.com/package/glob) for more globbing examples.\n\n  - `proxy('**', {...})` matches any path, all requests will be proxied.\n  - `proxy('**/*.html', {...})` matches any path which ends with `.html`\n  - `proxy('/*.html', {...})` matches paths directly under path-absolute\n  - `proxy('/api/**/*.html', {...})` matches requests ending with `.html` in the path of `/api`\n  - `proxy(['/api/**', '/ajax/**'], {...})` combine multiple patterns\n  - `proxy(['/api/**', '!**/bad.json'], {...})` exclusion\n\n  **Note**: In multiple path matching, you cannot use string paths and wildcard paths together.\n\n- **custom matching**\n\n  For full control you can provide a custom function to determine which requests should be proxied or not.\n\n  ```javascript\n  /**\n   * @return {Boolean}\n   */\n  var filter = function(pathname, req) {\n    return pathname.match('^/api') && req.method === 'GET';\n  };\n\n  var apiProxy = proxy(filter, { target: 'http://www.example.org' });\n  ```\n\n## Options\n\n### http-proxy-middleware options\n\n- **option.pathRewrite**: object/function, rewrite target's url path. Object-keys will be used as _RegExp_ to match paths.\n\n  ```javascript\n  // rewrite path\n  pathRewrite: {'^/old/api' : '/new/api'}\n\n  // remove path\n  pathRewrite: {'^/remove/api' : ''}\n\n  // add base path\n  pathRewrite: {'^/' : '/basepath/'}\n\n  // custom rewriting\n  pathRewrite: function (path, req) { return path.replace('/api', '/base/api') }\n  ```\n\n- **option.router**: object/function, re-target `option.target` for specific requests.\n\n  ```javascript\n  // Use `host` and/or `path` to match requests. First match will be used.\n  // The order of the configuration matters.\n  router: {\n      'integration.localhost:3000' : 'http://localhost:8001',  // host only\n      'staging.localhost:3000'     : 'http://localhost:8002',  // host only\n      'localhost:3000/api'         : 'http://localhost:8003',  // host + path\n      '/rest'                      : 'http://localhost:8004'   // path only\n  }\n\n  // Custom router function\n  router: function(req) {\n      return 'http://localhost:8004';\n  }\n\n  // Asynchronous router function which returns promise\n  router: async function(req) {\n      const url = await doSomeIO();\n      return url;\n  }\n  ```\n\n- **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`\n\n- **option.logProvider**: function, modify or replace log provider. Default: `console`.\n\n  ```javascript\n  // simple replace\n  function logProvider(provider) {\n    // replace the default console log provider.\n    return require('winston');\n  }\n  ```\n\n  ```javascript\n  // verbose replacement\n  function logProvider(provider) {\n    var logger = new (require('winston')).Logger();\n\n    var myCustomProvider = {\n      log: logger.log,\n      debug: logger.debug,\n      info: logger.info,\n      warn: logger.warn,\n      error: logger.error\n    };\n    return myCustomProvider;\n  }\n  ```\n\n### http-proxy events\n\nSubscribe to [http-proxy events](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events):\n\n- **option.onError**: function, subscribe to http-proxy's `error` event for custom error handling.\n\n  ```javascript\n  function onError(err, req, res) {\n    res.writeHead(500, {\n      'Content-Type': 'text/plain'\n    });\n    res.end(\n      'Something went wrong. And we are reporting a custom error message.'\n    );\n  }\n  ```\n\n- **option.onProxyRes**: function, subscribe to http-proxy's `proxyRes` event.\n\n  ```javascript\n  function onProxyRes(proxyRes, req, res) {\n    proxyRes.headers['x-added'] = 'foobar'; // add new header to response\n    delete proxyRes.headers['x-removed']; // remove header from response\n  }\n  ```\n\n- **option.onProxyReq**: function, subscribe to http-proxy's `proxyReq` event.\n\n  ```javascript\n  function onProxyReq(proxyReq, req, res) {\n    // add custom header to request\n    proxyReq.setHeader('x-added', 'foobar');\n    // or log the req\n  }\n  ```\n\n- **option.onProxyReqWs**: function, subscribe to http-proxy's `proxyReqWs` event.\n\n  ```javascript\n  function onProxyReqWs(proxyReq, req, socket, options, head) {\n    // add custom header\n    proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n  }\n  ```\n\n- **option.onOpen**: function, subscribe to http-proxy's `open` event.\n\n  ```javascript\n  function onOpen(proxySocket) {\n    // listen for messages coming FROM the target here\n    proxySocket.on('data', hybiParseAndLogMessage);\n  }\n  ```\n\n- **option.onClose**: function, subscribe to http-proxy's `close` event.\n  ```javascript\n  function onClose(res, socket, head) {\n    // view disconnected websocket connections\n    console.log('Client disconnected');\n  }\n  ```\n\n### http-proxy options\n\nThe following options are provided by the underlying [http-proxy](https://github.com/nodejitsu/node-http-proxy#options) library.\n\n- **option.target**: url string to be parsed with the url module\n- **option.forward**: url string to be parsed with the url module\n- **option.agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n- **option.ssl**: object to be passed to https.createServer()\n- **option.ws**: true/false: if you want to proxy websockets\n- **option.xfwd**: true/false, adds x-forward headers\n- **option.secure**: true/false, if you want to verify the SSL Certs\n- **option.toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n- **option.prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n- **option.ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n- **option.localAddress** : Local interface string to bind for outgoing connections\n- **option.changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n- **option.preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n- **option.auth** : Basic authentication i.e. 'user:password' to compute an Authorization header.\n- **option.hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.\n- **option.autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.\n- **option.protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.\n- **option.cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n  - Object: mapping of domains to new domains, use `\"*\"` to match all domains.  \n    For example keep one domain unchanged, rewrite one domain and remove other domains:\n    ```\n    cookieDomainRewrite: {\n      \"unchanged.domain\": \"unchanged.domain\",\n      \"old.domain\": \"new.domain\",\n      \"*\": \"\"\n    }\n    ```\n- **option.cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n  - Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n    For example, to keep one path unchanged, rewrite one path and remove other paths:\n    ```\n    cookiePathRewrite: {\n      \"/unchanged.path/\": \"/unchanged.path/\",\n      \"/old.path/\": \"/new.path/\",\n      \"*\": \"\"\n    }\n    ```\n- **option.headers**: object, adds [request headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields). (Example: `{host:'www.example.org'}`)\n- **option.proxyTimeout**: timeout (in millis) when proxy receives no response from target\n- **option.timeout**: timeout (in millis) for incoming requests\n- **option.followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n- **option.selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n- **option.buffer**: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on e.g. If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n  ```\n  'use strict';\n\n  const streamify = require('stream-array');\n  const HttpProxy = require('http-proxy');\n  const proxy = new HttpProxy();\n\n  module.exports = (req, res, next) => {\n\n    proxy.web(req, res, {\n      target: 'http://localhost:4003/',\n      buffer: streamify(req.rawBody)\n    }, next);\n\n  };\n  ```\n\n## Shorthand\n\nUse the shorthand syntax when verbose configuration is not needed. The `context` and `option.target` will be automatically configured when shorthand is used. Options can still be used if needed.\n\n```javascript\nproxy('http://www.example.org:8000/api');\n// proxy('/api', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api/books/*/**.json');\n// proxy('/api/books/*/**.json', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api', { changeOrigin: true });\n// proxy('/api', {target: 'http://www.example.org:8000', changeOrigin: true});\n```\n\n### app.use(path, proxy)\n\nIf you want to use the server's `app.use` `path` parameter to match requests;\nCreate and mount the proxy without the http-proxy-middleware `context` parameter:\n\n```javascript\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\n```\n\n`app.use` documentation:\n\n- express: http://expressjs.com/en/4x/api.html#app.use\n- connect: https://github.com/senchalabs/connect#mount-middleware\n\n## WebSocket\n\n```javascript\n// verbose api\nproxy('/', { target: 'http://echo.websocket.org', ws: true });\n\n// shorthand\nproxy('http://echo.websocket.org', { ws: true });\n\n// shorter shorthand\nproxy('ws://echo.websocket.org');\n```\n\n### External WebSocket upgrade\n\nIn the previous WebSocket examples, http-proxy-middleware relies on a initial http request in order to listen to the http `upgrade` event. If you need to proxy WebSockets without the initial http request, you can subscribe to the server's http `upgrade` event manually.\n\n```javascript\nvar wsProxy = proxy('ws://echo.websocket.org', { changeOrigin: true });\n\nvar app = express();\napp.use(wsProxy);\n\nvar server = app.listen(3000);\nserver.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'\n```\n\n## Working examples\n\nView and play around with [working examples](https://github.com/chimurai/http-proxy-middleware/tree/master/examples).\n\n- Browser-Sync ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/browser-sync/index.js))\n- express ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/express/index.js))\n- connect ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/connect/index.js))\n- WebSocket ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/websocket/index.js))\n\n## Recipes\n\nView the [recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes) for common use cases.\n\n## Compatible servers\n\n`http-proxy-middleware` is compatible with the following servers:\n\n- [connect](https://www.npmjs.com/package/connect)\n- [express](https://www.npmjs.com/package/express)\n- [browser-sync](https://www.npmjs.com/package/browser-sync)\n- [lite-server](https://www.npmjs.com/package/lite-server)\n- [grunt-contrib-connect](https://www.npmjs.com/package/grunt-contrib-connect)\n- [grunt-browser-sync](https://www.npmjs.com/package/grunt-browser-sync)\n- [gulp-connect](https://www.npmjs.com/package/gulp-connect)\n- [gulp-webserver](https://www.npmjs.com/package/gulp-webserver)\n\nSample implementations can be found in the [server recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes/servers.md).\n\n## Tests\n\nRun the test suite:\n\n```bash\n# install dependencies\n$ yarn\n\n# linting\n$ yarn lint\n$ yarn lint:fix\n\n# building (compile typescript to js)\n$ yarn build\n\n# unit tests\n$ yarn test\n\n# code coverage\n$ yarn cover\n```\n\n## Changelog\n\n- [View changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2015-2019 Steven Chim\n",
+      "readmeFilename": "README.md",
+      "gitHead": "b2f5f69b8fd835b79bd514004b807444185107fc",
+      "_id": "http-proxy-middleware@0.21.0-beta.2",
+      "_nodeVersion": "12.14.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-Cvemlr1M237MEgXpL+Tti9w6aUV5emMBkAXW3JaECIBeW+voER6A5Zjs5OzgAHcoeT7rz7aiVmCC3gFpo/r3Ag==",
+        "shasum": "ff38e92a3b666c5cd019bb5019884aaf350200fe",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.21.0-beta.2.tgz",
+        "fileCount": 24,
+        "unpackedSize": 59320,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeEhc/CRA9TVsSAnZWagAAy1kP/31RqHzQY2vZacutkcqf\nWndTw3VOvCouEwws4/a9ONBAdcbQ1Sp4UvGwtsiuYbaXU+FnryZWpkQg26Hh\nrUNrwd7aY3s1kiEVD7l6DlexQonm+JbiuOdjksy3okej770MOuWW31xhBFpq\ngyyE4aLZXdzZ0OO5NeUErMfK4Ghm6FQK78oaQoBM9Ef6lst8qs3fVhsbq+MP\nswArYa19g5Exsw97wkZMx043tlrAxkrMWhTa1WAzQIlUEk4CgfNS4ScRjcCq\ns66HbkC5oDBGFhKDPaHx7gdZjNQeGHV1pU2EKurWWvvmeL2J6+eGI14fLwNO\n54Wtn9lcy9WlUSggT4U305LNkrQgBiEVSld2viuelIWHuMPHUtQA5WMNLozO\npyIUJ7pfEF9n5Q8Jq1erps0Sm6yGeCfInFQ5ULDwpAWVn7TGPvrG2h0nAiMM\nFdeRr7KS5YflJhWIgeszpEvTHVgo1xCcWDiVP6jrrnGI4HL/WQHiBmkCHeMo\nCbZPr33dCC3Z10AX8YLtA4n04eQbqW07EEdOwEGMyKM6BIx4onb7qQpA5Q4Z\nB5FgRd78iy6h1ZPPxIsmp6zYaX0u6cwkrCR4vvKVob3u7zKuZMnS32tt97YY\nC4lRGb/SU9oLnzyU6DIRxCXBAgaPftOUAHG7EWZotYtTGlC+9GfCf2u3ySbO\ndOfR\r\n=eGx2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.21.0-beta.2_1578243903123_0.7557270896855537"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.21.0-beta.3": {
+      "name": "http-proxy-middleware",
+      "version": "0.21.0-beta.3",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^25.1.2",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^25.1.0",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.7.5",
+        "ws": "^7.1.0"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "readme": "# http-proxy-middleware\n\n[![Build Status](https://img.shields.io/travis/chimurai/http-proxy-middleware/master.svg?style=flat-square)](https://travis-ci.org/chimurai/http-proxy-middleware)\n[![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square)](https://coveralls.io/r/chimurai/http-proxy-middleware)\n[![dependency Status](https://img.shields.io/david/chimurai/http-proxy-middleware.svg?style=flat-square)](https://david-dm.org/chimurai/http-proxy-middleware#info=dependencies)\n[![dependency Status](https://snyk.io/test/npm/http-proxy-middleware/badge.svg?style=flat-square)](https://snyk.io/test/npm/http-proxy-middleware)\n[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)\n\nNode.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/strongloop/express), [browser-sync](https://github.com/BrowserSync/browser-sync) and [many more](#compatible-servers).\n\nPowered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)\n\n## TL;DR\n\nProxy `/api` requests to `http://www.example.org`\n\n```javascript\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\nvar app = express();\n\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n_All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#options) can be used, along with some extra `http-proxy-middleware` [options](#options).\n\n:bulb: **Tip:** Set the option `changeOrigin` to `true` for [name-based virtual hosted sites](http://en.wikipedia.org/wiki/Virtual_hosting#Name-based).\n\n## Table of Contents\n\n<!-- MarkdownTOC autolink=true bracket=round depth=2 -->\n\n- [Install](#install)\n- [Core concept](#core-concept)\n- [Example](#example)\n- [Context matching](#context-matching)\n- [Options](#options)\n  - [http-proxy-middleware options](#http-proxy-middleware-options)\n  - [http-proxy events](#http-proxy-events)\n  - [http-proxy options](#http-proxy-options)\n- [Shorthand](#shorthand)\n  - [app.use\\(path, proxy\\)](#appusepath-proxy)\n- [WebSocket](#websocket)\n  - [External WebSocket upgrade](#external-websocket-upgrade)\n- [Working examples](#working-examples)\n- [Recipes](#recipes)\n- [Compatible servers](#compatible-servers)\n- [Tests](#tests)\n- [Changelog](#changelog)\n- [License](#license)\n\n<!-- /MarkdownTOC -->\n\n## Install\n\n```javascript\n$ npm install --save-dev http-proxy-middleware\n```\n\n## Core concept\n\nProxy middleware configuration.\n\n#### proxy([context,] config)\n\n```javascript\nvar proxy = require('http-proxy-middleware');\n\nvar apiProxy = proxy('/api', { target: 'http://www.example.org' });\n//                   \\____/   \\_____________________________/\n//                     |                    |\n//                   context             options\n\n// 'apiProxy' is now ready to be used as middleware in a server.\n```\n\n- **context**: Determine which requests should be proxied to the target host.\n  (more on [context matching](#context-matching))\n- **options.target**: target host to proxy to. _(protocol + host)_\n\n(full list of [`http-proxy-middleware` configuration options](#options))\n\n#### proxy(uri [, config])\n\n```javascript\n// shorthand syntax for the example above:\nvar apiProxy = proxy('http://www.example.org/api');\n```\n\nMore about the [shorthand configuration](#shorthand).\n\n## Example\n\nAn example with `express` server.\n\n```javascript\n// include dependencies\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\n// proxy middleware options\nvar options = {\n  target: 'http://www.example.org', // target host\n  changeOrigin: true, // needed for virtual hosted sites\n  ws: true, // proxy websockets\n  pathRewrite: {\n    '^/api/old-path': '/api/new-path', // rewrite path\n    '^/api/remove/path': '/path' // remove base path\n  },\n  router: {\n    // when request.headers.host == 'dev.localhost:3000',\n    // override target 'http://www.example.org' to 'http://localhost:8000'\n    'dev.localhost:3000': 'http://localhost:8000'\n  }\n};\n\n// create the proxy (without context)\nvar exampleProxy = proxy(options);\n\n// mount `exampleProxy` in web server\nvar app = express();\napp.use('/api', exampleProxy);\napp.listen(3000);\n```\n\n## Context matching\n\nProviding an alternative way to decide which requests should be proxied; In case you are not able to use the server's [`path` parameter](http://expressjs.com/en/4x/api.html#app.use) to mount the proxy or when you need more flexibility.\n\n[RFC 3986 `path`](https://tools.ietf.org/html/rfc3986#section-3.3) is used for context matching.\n\n```\n         foo://example.com:8042/over/there?name=ferret#nose\n         \\_/   \\______________/\\_________/ \\_________/ \\__/\n          |           |            |            |        |\n       scheme     authority       path        query   fragment\n```\n\n- **path matching**\n\n  - `proxy({...})` - matches any path, all requests will be proxied.\n  - `proxy('/', {...})` - matches any path, all requests will be proxied.\n  - `proxy('/api', {...})` - matches paths starting with `/api`\n\n- **multiple path matching**\n\n  - `proxy(['/api', '/ajax', '/someotherpath'], {...})`\n\n- **wildcard path matching**\n\n  For fine-grained control you can use wildcard matching. Glob pattern matching is done by _micromatch_. Visit [micromatch](https://www.npmjs.com/package/micromatch) or [glob](https://www.npmjs.com/package/glob) for more globbing examples.\n\n  - `proxy('**', {...})` matches any path, all requests will be proxied.\n  - `proxy('**/*.html', {...})` matches any path which ends with `.html`\n  - `proxy('/*.html', {...})` matches paths directly under path-absolute\n  - `proxy('/api/**/*.html', {...})` matches requests ending with `.html` in the path of `/api`\n  - `proxy(['/api/**', '/ajax/**'], {...})` combine multiple patterns\n  - `proxy(['/api/**', '!**/bad.json'], {...})` exclusion\n\n  **Note**: In multiple path matching, you cannot use string paths and wildcard paths together.\n\n- **custom matching**\n\n  For full control you can provide a custom function to determine which requests should be proxied or not.\n\n  ```javascript\n  /**\n   * @return {Boolean}\n   */\n  var filter = function(pathname, req) {\n    return pathname.match('^/api') && req.method === 'GET';\n  };\n\n  var apiProxy = proxy(filter, { target: 'http://www.example.org' });\n  ```\n\n## Options\n\n### http-proxy-middleware options\n\n- **option.pathRewrite**: object/function, rewrite target's url path. Object-keys will be used as _RegExp_ to match paths.\n\n  ```javascript\n  // rewrite path\n  pathRewrite: {'^/old/api' : '/new/api'}\n\n  // remove path\n  pathRewrite: {'^/remove/api' : ''}\n\n  // add base path\n  pathRewrite: {'^/' : '/basepath/'}\n\n  // custom rewriting\n  pathRewrite: function (path, req) { return path.replace('/api', '/base/api') }\n\n  // custom rewriting, returning Promise\n  pathRewrite: async function (path, req) {\n    var should_add_something = await httpRequestToDecideSomething(path);\n    if (should_add_something) path += \"something\";\n    return path;\n  }\n\n  ```\n\n- **option.router**: object/function, re-target `option.target` for specific requests.\n\n  ```javascript\n  // Use `host` and/or `path` to match requests. First match will be used.\n  // The order of the configuration matters.\n  router: {\n      'integration.localhost:3000' : 'http://localhost:8001',  // host only\n      'staging.localhost:3000'     : 'http://localhost:8002',  // host only\n      'localhost:3000/api'         : 'http://localhost:8003',  // host + path\n      '/rest'                      : 'http://localhost:8004'   // path only\n  }\n\n  // Custom router function\n  router: function(req) {\n      return 'http://localhost:8004';\n  }\n\n  // Asynchronous router function which returns promise\n  router: async function(req) {\n      const url = await doSomeIO();\n      return url;\n  }\n  ```\n\n- **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`\n\n- **option.logProvider**: function, modify or replace log provider. Default: `console`.\n\n  ```javascript\n  // simple replace\n  function logProvider(provider) {\n    // replace the default console log provider.\n    return require('winston');\n  }\n  ```\n\n  ```javascript\n  // verbose replacement\n  function logProvider(provider) {\n    var logger = new (require('winston').Logger)();\n\n    var myCustomProvider = {\n      log: logger.log,\n      debug: logger.debug,\n      info: logger.info,\n      warn: logger.warn,\n      error: logger.error\n    };\n    return myCustomProvider;\n  }\n  ```\n\n### http-proxy events\n\nSubscribe to [http-proxy events](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events):\n\n- **option.onError**: function, subscribe to http-proxy's `error` event for custom error handling.\n\n  ```javascript\n  function onError(err, req, res) {\n    res.writeHead(500, {\n      'Content-Type': 'text/plain'\n    });\n    res.end(\n      'Something went wrong. And we are reporting a custom error message.'\n    );\n  }\n  ```\n\n- **option.onProxyRes**: function, subscribe to http-proxy's `proxyRes` event.\n\n  ```javascript\n  function onProxyRes(proxyRes, req, res) {\n    proxyRes.headers['x-added'] = 'foobar'; // add new header to response\n    delete proxyRes.headers['x-removed']; // remove header from response\n  }\n  ```\n\n- **option.onProxyReq**: function, subscribe to http-proxy's `proxyReq` event.\n\n  ```javascript\n  function onProxyReq(proxyReq, req, res) {\n    // add custom header to request\n    proxyReq.setHeader('x-added', 'foobar');\n    // or log the req\n  }\n  ```\n\n- **option.onProxyReqWs**: function, subscribe to http-proxy's `proxyReqWs` event.\n\n  ```javascript\n  function onProxyReqWs(proxyReq, req, socket, options, head) {\n    // add custom header\n    proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n  }\n  ```\n\n- **option.onOpen**: function, subscribe to http-proxy's `open` event.\n\n  ```javascript\n  function onOpen(proxySocket) {\n    // listen for messages coming FROM the target here\n    proxySocket.on('data', hybiParseAndLogMessage);\n  }\n  ```\n\n- **option.onClose**: function, subscribe to http-proxy's `close` event.\n  ```javascript\n  function onClose(res, socket, head) {\n    // view disconnected websocket connections\n    console.log('Client disconnected');\n  }\n  ```\n\n### http-proxy options\n\nThe following options are provided by the underlying [http-proxy](https://github.com/nodejitsu/node-http-proxy#options) library.\n\n- **option.target**: url string to be parsed with the url module\n- **option.forward**: url string to be parsed with the url module\n- **option.agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n- **option.ssl**: object to be passed to https.createServer()\n- **option.ws**: true/false: if you want to proxy websockets\n- **option.xfwd**: true/false, adds x-forward headers\n- **option.secure**: true/false, if you want to verify the SSL Certs\n- **option.toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n- **option.prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n- **option.ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n- **option.localAddress** : Local interface string to bind for outgoing connections\n- **option.changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n- **option.preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n- **option.auth** : Basic authentication i.e. 'user:password' to compute an Authorization header.\n- **option.hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.\n- **option.autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.\n- **option.protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.\n- **option.cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n  - Object: mapping of domains to new domains, use `\"*\"` to match all domains.  \n    For example keep one domain unchanged, rewrite one domain and remove other domains:\n    ```\n    cookieDomainRewrite: {\n      \"unchanged.domain\": \"unchanged.domain\",\n      \"old.domain\": \"new.domain\",\n      \"*\": \"\"\n    }\n    ```\n- **option.cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n  - Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n    For example, to keep one path unchanged, rewrite one path and remove other paths:\n    ```\n    cookiePathRewrite: {\n      \"/unchanged.path/\": \"/unchanged.path/\",\n      \"/old.path/\": \"/new.path/\",\n      \"*\": \"\"\n    }\n    ```\n- **option.headers**: object, adds [request headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields). (Example: `{host:'www.example.org'}`)\n- **option.proxyTimeout**: timeout (in millis) when proxy receives no response from target\n- **option.timeout**: timeout (in millis) for incoming requests\n- **option.followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n- **option.selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n- **option.buffer**: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on e.g. If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n  ```\n  'use strict';\n\n  const streamify = require('stream-array');\n  const HttpProxy = require('http-proxy');\n  const proxy = new HttpProxy();\n\n  module.exports = (req, res, next) => {\n\n    proxy.web(req, res, {\n      target: 'http://localhost:4003/',\n      buffer: streamify(req.rawBody)\n    }, next);\n\n  };\n  ```\n\n## Shorthand\n\nUse the shorthand syntax when verbose configuration is not needed. The `context` and `option.target` will be automatically configured when shorthand is used. Options can still be used if needed.\n\n```javascript\nproxy('http://www.example.org:8000/api');\n// proxy('/api', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api/books/*/**.json');\n// proxy('/api/books/*/**.json', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api', { changeOrigin: true });\n// proxy('/api', {target: 'http://www.example.org:8000', changeOrigin: true});\n```\n\n### app.use(path, proxy)\n\nIf you want to use the server's `app.use` `path` parameter to match requests;\nCreate and mount the proxy without the http-proxy-middleware `context` parameter:\n\n```javascript\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\n```\n\n`app.use` documentation:\n\n- express: http://expressjs.com/en/4x/api.html#app.use\n- connect: https://github.com/senchalabs/connect#mount-middleware\n\n## WebSocket\n\n```javascript\n// verbose api\nproxy('/', { target: 'http://echo.websocket.org', ws: true });\n\n// shorthand\nproxy('http://echo.websocket.org', { ws: true });\n\n// shorter shorthand\nproxy('ws://echo.websocket.org');\n```\n\n### External WebSocket upgrade\n\nIn the previous WebSocket examples, http-proxy-middleware relies on a initial http request in order to listen to the http `upgrade` event. If you need to proxy WebSockets without the initial http request, you can subscribe to the server's http `upgrade` event manually.\n\n```javascript\nvar wsProxy = proxy('ws://echo.websocket.org', { changeOrigin: true });\n\nvar app = express();\napp.use(wsProxy);\n\nvar server = app.listen(3000);\nserver.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'\n```\n\n## Working examples\n\nView and play around with [working examples](https://github.com/chimurai/http-proxy-middleware/tree/master/examples).\n\n- Browser-Sync ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/browser-sync/index.js))\n- express ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/express/index.js))\n- connect ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/connect/index.js))\n- WebSocket ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/websocket/index.js))\n\n## Recipes\n\nView the [recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes) for common use cases.\n\n## Compatible servers\n\n`http-proxy-middleware` is compatible with the following servers:\n\n- [connect](https://www.npmjs.com/package/connect)\n- [express](https://www.npmjs.com/package/express)\n- [browser-sync](https://www.npmjs.com/package/browser-sync)\n- [lite-server](https://www.npmjs.com/package/lite-server)\n- [grunt-contrib-connect](https://www.npmjs.com/package/grunt-contrib-connect)\n- [grunt-browser-sync](https://www.npmjs.com/package/grunt-browser-sync)\n- [gulp-connect](https://www.npmjs.com/package/gulp-connect)\n- [gulp-webserver](https://www.npmjs.com/package/gulp-webserver)\n\nSample implementations can be found in the [server recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes/servers.md).\n\n## Tests\n\nRun the test suite:\n\n```bash\n# install dependencies\n$ yarn\n\n# linting\n$ yarn lint\n$ yarn lint:fix\n\n# building (compile typescript to js)\n$ yarn build\n\n# unit tests\n$ yarn test\n\n# code coverage\n$ yarn cover\n```\n\n## Changelog\n\n- [View changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2015-2020 Steven Chim\n",
+      "readmeFilename": "README.md",
+      "gitHead": "b3cfae63a1b36a9184c2b314f8de64902d968206",
+      "_id": "http-proxy-middleware@0.21.0-beta.3",
+      "_nodeVersion": "12.15.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-uI1yiC+bS3NcY8KBbZ9QpIdgLOoTUsJBb1HJYWlB1K6aTArwyFR1Tf1T73kyP3miEXoFI2tebsfTGbddm1e9XQ==",
+        "shasum": "ff5cbd11863aaf7e0012d2ad7520625e2e840255",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.21.0-beta.3.tgz",
+        "fileCount": 24,
+        "unpackedSize": 59849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeRvx4CRA9TVsSAnZWagAA6U8P/j56q2SkaGQ4Q7P/KU/2\nzEdomyN+Zx1V9oysfRETL4IaZsIgkdM7lCQidhpSz1jn6ODHO3Hfj226ZvUz\nzefR3+QHT0TY+Ekk+uVA8Y5IygJR8TsXhwPpkXSQ2owPtu1hyD3LMSRu51LN\nJAV5ItkB3lgcL8dF2yKqqjju9Hi6tmzjnLdN1ax8/pPxecruhOXkepu30mqH\nk4OheovQ9t9Rgkeilng7N8hZ5V1IbRWfp/z924G7xA2+eSdJL2SM+B420fLK\nYV7DNGkTys8FznijyrYLafoR1Ss0AeAo8Ce1Xv6uJeyM8UvuLUP8sXkZSBWt\netIY8S/vwJwAzHBMvriyaFMBDrz2YaO5v/ZAyRd0FY8BpGEltvJElQpoJtI8\nFDNzimr1jIXQuZuVGQl89QDh2l2SYZvirX9Pg1jwQvzkOfiQRk7TImryensW\nwUZ4OaRIi/VJ94EZl11CIEZ1iWfYRRDXGgB8FNFQe5aqHyTj/OunDZ0p9aUT\ntDw3lPaNb240LPtPBAlnMVpPjbA5uTUo7s99FV5ByrjagXanPIkhe8GFO4Jd\nrCDFztheQnetD5Q5qy9lk59QVZG3Mgp+tmJWeitil0cA5/VvpK3aCVPUEnBR\nqh/uTV6Mdho++6F/D3HbbPtuHfTGzATMfRmb/bG3ULcH8bvQ/digWvhhyLoK\nLehD\r\n=lPlZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.21.0-beta.3_1581710456295_0.6966047978814855"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.21.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.21.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^25.1.2",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^25.1.0",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.7.5",
+        "ws": "^7.1.0"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "b8f33210770878685202ceb7494e53399ed838a0",
+      "_id": "http-proxy-middleware@0.21.0",
+      "_nodeVersion": "12.15.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-4Arcl5QQ6pRMRJmtM1WVHKHkFAQn5uvw83XuNeqnMTOikDiCoTxv5/vdudhKQsF+1mtaAawrK2SEB1v2tYecdQ==",
+        "shasum": "c6b1ca05174b5fbc57bee9485ffa0fa2f0dabeb0",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.21.0.tgz",
+        "fileCount": 24,
+        "unpackedSize": 59919,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeSYqmCRA9TVsSAnZWagAAZjEP/iJtDP2vl9xSaH2Ii8gC\nliwQiqsHwmscx2cWyp+77nuts/R1szQCiCISv4gkLuYIUBRpgnyQ4FcKk/vf\nUqcXxNzQNHbndlNxhbBdGU4tHOVdAIhhaN/r+8F3PFOyHqzwo8wTiO31T8U5\nDCkQ5SuZj8jCJaAzTkO2kS5Xtl1nCaQU/SBHGmIunE5pnBY294UyWLljwDfC\nlS2y2r3WDswqlSw9lguLwocv6iyeujG3GlFkLnM+IyY3O1LM8lT/iOkc4ETV\nRWZjHYv+98Djky9S7K7YsFle5cWnHdc41XyOfm2YDqSAQhc94XxMxGvXniyH\nQO15Y91hlWK/eZDWaaXXT8HzhOTiRzKXeHSo5Bv8ZaxROnGwYcSxFcMZmVRC\n50Bp1Iecy+HwbLs3DNBU06DNLRdcAedo15a8J+3I3J4blL9DJue5MSj4A2aR\nF5yzn0g976E8lTwOJEOZ802H4aTL7ifZWasioANPEQ8hPUr8ce/UVHqq2t8O\nz+k310fc+6Muu48ZMNItzFUABEWY3g49Oky/d54EIHRxcr4SESvC5vDyQ2wy\npc4wTbKyM0cOOL80SMV6jZZ/NRee9DH46FoOp+Jnidg+n0UQxJqhZRyLycSY\nCVBP3ohtFzMk35hUquIqg62Ebsh8yYHDWigAwviOCaB0GERAWj6k423sNdUF\naAQU\r\n=yWY4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.21.0_1581877926342_0.799923503941687"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.22.0-alpha": {
+      "name": "http-proxy-middleware",
+      "version": "0.22.0-alpha",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "polka",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^25.1.2",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^25.1.0",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.7.5",
+        "ws": "^7.1.0"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "readme": "# http-proxy-middleware\n\n[![Build Status](https://img.shields.io/travis/chimurai/http-proxy-middleware/master.svg?style=flat-square)](https://travis-ci.org/chimurai/http-proxy-middleware)\n[![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square)](https://coveralls.io/r/chimurai/http-proxy-middleware)\n[![dependency Status](https://img.shields.io/david/chimurai/http-proxy-middleware.svg?style=flat-square)](https://david-dm.org/chimurai/http-proxy-middleware#info=dependencies)\n[![dependency Status](https://snyk.io/test/npm/http-proxy-middleware/badge.svg?style=flat-square)](https://snyk.io/test/npm/http-proxy-middleware)\n[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)\n\nNode.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/strongloop/express), [browser-sync](https://github.com/BrowserSync/browser-sync) and [many more](#compatible-servers).\n\nPowered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)\n\n## TL;DR\n\nProxy `/api` requests to `http://www.example.org`\n\n```javascript\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\nvar app = express();\n\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n_All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#options) can be used, along with some extra `http-proxy-middleware` [options](#options).\n\n:bulb: **Tip:** Set the option `changeOrigin` to `true` for [name-based virtual hosted sites](http://en.wikipedia.org/wiki/Virtual_hosting#Name-based).\n\n## Table of Contents\n\n<!-- MarkdownTOC autolink=true bracket=round depth=2 -->\n\n- [Install](#install)\n- [Core concept](#core-concept)\n- [Example](#example)\n- [Context matching](#context-matching)\n- [Options](#options)\n  - [http-proxy-middleware options](#http-proxy-middleware-options)\n  - [http-proxy events](#http-proxy-events)\n  - [http-proxy options](#http-proxy-options)\n- [Shorthand](#shorthand)\n  - [app.use\\(path, proxy\\)](#appusepath-proxy)\n- [WebSocket](#websocket)\n  - [External WebSocket upgrade](#external-websocket-upgrade)\n- [Working examples](#working-examples)\n- [Recipes](#recipes)\n- [Compatible servers](#compatible-servers)\n- [Tests](#tests)\n- [Changelog](#changelog)\n- [License](#license)\n\n<!-- /MarkdownTOC -->\n\n## Install\n\n```bash\n$ npm install --save-dev http-proxy-middleware\n```\n\n## Core concept\n\nProxy middleware configuration.\n\n#### proxy([context,] config)\n\n```javascript\nvar proxy = require('http-proxy-middleware');\n\nvar apiProxy = proxy('/api', { target: 'http://www.example.org' });\n//                   \\____/   \\_____________________________/\n//                     |                    |\n//                   context             options\n\n// 'apiProxy' is now ready to be used as middleware in a server.\n```\n\n- **context**: Determine which requests should be proxied to the target host.\n  (more on [context matching](#context-matching))\n- **options.target**: target host to proxy to. _(protocol + host)_\n\n(full list of [`http-proxy-middleware` configuration options](#options))\n\n#### proxy(uri [, config])\n\n```javascript\n// shorthand syntax for the example above:\nvar apiProxy = proxy('http://www.example.org/api');\n```\n\nMore about the [shorthand configuration](#shorthand).\n\n## Example\n\nAn example with `express` server.\n\n```javascript\n// include dependencies\nvar express = require('express');\nvar proxy = require('http-proxy-middleware');\n\n// proxy middleware options\nvar options = {\n  target: 'http://www.example.org', // target host\n  changeOrigin: true, // needed for virtual hosted sites\n  ws: true, // proxy websockets\n  pathRewrite: {\n    '^/api/old-path': '/api/new-path', // rewrite path\n    '^/api/remove/path': '/path' // remove base path\n  },\n  router: {\n    // when request.headers.host == 'dev.localhost:3000',\n    // override target 'http://www.example.org' to 'http://localhost:8000'\n    'dev.localhost:3000': 'http://localhost:8000'\n  }\n};\n\n// create the proxy (without context)\nvar exampleProxy = proxy(options);\n\n// mount `exampleProxy` in web server\nvar app = express();\napp.use('/api', exampleProxy);\napp.listen(3000);\n```\n\n## Context matching\n\nProviding an alternative way to decide which requests should be proxied; In case you are not able to use the server's [`path` parameter](http://expressjs.com/en/4x/api.html#app.use) to mount the proxy or when you need more flexibility.\n\n[RFC 3986 `path`](https://tools.ietf.org/html/rfc3986#section-3.3) is used for context matching.\n\n```ascii\n         foo://example.com:8042/over/there?name=ferret#nose\n         \\_/   \\______________/\\_________/ \\_________/ \\__/\n          |           |            |            |        |\n       scheme     authority       path        query   fragment\n```\n\n- **path matching**\n\n  - `proxy({...})` - matches any path, all requests will be proxied.\n  - `proxy('/', {...})` - matches any path, all requests will be proxied.\n  - `proxy('/api', {...})` - matches paths starting with `/api`\n\n- **multiple path matching**\n\n  - `proxy(['/api', '/ajax', '/someotherpath'], {...})`\n\n- **wildcard path matching**\n\n  For fine-grained control you can use wildcard matching. Glob pattern matching is done by _micromatch_. Visit [micromatch](https://www.npmjs.com/package/micromatch) or [glob](https://www.npmjs.com/package/glob) for more globbing examples.\n\n  - `proxy('**', {...})` matches any path, all requests will be proxied.\n  - `proxy('**/*.html', {...})` matches any path which ends with `.html`\n  - `proxy('/*.html', {...})` matches paths directly under path-absolute\n  - `proxy('/api/**/*.html', {...})` matches requests ending with `.html` in the path of `/api`\n  - `proxy(['/api/**', '/ajax/**'], {...})` combine multiple patterns\n  - `proxy(['/api/**', '!**/bad.json'], {...})` exclusion\n\n  **Note**: In multiple path matching, you cannot use string paths and wildcard paths together.\n\n- **custom matching**\n\n  For full control you can provide a custom function to determine which requests should be proxied or not.\n\n  ```javascript\n  /**\n   * @return {Boolean}\n   */\n  var filter = function(pathname, req) {\n    return pathname.match('^/api') && req.method === 'GET';\n  };\n\n  var apiProxy = proxy(filter, { target: 'http://www.example.org' });\n  ```\n\n## Options\n\n### http-proxy-middleware options\n\n- **option.pathRewrite**: object/function, rewrite target's url path. Object-keys will be used as _RegExp_ to match paths.\n\n  ```javascript\n  // rewrite path\n  pathRewrite: {'^/old/api' : '/new/api'}\n\n  // remove path\n  pathRewrite: {'^/remove/api' : ''}\n\n  // add base path\n  pathRewrite: {'^/' : '/basepath/'}\n\n  // custom rewriting\n  pathRewrite: function (path, req) { return path.replace('/api', '/base/api') }\n\n  // custom rewriting, returning Promise\n  pathRewrite: async function (path, req) {\n    var should_add_something = await httpRequestToDecideSomething(path);\n    if (should_add_something) path += \"something\";\n    return path;\n  }\n\n  ```\n\n- **option.router**: object/function, re-target `option.target` for specific requests.\n\n  ```javascript\n  // Use `host` and/or `path` to match requests. First match will be used.\n  // The order of the configuration matters.\n  router: {\n      'integration.localhost:3000' : 'http://localhost:8001',  // host only\n      'staging.localhost:3000'     : 'http://localhost:8002',  // host only\n      'localhost:3000/api'         : 'http://localhost:8003',  // host + path\n      '/rest'                      : 'http://localhost:8004'   // path only\n  }\n\n  // Custom router function\n  router: function(req) {\n      return 'http://localhost:8004';\n  }\n\n  // Asynchronous router function which returns promise\n  router: async function(req) {\n      const url = await doSomeIO();\n      return url;\n  }\n  ```\n\n- **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`\n\n- **option.logProvider**: function, modify or replace log provider. Default: `console`.\n\n  ```javascript\n  // simple replace\n  function logProvider(provider) {\n    // replace the default console log provider.\n    return require('winston');\n  }\n  ```\n\n  ```javascript\n  // verbose replacement\n  function logProvider(provider) {\n    var logger = new (require('winston').Logger)();\n\n    var myCustomProvider = {\n      log: logger.log,\n      debug: logger.debug,\n      info: logger.info,\n      warn: logger.warn,\n      error: logger.error\n    };\n    return myCustomProvider;\n  }\n  ```\n\n### http-proxy events\n\nSubscribe to [http-proxy events](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events):\n\n- **option.onError**: function, subscribe to http-proxy's `error` event for custom error handling.\n\n  ```javascript\n  function onError(err, req, res) {\n    res.writeHead(500, {\n      'Content-Type': 'text/plain'\n    });\n    res.end(\n      'Something went wrong. And we are reporting a custom error message.'\n    );\n  }\n  ```\n\n- **option.onProxyRes**: function, subscribe to http-proxy's `proxyRes` event.\n\n  ```javascript\n  function onProxyRes(proxyRes, req, res) {\n    proxyRes.headers['x-added'] = 'foobar'; // add new header to response\n    delete proxyRes.headers['x-removed']; // remove header from response\n  }\n  ```\n\n- **option.onProxyReq**: function, subscribe to http-proxy's `proxyReq` event.\n\n  ```javascript\n  function onProxyReq(proxyReq, req, res) {\n    // add custom header to request\n    proxyReq.setHeader('x-added', 'foobar');\n    // or log the req\n  }\n  ```\n\n- **option.onProxyReqWs**: function, subscribe to http-proxy's `proxyReqWs` event.\n\n  ```javascript\n  function onProxyReqWs(proxyReq, req, socket, options, head) {\n    // add custom header\n    proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n  }\n  ```\n\n- **option.onOpen**: function, subscribe to http-proxy's `open` event.\n\n  ```javascript\n  function onOpen(proxySocket) {\n    // listen for messages coming FROM the target here\n    proxySocket.on('data', hybiParseAndLogMessage);\n  }\n  ```\n\n- **option.onClose**: function, subscribe to http-proxy's `close` event.\n\n  ```javascript\n  function onClose(res, socket, head) {\n    // view disconnected websocket connections\n    console.log('Client disconnected');\n  }\n  ```\n\n### http-proxy options\n\nThe following options are provided by the underlying [http-proxy](https://github.com/nodejitsu/node-http-proxy#options) library.\n\n- **option.target**: url string to be parsed with the url module\n- **option.forward**: url string to be parsed with the url module\n- **option.agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n- **option.ssl**: object to be passed to https.createServer()\n- **option.ws**: true/false: if you want to proxy websockets\n- **option.xfwd**: true/false, adds x-forward headers\n- **option.secure**: true/false, if you want to verify the SSL Certs\n- **option.toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n- **option.prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n- **option.ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n- **option.localAddress** : Local interface string to bind for outgoing connections\n- **option.changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n- **option.preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n- **option.auth** : Basic authentication i.e. 'user:password' to compute an Authorization header.\n- **option.hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.\n- **option.autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.\n- **option.protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.\n- **option.cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n  - Object: mapping of domains to new domains, use `\"*\"` to match all domains.  \n    For example keep one domain unchanged, rewrite one domain and remove other domains:\n    ```json\n    cookieDomainRewrite: {\n      \"unchanged.domain\": \"unchanged.domain\",\n      \"old.domain\": \"new.domain\",\n      \"*\": \"\"\n    }\n    ```\n- **option.cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n  - Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n    For example, to keep one path unchanged, rewrite one path and remove other paths:\n    ```json\n    cookiePathRewrite: {\n      \"/unchanged.path/\": \"/unchanged.path/\",\n      \"/old.path/\": \"/new.path/\",\n      \"*\": \"\"\n    }\n    ```\n- **option.headers**: object, adds [request headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields). (Example: `{host:'www.example.org'}`)\n- **option.proxyTimeout**: timeout (in millis) when proxy receives no response from target\n- **option.timeout**: timeout (in millis) for incoming requests\n- **option.followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n- **option.selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n- **option.buffer**: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on e.g. If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n  ```javascript\n  'use strict';\n\n  const streamify = require('stream-array');\n  const HttpProxy = require('http-proxy');\n  const proxy = new HttpProxy();\n\n  module.exports = (req, res, next) => {\n    proxy.web(\n      req,\n      res,\n      {\n        target: 'http://localhost:4003/',\n        buffer: streamify(req.rawBody)\n      },\n      next\n    );\n  };\n  ```\n\n## Shorthand\n\nUse the shorthand syntax when verbose configuration is not needed. The `context` and `option.target` will be automatically configured when shorthand is used. Options can still be used if needed.\n\n```javascript\nproxy('http://www.example.org:8000/api');\n// proxy('/api', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api/books/*/**.json');\n// proxy('/api/books/*/**.json', {target: 'http://www.example.org:8000'});\n\nproxy('http://www.example.org:8000/api', { changeOrigin: true });\n// proxy('/api', {target: 'http://www.example.org:8000', changeOrigin: true});\n```\n\n### app.use(path, proxy)\n\nIf you want to use the server's `app.use` `path` parameter to match requests;\nCreate and mount the proxy without the http-proxy-middleware `context` parameter:\n\n```javascript\napp.use(\n  '/api',\n  proxy({ target: 'http://www.example.org', changeOrigin: true })\n);\n```\n\n`app.use` documentation:\n\n- express: http://expressjs.com/en/4x/api.html#app.use\n- connect: https://github.com/senchalabs/connect#mount-middleware\n- polka: https://github.com/lukeed/polka#usebase-fn\n\n## WebSocket\n\n```javascript\n// verbose api\nproxy('/', { target: 'http://echo.websocket.org', ws: true });\n\n// shorthand\nproxy('http://echo.websocket.org', { ws: true });\n\n// shorter shorthand\nproxy('ws://echo.websocket.org');\n```\n\n### External WebSocket upgrade\n\nIn the previous WebSocket examples, http-proxy-middleware relies on a initial http request in order to listen to the http `upgrade` event. If you need to proxy WebSockets without the initial http request, you can subscribe to the server's http `upgrade` event manually.\n\n```javascript\nvar wsProxy = proxy('ws://echo.websocket.org', { changeOrigin: true });\n\nvar app = express();\napp.use(wsProxy);\n\nvar server = app.listen(3000);\nserver.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'\n```\n\n## Working examples\n\nView and play around with [working examples](https://github.com/chimurai/http-proxy-middleware/tree/master/examples).\n\n- Browser-Sync ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/browser-sync/index.js))\n- express ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/express/index.js))\n- connect ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/connect/index.js))\n- WebSocket ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/websocket/index.js))\n\n## Recipes\n\nView the [recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes) for common use cases.\n\n## Compatible servers\n\n`http-proxy-middleware` is compatible with the following servers:\n\n- [connect](https://www.npmjs.com/package/connect)\n- [express](https://www.npmjs.com/package/express)\n- [browser-sync](https://www.npmjs.com/package/browser-sync)\n- [lite-server](https://www.npmjs.com/package/lite-server)\n- [polka](https://github.com/lukeed/polka)\n- [grunt-contrib-connect](https://www.npmjs.com/package/grunt-contrib-connect)\n- [grunt-browser-sync](https://www.npmjs.com/package/grunt-browser-sync)\n- [gulp-connect](https://www.npmjs.com/package/gulp-connect)\n- [gulp-webserver](https://www.npmjs.com/package/gulp-webserver)\n\nSample implementations can be found in the [server recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes/servers.md).\n\n## Tests\n\nRun the test suite:\n\n```bash\n# install dependencies\n$ yarn\n\n# linting\n$ yarn lint\n$ yarn lint:fix\n\n# building (compile typescript to js)\n$ yarn build\n\n# unit tests\n$ yarn test\n\n# code coverage\n$ yarn cover\n```\n\n## Changelog\n\n- [View changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2015-2020 Steven Chim\n",
+      "readmeFilename": "README.md",
+      "gitHead": "d2740d77c1232935733490f17a3ea36246d30a43",
+      "_id": "http-proxy-middleware@0.22.0-alpha",
+      "_nodeVersion": "12.15.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-8Pv0BDLHxYR28wxIkFzV8bO6B1N1YvdWSRrs49iHWLTYwzKPhXp8TyFaK036+eoqAgm03BkmO1HV+11oADhX2A==",
+        "shasum": "b08602cf1b9392d8a989159af10cf7f7e5dfea60",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.22.0-alpha.tgz",
+        "fileCount": 24,
+        "unpackedSize": 58109,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeSwDoCRA9TVsSAnZWagAAAUMP/A17Tl8IIL5KeSQ+qqEQ\nMxJ/YRjJH7FOiyVlT9sINW+ytfD+3lJtOTD5MNY6ddg3EgBvPSmfHu3dqexA\n3735KbZ/eCkhIFg2vhlbrjaJrFZzZfUDiXd4rlPOptmrjRRhfPIDyKydXpdK\niBos2k6ahHICratlCnNNbiZFWO3Gv0HzAWDPEDLoy3423LnqsZrJPHLgnujb\nxoKwWrc3YyMlrkQ/+9bBVB1xchqyCBKtG6khRGQGm7f6VMSr940jqqh6WVfs\nHefWsNxmqpVK4ZFUD0hdBlw3ypnFfGFa8kfbfFi8AqoQL6+T7WtuQunNO1fG\nultSQVaB/jd3kzNzdtBba37ZU80sCgv2F3smu8Er9YqaRVNjtMzT/ThHqeHP\ntPys31QSJic9LD6Af4ml2n7O+7utuV6/Q1TLQAsNR+iAjde1RcltCTLgIyGR\n4XUrFm+VKmKMtzU3Rov1jqn58ZbJJyYhbm+bhGCXBapmZxpossJHA8HHW0Qd\nn6m6JHBFMJY5Y2uv2m1rCyjdgVv6etjPFzEvHSBarL1RHj2xaLPBXSPXZM1P\nqf5qy0qb5Pv+zbiLYD3j1GmzzYYuJkdjQihgN4wyM7wSZS8O8PtTVLuhsXUM\n9Gy8jW+dKUA88JSQ1v3Qaw17Xldj2oeg9NjhyBJaj4d6+rEOsgZRw2M+JkC/\n4K8/\r\n=LYOP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.22.0-alpha_1581973735722_0.1378931847480287"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.0": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.0",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest --runInBand",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --runInBand --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --runInBand --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "polka",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware#readme",
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^25.1.2",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^25.1.0",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.7.5",
+        "ws": "^7.1.0"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "aefdbe8688f3e1491a9e94c08e17fb6b3a0d6a8f",
+      "_id": "http-proxy-middleware@1.0.0",
+      "_nodeVersion": "12.15.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-1yM4gD7R/U9R5AwA6STkoj8JfjnMeZIUrd8e23Yc14A7xVVLUWlAikgvidklwq1UOroJ07sc6NWNULeOJMYOeQ==",
+        "shasum": "984bbbb38cda7ce4495889388afe8b0f39ccd5c8",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.0.tgz",
+        "fileCount": 24,
+        "unpackedSize": 59829,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTGV+CRA9TVsSAnZWagAAM7YP/0TU7JcGzVw5x2sI7pw0\npHU7A0Ut3ZBPSm7QittvCrb7XEdOGLMj7bwIUm4f83MJzxT97zogJWYQ+Tki\nOfRH86TIVuoo4JTMz5yv6DxjdWTXfMN11cZ33xFNZj15U/uRPg6IiFxImK7A\nwPq3LbcKfpDZQIfyrT2ntEesWZ/KLacF7ICaVgDgmld12Ia3fyj1yH5ZC4bE\n27PniIvlOIASPWCfu4VzMTfxv3sf3lWGRv6sNzuLdq5hI1/Z5iE4SNgSiWN3\nnVJ1BfeaYqEphBYVBy7ZCeneOum3m/5ibBXK/Za1tz392cEiTcXXekbguhE/\nleT8tgRReug3vdWPIhKeXMp2PWEdcNHH5T/Juuv9d+dvgStitJdLzr4p06L1\nDca+NeUEDBD7wA+ohAzy6Nw6EgKfrQo8sNOZ5pYJu19D6b8RMLoCY8vO80gQ\nFAumAzl/dtAFw1WQ8wPBewS2/iNXNpKTpz+7odfuiI7IZahD9piPoNFSqrIL\nNUyJwshUGwYyR4fypIh+XSR3zDIZ7c04jIiRx7B7IU8wMdX5owCKvs1UtC0j\nixEWjO8xqZxLyBJNuvK4TEc0bntol4CEZZW5dyvVELhhU/QiBnkRLF6eKeI4\nmtIGQj2YRUoaEkDsYc1gr2H3ENkCtDxHpeBjibKpvxofQYR5QkUz8wLajwOj\nivD6\r\n=Pbr3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_1.0.0_1582065022028_0.619826721419185"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.1": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.1",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "polka",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware#readme",
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.2",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.1.3",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^13.7.4",
+        "@types/supertest": "^2.0.8",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "coveralls": "^3.0.5",
+        "express": "^4.17.1",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "lint-staged": "^10.0.7",
+        "mockttp": "^0.19.3",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "supertest": "^4.0.2",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.8.2",
+        "ws": "^7.2.1"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+          "pre-commit": "lint-staged"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "23522c7a88098e2e18d4a836e41c3dde9d55c4a6",
+      "_id": "http-proxy-middleware@1.0.1",
+      "_nodeVersion": "12.15.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-tVLWnJMEUANithPrWeYgReU+mi6/BJOlyvWKQGS4k8L+j2ZjituJdXhejd31X5J8Ux0SSIH7Iw+RItH9bwkGcw==",
+        "shasum": "a87ee6564991faca4844ae4ab1cf4221279c28f0",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.1.tgz",
+        "fileCount": 25,
+        "unpackedSize": 208005,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeWlukCRA9TVsSAnZWagAA8aQQAIZe1PCCvYVOjxk/LoCc\nRi8rEWdjcQXxJDTbsQqjPtYlEgRb2ypw1liL6iauPyXQ1e/WVEJasIpKB7RC\nyn7SLWEvVXROrMibhzJbs0XYBzBqyp101YOcgNXbOVAbQo32/me0+bK0iddb\nkvzh8OYet+qy2bX0jEFWVnCiL6bnqj7nV8508bmov+u9lzeb1O4wef0hAfMM\noU1pomt0cJEWegP5bdCqEx2AOChxtuZYTZftsrCs0TJHFmBYaz/jvpLwNRYc\ntRq636hbYWKxVCJAGOy4X0IEVZOsW3889dOqDoCbtLMkJcp0Xvj0+XaQcnU4\nDqaLoicKCiREd1OJewTjL6TZfT1zasOSyZfTnbfivw0TcSBR0w5VgutF9fb1\n1w9M++9ClJn8OSrDoYTs5V861dTQU1wMD5Rt1OFAYySyzMrcuX1YOIrNzMKO\n1fbTk60vOddQKwf/fCg8hLIv0t0fmLCLV7Ed7aYO29u4i3Va3Z66bgrANVUf\nwO6ade7yTBSfkAHEE8qJcQ/fUBPqbfnu7HrBumk3LHpyrG+sOOm/ABJgQO9m\niw0uWcqBcv5zjtqUSVslFfxyN7L10QpfhTSinprWkOiwWJPVNtiU0nSeCbO9\nAdKwdobuZVN1NWl1Rwxe/H4xoLVpnexO7FBoWsxpgQCjKwICu/f6j3ixau3B\nvvcl\r\n=Hbik\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_1.0.1_1582980003393_0.47823463577926817"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.2": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.2",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "polka",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware#readme",
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.2",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.1.3",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^13.7.4",
+        "@types/supertest": "^2.0.8",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "coveralls": "^3.0.5",
+        "express": "^4.17.1",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "lint-staged": "^10.0.7",
+        "mockttp": "^0.19.3",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "supertest": "^4.0.2",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.8.2",
+        "ws": "^7.2.1"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+          "pre-commit": "lint-staged"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "573a8c45fbdf6b41ea99a8d8216d43f2455bb604",
+      "_id": "http-proxy-middleware@1.0.2",
+      "_nodeVersion": "12.16.1",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-JHBdMgynLHdKXK9I3BjP8XUKERBCqxvA7dtWj2Da5Bqdo2CRCRQMuUdI36eK1FUFyh6JFIOCBQiQ2ZS+LOs7ww==",
+        "shasum": "63e8d6b039c72e7148e410e7a4690be6dc1a3b8d",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.2.tgz",
+        "fileCount": 25,
+        "unpackedSize": 208382,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJebNtZCRA9TVsSAnZWagAAYwcP/AmPitZl+Q2IzgLeRld3\n1OyjjdhrxiDCAT3Wqa319URhySL7Inxog2Omb8wI5degmArsZhjtQEenae3D\nOacaoi3gKHbOQn6cUoaGU+4Fb0di3S1DbOlN534hJDaoORewBrvfM1AHCRV4\ndSgdTaCDPzuFytzfowVM6148/jXXk1GQPW/i44lRnHCWsjoOuyfaheyj8BHg\n4Lu70bEQB7Qg+QwPiCtdhsiHId60oqrsOvyUo2Ux3EJDkNB7pMsOYW5ALb28\n9MHmmEpq1CcxWy2hv+l9J3IqzfQ8WbdjHU/YfbcQpT0Wx+rubkDpcMHbYVsz\n8quMiHAT0M4ebXt+H5ez4jd/b/iXSTEKf0yRYCAvwwrGPTsgu4suPevgJSq0\ngkQWikIDzGIfQCRDyEv0oNC9vJytG8ttjvyB3ztG6q9PUC/HoR4fC+LR+hlC\na/bItafs8/21X6e0mqKuMhPr6TJnyROGJ/HxayizRjG4/Lgps0GKXRHpp8Jr\n6mKClZWbFi3aflSbvAWRhIM6qvFL0kWgxlVPbUnzeOVRy4Nujjft0JvdoDd+\nN+av6tsasYEclgFsKzloiO8eQ73J6/VxcbNz1q0U5l6FaAqa3QuI0i+75Bh0\nP6Rii0A31vlReadrVYDwtUniZqaN/l+8CdcOQpbIm1f0/5ElAJX2rXdjCD2X\nXk6y\r\n=bgRe\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_1.0.2_1584192345027_0.7979243440019215"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.3": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.3",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest",
+        "precover": "yarn clean && yarn build",
+        "cover": "jest --coverage",
+        "precoveralls": "yarn clean && yarn build",
+        "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
+        "postcoveralls": "yarn clean",
+        "prepare": "yarn clean && yarn build && rm dist/tsconfig.tsbuildinfo"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "polka",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware#readme",
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.2",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.1.3",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^13.7.4",
+        "@types/supertest": "^2.0.8",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "coveralls": "^3.0.5",
+        "express": "^4.17.1",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "lint-staged": "^10.0.7",
+        "mockttp": "^0.19.3",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "supertest": "^4.0.2",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.8.2",
+        "ws": "^7.2.1"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+          "pre-commit": "lint-staged"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "e767654221fbc866adf16e3c0c96c29ca6800220",
+      "_id": "http-proxy-middleware@1.0.3",
+      "_nodeVersion": "12.16.1",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-GHvPeBD+A357zS5tHjzj6ISrVOjjCiy0I92bdyTJz0pNmIjFxO0NX/bX+xkGgnclKQE/5hHAB9JEQ7u9Pw4olg==",
+        "shasum": "f73daad8dac622d51fe1769960c914b9b1f75a72",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.3.tgz",
+        "fileCount": 24,
+        "unpackedSize": 61172,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeb+60CRA9TVsSAnZWagAA3TEQAIdqzqTt1VDjJdBdeJrx\ncbW7+g9QKgm2yU0FOxPZt9pn6dHgyQ6aMTdnz1dHDNUzzNxPTMCWfokj4R0C\n58eZFUBVZTrsLDWFzUuzp9waFMJmCXmZ3A7aoVINhBuUh80IQflXejDjUb5H\nwXssYU0N5chW7dPPNAyfL3z8ploILDWU9OFrwq3Ihf3qmu+oGXVGaoXl/r7n\nquKR4B0Q3g7qynqUU6uL+kcX5T5OSLujJaN9CuX5SaNkUQhfZg0AqYCk9Yf0\naojIgN/sb7IWreQPn4kFu+jovFPQdDb1TQS3RaRvoM0FseDX7qmph80yee/c\nAQkv6oIHLI/AsfVsGGHuKlaZr4x8zyfwVWA0mCk3m41DvqkPgRnw15KCEtFd\nzMQPJpoBIBvDiNJjSYYSSVg4/Hkr+ab/6ByJTCyZ1G3NOVT9XCsKiZYr9yg7\nL5enUKyp0QO2e7yEJwbABn/UZf1ix145Nmb3avFYoBSjq1i32Iqm6m89TZ6V\nS0WnRzpzmUE8GEXkvxGHqQf8PF1dvXHsbXwaJ2kErdKX9peqiG+DWm8SVUdq\nLluhk7ClAMoAntAcoLbXTFoLTDCqJU6gnO3VCdiUc3zi+UHaQQg72KToOBiy\nWQmxWL4buEl8CwJCaRuLXcwCEa3RVfbNcamX30AvQ0Sd2coFgZkrWBwx9Va2\n7Kio\r\n=wLwG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_1.0.3_1584393907695_0.47919582672539907"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.4": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.4",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest",
+        "coverage": "jest --coverage --coverageReporters=lcov",
+        "prepare": "yarn clean && yarn build && rm dist/tsconfig.tsbuildinfo"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "polka",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware#readme",
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.3",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.2.1",
+        "@types/lodash": "^4.14.150",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^13.13.5",
+        "@types/supertest": "^2.0.9",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "express": "^4.17.1",
+        "husky": "^4.2.5",
+        "jest": "^26.0.1",
+        "lint-staged": "^10.2.2",
+        "mockttp": "^0.20.1",
+        "open": "^7.0.3",
+        "prettier": "^2.0.5",
+        "supertest": "^4.0.2",
+        "ts-jest": "^25.5.0",
+        "tslint": "^6.1.2",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.8.3",
+        "ws": "^7.2.5"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+          "pre-commit": "lint-staged"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "68e3e300574d275ea99f264dedcfd72d7dccc626",
+      "_id": "http-proxy-middleware@1.0.4",
+      "_nodeVersion": "12.16.1",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-8wiqujNWlsZNbeTSSWMLUl/u70xbJ5VYRwPR8RcAbvsNxzAZbgwLzRvT96btbm3fAitZUmo5i8LY6WKGyHDgvA==",
+        "shasum": "425ea177986a0cda34f9c81ec961c719adb6c2a9",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.4.tgz",
+        "fileCount": 24,
+        "unpackedSize": 61170,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJewrezCRA9TVsSAnZWagAATeUQAIjWXDuQael1Xm1p4Wkh\nSxSzWFtHgHXiFvq3vHrn8TL8skN+ZTMeBD7lQIFGJGcQsKFn8U1NYGQ4DUcJ\nBzQtMTH9+E2YgGMcXrKMXgsHNXSKvDUvUyKpQalSeaiyPByn6ijH7PmanYF+\n5YmhkeDchkWgTHWcUPcUAmakC7/4bZQCZ6fxLZVuf/Xz8IE02F94WMyKj6gJ\nadWj7BOMCutWeh1DdU7l5Nn6k2IuE+WBapTieoH/gfJZYSBX6orl/II2M5lc\nke1mitUJ7WPCk+WyndrI/oVH535NOEJ6LubrjemInr7wly6v1ZMLFMIjCfSE\nUvz67mZSuCtkbPMPlLrhWRI+Q5e+2wONR3W1BxQDzgze+eadk0+RnAN1vcTv\nxGkv+XAWprLriMvhJFPWl1orA9aSLKxwny5tgfxgDsHvj1RNv5OowttcKVB0\n5QFYYZVFmOR8siQMJRL/0CP8rpkdppj6aFahdCFTDLIiA/I1WdrhVGtdnegc\nAS2R9TS9X5BJcdimTwjG5gp+c+v9cGEOaAOGyTVno5dWPeq+ZuYFn+K9N6uo\nvpjvcSuPTMb06B6VteZWnTjZBmrEZyDLUc/PdmyZmotzxiNWbZceYxxTmweL\nXnkMcWUqIrZaIIWWLWwnS2Q8bxp6cmTiCT4eHI7aHgdopUWKKMdbsA0f65BW\nDz78\r\n=Vyf6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_1.0.4_1589819315004_0.22635473245502125"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.19.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.19.2",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "index.js",
+      "scripts": {
+        "clean": "rm -rf coverage",
+        "lint": "prettier \"**/*.{js,md}\" --list-different",
+        "lint:fix": "prettier \"**/*.{js,md}\" --write",
+        "test": "mocha --recursive --colors --reporter spec",
+        "cover": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha -- --recursive",
+        "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- --recursive --reporter spec && istanbul-coveralls && npm run clean"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware",
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "browser-sync": "^2.26.3",
+        "chai": "^4.2.0",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.2",
+        "express": "^4.16.4",
+        "husky": "^1.2.0",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "1.3.0",
+        "opn": "^5.4.0",
+        "precise-commits": "^1.0.2",
+        "prettier": "^1.15.2",
+        "ws": "^6.1.2"
+      },
+      "dependencies": {
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+          "pre-commit": "precise-commits"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "ffcd889b2aa8bbc59ed93f2bd34a61923748942f",
+      "_id": "http-proxy-middleware@0.19.2",
+      "_nodeVersion": "12.16.1",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-aYk1rTKqLTus23X3L96LGNCGNgWpG4cG0XoZIT1GUPhhulEHX/QalnO6Vbo+WmKWi4AL2IidjuC0wZtbpg0yhQ==",
+        "shasum": "ee73dcc8348165afefe8de2ff717751d181608ee",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 47853,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexC3fCRA9TVsSAnZWagAA2VQP/Rqp9cPOtEy9vWQTjgMM\ngmBEspZoZg4C/EKGcQ0XP68mbb16M3YKP33AtoEd8J2UL6xdUqsWa3iSVxin\n5ytxr6+t26QtF7gn0Zl6lM9ckmHmseGyt6F/N2/d3op8StgF6pDIdXJQqMG8\nwJEAk8FcnrqR3JMYm5iscy5PpOHn11VHWgGBBBGsVKglm5iZozCMINCBPc73\nm5Prd4ae9pTz1Pf59WfH0UBM2TOSNpXTGBICSghHo4CxcG6N+x8Kl2XUsuyk\npnX9PIqWVZb2N1E/VrzRtIiDataCthlixZqQHZKJ8Y4jR1n3oqQK416yjehq\nfH67yeDJx2k5B14cuY9ef1XFJTAKMhgUM+2JDdgHCbA1ppQdN+VctFW7X3Ex\njvr1Ie+PBTtR9b1FUwluQA9TgtXF0BiLP1IrZtS0HSPvbDRPydhrcKLFco9C\nahsstiu2r9nhHhe9L5LhdsFL3nNY9zQEHZkofG76lvz9k5s1y0+pct89lAR0\n+d3Q7mUb+XwKDD1mm304Z5ZE0hpBCwc+km08f+BzjWqNWSOIXE0naMnP+0dF\nCOTPKlm9ZmZ7Qw2E999pbaukET2j6UoZPeVCsXc27k7UCytq1QZwOU585Fy8\nck8Tk+Sqk0LG3GQwIF3DxXxmA1kbwbCjrt6lX0zZzeOTvjr98YuFTtJAI3oQ\n+DNg\r\n=AX3P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_0.19.2_1589915102540_0.6155244724847357"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.5": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.5",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest",
+        "coverage": "jest --coverage --coverageReporters=lcov",
+        "prepare": "yarn clean && yarn build && rm dist/tsconfig.tsbuildinfo"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "polka",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware#readme",
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.3",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.2.3",
+        "@types/lodash": "^4.14.151",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^14.0.3",
+        "@types/supertest": "^2.0.9",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "express": "^4.17.1",
+        "husky": "^4.2.5",
+        "jest": "^26.0.1",
+        "lint-staged": "^10.2.4",
+        "mockttp": "^0.20.1",
+        "open": "^7.0.4",
+        "prettier": "^2.0.5",
+        "supertest": "^4.0.2",
+        "ts-jest": "^26.0.0",
+        "tslint": "^6.1.2",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.9.2",
+        "ws": "^7.3.0"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.19",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+          "pre-commit": "lint-staged"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "5384dcfab6e5d565b97b2ff5d6cac3209aada6e8",
+      "_id": "http-proxy-middleware@1.0.5",
+      "_nodeVersion": "12.18.2",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-CKzML7u4RdGob8wuKI//H8Ein6wNTEQR7yjVEzPbhBLGdOfkfvgTnp2HLnniKBDP9QW4eG10/724iTWLBeER3g==",
+        "shasum": "4c6e25d95a411e3d750bc79ccf66290675176dc2",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.5.tgz",
+        "fileCount": 24,
+        "unpackedSize": 61670,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfB0kHCRA9TVsSAnZWagAALpUP/j4YDwQnfnjhdYWH8ZvD\nmGF0eM4yJR5BjHosTqfs6MnL42ArKo7ypF7DGmIJFHouCogayiWTB+3SrxkL\n0jVnpK5+He3dOaW6KT+3ah2et53KOPid4s9QFyhBxilnQDGYpj2WZgvmR6fI\noy3gVV3dakH/GLRTOGyBnKlKXClvVGDAUhoFfmVpK15SPxFTlLTqiWzd7ept\nSw8C/vFbXNqDm2R+tfeP2+BCOJt8lgp2qtMG6w+rXLBn14woYw7sIKPlV+ta\nuaYX88gj6VwDkj0lxIbaPr45O4cAgbSc+1G8gWSG5C5ARPCjXoH3ndDzyoy3\nTifzlefNNP8a1rFRTVD9I/asVN0bUzD/imSkeFhL3K7W3o4yq5yc7VRLmjzT\n5Q+tvKHSI3oU6oAYwp9wsKTXdP716g2QSRYqKUWU5ZZsg9Q3HrhIKffUVr+N\nfUQw/0yqD6AO/migQJM5MKbR9Y2DQxvWFZtK9qvqxWIWqm24f0uxyZpx4wEC\nnHqSASc75+mfgXuI8rTSfZRJ5N23zUPptoFUdsDOr8krFUdEemfq4zpN1xjq\nzFg/x/vHGqwMb0Dzw12CwIBZv15Fa6WMBgwkJ2jYTROoMcKe3VPMfSC55GnV\nmI0snhPv13RXtEl2MxomOPzTwq8mgsFkwPW8oU4uu8MeTE5QhpBYN+WR+zB1\n0MJd\r\n=03D7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_1.0.5_1594312967411_0.25744450312708334"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.6": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.6",
+      "description": "The one-liner node.js proxy middleware for connect, express and browser-sync",
+      "main": "dist/index.js",
+      "types": "dist/index.d.ts",
+      "scripts": {
+        "clean": "rm -rf dist && rm -rf coverage",
+        "lint": "yarn lint:prettier && yarn lint:tslint",
+        "lint:prettier": "prettier --check \"**/*.{js,ts,md}\"",
+        "lint:tslint": "yarn tslint -c tslint.json '{lib,test}/**/*.ts'",
+        "lint:fix": "prettier --write \"**/*.{js,ts,md}\"",
+        "build": "tsc",
+        "pretest": "yarn build",
+        "test": "jest",
+        "coverage": "jest --coverage --coverageReporters=lcov",
+        "prepare": "yarn clean && yarn build && rm dist/tsconfig.tsbuildinfo"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "middleware",
+        "http",
+        "https",
+        "connect",
+        "express",
+        "polka",
+        "browser-sync",
+        "gulp",
+        "grunt-contrib-connect",
+        "websocket",
+        "ws",
+        "cors"
+      ],
+      "author": {
+        "name": "Steven Chim"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+      },
+      "homepage": "https://github.com/chimurai/http-proxy-middleware#readme",
+      "devDependencies": {
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@types/express": "^4.17.3",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^26.0.14",
+        "@types/lodash": "^4.14.162",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^14.11.8",
+        "@types/supertest": "^2.0.10",
+        "browser-sync": "^2.26.12",
+        "connect": "^3.7.0",
+        "express": "^4.17.1",
+        "husky": "^4.3.0",
+        "jest": "^26.5.3",
+        "lint-staged": "^10.4.0",
+        "mockttp": "^1.0.2",
+        "open": "^7.3.0",
+        "prettier": "^2.1.2",
+        "supertest": "^5.0.0",
+        "ts-jest": "^26.4.1",
+        "tslint": "^6.1.3",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^4.0.3",
+        "ws": "^7.3.1"
+      },
+      "dependencies": {
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.20",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+          "pre-commit": "lint-staged"
+        }
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "gitHead": "f212a047ef45898ce6053b622cada4b0617b9ddf",
+      "_id": "http-proxy-middleware@1.0.6",
+      "_nodeVersion": "14.13.1",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==",
+        "shasum": "0618557722f450375d3796d701a8ac5407b3b94e",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.6.tgz",
+        "fileCount": 24,
+        "unpackedSize": 61859,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfg1/ZCRA9TVsSAnZWagAAdP8QAJXqF8bThIYwQzZeGxLO\nad1hs8DE7BooTP9ufkkugyHt4v7TY+3sQVn7CdVkZvVinldx0+27LJ0VB29J\nKrHAewjdKl29z0GwgDF6fPpjvArBZHiwzGB/O3UhyKYRtqBJd7gPN0KdTMKF\nfSFeVqRgJQpoRb1BxIltjAywLmtHHMd0NamcnRJjT3UtpbfAWFKEWcQvFyVB\nJ3PNktNpzZG9zLOtmbT0aDaMHjx+IhY9CEehSQd6MZzqMZ4FE0sZks1u6j4e\nnBUm8fuKIJKsyCxeKbOouTk1ejuKBbv8JefS3LjnVp42LlCceH3BlRVmlku6\nq0ituEoVC7mKzeuXtFk+UPD1KIxuk9gvwEHCLE5qU+7zkmpVl1UzG2+h8u3y\n6RJrvESYxidANo0Tim8ueg7comDL+qh3QX0D0xIxox3nSqiGx9vXWYSgFGfI\nHD2fXGnZCIy6zk52+wOPJW7Lt4ySIQL1t+GkOcNO2lXMGhbClmcGQCqkmZDd\neRFSufwlY6P+kIZuua+9n5rcYfRFuLMDFDKyz8wUQ7guWlT/XvF9d/+e7Q+0\n2rmri4dfzQmDQBZplSamyk6lS3qTo20ImYk5NEwl/cSyYWtvs6+F6n8fMZwM\n1U+HokrmJ7L8/JJxG1QmZdktkMlpt0LeOfJzHCrL1JgSKP9QHKY7LILvUzp7\nphkK\r\n=KREU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "chimurai",
+          "email": "stevenchim@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "chimurai",
+        "email": "stevenchim@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy-middleware_1.0.6_1602445272732_0.03670054966795577"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# http-proxy-middleware\n\n[![Build Status](https://img.shields.io/travis/chimurai/http-proxy-middleware/master.svg?style=flat-square)](https://travis-ci.org/chimurai/http-proxy-middleware)\n[![Coveralls](https://img.shields.io/coveralls/chimurai/http-proxy-middleware.svg?style=flat-square)](https://coveralls.io/r/chimurai/http-proxy-middleware)\n[![dependency Status](https://img.shields.io/david/chimurai/http-proxy-middleware.svg?style=flat-square)](https://david-dm.org/chimurai/http-proxy-middleware#info=dependencies)\n[![dependency Status](https://snyk.io/test/npm/http-proxy-middleware/badge.svg?style=flat-square)](https://snyk.io/test/npm/http-proxy-middleware)\n[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)\n\nNode.js proxying made simple. Configure proxy middleware with ease for [connect](https://github.com/senchalabs/connect), [express](https://github.com/strongloop/express), [browser-sync](https://github.com/BrowserSync/browser-sync) and [many more](#compatible-servers).\n\nPowered by the popular Nodejitsu [`http-proxy`](https://github.com/nodejitsu/node-http-proxy). [![GitHub stars](https://img.shields.io/github/stars/nodejitsu/node-http-proxy.svg?style=social&label=Star)](https://github.com/nodejitsu/node-http-proxy)\n\n## ⚠️ Note\n\nThis page is showing documentation for version v1.x.x ([release notes](https://github.com/chimurai/http-proxy-middleware/releases))\n\nIf you're looking for v0.x documentation. Go to:\nhttps://github.com/chimurai/http-proxy-middleware/tree/v0.21.0#readme\n\n## TL;DR\n\nProxy `/api` requests to `http://www.example.org`\n\n```javascript\n// javascript\n\nconst express = require('express');\nconst { createProxyMiddleware } = require('http-proxy-middleware');\n\nconst app = express();\n\napp.use('/api', createProxyMiddleware({ target: 'http://www.example.org', changeOrigin: true }));\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n```typescript\n// typescript\n\nimport * as express from 'express';\nimport { createProxyMiddleware, Filter, Options, RequestHandler } from 'http-proxy-middleware';\n\nconst app = express();\n\napp.use('/api', createProxyMiddleware({ target: 'http://www.example.org', changeOrigin: true }));\napp.listen(3000);\n\n// http://localhost:3000/api/foo/bar -> http://www.example.org/api/foo/bar\n```\n\n_All_ `http-proxy` [options](https://github.com/nodejitsu/node-http-proxy#options) can be used, along with some extra `http-proxy-middleware` [options](#options).\n\n:bulb: **Tip:** Set the option `changeOrigin` to `true` for [name-based virtual hosted sites](http://en.wikipedia.org/wiki/Virtual_hosting#Name-based).\n\n## Table of Contents\n\n<!-- MarkdownTOC autolink=true bracket=round depth=2 -->\n\n- [Install](#install)\n- [Core concept](#core-concept)\n- [Example](#example)\n- [Context matching](#context-matching)\n- [Options](#options)\n  - [http-proxy-middleware options](#http-proxy-middleware-options)\n  - [http-proxy events](#http-proxy-events)\n  - [http-proxy options](#http-proxy-options)\n- [Shorthand](#shorthand)\n  - [app.use\\(path, proxy\\)](#appusepath-proxy)\n- [WebSocket](#websocket)\n  - [External WebSocket upgrade](#external-websocket-upgrade)\n- [Working examples](#working-examples)\n- [Recipes](#recipes)\n- [Compatible servers](#compatible-servers)\n- [Tests](#tests)\n- [Changelog](#changelog)\n- [License](#license)\n\n<!-- /MarkdownTOC -->\n\n## Install\n\n```bash\n$ npm install --save-dev http-proxy-middleware\n```\n\n## Core concept\n\nProxy middleware configuration.\n\n#### createProxyMiddleware([context,] config)\n\n```javascript\nconst { createProxyMiddleware } = require('http-proxy-middleware');\n\nconst apiProxy = createProxyMiddleware('/api', { target: 'http://www.example.org' });\n//                                    \\____/   \\_____________________________/\n//                                      |                    |\n//                                    context             options\n\n// 'apiProxy' is now ready to be used as middleware in a server.\n```\n\n- **context**: Determine which requests should be proxied to the target host.\n  (more on [context matching](#context-matching))\n- **options.target**: target host to proxy to. _(protocol + host)_\n\n(full list of [`http-proxy-middleware` configuration options](#options))\n\n#### createProxyMiddleware(uri [, config])\n\n```javascript\n// shorthand syntax for the example above:\nconst apiProxy = createProxyMiddleware('http://www.example.org/api');\n```\n\nMore about the [shorthand configuration](#shorthand).\n\n## Example\n\nAn example with `express` server.\n\n```javascript\n// include dependencies\nconst express = require('express');\nconst { createProxyMiddleware } = require('http-proxy-middleware');\n\n// proxy middleware options\nconst options = {\n  target: 'http://www.example.org', // target host\n  changeOrigin: true, // needed for virtual hosted sites\n  ws: true, // proxy websockets\n  pathRewrite: {\n    '^/api/old-path': '/api/new-path', // rewrite path\n    '^/api/remove/path': '/path', // remove base path\n  },\n  router: {\n    // when request.headers.host == 'dev.localhost:3000',\n    // override target 'http://www.example.org' to 'http://localhost:8000'\n    'dev.localhost:3000': 'http://localhost:8000',\n  },\n};\n\n// create the proxy (without context)\nconst exampleProxy = createProxyMiddleware(options);\n\n// mount `exampleProxy` in web server\nconst app = express();\napp.use('/api', exampleProxy);\napp.listen(3000);\n```\n\n## Context matching\n\nProviding an alternative way to decide which requests should be proxied; In case you are not able to use the server's [`path` parameter](http://expressjs.com/en/4x/api.html#app.use) to mount the proxy or when you need more flexibility.\n\n[RFC 3986 `path`](https://tools.ietf.org/html/rfc3986#section-3.3) is used for context matching.\n\n```ascii\n         foo://example.com:8042/over/there?name=ferret#nose\n         \\_/   \\______________/\\_________/ \\_________/ \\__/\n          |           |            |            |        |\n       scheme     authority       path        query   fragment\n```\n\n- **path matching**\n\n  - `createProxyMiddleware({...})` - matches any path, all requests will be proxied.\n  - `createProxyMiddleware('/', {...})` - matches any path, all requests will be proxied.\n  - `createProxyMiddleware('/api', {...})` - matches paths starting with `/api`\n\n- **multiple path matching**\n\n  - `createProxyMiddleware(['/api', '/ajax', '/someotherpath'], {...})`\n\n- **wildcard path matching**\n\n  For fine-grained control you can use wildcard matching. Glob pattern matching is done by _micromatch_. Visit [micromatch](https://www.npmjs.com/package/micromatch) or [glob](https://www.npmjs.com/package/glob) for more globbing examples.\n\n  - `createProxyMiddleware('**', {...})` matches any path, all requests will be proxied.\n  - `createProxyMiddleware('**/*.html', {...})` matches any path which ends with `.html`\n  - `createProxyMiddleware('/*.html', {...})` matches paths directly under path-absolute\n  - `createProxyMiddleware('/api/**/*.html', {...})` matches requests ending with `.html` in the path of `/api`\n  - `createProxyMiddleware(['/api/**', '/ajax/**'], {...})` combine multiple patterns\n  - `createProxyMiddleware(['/api/**', '!**/bad.json'], {...})` exclusion\n\n  **Note**: In multiple path matching, you cannot use string paths and wildcard paths together.\n\n- **custom matching**\n\n  For full control you can provide a custom function to determine which requests should be proxied or not.\n\n  ```javascript\n  /**\n   * @return {Boolean}\n   */\n  const filter = function (pathname, req) {\n    return pathname.match('^/api') && req.method === 'GET';\n  };\n\n  const apiProxy = createProxyMiddleware(filter, {\n    target: 'http://www.example.org',\n  });\n  ```\n\n## Options\n\n### http-proxy-middleware options\n\n- **option.pathRewrite**: object/function, rewrite target's url path. Object-keys will be used as _RegExp_ to match paths.\n\n  ```javascript\n  // rewrite path\n  pathRewrite: {'^/old/api' : '/new/api'}\n\n  // remove path\n  pathRewrite: {'^/remove/api' : ''}\n\n  // add base path\n  pathRewrite: {'^/' : '/basepath/'}\n\n  // custom rewriting\n  pathRewrite: function (path, req) { return path.replace('/api', '/base/api') }\n\n  // custom rewriting, returning Promise\n  pathRewrite: async function (path, req) {\n    const should_add_something = await httpRequestToDecideSomething(path);\n    if (should_add_something) path += \"something\";\n    return path;\n  }\n  ```\n\n- **option.router**: object/function, re-target `option.target` for specific requests.\n\n  ```javascript\n  // Use `host` and/or `path` to match requests. First match will be used.\n  // The order of the configuration matters.\n  router: {\n      'integration.localhost:3000' : 'http://localhost:8001',  // host only\n      'staging.localhost:3000'     : 'http://localhost:8002',  // host only\n      'localhost:3000/api'         : 'http://localhost:8003',  // host + path\n      '/rest'                      : 'http://localhost:8004'   // path only\n  }\n\n  // Custom router function (string target)\n  router: function(req) {\n      return 'http://localhost:8004';\n  }\n\n  // Custom router function (target object)\n  router: function(req) {\n      return {\n          protocol: 'https:', // The : is required\n          host: 'localhost',\n          port: 8004\n      };\n  }\n\n  // Asynchronous router function which returns promise\n  router: async function(req) {\n      const url = await doSomeIO();\n      return url;\n  }\n  ```\n\n- **option.logLevel**: string, ['debug', 'info', 'warn', 'error', 'silent']. Default: `'info'`\n\n- **option.logProvider**: function, modify or replace log provider. Default: `console`.\n\n  ```javascript\n  // simple replace\n  function logProvider(provider) {\n    // replace the default console log provider.\n    return require('winston');\n  }\n  ```\n\n  ```javascript\n  // verbose replacement\n  function logProvider(provider) {\n    const logger = new (require('winston').Logger)();\n\n    const myCustomProvider = {\n      log: logger.log,\n      debug: logger.debug,\n      info: logger.info,\n      warn: logger.warn,\n      error: logger.error,\n    };\n    return myCustomProvider;\n  }\n  ```\n\n### http-proxy events\n\nSubscribe to [http-proxy events](https://github.com/nodejitsu/node-http-proxy#listening-for-proxy-events):\n\n- **option.onError**: function, subscribe to http-proxy's `error` event for custom error handling.\n\n  ```javascript\n  function onError(err, req, res) {\n    res.writeHead(500, {\n      'Content-Type': 'text/plain',\n    });\n    res.end('Something went wrong. And we are reporting a custom error message.');\n  }\n  ```\n\n- **option.onProxyRes**: function, subscribe to http-proxy's `proxyRes` event.\n\n  ```javascript\n  function onProxyRes(proxyRes, req, res) {\n    proxyRes.headers['x-added'] = 'foobar'; // add new header to response\n    delete proxyRes.headers['x-removed']; // remove header from response\n  }\n  ```\n\n- **option.onProxyReq**: function, subscribe to http-proxy's `proxyReq` event.\n\n  ```javascript\n  function onProxyReq(proxyReq, req, res) {\n    // add custom header to request\n    proxyReq.setHeader('x-added', 'foobar');\n    // or log the req\n  }\n  ```\n\n- **option.onProxyReqWs**: function, subscribe to http-proxy's `proxyReqWs` event.\n\n  ```javascript\n  function onProxyReqWs(proxyReq, req, socket, options, head) {\n    // add custom header\n    proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n  }\n  ```\n\n- **option.onOpen**: function, subscribe to http-proxy's `open` event.\n\n  ```javascript\n  function onOpen(proxySocket) {\n    // listen for messages coming FROM the target here\n    proxySocket.on('data', hybiParseAndLogMessage);\n  }\n  ```\n\n- **option.onClose**: function, subscribe to http-proxy's `close` event.\n\n  ```javascript\n  function onClose(res, socket, head) {\n    // view disconnected websocket connections\n    console.log('Client disconnected');\n  }\n  ```\n\n### http-proxy options\n\nThe following options are provided by the underlying [http-proxy](https://github.com/nodejitsu/node-http-proxy#options) library.\n\n- **option.target**: url string to be parsed with the url module\n- **option.forward**: url string to be parsed with the url module\n- **option.agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n- **option.ssl**: object to be passed to https.createServer()\n- **option.ws**: true/false: if you want to proxy websockets\n- **option.xfwd**: true/false, adds x-forward headers\n- **option.secure**: true/false, if you want to verify the SSL Certs\n- **option.toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n- **option.prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n- **option.ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n- **option.localAddress** : Local interface string to bind for outgoing connections\n- **option.changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n- **option.preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n- **option.auth** : Basic authentication i.e. 'user:password' to compute an Authorization header.\n- **option.hostRewrite**: rewrites the location hostname on (301/302/307/308) redirects.\n- **option.autoRewrite**: rewrites the location host/port on (301/302/307/308) redirects based on requested host/port. Default: false.\n- **option.protocolRewrite**: rewrites the location protocol on (301/302/307/308) redirects to 'http' or 'https'. Default: null.\n- **option.cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n  - Object: mapping of domains to new domains, use `\"*\"` to match all domains.  \n    For example keep one domain unchanged, rewrite one domain and remove other domains:\n    ```json\n    cookieDomainRewrite: {\n      \"unchanged.domain\": \"unchanged.domain\",\n      \"old.domain\": \"new.domain\",\n      \"*\": \"\"\n    }\n    ```\n- **option.cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n  - `false` (default): disable cookie rewriting\n  - String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n  - Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n    For example, to keep one path unchanged, rewrite one path and remove other paths:\n    ```json\n    cookiePathRewrite: {\n      \"/unchanged.path/\": \"/unchanged.path/\",\n      \"/old.path/\": \"/new.path/\",\n      \"*\": \"\"\n    }\n    ```\n- **option.headers**: object, adds [request headers](https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Request_fields). (Example: `{host:'www.example.org'}`)\n- **option.proxyTimeout**: timeout (in millis) when proxy receives no response from target\n- **option.timeout**: timeout (in millis) for incoming requests\n- **option.followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n- **option.selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n- **option.buffer**: stream of data to send as the request body. Maybe you have some middleware that consumes the request stream before proxying it on e.g. If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n  ```javascript\n  'use strict';\n\n  const streamify = require('stream-array');\n  const HttpProxy = require('http-proxy');\n  const proxy = new HttpProxy();\n\n  module.exports = (req, res, next) => {\n    proxy.web(\n      req,\n      res,\n      {\n        target: 'http://localhost:4003/',\n        buffer: streamify(req.rawBody),\n      },\n      next\n    );\n  };\n  ```\n\n## Shorthand\n\nUse the shorthand syntax when verbose configuration is not needed. The `context` and `option.target` will be automatically configured when shorthand is used. Options can still be used if needed.\n\n```javascript\ncreateProxyMiddleware('http://www.example.org:8000/api');\n// createProxyMiddleware('/api', {target: 'http://www.example.org:8000'});\n\ncreateProxyMiddleware('http://www.example.org:8000/api/books/*/**.json');\n// createProxyMiddleware('/api/books/*/**.json', {target: 'http://www.example.org:8000'});\n\ncreateProxyMiddleware('http://www.example.org:8000/api', { changeOrigin: true });\n// createProxyMiddleware('/api', {target: 'http://www.example.org:8000', changeOrigin: true});\n```\n\n### app.use(path, proxy)\n\nIf you want to use the server's `app.use` `path` parameter to match requests;\nCreate and mount the proxy without the http-proxy-middleware `context` parameter:\n\n```javascript\napp.use('/api', createProxyMiddleware({ target: 'http://www.example.org', changeOrigin: true }));\n```\n\n`app.use` documentation:\n\n- express: http://expressjs.com/en/4x/api.html#app.use\n- connect: https://github.com/senchalabs/connect#mount-middleware\n- polka: https://github.com/lukeed/polka#usebase-fn\n\n## WebSocket\n\n```javascript\n// verbose api\ncreateProxyMiddleware('/', { target: 'http://echo.websocket.org', ws: true });\n\n// shorthand\ncreateProxyMiddleware('http://echo.websocket.org', { ws: true });\n\n// shorter shorthand\ncreateProxyMiddleware('ws://echo.websocket.org');\n```\n\n### External WebSocket upgrade\n\nIn the previous WebSocket examples, http-proxy-middleware relies on a initial http request in order to listen to the http `upgrade` event. If you need to proxy WebSockets without the initial http request, you can subscribe to the server's http `upgrade` event manually.\n\n```javascript\nconst wsProxy = createProxyMiddleware('ws://echo.websocket.org', { changeOrigin: true });\n\nconst app = express();\napp.use(wsProxy);\n\nconst server = app.listen(3000);\nserver.on('upgrade', wsProxy.upgrade); // <-- subscribe to http 'upgrade'\n```\n\n## Working examples\n\nView and play around with [working examples](https://github.com/chimurai/http-proxy-middleware/tree/master/examples).\n\n- Browser-Sync ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/browser-sync/index.js))\n- express ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/express/index.js))\n- connect ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/connect/index.js))\n- WebSocket ([example source](https://github.com/chimurai/http-proxy-middleware/tree/master/examples/websocket/index.js))\n\n## Recipes\n\nView the [recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes) for common use cases.\n\n## Compatible servers\n\n`http-proxy-middleware` is compatible with the following servers:\n\n- [connect](https://www.npmjs.com/package/connect)\n- [express](https://www.npmjs.com/package/express)\n- [browser-sync](https://www.npmjs.com/package/browser-sync)\n- [lite-server](https://www.npmjs.com/package/lite-server)\n- [polka](https://github.com/lukeed/polka)\n- [grunt-contrib-connect](https://www.npmjs.com/package/grunt-contrib-connect)\n- [grunt-browser-sync](https://www.npmjs.com/package/grunt-browser-sync)\n- [gulp-connect](https://www.npmjs.com/package/gulp-connect)\n- [gulp-webserver](https://www.npmjs.com/package/gulp-webserver)\n\nSample implementations can be found in the [server recipes](https://github.com/chimurai/http-proxy-middleware/tree/master/recipes/servers.md).\n\n## Tests\n\nRun the test suite:\n\n```bash\n# install dependencies\n$ yarn\n\n# linting\n$ yarn lint\n$ yarn lint:fix\n\n# building (compile typescript to js)\n$ yarn build\n\n# unit tests\n$ yarn test\n\n# code coverage\n$ yarn cover\n```\n\n## Changelog\n\n- [View changelog](https://github.com/chimurai/http-proxy-middleware/blob/master/CHANGELOG.md)\n\n## License\n\nThe MIT License (MIT)\n\nCopyright (c) 2015-2020 Steven Chim\n",
+  "maintainers": [
+    {
+      "name": "chimurai",
+      "email": "stevenchim@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-11T19:41:15.158Z",
+    "created": "2015-03-14T21:57:46.940Z",
+    "0.0.1": "2015-03-14T21:57:46.940Z",
+    "0.0.2": "2015-03-15T00:13:33.039Z",
+    "0.0.3": "2015-03-15T00:28:46.736Z",
+    "0.0.4": "2015-03-16T13:04:00.213Z",
+    "0.0.5": "2015-03-31T12:42:27.334Z",
+    "0.1.0": "2015-07-09T03:49:23.416Z",
+    "0.2.0": "2015-07-13T09:38:01.476Z",
+    "0.3.0": "2015-07-19T11:13:43.967Z",
+    "0.3.1": "2015-07-24T15:54:23.908Z",
+    "0.3.2": "2015-07-25T13:02:45.831Z",
+    "0.4.0": "2015-07-28T21:26:17.656Z",
+    "0.5.0": "2015-08-07T18:31:38.698Z",
+    "0.6.0": "2015-08-18T11:42:02.364Z",
+    "0.7.0": "2015-08-23T21:02:39.919Z",
+    "0.8.0": "2015-08-31T10:50:34.399Z",
+    "0.8.1": "2015-09-09T16:04:28.500Z",
+    "0.8.2": "2015-09-23T18:45:34.376Z",
+    "0.9.0": "2015-09-28T22:04:08.950Z",
+    "0.9.1": "2016-01-18T21:46:10.860Z",
+    "0.10.0-beta": "2016-01-26T21:30:19.853Z",
+    "0.10.0": "2016-02-05T19:20:01.172Z",
+    "0.11.0": "2016-02-24T20:00:47.471Z",
+    "0.12.0": "2016-03-13T17:51:38.449Z",
+    "0.13.0": "2016-03-23T20:22:52.857Z",
+    "0.14.0": "2016-04-18T20:37:44.882Z",
+    "0.15.0": "2016-05-03T21:02:36.666Z",
+    "0.15.1-beta": "2016-05-18T16:54:18.659Z",
+    "0.15.1": "2016-05-26T22:02:04.255Z",
+    "0.15.2": "2016-05-29T12:51:16.198Z",
+    "0.16.0": "2016-06-13T18:52:35.740Z",
+    "0.17.0-beta": "2016-06-16T15:24:47.966Z",
+    "0.17.0": "2016-07-03T15:35:21.923Z",
+    "0.17.1": "2016-08-11T21:30:30.925Z",
+    "0.17.2-beta": "2016-09-10T13:14:50.421Z",
+    "0.17.2": "2016-09-28T22:28:13.856Z",
+    "0.17.3": "2016-12-07T21:22:00.680Z",
+    "0.17.4": "2017-03-02T23:07:30.843Z",
+    "0.18.0": "2018-03-12T22:47:20.345Z",
+    "0.19.0": "2018-08-29T21:15:47.242Z",
+    "0.19.1": "2018-11-25T20:18:42.852Z",
+    "0.20.0-beta.0": "2019-05-31T21:02:11.520Z",
+    "0.20.0-beta.1": "2019-06-02T19:09:52.421Z",
+    "0.20.0-beta.2": "2019-07-09T19:41:34.272Z",
+    "0.20.0": "2019-09-03T19:56:26.579Z",
+    "0.21.0-beta.1": "2019-12-25T23:46:49.903Z",
+    "0.21.0-beta.2": "2020-01-05T17:05:03.266Z",
+    "0.21.0-beta.3": "2020-02-14T20:00:56.387Z",
+    "0.21.0": "2020-02-16T18:32:06.492Z",
+    "0.22.0-alpha": "2020-02-17T21:08:55.856Z",
+    "1.0.0": "2020-02-18T22:30:22.194Z",
+    "1.0.1": "2020-02-29T12:40:03.575Z",
+    "1.0.2": "2020-03-14T13:25:45.248Z",
+    "1.0.3": "2020-03-16T21:25:07.879Z",
+    "1.0.4": "2020-05-18T16:28:35.104Z",
+    "0.19.2": "2020-05-19T19:05:02.777Z",
+    "1.0.5": "2020-07-09T16:42:47.545Z",
+    "1.0.6": "2020-10-11T19:41:12.902Z"
+  },
+  "homepage": "https://github.com/chimurai/http-proxy-middleware#readme",
+  "keywords": [
+    "reverse",
+    "proxy",
+    "middleware",
+    "http",
+    "https",
+    "connect",
+    "express",
+    "polka",
+    "browser-sync",
+    "gulp",
+    "grunt-contrib-connect",
+    "websocket",
+    "ws",
+    "cors"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chimurai/http-proxy-middleware.git"
+  },
+  "author": {
+    "name": "Steven Chim"
+  },
+  "bugs": {
+    "url": "https://github.com/chimurai/http-proxy-middleware/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "kongxianghuan": true,
+    "chimurai": true,
+    "pensierinmusica": true,
+    "hbin000": true,
+    "cqcookie": true,
+    "program247365": true,
+    "jonniespratley": true,
+    "dnik": true,
+    "zhanghaili": true,
+    "smcmill2": true,
+    "quality520": true,
+    "craigpatten": true,
+    "ymk": true,
+    "roccomuso": true,
+    "manikantag": true,
+    "antixrist": true,
+    "quafoo": true,
+    "taoqianbao": true,
+    "wangnan0610": true,
+    "monolithed": true,
+    "ystrdy": true,
+    "wickie": true,
+    "johnnychq": true,
+    "dyyz993": true,
+    "vur": true,
+    "nanxing": true,
+    "leizongmin": true,
+    "onursimsek": true,
+    "wujr5": true,
+    "jits": true,
+    "shakakira": true,
+    "abuelwafa": true,
+    "nuer": true,
+    "zollero": true,
+    "iori20091101": true,
+    "panlw": true,
+    "bengi": true,
+    "mark24code": true,
+    "jacky3399": true,
+    "scott.m.sarsfield": true,
+    "xueboren": true,
+    "dean-xu": true,
+    "xiaochao": true,
+    "wangfeia": true,
+    "richleego": true,
+    "king.v": true,
+    "stone_breaker": true,
+    "npmlincq": true,
+    "caikan": true,
+    "ierceg": true,
+    "edwardxyt": true,
+    "hehehai": true,
+    "bigbird92": true,
+    "chirag8642": true,
+    "jamiemagique": true,
+    "yikuo": true,
+    "jinglf000": true,
+    "jedaviata": true,
+    "rocket0191": true,
+    "hehaiyang": true,
+    "joe.li": true,
+    "largepuma": true,
+    "icoon.li": true,
+    "yeming": true,
+    "xyyjk": true,
+    "dai'liljian": true,
+    "sayrilamar": true,
+    "fakefarm": true,
+    "jonschlinkert": true,
+    "stona": true,
+    "xfloops": true,
+    "netoperatorwibby": true,
+    "zuojiang": true,
+    "vivek.vikhere": true,
+    "warmilk": true,
+    "maxwelldu": true,
+    "hewenxuan": true,
+    "xingtao": true,
+    "ganeshkbhat": true,
+    "jameskrill": true,
+    "rubiadias": true,
+    "syrontillp": true,
+    "prasad.adss": true,
+    "karzanosman984": true,
+    "yangteng": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/http-proxy-middleware.min.json
+++ b/test/fixtures/registry-mocks/content/http-proxy-middleware.min.json
@@ -1,0 +1,1827 @@
+{
+  "name": "http-proxy-middleware",
+  "dist-tags": {
+    "latest": "1.0.6",
+    "beta": "0.21.0-beta.3",
+    "alpha": "0.22.0-alpha"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.1",
+      "devDependencies": {
+        "http-proxy": "^1.9.0",
+        "mocha": "^2.2.1",
+        "should": "^5.2.0",
+        "url": "^0.10.3"
+      },
+      "dist": {
+        "shasum": "2b9feaec5fb582db09cf3693f5a5a09a5c1beee6",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.2",
+      "dependencies": {
+        "http-proxy": "^1.9.0"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.1",
+        "should": "^5.2.0",
+        "url": "^0.10.3"
+      },
+      "dist": {
+        "shasum": "6e9fde5ec41fb46fd0e3e3885cd4aa7c2e4b2d6f",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.3",
+      "dependencies": {
+        "http-proxy": "^1.9.0",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "mocha": "^2.2.1",
+        "should": "^5.2.0"
+      },
+      "dist": {
+        "shasum": "fb97acc26f49a1449eb8112b4711b1bd0723e62c",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.4",
+      "dependencies": {
+        "http-proxy": "^1.9.0",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "chai": "^2.1.1",
+        "coveralls": "^2.11.2",
+        "mocha": "^2.2.1",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dist": {
+        "shasum": "1cc89b5e4ecc1a1c023594306cf79ae3d4321ea9",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.4.tgz"
+      }
+    },
+    "0.0.5": {
+      "name": "http-proxy-middleware",
+      "version": "0.0.5",
+      "dependencies": {
+        "http-proxy": "^1.9.0",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "chai": "^2.1.1",
+        "coveralls": "^2.11.2",
+        "mocha": "^2.2.1",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dist": {
+        "shasum": "6ae35180fdaabc5e69c6112e7d4d1919656a6bfa",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.0.5.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.1.0",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dist": {
+        "shasum": "7f189e2a56c026eb41cdf1837e58ac6a0155e0b1",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.2.0",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dist": {
+        "shasum": "b17921ebef893b9d8e85a7809c979bc626f16320",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.3.0",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "^2.1.6",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dist": {
+        "shasum": "6122fb3e1ac0e63c1f063f34f1344a5eecafcb55",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.3.1",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "~2.1.6",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dist": {
+        "shasum": "578855ae2b602dc0dc1ce9e6e16f72d60eae5cd0",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.3.1.tgz"
+      }
+    },
+    "0.3.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.3.2",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2"
+      },
+      "dist": {
+        "shasum": "159cf6e50f712b50a25582f43b2672869bcd5a4d",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.3.2.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.4.0",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.7.2"
+      },
+      "dist": {
+        "shasum": "82fc0fa2602ad8cd5adb35e0e4e15f9a612e26d6",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.4.0.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.5.0",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.7.2"
+      },
+      "dist": {
+        "shasum": "404e8e8104f2bd000fa6946c9624214a8ba19e3a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.5.0.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.6.0",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.7.13",
+        "chai": "^3.0.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.2",
+        "express": "^4.13.1",
+        "istanbul": "^0.3.17",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.7.2"
+      },
+      "dist": {
+        "shasum": "d5ac345ddb60fb9902c0c82c4754ec243e52018c",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.6.0.tgz"
+      }
+    },
+    "0.7.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.7.0",
+      "dependencies": {
+        "http-proxy": "^1.11.1",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0",
+        "url": "^0.10.3"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.18",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.2.5",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "350d6c2c849dd322535e1b042a01fde386d1f308",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.7.0.tgz"
+      }
+    },
+    "0.8.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.8.0",
+      "dependencies": {
+        "http-proxy": "^1.11.2",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.19",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.0",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "47698ccccee8fd6ff35013ff3dbe70150dae628c",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.8.0.tgz"
+      }
+    },
+    "0.8.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.8.1",
+      "dependencies": {
+        "http-proxy": "^1.11.2",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.19",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.0",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "081b8251f40997ea94f3d7909ffa853cdfc86455",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.8.1.tgz"
+      }
+    },
+    "0.8.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.8.2",
+      "dependencies": {
+        "http-proxy": "^1.11.2",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.19",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.0",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "8ea108c0e2c5b06a889fdec11328782a420e87c6",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.8.2.tgz"
+      }
+    },
+    "0.9.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.9.0",
+      "dependencies": {
+        "http-proxy": "^1.11.2",
+        "is-glob": "^2.0.0",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.2.0"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.8.2",
+        "chai": "^3.2.0",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.4",
+        "express": "^4.13.3",
+        "istanbul": "^0.3.19",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.0",
+        "mocha-lcov-reporter": "0.0.2",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "017be05797de74548653e02453b42ba42b7b0326",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.9.0.tgz"
+      }
+    },
+    "0.9.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.9.1",
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "f068d8f4b6faf96cf57712f16a5e6eb50731549a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.9.1.tgz"
+      }
+    },
+    "0.10.0-beta": {
+      "name": "http-proxy-middleware",
+      "version": "0.10.0-beta",
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "5573a0d75182da174488a44d56d3427081a1fc61",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.10.0-beta.tgz"
+      }
+    },
+    "0.10.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.10.0",
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "6060a8bf03c8443a5de7d5f279e95fa0ac0b1cfa",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.10.0.tgz"
+      }
+    },
+    "0.11.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.11.0",
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "0d279b6791b1d1620dca09b657f186e63c84763e",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.11.0.tgz"
+      }
+    },
+    "0.12.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.12.0",
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^3.10.1",
+        "micromatch": "^2.3.7"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.0.0",
+        "ws": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "014849335422dcd28e6eeddb5af1d9d2917fcb36",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.12.0.tgz"
+      }
+    },
+    "0.13.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.13.0",
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.6.1",
+        "micromatch": "^2.3.7"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.2.0",
+        "ws": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "9c765abb4027b3a95b9e8da8e4f4fa65b1ecca39",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.13.0.tgz"
+      }
+    },
+    "0.14.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.14.0",
+      "dependencies": {
+        "http-proxy": "^1.12.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.6.1",
+        "micromatch": "^2.3.7"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.11.0",
+        "chai": "^3.4.1",
+        "connect": "^3.4.0",
+        "coveralls": "^2.11.6",
+        "express": "^4.13.3",
+        "istanbul": "^0.4.1",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.3.4",
+        "mocha-lcov-reporter": "1.2.0",
+        "open": "0.0.5",
+        "ws": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "4bf97e2794201c5cd0ba07ca401c267f9d014444",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.14.0.tgz"
+      }
+    },
+    "0.15.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.15.0",
+      "dependencies": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.12.5",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.4.5",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.1",
+        "ws": "^1.1.0"
+      },
+      "dist": {
+        "shasum": "59b8c391b2b838763388b0fad48b5bd36b3c0152",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.0.tgz"
+      }
+    },
+    "0.15.1-beta": {
+      "name": "http-proxy-middleware",
+      "version": "0.15.1-beta",
+      "dependencies": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.12.5",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.4.5",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.1",
+        "ws": "^1.1.0"
+      },
+      "dist": {
+        "shasum": "ff501cb51a82d6ec3209c1f8c4345806a4fdaad8",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.1-beta.tgz"
+      }
+    },
+    "0.15.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.15.1",
+      "dependencies": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.12.5",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.4.5",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.1",
+        "ws": "^1.1.0"
+      },
+      "dist": {
+        "shasum": "bf455c567f6f411e66dce082d90c9049bfc391d2",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.1.tgz"
+      }
+    },
+    "0.15.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.15.2",
+      "dependencies": {
+        "http-proxy": "^1.13.2",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.11.2",
+        "micromatch": "^2.3.8"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.12.5",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.4.5",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.1",
+        "ws": "^1.1.0"
+      },
+      "dist": {
+        "shasum": "e1c69b8948fb04e2846ee22f38b650e4f09c027f",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.15.2.tgz"
+      }
+    },
+    "0.16.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.16.0",
+      "dependencies": {
+        "http-proxy": "^1.13.3",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.13.1",
+        "micromatch": "^2.3.8"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.13.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.5.3",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.0"
+      },
+      "dist": {
+        "shasum": "6879b8f1151a3289dd301372b81d8dd026e3162b",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.16.0.tgz"
+      }
+    },
+    "0.17.0-beta": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.0-beta",
+      "dependencies": {
+        "http-proxy": "^1.13.3",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.13.1",
+        "micromatch": "^2.3.8"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.13.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.5.3",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.0"
+      },
+      "dist": {
+        "shasum": "847e594412dccab5f20c1330bd1234de6612eda1",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.0-beta.tgz"
+      }
+    },
+    "0.17.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.0",
+      "dependencies": {
+        "http-proxy": "^1.13.3",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.13.1",
+        "micromatch": "^2.3.8"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.13.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.9",
+        "express": "^4.13.4",
+        "istanbul": "^0.4.3",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^2.5.3",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.0"
+      },
+      "dist": {
+        "shasum": "65770b0bb5d2b17792984e595afb082599bf81e7",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.0.tgz"
+      }
+    },
+    "0.17.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.1",
+      "dependencies": {
+        "http-proxy": "^1.14.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.14.2",
+        "micromatch": "^2.3.11"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.14.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.12",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.4",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.0.2",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dist": {
+        "shasum": "e2b847aa9962d8ce312cc82a3f443d5039cf197a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.1.tgz"
+      }
+    },
+    "0.17.2-beta": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.2-beta",
+      "dependencies": {
+        "http-proxy": "^1.14.0",
+        "is-glob": "^2.0.1",
+        "lodash": "^4.14.2",
+        "micromatch": "^2.3.11"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.14.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.12",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.4",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.0.2",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dist": {
+        "shasum": "a232f70909dd9848ab2b2da7d59068b83a9ff9a8",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.2-beta.tgz"
+      }
+    },
+    "0.17.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.2",
+      "dependencies": {
+        "http-proxy": "^1.15.1",
+        "is-glob": "^3.0.0",
+        "lodash": "^4.16.2",
+        "micromatch": "^2.3.11"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.14.0",
+        "chai": "^3.5.0",
+        "connect": "^3.4.1",
+        "coveralls": "^2.11.12",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.4",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.0.2",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dist": {
+        "shasum": "572d517a6d2fb1063a469de294eed96066352007",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.2.tgz"
+      }
+    },
+    "0.17.3": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.3",
+      "dependencies": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.18.2",
+        "chai": "^3.5.0",
+        "connect": "^3.5.0",
+        "coveralls": "^2.11.15",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.2.0",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dist": {
+        "shasum": "940382147149b856084f5534752d5b5a8168cd1d",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.3.tgz"
+      }
+    },
+    "0.17.4": {
+      "name": "http-proxy-middleware",
+      "version": "0.17.4",
+      "dependencies": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
+      },
+      "devDependencies": {
+        "browser-sync": "^2.18.2",
+        "chai": "^3.5.0",
+        "connect": "^3.5.0",
+        "coveralls": "^2.11.15",
+        "express": "^4.14.0",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^3.2.0",
+        "mocha-lcov-reporter": "1.2.0",
+        "opn": "^4.0.2",
+        "ws": "^1.1.1"
+      },
+      "dist": {
+        "shasum": "642e8848851d66f09d4f124912846dbaeb41b833",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz"
+      }
+    },
+    "0.18.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.18.0",
+      "dependencies": {
+        "http-proxy": "^1.16.2",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.5",
+        "micromatch": "^3.1.9"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^6.1.3",
+        "@commitlint/config-conventional": "^6.1.3",
+        "browser-sync": "^2.23.6",
+        "chai": "^4.1.2",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.0",
+        "express": "^4.16.3",
+        "husky": "^0.14.3",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^5.0.4",
+        "mocha-lcov-reporter": "1.3.0",
+        "opn": "^5.2.0",
+        "snazzy": "^7.1.1",
+        "standard": "^11.0.0",
+        "ws": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
+        "shasum": "0987e6bb5a5606e5a69168d8f967a87f15dd8aab",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 45653
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "0.19.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.19.0",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.10",
+        "micromatch": "^3.1.10"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^7.1.1",
+        "@commitlint/config-conventional": "^7.1.1",
+        "browser-sync": "^2.24.7",
+        "chai": "^4.1.2",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.2",
+        "express": "^4.16.3",
+        "husky": "^0.14.3",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "1.3.0",
+        "opn": "^5.3.0",
+        "snazzy": "^8.0.0",
+        "standard": "^12.0.0",
+        "ws": "^6.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Ab/zKDy2B0404mz83bgki0HHv/xqpYKAyFXhopAiJaVAUSJfLYrpBYynTl4ZSUJ7TqrAgjarTsxdX5yBb4unRQ==",
+        "shasum": "40992b5901dc44bc7bc3795da81b0b248eca02d8",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 47638,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbhw0DCRA9TVsSAnZWagAAUPcP/1A2WhkhsxkmhjldBC0L\n2g7MExS6bgGFP9gMvsCGXxGG4b6VlxM2oaQovWICSLrgkSJM+KdtNEw+jGjV\nBVlYMtBy25g3QYnYn9UIdmSC2mhZPg/4Th9K3GM8RFapxnzXCaB6IW9aXrrO\nWxIm2kwcHtg30j6EXdZP2dN8QXIA1hiP3cZUvnayP6knfGZmigtN53oL0aya\njK43LJnvLmGrsn8caBrCYKn/iJg/OS5vQ+efwDV9O6IKXdKDqN4FS/wwZ73B\nvgcR2avQP1ltRKxOhxczDSKB2zkSOPUBwYvsICU0HUC8YnkV54JxBFKXd9vZ\nElFjbUZu1VBYmLu2GpY13ohs6Fp6f+0rD31YWf9927pFfu/4bHcAE2TyGMF+\na7oeE6CfsKkKwwcnQAIGEpP2dJqF1B+HQ6PSVxXZu7Aul/coMNVFDrDclN3O\nRGMPZY1zruZd/rxN8EtkRfw8/3/7/kJ4xZLX9iT14CJMjyhSyAuNUrVEKMwa\nBxf2fIXMMPm8ixJDaoV1YAaguDuI175emLeYJQEIO4QRt26qwiFfNzNtncAD\nGfMvcK1iIPmmmqehBqAnykmY7X8vBwKibiqAqzcDIFvYRVBI6XuitpUtzAcj\nTxSPqbK1LK418yU9kyZTQmvIspJM208WSQg8god9nhZEsH6zuVznuJsDxElj\ncYoN\r\n=tNgg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "0.19.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.19.1",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "browser-sync": "^2.26.3",
+        "chai": "^4.2.0",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.2",
+        "express": "^4.16.4",
+        "husky": "^1.2.0",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "1.3.0",
+        "opn": "^5.4.0",
+        "precise-commits": "^1.0.2",
+        "prettier": "^1.15.2",
+        "ws": "^6.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+        "shasum": "183c7dc4aa1479150306498c210cdaf96080a43a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 47749,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb+wOjCRA9TVsSAnZWagAAF4wP/iFtdy3Uih6MOUfLwFse\n8CQE+LjzM+VtuI9/7Kgzq22OoLSk9HG4f2X0yOwochMFtzyoXpJiQHbx2VQd\nMV5PMDLfoDAU/U9aLzH/HEJY4cS5/+Aq5tcZJQAEEj2BFh2/HazJ9mor7iF/\n5tnSqANMytw4Ns5s481DQ7kWslmfv6tz1sJfUhu3WZ1KRdum4UNkElwdMDo1\nP1KNOmL6fKewy5gaBvagu79Tn7nbW7JJY9LE5FNlWcb3/CamHI/goiYYfOGB\n+voQbrqRKFkoCEsWQM7jsLaAh9ThaZAOLF2qDqdZOy2TC8JQ/eenxhiLUSxy\n7bDH7KAuRr68UrHXNru/SWFXd0UtOk2RgY26/crlJOCyez/wGrVZ879gen8b\npcJRqFmUOZylMrRLCytnfD6q4WDxFXh7Y8SNPBr6YW6MNS11mgiN2Nf2SD23\nrtU4WgtdD7W/ZazW3Nr3OOhF4rXDnsOZkffZq15Kkx7Au9+VkfIu184WdjN0\nELca91oKH4NtOXSXL+2btOwoxQZK9Cil87brxlJWqBp3oEQZkkapeB6hT+xF\nJmSAnUQHthlLr6Nqh9d+s6Atha/m1dlNNhYE/DlDHIBAPSXamhwi1EB2fO4z\noNl+CkmaNXFRG4i2xazaMDnIiWzwbcpS/X+1yVR3apUTRuqc/uaxe0BjhPwe\n/2D0\r\n=nSVz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "0.20.0-beta.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.20.0-beta.0",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.11",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "@types/express": "^4.16.1",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.11",
+        "@types/lodash": "^4.14.123",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.0.4",
+        "browser-sync": "^2.26.3",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.3",
+        "express": "^4.16.4",
+        "husky": "^2.3.0",
+        "jest": "^24.5.0",
+        "open": "^6.3.0",
+        "prettier": "^1.15.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.14.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.4.1",
+        "ws": "^7.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-rXjfA9c4qCfRPBuEjn4lLinMYmXFSmylBPszJiUBg43tAJx7feHWbbx0VsLMTURe1APw8mSXCuRCMBDhByGT4Q==",
+        "shasum": "8d38afb8ea264b8ea41a7b7b8e69411ba2eed224",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0-beta.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 51162,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc8ZZUCRA9TVsSAnZWagAARsoP/2VE+jurLfwtvCIDDVe4\nT+VKqcgNMPJEacyQ1eJBd2cs283zs75Bf/mzIHYAk8doK+X+LWwie1lW9QcP\nf+Rvr8L9bdITk4n+cGfU8es7evpVAuwB7A+h0vdEu5PPYgPhPGAZDVfT19q2\nGy2ByOUiamnNYqAlpIV1iGbPiL9nHqFXCZuEithRR/CYf/JvzW82UCQho5mk\naMhy/I05CFhRQNP30Se26L68NUofKIZnKQUGPoOUjwH5ez73xXWbV4A+gA8o\nNwvAznB9u3SwEwH3qfY880d2vCL0iZ6/wG/5G6BF4bJ/5JlpKEs8i7pxwCV9\nzlD3k0vxgms2g9g3XhuDDJE+rivLWFJa14dROKJGlfgCg8oQQuXMIl5oZJQh\n8uq10OJ2dVRmo/in0rm1BHKx0tugRGysygJ91Lml+AeavTVv719EX4VKgKpW\noXu6nu9cVktYaJN82iB/FKEjsUd2fq8QUsf0cPGj8wyDz6D1uhV76VmIH6Ml\n8HAKxtzlTR15JN9s3uCXqBYCGaAKDz4p6aA57kboWFbgqj3r1InBYhnDq53P\n+9j3xLkiawBnwb2Ckk9MendRklvbyl3Es9TERkEoIL+W/6V+MlImH0DH+uMB\noElTRggfmooAbh6GDjcS++AxlXo/mowisJpe581ndWcgXxE6j/czFt0KK3a4\nM5PT\r\n=HJp3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.20.0-beta.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.20.0-beta.1",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.11",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "@types/express": "^4.16.1",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.11",
+        "@types/lodash": "^4.14.123",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.0.4",
+        "browser-sync": "^2.26.3",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.3",
+        "express": "^4.16.4",
+        "husky": "^2.3.0",
+        "jest": "^24.5.0",
+        "open": "^6.3.0",
+        "prettier": "^1.15.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.14.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.4.1",
+        "ws": "^7.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-vsJ6+FeSwW6epQMXEKowYHmBN+sLxJ58O03Qf8pTyjZM+8hPSpPPasKfALkD7zEgqKJTKMoDskZH6JCkKTeFjg==",
+        "shasum": "55e021c8240e44f9e7cf2d9ec3e18bba6ccc7553",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0-beta.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 50619,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc9B8CCRA9TVsSAnZWagAA55kP/R/PkcwvAL6okwH1wmMy\nE5nhU9ei3BGIy/Jvd8El8vF6y5qg2Xlx+J9wLdxST9Wb4qxkC/kJR6UjH+ni\nTU88pRl+mpiP2UQrakZ234FFsmFfwj8zyXyBq0aQr2V3FCvwMXG+rsGtEjUD\nGtTcfEPs44uFwDwvlFzQZWxlU8ot+ae2PEEg21fj52bLawnTeP4y6cI0g0Z/\n+lhm85lX/r4tqwj+elxQhCDt7GhHgrG0r0Mv7Gmrw96+GIH5Jino3xjjGoAi\nRwz8e8kX8Ugecy/jOp2GNI74AdREzCmEoYEZ7fqCQYi6TtGgLoOJjpA4jZWI\nYrywi6XLcKoiVcBJkvZ1M+A34NuXR3/SsGZj8J64NZ0U0XHG79BRhL1o0gKb\n5JHm5T2697L32jKwRiHipz6lSYcTSaS0PwBrkV1C3DJKIj1mj3QPCFvh6uwb\nVdV2QP34pgucp4tWBZrJXM2URfQ79+fv3CMDfui2mkhZ/hTw2U0mLeKzyCBC\n1b/jcJ3tLFmOEE4FHoWbxtRFngoyxJ4B36iNRFtQgqAmStZUa+0PLHOaXMve\nX3VoTwF2HPx0Y8uKL4KEHlg5oJLNd8pbgVVBSMeI5xJlhBapq0B9h5tjuCHs\nVQzG5tImxFX3fP+u8LLuLUcUrlIStiLqj8uMdh75Z9XzyCylf6wn0xgQOxdv\nTw/7\r\n=gP+D\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.20.0-beta.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.20.0-beta.2",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.11",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "@types/express": "^4.16.1",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.11",
+        "@types/lodash": "^4.14.123",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.0.4",
+        "browser-sync": "^2.26.3",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.3",
+        "express": "^4.16.4",
+        "husky": "^2.3.0",
+        "jest": "^24.5.0",
+        "open": "^6.3.0",
+        "prettier": "^1.15.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.14.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.4.1",
+        "ws": "^7.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-OkO4poCBY2pt2Fn4iAte5Vy2vMsLjUzaHX69nxCPRZ8BMjvsv7LZcgyy0xI2fILBQL+D7B6WS+rUI9ugSJh9Ng==",
+        "shasum": "2e1f99591415ea388826f98c065a5fa173ee7d8a",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0-beta.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 50947,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdJO3uCRA9TVsSAnZWagAAUfUQAJVf9KYsosvC1oPpHoOu\nqdFXoijnD2S+LD3N5cvYeFG/NvCHOlh+jMuCC2+HPi7Jj2RKM/GmnH6Hvwib\n0wf4yZBU6tKmV/a1KVwZJ8UvahJjgAVjYnK2ri3Gk+4HjrlCtWPpJOm6tmmG\nwzsHQX2T8ZtRUk+bgLlwD84+73xdaYIBDH/eVmxjWFmBiUxOMb/otA5UFxYv\ngIo6+PwyztPMVVkrLsLGJxCH/SdJOEngwPEKwb63DVZmu2urq109v4Yz2U3g\nJmfJg3hbKnvRRejQBm9nOq6IxtVtusTfaIGRwU0p6HFbG9uxjpMWfUGH9yzO\nqXXR05X/bv5xkbI/zLqj5rPnl78BJm4473cWuqpEOW9TFpowuXvEGehLTieK\nnmpBY5qweummrJVLZ1K+N/f12T/MJQv/rmikDEwbiagA17b26r/8J+hINqYn\n9WJXnJn3aDkbY06hlWsw2/cNm22z44nTlD9W00mC7+syavyZFci5bUGzdoPQ\n6LzsFQqGCQHBZ9tZmaVAXbIDnzMQ0zg+9k0EI9fuyGiLRw/3xupP5Js3om4O\nObIVP8JVLajSADARg6HYEcvtiOvs4nFDNktIT9Zr4ex1DFWVcPoIXJJfSnYn\npIMqfC75Qq/FuCDkOAZwbhejlpiN2fWZTEZIsul0e/zZ1y0jPMNr13xpoOpY\n/bbz\r\n=Vg0O\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.20.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.20.0",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.14",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.15",
+        "@types/lodash": "^4.14.136",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^24.5.0",
+        "open": "^6.4.0",
+        "prettier": "^1.18.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.18.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.5.3",
+        "ws": "^7.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-dNJAk71nEJhPiAczQH9hGvE/MT9kEs+zn2Dh+Hi94PGZe1GluQirC7mw5rdREUtWx6qGS1Gu0bZd4qEAg+REgw==",
+        "shasum": "5b128f7207985c4ea91b53fab8ad897a48c690d6",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.20.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 51251,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdbsVrCRA9TVsSAnZWagAAouMP/j7gzAb7qpsFw9cwrsJF\nikrihxJpdZHwDmcWeZmo2GsFidAbGfDV6AtL6XDAhSO+XVMb6ALr/tXjWwns\n1I/yrNPWqFEsIJlmKXRZf/cauCPlIWQrPJoGfOVrCo7XunCAxyCT3EmQwjEV\nb40JoPyRUX8UpbmicU2mM0KoKogv2mKhDy85gdLmrpgOMLuk1L3PHSR9xAOB\n69FsAyNuUqNNMfIbKkyQfxLkkAe9AZEgd+1dTf6Qk/GbTIUuMvLBwhoC641q\nFz1VEcABAecS4PkdntwwY1g+Q7nbEFIu8qgJG/o9GQFzod0HORGZhLQy/vOV\nWZCottDnxfGv1p7Nr4IfHjTWn80MYeZbs5VijG0BC539d7DWbobE/qwzUvEA\n4Iu+7WnlqUKwNAh6LEQ/f7OzYuWHp+N2tZPbqr6uJA4Btd0HbpMstVXIGMaK\nzDIsk06Z1JRTva2ws8fMA1rbAZG9YgGN5d8HXTMxf67dmccMZFbnkoP5BlSi\nrmGUYGgwVH1x3v5kzzrbXPZ+6bLB+2s1TOfybcJg6b6hIYkAHq3zX5YzX89w\nmb5MTwUKCevKL/rOzQQRwjm2E6tFI16fXJvXv6OARA+Se/HG5f12ayKppZTD\nQ2okbuuCAasl/K6J0jE35XETiQmfzTGE/lSHS4ihw6lWjW4irXcniRqys0Gg\nXS65\r\n=sGAt\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.21.0-beta.1": {
+      "name": "http-proxy-middleware",
+      "version": "0.21.0-beta.1",
+      "dependencies": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.14",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/http-proxy": "^1.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.15",
+        "@types/lodash": "^4.14.136",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^24.5.0",
+        "open": "^6.4.0",
+        "prettier": "^1.18.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.18.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.5.3",
+        "ws": "^7.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-qiqFG3Ri+aTfQhpeAL1IHKSOdrHTBhiaQoJSKcD5FJwPdm5rxwq6qoVIITcGwHqz0iIZLe3YIkafwRO8FMwt6A==",
+        "shasum": "ddda0025b69f288475926dbe044b90f38278ce32",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.21.0-beta.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 52422,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeA/TqCRA9TVsSAnZWagAACOwP/RVXofcPWn7LTE140UKq\ny4N5PWgXu27qd7twIRWYDF1irH776Qa05DY7RnjbWK6R4+uFZ/Jf+l5ZGdkx\nBOlJVGAEa033Ic3o/BZZh3l3AwO1caR1J47rKRaE9qBWUo+0HD3BNFMbyvSH\n1knyE2af6Q+9HVic3k8ILaSZTbuvFffuR6A9kWgpjTkB22aGaA6ZvfVJCWZP\n/trm8cjUl+oCbF51eQdD38PE4Cmv/UraFDJu7zgeCgjMomH5bbrSN1vpsdvy\n+CD6k2a7j0lLPoXpOG5ehB7u6t07eBOixT0/qfJTntKdV2IOycEGXaSH35j6\n6UKvVJ47FRiV4zxLBiM2/XRhBUyaRzzie61uVDFs2gLV5aKVoS1vjWqzJ1Xl\n/BM9gb9+mWYtbST3/sIZHjzDVyHW0JXG/6KX/ufXm0yKbmqUFEpSIhq1lg24\nOkiHyx+Zmr0Rftj0NpM+2vIDa729+y2g/6DTvAh40cOtxJLSu5KawC0Z7p4L\nV0x/npTRKG49zmrcJz8JdHgTtWOxu3dIhgfCXxV4dqGTDT3dBqLofFbot+71\nwbvE5+lgJWYqAtwk+47HV4HlYm0SjAaHszU5gbdGsQveziKHvOd1wEfcVJ4t\n/aNXDfrbfwXn8OkYi+VlVRDaDhBzL0ZYufKzvhwQF3evGfEr8LfeIRTOJuKP\nhWn0\r\n=MUL+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.21.0-beta.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.21.0-beta.2",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.0",
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.14",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^24.0.15",
+        "@types/lodash": "^4.14.136",
+        "@types/micromatch": "^3.1.0",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^24.5.0",
+        "open": "^6.4.0",
+        "prettier": "^1.18.2",
+        "ts-jest": "^24.0.0",
+        "tslint": "^5.18.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.5.3",
+        "ws": "^7.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-Cvemlr1M237MEgXpL+Tti9w6aUV5emMBkAXW3JaECIBeW+voER6A5Zjs5OzgAHcoeT7rz7aiVmCC3gFpo/r3Ag==",
+        "shasum": "ff38e92a3b666c5cd019bb5019884aaf350200fe",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.21.0-beta.2.tgz",
+        "fileCount": 24,
+        "unpackedSize": 59320,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeEhc/CRA9TVsSAnZWagAAy1kP/31RqHzQY2vZacutkcqf\nWndTw3VOvCouEwws4/a9ONBAdcbQ1Sp4UvGwtsiuYbaXU+FnryZWpkQg26Hh\nrUNrwd7aY3s1kiEVD7l6DlexQonm+JbiuOdjksy3okej770MOuWW31xhBFpq\ngyyE4aLZXdzZ0OO5NeUErMfK4Ghm6FQK78oaQoBM9Ef6lst8qs3fVhsbq+MP\nswArYa19g5Exsw97wkZMx043tlrAxkrMWhTa1WAzQIlUEk4CgfNS4ScRjcCq\ns66HbkC5oDBGFhKDPaHx7gdZjNQeGHV1pU2EKurWWvvmeL2J6+eGI14fLwNO\n54Wtn9lcy9WlUSggT4U305LNkrQgBiEVSld2viuelIWHuMPHUtQA5WMNLozO\npyIUJ7pfEF9n5Q8Jq1erps0Sm6yGeCfInFQ5ULDwpAWVn7TGPvrG2h0nAiMM\nFdeRr7KS5YflJhWIgeszpEvTHVgo1xCcWDiVP6jrrnGI4HL/WQHiBmkCHeMo\nCbZPr33dCC3Z10AX8YLtA4n04eQbqW07EEdOwEGMyKM6BIx4onb7qQpA5Q4Z\nB5FgRd78iy6h1ZPPxIsmp6zYaX0u6cwkrCR4vvKVob3u7zKuZMnS32tt97YY\nC4lRGb/SU9oLnzyU6DIRxCXBAgaPftOUAHG7EWZotYtTGlC+9GfCf2u3ySbO\ndOfR\r\n=eGx2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.21.0-beta.3": {
+      "name": "http-proxy-middleware",
+      "version": "0.21.0-beta.3",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^25.1.2",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^25.1.0",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.7.5",
+        "ws": "^7.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-uI1yiC+bS3NcY8KBbZ9QpIdgLOoTUsJBb1HJYWlB1K6aTArwyFR1Tf1T73kyP3miEXoFI2tebsfTGbddm1e9XQ==",
+        "shasum": "ff5cbd11863aaf7e0012d2ad7520625e2e840255",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.21.0-beta.3.tgz",
+        "fileCount": 24,
+        "unpackedSize": 59849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeRvx4CRA9TVsSAnZWagAA6U8P/j56q2SkaGQ4Q7P/KU/2\nzEdomyN+Zx1V9oysfRETL4IaZsIgkdM7lCQidhpSz1jn6ODHO3Hfj226ZvUz\nzefR3+QHT0TY+Ekk+uVA8Y5IygJR8TsXhwPpkXSQ2owPtu1hyD3LMSRu51LN\nJAV5ItkB3lgcL8dF2yKqqjju9Hi6tmzjnLdN1ax8/pPxecruhOXkepu30mqH\nk4OheovQ9t9Rgkeilng7N8hZ5V1IbRWfp/z924G7xA2+eSdJL2SM+B420fLK\nYV7DNGkTys8FznijyrYLafoR1Ss0AeAo8Ce1Xv6uJeyM8UvuLUP8sXkZSBWt\netIY8S/vwJwAzHBMvriyaFMBDrz2YaO5v/ZAyRd0FY8BpGEltvJElQpoJtI8\nFDNzimr1jIXQuZuVGQl89QDh2l2SYZvirX9Pg1jwQvzkOfiQRk7TImryensW\nwUZ4OaRIi/VJ94EZl11CIEZ1iWfYRRDXGgB8FNFQe5aqHyTj/OunDZ0p9aUT\ntDw3lPaNb240LPtPBAlnMVpPjbA5uTUo7s99FV5ByrjagXanPIkhe8GFO4Jd\nrCDFztheQnetD5Q5qy9lk59QVZG3Mgp+tmJWeitil0cA5/VvpK3aCVPUEnBR\nqh/uTV6Mdho++6F/D3HbbPtuHfTGzATMfRmb/bG3ULcH8bvQ/digWvhhyLoK\nLehD\r\n=lPlZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.21.0": {
+      "name": "http-proxy-middleware",
+      "version": "0.21.0",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^25.1.2",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^25.1.0",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.7.5",
+        "ws": "^7.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-4Arcl5QQ6pRMRJmtM1WVHKHkFAQn5uvw83XuNeqnMTOikDiCoTxv5/vdudhKQsF+1mtaAawrK2SEB1v2tYecdQ==",
+        "shasum": "c6b1ca05174b5fbc57bee9485ffa0fa2f0dabeb0",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.21.0.tgz",
+        "fileCount": 24,
+        "unpackedSize": 59919,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeSYqmCRA9TVsSAnZWagAAZjEP/iJtDP2vl9xSaH2Ii8gC\nliwQiqsHwmscx2cWyp+77nuts/R1szQCiCISv4gkLuYIUBRpgnyQ4FcKk/vf\nUqcXxNzQNHbndlNxhbBdGU4tHOVdAIhhaN/r+8F3PFOyHqzwo8wTiO31T8U5\nDCkQ5SuZj8jCJaAzTkO2kS5Xtl1nCaQU/SBHGmIunE5pnBY294UyWLljwDfC\nlS2y2r3WDswqlSw9lguLwocv6iyeujG3GlFkLnM+IyY3O1LM8lT/iOkc4ETV\nRWZjHYv+98Djky9S7K7YsFle5cWnHdc41XyOfm2YDqSAQhc94XxMxGvXniyH\nQO15Y91hlWK/eZDWaaXXT8HzhOTiRzKXeHSo5Bv8ZaxROnGwYcSxFcMZmVRC\n50Bp1Iecy+HwbLs3DNBU06DNLRdcAedo15a8J+3I3J4blL9DJue5MSj4A2aR\nF5yzn0g976E8lTwOJEOZ802H4aTL7ifZWasioANPEQ8hPUr8ce/UVHqq2t8O\nz+k310fc+6Muu48ZMNItzFUABEWY3g49Oky/d54EIHRxcr4SESvC5vDyQ2wy\npc4wTbKyM0cOOL80SMV6jZZ/NRee9DH46FoOp+Jnidg+n0UQxJqhZRyLycSY\nCVBP3ohtFzMk35hUquIqg62Ebsh8yYHDWigAwviOCaB0GERAWj6k423sNdUF\naAQU\r\n=yWY4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.22.0-alpha": {
+      "name": "http-proxy-middleware",
+      "version": "0.22.0-alpha",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^25.1.2",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^25.1.0",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.7.5",
+        "ws": "^7.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-8Pv0BDLHxYR28wxIkFzV8bO6B1N1YvdWSRrs49iHWLTYwzKPhXp8TyFaK036+eoqAgm03BkmO1HV+11oADhX2A==",
+        "shasum": "b08602cf1b9392d8a989159af10cf7f7e5dfea60",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.22.0-alpha.tgz",
+        "fileCount": 24,
+        "unpackedSize": 58109,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeSwDoCRA9TVsSAnZWagAAAUMP/A17Tl8IIL5KeSQ+qqEQ\nMxJ/YRjJH7FOiyVlT9sINW+ytfD+3lJtOTD5MNY6ddg3EgBvPSmfHu3dqexA\n3735KbZ/eCkhIFg2vhlbrjaJrFZzZfUDiXd4rlPOptmrjRRhfPIDyKydXpdK\niBos2k6ahHICratlCnNNbiZFWO3Gv0HzAWDPEDLoy3423LnqsZrJPHLgnujb\nxoKwWrc3YyMlrkQ/+9bBVB1xchqyCBKtG6khRGQGm7f6VMSr940jqqh6WVfs\nHefWsNxmqpVK4ZFUD0hdBlw3ypnFfGFa8kfbfFi8AqoQL6+T7WtuQunNO1fG\nultSQVaB/jd3kzNzdtBba37ZU80sCgv2F3smu8Er9YqaRVNjtMzT/ThHqeHP\ntPys31QSJic9LD6Af4ml2n7O+7utuV6/Q1TLQAsNR+iAjde1RcltCTLgIyGR\n4XUrFm+VKmKMtzU3Rov1jqn58ZbJJyYhbm+bhGCXBapmZxpossJHA8HHW0Qd\nn6m6JHBFMJY5Y2uv2m1rCyjdgVv6etjPFzEvHSBarL1RHj2xaLPBXSPXZM1P\nqf5qy0qb5Pv+zbiLYD3j1GmzzYYuJkdjQihgN4wyM7wSZS8O8PtTVLuhsXUM\n9Gy8jW+dKUA88JSQ1v3Qaw17Xldj2oeg9NjhyBJaj4d6+rEOsgZRw2M+JkC/\n4K8/\r\n=LYOP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "1.0.0": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.0",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@types/express": "^4.17.0",
+        "@types/is-glob": "^4.0.0",
+        "@types/jest": "^25.1.2",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^12.6.2",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.5",
+        "express": "^4.16.4",
+        "husky": "^3.0.0",
+        "jest": "^25.1.0",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.7.5",
+        "ws": "^7.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-1yM4gD7R/U9R5AwA6STkoj8JfjnMeZIUrd8e23Yc14A7xVVLUWlAikgvidklwq1UOroJ07sc6NWNULeOJMYOeQ==",
+        "shasum": "984bbbb38cda7ce4495889388afe8b0f39ccd5c8",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.0.tgz",
+        "fileCount": 24,
+        "unpackedSize": 59829,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTGV+CRA9TVsSAnZWagAAM7YP/0TU7JcGzVw5x2sI7pw0\npHU7A0Ut3ZBPSm7QittvCrb7XEdOGLMj7bwIUm4f83MJzxT97zogJWYQ+Tki\nOfRH86TIVuoo4JTMz5yv6DxjdWTXfMN11cZ33xFNZj15U/uRPg6IiFxImK7A\nwPq3LbcKfpDZQIfyrT2ntEesWZ/KLacF7ICaVgDgmld12Ia3fyj1yH5ZC4bE\n27PniIvlOIASPWCfu4VzMTfxv3sf3lWGRv6sNzuLdq5hI1/Z5iE4SNgSiWN3\nnVJ1BfeaYqEphBYVBy7ZCeneOum3m/5ibBXK/Za1tz392cEiTcXXekbguhE/\nleT8tgRReug3vdWPIhKeXMp2PWEdcNHH5T/Juuv9d+dvgStitJdLzr4p06L1\nDca+NeUEDBD7wA+ohAzy6Nw6EgKfrQo8sNOZ5pYJu19D6b8RMLoCY8vO80gQ\nFAumAzl/dtAFw1WQ8wPBewS2/iNXNpKTpz+7odfuiI7IZahD9piPoNFSqrIL\nNUyJwshUGwYyR4fypIh+XSR3zDIZ7c04jIiRx7B7IU8wMdX5owCKvs1UtC0j\nixEWjO8xqZxLyBJNuvK4TEc0bntol4CEZZW5dyvVELhhU/QiBnkRLF6eKeI4\nmtIGQj2YRUoaEkDsYc1gr2H3ENkCtDxHpeBjibKpvxofQYR5QkUz8wLajwOj\nivD6\r\n=Pbr3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "1.0.1": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.1",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.2",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.1.3",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^13.7.4",
+        "@types/supertest": "^2.0.8",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "coveralls": "^3.0.5",
+        "express": "^4.17.1",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "lint-staged": "^10.0.7",
+        "mockttp": "^0.19.3",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "supertest": "^4.0.2",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.8.2",
+        "ws": "^7.2.1"
+      },
+      "dist": {
+        "integrity": "sha512-tVLWnJMEUANithPrWeYgReU+mi6/BJOlyvWKQGS4k8L+j2ZjituJdXhejd31X5J8Ux0SSIH7Iw+RItH9bwkGcw==",
+        "shasum": "a87ee6564991faca4844ae4ab1cf4221279c28f0",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.1.tgz",
+        "fileCount": 25,
+        "unpackedSize": 208005,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeWlukCRA9TVsSAnZWagAA8aQQAIZe1PCCvYVOjxk/LoCc\nRi8rEWdjcQXxJDTbsQqjPtYlEgRb2ypw1liL6iauPyXQ1e/WVEJasIpKB7RC\nyn7SLWEvVXROrMibhzJbs0XYBzBqyp101YOcgNXbOVAbQo32/me0+bK0iddb\nkvzh8OYet+qy2bX0jEFWVnCiL6bnqj7nV8508bmov+u9lzeb1O4wef0hAfMM\noU1pomt0cJEWegP5bdCqEx2AOChxtuZYTZftsrCs0TJHFmBYaz/jvpLwNRYc\ntRq636hbYWKxVCJAGOy4X0IEVZOsW3889dOqDoCbtLMkJcp0Xvj0+XaQcnU4\nDqaLoicKCiREd1OJewTjL6TZfT1zasOSyZfTnbfivw0TcSBR0w5VgutF9fb1\n1w9M++9ClJn8OSrDoYTs5V861dTQU1wMD5Rt1OFAYySyzMrcuX1YOIrNzMKO\n1fbTk60vOddQKwf/fCg8hLIv0t0fmLCLV7Ed7aYO29u4i3Va3Z66bgrANVUf\nwO6ade7yTBSfkAHEE8qJcQ/fUBPqbfnu7HrBumk3LHpyrG+sOOm/ABJgQO9m\niw0uWcqBcv5zjtqUSVslFfxyN7L10QpfhTSinprWkOiwWJPVNtiU0nSeCbO9\nAdKwdobuZVN1NWl1Rwxe/H4xoLVpnexO7FBoWsxpgQCjKwICu/f6j3ixau3B\nvvcl\r\n=Hbik\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "1.0.2": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.2",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.2",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.1.3",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^13.7.4",
+        "@types/supertest": "^2.0.8",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "coveralls": "^3.0.5",
+        "express": "^4.17.1",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "lint-staged": "^10.0.7",
+        "mockttp": "^0.19.3",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "supertest": "^4.0.2",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.8.2",
+        "ws": "^7.2.1"
+      },
+      "dist": {
+        "integrity": "sha512-JHBdMgynLHdKXK9I3BjP8XUKERBCqxvA7dtWj2Da5Bqdo2CRCRQMuUdI36eK1FUFyh6JFIOCBQiQ2ZS+LOs7ww==",
+        "shasum": "63e8d6b039c72e7148e410e7a4690be6dc1a3b8d",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.2.tgz",
+        "fileCount": 25,
+        "unpackedSize": 208382,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJebNtZCRA9TVsSAnZWagAAYwcP/AmPitZl+Q2IzgLeRld3\n1OyjjdhrxiDCAT3Wqa319URhySL7Inxog2Omb8wI5degmArsZhjtQEenae3D\nOacaoi3gKHbOQn6cUoaGU+4Fb0di3S1DbOlN534hJDaoORewBrvfM1AHCRV4\ndSgdTaCDPzuFytzfowVM6148/jXXk1GQPW/i44lRnHCWsjoOuyfaheyj8BHg\n4Lu70bEQB7Qg+QwPiCtdhsiHId60oqrsOvyUo2Ux3EJDkNB7pMsOYW5ALb28\n9MHmmEpq1CcxWy2hv+l9J3IqzfQ8WbdjHU/YfbcQpT0Wx+rubkDpcMHbYVsz\n8quMiHAT0M4ebXt+H5ez4jd/b/iXSTEKf0yRYCAvwwrGPTsgu4suPevgJSq0\ngkQWikIDzGIfQCRDyEv0oNC9vJytG8ttjvyB3ztG6q9PUC/HoR4fC+LR+hlC\na/bItafs8/21X6e0mqKuMhPr6TJnyROGJ/HxayizRjG4/Lgps0GKXRHpp8Jr\n6mKClZWbFi3aflSbvAWRhIM6qvFL0kWgxlVPbUnzeOVRy4Nujjft0JvdoDd+\nN+av6tsasYEclgFsKzloiO8eQ73J6/VxcbNz1q0U5l6FaAqa3QuI0i+75Bh0\nP6Rii0A31vlReadrVYDwtUniZqaN/l+8CdcOQpbIm1f0/5ElAJX2rXdjCD2X\nXk6y\r\n=bgRe\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "1.0.3": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.3",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.3",
+        "http-proxy": "^1.18.0",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.2",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.1.3",
+        "@types/lodash": "^4.14.149",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^13.7.4",
+        "@types/supertest": "^2.0.8",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "coveralls": "^3.0.5",
+        "express": "^4.17.1",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "lint-staged": "^10.0.7",
+        "mockttp": "^0.19.3",
+        "open": "^7.0.2",
+        "prettier": "^1.19.1",
+        "supertest": "^4.0.2",
+        "ts-jest": "^25.2.0",
+        "tslint": "^6.0.0",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.8.2",
+        "ws": "^7.2.1"
+      },
+      "dist": {
+        "integrity": "sha512-GHvPeBD+A357zS5tHjzj6ISrVOjjCiy0I92bdyTJz0pNmIjFxO0NX/bX+xkGgnclKQE/5hHAB9JEQ7u9Pw4olg==",
+        "shasum": "f73daad8dac622d51fe1769960c914b9b1f75a72",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.3.tgz",
+        "fileCount": 24,
+        "unpackedSize": 61172,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeb+60CRA9TVsSAnZWagAA3TEQAIdqzqTt1VDjJdBdeJrx\ncbW7+g9QKgm2yU0FOxPZt9pn6dHgyQ6aMTdnz1dHDNUzzNxPTMCWfokj4R0C\n58eZFUBVZTrsLDWFzUuzp9waFMJmCXmZ3A7aoVINhBuUh80IQflXejDjUb5H\nwXssYU0N5chW7dPPNAyfL3z8ploILDWU9OFrwq3Ihf3qmu+oGXVGaoXl/r7n\nquKR4B0Q3g7qynqUU6uL+kcX5T5OSLujJaN9CuX5SaNkUQhfZg0AqYCk9Yf0\naojIgN/sb7IWreQPn4kFu+jovFPQdDb1TQS3RaRvoM0FseDX7qmph80yee/c\nAQkv6oIHLI/AsfVsGGHuKlaZr4x8zyfwVWA0mCk3m41DvqkPgRnw15KCEtFd\nzMQPJpoBIBvDiNJjSYYSSVg4/Hkr+ab/6ByJTCyZ1G3NOVT9XCsKiZYr9yg7\nL5enUKyp0QO2e7yEJwbABn/UZf1ix145Nmb3avFYoBSjq1i32Iqm6m89TZ6V\nS0WnRzpzmUE8GEXkvxGHqQf8PF1dvXHsbXwaJ2kErdKX9peqiG+DWm8SVUdq\nLluhk7ClAMoAntAcoLbXTFoLTDCqJU6gnO3VCdiUc3zi+UHaQQg72KToOBiy\nWQmxWL4buEl8CwJCaRuLXcwCEa3RVfbNcamX30AvQ0Sd2coFgZkrWBwx9Va2\n7Kio\r\n=wLwG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "1.0.4": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.4",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.3",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.2.1",
+        "@types/lodash": "^4.14.150",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^13.13.5",
+        "@types/supertest": "^2.0.9",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "express": "^4.17.1",
+        "husky": "^4.2.5",
+        "jest": "^26.0.1",
+        "lint-staged": "^10.2.2",
+        "mockttp": "^0.20.1",
+        "open": "^7.0.3",
+        "prettier": "^2.0.5",
+        "supertest": "^4.0.2",
+        "ts-jest": "^25.5.0",
+        "tslint": "^6.1.2",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.8.3",
+        "ws": "^7.2.5"
+      },
+      "dist": {
+        "integrity": "sha512-8wiqujNWlsZNbeTSSWMLUl/u70xbJ5VYRwPR8RcAbvsNxzAZbgwLzRvT96btbm3fAitZUmo5i8LY6WKGyHDgvA==",
+        "shasum": "425ea177986a0cda34f9c81ec961c719adb6c2a9",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.4.tgz",
+        "fileCount": 24,
+        "unpackedSize": 61170,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJewrezCRA9TVsSAnZWagAATeUQAIjWXDuQael1Xm1p4Wkh\nSxSzWFtHgHXiFvq3vHrn8TL8skN+ZTMeBD7lQIFGJGcQsKFn8U1NYGQ4DUcJ\nBzQtMTH9+E2YgGMcXrKMXgsHNXSKvDUvUyKpQalSeaiyPByn6ijH7PmanYF+\n5YmhkeDchkWgTHWcUPcUAmakC7/4bZQCZ6fxLZVuf/Xz8IE02F94WMyKj6gJ\nadWj7BOMCutWeh1DdU7l5Nn6k2IuE+WBapTieoH/gfJZYSBX6orl/II2M5lc\nke1mitUJ7WPCk+WyndrI/oVH535NOEJ6LubrjemInr7wly6v1ZMLFMIjCfSE\nUvz67mZSuCtkbPMPlLrhWRI+Q5e+2wONR3W1BxQDzgze+eadk0+RnAN1vcTv\nxGkv+XAWprLriMvhJFPWl1orA9aSLKxwny5tgfxgDsHvj1RNv5OowttcKVB0\n5QFYYZVFmOR8siQMJRL/0CP8rpkdppj6aFahdCFTDLIiA/I1WdrhVGtdnegc\nAS2R9TS9X5BJcdimTwjG5gp+c+v9cGEOaAOGyTVno5dWPeq+ZuYFn+K9N6uo\nvpjvcSuPTMb06B6VteZWnTjZBmrEZyDLUc/PdmyZmotzxiNWbZceYxxTmweL\nXnkMcWUqIrZaIIWWLWwnS2Q8bxp6cmTiCT4eHI7aHgdopUWKKMdbsA0f65BW\nDz78\r\n=Vyf6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "0.19.2": {
+      "name": "http-proxy-middleware",
+      "version": "0.19.2",
+      "dependencies": {
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "browser-sync": "^2.26.3",
+        "chai": "^4.2.0",
+        "connect": "^3.6.6",
+        "coveralls": "^3.0.2",
+        "express": "^4.16.4",
+        "husky": "^1.2.0",
+        "istanbul": "^0.4.5",
+        "istanbul-coveralls": "^1.0.3",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "1.3.0",
+        "opn": "^5.4.0",
+        "precise-commits": "^1.0.2",
+        "prettier": "^1.15.2",
+        "ws": "^6.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-aYk1rTKqLTus23X3L96LGNCGNgWpG4cG0XoZIT1GUPhhulEHX/QalnO6Vbo+WmKWi4AL2IidjuC0wZtbpg0yhQ==",
+        "shasum": "ee73dcc8348165afefe8de2ff717751d181608ee",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 47853,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJexC3fCRA9TVsSAnZWagAA2VQP/Rqp9cPOtEy9vWQTjgMM\ngmBEspZoZg4C/EKGcQ0XP68mbb16M3YKP33AtoEd8J2UL6xdUqsWa3iSVxin\n5ytxr6+t26QtF7gn0Zl6lM9ckmHmseGyt6F/N2/d3op8StgF6pDIdXJQqMG8\nwJEAk8FcnrqR3JMYm5iscy5PpOHn11VHWgGBBBGsVKglm5iZozCMINCBPc73\nm5Prd4ae9pTz1Pf59WfH0UBM2TOSNpXTGBICSghHo4CxcG6N+x8Kl2XUsuyk\npnX9PIqWVZb2N1E/VrzRtIiDataCthlixZqQHZKJ8Y4jR1n3oqQK416yjehq\nfH67yeDJx2k5B14cuY9ef1XFJTAKMhgUM+2JDdgHCbA1ppQdN+VctFW7X3Ex\njvr1Ie+PBTtR9b1FUwluQA9TgtXF0BiLP1IrZtS0HSPvbDRPydhrcKLFco9C\nahsstiu2r9nhHhe9L5LhdsFL3nNY9zQEHZkofG76lvz9k5s1y0+pct89lAR0\n+d3Q7mUb+XwKDD1mm304Z5ZE0hpBCwc+km08f+BzjWqNWSOIXE0naMnP+0dF\nCOTPKlm9ZmZ7Qw2E999pbaukET2j6UoZPeVCsXc27k7UCytq1QZwOU585Fy8\nck8Tk+Sqk0LG3GQwIF3DxXxmA1kbwbCjrt6lX0zZzeOTvjr98YuFTtJAI3oQ\n+DNg\r\n=AX3P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.0.5": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.5",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.19",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@types/express": "^4.17.3",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^25.2.3",
+        "@types/lodash": "^4.14.151",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^14.0.3",
+        "@types/supertest": "^2.0.9",
+        "browser-sync": "^2.26.7",
+        "connect": "^3.7.0",
+        "express": "^4.17.1",
+        "husky": "^4.2.5",
+        "jest": "^26.0.1",
+        "lint-staged": "^10.2.4",
+        "mockttp": "^0.20.1",
+        "open": "^7.0.4",
+        "prettier": "^2.0.5",
+        "supertest": "^4.0.2",
+        "ts-jest": "^26.0.0",
+        "tslint": "^6.1.2",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^3.9.2",
+        "ws": "^7.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-CKzML7u4RdGob8wuKI//H8Ein6wNTEQR7yjVEzPbhBLGdOfkfvgTnp2HLnniKBDP9QW4eG10/724iTWLBeER3g==",
+        "shasum": "4c6e25d95a411e3d750bc79ccf66290675176dc2",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.5.tgz",
+        "fileCount": 24,
+        "unpackedSize": 61670,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfB0kHCRA9TVsSAnZWagAALpUP/j4YDwQnfnjhdYWH8ZvD\nmGF0eM4yJR5BjHosTqfs6MnL42ArKo7ypF7DGmIJFHouCogayiWTB+3SrxkL\n0jVnpK5+He3dOaW6KT+3ah2et53KOPid4s9QFyhBxilnQDGYpj2WZgvmR6fI\noy3gVV3dakH/GLRTOGyBnKlKXClvVGDAUhoFfmVpK15SPxFTlLTqiWzd7ept\nSw8C/vFbXNqDm2R+tfeP2+BCOJt8lgp2qtMG6w+rXLBn14woYw7sIKPlV+ta\nuaYX88gj6VwDkj0lxIbaPr45O4cAgbSc+1G8gWSG5C5ARPCjXoH3ndDzyoy3\nTifzlefNNP8a1rFRTVD9I/asVN0bUzD/imSkeFhL3K7W3o4yq5yc7VRLmjzT\n5Q+tvKHSI3oU6oAYwp9wsKTXdP716g2QSRYqKUWU5ZZsg9Q3HrhIKffUVr+N\nfUQw/0yqD6AO/migQJM5MKbR9Y2DQxvWFZtK9qvqxWIWqm24f0uxyZpx4wEC\nnHqSASc75+mfgXuI8rTSfZRJ5N23zUPptoFUdsDOr8krFUdEemfq4zpN1xjq\nzFg/x/vHGqwMb0Dzw12CwIBZv15Fa6WMBgwkJ2jYTROoMcKe3VPMfSC55GnV\nmI0snhPv13RXtEl2MxomOPzTwq8mgsFkwPW8oU4uu8MeTE5QhpBYN+WR+zB1\n0MJd\r\n=03D7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "1.0.6": {
+      "name": "http-proxy-middleware",
+      "version": "1.0.6",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.20",
+        "micromatch": "^4.0.2"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@types/express": "^4.17.3",
+        "@types/is-glob": "^4.0.1",
+        "@types/jest": "^26.0.14",
+        "@types/lodash": "^4.14.162",
+        "@types/micromatch": "^4.0.1",
+        "@types/node": "^14.11.8",
+        "@types/supertest": "^2.0.10",
+        "browser-sync": "^2.26.12",
+        "connect": "^3.7.0",
+        "express": "^4.17.1",
+        "husky": "^4.3.0",
+        "jest": "^26.5.3",
+        "lint-staged": "^10.4.0",
+        "mockttp": "^1.0.2",
+        "open": "^7.3.0",
+        "prettier": "^2.1.2",
+        "supertest": "^5.0.0",
+        "ts-jest": "^26.4.1",
+        "tslint": "^6.1.3",
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^4.0.3",
+        "ws": "^7.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-NyL6ZB6cVni7pl+/IT2W0ni5ME00xR0sN27AQZZrpKn1b+qRh+mLbBxIq9Cq1oGfmTc7BUq4HB77mxwCaxAYNg==",
+        "shasum": "0618557722f450375d3796d701a8ac5407b3b94e",
+        "tarball": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.6.tgz",
+        "fileCount": 24,
+        "unpackedSize": 61859,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfg1/ZCRA9TVsSAnZWagAAdP8QAJXqF8bThIYwQzZeGxLO\nad1hs8DE7BooTP9ufkkugyHt4v7TY+3sQVn7CdVkZvVinldx0+27LJ0VB29J\nKrHAewjdKl29z0GwgDF6fPpjvArBZHiwzGB/O3UhyKYRtqBJd7gPN0KdTMKF\nfSFeVqRgJQpoRb1BxIltjAywLmtHHMd0NamcnRJjT3UtpbfAWFKEWcQvFyVB\nJ3PNktNpzZG9zLOtmbT0aDaMHjx+IhY9CEehSQd6MZzqMZ4FE0sZks1u6j4e\nnBUm8fuKIJKsyCxeKbOouTk1ejuKBbv8JefS3LjnVp42LlCceH3BlRVmlku6\nq0ituEoVC7mKzeuXtFk+UPD1KIxuk9gvwEHCLE5qU+7zkmpVl1UzG2+h8u3y\n6RJrvESYxidANo0Tim8ueg7comDL+qh3QX0D0xIxox3nSqiGx9vXWYSgFGfI\nHD2fXGnZCIy6zk52+wOPJW7Lt4ySIQL1t+GkOcNO2lXMGhbClmcGQCqkmZDd\neRFSufwlY6P+kIZuua+9n5rcYfRFuLMDFDKyz8wUQ7guWlT/XvF9d/+e7Q+0\n2rmri4dfzQmDQBZplSamyk6lS3qTo20ImYk5NEwl/cSyYWtvs6+F6n8fMZwM\n1U+HokrmJ7L8/JJxG1QmZdktkMlpt0LeOfJzHCrL1JgSKP9QHKY7LILvUzp7\nphkK\r\n=KREU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    }
+  },
+  "modified": "2020-10-11T19:41:15.158Z"
+}

--- a/test/fixtures/registry-mocks/content/http-proxy.json
+++ b/test/fixtures/registry-mocks/content/http-proxy.json
@@ -1,0 +1,6906 @@
+{
+  "_id": "http-proxy",
+  "_rev": "446-869da93814c7fb3e19e4a12db22de4cb",
+  "name": "http-proxy",
+  "description": "HTTP proxying for the masses",
+  "dist-tags": {
+    "latest": "1.18.1"
+  },
+  "versions": {
+    "0.5.9": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.5.9",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": ">= 0.x.x",
+        "optimist": ">= 0.1.x",
+        "request": ">= 1.9.x"
+      },
+      "devDependencies": {
+        "vows": ">= 0.5.x",
+        "socket.io": ">= 0.6.x",
+        "docco": ">= 0.3.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_id": "http-proxy@0.5.9",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.6",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "957103fa0515e475f99a2b4c5bfe3507d513a81e",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.5.9.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.10": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.5.10",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": ">= 0.x.x",
+        "optimist": ">= 0.1.x",
+        "request": ">= 1.9.x"
+      },
+      "devDependencies": {
+        "vows": ">= 0.5.x",
+        "socket.io": ">= 0.6.x",
+        "docco": ">= 0.3.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_id": "http-proxy@0.5.10",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.10",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "acd2b9126569dea265fc01bcaca1b2293232067b",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.5.10.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.11": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.5.11",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/http-proxy/0.5.11/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.5.11",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f58f2572765d06c71749b09275b1ba167ffabdf2",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.5.11.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.6.0",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/home/dominic/.npm/http-proxy/0.6.0/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.6.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "4fbcdc84d01f20c2531f375c437ec619c9e1012c",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.6.1",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/home/dominic/.npm/http-proxy/0.6.1/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.6.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "0e786540c438fa139781d1b0be3521c3d7c6e728",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.2": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.6.2",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/home/dominic/.npm/http-proxy/0.6.2/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.6.2",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "5114c56b4cf6dbe33094d6f0bbcb79d757210708",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.4": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.6.4",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/http-proxy/0.6.4/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.6.4",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.23",
+      "_nodeVersion": "v0.4.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "1301de97d023eadbf7bdda81e1dc7efb5cedf4c5",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.5": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.6.5",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/http-proxy/0.6.5/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.6.5",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.23",
+      "_nodeVersion": "v0.4.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "1b17209ee173b71fd74961e23a1f6f369978077f",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.6": {
+      "name": "http-proxy",
+      "description": "A full-featured http reverse proxy for node.js",
+      "version": "0.6.6",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "vows test/*-test.js --spec && vows test/*-test.js --spec --https"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/http-proxy/0.6.6/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.6.6",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.23",
+      "_nodeVersion": "v0.4.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "5a9cdbb02fc3cb740f2e511497da5e9e2b3ac469",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "http-proxy",
+      "version": "0.7.0",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "Dominic Tarr",
+          "email": "dominic@nodejitsu.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=secure",
+        "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/http-proxy/0.7.0/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.7.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.23",
+      "_nodeVersion": "v0.4.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "36c843818cdab7052f2f93aeed778e0f3cde5ada",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.2": {
+      "name": "http-proxy",
+      "version": "0.7.2",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "Dominic Tarr",
+          "email": "dominic@nodejitsu.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=secure",
+        "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/http-proxy/0.7.2/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.7.2",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.23",
+      "_nodeVersion": "v0.4.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "4e2e473b2c8875313101fbc657b2706e064525dd",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.3": {
+      "name": "http-proxy",
+      "version": "0.7.3",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "Dominic Tarr",
+          "email": "dominic@nodejitsu.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=secure",
+        "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/http-proxy/0.7.3/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "http-proxy@0.7.3",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.23",
+      "_nodeVersion": "v0.4.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "4f4bc8bbd08a206c6d822ba7a3dc582f4e8e7b32",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.4": {
+      "name": "http-proxy",
+      "version": "0.7.4",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "Dominic Tarr",
+          "email": "dominic@nodejitsu.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=secure",
+        "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "_id": "http-proxy@0.7.4",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.103",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "385556d7e84ca1f367f8a3887f4c8263f8d8a3ca",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.5": {
+      "name": "http-proxy",
+      "version": "0.7.5",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "Dominic Tarr",
+          "email": "dominic@nodejitsu.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=secure",
+        "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "_id": "http-proxy@0.7.5",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.103",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "ce69c26ccd432837548caf606ea44d2997d9d337",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.6": {
+      "name": "http-proxy",
+      "version": "0.7.6",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "Dominic Tarr",
+          "email": "dominic@nodejitsu.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=secure",
+        "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      },
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "_id": "http-proxy@0.7.6",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.103",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "7193cca1ebdf828d1582e740630b5caf816fd1e0",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "http-proxy",
+      "version": "0.8.0",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Mikeal Rogers",
+          "email": "mikeal.rogers@gmail.com"
+        },
+        {
+          "name": "Marak Squires",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "Fedor Indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "Dominic Tarr",
+          "email": "dominic@nodejitsu.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "async": "0.1.x",
+        "socket.io": "0.6.x"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=secure",
+        "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "_id": "http-proxy@0.8.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "b366d265688ffcaa9e3c77ead20d154ddf94489e",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "http-proxy",
+      "version": "0.8.1",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "async": "0.1.x",
+        "socket.io": "0.6.17"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=secure",
+        "test-https": "vows --spec --source=secure && vows --spec --source=secure --target=secure",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_npmUser": {
+        "name": "cronopio",
+        "email": "aristizabal.daniel@gmail.com"
+      },
+      "_id": "http-proxy@0.8.1",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.21",
+      "_nodeVersion": "v0.6.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "cc4dd5793ba7bb17fa1834e6abc72a99e94bb996",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.2": {
+      "name": "http-proxy",
+      "version": "0.8.2",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "marak",
+          "email": "marak.squires@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.6",
+        "socket.io-client": "0.9.6",
+        "ws": "0.4.21"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "_id": "http-proxy@0.8.2",
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.2",
+      "_nodeVersion": "v0.8.1",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f75a3a754b5c27bea2fddad16e9b267b325a8273",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.3": {
+      "name": "http-proxy",
+      "version": "0.8.3",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.6",
+        "socket.io-client": "0.9.6",
+        "ws": "0.4.21"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.8.3",
+      "dist": {
+        "shasum": "031cb4512df4cf28f387277dfcd2a0ea4f2a5466",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.3.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "bradleymeck",
+        "email": "bradley.meck@gmail.com"
+      },
+      "directories": {}
+    },
+    "0.8.4": {
+      "name": "http-proxy",
+      "version": "0.8.4",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.6",
+        "socket.io-client": "0.9.6",
+        "ws": "0.4.21"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.8.4",
+      "dist": {
+        "shasum": "00075c99098041cb0336c6dbe7f13bf6144e5b23",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.5": {
+      "name": "http-proxy",
+      "version": "0.8.5",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.6",
+        "socket.io-client": "0.9.6",
+        "ws": "0.4.21"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.8.5",
+      "dist": {
+        "shasum": "32eee6272cabdc1ef6bc5a732196262b6b687faf",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.6": {
+      "name": "http-proxy",
+      "version": "0.8.6",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.8.6",
+      "dist": {
+        "shasum": "176f54a4fee949447807c58b69fdbb9e122d1394",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.6.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "mmalecki",
+        "email": "me@mmalecki.com"
+      },
+      "directories": {}
+    },
+    "0.8.7": {
+      "name": "http-proxy",
+      "version": "0.8.7",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.8.7",
+      "dist": {
+        "shasum": "a7bc538618092cd26ed191e4625933baef6de80e",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.7.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "mmalecki",
+        "email": "me@mmalecki.com"
+      },
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "http-proxy",
+      "version": "0.9.0",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.9.0",
+      "dist": {
+        "shasum": "c3f3601bf0fac3d9961bea8deb30a84360c34ef5",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.9.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "directories": {}
+    },
+    "0.9.1": {
+      "name": "http-proxy",
+      "version": "0.9.1",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.9.1",
+      "dist": {
+        "shasum": "ba074a55cb21cfde4deb359d19334a3eedda9325",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.9.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "http-proxy",
+      "version": "0.10.0",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.10.0",
+      "dist": {
+        "shasum": "a20b718d05ec40427ae61644dabdcc427ba62508",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "directories": {}
+    },
+    "0.10.1": {
+      "name": "http-proxy",
+      "version": "0.10.1",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.10.1",
+      "dist": {
+        "shasum": "50f1ce725c87c90a4ec42679dbf4e3d774dfb181",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "directories": {}
+    },
+    "0.10.2": {
+      "name": "http-proxy",
+      "version": "0.10.2",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "_id": "http-proxy@0.10.2",
+      "dist": {
+        "shasum": "c28ebf268946faf4cce13104e7266b6827fc3a20",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "directories": {}
+    },
+    "0.10.3": {
+      "name": "http-proxy",
+      "version": "0.10.3",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "avianflu",
+          "email": "charlie@charlieistheman.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "_id": "http-proxy@0.10.3",
+      "dist": {
+        "shasum": "72ca9d503a75e064650084c58ca11b82e4b0196d",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "mmalecki",
+        "email": "me@mmalecki.com"
+      },
+      "directories": {}
+    },
+    "0.10.4": {
+      "name": "http-proxy",
+      "version": "0.10.4",
+      "description": "A full-featured http reverse proxy for node.js",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "keywords": [
+        "reverse",
+        "proxy",
+        "http"
+      ],
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.6.x",
+        "pkginfo": "0.3.x",
+        "utile": "~0.2.1"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "main": "./lib/node-http-proxy",
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "scripts": {
+        "test": "npm run-script test-http && npm run-script test-https && npm run-script test-core",
+        "test-http": "vows --spec && vows --spec --target=https",
+        "test-https": "vows --spec --proxy=https && vows --spec --proxy=https --target=https",
+        "test-core": "test/core/run"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      },
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@0.10.4",
+      "dist": {
+        "shasum": "14ba0ceaa2197f89fa30dea9e7b09e19cd93c22f",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.22",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "http-proxy",
+      "version": "1.0.0",
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "_id": "http-proxy@1.0.0",
+      "dist": {
+        "shasum": "81e0443e67c8292842892ded718553dff7000603",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "yawnt",
+        "email": "yawn.localhost@gmail.com"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "http-proxy",
+      "version": "1.0.1",
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "_id": "http-proxy@1.0.1",
+      "dist": {
+        "shasum": "d203d3b2dc34e968174956f11a6c35140da84384",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "yawnt",
+        "email": "yawn.localhost@gmail.com"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "http-proxy",
+      "version": "1.0.2",
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "_id": "http-proxy@1.0.2",
+      "dist": {
+        "shasum": "08060ff2edb2189e57aa3a152d3ac63ed1af7254",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "http-proxy",
+      "version": "1.0.3",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.0.3",
+      "dist": {
+        "shasum": "3867396ab7d8fc70855fa72b55a527cc13427ea5",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "http-proxy",
+      "version": "1.1.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.1.0",
+      "dist": {
+        "shasum": "309056d122bd5708ec806b40b22e379a9dcbdc83",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "http-proxy",
+      "version": "1.1.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.1.1",
+      "dist": {
+        "shasum": "3ddbfae24ead5f0edd04beb5881d9fa779a709f1",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "http-proxy",
+      "version": "1.1.2",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.1.2",
+      "dist": {
+        "shasum": "d78d0793c46815dbf39fb27723a4ddfe767777b0",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "http-proxy",
+      "version": "1.1.3",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.1.3",
+      "_shasum": "4f93ed116fa975d63c2880e7818504678287b300",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "4f93ed116fa975d63c2880e7818504678287b300",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "http-proxy",
+      "version": "1.1.4",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.1.4",
+      "_shasum": "65bb5bfe645f322c65761febcc145a38111174b1",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "65bb5bfe645f322c65761febcc145a38111174b1",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "http-proxy",
+      "version": "1.1.5",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "7104a7c023073a49091969f825738c79ae036123",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.1.5",
+      "_shasum": "ade491a3d40e61b31334ee9a40cd91ac125d1839",
+      "_from": ".",
+      "_npmVersion": "1.4.13",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "ade491a3d40e61b31334ee9a40cd91ac125d1839",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.6": {
+      "name": "http-proxy",
+      "version": "1.1.6",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "ed9e12b0edb0fc206610e94bd696425619868474",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.1.6",
+      "_shasum": "1d9262f6dff3a325c0eb84e125502b5a930a1a58",
+      "_from": ".",
+      "_npmVersion": "1.4.13",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "1d9262f6dff3a325c0eb84e125502b5a930a1a58",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "http-proxy",
+      "version": "1.2.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "63c53a177217283ec14e4f7c2e891db48842ab4b",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.2.0",
+      "_shasum": "17f4626950d75c0fcdcb3c4d3af35bfae5fdc016",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "17f4626950d75c0fcdcb3c4d3af35bfae5fdc016",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "http-proxy",
+      "version": "1.2.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "0a6b424e2c3b6cef68362a71f0e56740b2605af7",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.2.1",
+      "_shasum": "83d93c05431e5b7753db22c961d1196cfc39877d",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "83d93c05431e5b7753db22c961d1196cfc39877d",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "http-proxy",
+      "version": "1.3.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "05f0b891a610fb7779f90916fcd9ed750df818b2",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.3.0",
+      "_shasum": "21fa4368accc09c6341abb9c16275db4645053fa",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "21fa4368accc09c6341abb9c16275db4645053fa",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "http-proxy",
+      "version": "1.4.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "c82f5dfc621c6fafb8702e3ea87cb1560fec7455",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.4.0",
+      "_shasum": "4173cbe81564f8ca94c7228e46d2898048066d3b",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "4173cbe81564f8ca94c7228e46d2898048066d3b",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "http-proxy",
+      "version": "1.4.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "d5c656bceb50dc9008ef223bc58b918adcf05352",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.4.1",
+      "_shasum": "31cbd2d89383bfa1885da260ad1fc023df13662c",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "31cbd2d89383bfa1885da260ad1fc023df13662c",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.2": {
+      "name": "http-proxy",
+      "version": "1.4.2",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "df12aeb12de79de1157898d45f4347fd0037dd70",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.4.2",
+      "_shasum": "4ebe93aedd7f00ea3cd60dec86fb2db6764b971a",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "4ebe93aedd7f00ea3cd60dec86fb2db6764b971a",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.3": {
+      "name": "http-proxy",
+      "version": "1.4.3",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "554f59c5182d58b359df0159a29ff5ea35dd3830",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.4.3",
+      "_shasum": "27d3e4978a5e64641ed810ecc4a415fd00067020",
+      "_from": ".",
+      "_npmVersion": "1.4.13",
+      "_npmUser": {
+        "name": "cronopio",
+        "email": "aristizabal.daniel@gmail.com"
+      },
+      "dist": {
+        "shasum": "27d3e4978a5e64641ed810ecc4a415fd00067020",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "http-proxy",
+      "version": "1.5.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "232258b6ec2229497fe557454a121d917968f5e8",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.5.0",
+      "_shasum": "11d4c81100f5cbd7303b4bf8b62478fda7af728e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "11d4c81100f5cbd7303b4bf8b62478fda7af728e",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "http-proxy",
+      "version": "1.5.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "f0bf7418156db2cb87a616b0a34bb1f028db9142",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.5.1",
+      "_shasum": "40e09f6a3311a28936dfa704d86584c8b6185bde",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "40e09f6a3311a28936dfa704d86584c8b6185bde",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "http-proxy",
+      "version": "1.5.2",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "43c6f0c7c06d25a670c410500a8623531df458b1",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.5.2",
+      "_shasum": "60afc612cfd82c9d19a502835192e3c5f530aff9",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "60afc612cfd82c9d19a502835192e3c5f530aff9",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.3": {
+      "name": "http-proxy",
+      "version": "1.5.3",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "9577a0faf2b78af606168673407ac47a851c084c",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.5.3",
+      "_shasum": "d89aee8f1304caf847723d2456a18d7422ef33df",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "d89aee8f1304caf847723d2456a18d7422ef33df",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "http-proxy",
+      "version": "1.6.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "43641b00b34ccc05bdf09f904695061d7c857aeb",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.6.0",
+      "_shasum": "1cc1614be2a09593d936a26013546e485c4b1d35",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "1cc1614be2a09593d936a26013546e485c4b1d35",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "http-proxy",
+      "version": "1.6.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "fa797fca900c10ebc848a2b445204b47da799483",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.6.1",
+      "_shasum": "8b163a57114f419f42476effa4d9aec83eec73f5",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "8b163a57114f419f42476effa4d9aec83eec73f5",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "http-proxy",
+      "version": "1.6.2",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "709b3e96560d619fab2617f9ddb902b4982b4103",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.6.2",
+      "_shasum": "bfbc07134806b6790368c31d88048c5575228d04",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "bfbc07134806b6790368c31d88048c5575228d04",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "http-proxy",
+      "version": "1.7.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "bradleymeck",
+          "email": "bradley.meck@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "276f65a3b810ded01757ec4bfd4fe2b00a1e66a8",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.7.0",
+      "_shasum": "ec05dd041207ef038922af38948d8b6a4114074d",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "ec05dd041207ef038922af38948d8b6a4114074d",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.1": {
+      "name": "http-proxy",
+      "version": "1.7.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "56a7b77645b13d337c1a2f879460193d310454c8",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.7.1",
+      "_shasum": "5fabe2e1d617beb09cc108b3a45c416372c3d36a",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "5fabe2e1d617beb09cc108b3a45c416372c3d36a",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.7.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.2": {
+      "name": "http-proxy",
+      "version": "1.7.2",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "2086e4917c97f347f84c54b166799bc8db9f4162",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.7.2",
+      "_shasum": "5538cc6ff89266c6eeaa793c28e62d43fa60118b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "5538cc6ff89266c6eeaa793c28e62d43fa60118b",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.7.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.3": {
+      "name": "http-proxy",
+      "version": "1.7.3",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "6a330ff904d02a41f9a1cac338a98da1849c54ca",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.7.3",
+      "_shasum": "9e4b6eabae3e94f10130db97d858063fb6197718",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "9e4b6eabae3e94f10130db97d858063fb6197718",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.7.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "http-proxy",
+      "version": "1.8.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "f0db5b3f708b0858f617d472dfdd0ba211b774ef",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.8.0",
+      "_shasum": "60cae018462824084b27f0840d9c366d599e7077",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "60cae018462824084b27f0840d9c366d599e7077",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.1": {
+      "name": "http-proxy",
+      "version": "1.8.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "3311106c2c2346f3ac1ffe402b80bca3c7c59275",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.8.1",
+      "_shasum": "95ee083305c719dba858aee01da1bfc8d7ab9efe",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "95ee083305c719dba858aee01da1bfc8d7ab9efe",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.0": {
+      "name": "http-proxy",
+      "version": "1.9.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "87a92a72802a27f817fcba87382d55831fd04ddb",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.9.0",
+      "_shasum": "adbb99b55027e15e802ef32737d2de3b88ef52a6",
+      "_from": ".",
+      "_npmVersion": "2.1.7",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "adbb99b55027e15e802ef32737d2de3b88ef52a6",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.1": {
+      "name": "http-proxy",
+      "version": "1.9.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "21b30b754db4f6410c3d2052bc123b3fdae57c46",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.9.1",
+      "_shasum": "4026281e35e4cf93f169a6fcd8ab55a0b5cc7d87",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "0.10.37",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "4026281e35e4cf93f169a6fcd8ab55a0b5cc7d87",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.0": {
+      "name": "http-proxy",
+      "version": "1.10.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "1dabda241f3b93eb9195134042e7a3b84fd0ef57",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.10.0",
+      "_shasum": "406762e8a22bbeab387d3a7df24cb1e9f3b91a78",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "0.10.37",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "406762e8a22bbeab387d3a7df24cb1e9f3b91a78",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.1": {
+      "name": "http-proxy",
+      "version": "1.10.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "0bd446c680e9991accfaa3a6a70e411fdac79164",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.10.1",
+      "_shasum": "0bb51c2727bdc094722cff569c7cf1455bd18d59",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "1.6.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "0bb51c2727bdc094722cff569c7cf1455bd18d59",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.11.0": {
+      "name": "http-proxy",
+      "version": "1.11.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "934e6c4d54292a1b961452074e02fb5d45da729a",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.11.0",
+      "_shasum": "66fb73ece772e6b789287b542829cdb6e628f263",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.10.37",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "66fb73ece772e6b789287b542829cdb6e628f263",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.11.1": {
+      "name": "http-proxy",
+      "version": "1.11.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "7e6c66a7e485a6c0ec3a1c567bbe800fdc56c9fd",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy",
+      "_id": "http-proxy@1.11.1",
+      "_shasum": "71df55757e802d58ea810df2244019dda05ae85d",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.10.37",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "71df55757e802d58ea810df2244019dda05ae85d",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.11.2": {
+      "name": "http-proxy",
+      "version": "1.11.2",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "30e3b371de0116e40e15156394f31c7e0b0aa9f1",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.11.2",
+      "_shasum": "c50d2fb06eca79d4238e66fd94393d2e41e63740",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "c50d2fb06eca79d4238e66fd94393d2e41e63740",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.11.3": {
+      "name": "http-proxy",
+      "version": "1.11.3",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "60baca5aed4f45ef1d7b3f7edd909375853d344b",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.11.3",
+      "_shasum": "1915dc888751e2a6bf3c2abfcb1808fa86c72353",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "1915dc888751e2a6bf3c2abfcb1808fa86c72353",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.12.0": {
+      "name": "http-proxy",
+      "version": "1.12.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "b5a6d0e58396363f4c457f6d1654614bdfcfcb73",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.12.0",
+      "_shasum": "4f02ea971e79e6affa12fa5f10ca2aebb5e3b17c",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "4f02ea971e79e6affa12fa5f10ca2aebb5e3b17c",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.12.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.12.1": {
+      "name": "http-proxy",
+      "version": "1.12.1",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "db576d75c18148e6ec3cdc455e6e8254cff40ada",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.12.1",
+      "_shasum": "23b4244d1b7f5a77ae333b8b189c13b4d2ccc468",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "23b4244d1b7f5a77ae333b8b189c13b4d2ccc468",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.12.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.13.0": {
+      "name": "http-proxy",
+      "version": "1.13.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "268994ea45d9f8737343001ab9542e03023a5c96",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.13.0",
+      "_shasum": "c29aa326dccd078d3e13c08c4cf474ce53f47c20",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "c29aa326dccd078d3e13c08c4cf474ce53f47c20",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.13.1": {
+      "name": "http-proxy",
+      "version": "1.13.1",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha -R landing test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "9d9fa940cff3aa6134c60732c23aea8171fc7296",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.13.1",
+      "_shasum": "d3eaa54f0d8d9d444ae0d9523c94391cb8bd6a43",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "d3eaa54f0d8d9d444ae0d9523c94391cb8bd6a43",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-8-eu.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.13.1.tgz_1454389381998_0.16280735889449716"
+      },
+      "directories": {}
+    },
+    "1.13.2": {
+      "name": "http-proxy",
+      "version": "1.13.2",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Nodejitsu Inc.",
+        "email": "info@nodejitsu.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "e1b2f4c31b34464431db251b3b6169689dadf518",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.13.2",
+      "_shasum": "636bcd09f3e7045377a5e919e92d16d29fdbff09",
+      "_from": ".",
+      "_npmVersion": "2.14.18",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "636bcd09f3e7045377a5e919e92d16d29fdbff09",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.13.2.tgz_1455724809490_0.5310903904028237"
+      },
+      "directories": {}
+    },
+    "1.13.3": {
+      "name": "http-proxy",
+      "version": "1.13.3",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "5082acc067bbf287f503bbd5b776f798ab169db1",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.13.3",
+      "_shasum": "d5ec0e25da0c4b2edaeaa9476672640deda59623",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "d5ec0e25da0c4b2edaeaa9476672640deda59623",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.13.3.tgz_1463368496695_0.25714756455272436"
+      },
+      "directories": {}
+    },
+    "1.14.0": {
+      "name": "http-proxy",
+      "version": "1.14.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "fcfb0b37f6ac61369565507446377f91d955cf29",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.14.0",
+      "_shasum": "be32ab34dd5229e87840f4c27cb335ee195b2a83",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "be32ab34dd5229e87840f4c27cb335ee195b2a83",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.14.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.14.0.tgz_1466002382159_0.5383694211486727"
+      },
+      "directories": {}
+    },
+    "1.15.0": {
+      "name": "http-proxy",
+      "version": "1.15.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "b98c75b1ff3ebdf7f78224eb0d9aa857af2db1d9",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.15.0",
+      "_shasum": "306c5e1a0e2df519ab4f4f71b0bd610d26bc4620",
+      "_from": ".",
+      "_npmVersion": "3.9.6",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "306c5e1a0e2df519ab4f4f71b0bd610d26bc4620",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.15.0.tgz_1473872763037_0.9233860978856683"
+      },
+      "directories": {}
+    },
+    "1.15.1": {
+      "name": "http-proxy",
+      "version": "1.15.1",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "912cd3acaef484f7ea08affc9339250082e04058",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.15.1",
+      "_shasum": "91a6088172e79bc0e821d5eb04ce702f32446393",
+      "_from": ".",
+      "_npmVersion": "3.9.6",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "91a6088172e79bc0e821d5eb04ce702f32446393",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.15.1.tgz_1473887557394_0.4286337874364108"
+      },
+      "directories": {}
+    },
+    "1.15.2": {
+      "name": "http-proxy",
+      "version": "1.15.2",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "d8223884f61a05fabf788a0bd921c7a6197a96ee",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.15.2",
+      "_shasum": "642fdcaffe52d3448d2bda3b0079e9409064da31",
+      "_from": ".",
+      "_npmVersion": "3.9.6",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "642fdcaffe52d3448d2bda3b0079e9409064da31",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.15.2.tgz_1477151248727_0.9627266463357955"
+      },
+      "directories": {}
+    },
+    "1.16.0": {
+      "name": "http-proxy",
+      "version": "1.16.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "c252b32f6c7f832f157cc4647ceaff33dd265d82",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.16.0",
+      "_shasum": "f9b52305e9f864811835277e4a486051b5d4a523",
+      "_from": ".",
+      "_npmVersion": "3.9.6",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "f9b52305e9f864811835277e4a486051b5d4a523",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.16.0.tgz_1480687997540_0.21387459617108107"
+      },
+      "directories": {}
+    },
+    "1.16.1": {
+      "name": "http-proxy",
+      "version": "1.16.1",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "ac1a01b1f3caa3a2a9433341bf5e7a95072d6612",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.16.1",
+      "_shasum": "734b32de6ca0e36e51b59c1e0115ff860d7668fd",
+      "_from": ".",
+      "_npmVersion": "3.9.6",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "734b32de6ca0e36e51b59c1e0115ff860d7668fd",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.16.1.tgz_1480867190646_0.43747326801531017"
+      },
+      "directories": {}
+    },
+    "1.16.2": {
+      "name": "http-proxy",
+      "version": "1.16.2",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "coveralls": "mocha --require blanket --reporter mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js",
+        "test": "mocha test/*-test.js",
+        "test-cov": "mocha --require blanket -R html-cov > cov/coverage.html"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "license": "MIT",
+      "gitHead": "c1fb596b856df971d291585ccf105233f7deca51",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.16.2",
+      "_shasum": "06dff292952bf64dbe8471fa9df73066d4f37742",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "shasum": "06dff292952bf64dbe8471fa9df73066d4f37742",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/http-proxy-1.16.2.tgz_1481039349196_0.5866330966819078"
+      },
+      "directories": {}
+    },
+    "1.17.0": {
+      "name": "http-proxy",
+      "version": "1.17.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodejitsu/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "^3.0.0",
+        "requires-port": "^1.0.0",
+        "follow-redirects": "^1.0.0"
+      },
+      "devDependencies": {
+        "async": "^2.0.0",
+        "concat-stream": "^1.6.2",
+        "expect.js": "~0.3.1",
+        "mocha": "^3.5.3",
+        "nyc": "^11.7.1",
+        "semver": "^5.0.3",
+        "socket.io": "^2.1.0",
+        "socket.io-client": "^2.1.0",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "scripts": {
+        "mocha": "mocha test/*-test.js",
+        "test": "nyc --reporter=text --reporter=lcov npm run mocha"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "42e8e1e099c086d818d8f62c8f15ec5a8f1a6624",
+      "bugs": {
+        "url": "https://github.com/nodejitsu/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/nodejitsu/node-http-proxy#readme",
+      "_id": "http-proxy@1.17.0",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+        "shasum": "7ad38494658f84605e2f6db4436df410f4e5be9a",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+        "fileCount": 37,
+        "unpackedSize": 444265,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2gqOCRA9TVsSAnZWagAA0pgQAJ4lM4iyzp+3h/SpDlGQ\nMkG6oT+gkdCkdU+J8y0nIkFT6Pr8c61vMXhuzaBsm3SUlxb2myIYxQp1t64p\nOYaBLeKcS2Fsts4xTRDQc+1LNnHHdpWZ0kxGE9hnRZo2aLe4S+RU/6w3tpTC\nVA6VmLW81sVTYEBQ9CEzQLYWzAKjJlX9XoQi4kufIiDnCes7J5IPFev9kPPp\nj0Gy/dzJX6Dy1UjsPqzajcno+1wEU9QYUvuqs73W0UevmmwTWGZ63MKJjqk/\nKZujjPQSp4ofyaQyWFC7KsWN6G84/dRioUnuGCNr6p1hykqO60jM5imRzbyV\n+L5D2gPH1R89G0ECgD1FmMKSFIRhtUc3YSyuDG/TJ3YbGGkLL0Gl0qa/puqB\nDBifu4jANNvNsP8hA5ms9xWYKBqc5DHbmSGmJk54nagVc9kEoaKOMKY4lU/h\nrJ4k4JxOFoDlgxilB6l1Vkjb06EgzCTcGbCeGfbK/hgIG4+gvhGlKAlsj6KC\nIGDPlpxihQ/SZAh5mgyXIkmHvF7wh+oukAMZybgs3hYVLg4/AuCvJbgFOg4X\nytTd/6eBc5IEwANTTiRXB/AZ3AtyRKwpxbSs48mylYb/ChXw0gJej2RPw4V6\nNnWOckAe1+xSx0xA8sgAkwI0Lo3HBEAmmZFkQh5kf4yWeqaZ1VT38EjBNPp6\nDLnN\r\n=Ht4z\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy_1.17.0_1524238988902_0.2940207651042317"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.18.0": {
+      "name": "http-proxy",
+      "version": "1.18.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/http-party/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "requires-port": "^1.0.0",
+        "follow-redirects": "^1.0.0"
+      },
+      "devDependencies": {
+        "async": "^3.0.0",
+        "auto-changelog": "^1.15.0",
+        "concat-stream": "^2.0.0",
+        "expect.js": "~0.3.1",
+        "mocha": "^3.5.3",
+        "nyc": "^14.0.0",
+        "semver": "^5.0.3",
+        "socket.io": "^2.1.0",
+        "socket.io-client": "^2.1.0",
+        "sse": "0.0.8",
+        "ws": "^3.0.0"
+      },
+      "scripts": {
+        "mocha": "mocha test/*-test.js",
+        "test": "nyc --reporter=text --reporter=lcov npm run mocha",
+        "version": "auto-changelog -p && git add CHANGELOG.md"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "9bbe486c5efcc356fb4d189ef38eee275bbde345",
+      "bugs": {
+        "url": "https://github.com/http-party/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/http-party/node-http-proxy#readme",
+      "_id": "http-proxy@1.18.0",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.10.1",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+        "shasum": "dbe55f63e75a347db7f3d99974f2692a314a6a3a",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+        "fileCount": 16,
+        "unpackedSize": 231272,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdgYs1CRA9TVsSAnZWagAANs0P/jmblQqi6QxrRR/Ukxkw\npnEYpCE6E/bZ2lrkjMvtoTUpXrZe6YTORPm3ecHYtDXgp0V7NJ75As53XwkT\n5bqECrrRO7YlG6apwtGvTJyu5MO7pdyMQSRAyHgPZkJTZI8YLeKiEZF7Ajma\neoENrmhmb5Xu8y/PlfdHUK+X/5ymPugav9IAZpAEx/DaPfrBcRcIdVdJsS9S\n3dh1wq+4YYycR7RE7/9ZrJfwfAFXOafxhKBdovD7npjXpqvzdzXtYc257FXm\n1Y28CgaW5slwHPg3EpewOV63MABukAu5wDmI8laGnl82jlbMOVjhm3B5ch6Y\nFCuGJGj5C2+heA1boFFtW0oSg3Lqf49MFrFYkwUXoTVSw04IRo+5YM3xBawL\n3pv20ksc/PIQh/qGUhsqMSOmQEaIfLkVlGxw4JHLH1fWTmTbpFXqTo3t9jRn\nPS9SxywCZJs+oneNyVVdEqnQrjPK5ZLpw8543WGy5DPC/rUOeayNhuuJ1fAh\nvM8IRn7PldG4oU9sa+E66OGapINuLkLvqRosKBn/MKQl2et/gqru77cYichm\nso+I/lC2kfgy+3N1kEebCfHaOQYdLRwkx2bO+rfKQvnPqj8mvM9SGRxJtVNf\ns2F94EEtUh5xRm5Sg9zyUuAW62Owc7o2/x5xRjmwdJRqzmzKfJ0537gsm1Dn\ne2Pl\r\n=uhTM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy_1.18.0_1568770869081_0.9804964669439871"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.18.1": {
+      "name": "http-proxy",
+      "version": "1.18.1",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/http-party/node-http-proxy.git"
+      },
+      "description": "HTTP proxying for the masses",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cronopio",
+          "email": "aristizabal.daniel@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "jcrugzz",
+          "email": "jcrugzz@gmail.com"
+        },
+        {
+          "name": "yawnt",
+          "email": "yawn.localhost@gmail.com"
+        }
+      ],
+      "main": "index.js",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "requires-port": "^1.0.0",
+        "follow-redirects": "^1.0.0"
+      },
+      "devDependencies": {
+        "async": "^3.0.0",
+        "auto-changelog": "^1.15.0",
+        "concat-stream": "^2.0.0",
+        "expect.js": "~0.3.1",
+        "mocha": "^3.5.3",
+        "nyc": "^14.0.0",
+        "semver": "^5.0.3",
+        "socket.io": "^2.1.0",
+        "socket.io-client": "^2.1.0",
+        "sse": "0.0.8",
+        "ws": "^3.0.0"
+      },
+      "scripts": {
+        "mocha": "mocha test/*-test.js",
+        "test": "nyc --reporter=text --reporter=lcov npm run mocha",
+        "version": "auto-changelog -p && git add CHANGELOG.md"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "9b96cd725127a024dabebec6c7ea8c807272223d",
+      "bugs": {
+        "url": "https://github.com/http-party/node-http-proxy/issues"
+      },
+      "homepage": "https://github.com/http-party/node-http-proxy#readme",
+      "_id": "http-proxy@1.18.1",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "8.15.0",
+      "_npmUser": {
+        "name": "jcrugzz",
+        "email": "jcrugzz@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+        "shasum": "401541f0534884bbf95260334e72f88ee3976549",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+        "fileCount": 16,
+        "unpackedSize": 231812,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJewaxFCRA9TVsSAnZWagAA+lIQAI1unze4a1LlWRns8e4c\nGlvLDeTCOq+wSHTgRvJXOpHyt+3x7mulAxkLrgtKOUPQ1hSb1SLJmlQcVHfh\nMpxfgHUufP2vSBIwDaM1J0VQj92sMovQvAhiSjK8rBdBfL1e8SY7vtRabF+A\nEXrKC3k94+p3enSVK0bIgGypJLfhGYTo/6mSlpfVO5hV1E4qIU3c4eL/M/p5\nFlfwEss1ASreRUy23/3oWJdnylEUJM5/BROiW8nnZ+DOWZZmdOktrdB9tPjA\n93i2TTvIPcNW4MVpwF2andNrPffCBocfvbfVLjbSwK8jY7wZhm325lzng9wO\nHLCrX2hiRe6HqYyGrCKFmWzzh5RpBa3/X5j7RFhCLYpDp2tQMoyWnXUj1Kwl\n/cA3jnc7pipeLPnI2ay0wre4mxo9kgGq/SlJxF82AOuN19x/XhXY6FqIdkeu\ndWEE32/8BnjVXEY8lVmEeObD+YEESufvtWhqJnwMPcL2le6k+fr3WBw8SUvI\nj64sA+44iNOPPcOr2xZOO/yIWovwtsT2tvonunHYTIdmCHwqGma2/8xBxrqH\nSClvDxKkexgQw59sdWiruGw0iQoilW2fAmCPSowYI52zojEA6c/iBoJbljUa\ns+WanFKm8fo+KfWSRpDBKTE3Tprbe+yHPXBtGjXpbIekq8p7QjsaLyPt+FOA\nwoEv\r\n=Z69L\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/http-proxy_1.18.1_1589750852626_0.652572838441352"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "name": "cronopio",
+      "email": "aristizabal.daniel@gmail.com"
+    },
+    {
+      "name": "indexzero",
+      "email": "charlie.robbins@gmail.com"
+    },
+    {
+      "name": "jcrugzz",
+      "email": "jcrugzz@gmail.com"
+    },
+    {
+      "name": "yawnt",
+      "email": "yawn.localhost@gmail.com"
+    }
+  ],
+  "author": {
+    "name": "Charlie Robbins",
+    "email": "charlie.robbins@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/http-party/node-http-proxy.git"
+  },
+  "time": {
+    "modified": "2020-05-17T21:27:36.472Z",
+    "created": "2011-03-20T18:37:42.115Z",
+    "0.1.5": "2011-03-20T18:37:42.115Z",
+    "0.2.0": "2011-03-20T18:37:42.115Z",
+    "0.3.0": "2011-03-20T18:37:42.115Z",
+    "0.3.1": "2011-03-20T18:37:42.115Z",
+    "0.4.0": "2011-03-20T18:37:42.115Z",
+    "0.4.1": "2011-03-20T21:42:39.710Z",
+    "0.4.2": "2011-04-13T21:24:43.807Z",
+    "0.5.0": "2011-04-18T01:37:47.127Z",
+    "0.5.1": "2011-05-10T22:31:25.797Z",
+    "0.5.2": "2011-05-17T22:40:59.948Z",
+    "0.5.3": "2011-05-18T01:38:07.066Z",
+    "0.5.4": "2011-05-19T01:10:09.614Z",
+    "0.5.5": "2011-05-19T04:38:37.820Z",
+    "0.5.6": "2011-05-19T06:00:15.396Z",
+    "0.5.7": "2011-05-19T06:46:03.717Z",
+    "0.5.8": "2011-05-21T14:43:40.621Z",
+    "0.5.9": "2011-05-23T06:19:07.714Z",
+    "0.5.10": "2011-06-13T06:53:20.983Z",
+    "0.5.11": "2011-06-26T17:26:08.499Z",
+    "0.6.0": "2011-07-26T01:21:02.357Z",
+    "0.6.1": "2011-08-02T14:08:09.011Z",
+    "0.7.0": "2011-08-04T13:00:37.432Z",
+    "0.6.2": "2011-08-09T10:35:13.520Z",
+    "0.6.4": "2011-08-28T23:34:01.455Z",
+    "0.6.5": "2011-08-29T01:15:15.681Z",
+    "0.6.6": "2011-08-31T15:49:12.708Z",
+    "0.7.2": "2011-09-30T08:22:30.123Z",
+    "0.7.3": "2011-10-04T19:18:15.451Z",
+    "0.7.4": "2011-11-10T06:01:09.076Z",
+    "0.7.5": "2011-11-11T01:28:13.015Z",
+    "0.7.6": "2011-11-14T20:44:10.580Z",
+    "0.8.0": "2011-12-23T06:42:46.315Z",
+    "0.8.1": "2012-06-05T22:04:55.630Z",
+    "0.0.0": "2012-06-09T04:39:14.601Z",
+    "0.8.2": "2012-07-22T21:25:11.761Z",
+    "0.8.3": "2012-09-20T15:58:56.473Z",
+    "0.8.4": "2012-10-23T20:03:32.147Z",
+    "0.8.5": "2012-11-16T05:22:12.255Z",
+    "0.8.6": "2012-12-21T15:53:23.000Z",
+    "0.8.7": "2012-12-23T00:02:31.258Z",
+    "0.9.0": "2013-03-09T10:00:18.512Z",
+    "0.9.1": "2013-03-09T10:09:39.807Z",
+    "0.10.0": "2013-03-18T05:53:33.812Z",
+    "0.10.1": "2013-04-12T08:55:48.088Z",
+    "0.10.2": "2013-04-21T21:07:15.779Z",
+    "0.10.3": "2013-06-20T13:29:53.381Z",
+    "0.10.4": "2013-12-27T08:08:12.488Z",
+    "1.0.0": "2014-01-17T17:40:53.312Z",
+    "1.0.1": "2014-01-17T21:20:42.852Z",
+    "1.0.2": "2014-01-28T19:53:09.257Z",
+    "1.0.3": "2014-03-27T02:41:54.073Z",
+    "1.1.0": "2014-04-09T17:38:47.920Z",
+    "1.1.1": "2014-04-11T00:03:08.371Z",
+    "1.1.2": "2014-04-14T17:17:56.828Z",
+    "1.1.3": "2014-05-11T05:03:07.262Z",
+    "1.1.4": "2014-05-11T23:02:33.492Z",
+    "1.1.5": "2014-07-10T03:26:58.943Z",
+    "1.1.6": "2014-07-17T14:56:54.267Z",
+    "1.2.0": "2014-08-05T21:26:15.190Z",
+    "1.2.1": "2014-08-14T17:39:24.604Z",
+    "1.3.0": "2014-08-14T21:26:42.455Z",
+    "1.3.1": "2014-09-09T17:20:29.027Z",
+    "1.4.0": "2014-09-11T22:49:43.531Z",
+    "1.4.1": "2014-09-11T22:50:22.495Z",
+    "1.4.2": "2014-09-12T11:48:42.965Z",
+    "1.4.3": "2014-09-12T17:39:53.684Z",
+    "1.5.0": "2014-09-30T02:39:19.553Z",
+    "1.5.1": "2014-09-30T19:23:19.995Z",
+    "1.5.2": "2014-10-01T01:21:22.695Z",
+    "1.5.3": "2014-10-01T11:11:08.444Z",
+    "1.6.0": "2014-10-29T02:55:12.833Z",
+    "1.6.1": "2014-11-04T23:15:42.020Z",
+    "1.6.2": "2014-11-11T16:48:00.045Z",
+    "1.7.0": "2014-11-25T22:32:18.245Z",
+    "1.7.1": "2014-12-02T17:29:08.462Z",
+    "1.7.2": "2014-12-08T21:17:23.000Z",
+    "1.7.3": "2014-12-09T04:06:21.442Z",
+    "1.8.0": "2014-12-17T07:59:53.862Z",
+    "1.8.1": "2014-12-17T17:13:20.879Z",
+    "1.9.0": "2015-03-12T22:59:35.397Z",
+    "1.9.1": "2015-04-01T16:09:50.130Z",
+    "1.10.0": "2015-04-01T16:24:30.797Z",
+    "1.10.1": "2015-04-02T16:41:11.463Z",
+    "1.11.0": "2015-04-20T20:48:19.302Z",
+    "1.11.1": "2015-04-22T15:09:42.215Z",
+    "1.11.2": "2015-08-30T21:29:34.435Z",
+    "1.11.3": "2015-10-19T13:30:29.496Z",
+    "1.12.0": "2015-10-22T23:27:39.971Z",
+    "1.12.1": "2016-01-24T20:20:39.588Z",
+    "1.13.0": "2016-01-26T22:12:02.896Z",
+    "1.13.1": "2016-02-02T05:03:05.566Z",
+    "1.13.2": "2016-02-17T16:00:11.846Z",
+    "1.13.3": "2016-05-16T03:14:58.875Z",
+    "1.14.0": "2016-06-15T14:53:05.632Z",
+    "1.15.0": "2016-09-14T17:06:05.133Z",
+    "1.15.1": "2016-09-14T21:12:38.554Z",
+    "1.15.2": "2016-10-22T15:47:30.866Z",
+    "1.16.0": "2016-12-02T14:13:19.709Z",
+    "1.16.1": "2016-12-04T15:59:51.283Z",
+    "1.16.2": "2016-12-06T15:49:10.117Z",
+    "1.17.0": "2018-04-20T15:43:09.143Z",
+    "1.18.0": "2019-09-18T01:41:09.233Z",
+    "1.18.1": "2020-05-17T21:27:32.770Z"
+  },
+  "users": {
+    "6174": true,
+    "285858315": true,
+    "306766053": true,
+    "pgte": true,
+    "fgribreau": true,
+    "leesei": true,
+    "joliva": true,
+    "kastor": true,
+    "cedx": true,
+    "eins78": true,
+    "steve-jansen": true,
+    "trusktr": true,
+    "putaoshu": true,
+    "leodutra": true,
+    "ajduke": true,
+    "jokesterfr": true,
+    "redbe4rd": true,
+    "maxzhang": true,
+    "guilbill": true,
+    "jbdoumenjou": true,
+    "xunuo": true,
+    "old9": true,
+    "ryanthejuggler": true,
+    "sourcesoft": true,
+    "djk": true,
+    "joe5yellow": true,
+    "maiah": true,
+    "tcoats": true,
+    "ataiemajid_63": true,
+    "dgarlitt": true,
+    "ivangaravito": true,
+    "devpaul": true,
+    "swmoon203": true,
+    "mr1024": true,
+    "reinoud": true,
+    "asilvas": true,
+    "pstoev": true,
+    "haeck": true,
+    "zhangwentao": true,
+    "sahilsk": true,
+    "wolfgangschoeffel": true,
+    "dudley": true,
+    "amirmehmood": true,
+    "subchen": true,
+    "baishuiz": true,
+    "brentonhouse": true,
+    "giphoo": true,
+    "ginof": true,
+    "tszopinski": true,
+    "jimster305": true,
+    "synchronous": true,
+    "pilsy": true,
+    "sbrajesh": true,
+    "loki2302": true,
+    "alexkval": true,
+    "arunrajmony": true,
+    "adamkdean": true,
+    "devalias": true,
+    "kunl": true,
+    "e23jiang": true,
+    "amanvirk": true,
+    "leejefon": true,
+    "loulin": true,
+    "xpk": true,
+    "vishnuvathsan": true,
+    "huangkai": true,
+    "ssh0702": true,
+    "program247365": true,
+    "markymark": true,
+    "martinkuba": true,
+    "reecegoddard": true,
+    "panlw": true,
+    "stany": true,
+    "perrywu": true,
+    "almccann": true,
+    "xieranmaya": true,
+    "senorsen": true,
+    "bojand": true,
+    "itskdk": true,
+    "sirrah": true,
+    "dexteryy": true,
+    "mygoare": true,
+    "ristostevcev": true,
+    "andrelion": true,
+    "dpjayasekara": true,
+    "scytalezero": true,
+    "roman-io": true,
+    "guumaster": true,
+    "natarajanmca11": true,
+    "kodekracker": true,
+    "jruif": true,
+    "ddkothari": true,
+    "jian263994241": true,
+    "daizch": true,
+    "sqrtthree": true,
+    "kuba0506": true,
+    "aquafadas": true,
+    "wangnan0610": true,
+    "programmer.severson": true,
+    "itsakt": true,
+    "hisabimbola": true,
+    "elussich": true,
+    "craigpatten": true,
+    "erichua23": true,
+    "jungae1000": true,
+    "mickaelb": true,
+    "crisperdue": true,
+    "vifird": true,
+    "youngmo": true,
+    "jez9999": true,
+    "manikantag": true,
+    "abdihaikal": true,
+    "chrisx": true,
+    "parkerproject": true,
+    "jsds": true,
+    "jerrywu": true,
+    "webbot": true,
+    "hafiidz": true,
+    "ahvonenj": true,
+    "mojaray2k": true,
+    "rocket0191": true,
+    "staydan": true,
+    "asaupup": true,
+    "coolhanddev": true,
+    "egantz": true,
+    "ssljivic": true,
+    "jovinbm": true,
+    "shanewholloway": true,
+    "junjiansyu": true,
+    "abuelwafa": true,
+    "isaacvitor": true,
+    "sachacr": true,
+    "yazanrawashdeh": true,
+    "iksnae": true,
+    "philiiiiiipp": true,
+    "scott.m.sarsfield": true,
+    "hanq": true,
+    "dcpesses": true,
+    "andygreenegrass": true,
+    "stone_breaker": true,
+    "nickeltobias": true,
+    "shuoshubao": true,
+    "dkblay": true,
+    "al123": true,
+    "ww522413622": true,
+    "xyyjk": true,
+    "laomu": true,
+    "papasavva": true,
+    "danielpavelic": true,
+    "ys_sidson_aidson": true,
+    "cheapsteak": true,
+    "rsp": true,
+    "plingply": true,
+    "wangfeia": true,
+    "dburdese": true,
+    "sprying": true,
+    "mmascanlin": true,
+    "yinxulai": true,
+    "pid": true,
+    "chhetrisushil": true,
+    "hehaiyang": true,
+    "ericteng177": true,
+    "stone-jin": true,
+    "undisclosed": true,
+    "drewigg": true,
+    "nogirev": true,
+    "nuwaio": true,
+    "touskar": true,
+    "tztz": true,
+    "l8niteowl": true,
+    "ziflex": true,
+    "yinyongcom666": true,
+    "monjer": true,
+    "zhenzhong": true,
+    "brunocarvalhodearaujo": true,
+    "chosan": true,
+    "xfloops": true,
+    "nikitenok_sl": true,
+    "xiaobing": true,
+    "danhodkinson": true,
+    "yanghcc": true
+  },
+  "readme": "<p align=\"center\">\n  <img src=\"https://raw.github.com/http-party/node-http-proxy/master/doc/logo.png\"/>\n</p>\n\n# node-http-proxy [![Build Status](https://travis-ci.org/http-party/node-http-proxy.svg?branch=master)](https://travis-ci.org/http-party/node-http-proxy) [![codecov](https://codecov.io/gh/http-party/node-http-proxy/branch/master/graph/badge.svg)](https://codecov.io/gh/http-party/node-http-proxy)\n\n`node-http-proxy` is an HTTP programmable proxying library that supports\nwebsockets. It is suitable for implementing components such as reverse\nproxies and load balancers.\n\n### Table of Contents\n  * [Installation](#installation)\n  * [Upgrading from 0.8.x ?](#upgrading-from-08x-)\n  * [Core Concept](#core-concept)\n  * [Use Cases](#use-cases)\n    * [Setup a basic stand-alone proxy server](#setup-a-basic-stand-alone-proxy-server)\n    * [Setup a stand-alone proxy server with custom server logic](#setup-a-stand-alone-proxy-server-with-custom-server-logic)\n    * [Setup a stand-alone proxy server with proxy request header re-writing](#setup-a-stand-alone-proxy-server-with-proxy-request-header-re-writing)\n    * [Modify a response from a proxied server](#modify-a-response-from-a-proxied-server)\n    * [Setup a stand-alone proxy server with latency](#setup-a-stand-alone-proxy-server-with-latency)\n    * [Using HTTPS](#using-https)\n    * [Proxying WebSockets](#proxying-websockets)\n  * [Options](#options)\n  * [Listening for proxy events](#listening-for-proxy-events)\n  * [Shutdown](#shutdown)\n  * [Miscellaneous](#miscellaneous)\n    * [Test](#test)\n    * [ProxyTable API](#proxytable-api)\n    * [Logo](#logo)\n  * [Contributing and Issues](#contributing-and-issues)\n  * [License](#license)\n\n### Installation\n\n`npm install http-proxy --save`\n\n**[Back to top](#table-of-contents)**\n\n### Upgrading from 0.8.x ?\n\nClick [here](UPGRADING.md)\n\n**[Back to top](#table-of-contents)**\n\n### Core Concept\n\nA new proxy is created by calling `createProxyServer` and passing\nan `options` object as argument ([valid properties are available here](lib/http-proxy.js#L26-L42))\n\n```javascript\nvar httpProxy = require('http-proxy');\n\nvar proxy = httpProxy.createProxyServer(options); // See (†)\n```\n†Unless listen(..) is invoked on the object, this does not create a webserver. See below.\n\nAn object will be returned with four methods:\n\n* web `req, res, [options]` (used for proxying regular HTTP(S) requests)\n* ws `req, socket, head, [options]` (used for proxying WS(S) requests)\n* listen `port` (a function that wraps the object in a webserver, for your convenience)\n* close `[callback]` (a function that closes the inner webserver and stops listening on given port)\n\nIt is then possible to proxy requests by calling these functions\n\n```javascript\nhttp.createServer(function(req, res) {\n  proxy.web(req, res, { target: 'http://mytarget.com:8080' });\n});\n```\n\nErrors can be listened on either using the Event Emitter API\n\n```javascript\nproxy.on('error', function(e) {\n  ...\n});\n```\n\nor using the callback API\n\n```javascript\nproxy.web(req, res, { target: 'http://mytarget.com:8080' }, function(e) { ... });\n```\n\nWhen a request is proxied it follows two different pipelines ([available here](lib/http-proxy/passes))\nwhich apply transformations to both the `req` and `res` object.\nThe first pipeline (incoming) is responsible for the creation and manipulation of the stream that connects your client to the target.\nThe second pipeline (outgoing) is responsible for the creation and manipulation of the stream that, from your target, returns data\nto the client.\n\n**[Back to top](#table-of-contents)**\n\n### Use Cases\n\n#### Setup a basic stand-alone proxy server\n\n```js\nvar http = require('http'),\n    httpProxy = require('http-proxy');\n//\n// Create your proxy server and set the target in the options.\n//\nhttpProxy.createProxyServer({target:'http://localhost:9000'}).listen(8000); // See (†)\n\n//\n// Create your target server\n//\nhttp.createServer(function (req, res) {\n  res.writeHead(200, { 'Content-Type': 'text/plain' });\n  res.write('request successfully proxied!' + '\\n' + JSON.stringify(req.headers, true, 2));\n  res.end();\n}).listen(9000);\n```\n†Invoking listen(..) triggers the creation of a web server. Otherwise, just the proxy instance is created.\n\n**[Back to top](#table-of-contents)**\n\n#### Setup a stand-alone proxy server with custom server logic\nThis example shows how you can proxy a request using your own HTTP server\nand also you can put your own logic to handle the request.\n\n```js\nvar http = require('http'),\n    httpProxy = require('http-proxy');\n\n//\n// Create a proxy server with custom application logic\n//\nvar proxy = httpProxy.createProxyServer({});\n\n//\n// Create your custom server and just call `proxy.web()` to proxy\n// a web request to the target passed in the options\n// also you can use `proxy.ws()` to proxy a websockets request\n//\nvar server = http.createServer(function(req, res) {\n  // You can define here your custom logic to handle the request\n  // and then proxy the request.\n  proxy.web(req, res, { target: 'http://127.0.0.1:5050' });\n});\n\nconsole.log(\"listening on port 5050\")\nserver.listen(5050);\n```\n\n**[Back to top](#table-of-contents)**\n\n#### Setup a stand-alone proxy server with proxy request header re-writing\nThis example shows how you can proxy a request using your own HTTP server that\nmodifies the outgoing proxy request by adding a special header.\n\n```js\nvar http = require('http'),\n    httpProxy = require('http-proxy');\n\n//\n// Create a proxy server with custom application logic\n//\nvar proxy = httpProxy.createProxyServer({});\n\n// To modify the proxy connection before data is sent, you can listen\n// for the 'proxyReq' event. When the event is fired, you will receive\n// the following arguments:\n// (http.ClientRequest proxyReq, http.IncomingMessage req,\n//  http.ServerResponse res, Object options). This mechanism is useful when\n// you need to modify the proxy request before the proxy connection\n// is made to the target.\n//\nproxy.on('proxyReq', function(proxyReq, req, res, options) {\n  proxyReq.setHeader('X-Special-Proxy-Header', 'foobar');\n});\n\nvar server = http.createServer(function(req, res) {\n  // You can define here your custom logic to handle the request\n  // and then proxy the request.\n  proxy.web(req, res, {\n    target: 'http://127.0.0.1:5050'\n  });\n});\n\nconsole.log(\"listening on port 5050\")\nserver.listen(5050);\n```\n\n**[Back to top](#table-of-contents)**\n\n#### Modify a response from a proxied server\nSometimes when you have received a HTML/XML document from the server of origin you would like to modify it before forwarding it on.\n\n[Harmon](https://github.com/No9/harmon) allows you to do this in a streaming style so as to keep the pressure on the proxy to a minimum.\n\n**[Back to top](#table-of-contents)**\n\n#### Setup a stand-alone proxy server with latency\n\n```js\nvar http = require('http'),\n    httpProxy = require('http-proxy');\n\n//\n// Create a proxy server with latency\n//\nvar proxy = httpProxy.createProxyServer();\n\n//\n// Create your server that makes an operation that waits a while\n// and then proxies the request\n//\nhttp.createServer(function (req, res) {\n  // This simulates an operation that takes 500ms to execute\n  setTimeout(function () {\n    proxy.web(req, res, {\n      target: 'http://localhost:9008'\n    });\n  }, 500);\n}).listen(8008);\n\n//\n// Create your target server\n//\nhttp.createServer(function (req, res) {\n  res.writeHead(200, { 'Content-Type': 'text/plain' });\n  res.write('request successfully proxied to: ' + req.url + '\\n' + JSON.stringify(req.headers, true, 2));\n  res.end();\n}).listen(9008);\n```\n\n**[Back to top](#table-of-contents)**\n\n#### Using HTTPS\nYou can activate the validation of a secure SSL certificate to the target connection (avoid self-signed certs), just set `secure: true` in the options.\n\n##### HTTPS -> HTTP\n\n```js\n//\n// Create the HTTPS proxy server in front of a HTTP server\n//\nhttpProxy.createServer({\n  target: {\n    host: 'localhost',\n    port: 9009\n  },\n  ssl: {\n    key: fs.readFileSync('valid-ssl-key.pem', 'utf8'),\n    cert: fs.readFileSync('valid-ssl-cert.pem', 'utf8')\n  }\n}).listen(8009);\n```\n\n##### HTTPS -> HTTPS\n\n```js\n//\n// Create the proxy server listening on port 443\n//\nhttpProxy.createServer({\n  ssl: {\n    key: fs.readFileSync('valid-ssl-key.pem', 'utf8'),\n    cert: fs.readFileSync('valid-ssl-cert.pem', 'utf8')\n  },\n  target: 'https://localhost:9010',\n  secure: true // Depends on your needs, could be false.\n}).listen(443);\n```\n\n##### HTTP -> HTTPS (using a PKCS12 client certificate)\n\n```js\n//\n// Create an HTTP proxy server with an HTTPS target\n//\nhttpProxy.createProxyServer({\n  target: {\n    protocol: 'https:',\n    host: 'my-domain-name',\n    port: 443,\n    pfx: fs.readFileSync('path/to/certificate.p12'),\n    passphrase: 'password',\n  },\n  changeOrigin: true,\n}).listen(8000);\n```\n\n**[Back to top](#table-of-contents)**\n\n#### Proxying WebSockets\nYou can activate the websocket support for the proxy using `ws:true` in the options.\n\n```js\n//\n// Create a proxy server for websockets\n//\nhttpProxy.createServer({\n  target: 'ws://localhost:9014',\n  ws: true\n}).listen(8014);\n```\n\nAlso you can proxy the websocket requests just calling the `ws(req, socket, head)` method.\n\n```js\n//\n// Setup our server to proxy standard HTTP requests\n//\nvar proxy = new httpProxy.createProxyServer({\n  target: {\n    host: 'localhost',\n    port: 9015\n  }\n});\nvar proxyServer = http.createServer(function (req, res) {\n  proxy.web(req, res);\n});\n\n//\n// Listen to the `upgrade` event and proxy the\n// WebSocket requests as well.\n//\nproxyServer.on('upgrade', function (req, socket, head) {\n  proxy.ws(req, socket, head);\n});\n\nproxyServer.listen(8015);\n```\n\n**[Back to top](#table-of-contents)**\n\n### Options\n\n`httpProxy.createProxyServer` supports the following options:\n\n*  **target**: url string to be parsed with the url module\n*  **forward**: url string to be parsed with the url module\n*  **agent**: object to be passed to http(s).request (see Node's [https agent](http://nodejs.org/api/https.html#https_class_https_agent) and [http agent](http://nodejs.org/api/http.html#http_class_http_agent) objects)\n*  **ssl**: object to be passed to https.createServer()\n*  **ws**: true/false, if you want to proxy websockets\n*  **xfwd**: true/false, adds x-forward headers\n*  **secure**: true/false, if you want to verify the SSL Certs\n*  **toProxy**: true/false, passes the absolute URL as the `path` (useful for proxying to proxies)\n*  **prependPath**: true/false, Default: true - specify whether you want to prepend the target's path to the proxy path\n*  **ignorePath**: true/false, Default: false - specify whether you want to ignore the proxy path of the incoming request (note: you will have to append / manually if required).\n*  **localAddress**: Local interface string to bind for outgoing connections\n*  **changeOrigin**: true/false, Default: false - changes the origin of the host header to the target URL\n*  **preserveHeaderKeyCase**: true/false, Default: false - specify whether you want to keep letter case of response header key\n*  **auth**: Basic authentication i.e. 'user:password' to compute an Authorization header.\n*  **hostRewrite**: rewrites the location hostname on (201/301/302/307/308) redirects.\n*  **autoRewrite**: rewrites the location host/port on (201/301/302/307/308) redirects based on requested host/port. Default: false.\n*  **protocolRewrite**: rewrites the location protocol on (201/301/302/307/308) redirects to 'http' or 'https'. Default: null.\n*  **cookieDomainRewrite**: rewrites domain of `set-cookie` headers. Possible values:\n   * `false` (default): disable cookie rewriting\n   * String: new domain, for example `cookieDomainRewrite: \"new.domain\"`. To remove the domain, use `cookieDomainRewrite: \"\"`.\n   * Object: mapping of domains to new domains, use `\"*\"` to match all domains.\n     For example keep one domain unchanged, rewrite one domain and remove other domains:\n     ```\n     cookieDomainRewrite: {\n       \"unchanged.domain\": \"unchanged.domain\",\n       \"old.domain\": \"new.domain\",\n       \"*\": \"\"\n     }\n     ```\n*  **cookiePathRewrite**: rewrites path of `set-cookie` headers. Possible values:\n   * `false` (default): disable cookie rewriting\n   * String: new path, for example `cookiePathRewrite: \"/newPath/\"`. To remove the path, use `cookiePathRewrite: \"\"`. To set path to root use `cookiePathRewrite: \"/\"`.\n   * Object: mapping of paths to new paths, use `\"*\"` to match all paths.\n     For example, to keep one path unchanged, rewrite one path and remove other paths:\n     ```\n     cookiePathRewrite: {\n       \"/unchanged.path/\": \"/unchanged.path/\",\n       \"/old.path/\": \"/new.path/\",\n       \"*\": \"\"\n     }\n     ```\n*  **headers**: object with extra headers to be added to target requests.\n*  **proxyTimeout**: timeout (in millis) for outgoing proxy requests\n*  **timeout**: timeout (in millis) for incoming requests\n*  **followRedirects**: true/false, Default: false - specify whether you want to follow redirects\n*  **selfHandleResponse** true/false, if set to true, none of the webOutgoing passes are called and it's your responsibility to appropriately return the response by listening and acting on the `proxyRes` event\n*  **buffer**: stream of data to send as the request body.  Maybe you have some middleware that consumes the request stream before proxying it on e.g.  If you read the body of a request into a field called 'req.rawbody' you could restream this field in the buffer option:\n\n    ```\n    'use strict';\n\n    const streamify = require('stream-array');\n    const HttpProxy = require('http-proxy');\n    const proxy = new HttpProxy();\n\n    module.exports = (req, res, next) => {\n\n      proxy.web(req, res, {\n        target: 'http://localhost:4003/',\n        buffer: streamify(req.rawBody)\n      }, next);\n\n    };\n    ```\n\n**NOTE:**\n`options.ws` and `options.ssl` are optional.\n`options.target` and `options.forward` cannot both be missing\n\nIf you are using the `proxyServer.listen` method, the following options are also applicable:\n\n *  **ssl**: object to be passed to https.createServer()\n *  **ws**: true/false, if you want to proxy websockets\n\n\n**[Back to top](#table-of-contents)**\n\n### Listening for proxy events\n\n* `error`: The error event is emitted if the request to the target fail. **We do not do any error handling of messages passed between client and proxy, and messages passed between proxy and target, so it is recommended that you listen on errors and handle them.**\n* `proxyReq`: This event is emitted before the data is sent. It gives you a chance to alter the proxyReq request object. Applies to \"web\" connections\n* `proxyReqWs`: This event is emitted before the data is sent. It gives you a chance to alter the proxyReq request object. Applies to \"websocket\" connections\n* `proxyRes`: This event is emitted if the request to the target got a response.\n* `open`: This event is emitted once the proxy websocket was created and piped into the target websocket.\n* `close`: This event is emitted once the proxy websocket was closed.\n* (DEPRECATED) `proxySocket`: Deprecated in favor of `open`.\n\n```js\nvar httpProxy = require('http-proxy');\n// Error example\n//\n// Http Proxy Server with bad target\n//\nvar proxy = httpProxy.createServer({\n  target:'http://localhost:9005'\n});\n\nproxy.listen(8005);\n\n//\n// Listen for the `error` event on `proxy`.\nproxy.on('error', function (err, req, res) {\n  res.writeHead(500, {\n    'Content-Type': 'text/plain'\n  });\n\n  res.end('Something went wrong. And we are reporting a custom error message.');\n});\n\n//\n// Listen for the `proxyRes` event on `proxy`.\n//\nproxy.on('proxyRes', function (proxyRes, req, res) {\n  console.log('RAW Response from the target', JSON.stringify(proxyRes.headers, true, 2));\n});\n\n//\n// Listen for the `open` event on `proxy`.\n//\nproxy.on('open', function (proxySocket) {\n  // listen for messages coming FROM the target here\n  proxySocket.on('data', hybiParseAndLogMessage);\n});\n\n//\n// Listen for the `close` event on `proxy`.\n//\nproxy.on('close', function (res, socket, head) {\n  // view disconnected websocket connections\n  console.log('Client disconnected');\n});\n```\n\n**[Back to top](#table-of-contents)**\n\n### Shutdown\n\n* When testing or running server within another program it may be necessary to close the proxy.\n* This will stop the proxy from accepting new connections.\n\n```js\nvar proxy = new httpProxy.createProxyServer({\n  target: {\n    host: 'localhost',\n    port: 1337\n  }\n});\n\nproxy.close();\n```\n\n**[Back to top](#table-of-contents)**\n\n### Miscellaneous\n\nIf you want to handle your own response after receiving the `proxyRes`, you can do\nso with `selfHandleResponse`. As you can see below, if you use this option, you\nare able to intercept and read the `proxyRes` but you must also make sure to\nreply to the `res` itself otherwise the original client will never receive any\ndata.\n\n### Modify response\n\n```js\n\n    var option = {\n      target: target,\n      selfHandleResponse : true\n    };\n    proxy.on('proxyRes', function (proxyRes, req, res) {\n        var body = [];\n        proxyRes.on('data', function (chunk) {\n            body.push(chunk);\n        });\n        proxyRes.on('end', function () {\n            body = Buffer.concat(body).toString();\n            console.log(\"res from proxied server:\", body);\n            res.end(\"my response to cli\");\n        });\n    });\n    proxy.web(req, res, option);\n\n\n```\n\n#### ProxyTable API\n\nA proxy table API is available through this add-on [module](https://github.com/donasaur/http-proxy-rules), which lets you define a set of rules to translate matching routes to target routes that the reverse proxy will talk to.\n\n#### Test\n\n```\n$ npm test\n```\n\n#### Logo\n\nLogo created by [Diego Pasquali](http://dribbble.com/diegopq)\n\n**[Back to top](#table-of-contents)**\n\n### Contributing and Issues\n\n* Read carefully our [Code Of Conduct](https://github.com/http-party/node-http-proxy/blob/master/CODE_OF_CONDUCT.md)\n* Search on Google/Github\n* If you can't find anything, open an issue\n* If you feel comfortable about fixing the issue, fork the repo\n* Commit to your local branch (which must be different from `master`)\n* Submit your Pull Request (be sure to include tests and update documentation)\n\n**[Back to top](#table-of-contents)**\n\n### License\n\n>The MIT License (MIT)\n>\n>Copyright (c) 2010 - 2016 Charlie Robbins, Jarrett Cruger & the Contributors.\n>\n>Permission is hereby granted, free of charge, to any person obtaining a copy\n>of this software and associated documentation files (the \"Software\"), to deal\n>in the Software without restriction, including without limitation the rights\n>to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n>copies of the Software, and to permit persons to whom the Software is\n>furnished to do so, subject to the following conditions:\n>\n>The above copyright notice and this permission notice shall be included in\n>all copies or substantial portions of the Software.\n>\n>THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n>IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n>FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n>AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n>LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n>OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n>THE SOFTWARE.\n",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/http-party/node-http-proxy#readme",
+  "bugs": {
+    "url": "https://github.com/http-party/node-http-proxy/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/http-proxy.min.json
+++ b/test/fixtures/registry-mocks/content/http-proxy.min.json
@@ -1,0 +1,2278 @@
+{
+  "name": "http-proxy",
+  "dist-tags": {
+    "latest": "1.18.1"
+  },
+  "versions": {
+    "0.5.9": {
+      "name": "http-proxy",
+      "version": "0.5.9",
+      "dependencies": {
+        "colors": ">= 0.x.x",
+        "optimist": ">= 0.1.x",
+        "request": ">= 1.9.x"
+      },
+      "devDependencies": {
+        "vows": ">= 0.5.x",
+        "socket.io": ">= 0.6.x",
+        "docco": ">= 0.3.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "957103fa0515e475f99a2b4c5bfe3507d513a81e",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.5.9.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.5.10": {
+      "name": "http-proxy",
+      "version": "0.5.10",
+      "dependencies": {
+        "colors": ">= 0.x.x",
+        "optimist": ">= 0.1.x",
+        "request": ">= 1.9.x"
+      },
+      "devDependencies": {
+        "vows": ">= 0.5.x",
+        "socket.io": ">= 0.6.x",
+        "docco": ">= 0.3.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "acd2b9126569dea265fc01bcaca1b2293232067b",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.5.10.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.5.11": {
+      "name": "http-proxy",
+      "version": "0.5.11",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "f58f2572765d06c71749b09275b1ba167ffabdf2",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.5.11.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.6.0": {
+      "name": "http-proxy",
+      "version": "0.6.0",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "4fbcdc84d01f20c2531f375c437ec619c9e1012c",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.0.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.6.1": {
+      "name": "http-proxy",
+      "version": "0.6.1",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "0e786540c438fa139781d1b0be3521c3d7c6e728",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.1.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.6.2": {
+      "name": "http-proxy",
+      "version": "0.6.2",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "5114c56b4cf6dbe33094d6f0bbcb79d757210708",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.2.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.6.4": {
+      "name": "http-proxy",
+      "version": "0.6.4",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "1301de97d023eadbf7bdda81e1dc7efb5cedf4c5",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.4.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.6.5": {
+      "name": "http-proxy",
+      "version": "0.6.5",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "1b17209ee173b71fd74961e23a1f6f369978077f",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.5.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.6.6": {
+      "name": "http-proxy",
+      "version": "0.6.6",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "5a9cdbb02fc3cb740f2e511497da5e9e2b3ac469",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.6.6.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.7.0": {
+      "name": "http-proxy",
+      "version": "0.7.0",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "36c843818cdab7052f2f93aeed778e0f3cde5ada",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.0.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.7.2": {
+      "name": "http-proxy",
+      "version": "0.7.2",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "4e2e473b2c8875313101fbc657b2706e064525dd",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.2.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.7.3": {
+      "name": "http-proxy",
+      "version": "0.7.3",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "4f4bc8bbd08a206c6d822ba7a3dc582f4e8e7b32",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.3.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.7.4": {
+      "name": "http-proxy",
+      "version": "0.7.4",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "385556d7e84ca1f367f8a3887f4c8263f8d8a3ca",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.4.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.7.5": {
+      "name": "http-proxy",
+      "version": "0.7.5",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "ce69c26ccd432837548caf606ea44d2997d9d337",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.5.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.7.6": {
+      "name": "http-proxy",
+      "version": "0.7.6",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "7193cca1ebdf828d1582e740630b5caf816fd1e0",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.7.6.tgz"
+      },
+      "engines": {
+        "node": "0.4.x || 0.5.x"
+      }
+    },
+    "0.8.0": {
+      "name": "http-proxy",
+      "version": "0.8.0",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "async": "0.1.x",
+        "socket.io": "0.6.x"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "b366d265688ffcaa9e3c77ead20d154ddf94489e",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.8.1": {
+      "name": "http-proxy",
+      "version": "0.8.1",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.2.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.5.x",
+        "async": "0.1.x",
+        "socket.io": "0.6.17"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "cc4dd5793ba7bb17fa1834e6abc72a99e94bb996",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.8.2": {
+      "name": "http-proxy",
+      "version": "0.8.2",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.6",
+        "socket.io-client": "0.9.6",
+        "ws": "0.4.21"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "f75a3a754b5c27bea2fddad16e9b267b325a8273",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.8.3": {
+      "name": "http-proxy",
+      "version": "0.8.3",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.6",
+        "socket.io-client": "0.9.6",
+        "ws": "0.4.21"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "031cb4512df4cf28f387277dfcd2a0ea4f2a5466",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.8.4": {
+      "name": "http-proxy",
+      "version": "0.8.4",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.6",
+        "socket.io-client": "0.9.6",
+        "ws": "0.4.21"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "00075c99098041cb0336c6dbe7f13bf6144e5b23",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.8.5": {
+      "name": "http-proxy",
+      "version": "0.8.5",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.6",
+        "socket.io-client": "0.9.6",
+        "ws": "0.4.21"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "32eee6272cabdc1ef6bc5a732196262b6b687faf",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.8.6": {
+      "name": "http-proxy",
+      "version": "0.8.6",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "176f54a4fee949447807c58b69fdbb9e122d1394",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.8.7": {
+      "name": "http-proxy",
+      "version": "0.8.7",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x"
+      },
+      "devDependencies": {
+        "request": "1.9.x",
+        "vows": "0.6.x",
+        "async": "0.1.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "a7bc538618092cd26ed191e4625933baef6de80e",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.8.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.9.0": {
+      "name": "http-proxy",
+      "version": "0.9.0",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "c3f3601bf0fac3d9961bea8deb30a84360c34ef5",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.9.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.9.1": {
+      "name": "http-proxy",
+      "version": "0.9.1",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "ba074a55cb21cfde4deb359d19334a3eedda9325",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.9.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.10.0": {
+      "name": "http-proxy",
+      "version": "0.10.0",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "a20b718d05ec40427ae61644dabdcc427ba62508",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.10.1": {
+      "name": "http-proxy",
+      "version": "0.10.1",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "50f1ce725c87c90a4ec42679dbf4e3d774dfb181",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.10.2": {
+      "name": "http-proxy",
+      "version": "0.10.2",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "c28ebf268946faf4cce13104e7266b6827fc3a20",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.10.3": {
+      "name": "http-proxy",
+      "version": "0.10.3",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.3.x",
+        "pkginfo": "0.2.x",
+        "utile": "~0.1.7"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "72ca9d503a75e064650084c58ca11b82e4b0196d",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "0.10.4": {
+      "name": "http-proxy",
+      "version": "0.10.4",
+      "dependencies": {
+        "colors": "0.x.x",
+        "optimist": "0.6.x",
+        "pkginfo": "0.3.x",
+        "utile": "~0.2.1"
+      },
+      "devDependencies": {
+        "request": "2.14.x",
+        "vows": "0.7.x",
+        "async": "0.2.x",
+        "socket.io": "0.9.11",
+        "socket.io-client": "0.9.11",
+        "ws": "0.4.23"
+      },
+      "bin": {
+        "node-http-proxy": "./bin/node-http-proxy"
+      },
+      "dist": {
+        "shasum": "14ba0ceaa2197f89fa30dea9e7b09e19cd93c22f",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
+      }
+    },
+    "1.0.0": {
+      "name": "http-proxy",
+      "version": "1.0.0",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "81e0443e67c8292842892ded718553dff7000603",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "http-proxy",
+      "version": "1.0.1",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "d203d3b2dc34e968174956f11a6c35140da84384",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.2": {
+      "name": "http-proxy",
+      "version": "1.0.2",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "08060ff2edb2189e57aa3a152d3ac63ed1af7254",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.3": {
+      "name": "http-proxy",
+      "version": "1.0.3",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "3867396ab7d8fc70855fa72b55a527cc13427ea5",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.0": {
+      "name": "http-proxy",
+      "version": "1.1.0",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "309056d122bd5708ec806b40b22e379a9dcbdc83",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.1": {
+      "name": "http-proxy",
+      "version": "1.1.1",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "3ddbfae24ead5f0edd04beb5881d9fa779a709f1",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.2": {
+      "name": "http-proxy",
+      "version": "1.1.2",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "d78d0793c46815dbf39fb27723a4ddfe767777b0",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.3": {
+      "name": "http-proxy",
+      "version": "1.1.3",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "4f93ed116fa975d63c2880e7818504678287b300",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.4": {
+      "name": "http-proxy",
+      "version": "1.1.4",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "65bb5bfe645f322c65761febcc145a38111174b1",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.5": {
+      "name": "http-proxy",
+      "version": "1.1.5",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "ade491a3d40e61b31334ee9a40cd91ac125d1839",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.6": {
+      "name": "http-proxy",
+      "version": "1.1.6",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "1d9262f6dff3a325c0eb84e125502b5a930a1a58",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.1.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.2.0": {
+      "name": "http-proxy",
+      "version": "1.2.0",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "17f4626950d75c0fcdcb3c4d3af35bfae5fdc016",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.2.1": {
+      "name": "http-proxy",
+      "version": "1.2.1",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "83d93c05431e5b7753db22c961d1196cfc39877d",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.3.0": {
+      "name": "http-proxy",
+      "version": "1.3.0",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "21fa4368accc09c6341abb9c16275db4645053fa",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.4.0": {
+      "name": "http-proxy",
+      "version": "1.4.0",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "4173cbe81564f8ca94c7228e46d2898048066d3b",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.4.1": {
+      "name": "http-proxy",
+      "version": "1.4.1",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "31cbd2d89383bfa1885da260ad1fc023df13662c",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.4.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.4.2": {
+      "name": "http-proxy",
+      "version": "1.4.2",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "4ebe93aedd7f00ea3cd60dec86fb2db6764b971a",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.4.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.4.3": {
+      "name": "http-proxy",
+      "version": "1.4.3",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "27d3e4978a5e64641ed810ecc4a415fd00067020",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.4.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.5.0": {
+      "name": "http-proxy",
+      "version": "1.5.0",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "11d4c81100f5cbd7303b4bf8b62478fda7af728e",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.5.1": {
+      "name": "http-proxy",
+      "version": "1.5.1",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "40e09f6a3311a28936dfa704d86584c8b6185bde",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.5.2": {
+      "name": "http-proxy",
+      "version": "1.5.2",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "60afc612cfd82c9d19a502835192e3c5f530aff9",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.5.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.5.3": {
+      "name": "http-proxy",
+      "version": "1.5.3",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "d89aee8f1304caf847723d2456a18d7422ef33df",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.5.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.6.0": {
+      "name": "http-proxy",
+      "version": "1.6.0",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "1cc1614be2a09593d936a26013546e485c4b1d35",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.6.1": {
+      "name": "http-proxy",
+      "version": "1.6.1",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "8b163a57114f419f42476effa4d9aec83eec73f5",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.6.2": {
+      "name": "http-proxy",
+      "version": "1.6.2",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "bfbc07134806b6790368c31d88048c5575228d04",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.6.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.7.0": {
+      "name": "http-proxy",
+      "version": "1.7.0",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "ec05dd041207ef038922af38948d8b6a4114074d",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.7.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.7.1": {
+      "name": "http-proxy",
+      "version": "1.7.1",
+      "dependencies": {
+        "eventemitter3": "*"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "*",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "5fabe2e1d617beb09cc108b3a45c416372c3d36a",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.7.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.7.2": {
+      "name": "http-proxy",
+      "version": "1.7.2",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "5538cc6ff89266c6eeaa793c28e62d43fa60118b",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.7.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.7.3": {
+      "name": "http-proxy",
+      "version": "1.7.3",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "9e4b6eabae3e94f10130db97d858063fb6197718",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.7.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.8.0": {
+      "name": "http-proxy",
+      "version": "1.8.0",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "60cae018462824084b27f0840d9c366d599e7077",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.8.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.8.1": {
+      "name": "http-proxy",
+      "version": "1.8.1",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "95ee083305c719dba858aee01da1bfc8d7ab9efe",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.8.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.9.0": {
+      "name": "http-proxy",
+      "version": "1.9.0",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "adbb99b55027e15e802ef32737d2de3b88ef52a6",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.9.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.9.1": {
+      "name": "http-proxy",
+      "version": "1.9.1",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "4026281e35e4cf93f169a6fcd8ab55a0b5cc7d87",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.9.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.10.0": {
+      "name": "http-proxy",
+      "version": "1.10.0",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "expect.js": "*",
+        "dox": "*",
+        "coveralls": "*",
+        "mocha-lcov-reporter": "*",
+        "blanket": "*",
+        "ws": "~0.5.0",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "async": "*"
+      },
+      "dist": {
+        "shasum": "406762e8a22bbeab387d3a7df24cb1e9f3b91a78",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.10.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.10.1": {
+      "name": "http-proxy",
+      "version": "1.10.1",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "dist": {
+        "shasum": "0bb51c2727bdc094722cff569c7cf1455bd18d59",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.10.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.11.0": {
+      "name": "http-proxy",
+      "version": "1.11.0",
+      "dependencies": {
+        "eventemitter3": "0.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "dist": {
+        "shasum": "66fb73ece772e6b789287b542829cdb6e628f263",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.11.1": {
+      "name": "http-proxy",
+      "version": "1.11.1",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "dist": {
+        "shasum": "71df55757e802d58ea810df2244019dda05ae85d",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.11.2": {
+      "name": "http-proxy",
+      "version": "1.11.2",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "dist": {
+        "shasum": "c50d2fb06eca79d4238e66fd94393d2e41e63740",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.11.3": {
+      "name": "http-proxy",
+      "version": "1.11.3",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "dist": {
+        "shasum": "1915dc888751e2a6bf3c2abfcb1808fa86c72353",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.12.0": {
+      "name": "http-proxy",
+      "version": "1.12.0",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "0.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^4.3.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "ws": "~0.5.0"
+      },
+      "dist": {
+        "shasum": "4f02ea971e79e6affa12fa5f10ca2aebb5e3b17c",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.12.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.12.1": {
+      "name": "http-proxy",
+      "version": "1.12.1",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "23b4244d1b7f5a77ae333b8b189c13b4d2ccc468",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.12.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.13.0": {
+      "name": "http-proxy",
+      "version": "1.13.0",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "c29aa326dccd078d3e13c08c4cf474ce53f47c20",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.13.1": {
+      "name": "http-proxy",
+      "version": "1.13.1",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "d3eaa54f0d8d9d444ae0d9523c94391cb8bd6a43",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.13.2": {
+      "name": "http-proxy",
+      "version": "1.13.2",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "636bcd09f3e7045377a5e919e92d16d29fdbff09",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.13.3": {
+      "name": "http-proxy",
+      "version": "1.13.3",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "d5ec0e25da0c4b2edaeaa9476672640deda59623",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.13.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.14.0": {
+      "name": "http-proxy",
+      "version": "1.14.0",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "be32ab34dd5229e87840f4c27cb335ee195b2a83",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.14.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.15.0": {
+      "name": "http-proxy",
+      "version": "1.15.0",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "306c5e1a0e2df519ab4f4f71b0bd610d26bc4620",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.15.1": {
+      "name": "http-proxy",
+      "version": "1.15.1",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "91a6088172e79bc0e821d5eb04ce702f32446393",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.15.2": {
+      "name": "http-proxy",
+      "version": "1.15.2",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "642fdcaffe52d3448d2bda3b0079e9409064da31",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.16.0": {
+      "name": "http-proxy",
+      "version": "1.16.0",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "f9b52305e9f864811835277e4a486051b5d4a523",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.16.1": {
+      "name": "http-proxy",
+      "version": "1.16.1",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "734b32de6ca0e36e51b59c1e0115ff860d7668fd",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.16.2": {
+      "name": "http-proxy",
+      "version": "1.16.2",
+      "dependencies": {
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
+      },
+      "devDependencies": {
+        "async": "*",
+        "blanket": "*",
+        "coveralls": "*",
+        "dox": "*",
+        "expect.js": "*",
+        "mocha": "*",
+        "mocha-lcov-reporter": "*",
+        "semver": "^5.0.3",
+        "socket.io": "*",
+        "socket.io-client": "*",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "shasum": "06dff292952bf64dbe8471fa9df73066d4f37742",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.17.0": {
+      "name": "http-proxy",
+      "version": "1.17.0",
+      "dependencies": {
+        "eventemitter3": "^3.0.0",
+        "requires-port": "^1.0.0",
+        "follow-redirects": "^1.0.0"
+      },
+      "devDependencies": {
+        "async": "^2.0.0",
+        "concat-stream": "^1.6.2",
+        "expect.js": "~0.3.1",
+        "mocha": "^3.5.3",
+        "nyc": "^11.7.1",
+        "semver": "^5.0.3",
+        "socket.io": "^2.1.0",
+        "socket.io-client": "^2.1.0",
+        "sse": "0.0.6",
+        "ws": "^0.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+        "shasum": "7ad38494658f84605e2f6db4436df410f4e5be9a",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+        "fileCount": 37,
+        "unpackedSize": 444265,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2gqOCRA9TVsSAnZWagAA0pgQAJ4lM4iyzp+3h/SpDlGQ\nMkG6oT+gkdCkdU+J8y0nIkFT6Pr8c61vMXhuzaBsm3SUlxb2myIYxQp1t64p\nOYaBLeKcS2Fsts4xTRDQc+1LNnHHdpWZ0kxGE9hnRZo2aLe4S+RU/6w3tpTC\nVA6VmLW81sVTYEBQ9CEzQLYWzAKjJlX9XoQi4kufIiDnCes7J5IPFev9kPPp\nj0Gy/dzJX6Dy1UjsPqzajcno+1wEU9QYUvuqs73W0UevmmwTWGZ63MKJjqk/\nKZujjPQSp4ofyaQyWFC7KsWN6G84/dRioUnuGCNr6p1hykqO60jM5imRzbyV\n+L5D2gPH1R89G0ECgD1FmMKSFIRhtUc3YSyuDG/TJ3YbGGkLL0Gl0qa/puqB\nDBifu4jANNvNsP8hA5ms9xWYKBqc5DHbmSGmJk54nagVc9kEoaKOMKY4lU/h\nrJ4k4JxOFoDlgxilB6l1Vkjb06EgzCTcGbCeGfbK/hgIG4+gvhGlKAlsj6KC\nIGDPlpxihQ/SZAh5mgyXIkmHvF7wh+oukAMZybgs3hYVLg4/AuCvJbgFOg4X\nytTd/6eBc5IEwANTTiRXB/AZ3AtyRKwpxbSs48mylYb/ChXw0gJej2RPw4V6\nNnWOckAe1+xSx0xA8sgAkwI0Lo3HBEAmmZFkQh5kf4yWeqaZ1VT38EjBNPp6\nDLnN\r\n=Ht4z\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.18.0": {
+      "name": "http-proxy",
+      "version": "1.18.0",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "requires-port": "^1.0.0",
+        "follow-redirects": "^1.0.0"
+      },
+      "devDependencies": {
+        "async": "^3.0.0",
+        "auto-changelog": "^1.15.0",
+        "concat-stream": "^2.0.0",
+        "expect.js": "~0.3.1",
+        "mocha": "^3.5.3",
+        "nyc": "^14.0.0",
+        "semver": "^5.0.3",
+        "socket.io": "^2.1.0",
+        "socket.io-client": "^2.1.0",
+        "sse": "0.0.8",
+        "ws": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+        "shasum": "dbe55f63e75a347db7f3d99974f2692a314a6a3a",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+        "fileCount": 16,
+        "unpackedSize": 231272,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdgYs1CRA9TVsSAnZWagAANs0P/jmblQqi6QxrRR/Ukxkw\npnEYpCE6E/bZ2lrkjMvtoTUpXrZe6YTORPm3ecHYtDXgp0V7NJ75As53XwkT\n5bqECrrRO7YlG6apwtGvTJyu5MO7pdyMQSRAyHgPZkJTZI8YLeKiEZF7Ajma\neoENrmhmb5Xu8y/PlfdHUK+X/5ymPugav9IAZpAEx/DaPfrBcRcIdVdJsS9S\n3dh1wq+4YYycR7RE7/9ZrJfwfAFXOafxhKBdovD7npjXpqvzdzXtYc257FXm\n1Y28CgaW5slwHPg3EpewOV63MABukAu5wDmI8laGnl82jlbMOVjhm3B5ch6Y\nFCuGJGj5C2+heA1boFFtW0oSg3Lqf49MFrFYkwUXoTVSw04IRo+5YM3xBawL\n3pv20ksc/PIQh/qGUhsqMSOmQEaIfLkVlGxw4JHLH1fWTmTbpFXqTo3t9jRn\nPS9SxywCZJs+oneNyVVdEqnQrjPK5ZLpw8543WGy5DPC/rUOeayNhuuJ1fAh\nvM8IRn7PldG4oU9sa+E66OGapINuLkLvqRosKBn/MKQl2et/gqru77cYichm\nso+I/lC2kfgy+3N1kEebCfHaOQYdLRwkx2bO+rfKQvnPqj8mvM9SGRxJtVNf\ns2F94EEtUh5xRm5Sg9zyUuAW62Owc7o2/x5xRjmwdJRqzmzKfJ0537gsm1Dn\ne2Pl\r\n=uhTM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "1.18.1": {
+      "name": "http-proxy",
+      "version": "1.18.1",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "requires-port": "^1.0.0",
+        "follow-redirects": "^1.0.0"
+      },
+      "devDependencies": {
+        "async": "^3.0.0",
+        "auto-changelog": "^1.15.0",
+        "concat-stream": "^2.0.0",
+        "expect.js": "~0.3.1",
+        "mocha": "^3.5.3",
+        "nyc": "^14.0.0",
+        "semver": "^5.0.3",
+        "socket.io": "^2.1.0",
+        "socket.io-client": "^2.1.0",
+        "sse": "0.0.8",
+        "ws": "^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+        "shasum": "401541f0534884bbf95260334e72f88ee3976549",
+        "tarball": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+        "fileCount": 16,
+        "unpackedSize": 231812,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJewaxFCRA9TVsSAnZWagAA+lIQAI1unze4a1LlWRns8e4c\nGlvLDeTCOq+wSHTgRvJXOpHyt+3x7mulAxkLrgtKOUPQ1hSb1SLJmlQcVHfh\nMpxfgHUufP2vSBIwDaM1J0VQj92sMovQvAhiSjK8rBdBfL1e8SY7vtRabF+A\nEXrKC3k94+p3enSVK0bIgGypJLfhGYTo/6mSlpfVO5hV1E4qIU3c4eL/M/p5\nFlfwEss1ASreRUy23/3oWJdnylEUJM5/BROiW8nnZ+DOWZZmdOktrdB9tPjA\n93i2TTvIPcNW4MVpwF2andNrPffCBocfvbfVLjbSwK8jY7wZhm325lzng9wO\nHLCrX2hiRe6HqYyGrCKFmWzzh5RpBa3/X5j7RFhCLYpDp2tQMoyWnXUj1Kwl\n/cA3jnc7pipeLPnI2ay0wre4mxo9kgGq/SlJxF82AOuN19x/XhXY6FqIdkeu\ndWEE32/8BnjVXEY8lVmEeObD+YEESufvtWhqJnwMPcL2le6k+fr3WBw8SUvI\nj64sA+44iNOPPcOr2xZOO/yIWovwtsT2tvonunHYTIdmCHwqGma2/8xBxrqH\nSClvDxKkexgQw59sdWiruGw0iQoilW2fAmCPSowYI52zojEA6c/iBoJbljUa\ns+WanFKm8fo+KfWSRpDBKTE3Tprbe+yHPXBtGjXpbIekq8p7QjsaLyPt+FOA\nwoEv\r\n=Z69L\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    }
+  },
+  "modified": "2020-05-17T21:27:36.472Z"
+}

--- a/test/fixtures/registry-mocks/content/https-browserify.json
+++ b/test/fixtures/registry-mocks/content/https-browserify.json
@@ -1,0 +1,220 @@
+{
+  "_id": "https-browserify",
+  "_rev": "9-880a61611dbcc5663dcb3364ce5cdfc3",
+  "name": "https-browserify",
+  "description": "https module compatability for browserify",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "https-browserify",
+      "version": "0.0.0",
+      "description": "https module compatability for browserify",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/https-browserify.git"
+      },
+      "homepage": "https://github.com/substack/https-browserify",
+      "keywords": [
+        "https",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/https-browserify/issues"
+      },
+      "_id": "https-browserify@0.0.0",
+      "dist": {
+        "shasum": "b3ffdfe734b2a3d4a9efd58e8654c91fce86eafd",
+        "tarball": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "https-browserify",
+      "version": "0.0.1",
+      "description": "https module compatability for browserify",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/https-browserify.git"
+      },
+      "homepage": "https://github.com/substack/https-browserify",
+      "keywords": [
+        "https",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "gitHead": "7ce43143cc6dd3e5576a977fd49d7e25f35bfdb8",
+      "bugs": {
+        "url": "https://github.com/substack/https-browserify/issues"
+      },
+      "_id": "https-browserify@0.0.1",
+      "scripts": {},
+      "_shasum": "3f91365cabe60b77ed0ebba24b454e3e09d95a82",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "1.8.4",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "3f91365cabe60b77ed0ebba24b454e3e09d95a82",
+        "tarball": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "ptarjan",
+          "email": "npm@paulisageek.com"
+        },
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "https-browserify",
+      "description": "https module compatability for browserify",
+      "version": "1.0.0",
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "devDependencies": {
+        "standard": "^9.0.2"
+      },
+      "homepage": "https://github.com/substack/https-browserify",
+      "keywords": [
+        "browser",
+        "browserify",
+        "https"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/https-browserify.git"
+      },
+      "scripts": {
+        "test": "standard"
+      },
+      "gitHead": "98a1310b385d24dd8cf1a67aa258e91ec03743e4",
+      "bugs": {
+        "url": "https://github.com/substack/https-browserify/issues"
+      },
+      "_id": "https-browserify@1.0.0",
+      "_shasum": "ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73",
+      "_from": ".",
+      "_npmVersion": "4.4.4",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73",
+        "tarball": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "ptarjan",
+          "email": "npm@paulisageek.com"
+        },
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/https-browserify-1.0.0.tgz_1491348915811_0.5395281950477511"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# https-browserify\n\nhttps module compatability for browserify\n\n# example\n\n``` js\nvar https = require('https-browserify')\nvar r = https.request('https://github.com')\nr.on('request', function (res) {\n  console.log(res)\n})\n```\n\n# methods\n\nThe API is the same as the client portion of the\n[node core https module](http://nodejs.org/docs/latest/api/https.html).\n\n# license\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "feross",
+      "email": "feross@feross.org"
+    },
+    {
+      "name": "ptarjan",
+      "email": "npm@paulisageek.com"
+    },
+    {
+      "name": "substack",
+      "email": "substack@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-04-04T23:35:16.037Z",
+    "created": "2013-12-03T19:26:39.434Z",
+    "0.0.0": "2013-12-03T19:26:40.780Z",
+    "0.0.1": "2015-09-03T13:59:08.918Z",
+    "1.0.0": "2017-04-04T23:35:16.037Z"
+  },
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/substack/https-browserify.git"
+  },
+  "users": {
+    "wenbing": true,
+    "simplyianm": true
+  },
+  "homepage": "https://github.com/substack/https-browserify",
+  "keywords": [
+    "browser",
+    "browserify",
+    "https"
+  ],
+  "bugs": {
+    "url": "https://github.com/substack/https-browserify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.markdown",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/https-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/https-browserify.min.json
@@ -1,0 +1,36 @@
+{
+  "name": "https-browserify",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "https-browserify",
+      "version": "0.0.0",
+      "dist": {
+        "shasum": "b3ffdfe734b2a3d4a9efd58e8654c91fce86eafd",
+        "tarball": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "https-browserify",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "3f91365cabe60b77ed0ebba24b454e3e09d95a82",
+        "tarball": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "https-browserify",
+      "version": "1.0.0",
+      "devDependencies": {
+        "standard": "^9.0.2"
+      },
+      "dist": {
+        "shasum": "ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73",
+        "tarball": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz"
+      }
+    }
+  },
+  "modified": "2017-04-04T23:35:16.037Z"
+}

--- a/test/fixtures/registry-mocks/content/ieee754.json
+++ b/test/fixtures/registry-mocks/content/ieee754.json
@@ -1,0 +1,1294 @@
+{
+  "_id": "ieee754",
+  "_rev": "26-00265f91c565a2d93f603f577d179cd8",
+  "name": "ieee754",
+  "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+  "dist-tags": {
+    "latest": "1.2.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "ieee754",
+      "version": "1.0.0",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "browserify": "*",
+        "tape": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "keywords": [
+        "ieee754",
+        "IEEE 754",
+        "floating point",
+        "buffer",
+        "convert"
+      ],
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754",
+      "_id": "ieee754@1.0.0",
+      "dist": {
+        "shasum": "202735c93842db2c3593ac58ab961373b2f0315e",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "ieee754",
+      "version": "1.1.0",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "keywords": [
+        "ieee754",
+        "IEEE 754",
+        "floating point",
+        "buffer",
+        "convert"
+      ],
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754",
+      "_id": "ieee754@1.1.0",
+      "dist": {
+        "shasum": "af1017cc1f6c88d087361ebd4d028ebb013f40ad",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "ieee754",
+      "version": "1.1.1",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "keywords": [
+        "ieee754",
+        "IEEE 754",
+        "floating point",
+        "buffer",
+        "convert"
+      ],
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754",
+      "_id": "ieee754@1.1.1",
+      "dist": {
+        "shasum": "eee2eae514617e22de232a08f299aaf5a2c3676c",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "ieee754",
+      "version": "1.1.2",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "keywords": [
+        "ieee754",
+        "IEEE 754",
+        "floating point",
+        "buffer",
+        "convert"
+      ],
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754",
+      "_id": "ieee754@1.1.2",
+      "dist": {
+        "shasum": "23f6091c2a76ce46f79d77303e5328cec903ee4f",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "ieee754",
+      "version": "1.1.3",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "keywords": [
+        "ieee754",
+        "IEEE 754",
+        "floating point",
+        "buffer",
+        "convert"
+      ],
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754",
+      "_id": "ieee754@1.1.3",
+      "dist": {
+        "shasum": "1d4baae872e15ba69f6ab7588a965e09d485ec50",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "ieee754",
+      "version": "1.1.4",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "*"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/4..latest",
+          "firefox/3..latest",
+          "safari/5.1..latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6"
+        ]
+      },
+      "keywords": [
+        "ieee754",
+        "IEEE 754",
+        "floating point",
+        "buffer",
+        "convert"
+      ],
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "license": "MIT",
+      "gitHead": "01fcb668d406696c24398da9cc7f95f0633dfa09",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754",
+      "_id": "ieee754@1.1.4",
+      "_shasum": "e3ec65200d4ad531d359aabdb6d3ec812699a30b",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "e3ec65200d4ad531d359aabdb6d3ec812699a30b",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "ieee754",
+      "version": "1.1.5",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tape": "^4.0.0",
+        "zuul": "^3.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "keywords": [
+        "ieee754",
+        "IEEE 754",
+        "floating point",
+        "buffer",
+        "convert"
+      ],
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "license": "MIT",
+      "gitHead": "a92e12057e5005f2b8903872a181f020ac5ba01c",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754",
+      "_id": "ieee754@1.1.5",
+      "_shasum": "2ddd7b4e3e48bcc67a32eed6abe9eeb18c5159e8",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "2ddd7b4e3e48bcc67a32eed6abe9eeb18c5159e8",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.6": {
+      "name": "ieee754",
+      "version": "1.1.6",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^4.1.1",
+        "tape": "^4.0.0",
+        "zuul": "^3.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "keywords": [
+        "ieee754",
+        "IEEE 754",
+        "floating point",
+        "buffer",
+        "convert"
+      ],
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org/"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "license": "MIT",
+      "gitHead": "d3b4a18991a20dd7977e32fe2e6cec1b73efe53d",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.1.6",
+      "_shasum": "2e1013219c6d6712973ec54d981ec19e5579de97",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "dist": {
+        "shasum": "2e1013219c6d6712973ec54d981ec19e5579de97",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.7": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.1.7",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "standard": "*",
+        "tape": "^4.0.0",
+        "zuul": "^3.0.0"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "gitHead": "25981754d8be54edf8846d3a5aebf43d3ae759c5",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.1.7",
+      "_shasum": "cc7a6ffd6142dc5bed0a76d5f30df0dcf660291d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "cc7a6ffd6142dc5bed0a76d5f30df0dcf660291d",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/ieee754-1.1.7.tgz_1475478818995_0.6850021036807448"
+      },
+      "directories": {}
+    },
+    "1.1.8": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.1.8",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "standard": "*",
+        "tape": "^4.0.0",
+        "zuul": "^3.0.0"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "BSD-3-Clause",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "zuul -- test/*.js",
+        "test-browser-local": "zuul --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "gitHead": "53d3f869cc527852156b8307353c55addc3e03ae",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.1.8",
+      "_shasum": "be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "shasum": "be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ieee754-1.1.8.tgz_1475481601035_0.6688473029062152"
+      },
+      "directories": {}
+    },
+    "1.1.9": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.1.9",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "airtap": "0.0.4",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "BSD-3-Clause",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "airtap -- test/*.js",
+        "test-browser-local": "airtap --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "gitHead": "c0b57da7e631c7b3b7f256c0c3640a804bb332bd",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.1.9",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-yWDsidMaZHbeTa0a1iSFpK8QhzicsFxo8zKxH0YU2g47rNUZql5+2o3DSc5Z070kjGPLP292BWiF4bd8Q+G87g==",
+        "shasum": "13acbc76462de80959be14b2d4ac93b96761b195",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.9.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7060
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ieee754_1.1.9_1521287296812_0.6477363359191368"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.10": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.1.10",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "airtap": "0.0.4",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "BSD-3-Clause",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "airtap -- test/*.js",
+        "test-browser-local": "airtap --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "gitHead": "0295917be9d9bdc773697af0187cc39b338d7760",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.1.10",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-byWFX8OyW/qeVxcY21r6Ncxl0ZYHgnf0cPup2h34eHXrCJbOp7IuqnJ4Q0omfyWl6Z++BTI6bByf31pZt7iRLg==",
+        "shasum": "719a6f7b026831e64bdb838b0de1bb0029bbf716",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.10.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7061
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ieee754_1.1.10_1521352939340_0.8187348933114915"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.11": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.1.11",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "airtap": "0.0.4",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "BSD-3-Clause",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "airtap -- test/*.js",
+        "test-browser-local": "airtap --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "gitHead": "1b454b58560efd08e47ff53827808bcee5df096b",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.1.11",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+        "shasum": "c16384ffe00f5b7835824e67b6f2bd44a5229455",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7061
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ieee754_1.1.11_1521876394621_0.8917228152846983"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.12": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.1.12",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "airtap": "0.0.7",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "BSD-3-Clause",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "airtap -- test/*.js",
+        "test-browser-local": "airtap --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "gitHead": "1e2646ce533930c16040cfb54ae54165575a4c19",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.1.12",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "8.11.2",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+        "shasum": "50bf24e5b9c8bb98af4964c941cdb0918da7b60b",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6116,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbHGGxCRA9TVsSAnZWagAAfu4QAId2qg9gpZvsVX1yXsAB\ndknmK313WeIFcyo5qDd17H6wLM8fyDy7h2LxG1yyQmoI+txBZEXml0hTTC+k\nBzH4aA20sAUUKb8c/TbH7ELNOa84MKclQo+lquZSVYqrvax1UE/hCDXxHBWw\nbYHNFOuqfyM16UTKP+bCqXwi61CC2oA4IQHdeKCdBIL2jIQ/u1OYSIdxK/H6\nYCmPoar7dF1OOBHGGmkDx1mSWDIep/rbad4apUfy2kIjJsQtGy4aKI/4cLc8\nPDfqIFDJ0N8lYmuczqgVsGPhP9OCMN2cX8xg31dnmyNDsRggPS1StkjU5gUE\nrTd921R9rl+rwRrPv6rZde6dWC26mmaYZ2NBOEtjAfHFy0O1yvniQrBmwxlC\nUeSx+rKv3cFEhHMm0y6jZgZqqN2OE8Is8ASIwTXVp8tCBWrcfcyc8eSQre0x\nulABWGsS029QRtR5U4F++l4pS0mBImL3zULNwvKB7IT0NrA9sBfAyzKomMdD\nej9QpbFduVedSvtLI9XqA5pdfU9CSCB2UiWmhiJjH3n3eXjPCYhN20LaJVYx\nxe0xMlS758n9C1ocr4dKbVIGlxluN/D4stgTh3lrtY8FRWOvV1F2t6pzXM0l\n28aM0olB+iyhHjkHgll+aofh85u/LFRrXAulBQNhF6u3serAcWKVeqFkaIYP\nlpAO\r\n=uhbC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ieee754_1.1.12_1528586672368_0.8737436726749925"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.13": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.1.13",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "http://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "airtap": "0.1.0",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "BSD-3-Clause",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "airtap -- test/*.js",
+        "test-browser-local": "airtap --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "gitHead": "4971f0e802c2cbdfad7791bd223c53e37b4ebb85",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.1.13",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.3",
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "dist": {
+        "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+        "shasum": "ec168558e95aa181fd87d37f55c32bbcb6708b84",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6245,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcmbnHCRA9TVsSAnZWagAAtYYP/22y6qTBTrSGYfV/TRaR\nK22j5TLZBkcv2v3yUEOhtlYOXcPyFFUwaAccm/dE1B5YEINqc/BLtonjHYNY\nITt47l/0glWUoG4X3hSgezZSYPS2z0OZXd+ACnHoMHryxXkhldIqHSisaAsQ\nakgx8oIAGOPA/eMg473zoqAzDyr6Jz7auTKXGhmxHCzd6u4xOmRB8db7JTZr\nSuE0sDN8iE2Dr2XPtfm4FV2E9I9qHHRC/kLigUAVaROUpHJilOmdTuz1eDYi\nQeShVfEVydkVnr0Cetx/d8RF+D777XKf/jomJJ+oHptcgF3bZqwhs8A75URJ\nEBA1AhbbWrQuOF+ESuaXhF0Mf4XlwZ9MA847GiF0j/JX6bGtyWSNI/1V/NEL\n9+DdvFaNvsUNfggwROJawmLwFyCusWsKzjXFnRO1hjHafLFOeXlE+vF9v3H5\nimZfnNkRxTq3+Vut2vwLF+yjz6hVVSRtuCnHb84geL1dmHDBRXctpfAcW24v\nfUTvZH0+KZT/Na6HooZgAUWcxGIiBT3vhAE1BQAjTTJukGie6mJAD1jfZb6l\nGMLt2WTF03UgkcgaosOAdudyTyHTW0w/ai23m10jP2xaFRhjErZkSv+oc/73\nyw+co0BsxN9T4fsXHSXcai+sI1r31KnO5arPUQmtYrRiAfH8LBGBggTn/Zl1\nsTwW\r\n=rYe2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ieee754_1.1.13_1553578438992_0.7571224818616284"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.0": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.2.0",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "https://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "standard": "*",
+        "tape": "^5.0.1"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "BSD-3-Clause",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "airtap -- test/*.js",
+        "test-browser-local": "airtap --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "c02ee853c508bbd6af0861f010f36b95250e79b8",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.2.0",
+      "_nodeVersion": "14.14.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-EWa7B4Ik9ncTIIojzGoKzpUdswDKO6v1BQ0pcKajYCrZckY9gNjiEparSGlyz5C2HcpV62qiVkmLBCPx77Hq2g==",
+        "shasum": "199187d07b31d4aa68ed02311914049795868ea6",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6464,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmKWNCRA9TVsSAnZWagAALBkQAJ40lK3TDpxWds/6W1eN\nsIBkFh7+ync+RgetKoNIk9g5E6zyGRPxGDr80+eBhNfg5XRANT7B6CuiDnk2\nkVb12bbZJPkBpKDuuygUW5sDJcUVQ/Kr0O+jF7NBc6X6+z8uaLD+spvDl7I5\n8sv/hLG6PF4I/dOQVZkI/7gopB0Jjr91Gj8oi2bfNBuRGAemO5GfcDcBtEAJ\nAMXXp7UbpxCp7bJdd9F8csnHUM+U1/I4wx+oj+qA1QT6dgScK0S6n95hqTTX\nIGGqik8W2JKWzU2bkHgGG4ZUVMqpBogqhONDikUEHnRtrOl2CiVHkJEcmKOD\ntpC7zem4fpXEJ0bEsnvg44Rb1ZhwCz/bKm+eSFR5ZkqEyW2FtQkJcwMV3wcm\n4LsjJlLcqdd82OPByY3YnRYtsqycwZCYRpMVjt/aVWwbBgltOpXpJYRylW4N\nvcCGbmK+LvaofxwHUZqH3kxyQuugQKnShIfFR56Lv2+xTp6y/2wf7lHK6U+1\naKI7kNrLNvqt8jgemR1ScPNjYWdvTjbxtol1ilrf8JMcEonkOn9CGH+AZX/S\nOTOpYKWnHecP5jqksxDojAxay3pCqqvYNQDdNGHwhT63E2D2gjklezd7hQ25\n9/Xz8TYztVjWzIelY7vZLWw0jgYt4Jg5dQvCh7VtdM+AhyDhz9UDywkvC5rg\nbUDj\r\n=acPc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ieee754_1.2.0_1603839373204_0.12442439275073669"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.1": {
+      "name": "ieee754",
+      "description": "Read/write IEEE754 floating point numbers from/to a Buffer or array-like object",
+      "version": "1.2.1",
+      "author": {
+        "name": "Feross Aboukhadijeh",
+        "email": "feross@feross.org",
+        "url": "https://feross.org"
+      },
+      "contributors": [
+        {
+          "name": "Romain Beauxis",
+          "email": "toots@rastageeks.org"
+        }
+      ],
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "standard": "*",
+        "tape": "^5.0.1"
+      },
+      "keywords": [
+        "IEEE 754",
+        "buffer",
+        "convert",
+        "floating point",
+        "ieee754"
+      ],
+      "license": "BSD-3-Clause",
+      "main": "index.js",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/feross/ieee754.git"
+      },
+      "scripts": {
+        "test": "standard && npm run test-node && npm run test-browser",
+        "test-browser": "airtap -- test/*.js",
+        "test-browser-local": "airtap --local -- test/*.js",
+        "test-node": "tape test/*.js"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "gitHead": "b60d148be9cad718f9ff007c211c2427cdc180a4",
+      "bugs": {
+        "url": "https://github.com/feross/ieee754/issues"
+      },
+      "homepage": "https://github.com/feross/ieee754#readme",
+      "_id": "ieee754@1.2.1",
+      "_nodeVersion": "14.14.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+        "shasum": "8eb7a10a63fff25d15a57b001586d177d1b0d352",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6796,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmKffCRA9TVsSAnZWagAADakP/0mqXfjH4OS4rtzd7bst\niGth3Ohks66Tx1Ev+bmlhQ2QdnVKfn0+IifXRYtzDIJocgcSHFJHghc2i8Ij\nfuQn6Evx/wsEwiOAQ7Ulf9pbW6OegmkFNvljNYsej5zBG/6Z3wASbEuHrGY1\nUO+lJ0HjNtQnMcj9QMdn5TX6UKS7r0/YAkXntjstKW9bajPP26XrbqDxuoCj\n8miijE4FU/dTZogiLxH09ny51fTBav0qJIIf2veFZYJ2JeUVHzGCvuVr5Uyc\nv1z78ehTz/ZmF8L1kN3yv+60UaqgbR9+CA06oGsOO7dJiwA2KTrSZKbBF7ai\nHDKuDveIoUDrSG0ly03A+PwCPOjQXTsuBQg9ah46SyQsWVgoPIq6cIDoxwU6\n628Pl3yYv4SG9RK/MMF8PVZKDhJ0OuDGakHuJPQgoZwo9T37sm+f2u9VfXnI\n0KJW8RIWJwAR4flY1tW82efS3SWng2ALT3cYc5zYA5WCuuQadxSi664Dk/ac\nzsHlt2DYqdYznm5/G9mfcaPW0ZMWfPOnnxTSOmsc0SjPwCqa1Uihg92yE+CZ\n2bpw8JD69zG73SN7NuQ5adlvM/CR3UIqnXUgGIfHN9vxJigOY2UM7d++guUB\nqormxvM32BOea5CT/9ruJeCq8c0oaEVn5h4V603ivlSFnoweJDo9N+/7Z71X\nAB70\r\n=9yaZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ieee754_1.2.1_1603839967317_0.34663956255577455"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# ieee754 [![travis][travis-image]][travis-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url] [![javascript style guide][standard-image]][standard-url]\n\n[travis-image]: https://img.shields.io/travis/feross/ieee754/master.svg\n[travis-url]: https://travis-ci.org/feross/ieee754\n[npm-image]: https://img.shields.io/npm/v/ieee754.svg\n[npm-url]: https://npmjs.org/package/ieee754\n[downloads-image]: https://img.shields.io/npm/dm/ieee754.svg\n[downloads-url]: https://npmjs.org/package/ieee754\n[standard-image]: https://img.shields.io/badge/code_style-standard-brightgreen.svg\n[standard-url]: https://standardjs.com\n\n[![saucelabs][saucelabs-image]][saucelabs-url]\n\n[saucelabs-image]: https://saucelabs.com/browser-matrix/ieee754.svg\n[saucelabs-url]: https://saucelabs.com/u/ieee754\n\n### Read/write IEEE754 floating point numbers from/to a Buffer or array-like object.\n\n## install\n\n```\nnpm install ieee754\n```\n\n## methods\n\n`var ieee754 = require('ieee754')`\n\nThe `ieee754` object has the following functions:\n\n```\nieee754.read = function (buffer, offset, isLE, mLen, nBytes)\nieee754.write = function (buffer, value, offset, isLE, mLen, nBytes)\n```\n\nThe arguments mean the following:\n\n- buffer = the buffer\n- offset = offset into the buffer\n- value = value to set (only for `write`)\n- isLe = is little endian?\n- mLen = mantissa length\n- nBytes = number of bytes\n\n## what is ieee754?\n\nThe IEEE Standard for Floating-Point Arithmetic (IEEE 754) is a technical standard for floating-point computation. [Read more](http://en.wikipedia.org/wiki/IEEE_floating_point).\n\n## license\n\nBSD 3 Clause. Copyright (c) 2008, Fair Oaks Labs, Inc.\n",
+  "maintainers": [
+    {
+      "name": "feross",
+      "email": "feross@feross.org"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-27T23:06:09.692Z",
+    "created": "2013-12-28T08:36:49.436Z",
+    "1.0.0": "2013-12-28T08:36:50.333Z",
+    "1.1.0": "2013-12-28T09:00:44.292Z",
+    "1.1.1": "2013-12-28T09:10:38.056Z",
+    "1.1.2": "2014-01-29T11:10:35.835Z",
+    "1.1.3": "2014-02-16T03:15:52.627Z",
+    "1.1.4": "2014-09-03T09:19:52.313Z",
+    "1.1.5": "2015-05-05T01:33:13.811Z",
+    "1.1.6": "2015-06-11T21:25:05.773Z",
+    "1.1.7": "2016-10-03T07:13:41.604Z",
+    "1.1.8": "2016-10-03T08:00:01.268Z",
+    "1.1.9": "2018-03-17T11:48:16.870Z",
+    "1.1.10": "2018-03-18T06:02:19.444Z",
+    "1.1.11": "2018-03-24T07:26:34.705Z",
+    "1.1.12": "2018-06-09T23:24:32.433Z",
+    "1.1.13": "2019-03-26T05:33:59.129Z",
+    "1.2.0": "2020-10-27T22:56:13.398Z",
+    "1.2.1": "2020-10-27T23:06:07.424Z"
+  },
+  "author": {
+    "name": "Feross Aboukhadijeh",
+    "email": "feross@feross.org",
+    "url": "https://feross.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/feross/ieee754.git"
+  },
+  "readmeFilename": "README.md",
+  "users": {
+    "thomasfoster96": true
+  },
+  "homepage": "https://github.com/feross/ieee754#readme",
+  "keywords": [
+    "IEEE 754",
+    "buffer",
+    "convert",
+    "floating point",
+    "ieee754"
+  ],
+  "contributors": [
+    {
+      "name": "Romain Beauxis",
+      "email": "toots@rastageeks.org"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/feross/ieee754/issues"
+  },
+  "license": "BSD-3-Clause"
+}

--- a/test/fixtures/registry-mocks/content/ieee754.min.json
+++ b/test/fixtures/registry-mocks/content/ieee754.min.json
@@ -1,0 +1,272 @@
+{
+  "name": "ieee754",
+  "dist-tags": {
+    "latest": "1.2.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "ieee754",
+      "version": "1.0.0",
+      "devDependencies": {
+        "browserify": "*",
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "202735c93842db2c3593ac58ab961373b2f0315e",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "ieee754",
+      "version": "1.1.0",
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "af1017cc1f6c88d087361ebd4d028ebb013f40ad",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "ieee754",
+      "version": "1.1.1",
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "eee2eae514617e22de232a08f299aaf5a2c3676c",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "ieee754",
+      "version": "1.1.2",
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "23f6091c2a76ce46f79d77303e5328cec903ee4f",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "ieee754",
+      "version": "1.1.3",
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "1d4baae872e15ba69f6ab7588a965e09d485ec50",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.3.tgz"
+      }
+    },
+    "1.1.4": {
+      "name": "ieee754",
+      "version": "1.1.4",
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "e3ec65200d4ad531d359aabdb6d3ec812699a30b",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+      }
+    },
+    "1.1.5": {
+      "name": "ieee754",
+      "version": "1.1.5",
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tape": "^4.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "2ddd7b4e3e48bcc67a32eed6abe9eeb18c5159e8",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
+      }
+    },
+    "1.1.6": {
+      "name": "ieee754",
+      "version": "1.1.6",
+      "devDependencies": {
+        "standard": "^4.1.1",
+        "tape": "^4.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "2e1013219c6d6712973ec54d981ec19e5579de97",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+      }
+    },
+    "1.1.7": {
+      "name": "ieee754",
+      "version": "1.1.7",
+      "devDependencies": {
+        "standard": "*",
+        "tape": "^4.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "cc7a6ffd6142dc5bed0a76d5f30df0dcf660291d",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.7.tgz"
+      }
+    },
+    "1.1.8": {
+      "name": "ieee754",
+      "version": "1.1.8",
+      "devDependencies": {
+        "standard": "*",
+        "tape": "^4.0.0",
+        "zuul": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+      }
+    },
+    "1.1.9": {
+      "name": "ieee754",
+      "version": "1.1.9",
+      "devDependencies": {
+        "airtap": "0.0.4",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-yWDsidMaZHbeTa0a1iSFpK8QhzicsFxo8zKxH0YU2g47rNUZql5+2o3DSc5Z070kjGPLP292BWiF4bd8Q+G87g==",
+        "shasum": "13acbc76462de80959be14b2d4ac93b96761b195",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.9.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7060
+      }
+    },
+    "1.1.10": {
+      "name": "ieee754",
+      "version": "1.1.10",
+      "devDependencies": {
+        "airtap": "0.0.4",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-byWFX8OyW/qeVxcY21r6Ncxl0ZYHgnf0cPup2h34eHXrCJbOp7IuqnJ4Q0omfyWl6Z++BTI6bByf31pZt7iRLg==",
+        "shasum": "719a6f7b026831e64bdb838b0de1bb0029bbf716",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.10.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7061
+      }
+    },
+    "1.1.11": {
+      "name": "ieee754",
+      "version": "1.1.11",
+      "devDependencies": {
+        "airtap": "0.0.4",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+        "shasum": "c16384ffe00f5b7835824e67b6f2bd44a5229455",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7061
+      }
+    },
+    "1.1.12": {
+      "name": "ieee754",
+      "version": "1.1.12",
+      "devDependencies": {
+        "airtap": "0.0.7",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+        "shasum": "50bf24e5b9c8bb98af4964c941cdb0918da7b60b",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6116,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbHGGxCRA9TVsSAnZWagAAfu4QAId2qg9gpZvsVX1yXsAB\ndknmK313WeIFcyo5qDd17H6wLM8fyDy7h2LxG1yyQmoI+txBZEXml0hTTC+k\nBzH4aA20sAUUKb8c/TbH7ELNOa84MKclQo+lquZSVYqrvax1UE/hCDXxHBWw\nbYHNFOuqfyM16UTKP+bCqXwi61CC2oA4IQHdeKCdBIL2jIQ/u1OYSIdxK/H6\nYCmPoar7dF1OOBHGGmkDx1mSWDIep/rbad4apUfy2kIjJsQtGy4aKI/4cLc8\nPDfqIFDJ0N8lYmuczqgVsGPhP9OCMN2cX8xg31dnmyNDsRggPS1StkjU5gUE\nrTd921R9rl+rwRrPv6rZde6dWC26mmaYZ2NBOEtjAfHFy0O1yvniQrBmwxlC\nUeSx+rKv3cFEhHMm0y6jZgZqqN2OE8Is8ASIwTXVp8tCBWrcfcyc8eSQre0x\nulABWGsS029QRtR5U4F++l4pS0mBImL3zULNwvKB7IT0NrA9sBfAyzKomMdD\nej9QpbFduVedSvtLI9XqA5pdfU9CSCB2UiWmhiJjH3n3eXjPCYhN20LaJVYx\nxe0xMlS758n9C1ocr4dKbVIGlxluN/D4stgTh3lrtY8FRWOvV1F2t6pzXM0l\n28aM0olB+iyhHjkHgll+aofh85u/LFRrXAulBQNhF6u3serAcWKVeqFkaIYP\nlpAO\r\n=uhbC\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.13": {
+      "name": "ieee754",
+      "version": "1.1.13",
+      "devDependencies": {
+        "airtap": "0.1.0",
+        "standard": "*",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+        "shasum": "ec168558e95aa181fd87d37f55c32bbcb6708b84",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6245,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcmbnHCRA9TVsSAnZWagAAtYYP/22y6qTBTrSGYfV/TRaR\nK22j5TLZBkcv2v3yUEOhtlYOXcPyFFUwaAccm/dE1B5YEINqc/BLtonjHYNY\nITt47l/0glWUoG4X3hSgezZSYPS2z0OZXd+ACnHoMHryxXkhldIqHSisaAsQ\nakgx8oIAGOPA/eMg473zoqAzDyr6Jz7auTKXGhmxHCzd6u4xOmRB8db7JTZr\nSuE0sDN8iE2Dr2XPtfm4FV2E9I9qHHRC/kLigUAVaROUpHJilOmdTuz1eDYi\nQeShVfEVydkVnr0Cetx/d8RF+D777XKf/jomJJ+oHptcgF3bZqwhs8A75URJ\nEBA1AhbbWrQuOF+ESuaXhF0Mf4XlwZ9MA847GiF0j/JX6bGtyWSNI/1V/NEL\n9+DdvFaNvsUNfggwROJawmLwFyCusWsKzjXFnRO1hjHafLFOeXlE+vF9v3H5\nimZfnNkRxTq3+Vut2vwLF+yjz6hVVSRtuCnHb84geL1dmHDBRXctpfAcW24v\nfUTvZH0+KZT/Na6HooZgAUWcxGIiBT3vhAE1BQAjTTJukGie6mJAD1jfZb6l\nGMLt2WTF03UgkcgaosOAdudyTyHTW0w/ai23m10jP2xaFRhjErZkSv+oc/73\nyw+co0BsxN9T4fsXHSXcai+sI1r31KnO5arPUQmtYrRiAfH8LBGBggTn/Zl1\nsTwW\r\n=rYe2\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.2.0": {
+      "name": "ieee754",
+      "version": "1.2.0",
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "standard": "*",
+        "tape": "^5.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-EWa7B4Ik9ncTIIojzGoKzpUdswDKO6v1BQ0pcKajYCrZckY9gNjiEparSGlyz5C2HcpV62qiVkmLBCPx77Hq2g==",
+        "shasum": "199187d07b31d4aa68ed02311914049795868ea6",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6464,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmKWNCRA9TVsSAnZWagAALBkQAJ40lK3TDpxWds/6W1eN\nsIBkFh7+ync+RgetKoNIk9g5E6zyGRPxGDr80+eBhNfg5XRANT7B6CuiDnk2\nkVb12bbZJPkBpKDuuygUW5sDJcUVQ/Kr0O+jF7NBc6X6+z8uaLD+spvDl7I5\n8sv/hLG6PF4I/dOQVZkI/7gopB0Jjr91Gj8oi2bfNBuRGAemO5GfcDcBtEAJ\nAMXXp7UbpxCp7bJdd9F8csnHUM+U1/I4wx+oj+qA1QT6dgScK0S6n95hqTTX\nIGGqik8W2JKWzU2bkHgGG4ZUVMqpBogqhONDikUEHnRtrOl2CiVHkJEcmKOD\ntpC7zem4fpXEJ0bEsnvg44Rb1ZhwCz/bKm+eSFR5ZkqEyW2FtQkJcwMV3wcm\n4LsjJlLcqdd82OPByY3YnRYtsqycwZCYRpMVjt/aVWwbBgltOpXpJYRylW4N\nvcCGbmK+LvaofxwHUZqH3kxyQuugQKnShIfFR56Lv2+xTp6y/2wf7lHK6U+1\naKI7kNrLNvqt8jgemR1ScPNjYWdvTjbxtol1ilrf8JMcEonkOn9CGH+AZX/S\nOTOpYKWnHecP5jqksxDojAxay3pCqqvYNQDdNGHwhT63E2D2gjklezd7hQ25\n9/Xz8TYztVjWzIelY7vZLWw0jgYt4Jg5dQvCh7VtdM+AhyDhz9UDywkvC5rg\nbUDj\r\n=acPc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "1.2.1": {
+      "name": "ieee754",
+      "version": "1.2.1",
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "standard": "*",
+        "tape": "^5.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+        "shasum": "8eb7a10a63fff25d15a57b001586d177d1b0d352",
+        "tarball": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6796,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmKffCRA9TVsSAnZWagAADakP/0mqXfjH4OS4rtzd7bst\niGth3Ohks66Tx1Ev+bmlhQ2QdnVKfn0+IifXRYtzDIJocgcSHFJHghc2i8Ij\nfuQn6Evx/wsEwiOAQ7Ulf9pbW6OegmkFNvljNYsej5zBG/6Z3wASbEuHrGY1\nUO+lJ0HjNtQnMcj9QMdn5TX6UKS7r0/YAkXntjstKW9bajPP26XrbqDxuoCj\n8miijE4FU/dTZogiLxH09ny51fTBav0qJIIf2veFZYJ2JeUVHzGCvuVr5Uyc\nv1z78ehTz/ZmF8L1kN3yv+60UaqgbR9+CA06oGsOO7dJiwA2KTrSZKbBF7ai\nHDKuDveIoUDrSG0ly03A+PwCPOjQXTsuBQg9ah46SyQsWVgoPIq6cIDoxwU6\n628Pl3yYv4SG9RK/MMF8PVZKDhJ0OuDGakHuJPQgoZwo9T37sm+f2u9VfXnI\n0KJW8RIWJwAR4flY1tW82efS3SWng2ALT3cYc5zYA5WCuuQadxSi664Dk/ac\nzsHlt2DYqdYznm5/G9mfcaPW0ZMWfPOnnxTSOmsc0SjPwCqa1Uihg92yE+CZ\n2bpw8JD69zG73SN7NuQ5adlvM/CR3UIqnXUgGIfHN9vxJigOY2UM7d++guUB\nqormxvM32BOea5CT/9ruJeCq8c0oaEVn5h4V603ivlSFnoweJDo9N+/7Z71X\nAB70\r\n=9yaZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    }
+  },
+  "modified": "2020-10-27T23:06:09.692Z"
+}

--- a/test/fixtures/registry-mocks/content/iferr.json
+++ b/test/fixtures/registry-mocks/content/iferr.json
@@ -1,0 +1,517 @@
+{
+  "_id": "iferr",
+  "_rev": "16-609a28d7785bdf1add05cf9e899c3868",
+  "name": "iferr",
+  "description": "Higher-order functions for easier error handling",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "iferr",
+      "version": "0.1.0",
+      "description": "Higher-order functions for easier error handling",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha",
+        "prepublish": "coffee -c index.coffee"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/shesek/iferr"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "_id": "iferr@0.1.0",
+      "dist": {
+        "shasum": "e2a9505d117c4c93c428390ded27692909425948",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "iferr",
+      "version": "0.1.1",
+      "description": "Higher-order functions for easier error handling",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha",
+        "prepublish": "coffee -c index.coffee"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/shesek/iferr"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "_id": "iferr@0.1.1",
+      "dist": {
+        "shasum": "b6cb6bb02a01e80f0ccfbddbe914ab3312c1308a",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "iferr",
+      "version": "0.1.2",
+      "description": "Higher-order functions for easier error handling",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha",
+        "prepublish": "coffee -c index.coffee"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/shesek/iferr"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "_id": "iferr@0.1.2",
+      "dist": {
+        "shasum": "1ae1a5fd330bd1fc4861b7381c72b28467ae3ae6",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "iferr",
+      "version": "0.1.3",
+      "description": "Higher-order functions for easier error handling",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha",
+        "prepublish": "coffee -c index.coffee"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/shesek/iferr"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "_id": "iferr@0.1.3",
+      "dist": {
+        "shasum": "2eb16f7bfd5c4fa6fe23fbdc6ca815facf0ab7c0",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "iferr",
+      "version": "0.1.4",
+      "description": "Higher-order functions for easier error handling",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha",
+        "prepublish": "coffee -c index.coffee"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/shesek/iferr"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "_id": "iferr@0.1.4",
+      "dist": {
+        "shasum": "6ebf320517ac963807d0beb8c6a5453f145267d8",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "iferr",
+      "version": "0.1.5",
+      "description": "Higher-order functions for easier error handling",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha",
+        "prepublish": "coffee -c index.coffee"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/shesek/iferr"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "_id": "iferr@0.1.5",
+      "dist": {
+        "shasum": "c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "iferr",
+      "version": "1.0.0",
+      "description": "Higher-order functions for easier error handling",
+      "main": "iferr.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/shesek/iferr.git"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffee-script": "^1.12.7",
+        "mocha": "^4.0.1"
+      },
+      "gitHead": "3d83da970e252d3f255bd95d100ec156e2f57661",
+      "_id": "iferr@1.0.0",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "dist": {
+        "integrity": "sha512-0+ecqiP/cxgnNBIPi+TgJlaxE7sFp2N3kBFg17klQUdf24YKiaEV6b9QgEqOlD5vCVCE0U7OV9lPSN2OfS4zoQ==",
+        "shasum": "36700e6a6d5d42e3e66b6d90fb55a018970b0aab",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/iferr-1.0.0.tgz_1511613509880_0.10885823937132955"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "iferr",
+      "version": "1.0.1",
+      "description": "Higher-order functions for easier error handling",
+      "main": "iferr.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/shesek/iferr.git"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffeescript": "^2.3.1",
+        "mocha": "^4.0.1"
+      },
+      "gitHead": "efcb6a990ac46f2b115e147ca27471a39140a9f2",
+      "_id": "iferr@1.0.1",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "dist": {
+        "integrity": "sha512-e7YmhEfXYL+P28J84UOYsBUCG56MBLWj7ofOMCRQHwU59sSJxXdeb31/1K6wfL3wtTH78rvrdUVylesh4VSC9g==",
+        "shasum": "37b878f51d1e91a12d9f84ae7fca922a64c53a54",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-1.0.1.tgz",
+        "fileCount": 232,
+        "unpackedSize": 2283858,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbIkYkCRA9TVsSAnZWagAAIGMP/35BkHQRD19rnE0UJ18h\n1WMgJSumhegNdrKhaxWA/MUxxf8q5dwQKhi4+XgFB9EfxsRyWDa+kOQTY7wR\nrD4yYcYpOUYSVcdzXtgkQzaEAh0wOaLj99DUICT4EJT7ozEzW4kmjp9F960D\n5O26uniW8ufBgSnuVWtOWdrmMy9IlsiRTZIc7err/FgjNqrmBNg2ZrST4RNE\noLZu3N4cdBaUrzU8Si+dS1vTPF+TWQMWiKGJoqDm6P+aHEmQ5/vHfOIA9PW/\n/hUrS/NcGhi9qgZP3ypLV+NsGJa84TwU2CypmzhoegaZ69E1cyAg00NuWJ4u\n4kqdiwVW3Sjn2E8oBvvNywOHUKyufmYu06fQpavS82rkmqGJ0iCTxcusGBbU\n06EPXVc7XXDlWnBu/9cdm2ULtO5zsl1/vt3YmogdBS0zHap4gQJVAgjHBbNa\nfMdTZNCIjtWYja229yPLGKCcDot23Kq9YLbS/AkHr9Rqpy/Oijn0czIYFlFP\nPqe4/M2kDKnce1nor7K5Mhdw7MsYTI6tfkaqoZR6e/HyJ75Saz4opMFwB7jB\nVdK0/SbspNmRqng5Zz794y+vvVpLvYANeUwXJzLA6/8IEyzh6olKW+DFp0uI\nJG49QiF+K28ehH5rUP6V+XEQTiVLz4Uz5io2Z0NbPLqkQcpZz1U+4ZmEF2wa\neZDe\r\n=1sRK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/iferr_1.0.1_1528972835813_0.6093736871182065"
+      }
+    },
+    "1.0.2": {
+      "name": "iferr",
+      "version": "1.0.2",
+      "description": "Higher-order functions for easier error handling",
+      "main": "iferr.js",
+      "files": [
+        "iferr.js"
+      ],
+      "scripts": {
+        "test": "mocha"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/shesek/iferr.git"
+      },
+      "keywords": [
+        "error",
+        "errors"
+      ],
+      "author": {
+        "name": "Nadav Ivgi"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/shesek/iferr/issues"
+      },
+      "homepage": "https://github.com/shesek/iferr",
+      "devDependencies": {
+        "coffeescript": "^2.3.1",
+        "mocha": "^4.0.1"
+      },
+      "gitHead": "036418970e60e0d400072b1fb7e830a13a07809c",
+      "_id": "iferr@1.0.2",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "nadav",
+        "email": "npm@shesek.info"
+      },
+      "dist": {
+        "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
+        "shasum": "e9fde49a9da06dc4a4194c6c9ed6d08305037a6d",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 3450,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbKB/iCRA9TVsSAnZWagAAqhUQAJ+v4dCyHuoKu6TTUUjP\n6QS7GTk9tHZI0U9wLy+RcGXL8QH3+1gSwQhUpNkCUBh/ZqiWpiA6ORrTznOs\ngMJ9XBQJ8pMvLIqgkydFfr1NpCmjwkgOTIFoaQekZNNzCgotNMZum0ZexeC+\nwU6vrRk9bD2yEW6/+WHy8wPduS54xipb6g6WHcCa3ZtHSWE2H37YSkGbztkA\nD5IgMUSI9JAhvF8kYbcNH8ctYa9vlN9ud2oYs7Ax3ZVcfndOxUoD1nM4cGuU\ngLddqEgTP8Cxf5Jgp0Bs+MQiFBRs4fyFV7vkBsDbUfh9c0izV5ZXT8pozs+J\ndNCT9d3sDEAfVk9pIjxR8gNimJuo7rJMnHAO8DVRYBJVTz7KFaQkOAWgCZAO\n0p27mi+Z1Q1xMm/p+JLQ6L/+JKS+jdzKn34p6/x2ZEzwquYn+1ijfO7eQT2K\nAAv+hEAr1X+qFrL2vOtz4ojXjsSCgyqdnmvQmEuZw69Pa+eboszbn+CbY2an\nhJyyTRNM8tDsKuu6Y29TAgccaPHVN+04pum62fMHD4Icp3aEjiC7FPlUzvAq\nuUmBtY/so+JyFlPbaU9z/tnfpr6WLjsyP+g6cSkr1UY0Vb6BQ4rHEgql4Cym\n1uJykdY9P88n0AGKg1Ag0ChT6qNxIQ2AbDOmCXjvj169V5rZ8O9Lppu3BIU+\nMaw5\r\n=jOYb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/iferr_1.0.2_1529356257707_0.5767475952082075"
+      }
+    }
+  },
+  "readme": "# iferr\n\nHigher-order functions for easier error handling.\n\n`if (err) return cb(err);` be gone!\n\n## Install\n```bash\nnpm install iferr\n```\n\n## Use\n\n### JavaScript/ES6 example\n```js\nvar iferr = require('iferr');\n\nfunction get_friends_count(id, cb) {\n  User.load_user(id, iferr(cb, user =>\n    user.load_friends(iferr(cb, friends =>\n      cb(null, friends.length)\n    ))\n  ))\n}\n```\n\n### JavaScript/ES5 example\n```js\nvar iferr = require('iferr');\n\nfunction get_friends_count(id, cb) {\n  User.load_user(id, iferr(cb, function(user) {\n    user.load_friends(iferr(cb, function(friends) {\n      cb(null, friends.length)\n    }))\n  }))\n}\n```\n\n### CoffeeScript example\n```coffee\niferr = require 'iferr'\n\nget_friends_count = (id, cb) ->\n  User.load_user id, iferr cb, (user) ->\n    user.load_friends iferr cb, (friends) ->\n      cb null, friends.length\n```\n\n(TODO: document tiferr, throwerr and printerr)\n\n## License\nMIT\n",
+  "maintainers": [
+    {
+      "name": "nadav",
+      "email": "npm@shesek.info"
+    }
+  ],
+  "time": {
+    "modified": "2018-06-18T21:11:03.825Z",
+    "created": "2014-04-11T16:08:32.883Z",
+    "0.1.0": "2014-04-11T16:08:32.883Z",
+    "0.1.1": "2014-04-26T13:27:23.641Z",
+    "0.1.2": "2014-04-26T13:59:44.136Z",
+    "0.1.3": "2014-12-01T09:38:37.675Z",
+    "0.1.4": "2014-12-02T13:33:28.901Z",
+    "0.1.5": "2014-12-02T13:35:53.618Z",
+    "1.0.0": "2017-11-25T12:38:30.757Z",
+    "1.0.1": "2018-06-14T10:40:35.885Z",
+    "1.0.2": "2018-06-18T21:10:57.769Z"
+  },
+  "homepage": "https://github.com/shesek/iferr",
+  "keywords": [
+    "error",
+    "errors"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shesek/iferr.git"
+  },
+  "author": {
+    "name": "Nadav Ivgi"
+  },
+  "bugs": {
+    "url": "https://github.com/shesek/iferr/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "wangnan0610": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/iferr.min.json
+++ b/test/fixtures/registry-mocks/content/iferr.min.json
@@ -1,0 +1,135 @@
+{
+  "name": "iferr",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "iferr",
+      "version": "0.1.0",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "e2a9505d117c4c93c428390ded27692909425948",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "iferr",
+      "version": "0.1.1",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "b6cb6bb02a01e80f0ccfbddbe914ab3312c1308a",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "iferr",
+      "version": "0.1.2",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "1ae1a5fd330bd1fc4861b7381c72b28467ae3ae6",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "iferr",
+      "version": "0.1.3",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "2eb16f7bfd5c4fa6fe23fbdc6ca815facf0ab7c0",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "iferr",
+      "version": "0.1.4",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "6ebf320517ac963807d0beb8c6a5453f145267d8",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "iferr",
+      "version": "0.1.5",
+      "devDependencies": {
+        "coffee-script": "^1.7.1",
+        "mocha": "^1.18.2"
+      },
+      "dist": {
+        "shasum": "c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "iferr",
+      "version": "1.0.0",
+      "devDependencies": {
+        "coffee-script": "^1.12.7",
+        "mocha": "^4.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-0+ecqiP/cxgnNBIPi+TgJlaxE7sFp2N3kBFg17klQUdf24YKiaEV6b9QgEqOlD5vCVCE0U7OV9lPSN2OfS4zoQ==",
+        "shasum": "36700e6a6d5d42e3e66b6d90fb55a018970b0aab",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "1.0.1": {
+      "name": "iferr",
+      "version": "1.0.1",
+      "devDependencies": {
+        "coffeescript": "^2.3.1",
+        "mocha": "^4.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-e7YmhEfXYL+P28J84UOYsBUCG56MBLWj7ofOMCRQHwU59sSJxXdeb31/1K6wfL3wtTH78rvrdUVylesh4VSC9g==",
+        "shasum": "37b878f51d1e91a12d9f84ae7fca922a64c53a54",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-1.0.1.tgz",
+        "fileCount": 232,
+        "unpackedSize": 2283858,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbIkYkCRA9TVsSAnZWagAAIGMP/35BkHQRD19rnE0UJ18h\n1WMgJSumhegNdrKhaxWA/MUxxf8q5dwQKhi4+XgFB9EfxsRyWDa+kOQTY7wR\nrD4yYcYpOUYSVcdzXtgkQzaEAh0wOaLj99DUICT4EJT7ozEzW4kmjp9F960D\n5O26uniW8ufBgSnuVWtOWdrmMy9IlsiRTZIc7err/FgjNqrmBNg2ZrST4RNE\noLZu3N4cdBaUrzU8Si+dS1vTPF+TWQMWiKGJoqDm6P+aHEmQ5/vHfOIA9PW/\n/hUrS/NcGhi9qgZP3ypLV+NsGJa84TwU2CypmzhoegaZ69E1cyAg00NuWJ4u\n4kqdiwVW3Sjn2E8oBvvNywOHUKyufmYu06fQpavS82rkmqGJ0iCTxcusGBbU\n06EPXVc7XXDlWnBu/9cdm2ULtO5zsl1/vt3YmogdBS0zHap4gQJVAgjHBbNa\nfMdTZNCIjtWYja229yPLGKCcDot23Kq9YLbS/AkHr9Rqpy/Oijn0czIYFlFP\nPqe4/M2kDKnce1nor7K5Mhdw7MsYTI6tfkaqoZR6e/HyJ75Saz4opMFwB7jB\nVdK0/SbspNmRqng5Zz794y+vvVpLvYANeUwXJzLA6/8IEyzh6olKW+DFp0uI\nJG49QiF+K28ehH5rUP6V+XEQTiVLz4Uz5io2Z0NbPLqkQcpZz1U+4ZmEF2wa\neZDe\r\n=1sRK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "1.0.2": {
+      "name": "iferr",
+      "version": "1.0.2",
+      "devDependencies": {
+        "coffeescript": "^2.3.1",
+        "mocha": "^4.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
+        "shasum": "e9fde49a9da06dc4a4194c6c9ed6d08305037a6d",
+        "tarball": "https://registry.npmjs.org/iferr/-/iferr-1.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 3450,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbKB/iCRA9TVsSAnZWagAAqhUQAJ+v4dCyHuoKu6TTUUjP\n6QS7GTk9tHZI0U9wLy+RcGXL8QH3+1gSwQhUpNkCUBh/ZqiWpiA6ORrTznOs\ngMJ9XBQJ8pMvLIqgkydFfr1NpCmjwkgOTIFoaQekZNNzCgotNMZum0ZexeC+\nwU6vrRk9bD2yEW6/+WHy8wPduS54xipb6g6WHcCa3ZtHSWE2H37YSkGbztkA\nD5IgMUSI9JAhvF8kYbcNH8ctYa9vlN9ud2oYs7Ax3ZVcfndOxUoD1nM4cGuU\ngLddqEgTP8Cxf5Jgp0Bs+MQiFBRs4fyFV7vkBsDbUfh9c0izV5ZXT8pozs+J\ndNCT9d3sDEAfVk9pIjxR8gNimJuo7rJMnHAO8DVRYBJVTz7KFaQkOAWgCZAO\n0p27mi+Z1Q1xMm/p+JLQ6L/+JKS+jdzKn34p6/x2ZEzwquYn+1ijfO7eQT2K\nAAv+hEAr1X+qFrL2vOtz4ojXjsSCgyqdnmvQmEuZw69Pa+eboszbn+CbY2an\nhJyyTRNM8tDsKuu6Y29TAgccaPHVN+04pum62fMHD4Icp3aEjiC7FPlUzvAq\nuUmBtY/so+JyFlPbaU9z/tnfpr6WLjsyP+g6cSkr1UY0Vb6BQ4rHEgql4Cym\n1uJykdY9P88n0AGKg1Ag0ChT6qNxIQ2AbDOmCXjvj169V5rZ8O9Lppu3BIU+\nMaw5\r\n=jOYb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    }
+  },
+  "modified": "2018-06-18T21:11:03.825Z"
+}

--- a/test/fixtures/registry-mocks/content/import-local.json
+++ b/test/fixtures/registry-mocks/content/import-local.json
@@ -1,0 +1,618 @@
+{
+  "_id": "import-local",
+  "_rev": "7-86a46d35357ff72ba88f7cb2c02521b5",
+  "name": "import-local",
+  "description": "Let a globally installed package use a locally installed version of itself if available",
+  "dist-tags": {
+    "latest": "3.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "import-local",
+      "version": "0.1.0",
+      "description": "Let a globally installed package use a locally installed version of itself if available",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/import-local.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "import",
+        "local",
+        "require",
+        "resolve",
+        "global",
+        "version",
+        "prefer",
+        "cli"
+      ],
+      "dependencies": {
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "cpy": "^5.0.0",
+        "del": "^2.2.2",
+        "execa": "^0.6.3",
+        "xo": "*"
+      },
+      "gitHead": "87a0c91a9a0ecea64471a95479b0366af296b989",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/import-local/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/import-local#readme",
+      "_id": "import-local@0.1.0",
+      "_shasum": "f6575ffbcd6bac3953def94ac91d12db2d603f67",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "f6575ffbcd6bac3953def94ac91d12db2d603f67",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/import-local-0.1.0.tgz_1493920790095_0.707845498342067"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "import-local",
+      "version": "0.1.1",
+      "description": "Let a globally installed package use a locally installed version of itself if available",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/import-local.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "fixtures/cli.js"
+      ],
+      "keywords": [
+        "import",
+        "local",
+        "require",
+        "resolve",
+        "global",
+        "version",
+        "prefer",
+        "cli"
+      ],
+      "dependencies": {
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "cpy": "^5.0.0",
+        "del": "^2.2.2",
+        "execa": "^0.6.3",
+        "xo": "*"
+      },
+      "gitHead": "05e7e5d29ee3eec3a5ec535db802b9906f27afd9",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/import-local/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/import-local#readme",
+      "_id": "import-local@0.1.1",
+      "_shasum": "b1179572aacdc11c6a91009fb430dbcab5f668a8",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "b1179572aacdc11c6a91009fb430dbcab5f668a8",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/import-local-0.1.1.tgz_1494063512345_0.08312201895751059"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "import-local",
+      "version": "1.0.0",
+      "description": "Let a globally installed package use a locally installed version of itself if available",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/import-local.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "fixtures/cli.js"
+      ],
+      "keywords": [
+        "import",
+        "local",
+        "require",
+        "resolve",
+        "global",
+        "version",
+        "prefer",
+        "cli"
+      ],
+      "dependencies": {
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "cpy": "^6.0.0",
+        "del": "^3.0.0",
+        "execa": "^0.8.0",
+        "xo": "*"
+      },
+      "gitHead": "b3a40b30273907ddcf53d7c9df9687ef02d5d6dc",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/import-local/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/import-local#readme",
+      "_id": "import-local@1.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+        "shasum": "5e4ffdc03f4fe6c009c6729beb29631c2f8227bc",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/import-local-1.0.0.tgz_1513333080491_0.8174301576800644"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "import-local",
+      "version": "2.0.0",
+      "description": "Let a globally installed package use a locally installed version of itself if available",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/import-local.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "keywords": [
+        "import",
+        "local",
+        "require",
+        "resolve",
+        "global",
+        "version",
+        "prefer",
+        "cli"
+      ],
+      "dependencies": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "cpy": "^7.0.1",
+        "del": "^3.0.0",
+        "execa": "^0.11.0",
+        "xo": "*"
+      },
+      "xo": {
+        "ignores": [
+          "fixtures"
+        ]
+      },
+      "gitHead": "ca0a08fe9b9072a73294a875e93970ac0634f452",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/import-local/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/import-local#readme",
+      "_id": "import-local@2.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+        "shasum": "55070be38a5993cf18ef6db7e961f5bee5c5a09d",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3598,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbiZm/CRA9TVsSAnZWagAAqVoP/RvjCV9n5/YWAsXKXbdG\np3O+2MMA2dGA/UiXKus70KivRpQayAwCSw94LJkCESOA79zXYKfovzi4MJFE\nUlUwgZRD1/aeV+ujYHMaOTGjcMF1BAxm0xWLTcTq/HDKoN5ETdqGQMW6quou\nFHK5HJk6w2ZeBQD9+qd482nWyW1HbapuD2MpTZAWlTgc9LUj4jETPZ3LgcXd\nVSyQ8CA52FuLT7/LqXQ/DvXQQpKDx+LRfHP1iJASigOemJqvkFbLzciirm79\naf/F8a+YTh8z90fP9Zyo4mcA3OqwRCvDq8+/Ls3ZuKnbdofKmfjcM+s53YBl\nS5GVR0DfJA85Pv8sO0+/dRA/JDDHyy+vcmgYBCvTs6muSVk9eoMbBYs5PXpK\nMh/tSvNPuUD1/LLmE+tVvQ9NuriEQboH8WfmLUhQPZbtvBS4VunyddTNnMf7\nA6SVQjkHxwh5DR1gDFmc0k8jTnb50Vi1HnnTMz6tjrAz9WG0b0zhffpcfGRw\nTZ/D3DXSxvqLOqIfYHrl5c5wKgvS0+7Ed0TXR0lg8iwG+iavlOlTqvIz0jwO\nkugY+d+zJcGh9RHOIaNtduroB5nXAUTRPm0DyPvh3NfzhQJnFHTm8EMwEeSz\nRYZqMMO9PJKK+mdUTMNiU9M2wp4sAVSpT9XZIHCl560nDQfbQq0gRMh9v3CR\nQ8wF\r\n=BXgL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/import-local_2.0.0_1535744447258_0.3296999336977211"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "import-local",
+      "version": "3.0.0",
+      "description": "Let a globally installed package use a locally installed version of itself if available",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/import-local.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "keywords": [
+        "import",
+        "local",
+        "require",
+        "resolve",
+        "global",
+        "version",
+        "prefer",
+        "cli"
+      ],
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "devDependencies": {
+        "ava": "^2.1.0",
+        "cpy": "^7.0.1",
+        "del": "^4.1.1",
+        "execa": "^2.0.1",
+        "xo": "^0.24.0"
+      },
+      "xo": {
+        "ignores": [
+          "fixtures"
+        ]
+      },
+      "gitHead": "77bc808f6fb2d11fc79b95dbcda06c0e1d3ef10c",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/import-local/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/import-local#readme",
+      "_id": "import-local@3.0.0",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-8Uh3mLtqDxb3jUxHRev+qSdJbSe7RD0avbWM36kHj87KwCTIXdM7b/OfmwrJKjIVcSBK4w1XL5YCatdfV10e3A==",
+        "shasum": "ce45eb1528ac8fb921c99df7421326b8ee46c638",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3931,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdF7TvCRA9TVsSAnZWagAAhbQP/3I4U2dV+MjCKi5CqK3c\n13VOU71q9/58b8j8p/ewDdQ/Qz9Ie7lsqgViddmkeozJRuNk3mc6gM039pvb\nRbn2xacYzhXe4063K5yu3IgHFlZmdMnlNdngiQzsyvmNPoNewQlsXHPUircV\nremSXJkY3JdaebmXxGcjZlN/XObwVXGYJ4lWvD+jqZHPMsL56IaihqZ3DZ10\nLYD9Ii8/oLsdWQmVspthR0sSJuBZMiI21q7qDWvKth7Go/jnUMVJMZw+6Dn6\n9ksVI/DvJrLHN6cH4YMeP9bq7eCvqeRhVZ66acnk/rtqDwXBWCu2lx81zvah\nM9dOEr/Rhbf5dWVQEiBdG0gGFV7ELgBIgPSuGX9R867IYLpks5nmoBZxfsZK\n+jH2IE/0wqOUQunP8h5Fa9hFZmItHp6aFRItMiqaVc5yLRkzyJcFdorxb3Kn\nICsx5ubKu3QrPw20lXUVt5c7NL+MM9Dj0aAYQFXOlb880awrZqTNsxiJllc3\nXbj734ygRLNxFn11SMNspIs4dtaDGu5Xwcte8+9KBkyOcB2NvlWQ7MtDsxrF\nIl/NfI3RKsMrLjCbOflZFeya9AzENrj3g32HHiodAEykF/4DBK1pdnLS8Y4/\nRrKJto/HUEaSA5a0iMGi36sbo8SMJXing82Ppb78M5emVwUAy7c/iJSZYh0Z\nYyka\r\n=eHQk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/import-local_3.0.0_1561834734792_0.16239590100067613"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1": {
+      "name": "import-local",
+      "version": "3.0.1",
+      "description": "Let a globally installed package use a locally installed version of itself if available",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/import-local.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "keywords": [
+        "import",
+        "local",
+        "require",
+        "resolve",
+        "global",
+        "version",
+        "prefer",
+        "cli"
+      ],
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "devDependencies": {
+        "ava": "^2.1.0",
+        "cpy": "^7.0.1",
+        "del": "^4.1.1",
+        "execa": "^2.0.1",
+        "xo": "^0.24.0"
+      },
+      "xo": {
+        "ignores": [
+          "fixtures"
+        ]
+      },
+      "gitHead": "3b6d85bea895f8ef3acad55e7fb7d06a4d77a2aa",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/import-local/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/import-local#readme",
+      "_id": "import-local@3.0.1",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-XlabwTJ9tPOdyjnGdGvxUMnUhmhlnJhdYjp5e8UDb2fO+5Gto1Frlg66ixVAf1Os+zQlrKt3QlTCVodyxYBZjQ==",
+        "shasum": "0b0f61a207b6c6b005c931dc72951ddde8303713",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-3.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3918,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdIflsCRA9TVsSAnZWagAAQa8P/3YWYA83dfLiUkHGLzsn\naAfz3W/FIKciazvy/9UYxqBQoECCNAvCdP6DuSShRAPaPC9OuLDODA/5KX4D\n/0hqVlqs9lW5IlgX7wbaX673/ny77mCPte/OvgwNAEbhhhOZ1ilUpUA8TXyM\njaYfDJy40SHDToll3hGu+KHKcLv9BV8JidZ5bVItgw+Gd1RZPnnOLgubU6RB\nAUlLoZPmraNMZpo6iIMP5mR3GegeMFVM9I0AJ5SqAM53fIs4geMV1G1jAPuA\nJ5FJrGa1r2fgX8bs9Gic1Y9VqMLtkMp7zFPt/4o4jKYC1oIqneM+PC8z1b/3\n4txunpp1QA92jtJEaTgbLVNh7IUOBn1DIH0lF5ZgsEUNk3m6ebxM1qekF1op\nq7rw2GZijicF4Vf+rp1nmiPCSgzrCI7IUmUmzUID0Oz0pzoaoqaK/NwJvxv8\nZkwcUAfYCG4f6+OltzFMlL7am1/Mh/ScvoB6iz8pSooSUczU0cPS6ERLq1T/\nd5tw3iqEePz9KloQtfPTWZiYCAZhxHGlZc77UfaKWRqCaJ5uVxUYo9kygU76\n6tJ/+SZgyXi6UVF6Z+IIQcLBDvLJI1JamX3aJkD0brKCbOH0WzubfWAds8do\nyqgPmJ3Pxy4X6KongXNTssIkBntJtq5XRbu2x2H8VC4cHCpdjRMc9LA/oFAb\nyYTp\r\n=fE+4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/import-local_3.0.1_1562507627368_0.3233282122265466"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.2": {
+      "name": "import-local",
+      "version": "3.0.2",
+      "description": "Let a globally installed package use a locally installed version of itself if available",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/import-local.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "keywords": [
+        "import",
+        "local",
+        "require",
+        "resolve",
+        "global",
+        "version",
+        "prefer",
+        "cli"
+      ],
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "devDependencies": {
+        "ava": "2.1.0",
+        "cpy": "^7.0.1",
+        "del": "^4.1.1",
+        "execa": "^2.0.1",
+        "xo": "^0.24.0"
+      },
+      "xo": {
+        "ignores": [
+          "fixtures"
+        ]
+      },
+      "gitHead": "101c4517c940f65799db1fb4de1d178f4c5b7b08",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/import-local/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/import-local#readme",
+      "_id": "import-local@3.0.2",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+        "shasum": "a8cfd0431d1de4a2199703d003e3e62364fa6db6",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 4177,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdN/u/CRA9TVsSAnZWagAA9IcP/iryGyKb6ZbQFewtzAO5\nPhTg6bBjk4EL4DwpXhWfKA30KsGC0RY3ki0hALG7tMY3PiV5iZmMuQKE+PHp\nOZzAGrNoNxju+DI9UwYKToyHElARd0fl3uPTmWl5kUmKzea7qpTmmKxC6Z/w\n4oizotszrJOqW40bNVRyU7KKutfyRxn2NdSJaYLpJU0RbzN/HFfpS+RngYGf\nVbgV4mcSiXjZmtOYkhuQl+8GHx1KDQSPOsFj3kB1UYaq8t4zqxl/NPsS9TxE\nVuJF2/noa/Wi5IT30+9iJTTy2fVA0tH+H15HqzLROUdJUs+wt6XZUrfOGC9i\n2bpOAHEp/CdpTXprzEMt603vioiuZApZIOVp+JvCAcMnG2b5q1ekVf94xXw9\nPDmBZp9q2QjGwoZ/zB3g3/NBgulR0OyhsTk8AROzoj96FDmeveBSksfHV7fD\n+IG+z1z/bP1lc8TxTKkI2nKhAINXGGXrptZoVncX6hBjpAYf445dL0abqcMt\n5FwjOT5gcSWx4r8DdDozOUHrlLOjQuaf5LKpzoe3ysVut4quUkKNehz7/ykN\n1NsAwXTy7aXGZKT3XLz8LuDHpYr68mQrLSK8W43ArkQt9BwFqxFosNRlLQKi\nRJE61AqHH4M6Ixc43Gir+Sys0jL49SSIRPECdWz6f5Eg/h7LDQcNdpD9VXmT\nJJ6v\r\n=/aKs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/import-local_3.0.2_1563950014712_0.05855547209453382"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# import-local [![Build Status](https://travis-ci.org/sindresorhus/import-local.svg?branch=master)](https://travis-ci.org/sindresorhus/import-local)\n\n> Let a globally installed package use a locally installed version of itself if available\n\nUseful for CLI tools that want to defer to the user's locally installed version when available, but still work if it's not installed locally. For example, [AVA](http://ava.li) and [XO](https://github.com/xojs/xo) uses this method.\n\n\n## Install\n\n```\n$ npm install import-local\n```\n\n\n## Usage\n\n```js\nconst importLocal = require('import-local');\n\nif (importLocal(__filename)) {\n\tconsole.log('Using local version of this package');\n} else {\n\t// Code for both global and local version here…\n}\n```\n\n\n---\n\n<div align=\"center\">\n\t<b>\n\t\t<a href=\"https://tidelift.com/subscription/pkg/npm-import-local?utm_source=npm-import-local&utm_medium=referral&utm_campaign=readme\">Get professional support for this package with a Tidelift subscription</a>\n\t</b>\n\t<br>\n\t<sub>\n\t\tTidelift helps make open source sustainable for maintainers while giving companies<br>assurances about security, maintenance, and licensing for their dependencies.\n\t</sub>\n</div>\n",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-07-24T06:33:37.500Z",
+    "created": "2017-05-04T17:59:50.343Z",
+    "0.1.0": "2017-05-04T17:59:50.343Z",
+    "0.1.1": "2017-05-06T09:38:35.003Z",
+    "1.0.0": "2017-12-15T10:18:01.261Z",
+    "2.0.0": "2018-08-31T19:40:47.407Z",
+    "3.0.0": "2019-06-29T18:58:54.926Z",
+    "3.0.1": "2019-07-07T13:53:47.456Z",
+    "3.0.2": "2019-07-24T06:33:34.846Z"
+  },
+  "homepage": "https://github.com/sindresorhus/import-local#readme",
+  "keywords": [
+    "import",
+    "local",
+    "require",
+    "resolve",
+    "global",
+    "version",
+    "prefer",
+    "cli"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/import-local.git"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/import-local/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "rocket0191": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/import-local.min.json
+++ b/test/fixtures/registry-mocks/content/import-local.min.json
@@ -1,0 +1,202 @@
+{
+  "name": "import-local",
+  "dist-tags": {
+    "latest": "3.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "import-local",
+      "version": "0.1.0",
+      "dependencies": {
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "cpy": "^5.0.0",
+        "del": "^2.2.2",
+        "execa": "^0.6.3",
+        "xo": "*"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "dist": {
+        "shasum": "f6575ffbcd6bac3953def94ac91d12db2d603f67",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "0.1.1": {
+      "name": "import-local",
+      "version": "0.1.1",
+      "dependencies": {
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "cpy": "^5.0.0",
+        "del": "^2.2.2",
+        "execa": "^0.6.3",
+        "xo": "*"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "dist": {
+        "shasum": "b1179572aacdc11c6a91009fb430dbcab5f668a8",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.0": {
+      "name": "import-local",
+      "version": "1.0.0",
+      "dependencies": {
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "cpy": "^6.0.0",
+        "del": "^3.0.0",
+        "execa": "^0.8.0",
+        "xo": "*"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+        "shasum": "5e4ffdc03f4fe6c009c6729beb29631c2f8227bc",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "2.0.0": {
+      "name": "import-local",
+      "version": "2.0.0",
+      "dependencies": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "cpy": "^7.0.1",
+        "del": "^3.0.0",
+        "execa": "^0.11.0",
+        "xo": "*"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+        "shasum": "55070be38a5993cf18ef6db7e961f5bee5c5a09d",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3598,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbiZm/CRA9TVsSAnZWagAAqVoP/RvjCV9n5/YWAsXKXbdG\np3O+2MMA2dGA/UiXKus70KivRpQayAwCSw94LJkCESOA79zXYKfovzi4MJFE\nUlUwgZRD1/aeV+ujYHMaOTGjcMF1BAxm0xWLTcTq/HDKoN5ETdqGQMW6quou\nFHK5HJk6w2ZeBQD9+qd482nWyW1HbapuD2MpTZAWlTgc9LUj4jETPZ3LgcXd\nVSyQ8CA52FuLT7/LqXQ/DvXQQpKDx+LRfHP1iJASigOemJqvkFbLzciirm79\naf/F8a+YTh8z90fP9Zyo4mcA3OqwRCvDq8+/Ls3ZuKnbdofKmfjcM+s53YBl\nS5GVR0DfJA85Pv8sO0+/dRA/JDDHyy+vcmgYBCvTs6muSVk9eoMbBYs5PXpK\nMh/tSvNPuUD1/LLmE+tVvQ9NuriEQboH8WfmLUhQPZbtvBS4VunyddTNnMf7\nA6SVQjkHxwh5DR1gDFmc0k8jTnb50Vi1HnnTMz6tjrAz9WG0b0zhffpcfGRw\nTZ/D3DXSxvqLOqIfYHrl5c5wKgvS0+7Ed0TXR0lg8iwG+iavlOlTqvIz0jwO\nkugY+d+zJcGh9RHOIaNtduroB5nXAUTRPm0DyPvh3NfzhQJnFHTm8EMwEeSz\nRYZqMMO9PJKK+mdUTMNiU9M2wp4sAVSpT9XZIHCl560nDQfbQq0gRMh9v3CR\nQ8wF\r\n=BXgL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.0": {
+      "name": "import-local",
+      "version": "3.0.0",
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "devDependencies": {
+        "ava": "^2.1.0",
+        "cpy": "^7.0.1",
+        "del": "^4.1.1",
+        "execa": "^2.0.1",
+        "xo": "^0.24.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-8Uh3mLtqDxb3jUxHRev+qSdJbSe7RD0avbWM36kHj87KwCTIXdM7b/OfmwrJKjIVcSBK4w1XL5YCatdfV10e3A==",
+        "shasum": "ce45eb1528ac8fb921c99df7421326b8ee46c638",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3931,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdF7TvCRA9TVsSAnZWagAAhbQP/3I4U2dV+MjCKi5CqK3c\n13VOU71q9/58b8j8p/ewDdQ/Qz9Ie7lsqgViddmkeozJRuNk3mc6gM039pvb\nRbn2xacYzhXe4063K5yu3IgHFlZmdMnlNdngiQzsyvmNPoNewQlsXHPUircV\nremSXJkY3JdaebmXxGcjZlN/XObwVXGYJ4lWvD+jqZHPMsL56IaihqZ3DZ10\nLYD9Ii8/oLsdWQmVspthR0sSJuBZMiI21q7qDWvKth7Go/jnUMVJMZw+6Dn6\n9ksVI/DvJrLHN6cH4YMeP9bq7eCvqeRhVZ66acnk/rtqDwXBWCu2lx81zvah\nM9dOEr/Rhbf5dWVQEiBdG0gGFV7ELgBIgPSuGX9R867IYLpks5nmoBZxfsZK\n+jH2IE/0wqOUQunP8h5Fa9hFZmItHp6aFRItMiqaVc5yLRkzyJcFdorxb3Kn\nICsx5ubKu3QrPw20lXUVt5c7NL+MM9Dj0aAYQFXOlb880awrZqTNsxiJllc3\nXbj734ygRLNxFn11SMNspIs4dtaDGu5Xwcte8+9KBkyOcB2NvlWQ7MtDsxrF\nIl/NfI3RKsMrLjCbOflZFeya9AzENrj3g32HHiodAEykF/4DBK1pdnLS8Y4/\nRrKJto/HUEaSA5a0iMGi36sbo8SMJXing82Ppb78M5emVwUAy7c/iJSZYh0Z\nYyka\r\n=eHQk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "3.0.1": {
+      "name": "import-local",
+      "version": "3.0.1",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "devDependencies": {
+        "ava": "^2.1.0",
+        "cpy": "^7.0.1",
+        "del": "^4.1.1",
+        "execa": "^2.0.1",
+        "xo": "^0.24.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-XlabwTJ9tPOdyjnGdGvxUMnUhmhlnJhdYjp5e8UDb2fO+5Gto1Frlg66ixVAf1Os+zQlrKt3QlTCVodyxYBZjQ==",
+        "shasum": "0b0f61a207b6c6b005c931dc72951ddde8303713",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-3.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3918,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdIflsCRA9TVsSAnZWagAAQa8P/3YWYA83dfLiUkHGLzsn\naAfz3W/FIKciazvy/9UYxqBQoECCNAvCdP6DuSShRAPaPC9OuLDODA/5KX4D\n/0hqVlqs9lW5IlgX7wbaX673/ny77mCPte/OvgwNAEbhhhOZ1ilUpUA8TXyM\njaYfDJy40SHDToll3hGu+KHKcLv9BV8JidZ5bVItgw+Gd1RZPnnOLgubU6RB\nAUlLoZPmraNMZpo6iIMP5mR3GegeMFVM9I0AJ5SqAM53fIs4geMV1G1jAPuA\nJ5FJrGa1r2fgX8bs9Gic1Y9VqMLtkMp7zFPt/4o4jKYC1oIqneM+PC8z1b/3\n4txunpp1QA92jtJEaTgbLVNh7IUOBn1DIH0lF5ZgsEUNk3m6ebxM1qekF1op\nq7rw2GZijicF4Vf+rp1nmiPCSgzrCI7IUmUmzUID0Oz0pzoaoqaK/NwJvxv8\nZkwcUAfYCG4f6+OltzFMlL7am1/Mh/ScvoB6iz8pSooSUczU0cPS6ERLq1T/\nd5tw3iqEePz9KloQtfPTWZiYCAZhxHGlZc77UfaKWRqCaJ5uVxUYo9kygU76\n6tJ/+SZgyXi6UVF6Z+IIQcLBDvLJI1JamX3aJkD0brKCbOH0WzubfWAds8do\nyqgPmJ3Pxy4X6KongXNTssIkBntJtq5XRbu2x2H8VC4cHCpdjRMc9LA/oFAb\nyYTp\r\n=fE+4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "3.0.2": {
+      "name": "import-local",
+      "version": "3.0.2",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "devDependencies": {
+        "ava": "2.1.0",
+        "cpy": "^7.0.1",
+        "del": "^4.1.1",
+        "execa": "^2.0.1",
+        "xo": "^0.24.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+        "shasum": "a8cfd0431d1de4a2199703d003e3e62364fa6db6",
+        "tarball": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 4177,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdN/u/CRA9TVsSAnZWagAA9IcP/iryGyKb6ZbQFewtzAO5\nPhTg6bBjk4EL4DwpXhWfKA30KsGC0RY3ki0hALG7tMY3PiV5iZmMuQKE+PHp\nOZzAGrNoNxju+DI9UwYKToyHElARd0fl3uPTmWl5kUmKzea7qpTmmKxC6Z/w\n4oizotszrJOqW40bNVRyU7KKutfyRxn2NdSJaYLpJU0RbzN/HFfpS+RngYGf\nVbgV4mcSiXjZmtOYkhuQl+8GHx1KDQSPOsFj3kB1UYaq8t4zqxl/NPsS9TxE\nVuJF2/noa/Wi5IT30+9iJTTy2fVA0tH+H15HqzLROUdJUs+wt6XZUrfOGC9i\n2bpOAHEp/CdpTXprzEMt603vioiuZApZIOVp+JvCAcMnG2b5q1ekVf94xXw9\nPDmBZp9q2QjGwoZ/zB3g3/NBgulR0OyhsTk8AROzoj96FDmeveBSksfHV7fD\n+IG+z1z/bP1lc8TxTKkI2nKhAINXGGXrptZoVncX6hBjpAYf445dL0abqcMt\n5FwjOT5gcSWx4r8DdDozOUHrlLOjQuaf5LKpzoe3ysVut4quUkKNehz7/ykN\n1NsAwXTy7aXGZKT3XLz8LuDHpYr68mQrLSK8W43ArkQt9BwFqxFosNRlLQKi\nRJE61AqHH4M6Ixc43Gir+Sys0jL49SSIRPECdWz6f5Eg/h7LDQcNdpD9VXmT\nJJ6v\r\n=/aKs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "modified": "2019-07-24T06:33:37.500Z"
+}

--- a/test/fixtures/registry-mocks/content/infer-owner.json
+++ b/test/fixtures/registry-mocks/content/infer-owner.json
@@ -1,0 +1,183 @@
+{
+  "_id": "infer-owner",
+  "_rev": "17-b6c4d4cf244ec0592e72684ca2557667",
+  "name": "infer-owner",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "1.0.3": {
+      "name": "infer-owner",
+      "version": "1.0.3",
+      "description": "Infer the owner of a path based on the owner of its nearest existing parent",
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "https://izs.me"
+      },
+      "license": "ISC",
+      "scripts": {
+        "test": "tap -J test/*.js --100",
+        "snap": "TAP_SNAPSHOT=1 tap -J test/*.js --100",
+        "preversion": "npm test",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --follow-tags"
+      },
+      "devDependencies": {
+        "mutate-fs": "^2.1.1",
+        "tap": "^12.4.2"
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/infer-owner.git"
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "gitHead": "0d0729db142c6401963e97a136c7d29ecc55746a",
+      "bugs": {
+        "url": "https://github.com/npm/infer-owner/issues"
+      },
+      "homepage": "https://github.com/npm/infer-owner#readme",
+      "_id": "infer-owner@1.0.3",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-E/a+pKtYg72HufDVF9FnA2NPeNYLAnAN/wrIbUnCJVz2JvZmj67b2Tw2Mxz0vugWBmRVhb2XHk26ZQIMF0Irjg==",
+        "shasum": "38d030afce90f1759c16b783e841522cb8995656",
+        "tarball": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 82597,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMk2DCRA9TVsSAnZWagAAqIgP/0a8cCxAGwJCPjUhhkoe\njUTjX//US3Eh7Iu+/9hg1q8Z9JjzOFSgZf2EY+tHtmqXdu8M68RmQr5s+UTU\nA87pnXdu2FmzRpPeZnJJBiI7UuqbTPRwvbhSA3W2+Eubp+7MrYpBUrwLU+Cj\nymqDFYFUQeyJ6JVpmWJGRhT0YIYUVypiQgZy5eqcnZkE1bvMbF5UCH57kiiv\nJ2JOux58SqRka/4E7N4KXVVBZnSTNwPxqLeLGerdbQ9F8PSKJGnrGnECxZPy\nJXWRMsKtMbP6VZe/XljXphj++C9t+ULVWSpZxnWeSQGXqyVBXoJsAY6a7oVG\nAVkSdi3M8DQSu+C9vRM582HNFF1m9RpQUBBujWO5ngQcOzaGuXZbuBWQh9he\nkbTNWrVzaDbGTKnoAI5gIgb5K315k5tGQ8wSKcQgWeuP/MOaTFkB4AXDrtNq\nkW3oBrzai9stp9VVyvNhPdwgyDVJ/aT6+bMx0XVFUfJ3W5h66BgW5YSz3G7Y\nbTGFh9rfbBHTNMm420u/TaJ5MRKAJ/oIfAMyN38J2hl3/n60mPji5Otw82ny\n7X0Rol7ELH73034vjhBhl6eDNAzeFf0b02K/LiDe/lkxc3uwwRcQBP3wSgL1\nHekY/CnvOVrpo2QtVt/nEwyjnmqkgXxmGVR6O9S/Na7zFI7NaU0+gGoaGb7f\npITv\r\n=RkTF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "isaacs",
+          "email": "i@izs.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/infer-owner_1.0.3_1563577731234_0.6947691890893826"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.4": {
+      "name": "infer-owner",
+      "version": "1.0.4",
+      "description": "Infer the owner of a path based on the owner of its nearest existing parent",
+      "author": {
+        "name": "Isaac Z. Schlueter",
+        "email": "i@izs.me",
+        "url": "https://izs.me"
+      },
+      "license": "ISC",
+      "scripts": {
+        "test": "tap -J test/*.js --100",
+        "snap": "TAP_SNAPSHOT=1 tap -J test/*.js --100",
+        "preversion": "npm test",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --follow-tags"
+      },
+      "devDependencies": {
+        "mutate-fs": "^2.1.1",
+        "tap": "^12.4.2"
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/infer-owner.git"
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "gitHead": "264706f28c1bd50c83ecee87e3ff794bf75478f2",
+      "bugs": {
+        "url": "https://github.com/npm/infer-owner/issues"
+      },
+      "homepage": "https://github.com/npm/infer-owner#readme",
+      "_id": "infer-owner@1.0.4",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+        "shasum": "c4cefcaa8e51051c2a40ba2ce8a3d27295af9467",
+        "tarball": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4290,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMk6DCRA9TVsSAnZWagAAX1QQAJwpFKxPcykGPXK8B/ft\nO67WidmVuHygLhdtAj2YlKgZUv3eAkdDNqofh7hFI/GccqWWHptLE1KyjVdi\nZRKUet69TRmEwD1WjROCF4yTSNdU96orw9KWSO7vr+/7a9EED5Ff76eDv5S4\nLiWxGBGIUch7EqCjmCsmICtU54bnI3xPrzTlAwO1auw4st0BCK48NA/v/7Pm\nM+pzmO4gNqlvk1CLKvjFgDbDPJkVirFLoIVM6cz9VKGLW8foscj3LCvbsC0e\nLgSvXp5enJMiZ6Y1n/Jo0roaq7sxeL9Rb0+Oo5bumKZtcRtbLbFZwgPekNwD\nRiYdQJOXaYvIE04AX1c/b6zPYvyD5wKOHfKpZKdAKU8tjKf8B9ATEe7q+ZFl\nB4pE3+5Yxlydtopg/SoR9s+ex/LW30c/p0WsqD/s5bxM9vN5EBWA2+wUH4nO\nene1AohsNGODJS7o6qptZLP6TSVr7VIs1e3Dfh9JXNZe11tN/Dht2r6+hrWO\n+UdZ3Wwkd3CDj6KXSTG7rgsxnhtO6lJC7CRYlET8vpFHuyLnuemRUyJjFB4W\nMtBtld8B4u6JY6tLUfqQhLSHlXc8arAHG+S5SzQNtwOu1yniGfSLBRf0n3zq\nj06AFTiCl4+0nLkWUQPlQmk76q8fs56XgKqt6K5UwYjd321WvQZgZaXLFD8m\n4J3V\r\n=3pII\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/infer-owner_1.0.4_1563577987148_0.9732602885812718"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2019-07-19T23:08:51.021Z",
+    "1.0.3": "2019-07-19T23:08:51.367Z",
+    "modified": "2020-10-19T13:49:53.172Z",
+    "1.0.4": "2019-07-19T23:13:07.339Z"
+  },
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "description": "Infer the owner of a path based on the owner of its nearest existing parent",
+  "homepage": "https://github.com/npm/infer-owner#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/infer-owner.git"
+  },
+  "author": {
+    "name": "Isaac Z. Schlueter",
+    "email": "i@izs.me",
+    "url": "https://izs.me"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/infer-owner/issues"
+  },
+  "license": "ISC",
+  "readme": "# infer-owner\n\nInfer the owner of a path based on the owner of its nearest existing parent\n\n## USAGE\n\n```js\nconst inferOwner = require('infer-owner')\n\ninferOwner('/some/cache/folder/file').then(owner => {\n  // owner is {uid, gid} that should be attached to\n  // the /some/cache/folder/file, based on ownership\n  // of /some/cache/folder, /some/cache, /some, or /,\n  // whichever is the first to exist\n})\n\n// same, but not async\nconst owner = inferOwner.sync('/some/cache/folder/file')\n\n// results are cached!  to reset the cache (eg, to change\n// permissions for whatever reason), do this:\ninferOwner.clearCache()\n```\n\nThis module endeavors to be as performant as possible.  Parallel requests\nfor ownership of the same path will only stat the directories one time.\n\n## API\n\n* `inferOwner(path) -> Promise<{ uid, gid }>`\n\n    If the path exists, return its uid and gid.  If it does not, look to\n    its parent, then its grandparent, and so on.\n\n* `inferOwner(path) -> { uid, gid }`\n\n    Sync form of `inferOwner(path)`.\n\n* `inferOwner.clearCache()`\n\n    Delete all cached ownership information and in-flight tracking.\n",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/infer-owner.min.json
+++ b/test/fixtures/registry-mocks/content/infer-owner.min.json
@@ -1,0 +1,41 @@
+{
+  "name": "infer-owner",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "1.0.3": {
+      "name": "infer-owner",
+      "version": "1.0.3",
+      "devDependencies": {
+        "mutate-fs": "^2.1.1",
+        "tap": "^12.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-E/a+pKtYg72HufDVF9FnA2NPeNYLAnAN/wrIbUnCJVz2JvZmj67b2Tw2Mxz0vugWBmRVhb2XHk26ZQIMF0Irjg==",
+        "shasum": "38d030afce90f1759c16b783e841522cb8995656",
+        "tarball": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 82597,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMk2DCRA9TVsSAnZWagAAqIgP/0a8cCxAGwJCPjUhhkoe\njUTjX//US3Eh7Iu+/9hg1q8Z9JjzOFSgZf2EY+tHtmqXdu8M68RmQr5s+UTU\nA87pnXdu2FmzRpPeZnJJBiI7UuqbTPRwvbhSA3W2+Eubp+7MrYpBUrwLU+Cj\nymqDFYFUQeyJ6JVpmWJGRhT0YIYUVypiQgZy5eqcnZkE1bvMbF5UCH57kiiv\nJ2JOux58SqRka/4E7N4KXVVBZnSTNwPxqLeLGerdbQ9F8PSKJGnrGnECxZPy\nJXWRMsKtMbP6VZe/XljXphj++C9t+ULVWSpZxnWeSQGXqyVBXoJsAY6a7oVG\nAVkSdi3M8DQSu+C9vRM582HNFF1m9RpQUBBujWO5ngQcOzaGuXZbuBWQh9he\nkbTNWrVzaDbGTKnoAI5gIgb5K315k5tGQ8wSKcQgWeuP/MOaTFkB4AXDrtNq\nkW3oBrzai9stp9VVyvNhPdwgyDVJ/aT6+bMx0XVFUfJ3W5h66BgW5YSz3G7Y\nbTGFh9rfbBHTNMm420u/TaJ5MRKAJ/oIfAMyN38J2hl3/n60mPji5Otw82ny\n7X0Rol7ELH73034vjhBhl6eDNAzeFf0b02K/LiDe/lkxc3uwwRcQBP3wSgL1\nHekY/CnvOVrpo2QtVt/nEwyjnmqkgXxmGVR6O9S/Na7zFI7NaU0+gGoaGb7f\npITv\r\n=RkTF\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.4": {
+      "name": "infer-owner",
+      "version": "1.0.4",
+      "devDependencies": {
+        "mutate-fs": "^2.1.1",
+        "tap": "^12.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+        "shasum": "c4cefcaa8e51051c2a40ba2ce8a3d27295af9467",
+        "tarball": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4290,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdMk6DCRA9TVsSAnZWagAAX1QQAJwpFKxPcykGPXK8B/ft\nO67WidmVuHygLhdtAj2YlKgZUv3eAkdDNqofh7hFI/GccqWWHptLE1KyjVdi\nZRKUet69TRmEwD1WjROCF4yTSNdU96orw9KWSO7vr+/7a9EED5Ff76eDv5S4\nLiWxGBGIUch7EqCjmCsmICtU54bnI3xPrzTlAwO1auw4st0BCK48NA/v/7Pm\nM+pzmO4gNqlvk1CLKvjFgDbDPJkVirFLoIVM6cz9VKGLW8foscj3LCvbsC0e\nLgSvXp5enJMiZ6Y1n/Jo0roaq7sxeL9Rb0+Oo5bumKZtcRtbLbFZwgPekNwD\nRiYdQJOXaYvIE04AX1c/b6zPYvyD5wKOHfKpZKdAKU8tjKf8B9ATEe7q+ZFl\nB4pE3+5Yxlydtopg/SoR9s+ex/LW30c/p0WsqD/s5bxM9vN5EBWA2+wUH4nO\nene1AohsNGODJS7o6qptZLP6TSVr7VIs1e3Dfh9JXNZe11tN/Dht2r6+hrWO\n+UdZ3Wwkd3CDj6KXSTG7rgsxnhtO6lJC7CRYlET8vpFHuyLnuemRUyJjFB4W\nMtBtld8B4u6JY6tLUfqQhLSHlXc8arAHG+S5SzQNtwOu1yniGfSLBRf0n3zq\nj06AFTiCl4+0nLkWUQPlQmk76q8fs56XgKqt6K5UwYjd321WvQZgZaXLFD8m\n4J3V\r\n=3pII\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:49:53.172Z"
+}

--- a/test/fixtures/registry-mocks/content/internal-ip.json
+++ b/test/fixtures/registry-mocks/content/internal-ip.json
@@ -1,0 +1,1393 @@
+{
+  "_id": "internal-ip",
+  "_rev": "29-9beb9fbb54438d2af14151653b6626c1",
+  "name": "internal-ip",
+  "description": "Get your internal IP address",
+  "dist-tags": {
+    "latest": "6.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "internal-ip",
+      "version": "1.0.0",
+      "description": "Get your internal IPv4 address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/internal-ip"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "bin": {
+        "internal-ip": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "node test.js"
+      },
+      "files": [
+        "index.js",
+        "cli.js"
+      ],
+      "keywords": [
+        "cli-app",
+        "cli",
+        "bin",
+        "ip",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine"
+      ],
+      "devDependencies": {
+        "ava": "0.0.4",
+        "is-ip": "^1.0.0"
+      },
+      "gitHead": "fba9184d284ae01ac8a8086064f04812f35c50a0",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip",
+      "_id": "internal-ip@1.0.0",
+      "_shasum": "b484048e9051d07251bcc7e4396df547f4e3497e",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b484048e9051d07251bcc7e4396df547f4e3497e",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "internal-ip",
+      "version": "1.0.1",
+      "description": "Get your internal IPv4 address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/internal-ip"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "internal-ip": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "node test.js"
+      },
+      "files": [
+        "index.js",
+        "cli.js"
+      ],
+      "keywords": [
+        "cli-app",
+        "cli",
+        "bin",
+        "ip",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine"
+      ],
+      "dependencies": {
+        "meow": "^3.1.0"
+      },
+      "devDependencies": {
+        "ava": "0.0.4",
+        "is-ip": "^1.0.0"
+      },
+      "gitHead": "c0e2abbfefe3b544dbc87da0a72257e3fc274f1d",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip",
+      "_id": "internal-ip@1.0.1",
+      "_shasum": "d00550768cb280f417eb05fd2feed774afeaa7e9",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "d00550768cb280f417eb05fd2feed774afeaa7e9",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "internal-ip",
+      "version": "1.1.0",
+      "description": "Get your internal IPv4 or IPv6 address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/internal-ip"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "internal-ip": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "cli.js"
+      ],
+      "keywords": [
+        "cli-app",
+        "cli",
+        "bin",
+        "ip",
+        "ipv4",
+        "ipv6",
+        "address",
+        "internal",
+        "local",
+        "machine"
+      ],
+      "dependencies": {
+        "meow": "^3.3.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "is-ip": "^1.0.0",
+        "xo": "*"
+      },
+      "gitHead": "35013e90f568637faad59c645e8f73cebffa9098",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip",
+      "_id": "internal-ip@1.1.0",
+      "_shasum": "bc2a617b39ec37f4cf1616a531a96c2867faf788",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "bc2a617b39ec37f4cf1616a531a96c2867faf788",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "internal-ip",
+      "version": "1.2.0",
+      "description": "Get your internal IPv4 or IPv6 address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/internal-ip"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "bin": {
+        "internal-ip": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "cli.js"
+      ],
+      "keywords": [
+        "cli-app",
+        "cli",
+        "bin",
+        "ip",
+        "ipv4",
+        "ipv6",
+        "address",
+        "internal",
+        "local",
+        "machine"
+      ],
+      "dependencies": {
+        "meow": "^3.3.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "is-ip": "^1.0.0",
+        "xo": "*"
+      },
+      "gitHead": "ef43d204ee3e36dbc0bc8333b5ab816208553269",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip",
+      "_id": "internal-ip@1.2.0",
+      "_shasum": "ae9fbf93b984878785d50a8de1b356956058cf5c",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "ae9fbf93b984878785d50a8de1b356956058cf5c",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/internal-ip-1.2.0.tgz_1456342188905_0.8255082112737"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "internal-ip",
+      "version": "2.0.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^2.0.0",
+        "ip": "^1.1.5",
+        "ipaddr.js": "^1.4.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "df16f28cd59238ed7e5297a73745f09a43d09064",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@2.0.0",
+      "_npmVersion": "5.0.0",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-VRmpKSelhyRwe+Yo4nsVi1ZQsOhLgkj61FxfWCEqtCIglxtoSot3vHrKvmL/+bTPBriCHCnNmh+/XTWNwMrPBg==",
+        "shasum": "abbb555d4718b84f88625bcc04ab80b68acaa3f8",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip-2.0.0.tgz_1498822902504_0.20054985862225294"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "internal-ip",
+      "version": "2.0.1",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^2.0.0",
+        "ip": "^1.1.5",
+        "ipaddr.js": "^1.4.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "6dac8ced9fb7f2272e447e188ff5120340fbf8b3",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@2.0.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-Sy3CkuisvDyFd+Sw+nCJbBT11yI6oGNOFA2rZVF7uvlz4U6IQfzLCOjYfqSctC/kbUXjmmSmdkq9CR5c5iT96w==",
+        "shasum": "ac6eaf4f79c8ff8844f65e351a745280ef868b38",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip-2.0.1.tgz_1502548045100_0.9065437342505902"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "internal-ip",
+      "version": "2.0.2",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^2.0.2",
+        "ipaddr.js": "^1.5.1"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "6b17cd6379f400eaae7041b6d5a0e67967828067",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@2.0.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-1OBR5z3Te0FrUtpsPP04XQ2Tsgj+AwujBioVtM9WVW/Jyoe7xR3BIfWnnmg1eUwRuYFelIJM9mQwB7u3bLXD7Q==",
+        "shasum": "bed2b35491e8b42aee087de7614e870908ee80f2",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip-2.0.2.tgz_1503506543596_0.5833584431093186"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "internal-ip",
+      "version": "2.0.3",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^2.2.2",
+        "ipaddr.js": "^1.5.2"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "01c2d31f62823e360ba23a6aad00653345aff245",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@2.0.3",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-XxJMiJOjXbb9LlwH6SVTsnUPymYACunXzKg3dqU+HIC+xYIkUhMyTiT/H6xxPmhlE4zHq50lKlx0CZlyN2C76Q==",
+        "shasum": "ed3cf9b671ac7ff23037bfacad42eb439cd9546c",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-2.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip-2.0.3.tgz_1505582019779_0.6302005373872817"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "internal-ip",
+      "version": "3.0.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "dependencies": {
+        "default-gateway": "^2.6.0",
+        "ipaddr.js": "^1.5.2"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "de43f8f9dbf482860906bb81bb3d03abb149d022",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@3.0.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-BfOXr402PoF0orMXqT+jqxXi82oWbfnoMzDzSpp676+kril5lOot9s75UYaWP/TIcm7tGTTPXKGsu5k04xGyeg==",
+        "shasum": "2aac6dd048c0c97a6fbc95de8e5fa15b88da596e",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip-3.0.0.tgz_1506758555950_0.19928116141818464"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "internal-ip",
+      "version": "3.0.1",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ],
+      "dependencies": {
+        "default-gateway": "^2.6.0",
+        "ipaddr.js": "^1.5.2"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "389a3089bbb739aa3de44084c356b3dda60678ab",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@3.0.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "silverwind",
+        "email": "npm@silverwind.io"
+      },
+      "dist": {
+        "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+        "shasum": "df5c99876e1d2eb2ea2d74f520e3f669a00ece27",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip-3.0.1.tgz_1507782060347_0.030048957094550133"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "internal-ip",
+      "version": "4.0.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^3.1.0",
+        "ipaddr.js": "^1.9.0"
+      },
+      "devDependencies": {
+        "ava": "^1.2.1",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "a8c9c56f5d10298ae4583e6783dca97d36f25c74",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@4.0.0",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.8.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-3Raw3cuBScBi7iQzisDbmG0KE/FyTYNYmBO34D9CCao3Exa7s4Eqxe3cQMDNuhTtKvG/zlYCXB4GBhxH2uARLg==",
+        "shasum": "9e2637d1ac16e78d0f64f2b94e1519b92f373f2b",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4205,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcZ5zcCRA9TVsSAnZWagAArOYQAKLiZOHvp/tULuXuph/M\nAiG4qWLnMdRe56dVIuocxYc3CPAZbaOIXGM0i7I+Vj9+thSNlvWH9Ey7Qbte\nFSksDK4eb8fWSPJSmZ3Obv5dhLCKnp82/jlJLCwtGVn2T9gSjNISa1xrNIBv\nejvG/2jYtavOUKn8iU1Qm1Ci5if618pqMohj/UPHw5dkA1Hh0iFETqRlGAHX\n7jA5ieesxsfe8ixOmqOa6AoKSr8L60lUzP3QW9StTCqtbtS7D8lhKuLC2a0e\n7Z/Sl+x96MKEsvZAbXVfI8KGzYEwvp1weTLYOijSss7Wr1NJYWT69k/UMpzi\nKIbXxN3AlFB45eVZ/ZuktZ3c7AF3vOW70aHmH+LjsA2XqjF+4zXj57C2PTeR\nCtdL/XZ5qRB/ppZTukCuuSe0DRXCIqgWlyHvWFl6fJ9PSohkUEtfBHbgZdXg\n4adpdaXku9r8R9FF9+z1zaXSQZjKU2xb0zYn00HU9p3zOIb5WFirZ3ShLDsS\nXiFtsmGfyMITCEIbbDifkJUm3pD3ASAMzx+tw9HVQQH7F00AjVI9IH3rxqhA\nS5VZ37ihgVPZpRdB17OBu4lf0+BgdVzz1Mx2XDk822oWihM9oZZiYyMTJFcu\nX3ohbbx5WlYdoRCwZ+C1iui86rfa1631QQKywk7oZVmX/NRtyMrDWuNSVaOw\n13RY\r\n=bZxg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip_4.0.0_1550294235315_0.6528111327076651"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.0": {
+      "name": "internal-ip",
+      "version": "4.1.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd-check"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^3.1.0",
+        "ipaddr.js": "^1.9.0"
+      },
+      "devDependencies": {
+        "ava": "^1.2.1",
+        "tsd-check": "^0.3.0",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "3ae74792b8e7e66c4fe8c56de45701793f88c1dc",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@4.1.0",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.8.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-vMbCq5+5xM6cQ5Zpzw2fPirS3uOAabk0ep+plu8P659c7XuvaVN3G//utF0AWboZIKKL5YDpti7PO51m/wfomw==",
+        "shasum": "6658767ca7087b67f720df711605188e8364e340",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 5688,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcbk/jCRA9TVsSAnZWagAA78cP/0LKV9yPmb11SkeJ1f8/\nakxldd9wLvNFF1Go/w+9G1HcfLm8YUqn+vVSISrbJnm1MLeVbJ5ocXbJFg3m\n96IkJJJBR1QY9Ir+gimegzdaEPGKcyxsiivdxjnykKCzwVMUywHkNqEMrqTw\nLcgYa+MamcfyOfRXR+J7YUs7rTKjssApckk2KMxWlDieijD8Ys+Es5/McJYX\npHwU7yKCjJ1bssMNLGKvsonIJCilUGM6GSU9oGy2ySGWAD+1DHVbrk0I9u8r\n+0ZEZc5Iy3lCK4DmZtTXTEf8kkHZWtTz52fJEqDQZU1ZBBbqINR6M6ue76ue\nQIvYTSx7D+14JQioeExUD4WH3a5CDQlqAEwmhcRSl0kAVltGTwCB1PKrzWic\nBw2ioOzTVpK6jvK9FPZ17zKtnl1Q7XwjbHJMGw3O2BSSyKouZk+4CvYAsmrD\n9EYUaVzAQIFu/gpEX9jYEoMBmg93qb5T3pHf3HOTqTW13qeiXmE8/bWQhmAL\nliUAo/zaTvjSVDvrJ6ubfJWkmKzYE8Gd1uin7D1svFaUqNlkGY9spgbcn2i0\nSIr70s6RM1F764sSjTmktCG2G46fnlqD5EvLgLzl/r/9Q2kk2Uck4Nls/w1o\nuVkMYdoQap7ROf944i+h874WjUeoXilllLZXOLN/obri9JkUyGDjv7X7mTbp\nGTRJ\r\n=xSRK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip_4.1.0_1550733283113_0.7537145436937385"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.0": {
+      "name": "internal-ip",
+      "version": "4.2.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd-check"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^4.0.1",
+        "ipaddr.js": "^1.9.0"
+      },
+      "devDependencies": {
+        "ava": "^1.2.1",
+        "tsd-check": "^0.3.0",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "7548b775c7f94241a615e6322efd8e65d6c0fa97",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@4.2.0",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.8.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-ZY8Rk+hlvFeuMmG5uH1MXhhdeMntmIaxaInvAmzMq/SHV8rv4Kh+6GiQNNDQd0wZFrcO+FiTBo8lui/osKOyJw==",
+        "shasum": "46e81b638d84c338e5c67e42b1a17db67d0814fa",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 5688,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJccUaUCRA9TVsSAnZWagAAYnkP/RB1ztz8DqEzR5IT9rkd\nhQCdPJH/64VmGbjPpargpvNFC63oYwHlfshiZxL/rAShPOFlVcEQhacEOs1h\nUn8fIJLoIyG8ocbnd4riwjF+DqcaayzMFCBReUdzTpM6xR0Gi+dfVN8DJSh9\nXih2IK/A2dFIRA8YyKxjtYPAekJ34VZiwxN41Rb3ftxZ9q6hwVBHFcwP+b3l\nEXxU/PFcfoDOjZCscK/eS3ts1uDW5nn74G9R4zEsei4WygZVhOeLaUHvMYgW\nxLRRECtaaXIt8bihMwJhjiCv5mDe/+6DijDdQYfs0Z2+GqME+6edBpWFa9Ng\na4RSE+AXVSYEf5ifh07uVMGSLotyLDp4tbrCX8/H7+8hw98TNnlpCCgLeAdP\nG9rj3UQDdjx04xpxu/mtxFAcreuoxCIGXzGlaZ4ZwmqpZcowE2RDvlWt9Ira\noKRmhoTKCj7kF8v2RcFXNvichQln9hVqDjIaTSjjZkQBa2VxC9ejC/xYc5Bu\naBQDGQHe5XGfkkKBI+ZAo1uh54QAilDDVN6YXH+nSu3rhPAyMRXRBa9rJYVv\nt9GDVASeQ1KCqgcdHMEg3HoF5I+BBUR4VPdJPOPvaojeAwfpO3J39bdLOJX7\n6xDb+6DnO2QEyv7HDG8dRnOX8rIqg5g+T/hcGgNOcHC88n4xwzgZnELgsqJz\njDXV\r\n=ch3H\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip_4.2.0_1550927507407_0.15512484925100534"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.3.0": {
+      "name": "internal-ip",
+      "version": "4.3.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "4f496a9befa86c40dba4a3ed57fedfb7c089599d",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@4.3.0",
+      "_nodeVersion": "8.15.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
+        "shasum": "845452baad9d2ca3b69c635a137acb9a0dad0907",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 5726,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcpvx8CRA9TVsSAnZWagAAkA4P/AzhCx9/bZ4sp8d89C8p\n4dWUyzIG6YvXfAZaOqFcmMmm6X7efn5/DSF+VY4CMUb4kyQ5BJCMhPDpxLsk\nXFvWs0KwIUThc+c9UINkyMsynviDHvgxBbbA9vMqdK8rphYaYYEdaiH5LXbI\nPLnItmzZKZiOHK4pvHNeb2OtfEMmbWTqrZc5E3FTk+H6fJf0E9/rgnNVSawy\nH889Iyi6xtmRccxDn7kEHcyYVsSrf6l1riAJvb0CV1UJkN1f5FvSi4A87FHd\nVysUaRfS9YBJC16lbrlIEgGakDZLnqhWfSC5fZTIl3ANqQlw9SIsU6xPEcQQ\nNjLP9r4qWWgSwMAsDTQxYu8LFF0Rq9/yhj5SpTn5TxhX0v7vALj3QIF5ZuIM\n4uPt32zwQbLtaXG5L0sKyPMpjsZFt+9ALqlmVBxmLdu7UNTYvcVZPhQZgm+U\nq8nR/AbpRAYfWpEn80AJfIndCxFwTjYcnPW2sc76o2++Kge9r8mreBfBgb4v\n1brrvOKLVmui9pFhNk2v3t/DWVrbbFyrcRCSRQpNuUMu05MvocFQDNdPx76i\n1Nx3hlu+tVTE+oEAKfhN6K9fw/W7VtPv/jCaXTrGFBFIms1o3lQFkcYYHNao\nWOE+2MOflHa7XhBP2H3L45rpAEZxboY4oIBsrO+AEpnLQ+lUqRvio1PYOUGI\n+B+d\r\n=gFEh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip_4.3.0_1554447483357_0.4200649506716061"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.0": {
+      "name": "internal-ip",
+      "version": "5.0.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^5.0.4",
+        "ipaddr.js": "^1.9.1"
+      },
+      "devDependencies": {
+        "ava": "^2.4.0",
+        "tsd": "^0.9.0",
+        "xo": "^0.25.3"
+      },
+      "gitHead": "85e981f1c60ac73ec1b15f70aa8132be39eacf66",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@5.0.0",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.11.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-2rbiwUsG8My+vT/JBdaE2r6EjzOibu4VXjkfdVBP9PbfTn68EE1DCZ4iw6dOnc+FGsFL4uAqap/eeNoqK5sdtA==",
+        "shasum": "e7c24aea05308f57b7b3ca7c80c07da8f25e224f",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-5.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6125,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdpq4pCRA9TVsSAnZWagAA0+EQAJZBrJZd+nQf04PK6Jac\n7/AAC/dQ56DtRVElNMPMKeEcouaJEkZBrMOLCrYpmExqGeJMsK6USY44HHMM\nzA93bAapxDa34IZjabf1kyqEcFzkgbzLSrPGFFd0xdyQqhNBAb1M+dUsValw\n1pqZ3DDKynuKy2SDg5346CcgRxxQk6g/iD4W9PSJk4pFG2jIyNn7HBj/7Ha1\nBNeAjOPwr+VycH7VmqKi5HpO2XP/5Xnl4zV0tSJME146iRU9fjaaDjG9QsnO\nNKMZbfVAUlZ+SdnbFOTdBU8ZGjyTGHwQEaOqFy0N7/wV2SujJW0a9Rlfu68A\n9FKbNcun/RPM+hmti4E6Y/B64mjeldkVDg3DDALAuDNuTWkasRMxTU7ZqY1B\nWr6ypvIJBQCDjGbO6Izd3kyXiJX1zMurv8e5mMe/DM4rshDlB3vc3RvnCQ0n\ntlhnVPpNIck8nKpNQXW2OW+g6PiRTrpzE+GuTWLZYDxZnM8fBODyfAjSMzmF\n5eEqGZm8Td23h3S4Q6f8oEyZXiubo1NGhM+wdy9VCS+uDNUBg10fNI5+AOhS\ndqOXEgd56nOuwlM06f8mEJ6jHNjB8MbQsoXEUmyTt7plIXX6Um+On7E0w61G\najQHTekJNBbxsCumCiwFW8NAFNx5xlfsWf4EMBig4VI3+5VrK3kvkYoUnzjN\nNs8N\r\n=Kuig\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip_5.0.0_1571204648738_0.18918474974201294"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.0": {
+      "name": "internal-ip",
+      "version": "6.0.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "funding": "https://github.com/sindresorhus/internal-ip?sponsor=1",
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "https://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1"
+      },
+      "devDependencies": {
+        "ava": "^2.4.0",
+        "tsd": "^0.11.0",
+        "xo": "^0.25.3"
+      },
+      "gitHead": "13af835a2ecfc367ffc24e44499bc1a5e0d64484",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@6.0.0",
+      "_nodeVersion": "10.18.1",
+      "_npmVersion": "6.14.2",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-TgdC/bqCeRUXHXFLY21mHGyi47WAAnxW5M/VXgr7XB5qbP7smFyVXRmIcec/RQ6oP4dUpxqecOOHwzBVpp5t4A==",
+        "shasum": "be57b018e8e6994048134e6f4262fcd3d467e6e7",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeaaqECRA9TVsSAnZWagAAXX4QAJqnfUj/7zBYrFCFBlAv\nhYohNQa1ID5UxYEG+BZNbtcT8xVKCEuvgGMukp/MUkfMJbp7Wg+kyBao5OMc\nWLADHu4Q6Rj8SD67KxlXkhhtPVFqC7Op+82Z6H9G2Vg+5HmZ/t5FeyYcuUb2\nC+0QlZeh/zqdLiwbg47xe1Jz3lbIsDNBPahYGnTQx+xJvDlNbCFZgsWTIoQT\nVadI2lefTHKoo8052BxOIKOUYm105q5ZmI2GVr6B7uq016H6UwzzyLIWX5uS\n8lHQr8OH1cu6gFexFIeiNBWSwCH4LLZy9iqYQv1NFOTHXWwZPYZsUHqY6d5I\nza2KVYuyLNs1KR4U7DvT6rGtpxsZVQouPDHwaL3WKKG83Jm8l6t6W45xkHUF\nxdBRGfwtctD3PY9YmwWJv7RBnHcAMLqqqkUurdrXcyGKNv6VH1fjoYqxsMhJ\nTDOhtgbUrlrpN5YPvKGmx/7CSOGDSUTYrUODMj03wv2osWV8n4+/hCbjzdsw\nbU5a43OdpPW6VVZGMo5hVeLTJ8erepVd6QI+JWdgVgtvBnabsg3gZq9vKqUn\nwcOyfJeQQqfIs5zoROZhq9iNe5TD/yZeJlwzYxqNJUkDUhDOK9sRSYaeN0Vz\nVt2eIOixlGvfTKWHNC7tYkC8SjF93k7fhxNznRCZTruYl/4MqngeuCGxjLrg\n9MRP\r\n=f68J\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip_6.0.0_1583983236119_0.33588730654717724"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.1.0": {
+      "name": "internal-ip",
+      "version": "6.1.0",
+      "description": "Get your internal IP address",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/internal-ip.git"
+      },
+      "funding": "https://github.com/sindresorhus/internal-ip?sponsor=1",
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "https://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "address",
+        "internal",
+        "local",
+        "machine",
+        "system",
+        "net",
+        "gateway"
+      ],
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1"
+      },
+      "devDependencies": {
+        "ava": "^2.4.0",
+        "tsd": "^0.13.1",
+        "xo": "^0.32.1"
+      },
+      "gitHead": "f2a688ee1a8cc8ddb0f3583cba3938cb646859c5",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/internal-ip/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+      "_id": "internal-ip@6.1.0",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Cs1iaqrl3z3KJ2ejWyfKkMcuv9NTEJWXtUBSGVc+Eg9BjBLS0k11CsOkf/p5quOkVhhRuq9zwZ/PuJpPUuDP9Q==",
+        "shasum": "3ce3a9155dc9e2a423af0059efcf5f4b0de3399c",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6051,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKZ4qCRA9TVsSAnZWagAAYSgQAIZPu5fF2zvz50pr1z2s\n6LAg5vah841I57M2Ao1km0zer+uNpgBMK7Rlj5nwOEhLgWCgunvqgf+YEmDS\nAQuC6/0vLkVei5nhK387iSef38GzoBAur0602+jKEnPOII4D9badt5tqY2tE\nOPFet4Nt1yiZDwwIY57wrtTbp28J9r7RN3Yh6yfFp06VrIGLce+tES/vjrQG\naOhbgPWenOAOUcgomY7KkXDe7Dw5uE+ZxA2bnqnJhq374N+6S4DiMVguXpHJ\nG2B93pCVlZJMpntJVBbIkvnqtslf8C/G+Gt4jnYdpBdtr4lZNeRBvTp2XFEf\nfGef5YE1VYRJGmhcTF6xZBhR5mffUgpY4v9U6vhiGTA7L9RJDh8ax567+hga\npvc0GgisYohDCeUoNUBrJySXMmM0F2Z5MFTbtvCehEGKi7bHSJu+KNhjpIPY\n0vTE4r7cjeju13E3Yt2XtFBDr7s1BAgajF1Vke4M1/iaLGuil/Y8JRauFpR+\nil6OFrVSBx2qtWKOy5kK1rarPfPyYblFPE/u5pYZ0lBb74/DhAYO0a7U53wm\nWG4aLnxFKAC10MWTPRK+qWUh1ZPuNG5ecDIi+b0Os1/IAkuCrpQK5k0Ztk80\nJJIzp4Eh6CQ6IDfVuJ6Vvde4Aj7F+iiPJ76jYSC64KZ6eiM6mHGcZ9VfeoPO\nPv/G\r\n=zeg/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@silverwind.io",
+          "name": "silverwind"
+        },
+        {
+          "email": "sindresorhus@gmail.com",
+          "name": "sindresorhus"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/internal-ip_6.1.0_1596562985924_0.7300866951420435"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# internal-ip [![Build Status](https://travis-ci.com/sindresorhus/internal-ip.svg?branch=master)](https://travis-ci.com/github/sindresorhus/internal-ip)\n\n> Get your internal IP address\n\n## Install\n\n```\n$ npm install internal-ip\n```\n\n## Usage\n\n```js\nconst internalIp = require('internal-ip');\n\n(async () => {\n\tconsole.log(await internalIp.v6());\n\t//=> 'fe80::1'\n\n\tconsole.log(await internalIp.v4());\n\t//=> '10.0.0.79'\n})();\n\nconsole.log(internalIp.v6.sync())\n//=> 'fe80::1'\n\nconsole.log(internalIp.v4.sync())\n//=> '10.0.0.79'\n```\n\nThe module returns the address of the internet-facing interface, as determined from the default gateway. When the address cannot be determined for any reason, `undefined` will be returned.\n\nThe module relies on operating systems tools. On Linux and Android, the `ip` command must be available, which depending on distribution might not be installed by default. It is usually provided by the `iproute2` package.\n\n## Related\n\n- [internal-ip-cli](https://github.com/sindresorhus/internal-ip-cli) - CLI for this module\n- [public-ip](https://github.com/sindresorhus/public-ip) - Get your public IP address\n- [default-gateway](https://github.com/silverwind/default-gateway) - Get your default gateway address\n\n---\n\n<div align=\"center\">\n\t<b>\n\t\t<a href=\"https://tidelift.com/subscription/pkg/npm-internal-ip?utm_source=npm-internal-ip&utm_medium=referral&utm_campaign=readme\">Get professional support for this package with a Tidelift subscription</a>\n\t</b>\n\t<br>\n\t<sub>\n\t\tTidelift helps make open source sustainable for maintainers while giving companies<br>assurances about security, maintenance, and licensing for their dependencies.\n\t</sub>\n</div>\n",
+  "maintainers": [
+    {
+      "email": "npm@silverwind.io",
+      "name": "silverwind"
+    },
+    {
+      "email": "sindresorhus@gmail.com",
+      "name": "sindresorhus"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-04T17:43:08.320Z",
+    "created": "2014-09-14T20:44:46.645Z",
+    "1.0.0": "2014-09-14T20:44:46.645Z",
+    "1.0.1": "2015-05-16T11:21:45.877Z",
+    "1.1.0": "2015-09-28T16:38:40.649Z",
+    "1.2.0": "2016-02-24T19:29:51.134Z",
+    "2.0.0": "2017-06-30T11:41:43.410Z",
+    "2.0.1": "2017-08-12T14:27:26.317Z",
+    "2.0.2": "2017-08-23T16:42:24.836Z",
+    "2.0.3": "2017-09-16T17:13:40.838Z",
+    "3.0.0": "2017-09-30T08:02:36.935Z",
+    "3.0.1": "2017-10-12T04:21:01.532Z",
+    "4.0.0": "2019-02-16T05:17:15.491Z",
+    "4.1.0": "2019-02-21T07:14:43.324Z",
+    "4.2.0": "2019-02-23T13:11:47.601Z",
+    "4.3.0": "2019-04-05T06:58:03.492Z",
+    "5.0.0": "2019-10-16T05:44:08.879Z",
+    "6.0.0": "2020-03-12T03:20:36.231Z",
+    "6.1.0": "2020-08-04T17:43:06.059Z"
+  },
+  "homepage": "https://github.com/sindresorhus/internal-ip#readme",
+  "keywords": [
+    "ip",
+    "ipv6",
+    "ipv4",
+    "address",
+    "internal",
+    "local",
+    "machine",
+    "system",
+    "net",
+    "gateway"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/internal-ip.git"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "https://sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/internal-ip/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "ericwbailey": true,
+    "gaboesquivel": true,
+    "rocket0191": true,
+    "xiaochao": true,
+    "sopepos": true,
+    "tongjieme": true,
+    "itonyyo": true,
+    "ganeshkbhat": true,
+    "xtx1130": true,
+    "heartnett": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/internal-ip.min.json
+++ b/test/fixtures/registry-mocks/content/internal-ip.min.json
@@ -1,0 +1,401 @@
+{
+  "name": "internal-ip",
+  "dist-tags": {
+    "latest": "6.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "internal-ip",
+      "version": "1.0.0",
+      "devDependencies": {
+        "ava": "0.0.4",
+        "is-ip": "^1.0.0"
+      },
+      "bin": {
+        "internal-ip": "cli.js"
+      },
+      "dist": {
+        "shasum": "b484048e9051d07251bcc7e4396df547f4e3497e",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "internal-ip",
+      "version": "1.0.1",
+      "dependencies": {
+        "meow": "^3.1.0"
+      },
+      "devDependencies": {
+        "ava": "0.0.4",
+        "is-ip": "^1.0.0"
+      },
+      "bin": {
+        "internal-ip": "cli.js"
+      },
+      "dist": {
+        "shasum": "d00550768cb280f417eb05fd2feed774afeaa7e9",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.0": {
+      "name": "internal-ip",
+      "version": "1.1.0",
+      "dependencies": {
+        "meow": "^3.3.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "is-ip": "^1.0.0",
+        "xo": "*"
+      },
+      "bin": {
+        "internal-ip": "cli.js"
+      },
+      "dist": {
+        "shasum": "bc2a617b39ec37f4cf1616a531a96c2867faf788",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.2.0": {
+      "name": "internal-ip",
+      "version": "1.2.0",
+      "dependencies": {
+        "meow": "^3.3.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "is-ip": "^1.0.0",
+        "xo": "*"
+      },
+      "bin": {
+        "internal-ip": "cli.js"
+      },
+      "dist": {
+        "shasum": "ae9fbf93b984878785d50a8de1b356956058cf5c",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "internal-ip",
+      "version": "2.0.0",
+      "dependencies": {
+        "default-gateway": "^2.0.0",
+        "ip": "^1.1.5",
+        "ipaddr.js": "^1.4.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-VRmpKSelhyRwe+Yo4nsVi1ZQsOhLgkj61FxfWCEqtCIglxtoSot3vHrKvmL/+bTPBriCHCnNmh+/XTWNwMrPBg==",
+        "shasum": "abbb555d4718b84f88625bcc04ab80b68acaa3f8",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.1": {
+      "name": "internal-ip",
+      "version": "2.0.1",
+      "dependencies": {
+        "default-gateway": "^2.0.0",
+        "ip": "^1.1.5",
+        "ipaddr.js": "^1.4.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-Sy3CkuisvDyFd+Sw+nCJbBT11yI6oGNOFA2rZVF7uvlz4U6IQfzLCOjYfqSctC/kbUXjmmSmdkq9CR5c5iT96w==",
+        "shasum": "ac6eaf4f79c8ff8844f65e351a745280ef868b38",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.2": {
+      "name": "internal-ip",
+      "version": "2.0.2",
+      "dependencies": {
+        "default-gateway": "^2.0.2",
+        "ipaddr.js": "^1.5.1"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-1OBR5z3Te0FrUtpsPP04XQ2Tsgj+AwujBioVtM9WVW/Jyoe7xR3BIfWnnmg1eUwRuYFelIJM9mQwB7u3bLXD7Q==",
+        "shasum": "bed2b35491e8b42aee087de7614e870908ee80f2",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.3": {
+      "name": "internal-ip",
+      "version": "2.0.3",
+      "dependencies": {
+        "default-gateway": "^2.2.2",
+        "ipaddr.js": "^1.5.2"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-XxJMiJOjXbb9LlwH6SVTsnUPymYACunXzKg3dqU+HIC+xYIkUhMyTiT/H6xxPmhlE4zHq50lKlx0CZlyN2C76Q==",
+        "shasum": "ed3cf9b671ac7ff23037bfacad42eb439cd9546c",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-2.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "3.0.0": {
+      "name": "internal-ip",
+      "version": "3.0.0",
+      "dependencies": {
+        "default-gateway": "^2.6.0",
+        "ipaddr.js": "^1.5.2"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-BfOXr402PoF0orMXqT+jqxXi82oWbfnoMzDzSpp676+kril5lOot9s75UYaWP/TIcm7tGTTPXKGsu5k04xGyeg==",
+        "shasum": "2aac6dd048c0c97a6fbc95de8e5fa15b88da596e",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "3.0.1": {
+      "name": "internal-ip",
+      "version": "3.0.1",
+      "dependencies": {
+        "default-gateway": "^2.6.0",
+        "ipaddr.js": "^1.5.2"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+        "shasum": "df5c99876e1d2eb2ea2d74f520e3f669a00ece27",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "os": [
+        "android",
+        "darwin",
+        "freebsd",
+        "linux",
+        "openbsd",
+        "sunos",
+        "win32"
+      ]
+    },
+    "4.0.0": {
+      "name": "internal-ip",
+      "version": "4.0.0",
+      "dependencies": {
+        "default-gateway": "^3.1.0",
+        "ipaddr.js": "^1.9.0"
+      },
+      "devDependencies": {
+        "ava": "^1.2.1",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-3Raw3cuBScBi7iQzisDbmG0KE/FyTYNYmBO34D9CCao3Exa7s4Eqxe3cQMDNuhTtKvG/zlYCXB4GBhxH2uARLg==",
+        "shasum": "9e2637d1ac16e78d0f64f2b94e1519b92f373f2b",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4205,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcZ5zcCRA9TVsSAnZWagAArOYQAKLiZOHvp/tULuXuph/M\nAiG4qWLnMdRe56dVIuocxYc3CPAZbaOIXGM0i7I+Vj9+thSNlvWH9Ey7Qbte\nFSksDK4eb8fWSPJSmZ3Obv5dhLCKnp82/jlJLCwtGVn2T9gSjNISa1xrNIBv\nejvG/2jYtavOUKn8iU1Qm1Ci5if618pqMohj/UPHw5dkA1Hh0iFETqRlGAHX\n7jA5ieesxsfe8ixOmqOa6AoKSr8L60lUzP3QW9StTCqtbtS7D8lhKuLC2a0e\n7Z/Sl+x96MKEsvZAbXVfI8KGzYEwvp1weTLYOijSss7Wr1NJYWT69k/UMpzi\nKIbXxN3AlFB45eVZ/ZuktZ3c7AF3vOW70aHmH+LjsA2XqjF+4zXj57C2PTeR\nCtdL/XZ5qRB/ppZTukCuuSe0DRXCIqgWlyHvWFl6fJ9PSohkUEtfBHbgZdXg\n4adpdaXku9r8R9FF9+z1zaXSQZjKU2xb0zYn00HU9p3zOIb5WFirZ3ShLDsS\nXiFtsmGfyMITCEIbbDifkJUm3pD3ASAMzx+tw9HVQQH7F00AjVI9IH3rxqhA\nS5VZ37ihgVPZpRdB17OBu4lf0+BgdVzz1Mx2XDk822oWihM9oZZiYyMTJFcu\nX3ohbbx5WlYdoRCwZ+C1iui86rfa1631QQKywk7oZVmX/NRtyMrDWuNSVaOw\n13RY\r\n=bZxg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "4.1.0": {
+      "name": "internal-ip",
+      "version": "4.1.0",
+      "dependencies": {
+        "default-gateway": "^3.1.0",
+        "ipaddr.js": "^1.9.0"
+      },
+      "devDependencies": {
+        "ava": "^1.2.1",
+        "tsd-check": "^0.3.0",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-vMbCq5+5xM6cQ5Zpzw2fPirS3uOAabk0ep+plu8P659c7XuvaVN3G//utF0AWboZIKKL5YDpti7PO51m/wfomw==",
+        "shasum": "6658767ca7087b67f720df711605188e8364e340",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 5688,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcbk/jCRA9TVsSAnZWagAA78cP/0LKV9yPmb11SkeJ1f8/\nakxldd9wLvNFF1Go/w+9G1HcfLm8YUqn+vVSISrbJnm1MLeVbJ5ocXbJFg3m\n96IkJJJBR1QY9Ir+gimegzdaEPGKcyxsiivdxjnykKCzwVMUywHkNqEMrqTw\nLcgYa+MamcfyOfRXR+J7YUs7rTKjssApckk2KMxWlDieijD8Ys+Es5/McJYX\npHwU7yKCjJ1bssMNLGKvsonIJCilUGM6GSU9oGy2ySGWAD+1DHVbrk0I9u8r\n+0ZEZc5Iy3lCK4DmZtTXTEf8kkHZWtTz52fJEqDQZU1ZBBbqINR6M6ue76ue\nQIvYTSx7D+14JQioeExUD4WH3a5CDQlqAEwmhcRSl0kAVltGTwCB1PKrzWic\nBw2ioOzTVpK6jvK9FPZ17zKtnl1Q7XwjbHJMGw3O2BSSyKouZk+4CvYAsmrD\n9EYUaVzAQIFu/gpEX9jYEoMBmg93qb5T3pHf3HOTqTW13qeiXmE8/bWQhmAL\nliUAo/zaTvjSVDvrJ6ubfJWkmKzYE8Gd1uin7D1svFaUqNlkGY9spgbcn2i0\nSIr70s6RM1F764sSjTmktCG2G46fnlqD5EvLgLzl/r/9Q2kk2Uck4Nls/w1o\nuVkMYdoQap7ROf944i+h874WjUeoXilllLZXOLN/obri9JkUyGDjv7X7mTbp\nGTRJ\r\n=xSRK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "4.2.0": {
+      "name": "internal-ip",
+      "version": "4.2.0",
+      "dependencies": {
+        "default-gateway": "^4.0.1",
+        "ipaddr.js": "^1.9.0"
+      },
+      "devDependencies": {
+        "ava": "^1.2.1",
+        "tsd-check": "^0.3.0",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-ZY8Rk+hlvFeuMmG5uH1MXhhdeMntmIaxaInvAmzMq/SHV8rv4Kh+6GiQNNDQd0wZFrcO+FiTBo8lui/osKOyJw==",
+        "shasum": "46e81b638d84c338e5c67e42b1a17db67d0814fa",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 5688,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJccUaUCRA9TVsSAnZWagAAYnkP/RB1ztz8DqEzR5IT9rkd\nhQCdPJH/64VmGbjPpargpvNFC63oYwHlfshiZxL/rAShPOFlVcEQhacEOs1h\nUn8fIJLoIyG8ocbnd4riwjF+DqcaayzMFCBReUdzTpM6xR0Gi+dfVN8DJSh9\nXih2IK/A2dFIRA8YyKxjtYPAekJ34VZiwxN41Rb3ftxZ9q6hwVBHFcwP+b3l\nEXxU/PFcfoDOjZCscK/eS3ts1uDW5nn74G9R4zEsei4WygZVhOeLaUHvMYgW\nxLRRECtaaXIt8bihMwJhjiCv5mDe/+6DijDdQYfs0Z2+GqME+6edBpWFa9Ng\na4RSE+AXVSYEf5ifh07uVMGSLotyLDp4tbrCX8/H7+8hw98TNnlpCCgLeAdP\nG9rj3UQDdjx04xpxu/mtxFAcreuoxCIGXzGlaZ4ZwmqpZcowE2RDvlWt9Ira\noKRmhoTKCj7kF8v2RcFXNvichQln9hVqDjIaTSjjZkQBa2VxC9ejC/xYc5Bu\naBQDGQHe5XGfkkKBI+ZAo1uh54QAilDDVN6YXH+nSu3rhPAyMRXRBa9rJYVv\nt9GDVASeQ1KCqgcdHMEg3HoF5I+BBUR4VPdJPOPvaojeAwfpO3J39bdLOJX7\n6xDb+6DnO2QEyv7HDG8dRnOX8rIqg5g+T/hcGgNOcHC88n4xwzgZnELgsqJz\njDXV\r\n=ch3H\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "4.3.0": {
+      "name": "internal-ip",
+      "version": "4.3.0",
+      "dependencies": {
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
+        "shasum": "845452baad9d2ca3b69c635a137acb9a0dad0907",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 5726,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcpvx8CRA9TVsSAnZWagAAkA4P/AzhCx9/bZ4sp8d89C8p\n4dWUyzIG6YvXfAZaOqFcmMmm6X7efn5/DSF+VY4CMUb4kyQ5BJCMhPDpxLsk\nXFvWs0KwIUThc+c9UINkyMsynviDHvgxBbbA9vMqdK8rphYaYYEdaiH5LXbI\nPLnItmzZKZiOHK4pvHNeb2OtfEMmbWTqrZc5E3FTk+H6fJf0E9/rgnNVSawy\nH889Iyi6xtmRccxDn7kEHcyYVsSrf6l1riAJvb0CV1UJkN1f5FvSi4A87FHd\nVysUaRfS9YBJC16lbrlIEgGakDZLnqhWfSC5fZTIl3ANqQlw9SIsU6xPEcQQ\nNjLP9r4qWWgSwMAsDTQxYu8LFF0Rq9/yhj5SpTn5TxhX0v7vALj3QIF5ZuIM\n4uPt32zwQbLtaXG5L0sKyPMpjsZFt+9ALqlmVBxmLdu7UNTYvcVZPhQZgm+U\nq8nR/AbpRAYfWpEn80AJfIndCxFwTjYcnPW2sc76o2++Kge9r8mreBfBgb4v\n1brrvOKLVmui9pFhNk2v3t/DWVrbbFyrcRCSRQpNuUMu05MvocFQDNdPx76i\n1Nx3hlu+tVTE+oEAKfhN6K9fw/W7VtPv/jCaXTrGFBFIms1o3lQFkcYYHNao\nWOE+2MOflHa7XhBP2H3L45rpAEZxboY4oIBsrO+AEpnLQ+lUqRvio1PYOUGI\n+B+d\r\n=gFEh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.0": {
+      "name": "internal-ip",
+      "version": "5.0.0",
+      "dependencies": {
+        "default-gateway": "^5.0.4",
+        "ipaddr.js": "^1.9.1"
+      },
+      "devDependencies": {
+        "ava": "^2.4.0",
+        "tsd": "^0.9.0",
+        "xo": "^0.25.3"
+      },
+      "dist": {
+        "integrity": "sha512-2rbiwUsG8My+vT/JBdaE2r6EjzOibu4VXjkfdVBP9PbfTn68EE1DCZ4iw6dOnc+FGsFL4uAqap/eeNoqK5sdtA==",
+        "shasum": "e7c24aea05308f57b7b3ca7c80c07da8f25e224f",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-5.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6125,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdpq4pCRA9TVsSAnZWagAA0+EQAJZBrJZd+nQf04PK6Jac\n7/AAC/dQ56DtRVElNMPMKeEcouaJEkZBrMOLCrYpmExqGeJMsK6USY44HHMM\nzA93bAapxDa34IZjabf1kyqEcFzkgbzLSrPGFFd0xdyQqhNBAb1M+dUsValw\n1pqZ3DDKynuKy2SDg5346CcgRxxQk6g/iD4W9PSJk4pFG2jIyNn7HBj/7Ha1\nBNeAjOPwr+VycH7VmqKi5HpO2XP/5Xnl4zV0tSJME146iRU9fjaaDjG9QsnO\nNKMZbfVAUlZ+SdnbFOTdBU8ZGjyTGHwQEaOqFy0N7/wV2SujJW0a9Rlfu68A\n9FKbNcun/RPM+hmti4E6Y/B64mjeldkVDg3DDALAuDNuTWkasRMxTU7ZqY1B\nWr6ypvIJBQCDjGbO6Izd3kyXiJX1zMurv8e5mMe/DM4rshDlB3vc3RvnCQ0n\ntlhnVPpNIck8nKpNQXW2OW+g6PiRTrpzE+GuTWLZYDxZnM8fBODyfAjSMzmF\n5eEqGZm8Td23h3S4Q6f8oEyZXiubo1NGhM+wdy9VCS+uDNUBg10fNI5+AOhS\ndqOXEgd56nOuwlM06f8mEJ6jHNjB8MbQsoXEUmyTt7plIXX6Um+On7E0w61G\najQHTekJNBbxsCumCiwFW8NAFNx5xlfsWf4EMBig4VI3+5VrK3kvkYoUnzjN\nNs8N\r\n=Kuig\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "6.0.0": {
+      "name": "internal-ip",
+      "version": "6.0.0",
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1"
+      },
+      "devDependencies": {
+        "ava": "^2.4.0",
+        "tsd": "^0.11.0",
+        "xo": "^0.25.3"
+      },
+      "dist": {
+        "integrity": "sha512-TgdC/bqCeRUXHXFLY21mHGyi47WAAnxW5M/VXgr7XB5qbP7smFyVXRmIcec/RQ6oP4dUpxqecOOHwzBVpp5t4A==",
+        "shasum": "be57b018e8e6994048134e6f4262fcd3d467e6e7",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeaaqECRA9TVsSAnZWagAAXX4QAJqnfUj/7zBYrFCFBlAv\nhYohNQa1ID5UxYEG+BZNbtcT8xVKCEuvgGMukp/MUkfMJbp7Wg+kyBao5OMc\nWLADHu4Q6Rj8SD67KxlXkhhtPVFqC7Op+82Z6H9G2Vg+5HmZ/t5FeyYcuUb2\nC+0QlZeh/zqdLiwbg47xe1Jz3lbIsDNBPahYGnTQx+xJvDlNbCFZgsWTIoQT\nVadI2lefTHKoo8052BxOIKOUYm105q5ZmI2GVr6B7uq016H6UwzzyLIWX5uS\n8lHQr8OH1cu6gFexFIeiNBWSwCH4LLZy9iqYQv1NFOTHXWwZPYZsUHqY6d5I\nza2KVYuyLNs1KR4U7DvT6rGtpxsZVQouPDHwaL3WKKG83Jm8l6t6W45xkHUF\nxdBRGfwtctD3PY9YmwWJv7RBnHcAMLqqqkUurdrXcyGKNv6VH1fjoYqxsMhJ\nTDOhtgbUrlrpN5YPvKGmx/7CSOGDSUTYrUODMj03wv2osWV8n4+/hCbjzdsw\nbU5a43OdpPW6VVZGMo5hVeLTJ8erepVd6QI+JWdgVgtvBnabsg3gZq9vKqUn\nwcOyfJeQQqfIs5zoROZhq9iNe5TD/yZeJlwzYxqNJUkDUhDOK9sRSYaeN0Vz\nVt2eIOixlGvfTKWHNC7tYkC8SjF93k7fhxNznRCZTruYl/4MqngeuCGxjLrg\n9MRP\r\n=f68J\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+    },
+    "6.1.0": {
+      "name": "internal-ip",
+      "version": "6.1.0",
+      "dependencies": {
+        "default-gateway": "^6.0.0",
+        "ipaddr.js": "^1.9.1"
+      },
+      "devDependencies": {
+        "ava": "^2.4.0",
+        "tsd": "^0.13.1",
+        "xo": "^0.32.1"
+      },
+      "dist": {
+        "integrity": "sha512-Cs1iaqrl3z3KJ2ejWyfKkMcuv9NTEJWXtUBSGVc+Eg9BjBLS0k11CsOkf/p5quOkVhhRuq9zwZ/PuJpPUuDP9Q==",
+        "shasum": "3ce3a9155dc9e2a423af0059efcf5f4b0de3399c",
+        "tarball": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 6051,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfKZ4qCRA9TVsSAnZWagAAYSgQAIZPu5fF2zvz50pr1z2s\n6LAg5vah841I57M2Ao1km0zer+uNpgBMK7Rlj5nwOEhLgWCgunvqgf+YEmDS\nAQuC6/0vLkVei5nhK387iSef38GzoBAur0602+jKEnPOII4D9badt5tqY2tE\nOPFet4Nt1yiZDwwIY57wrtTbp28J9r7RN3Yh6yfFp06VrIGLce+tES/vjrQG\naOhbgPWenOAOUcgomY7KkXDe7Dw5uE+ZxA2bnqnJhq374N+6S4DiMVguXpHJ\nG2B93pCVlZJMpntJVBbIkvnqtslf8C/G+Gt4jnYdpBdtr4lZNeRBvTp2XFEf\nfGef5YE1VYRJGmhcTF6xZBhR5mffUgpY4v9U6vhiGTA7L9RJDh8ax567+hga\npvc0GgisYohDCeUoNUBrJySXMmM0F2Z5MFTbtvCehEGKi7bHSJu+KNhjpIPY\n0vTE4r7cjeju13E3Yt2XtFBDr7s1BAgajF1Vke4M1/iaLGuil/Y8JRauFpR+\nil6OFrVSBx2qtWKOy5kK1rarPfPyYblFPE/u5pYZ0lBb74/DhAYO0a7U53wm\nWG4aLnxFKAC10MWTPRK+qWUh1ZPuNG5ecDIi+b0Os1/IAkuCrpQK5k0Ztk80\nJJIzp4Eh6CQ6IDfVuJ6Vvde4Aj7F+iiPJ76jYSC64KZ6eiM6mHGcZ9VfeoPO\nPv/G\r\n=zeg/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": "https://github.com/sindresorhus/internal-ip?sponsor=1"
+    }
+  },
+  "modified": "2020-08-04T17:43:08.320Z"
+}

--- a/test/fixtures/registry-mocks/content/ip-regex.json
+++ b/test/fixtures/registry-mocks/content/ip-regex.json
@@ -1,0 +1,791 @@
+{
+  "_id": "ip-regex",
+  "_rev": "21-bf117fb76c42a28cb1d777a42c855374",
+  "name": "ip-regex",
+  "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
+  "dist-tags": {
+    "latest": "4.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "ip-regex",
+      "version": "1.0.0",
+      "description": "Regular expression for matching IP addresses",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sindresorhus/ip-regex"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "node test.js"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "text",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "pattern",
+        "ip",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "0.0.4"
+      },
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex",
+      "_id": "ip-regex@1.0.0",
+      "_shasum": "ea90b7e1951898d36eecd24f2ab6942347b4ab28",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ea90b7e1951898d36eecd24f2ab6942347b4ab28",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "ip-regex",
+      "version": "1.0.1",
+      "description": "Regular expression for matching IP addresses",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/ip-regex"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "node test.js"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "text",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "pattern",
+        "ip",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "0.0.4"
+      },
+      "gitHead": "1844317d3c1adaa8848e893269fc599a54b0057e",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex",
+      "_id": "ip-regex@1.0.1",
+      "_shasum": "3f1da464e47290591023a70617e45361b41123f7",
+      "_from": ".",
+      "_npmVersion": "2.1.5",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3f1da464e47290591023a70617e45361b41123f7",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "ip-regex",
+      "version": "1.0.2",
+      "description": "Regular expression for matching IP addresses",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/ip-regex"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "node test.js"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "text",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "pattern",
+        "ip",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "0.0.4"
+      },
+      "gitHead": "077df3268bbad242f5b7de42b97e6d8b6165bb76",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex",
+      "_id": "ip-regex@1.0.2",
+      "_shasum": "1e7daad2c2d0c268729ecca91f8ec463ad58f56b",
+      "_from": ".",
+      "_npmVersion": "2.1.5",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1e7daad2c2d0c268729ecca91f8ec463ad58f56b",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "ip-regex",
+      "version": "1.0.3",
+      "description": "Regular expression for matching IP addresses",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/ip-regex"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "node test.js"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "text",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "pattern",
+        "ip",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "0.0.4"
+      },
+      "gitHead": "4237cf39da0e1b2ea883bc65bde2b69921d78ceb",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex",
+      "_id": "ip-regex@1.0.3",
+      "_shasum": "dc589076f659f419c222039a33316f1c7387effd",
+      "_from": ".",
+      "_npmVersion": "2.5.0",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dc589076f659f419c222039a33316f1c7387effd",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "ip-regex",
+      "version": "2.0.0",
+      "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/ip-regex.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "text",
+        "pattern",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "xo": {
+        "esnext": true
+      },
+      "gitHead": "425bb476fa3c1d73507047fda1586c719ae23641",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex#readme",
+      "_id": "ip-regex@2.0.0",
+      "_shasum": "913a92db023723d6d1a38b874c543893165b24ff",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.6.2",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "913a92db023723d6d1a38b874c543893165b24ff",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ip-regex-2.0.0.tgz_1483952683792_0.4461984606459737"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "ip-regex",
+      "version": "2.1.0",
+      "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/ip-regex.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "text",
+        "pattern",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "xo": {
+        "esnext": true
+      },
+      "gitHead": "3f6478e54773d2ad79de39da4f4e1b9df34fa9a7",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex#readme",
+      "_id": "ip-regex@2.1.0",
+      "_shasum": "fa78bf5d2e6913c911ce9f819ee5146bb6d844e9",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "fa78bf5d2e6913c911ce9f819ee5146bb6d844e9",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/ip-regex-2.1.0.tgz_1489226167327_0.37895454838871956"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "ip-regex",
+      "version": "3.0.0",
+      "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/ip-regex.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "text",
+        "pattern",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "605041b6a32ac7cca8b9c827bb9abc34e9336be0",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex#readme",
+      "_id": "ip-regex@3.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-T8wDtjy+Qf2TAPDQmBp0eGKJ8GavlWlUnamr3wRn6vvdZlKVuJXXMlSncYFRYgVHOM3If5NR1H4+OvVQU9Idvg==",
+        "shasum": "0a934694b4066558c46294244a23cc33116bf732",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-3.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5145
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ip-regex_3.0.0_1522739305091_0.2901866906975463"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "ip-regex",
+      "version": "4.0.0",
+      "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/ip-regex.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "text",
+        "pattern",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "^1.1.0",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "45f4ab50a93cf129461c39494be2ed375ef9678e",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex#readme",
+      "_id": "ip-regex@4.0.0",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-3WQiamA4s/EGI9WxXhSWeR7X+fYxD7LqjJ0nIjMwXYSLOuJ2/ix13QOLvy/TGRDKEhhfLzHnCduANvdCIsn/+A==",
+        "shasum": "0120e0558a355604d511709c831a19adf8487b10",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5822,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQXyfCRA9TVsSAnZWagAA5G4QAKMo+boehdGpHHCA5+oW\n/BSdLqeGhyMZ1X4KMIQ7YRXnI/PEc2vU+gHCwUCgy1Mxa/Npw0iuaM2Cqpft\nQwLVtdQb1t0ujQ0ji1623mJ32UmnNwXN+EH3ZENUT88SN1Ezhu0kudSL5kFC\n1bIghmlMQxAL67mrLlg4BkiVW1IHmyP/7/pqSh3k2SHjJSRwu/Vkm5ewzTSO\nQ2puFQozI4whYEHEPLZ9rDTzATmS1llMbmREabK+UH8fiAHEO8GPLMRgXHmb\nr2MwRIYqHV9iZU1oaPnj1OazaU6FY/l+Sqjdzz5ePVfMn09X8IkSweYDMbxx\nZIeepc2nzRzMTVOp7OzTM8x2riL8wH0D16PRMZmQUiR95k3yKOQiEwbE1yKd\nXDe3gRNCD/semmvECCrVPKDW09EVNpzk2Ud2gQid1qkDLqrKn1RFaQAIk66e\n9LkBkQTsEe8oTOSlXyE+boWn99YIkjAL5lEIV0A4RQU1oiv70hwgnmhbQGlh\n4x4Mzy7CQwJ0kBcU+93ev5nOQ92utpphNnT/KnrB1oeFYQxlkr+UHMwDnWOE\nNnjJCVBckVqBbYHk+2gVdPgmuuALuLvpgKG+bmWAqGG1Y91xcIqaPuOjf2KC\nC7R69AIdJlcqUcOSGFXzQ5q9xv/tX4ZXoYGG6s97TYn6Bpz5nQxhv+hWhPKV\nWb/U\r\n=Imak\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ip-regex_4.0.0_1547795615436_0.0800270746604328"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.0": {
+      "name": "ip-regex",
+      "version": "4.1.0",
+      "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/ip-regex.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "text",
+        "pattern",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "ebdcc9c7b4136ba3c7503730e4bf92ba855f136f",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex#readme",
+      "_id": "ip-regex@4.1.0",
+      "_nodeVersion": "8.15.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
+        "shasum": "5ad62f685a14edb421abebc2fff8db94df67b455",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7422,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcto29CRA9TVsSAnZWagAAzAIQAIm7avORuFoVw3Vg1jSm\ncpMu7L3IsQSBeaqPv0y0vzcCqIKkN9PPkcXuN1ch72Skb9t2KocY7wObedh4\nHmhK64dPDG1l5vkS5InOnbL9s6Ih1aBHeXHmyvtz74v2x+A87iNEGhRjnckw\nFdZ8n9OFOGH5vxdBwqnr5EjLvMZ3jLjtnm/cNO9pFMmVxfXViRvTIinfQcMc\nH4vya3ULzWrgUrmFC1sn3ZLJy6qqDRAb0SjOjk8nnIZlZUWjsmlxw2mivFJy\nx6+QnXZSQxrma3XviJTw+s7RK5INJW5S7S0kDENnlH4O5GYYGEHWyvDKfLy3\nig0atQ7AQP0l6xJXAsR0nj1g8BuGIrucZIVWYNznJ6qhdPsUqUfalOOwlUjj\ng0QQ8RO8mHVn1ricOnmkrl5Xu+s1uwrDdD0YxwnOdXZdzWIRGmrDKEcQNaZn\nZ8vbrIY5Mx9MMwAPhUc5KnLG7WMwJMyl+bLJSwVXoXWwfnUl1WfoCd+uh6k8\nIcrvMcblvvi774fx1NL81UpL47kjC8Lw1q1QZI9r+hMv+an8RdM0VzEEk/Fq\nRxinlGGMyFJ3oee8AzKw84gmLbMwlbz0f2hhbP4GXHfadsgoQ5EmVTXVxQuS\n9D/fArrtu6E4EnAwIAjT1dbbPUxMsVYj6J6eisSD2qiZKD9hHSEodPUHPOkk\neiKi\r\n=O9jy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ip-regex_4.1.0_1555467708812_0.31749112399295076"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.0": {
+      "name": "ip-regex",
+      "version": "4.2.0",
+      "description": "Regular expression for matching IP addresses (IPv4 & IPv6)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/ip-regex.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "ip",
+        "ipv6",
+        "ipv4",
+        "regex",
+        "regexp",
+        "re",
+        "match",
+        "test",
+        "find",
+        "text",
+        "pattern",
+        "internet",
+        "protocol",
+        "address",
+        "validate"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "eea8da6a69598e06908af3ecd9599a1734b20652",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/ip-regex/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/ip-regex#readme",
+      "_id": "ip-regex@4.2.0",
+      "_nodeVersion": "14.11.0",
+      "_npmVersion": "6.14.8",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==",
+        "shasum": "a03f5eb661d9a154e3973a03de8b23dd0ad6892e",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7589,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfcmtSCRA9TVsSAnZWagAAdc0P/3litGVovGjTMKtrPODM\nvX54wHV6oosHT/1Y8Ez2g1MSbo/sQr0QOcGTOUk9A2Rq5FDwk6xGBuK0BE6x\nz1V5ozaoWd2MqZj87GQ4CPMstPO2DxgCqofIAhnQJYigFbFVB1sV6YinNly6\nj0pt9wknNjsq5jYzS8eoLJI1xE0wAZgfJh2RFMflFlOMIaOJPSHQhpnFOPNk\n5e+Cuwayxe32sxUHi+GKgZ0fYvoAQFhV6ajvUl4+w+r5pltKBVRXwdDm1NcO\naa1CHrlRQstFex7zXdP4mn4demx5NVSy9h0EtvFp+ler4z1znz+Y9V22Zx+X\nYC0yxbXuLh/Lu7VPULiGYlJLlE7kFUzykqG3xryBepajGVIXHddAhK4Rs3jU\njwKeZZDz1sJpvn8OJhXjfVwdQWmF7ZXL4rGBCZSaQmn/UWS5S3tfbR8St8L5\nxNbPSmx0473aNCp3TdapoRbVd6lT/G344gED+UXw7jv5ee8v4SdTDS8wXYU1\nISRp1tMo4wCpPAp7pccyMgvtW2H7UCeS8O1Nd/qgB8picsn/SVzBH3EDR/TU\nvN9aVsgJOzLOMVxIuJYsZpTR7/FMaiAD/eqMG7GjUkX6tLDNowwqbMqGvb6x\n+D7I5vhcr5NAYJtrua7QnBE5qk3gVPLe5LYNnMXyERIrnusE05Xlg07lJ0yl\n6qvE\r\n=md7Y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ip-regex_4.2.0_1601334097516_0.33303842781861515"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# ip-regex [![Build Status](https://travis-ci.org/sindresorhus/ip-regex.svg?branch=master)](https://travis-ci.org/sindresorhus/ip-regex)\n\n> Regular expression for matching IP addresses\n\n\n## Install\n\n```\n$ npm install ip-regex\n```\n\nThis module targets Node.js 8 or later and the latest version of Chrome, Firefox, and Safari. If you want support for older browsers, use version 2.1.0: `npm install ip-regex@2.1.0`\n\n\n## Usage\n\n```js\nconst ipRegex = require('ip-regex');\n\n// Contains an IP address?\nipRegex().test('unicorn 192.168.0.1');\n//=> true\n\n// Is an IP address?\nipRegex({exact: true}).test('unicorn 192.168.0.1');\n//=> false\n\nipRegex.v6({exact: true}).test('1:2:3:4:5:6:7:8');\n//=> true\n\n'unicorn 192.168.0.1 cake 1:2:3:4:5:6:7:8 rainbow'.match(ipRegex());\n//=> ['192.168.0.1', '1:2:3:4:5:6:7:8']\n\n// Contains an IP address?\nipRegex({includeBoundaries: true}).test('192.168.0.2000000000');\n//=> false\n\n// Matches an IP address?\n'192.168.0.2000000000'.match(ipRegex({includeBoundaries: true}));\n//=> null\n```\n\n\n## API\n\n### ipRegex([options])\n\nReturns a regex for matching both IPv4 and IPv6.\n\n### ipRegex.v4([options])\n\nReturns a regex for matching IPv4.\n\n### ipRegex.v6([options])\n\nReturns a regex for matching IPv6.\n\n#### options\n\nType: `Object`\n\n##### exact\n\nType: `boolean`<br>\nDefault: `false` *(Matches any IP address in a string)*\n\nOnly match an exact string. Useful with `RegExp#test()` to check if a string is an IP address.\n\n##### includeBoundaries\n\nType: `boolean`<br>\nDefault: `false`\n\nInclude boundaries in the regex. When `true`, `192.168.0.2000000000` will report as an invalid IPv4 address. If this option is not set, the mentioned IPv4 address would report as valid (ignoring the trailing zeros).\n\n\n## Related\n\n- [is-ip](https://github.com/sindresorhus/is-ip) - Check if a string is an IP address\n- [is-cidr](https://github.com/silverwind/is-cidr) - Check if a string is an IP address in CIDR notation\n- [cidr-regex](https://github.com/silverwind/cidr-regex) - Regular expression for matching IP addresses in CIDR notation\n\n\n## License\n\nMIT © [Sindre Sorhus](https://sindresorhus.com)\n",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-09-28T23:01:40.096Z",
+    "created": "2014-09-06T11:39:45.351Z",
+    "1.0.0": "2014-09-06T11:39:45.351Z",
+    "1.0.1": "2014-11-29T16:20:14.443Z",
+    "1.0.2": "2014-12-10T14:53:56.499Z",
+    "1.0.3": "2015-02-09T07:23:47.217Z",
+    "2.0.0": "2017-01-09T09:04:44.010Z",
+    "2.1.0": "2017-03-11T09:56:09.108Z",
+    "3.0.0": "2018-04-03T07:08:25.182Z",
+    "4.0.0": "2019-01-18T07:13:35.555Z",
+    "4.1.0": "2019-04-17T02:21:48.990Z",
+    "4.2.0": "2020-09-28T23:01:37.746Z"
+  },
+  "homepage": "https://github.com/sindresorhus/ip-regex#readme",
+  "keywords": [
+    "ip",
+    "ipv6",
+    "ipv4",
+    "regex",
+    "regexp",
+    "re",
+    "match",
+    "test",
+    "find",
+    "text",
+    "pattern",
+    "internet",
+    "protocol",
+    "address",
+    "validate"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/ip-regex.git"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/ip-regex/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "mojaray2k": true,
+    "rocket0191": true,
+    "xinwangwang": true,
+    "ganeshkbhat": true,
+    "hualei": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/ip-regex.min.json
+++ b/test/fixtures/registry-mocks/content/ip-regex.min.json
@@ -1,0 +1,172 @@
+{
+  "name": "ip-regex",
+  "dist-tags": {
+    "latest": "4.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "ip-regex",
+      "version": "1.0.0",
+      "devDependencies": {
+        "ava": "0.0.4"
+      },
+      "dist": {
+        "shasum": "ea90b7e1951898d36eecd24f2ab6942347b4ab28",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "ip-regex",
+      "version": "1.0.1",
+      "devDependencies": {
+        "ava": "0.0.4"
+      },
+      "dist": {
+        "shasum": "3f1da464e47290591023a70617e45361b41123f7",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.2": {
+      "name": "ip-regex",
+      "version": "1.0.2",
+      "devDependencies": {
+        "ava": "0.0.4"
+      },
+      "dist": {
+        "shasum": "1e7daad2c2d0c268729ecca91f8ec463ad58f56b",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.3": {
+      "name": "ip-regex",
+      "version": "1.0.3",
+      "devDependencies": {
+        "ava": "0.0.4"
+      },
+      "dist": {
+        "shasum": "dc589076f659f419c222039a33316f1c7387effd",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "ip-regex",
+      "version": "2.0.0",
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "913a92db023723d6d1a38b874c543893165b24ff",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "2.1.0": {
+      "name": "ip-regex",
+      "version": "2.1.0",
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "fa78bf5d2e6913c911ce9f819ee5146bb6d844e9",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "3.0.0": {
+      "name": "ip-regex",
+      "version": "3.0.0",
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-T8wDtjy+Qf2TAPDQmBp0eGKJ8GavlWlUnamr3wRn6vvdZlKVuJXXMlSncYFRYgVHOM3If5NR1H4+OvVQU9Idvg==",
+        "shasum": "0a934694b4066558c46294244a23cc33116bf732",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-3.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5145
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "4.0.0": {
+      "name": "ip-regex",
+      "version": "4.0.0",
+      "devDependencies": {
+        "ava": "^1.1.0",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-3WQiamA4s/EGI9WxXhSWeR7X+fYxD7LqjJ0nIjMwXYSLOuJ2/ix13QOLvy/TGRDKEhhfLzHnCduANvdCIsn/+A==",
+        "shasum": "0120e0558a355604d511709c831a19adf8487b10",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5822,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQXyfCRA9TVsSAnZWagAA5G4QAKMo+boehdGpHHCA5+oW\n/BSdLqeGhyMZ1X4KMIQ7YRXnI/PEc2vU+gHCwUCgy1Mxa/Npw0iuaM2Cqpft\nQwLVtdQb1t0ujQ0ji1623mJ32UmnNwXN+EH3ZENUT88SN1Ezhu0kudSL5kFC\n1bIghmlMQxAL67mrLlg4BkiVW1IHmyP/7/pqSh3k2SHjJSRwu/Vkm5ewzTSO\nQ2puFQozI4whYEHEPLZ9rDTzATmS1llMbmREabK+UH8fiAHEO8GPLMRgXHmb\nr2MwRIYqHV9iZU1oaPnj1OazaU6FY/l+Sqjdzz5ePVfMn09X8IkSweYDMbxx\nZIeepc2nzRzMTVOp7OzTM8x2riL8wH0D16PRMZmQUiR95k3yKOQiEwbE1yKd\nXDe3gRNCD/semmvECCrVPKDW09EVNpzk2Ud2gQid1qkDLqrKn1RFaQAIk66e\n9LkBkQTsEe8oTOSlXyE+boWn99YIkjAL5lEIV0A4RQU1oiv70hwgnmhbQGlh\n4x4Mzy7CQwJ0kBcU+93ev5nOQ92utpphNnT/KnrB1oeFYQxlkr+UHMwDnWOE\nNnjJCVBckVqBbYHk+2gVdPgmuuALuLvpgKG+bmWAqGG1Y91xcIqaPuOjf2KC\nC7R69AIdJlcqUcOSGFXzQ5q9xv/tX4ZXoYGG6s97TYn6Bpz5nQxhv+hWhPKV\nWb/U\r\n=Imak\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "4.1.0": {
+      "name": "ip-regex",
+      "version": "4.1.0",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA==",
+        "shasum": "5ad62f685a14edb421abebc2fff8db94df67b455",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7422,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcto29CRA9TVsSAnZWagAAzAIQAIm7avORuFoVw3Vg1jSm\ncpMu7L3IsQSBeaqPv0y0vzcCqIKkN9PPkcXuN1ch72Skb9t2KocY7wObedh4\nHmhK64dPDG1l5vkS5InOnbL9s6Ih1aBHeXHmyvtz74v2x+A87iNEGhRjnckw\nFdZ8n9OFOGH5vxdBwqnr5EjLvMZ3jLjtnm/cNO9pFMmVxfXViRvTIinfQcMc\nH4vya3ULzWrgUrmFC1sn3ZLJy6qqDRAb0SjOjk8nnIZlZUWjsmlxw2mivFJy\nx6+QnXZSQxrma3XviJTw+s7RK5INJW5S7S0kDENnlH4O5GYYGEHWyvDKfLy3\nig0atQ7AQP0l6xJXAsR0nj1g8BuGIrucZIVWYNznJ6qhdPsUqUfalOOwlUjj\ng0QQ8RO8mHVn1ricOnmkrl5Xu+s1uwrDdD0YxwnOdXZdzWIRGmrDKEcQNaZn\nZ8vbrIY5Mx9MMwAPhUc5KnLG7WMwJMyl+bLJSwVXoXWwfnUl1WfoCd+uh6k8\nIcrvMcblvvi774fx1NL81UpL47kjC8Lw1q1QZI9r+hMv+an8RdM0VzEEk/Fq\nRxinlGGMyFJ3oee8AzKw84gmLbMwlbz0f2hhbP4GXHfadsgoQ5EmVTXVxQuS\n9D/fArrtu6E4EnAwIAjT1dbbPUxMsVYj6J6eisSD2qiZKD9hHSEodPUHPOkk\neiKi\r\n=O9jy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "4.2.0": {
+      "name": "ip-regex",
+      "version": "4.2.0",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==",
+        "shasum": "a03f5eb661d9a154e3973a03de8b23dd0ad6892e",
+        "tarball": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7589,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfcmtSCRA9TVsSAnZWagAAdc0P/3litGVovGjTMKtrPODM\nvX54wHV6oosHT/1Y8Ez2g1MSbo/sQr0QOcGTOUk9A2Rq5FDwk6xGBuK0BE6x\nz1V5ozaoWd2MqZj87GQ4CPMstPO2DxgCqofIAhnQJYigFbFVB1sV6YinNly6\nj0pt9wknNjsq5jYzS8eoLJI1xE0wAZgfJh2RFMflFlOMIaOJPSHQhpnFOPNk\n5e+Cuwayxe32sxUHi+GKgZ0fYvoAQFhV6ajvUl4+w+r5pltKBVRXwdDm1NcO\naa1CHrlRQstFex7zXdP4mn4demx5NVSy9h0EtvFp+ler4z1znz+Y9V22Zx+X\nYC0yxbXuLh/Lu7VPULiGYlJLlE7kFUzykqG3xryBepajGVIXHddAhK4Rs3jU\njwKeZZDz1sJpvn8OJhXjfVwdQWmF7ZXL4rGBCZSaQmn/UWS5S3tfbR8St8L5\nxNbPSmx0473aNCp3TdapoRbVd6lT/G344gED+UXw7jv5ee8v4SdTDS8wXYU1\nISRp1tMo4wCpPAp7pccyMgvtW2H7UCeS8O1Nd/qgB8picsn/SVzBH3EDR/TU\nvN9aVsgJOzLOMVxIuJYsZpTR7/FMaiAD/eqMG7GjUkX6tLDNowwqbMqGvb6x\n+D7I5vhcr5NAYJtrua7QnBE5qk3gVPLe5LYNnMXyERIrnusE05Xlg07lJ0yl\n6qvE\r\n=md7Y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "modified": "2020-09-28T23:01:40.096Z"
+}

--- a/test/fixtures/registry-mocks/content/ip.json
+++ b/test/fixtures/registry-mocks/content/ip.json
@@ -1,0 +1,1157 @@
+{
+  "_id": "ip",
+  "_rev": "103-0174571d3d925868c7a2936409c9cf89",
+  "name": "ip",
+  "description": "[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)",
+  "dist-tags": {
+    "latest": "1.1.5",
+    "stable": "0.1.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "ip",
+      "version": "0.0.1",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "_id": "ip@0.0.1",
+      "description": "IP address utilities for node.js",
+      "dist": {
+        "shasum": "bbc68d7cc448560a63fbe99237a01bc50fdca7ec",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "ip",
+      "version": "0.0.2",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "_id": "ip@0.0.2",
+      "description": "IP address utilities for node.js",
+      "dist": {
+        "shasum": "d91c53d43030073e4b9fe3775c19d6e883b73ff7",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "ip",
+      "version": "0.0.3",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "_id": "ip@0.0.3",
+      "description": "IP address utilities for node.js",
+      "dist": {
+        "shasum": "96cf8bbaf9e814c97f98c33946d5c4cf77a1d08d",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "ip",
+      "version": "0.0.4",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "_id": "ip@0.0.4",
+      "description": "IP address utilities for node.js",
+      "dist": {
+        "shasum": "1f4f02ea217bb01275817f30aef5b050b96412bb",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "ip",
+      "version": "0.0.5",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "_id": "ip@0.0.5",
+      "description": "IP address utilities for node.js",
+      "dist": {
+        "shasum": "0b405f761a565e2af045cba09854e484dca97706",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "ip",
+      "version": "0.1.0",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "_id": "ip@0.1.0",
+      "description": "IP address utilities for node.js",
+      "dist": {
+        "shasum": "bf7fccc1608097ecf8e873152ca011234bd99a40",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "ip",
+      "version": "0.2.0",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "description": "IP address utilities for node.js",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@0.2.0",
+      "dist": {
+        "shasum": "41bbf4e945613464c9672034347583811375a88b",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "ip",
+      "version": "0.3.0",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "description": "IP address utilities for node.js",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@0.3.0",
+      "dist": {
+        "shasum": "7a469fffa4e26e56d61b91056a40bf9dbdcd8a8b",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "ip",
+      "version": "0.3.1",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "description": "IP address utilities for node.js",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@0.3.1",
+      "_shasum": "d0871c6ee08449b081bb277fdd6c8ff5e6fc845b",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d0871c6ee08449b081bb277fdd6c8ff5e6fc845b",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "ip",
+      "version": "0.3.2",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "gitHead": "978e13d19531c9d9172044654df9dfb7ed116e45",
+      "description": "IP address utilities for node.js",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@0.3.2",
+      "_shasum": "7d5ed34326688b36b6ab81f1865ea8266c28f0db",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7d5ed34326688b36b6ab81f1865ea8266c28f0db",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.3": {
+      "name": "ip",
+      "version": "0.3.3",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/*-test.js"
+      },
+      "license": "MIT",
+      "gitHead": "7798e2d222718087863d8a5a99e3c02f3a30e2b9",
+      "description": "IP address utilities for node.js",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@0.3.3",
+      "_shasum": "8ee8309e92f0b040d287f72efaca1a21702d3fb4",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8ee8309e92f0b040d287f72efaca1a21702d3fb4",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "ip",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js"
+      },
+      "license": "MIT",
+      "gitHead": "2c5b85dc46076551d051ea9010088d9ecb593a78",
+      "description": "IP address utilities for node.js",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.0.0",
+      "_shasum": "fc627aca013cfe00921743cf0a291563f4a3c90a",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fc627aca013cfe00921743cf0a291563f4a3c90a",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "ip",
+      "version": "1.0.1",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js"
+      },
+      "license": "MIT",
+      "gitHead": "5fa3ae74c70f2af2f3bc1b8784685c5bc004d468",
+      "description": "IP address utilities for node.js",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.0.1",
+      "_shasum": "c7e356cdea225ae71b36d70f2e71a92ba4e42590",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c7e356cdea225ae71b36d70f2e71a92ba4e42590",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "ip",
+      "version": "1.0.2",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js"
+      },
+      "license": "MIT",
+      "gitHead": "f4d0ea6ea9eee10914f9d70c5be4d0997043b9d3",
+      "description": "[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.0.2",
+      "_shasum": "32e29159fc12840fbc5bca84c3cf0d80c8f5ab58",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "32e29159fc12840fbc5bca84c3cf0d80c8f5ab58",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "ip",
+      "version": "1.1.0",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js",
+        "fix": "jscs lib/*.js test/*.js --fix"
+      },
+      "license": "MIT",
+      "gitHead": "52f4ad3102669633f4d5585ac9c3e4da4e8379c6",
+      "description": "[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.1.0",
+      "_shasum": "a893493e83af47000e2f553f1176194c6050240e",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "a893493e83af47000e2f553f1176194c6050240e",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "ip",
+      "version": "1.1.1",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js",
+        "fix": "jscs lib/*.js test/*.js --fix"
+      },
+      "license": "MIT",
+      "gitHead": "580938b8ae94f689eb15b274ff11f57e2d84bff5",
+      "description": "[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.1.1",
+      "_shasum": "239171b6f353f9409827bcf9315e732d930e4199",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "239171b6f353f9409827bcf9315e732d930e4199",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ip-1.1.1.tgz_1456929054086_0.15509966993704438"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "ip",
+      "version": "1.1.2",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js",
+        "fix": "jscs lib/*.js test/*.js --fix"
+      },
+      "license": "MIT",
+      "gitHead": "ed9b6cada5ae340229dbd428401a7caaa7082f73",
+      "description": "[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.1.2",
+      "_shasum": "a05ba664479611d0229fd21d2572fec4505f778e",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a05ba664479611d0229fd21d2572fec4505f778e",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/ip-1.1.2.tgz_1457119789796_0.21723865694366395"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "ip",
+      "version": "1.1.3",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js",
+        "fix": "jscs lib/*.js test/*.js --fix"
+      },
+      "license": "MIT",
+      "gitHead": "7831a9fa1aa42b40b5693e643040e68d2b0c0813",
+      "description": "[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.1.3",
+      "_shasum": "12b16294a38925486d618a1103506e4eb4f8b296",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "12b16294a38925486d618a1103506e4eb4f8b296",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "bcbailey",
+          "email": "brad@memoryleak.org"
+        },
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ip-1.1.3.tgz_1462574789664_0.8987950989976525"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "ip",
+      "version": "1.1.4",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js",
+        "fix": "jscs lib/*.js test/*.js --fix"
+      },
+      "license": "MIT",
+      "gitHead": "d413771ed7497ce61ddc5071a44549e2804482bf",
+      "description": "[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.1.4",
+      "_shasum": "de8247ffef940451832550fba284945e6e039bfb",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "de8247ffef940451832550fba284945e6e039bfb",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "bcbailey",
+          "email": "brad@memoryleak.org"
+        },
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ip-1.1.4.tgz_1477939130667_0.25871887686662376"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "ip",
+      "version": "1.1.5",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "homepage": "https://github.com/indutny/node-ip",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/node-ip.git"
+      },
+      "main": "lib/ip",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter spec test/*-test.js",
+        "fix": "jscs lib/*.js test/*.js --fix"
+      },
+      "license": "MIT",
+      "gitHead": "43e442366bf5a93493c8c4c36736f87d675b0c3d",
+      "description": "[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)",
+      "bugs": {
+        "url": "https://github.com/indutny/node-ip/issues"
+      },
+      "_id": "ip@1.1.5",
+      "_shasum": "bdded70114290828c0a039e72ef25f5aaec4354a",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "bdded70114290828c0a039e72ef25f5aaec4354a",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "bcbailey",
+          "email": "brad@memoryleak.org"
+        },
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "mmalecki",
+          "email": "me@mmalecki.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ip-1.1.5.tgz_1488591504778_0.018333946587517858"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# IP  \n[![](https://badge.fury.io/js/ip.svg)](https://www.npmjs.com/package/ip)  \n\nIP address utilities for node.js\n\n## Installation\n\n###  npm\n```shell\nnpm install ip\n```\n\n### git\n\n```shell\ngit clone https://github.com/indutny/node-ip.git\n```\n  \n## Usage\nGet your ip address, compare ip addresses, validate ip addresses, etc.\n\n```js\nvar ip = require('ip');\n\nip.address() // my ip address\nip.isEqual('::1', '::0:1'); // true\nip.toBuffer('127.0.0.1') // Buffer([127, 0, 0, 1])\nip.toString(new Buffer([127, 0, 0, 1])) // 127.0.0.1\nip.fromPrefixLen(24) // 255.255.255.0\nip.mask('192.168.1.134', '255.255.255.0') // 192.168.1.0\nip.cidr('192.168.1.134/26') // 192.168.1.128\nip.not('255.255.255.0') // 0.0.0.255\nip.or('192.168.1.134', '0.0.0.255') // 192.168.1.255\nip.isPrivate('127.0.0.1') // true\nip.isV4Format('127.0.0.1'); // true\nip.isV6Format('::ffff:127.0.0.1'); // true\n\n// operate on buffers in-place\nvar buf = new Buffer(128);\nvar offset = 64;\nip.toBuffer('127.0.0.1', buf, offset);  // [127, 0, 0, 1] at offset 64\nip.toString(buf, offset, 4);            // '127.0.0.1'\n\n// subnet information\nip.subnet('192.168.1.134', '255.255.255.192')\n// { networkAddress: '192.168.1.128',\n//   firstAddress: '192.168.1.129',\n//   lastAddress: '192.168.1.190',\n//   broadcastAddress: '192.168.1.191',\n//   subnetMask: '255.255.255.192',\n//   subnetMaskLength: 26,\n//   numHosts: 62,\n//   length: 64,\n//   contains: function(addr){...} }\nip.cidrSubnet('192.168.1.134/26')\n// Same as previous.\n\n// range checking\nip.cidrSubnet('192.168.1.134/26').contains('192.168.1.190') // true\n\n\n// ipv4 long conversion\nip.toLong('127.0.0.1'); // 2130706433\nip.fromLong(2130706433); // '127.0.0.1'\n```\n\n### License\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2012.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "email": "brad@memoryleak.org",
+      "name": "bcbailey"
+    },
+    {
+      "email": "charlie.robbins@gmail.com",
+      "name": "indexzero"
+    },
+    {
+      "email": "me@mmalecki.com",
+      "name": "mmalecki"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "fedor.indutny@gmail.com",
+      "name": "fedor.indutny"
+    }
+  ],
+  "time": {
+    "modified": "2017-12-28T04:23:37.614Z",
+    "created": "2012-08-15T09:10:02.609Z",
+    "0.0.1": "2012-08-15T09:10:05.826Z",
+    "0.0.2": "2013-02-03T12:27:06.756Z",
+    "0.0.3": "2013-02-09T10:50:57.996Z",
+    "0.0.4": "2013-02-11T09:21:41.721Z",
+    "0.0.5": "2013-02-20T11:15:10.430Z",
+    "0.1.0": "2013-05-29T09:37:54.181Z",
+    "0.2.0": "2014-01-18T23:06:09.577Z",
+    "0.3.0": "2014-02-02T20:08:33.857Z",
+    "0.3.1": "2014-07-31T18:50:03.280Z",
+    "0.3.2": "2014-09-23T10:15:34.483Z",
+    "0.3.3": "2015-06-01T16:28:09.267Z",
+    "1.0.0": "2015-09-05T03:22:57.210Z",
+    "1.0.1": "2015-09-10T01:42:39.890Z",
+    "1.0.2": "2015-10-29T01:44:50.765Z",
+    "1.1.0": "2015-11-18T16:27:55.161Z",
+    "1.1.1": "2016-03-02T14:30:56.459Z",
+    "1.1.2": "2016-03-04T19:29:51.260Z",
+    "1.1.3": "2016-05-06T22:46:30.140Z",
+    "1.1.4": "2016-10-31T18:38:52.764Z",
+    "1.1.5": "2017-03-04T01:38:26.801Z"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/node-ip.git"
+  },
+  "users": {
+    "hij1nx": true,
+    "humantriangle": true,
+    "liveinjs": true,
+    "gammasoft": true,
+    "t1st3": true,
+    "amrav": true,
+    "kewin": true,
+    "robksawyer": true,
+    "chengen": true,
+    "sametsisartenep": true,
+    "tinyhill": true,
+    "itonyyo": true,
+    "dac2205": true,
+    "jerrywu": true,
+    "onheiron": true,
+    "mikepol": true,
+    "zedyu": true,
+    "joaocunha": true,
+    "kolomiichenko": true,
+    "evanyeung": true,
+    "jensnilsson": true,
+    "jasonwang1888": true,
+    "ahme-t": true,
+    "wkaifang": true,
+    "thotk": true,
+    "yoking": true,
+    "ghostcode521": true,
+    "psychollama": true,
+    "antixrist": true,
+    "vdeturckheim": true,
+    "shanewholloway": true,
+    "wangnan0610": true,
+    "maintao": true,
+    "programmer.severson": true,
+    "guzgarcia": true,
+    "svstanev": true,
+    "xiaochao": true,
+    "princetoad": true,
+    "comandan": true,
+    "monjer": true,
+    "sopepos": true,
+    "jeremyscalpello": true,
+    "chirag_purohit71085": true,
+    "chhetrisushil": true,
+    "luckyluke": true,
+    "xuu": true,
+    "tpkn": true,
+    "adrtho4": true,
+    "zuojiang": true,
+    "bluelovers": true,
+    "felipebergamin": true,
+    "yinfxs": true,
+    "thouky": true,
+    "ganeshkbhat": true
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/indutny/node-ip",
+  "bugs": {
+    "url": "https://github.com/indutny/node-ip/issues"
+  },
+  "license": "MIT",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/ip.min.json
+++ b/test/fixtures/registry-mocks/content/ip.min.json
@@ -1,0 +1,248 @@
+{
+  "name": "ip",
+  "dist-tags": {
+    "latest": "1.1.5",
+    "stable": "0.1.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "ip",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "bbc68d7cc448560a63fbe99237a01bc50fdca7ec",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "ip",
+      "version": "0.0.2",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "d91c53d43030073e4b9fe3775c19d6e883b73ff7",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "ip",
+      "version": "0.0.3",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "96cf8bbaf9e814c97f98c33946d5c4cf77a1d08d",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "ip",
+      "version": "0.0.4",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "1f4f02ea217bb01275817f30aef5b050b96412bb",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.4.tgz"
+      }
+    },
+    "0.0.5": {
+      "name": "ip",
+      "version": "0.0.5",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "0b405f761a565e2af045cba09854e484dca97706",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.0.5.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "ip",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "bf7fccc1608097ecf8e873152ca011234bd99a40",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "ip",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "41bbf4e945613464c9672034347583811375a88b",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "ip",
+      "version": "0.3.0",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "7a469fffa4e26e56d61b91056a40bf9dbdcd8a8b",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "ip",
+      "version": "0.3.1",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "d0871c6ee08449b081bb277fdd6c8ff5e6fc845b",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.3.1.tgz"
+      }
+    },
+    "0.3.2": {
+      "name": "ip",
+      "version": "0.3.2",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "7d5ed34326688b36b6ab81f1865ea8266c28f0db",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.3.2.tgz"
+      }
+    },
+    "0.3.3": {
+      "name": "ip",
+      "version": "0.3.3",
+      "devDependencies": {
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "8ee8309e92f0b040d287f72efaca1a21702d3fb4",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "ip",
+      "version": "1.0.0",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "fc627aca013cfe00921743cf0a291563f4a3c90a",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "ip",
+      "version": "1.0.1",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "c7e356cdea225ae71b36d70f2e71a92ba4e42590",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "ip",
+      "version": "1.0.2",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "32e29159fc12840fbc5bca84c3cf0d80c8f5ab58",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "ip",
+      "version": "1.1.0",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "a893493e83af47000e2f553f1176194c6050240e",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "ip",
+      "version": "1.1.1",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "239171b6f353f9409827bcf9315e732d930e4199",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "ip",
+      "version": "1.1.2",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "a05ba664479611d0229fd21d2572fec4505f778e",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "ip",
+      "version": "1.1.3",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "12b16294a38925486d618a1103506e4eb4f8b296",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.3.tgz"
+      }
+    },
+    "1.1.4": {
+      "name": "ip",
+      "version": "1.1.4",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "de8247ffef940451832550fba284945e6e039bfb",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.4.tgz"
+      }
+    },
+    "1.1.5": {
+      "name": "ip",
+      "version": "1.1.5",
+      "devDependencies": {
+        "jscs": "^2.1.1",
+        "jshint": "^2.8.0",
+        "mocha": "~1.3.2"
+      },
+      "dist": {
+        "shasum": "bdded70114290828c0a039e72ef25f5aaec4354a",
+        "tarball": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz"
+      }
+    }
+  },
+  "modified": "2017-12-28T04:23:37.614Z"
+}

--- a/test/fixtures/registry-mocks/content/ipaddr.js.json
+++ b/test/fixtures/registry-mocks/content/ipaddr.js.json
@@ -1,0 +1,2012 @@
+{
+  "_id": "ipaddr.js",
+  "_rev": "64-fb78dfd3f91fdf94e06a9c882bd83ffe",
+  "name": "ipaddr.js",
+  "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {
+        "coffee-script": ">= 1.1.1"
+      },
+      "devDependencies": {
+        "nodeunit": "0.5.3",
+        "uglify-js": "latest"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "_npmJsonOpts": {
+        "file": "/home/whitequark/.npm/ipaddr.js/0.1.0/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "ipaddr.js@0.1.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.22",
+      "_nodeVersion": "v0.4.9",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "d67fc6dcc153b15a8ed475a44158f854728b037e",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.0.tgz"
+      },
+      "scripts": {}
+    },
+    "0.1.1": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.1",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {
+        "coffee-script": ">= 1.1.1"
+      },
+      "devDependencies": {
+        "nodeunit": "0.5.3",
+        "uglify-js": "latest"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "_npmJsonOpts": {
+        "file": "/home/whitequark/.npm/ipaddr.js/0.1.1/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "ipaddr.js@0.1.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.22",
+      "_nodeVersion": "v0.4.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "28c6a7c116a021c555544f906ab1ad540b1d635a",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.1.tgz"
+      },
+      "scripts": {}
+    },
+    "0.1.2": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.2",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@0.1.2",
+      "dist": {
+        "shasum": "6a1fd3d854f5002965c34d7bbcd9b4a8d4b0467e",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.10",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ]
+    },
+    "0.1.3": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.3",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@0.1.3",
+      "dist": {
+        "shasum": "27a9ca37f148d2102b0ef191ccbf2c51a8f025c6",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ]
+    },
+    "0.1.4": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.4",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "gitHead": "9119cbbda8189888e326e003560694f77692c624",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@0.1.4",
+      "_shasum": "67b1956263daa9725b507700603b401013d2158c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "67b1956263daa9725b507700603b401013d2158c",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.5",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "gitHead": "5914ebd176f5333977f68ce372cc247f13de2a35",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@0.1.5",
+      "_shasum": "33d2693c95fbd4715165328dbfe25fb4fb5bbed8",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "33d2693c95fbd4715165328dbfe25fb4fb5bbed8",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.5.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.6",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "license": "MIT",
+      "gitHead": "87595aade23e18114b05efa09e1d46ea2ef20c12",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@0.1.6",
+      "_shasum": "8f0530b217993873025fd4b72bdfd69bc56a9a12",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "8f0530b217993873025fd4b72bdfd69bc56a9a12",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.6.tgz"
+      }
+    },
+    "0.1.7": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.7",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "license": "MIT",
+      "gitHead": "5c3e47429c1497d47caeb81e76c99d82da87d4cf",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@0.1.7",
+      "_shasum": "c08aaab60273d6c041e58f0dd2dafad3d43ea40f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "c08aaab60273d6c041e58f0dd2dafad3d43ea40f",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.7.tgz"
+      }
+    },
+    "0.1.8": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.8",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "license": "MIT",
+      "gitHead": "3099dba20984caa73a83864ee582548413a425d8",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@0.1.8",
+      "_shasum": "27442eda77b626c44724b4aa8a1867e8410579ee",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "27442eda77b626c44724b4aa8a1867e8410579ee",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.8.tgz"
+      }
+    },
+    "0.1.9": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "0.1.9",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "license": "MIT",
+      "gitHead": "d51df7aa41ef1875215ae4ffbd324c486f8c2799",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@0.1.9",
+      "_shasum": "a9c78ccc12dc9010f296ab9aef2f61f432d69efa",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "a9c78ccc12dc9010f296ab9aef2f61f432d69efa",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "license": "MIT",
+      "gitHead": "f8ee5ce11cd4f1f940903671808505dfe02ce90a",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@1.0.0",
+      "_shasum": "dc6723c4f83913106a6702113a2034696ec03469",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "dc6723c4f83913106a6702113a2034696ec03469",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.0.1",
+      "author": {
+        "name": "Peter Zotov",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "license": "MIT",
+      "gitHead": "0a5a26d9317a58d67047e7f32b5b1bbe7f2f7fbf",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@1.0.1",
+      "_shasum": "5f38801dc73e0400fc7076386f6ed5215fbd8f95",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "5f38801dc73e0400fc7076386f6ed5215fbd8f95",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.1.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.0.3",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.2.5"
+      },
+      "license": "MIT",
+      "gitHead": "bf26b1f5d00cf8526a54f79db994eea3e8526e10",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@1.0.3",
+      "_shasum": "2a9df7be73ea92aadb0d7f377497decd8e6d01bb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "2a9df7be73ea92aadb0d7f377497decd8e6d01bb",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.0.4",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "9885a29dfaab9519e3ec46f99c0bc0b81660a0d9",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@1.0.4",
+      "_shasum": "ef715deab1e923fc1fe8fe9ce7a561d9110e52e2",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "ef715deab1e923fc1fe8fe9ce7a561d9110e52e2",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.0.5",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "46438c8bfa187505b7007a277f09a4a9e73d5686",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@1.0.5",
+      "_shasum": "5fa78cf301b825c78abc3042d812723049ea23c7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "5fa78cf301b825c78abc3042d812723049ea23c7",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.1.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "9afdebb46eaeac3bee4e98c6a5cd731b210cdee8",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@1.1.0",
+      "_shasum": "5fd380584eb3e2d55904dbe3047a2627d4199a14",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "5fd380584eb3e2d55904dbe3047a2627d4199a14",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.1.1",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "dbc7d98bc0d8fff68a894be0c60721566807e2fc",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@1.1.1",
+      "_shasum": "c791d95f52b29c1247d5df80ada39b8a73647230",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "c791d95f52b29c1247d5df80ada39b8a73647230",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ipaddr.js-1.1.1.tgz_1464074293475_0.6683731523808092"
+      }
+    },
+    "1.2.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.2.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "87bcb487f1a6739101231e71b111da2823540398",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "_id": "ipaddr.js@1.2.0",
+      "_shasum": "8aba49c9192799585bdd643e0ccb50e8ae777ba4",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "8aba49c9192799585bdd643e0ccb50e8ae777ba4",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ipaddr.js-1.2.0.tgz_1467971539814_0.6815996605437249"
+      }
+    },
+    "1.3.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.3.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "9c557556e495a2c60a3c656e4f9f8b3a1e14dedc",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.3.0",
+      "_shasum": "1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ipaddr.js-1.3.0.tgz_1489544932893_0.961968986550346"
+      }
+    },
+    "1.4.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.4.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "e0f2a074f47c51941cbfd26cf38a327f847e6286",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.4.0",
+      "_shasum": "296aca878a821816e5b85d0a285a99bcff4582f0",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "296aca878a821816e5b85d0a285a99bcff4582f0",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js-1.4.0.tgz_1498164481108_0.6096577865537256"
+      }
+    },
+    "1.5.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.5.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "a54ecebfee155b54a8f9c1296ea5b6110cdc0d9b",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.5.0",
+      "_shasum": "48a04be500e66e6922a9e2aa3f54926eaeb96473",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "48a04be500e66e6922a9e2aa3f54926eaeb96473",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js-1.5.0.tgz_1503324740920_0.6814808119088411"
+      }
+    },
+    "1.5.1": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.5.1",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "d677623f75bd4c23361ed661d6f8977f572ec18b",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.5.1",
+      "_shasum": "ddafccea41e6f23f7f3ffe65e22d0d8cff6835b3",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "ddafccea41e6f23f7f3ffe65e22d0d8cff6835b3",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js-1.5.1.tgz_1503434118374_0.09781592315994203"
+      }
+    },
+    "1.5.2": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.5.2",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "8f6e21058792cf6e38c6f461219fb25f0caecf27",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.5.2",
+      "_shasum": "d4b505bde9946987ccf0fc58d9010ff9607e3fa0",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "d4b505bde9946987ccf0fc58d9010ff9607e3fa0",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js-1.5.2.tgz_1503546462209_0.10381372715346515"
+      }
+    },
+    "1.5.3": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.5.3",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "4be129b1b6e423fbfd236336003582d8a3cfac7d",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.5.3",
+      "_shasum": "ec68539dd70ff0990c3195ab7ec43124a83df589",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "ec68539dd70ff0990c3195ab7ec43124a83df589",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js-1.5.3.tgz_1507823089269_0.021649141097441316"
+      }
+    },
+    "1.5.4": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.5.4",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "gitHead": "d384881bd33cefda9c56eda74bc122350a31bd6a",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.5.4",
+      "_shasum": "962263d9d26132956fc5c630b638a30d3cdffc14",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "962263d9d26132956fc5c630b638a30d3cdffc14",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js-1.5.4.tgz_1508225226077_0.20283467858098447"
+      }
+    },
+    "1.6.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.6.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "types": "./lib/ipaddr.js.d.ts",
+      "gitHead": "c81198c2540a1df41571623c0bcbdb9d9b73a925",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.6.0",
+      "_shasum": "e3fa357b773da619f26e95f049d055c72796f86b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "e3fa357b773da619f26e95f049d055c72796f86b",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js-1.6.0.tgz_1517895655914_0.4097069769632071"
+      }
+    },
+    "1.7.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.7.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "files": [
+        "lib/",
+        "ipaddr.min.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "types": "./lib/ipaddr.js.d.ts",
+      "gitHead": "c645e0b0ac8646e2bc3f086399bb5c675d504dd8",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.7.0",
+      "_shasum": "2206ed334afc32e01fed3ee838b6b2521068b9d2",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "2206ed334afc32e01fed3ee838b6b2521068b9d2",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.7.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 38772
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js_1.7.0_1523355133770_0.22257876250113773"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.8.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.8.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "files": [
+        "lib/",
+        "ipaddr.min.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "types": "./lib/ipaddr.js.d.ts",
+      "gitHead": "d7f0a9bfea2888ea8b309b97d0eed1709e8c6ead",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.8.0",
+      "_shasum": "eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 39303
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js_1.8.0_1531193295710_0.6229373074337963"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.8.1": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.8.1",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "files": [
+        "lib/",
+        "ipaddr.min.js"
+      ],
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "types": "./lib/ipaddr.js.d.ts",
+      "gitHead": "0f676ef505ae314f62925c1de3640e6d45b2e8c4",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.8.1",
+      "_shasum": "fa4b79fa47fd3def5e3b159825161c0a519c9427",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "shasum": "fa4b79fa47fd3def5e3b159825161c0a519c9427",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 39327
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js_1.8.1_1533051081044_0.9626124293508547"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.9.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.9.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "types": "./lib/ipaddr.js.d.ts",
+      "gitHead": "8bd045f49f5b7695eea2c93e9706f4350e0bbaba",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.9.0",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "10.15.0",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+        "shasum": "37df74e430a0e47550fe54a2defe30d8acd95f65",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 42064,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcX9f6CRA9TVsSAnZWagAACN0P/3QaY26R9gIEKJMFRl3f\nComsl89/ZqAisw026wGodTWmYirIR5IbjDNxWETrCHXdriBCrSsDZ1SzzdGk\nTxkjv5/bQjv4CpPZV5/d91q6vkpFjPbVOk/N+K0fOJkmO9Fp4lwUQq4/B0gi\nEj+lPr1a5j5ZQwpMNB1pZrtoy3Fo/y0d5sYTNEQAlAQfjcJI4mFtc92tkc9s\nnzanygidCfoWEctnJIy9/lUjCxY2Irt8tMBa7cVExOLOqn6KegnJOtC+4g19\nCSjmv+lUj/r9QdT1kTbnej+118OQDjaZmjJ18/mxKdVXsYq6RLxKalWiez6E\nWKzCrMBSfwjDcErkaWr8tLn8b5zwwS5oLYG2pbzwDxA92P81LYeu+3wcmxa1\nPpvKkxBHLkUK1+19Xg0t5IP//B/C6ZCS5q+zckr+97U7SitK7aUajtRc3SYu\notiV+5t1Lgl+WLiymOq3WnBXMJwzXsq7nYBJgUlkoj0IE4Du5DFKao0UNvE2\nSBZTM8MJGm2rsm9xGKqWx9rBqWDudpnGipJIOV6l807BRn0yBrQjbx2jhV48\nK8UrwyOwYE1dwEYzhuviczDvE5o6qriTiFyYfA4DW0w1h3X3VDGWoI81g4dh\nGzP3V8SjsKV8g80HkrU8rboh1UKUIMjhINunU6PBD6YR+2fUqos3YlMxbprM\nOThn\r\n=Tk1a\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js_1.9.0_1549785081591_0.5220196467104794"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.9.1": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "1.9.1",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "nodeunit": "^0.11.3",
+        "uglify-js": "~3.0.19"
+      },
+      "scripts": {
+        "test": "cake build test"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "license": "MIT",
+      "types": "./lib/ipaddr.js.d.ts",
+      "gitHead": "760416b27a4b348e7a39fdacfccd6cb047026c98",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@1.9.1",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "10.15.2",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+        "shasum": "bff38543eeb8984825079ff3a2a8e6cbd46781b3",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 42145,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdLofECRA9TVsSAnZWagAAuqsQAIOiqKtRllNg8pMg89ea\nLFtGW49UBn0+nYUg9CSQM/h8nOYi+NH6Puw5dpDasTWt2tRmPtzqx/1vxaFk\nPmg73w49mtBPAxu2YLngv8tSx4dNvsClTe5RpLvpZFmopIRQojKUl0VSj3RW\nMtbkj/KozwgiYzguvHwGhjIhjerutQ1zoH0kJCZCRvVeLJrkdyj/PPzvLyF2\n3MZ7peqpGXg4k92ljrN7Q49itLIdYtrcm3tv2659e2W80E63RJUw0Buw9IGl\nYGX/1EfpBKW2l3QADjgW9Lz7/3oWt7NEDWNGGw+kMsivfAFAIKDiZ93v5H1M\ntaH+cLv3rHJ1s3cgz8gdlp3VGunG/OfP179e9J19AvcsLKhJ/Kho+fz0OD7d\nAEg+wMFlRLP5QR+x9X4naIN44VgjMZkTWZq8blx5hvJVCqSPtnYuORfYJstu\npQx9lSmmZl2Ma2LRjtpXUnbgtUOXIYpvPhn2+OV7NN/RbrigOPFHEHYw9YDQ\ndvChMV7RSmvRvDS+9YDqB+71/pcJljeztfGkznErW6xqc1DtdKg6WCw6k58H\nUTGjiMj+vytXJ3g9YnN5OlTmRAZCDj1XaHWPpGybfnm5j8MPetary6Dobian\nSbAaS1eqlMEhPd1G5t1RsLOy1ePI80HsARHZDQhqUY2Kl0/vIgtnWsx3KPHc\nUDnk\r\n=j6kw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js_1.9.1_1563330499468_0.2217102903600776"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "ipaddr.js",
+      "description": "A library for manipulating IPv4 and IPv6 addresses in JavaScript.",
+      "version": "2.0.0",
+      "author": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "eslint": "*",
+        "mocha": "*",
+        "uglify-es": "*"
+      },
+      "scripts": {
+        "lint": "npx eslint lib test",
+        "lintfix": "npx eslint --fix lib test",
+        "build": "npx uglifyjs --compress --mangle --wrap=window -o ipaddr.min.js lib/ipaddr.js",
+        "test": "npx _mocha"
+      },
+      "keywords": [
+        "ip",
+        "ipv4",
+        "ipv6"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/whitequark/ipaddr.js.git"
+      },
+      "main": "./lib/ipaddr.js",
+      "engines": {
+        "node": ">= 10"
+      },
+      "license": "MIT",
+      "types": "./lib/ipaddr.js.d.ts",
+      "gitHead": "88f9dde64ec4e2314063446492416fd6206f6e4d",
+      "bugs": {
+        "url": "https://github.com/whitequark/ipaddr.js/issues"
+      },
+      "homepage": "https://github.com/whitequark/ipaddr.js#readme",
+      "_id": "ipaddr.js@2.0.0",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "10.21.0",
+      "_npmUser": {
+        "name": "whitequark",
+        "email": "whitequark@whitequark.org"
+      },
+      "maintainers": [
+        {
+          "name": "whitequark",
+          "email": "whitequark@whitequark.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w==",
+        "shasum": "77ccccc8063ae71ab65c55f21b090698e763fc6e",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 55486,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfOgyZCRA9TVsSAnZWagAAxOgP/22JhlisEc6AQ9F4Gytx\n4Sfp2tThv2/zBGNqSQKBnLjBetQerCSCYPT2vli7zgwBs6hcSpLwteQI0VNY\ndTOaChwT6HMATCb4btBfuuZyt+9QLJzdxHwiNR+NtHkpnYJSgcZXNMLW5mMB\n5G6+tJGMit9mr232qEuwPOms2JdtmzWeZVzFu04FF6z6sMDbt/brcL4BhdAZ\n3S39W8dmWz3ETBFYb7gzuLwmAxSAqokpCwYpvZSQOPz9n0cLMuubSqxjxcbL\njukZemfirJv+R6eiQsbFxfkH9TAAswiIfSjIk6Anm1YmaD3FWriLlUhqpIvD\nIzJCXkA6HsEmshXZc44CvfU+HfCtOzZTkEpDcw7hyGZq8MczY81MzJsBXY0l\n+B5WsxVjzTHVzOm8F3RB3xaK+oBGoxmBEX6kCwnlsT6lRkAfLU+KHXB+aMcM\nuci9wwznxTKO/VTzI/TQ4PFDKLtNcFaah3/H5D7PgvvZD5L1yYx9mzwBrgQA\n7336LHkQs2r/KUdhXyhsjjJz0s4zMRiCsiqFbwzxp5OaMNPKEAg47UN0+Gc5\n0FMHP46qldHOP9/O3rs4q9qmF2OpNpbOSxXqE5gh/HAm1Vql3+EyEsguq5Og\nxJyGy5twGCTugwubqc82CYZ5446/zDxiadnx4QaxVb0hKEydGT15k9soxrfh\nlMSW\r\n=xaXW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ipaddr.js_2.0.0_1597639833538_0.966759294124411"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "name": "whitequark",
+      "email": "whitequark@whitequark.org"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-17T04:50:35.855Z",
+    "created": "2011-07-28T15:57:38.697Z",
+    "0.1.0": "2011-07-28T15:57:40.643Z",
+    "0.1.1": "2011-07-30T16:00:04.710Z",
+    "0.1.2": "2013-12-06T22:00:21.923Z",
+    "0.1.3": "2014-07-09T08:26:58.804Z",
+    "0.1.4": "2014-11-18T22:00:30.596Z",
+    "0.1.5": "2014-11-19T21:57:24.625Z",
+    "0.1.6": "2014-11-26T16:34:44.619Z",
+    "0.1.7": "2015-01-29T03:39:54.325Z",
+    "0.1.8": "2015-01-29T23:40:08.892Z",
+    "0.1.9": "2015-03-11T10:41:42.690Z",
+    "1.0.0": "2015-04-07T21:16:34.839Z",
+    "1.0.1": "2015-04-08T17:00:18.304Z",
+    "1.0.3": "2015-08-27T06:31:09.446Z",
+    "1.0.4": "2015-11-07T05:46:23.340Z",
+    "1.0.5": "2015-12-09T14:36:42.259Z",
+    "1.1.0": "2016-01-29T22:33:58.126Z",
+    "1.1.1": "2016-05-24T07:18:13.893Z",
+    "1.2.0": "2016-07-08T09:52:20.241Z",
+    "1.3.0": "2017-03-15T02:28:53.138Z",
+    "1.4.0": "2017-06-22T20:48:02.394Z",
+    "1.5.0": "2017-08-21T14:12:21.041Z",
+    "1.5.1": "2017-08-22T20:35:18.455Z",
+    "1.5.2": "2017-08-24T03:47:42.297Z",
+    "1.5.3": "2017-10-12T15:44:50.448Z",
+    "1.5.4": "2017-10-17T07:27:07.211Z",
+    "1.6.0": "2018-02-06T05:40:56.969Z",
+    "1.7.0": "2018-04-10T10:12:13.872Z",
+    "1.8.0": "2018-07-10T03:28:15.831Z",
+    "1.8.1": "2018-07-31T15:31:21.138Z",
+    "1.9.0": "2019-02-10T07:51:21.736Z",
+    "1.9.1": "2019-07-17T02:28:19.618Z",
+    "2.0.0": "2020-08-17T04:50:33.629Z"
+  },
+  "author": {
+    "name": "whitequark",
+    "email": "whitequark@whitequark.org"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/whitequark/ipaddr.js.git"
+  },
+  "readme": "# ipaddr.js — an IPv6 and IPv4 address manipulation library [![Build Status](https://travis-ci.org/whitequark/ipaddr.js.svg)](https://travis-ci.org/whitequark/ipaddr.js)\n\nipaddr.js is a small (1.9K minified and gzipped) library for manipulating\nIP addresses in JavaScript environments. It runs on both CommonJS runtimes\n(e.g. [nodejs]) and in a web browser.\n\nipaddr.js allows you to verify and parse string representation of an IP\naddress, match it against a CIDR range or range list, determine if it falls\ninto some reserved ranges (examples include loopback and private ranges),\nand convert between IPv4 and IPv4-mapped IPv6 addresses.\n\n[nodejs]: http://nodejs.org\n\n## Installation\n\n`npm install ipaddr.js`\n\nor\n\n`bower install ipaddr.js`\n\n## Older Node support\n\nUse 2.x release for nodejs versions 10+.\nUse the 1.x release for versions of nodejs older than 10.\n\n## API\n\nipaddr.js defines one object in the global scope: `ipaddr`. In CommonJS,\nit is exported from the module:\n\n```js\nconst ipaddr = require('ipaddr.js');\n```\n\nThe API consists of several global methods and two classes: ipaddr.IPv6 and ipaddr.IPv4.\n\n### Global methods\n\nThere are three global methods defined: `ipaddr.isValid`, `ipaddr.parse` and\n`ipaddr.process`. All of them receive a string as a single parameter.\n\nThe `ipaddr.isValid` method returns `true` if the address is a valid IPv4 or\nIPv6 address, and `false` otherwise. It does not throw any exceptions.\n\nThe `ipaddr.parse` method returns an object representing the IP address,\nor throws an `Error` if the passed string is not a valid representation of an\nIP address.\n\nThe `ipaddr.process` method works just like the `ipaddr.parse` one, but it\nautomatically converts IPv4-mapped IPv6 addresses to their IPv4 counterparts\nbefore returning. It is useful when you have a Node.js instance listening\non an IPv6 socket, and the `net.ivp6.bindv6only` sysctl parameter (or its\nequivalent on non-Linux OS) is set to 0. In this case, you can accept IPv4\nconnections on your IPv6-only socket, but the remote address will be mangled.\nUse `ipaddr.process` method to automatically demangle it.\n\n### Object representation\n\nParsing methods return an object which descends from `ipaddr.IPv6` or\n`ipaddr.IPv4`. These objects share some properties, but most of them differ.\n\n#### Shared properties\n\nOne can determine the type of address by calling `addr.kind()`. It will return\neither `\"ipv6\"` or `\"ipv4\"`.\n\nAn address can be converted back to its string representation with `addr.toString()`.\nNote that this method:\n * does not return the original string used to create the object (in fact, there is\n   no way of getting that string)\n * returns a compact representation (when it is applicable)\n\nA `match(range, bits)` method can be used to check if the address falls into a\ncertain CIDR range. Note that an address can be (obviously) matched only against an address of the same type.\n\nFor example:\n\n```js\nconst addr  = ipaddr.parse('2001:db8:1234::1');\nconst range = ipaddr.parse('2001:db8::');\n\naddr.match(range, 32); // => true\n```\n\nAlternatively, `match` can also be called as `match([range, bits])`. In this way, it can be used together with the `parseCIDR(string)` method, which parses an IP address together with a CIDR range.\n\nFor example:\n\n```js\nconst addr = ipaddr.parse('2001:db8:1234::1');\n\naddr.match(ipaddr.parseCIDR('2001:db8::/32')); // => true\n```\n\nA `range()` method returns one of predefined names for several special ranges defined by IP protocols. The exact names (and their respective CIDR ranges) can be looked up in the source: [IPv6 ranges] and [IPv4 ranges]. Some common ones include `\"unicast\"` (the default one) and `\"reserved\"`.\n\nYou can match against your own range list by using\n`ipaddr.subnetMatch(address, rangeList, defaultName)` method. It can work with a mix of IPv6 or IPv4 addresses, and accepts a name-to-subnet map as the range list. For example:\n\n```js\nconst rangeList = {\n  documentationOnly: [ ipaddr.parse('2001:db8::'), 32 ],\n  tunnelProviders: [\n    [ ipaddr.parse('2001:470::'), 32 ], // he.net\n    [ ipaddr.parse('2001:5c0::'), 32 ]  // freenet6\n  ]\n};\nipaddr.subnetMatch(ipaddr.parse('2001:470:8:66::1'), rangeList, 'unknown'); // => \"tunnelProviders\"\n```\n\nThe addresses can be converted to their byte representation with `toByteArray()`. (Actually, JavaScript mostly does not know about byte buffers. They are emulated with arrays of numbers, each in range of 0..255.)\n\n```js\nconst bytes = ipaddr.parse('2a00:1450:8007::68').toByteArray(); // ipv6.google.com\nbytes // => [42, 0x00, 0x14, 0x50, 0x80, 0x07, 0x00, <zeroes...>, 0x00, 0x68 ]\n```\n\nThe `ipaddr.IPv4` and `ipaddr.IPv6` objects have some methods defined, too. All of them have the same interface for both protocols, and are similar to global methods.\n\n`ipaddr.IPvX.isValid(string)` can be used to check if the string is a valid address for particular protocol, and `ipaddr.IPvX.parse(string)` is the error-throwing parser.\n\n`ipaddr.IPvX.isValid(string)` uses the same format for parsing as the POSIX `inet_ntoa` function, which accepts unusual formats like `0xc0.168.1.1` or `0x10000000`. The function `ipaddr.IPv4.isValidFourPartDecimal(string)` validates the IPv4 address and also ensures that it is written in four-part decimal format.\n\n[IPv6 ranges]: https://github.com/whitequark/ipaddr.js/blob/master/src/ipaddr.coffee#L186\n[IPv4 ranges]: https://github.com/whitequark/ipaddr.js/blob/master/src/ipaddr.coffee#L71\n\n#### IPv6 properties\n\nSometimes you will want to convert IPv6 not to a compact string representation (with the `::` substitution); the `toNormalizedString()` method will return an address where all zeroes are explicit.\n\nFor example:\n\n```js\nconst addr = ipaddr.parse('2001:0db8::0001');\naddr.toString(); // => '2001:db8::1'\naddr.toNormalizedString(); // => '2001:db8:0:0:0:0:0:1'\n```\n\nThe `isIPv4MappedAddress()` method will return `true` if this address is an IPv4-mapped\none, and `toIPv4Address()` will return an IPv4 object address.\n\nTo access the underlying binary representation of the address, use `addr.parts`.\n\n```js\nconst addr = ipaddr.parse('2001:db8:10::1234:DEAD');\naddr.parts // => [0x2001, 0xdb8, 0x10, 0, 0, 0, 0x1234, 0xdead]\n```\n\nA IPv6 zone index can be accessed via `addr.zoneId`:\n\n```js\nconst addr = ipaddr.parse('2001:db8::%eth0');\naddr.zoneId // => 'eth0'\n```\n\n#### IPv4 properties\n\n`toIPv4MappedAddress()` will return a corresponding IPv4-mapped IPv6 address.\n\nTo access the underlying representation of the address, use `addr.octets`.\n\n```js\nconst addr = ipaddr.parse('192.168.1.1');\naddr.octets // => [192, 168, 1, 1]\n```\n\n`prefixLengthFromSubnetMask()` will return a CIDR prefix length for a valid IPv4 netmask or\nnull if the netmask is not valid.\n\n```js\nipaddr.IPv4.parse('255.255.255.240').prefixLengthFromSubnetMask() == 28\nipaddr.IPv4.parse('255.192.164.0').prefixLengthFromSubnetMask()  == null\n```\n\n`subnetMaskFromPrefixLength()` will return an IPv4 netmask for a valid CIDR prefix length.\n\n```js\nipaddr.IPv4.subnetMaskFromPrefixLength(24) == '255.255.255.0'\nipaddr.IPv4.subnetMaskFromPrefixLength(29) == '255.255.255.248'\n```\n\n`broadcastAddressFromCIDR()` will return the broadcast address for a given IPv4 interface and netmask in CIDR notation.\n```js\nipaddr.IPv4.broadcastAddressFromCIDR('172.0.0.1/24') == '172.0.0.255'\n```\n`networkAddressFromCIDR()` will return the network address for a given IPv4 interface and netmask in CIDR notation.\n```js\nipaddr.IPv4.networkAddressFromCIDR('172.0.0.1/24') == '172.0.0.0'\n```\n\n#### Conversion\n\nIPv4 and IPv6 can be converted bidirectionally to and from network byte order (MSB) byte arrays.\n\nThe `fromByteArray()` method will take an array and create an appropriate IPv4 or IPv6 object\nif the input satisfies the requirements. For IPv4 it has to be an array of four 8-bit values,\nwhile for IPv6 it has to be an array of sixteen 8-bit values.\n\nFor example:\n```js\nconst addr = ipaddr.fromByteArray([0x7f, 0, 0, 1]);\naddr.toString(); // => '127.0.0.1'\n```\n\nor\n\n```js\nconst addr = ipaddr.fromByteArray([0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])\naddr.toString(); // => '2001:db8::1'\n```\n\nBoth objects also offer a `toByteArray()` method, which returns an array in network byte order (MSB).\n\nFor example:\n```js\nconst addr = ipaddr.parse('127.0.0.1');\naddr.toByteArray(); // => [0x7f, 0, 0, 1]\n```\n\nor\n\n```js\nconst addr = ipaddr.parse('2001:db8::1');\naddr.toByteArray(); // => [0x20, 1, 0xd, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]\n```\n",
+  "keywords": [
+    "ip",
+    "ipv4",
+    "ipv6"
+  ],
+  "bugs": {
+    "url": "https://github.com/whitequark/ipaddr.js/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "users": {
+    "msmiley": true,
+    "qlqllu": true,
+    "subchen": true,
+    "bacra": true,
+    "mojaray2k": true,
+    "dmdnkv": true,
+    "skellertor": true,
+    "michaelermer": true,
+    "omar84": true,
+    "monjer": true,
+    "keenwon": true,
+    "nazy": true,
+    "asaupup": true,
+    "nuwaio": true,
+    "heineiuo": true,
+    "morogasper": true,
+    "luckyluke": true,
+    "cedx": true
+  },
+  "homepage": "https://github.com/whitequark/ipaddr.js#readme"
+}

--- a/test/fixtures/registry-mocks/content/ipaddr.js.min.json
+++ b/test/fixtures/registry-mocks/content/ipaddr.js.min.json
@@ -1,0 +1,639 @@
+{
+  "name": "ipaddr.js",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "ipaddr.js",
+      "version": "0.1.0",
+      "dependencies": {
+        "coffee-script": ">= 1.1.1"
+      },
+      "devDependencies": {
+        "nodeunit": "0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "d67fc6dcc153b15a8ed475a44158f854728b037e",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.1": {
+      "name": "ipaddr.js",
+      "version": "0.1.1",
+      "dependencies": {
+        "coffee-script": ">= 1.1.1"
+      },
+      "devDependencies": {
+        "nodeunit": "0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "28c6a7c116a021c555544f906ab1ad540b1d635a",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.2": {
+      "name": "ipaddr.js",
+      "version": "0.1.2",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "6a1fd3d854f5002965c34d7bbcd9b4a8d4b0467e",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.3": {
+      "name": "ipaddr.js",
+      "version": "0.1.3",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "27a9ca37f148d2102b0ef191ccbf2c51a8f025c6",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.4": {
+      "name": "ipaddr.js",
+      "version": "0.1.4",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "67b1956263daa9725b507700603b401013d2158c",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.5": {
+      "name": "ipaddr.js",
+      "version": "0.1.5",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "33d2693c95fbd4715165328dbfe25fb4fb5bbed8",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.6": {
+      "name": "ipaddr.js",
+      "version": "0.1.6",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "8f0530b217993873025fd4b72bdfd69bc56a9a12",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.7": {
+      "name": "ipaddr.js",
+      "version": "0.1.7",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "c08aaab60273d6c041e58f0dd2dafad3d43ea40f",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.8": {
+      "name": "ipaddr.js",
+      "version": "0.1.8",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "27442eda77b626c44724b4aa8a1867e8410579ee",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "0.1.9": {
+      "name": "ipaddr.js",
+      "version": "0.1.9",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "a9c78ccc12dc9010f296ab9aef2f61f432d69efa",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "1.0.0": {
+      "name": "ipaddr.js",
+      "version": "1.0.0",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "dc6723c4f83913106a6702113a2034696ec03469",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "1.0.1": {
+      "name": "ipaddr.js",
+      "version": "1.0.1",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "5f38801dc73e0400fc7076386f6ed5215fbd8f95",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "1.0.3": {
+      "name": "ipaddr.js",
+      "version": "1.0.3",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": "~0.5.3",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "2a9df7be73ea92aadb0d7f377497decd8e6d01bb",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.5"
+      }
+    },
+    "1.0.4": {
+      "name": "ipaddr.js",
+      "version": "1.0.4",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "ef715deab1e923fc1fe8fe9ce7a561d9110e52e2",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.0.5": {
+      "name": "ipaddr.js",
+      "version": "1.0.5",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "5fa78cf301b825c78abc3042d812723049ea23c7",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.1.0": {
+      "name": "ipaddr.js",
+      "version": "1.1.0",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "5fd380584eb3e2d55904dbe3047a2627d4199a14",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.1.1": {
+      "name": "ipaddr.js",
+      "version": "1.1.1",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "c791d95f52b29c1247d5df80ada39b8a73647230",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.2.0": {
+      "name": "ipaddr.js",
+      "version": "1.2.0",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "8aba49c9192799585bdd643e0ccb50e8ae777ba4",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.3.0": {
+      "name": "ipaddr.js",
+      "version": "1.3.0",
+      "devDependencies": {
+        "coffee-script": "~1.6",
+        "nodeunit": ">=0.8.2 <0.8.7",
+        "uglify-js": "latest"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.4.0": {
+      "name": "ipaddr.js",
+      "version": "1.4.0",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "296aca878a821816e5b85d0a285a99bcff4582f0",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.5.0": {
+      "name": "ipaddr.js",
+      "version": "1.5.0",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "48a04be500e66e6922a9e2aa3f54926eaeb96473",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.5.1": {
+      "name": "ipaddr.js",
+      "version": "1.5.1",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "ddafccea41e6f23f7f3ffe65e22d0d8cff6835b3",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.5.2": {
+      "name": "ipaddr.js",
+      "version": "1.5.2",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "d4b505bde9946987ccf0fc58d9010ff9607e3fa0",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.5.3": {
+      "name": "ipaddr.js",
+      "version": "1.5.3",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "ec68539dd70ff0990c3195ab7ec43124a83df589",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.5.4": {
+      "name": "ipaddr.js",
+      "version": "1.5.4",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "962263d9d26132956fc5c630b638a30d3cdffc14",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.6.0": {
+      "name": "ipaddr.js",
+      "version": "1.6.0",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "e3fa357b773da619f26e95f049d055c72796f86b",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.7.0": {
+      "name": "ipaddr.js",
+      "version": "1.7.0",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "2206ed334afc32e01fed3ee838b6b2521068b9d2",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.7.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 38772
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.8.0": {
+      "name": "ipaddr.js",
+      "version": "1.8.0",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 39303
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.8.1": {
+      "name": "ipaddr.js",
+      "version": "1.8.1",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "fa4b79fa47fd3def5e3b159825161c0a519c9427",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 39327
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.9.0": {
+      "name": "ipaddr.js",
+      "version": "1.9.0",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "uglify-js": "~3.0.19",
+        "nodeunit": ">=0.8.2 <0.8.7"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+        "shasum": "37df74e430a0e47550fe54a2defe30d8acd95f65",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 42064,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcX9f6CRA9TVsSAnZWagAACN0P/3QaY26R9gIEKJMFRl3f\nComsl89/ZqAisw026wGodTWmYirIR5IbjDNxWETrCHXdriBCrSsDZ1SzzdGk\nTxkjv5/bQjv4CpPZV5/d91q6vkpFjPbVOk/N+K0fOJkmO9Fp4lwUQq4/B0gi\nEj+lPr1a5j5ZQwpMNB1pZrtoy3Fo/y0d5sYTNEQAlAQfjcJI4mFtc92tkc9s\nnzanygidCfoWEctnJIy9/lUjCxY2Irt8tMBa7cVExOLOqn6KegnJOtC+4g19\nCSjmv+lUj/r9QdT1kTbnej+118OQDjaZmjJ18/mxKdVXsYq6RLxKalWiez6E\nWKzCrMBSfwjDcErkaWr8tLn8b5zwwS5oLYG2pbzwDxA92P81LYeu+3wcmxa1\nPpvKkxBHLkUK1+19Xg0t5IP//B/C6ZCS5q+zckr+97U7SitK7aUajtRc3SYu\notiV+5t1Lgl+WLiymOq3WnBXMJwzXsq7nYBJgUlkoj0IE4Du5DFKao0UNvE2\nSBZTM8MJGm2rsm9xGKqWx9rBqWDudpnGipJIOV6l807BRn0yBrQjbx2jhV48\nK8UrwyOwYE1dwEYzhuviczDvE5o6qriTiFyYfA4DW0w1h3X3VDGWoI81g4dh\nGzP3V8SjsKV8g80HkrU8rboh1UKUIMjhINunU6PBD6YR+2fUqos3YlMxbprM\nOThn\r\n=Tk1a\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "1.9.1": {
+      "name": "ipaddr.js",
+      "version": "1.9.1",
+      "devDependencies": {
+        "coffee-script": "~1.12.6",
+        "nodeunit": "^0.11.3",
+        "uglify-js": "~3.0.19"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+        "shasum": "bff38543eeb8984825079ff3a2a8e6cbd46781b3",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 42145,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdLofECRA9TVsSAnZWagAAuqsQAIOiqKtRllNg8pMg89ea\nLFtGW49UBn0+nYUg9CSQM/h8nOYi+NH6Puw5dpDasTWt2tRmPtzqx/1vxaFk\nPmg73w49mtBPAxu2YLngv8tSx4dNvsClTe5RpLvpZFmopIRQojKUl0VSj3RW\nMtbkj/KozwgiYzguvHwGhjIhjerutQ1zoH0kJCZCRvVeLJrkdyj/PPzvLyF2\n3MZ7peqpGXg4k92ljrN7Q49itLIdYtrcm3tv2659e2W80E63RJUw0Buw9IGl\nYGX/1EfpBKW2l3QADjgW9Lz7/3oWt7NEDWNGGw+kMsivfAFAIKDiZ93v5H1M\ntaH+cLv3rHJ1s3cgz8gdlp3VGunG/OfP179e9J19AvcsLKhJ/Kho+fz0OD7d\nAEg+wMFlRLP5QR+x9X4naIN44VgjMZkTWZq8blx5hvJVCqSPtnYuORfYJstu\npQx9lSmmZl2Ma2LRjtpXUnbgtUOXIYpvPhn2+OV7NN/RbrigOPFHEHYw9YDQ\ndvChMV7RSmvRvDS+9YDqB+71/pcJljeztfGkznErW6xqc1DtdKg6WCw6k58H\nUTGjiMj+vytXJ3g9YnN5OlTmRAZCDj1XaHWPpGybfnm5j8MPetary6Dobian\nSbAaS1eqlMEhPd1G5t1RsLOy1ePI80HsARHZDQhqUY2Kl0/vIgtnWsx3KPHc\nUDnk\r\n=j6kw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.0.0": {
+      "name": "ipaddr.js",
+      "version": "2.0.0",
+      "devDependencies": {
+        "eslint": "*",
+        "mocha": "*",
+        "uglify-es": "*"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-S54H9mIj0rbxRIyrDMEuuER86LdlgUg9FSeZ8duQb6CUG2iRrA36MYVQBSprTF/ZeAwvyQ5mDGuNvIPM0BIl3w==",
+        "shasum": "77ccccc8063ae71ab65c55f21b090698e763fc6e",
+        "tarball": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 55486,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfOgyZCRA9TVsSAnZWagAAxOgP/22JhlisEc6AQ9F4Gytx\n4Sfp2tThv2/zBGNqSQKBnLjBetQerCSCYPT2vli7zgwBs6hcSpLwteQI0VNY\ndTOaChwT6HMATCb4btBfuuZyt+9QLJzdxHwiNR+NtHkpnYJSgcZXNMLW5mMB\n5G6+tJGMit9mr232qEuwPOms2JdtmzWeZVzFu04FF6z6sMDbt/brcL4BhdAZ\n3S39W8dmWz3ETBFYb7gzuLwmAxSAqokpCwYpvZSQOPz9n0cLMuubSqxjxcbL\njukZemfirJv+R6eiQsbFxfkH9TAAswiIfSjIk6Anm1YmaD3FWriLlUhqpIvD\nIzJCXkA6HsEmshXZc44CvfU+HfCtOzZTkEpDcw7hyGZq8MczY81MzJsBXY0l\n+B5WsxVjzTHVzOm8F3RB3xaK+oBGoxmBEX6kCwnlsT6lRkAfLU+KHXB+aMcM\nuci9wwznxTKO/VTzI/TQ4PFDKLtNcFaah3/H5D7PgvvZD5L1yYx9mzwBrgQA\n7336LHkQs2r/KUdhXyhsjjJz0s4zMRiCsiqFbwzxp5OaMNPKEAg47UN0+Gc5\n0FMHP46qldHOP9/O3rs4q9qmF2OpNpbOSxXqE5gh/HAm1Vql3+EyEsguq5Og\nxJyGy5twGCTugwubqc82CYZ5446/zDxiadnx4QaxVb0hKEydGT15k9soxrfh\nlMSW\r\n=xaXW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  },
+  "modified": "2020-08-17T04:50:35.855Z"
+}

--- a/test/fixtures/registry-mocks/content/is-absolute-url.json
+++ b/test/fixtures/registry-mocks/content/is-absolute-url.json
@@ -1,0 +1,563 @@
+{
+  "_id": "is-absolute-url",
+  "_rev": "13-ba04b4fde137ce85cca59d6872ebda7c",
+  "name": "is-absolute-url",
+  "description": "Check if a URL is absolute",
+  "dist-tags": {
+    "latest": "3.0.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "is-absolute-url",
+      "version": "0.1.0",
+      "description": "Check if an URL is absolute",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sindresorhus/is-absolute-url"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "url",
+        "absolute",
+        "relative",
+        "uri",
+        "is",
+        "check"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-absolute-url",
+      "_id": "is-absolute-url@0.1.0",
+      "_shasum": "7798f8564fa87273035614420bec41f02d546cfc",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7798f8564fa87273035614420bec41f02d546cfc",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "is-absolute-url",
+      "version": "1.0.0",
+      "description": "Check if an URL is absolute",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/is-absolute-url"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "url",
+        "absolute",
+        "relative",
+        "uri",
+        "is",
+        "check"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "aed5931a4f223339504593cb41e129512d2b7054",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-absolute-url",
+      "_id": "is-absolute-url@1.0.0",
+      "_shasum": "2d7ef0fd0bb2a88dac7e92253c6808a0ace24bfb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2d7ef0fd0bb2a88dac7e92253c6808a0ace24bfb",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "is-absolute-url",
+      "version": "2.0.0",
+      "description": "Check if an URL is absolute",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-absolute-url.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "url",
+        "absolute",
+        "relative",
+        "uri",
+        "is",
+        "check"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "8da870b59600da38e8e42edbfb3f83e56d76c37e",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-absolute-url#readme",
+      "_id": "is-absolute-url@2.0.0",
+      "_shasum": "9c4b20b0e5c0cbef9a479a367ede6f991679f359",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "9c4b20b0e5c0cbef9a479a367ede6f991679f359",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "is-absolute-url",
+      "version": "2.1.0",
+      "description": "Check if an URL is absolute",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-absolute-url.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "url",
+        "absolute",
+        "relative",
+        "uri",
+        "is",
+        "check"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "d2fb33c65ae6805df1fcbfb536d122c76c0f3abb",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-absolute-url#readme",
+      "_id": "is-absolute-url@2.1.0",
+      "_shasum": "50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/is-absolute-url-2.1.0.tgz_1481475250580_0.8468719229567796"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "is-absolute-url",
+      "version": "3.0.0",
+      "description": "Check if an URL is absolute",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-absolute-url.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "url",
+        "absolute",
+        "relative",
+        "uri",
+        "is",
+        "check"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "5170de95986994497ec74d0beeec872e80754533",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-absolute-url#readme",
+      "_id": "is-absolute-url@3.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-3OkP8XrM2Xq4/IxsJnClfMp3OaM3TAatLPLKPeWcxLBTrpe6hihwtX+XZfJTcXg/FTRi4qjy0y/C5qiyNxY24g==",
+        "shasum": "eb21d69df2ed8ef72a3e6f243e216563036a0913",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 2856,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcqFRJCRA9TVsSAnZWagAA7iUP/j27VIC+NSNbjq5d0aE0\nK4kceL2QDMaAZ3varASDuajuziAmSIpW+mexCIWX4SRl97myyyEHrEmRoWuP\nlOrayHUix4w39yghgnUKbWddgkgk3i2/Hhne6B3VPiyXeZc/j13e/oC7y+l1\n2CyeLCOMH7SHQ/7QlRKWV+AG2vA/PkgcI6Km7LX90cKDP0WkJFfpZNgiBqam\n5TYg3btmPBp17DLe456Vtv8wvKZUgPrFlZhifoTzHzDLfZSGmtCkbJ7gs7FF\nhJIGhC5C55aiQfwkWuRQxbvfDE46WIbEmyZVUW9TzbDK7zAlsNWo8ria1Xj0\ny0gqJDy79glBDBPlOfLlVzUi8czZtmfmvQqv7JFmgYfjVv5O26zN295L9BzN\n+eJU6sRRGM8liWcrGzUUifmxM4sEHYED1sE/MpZQ7YfTBWKafABXBCIW1i4T\n8UpEI7Sn1jpjoTOQyqK8c0AyrSPGAvDywiRIwKCvivKJuoAmP1nkPXK9Ecmh\nr9JO+4eVOvGwULzpCYycj2sr8zwjhvF0y5TJ8sY1OYytA/hxMAOwOd2/YAH5\nefqyALjeo7apjWj26KEoy+MnpU6rtCeVgJ2qflFs1gNNS9v7ZxYdyJmppyZ4\nqMX/UH7Dy6Mp0tfz+NIsOUZpkZPIc5ZNABWnSR96XVVWOixstcBIyTffW6yq\nkACC\r\n=LHDl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-absolute-url_3.0.0_1554535496810_0.42753297726587025"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1": {
+      "name": "is-absolute-url",
+      "version": "3.0.1",
+      "description": "Check if a URL is absolute",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-absolute-url.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "url",
+        "absolute",
+        "relative",
+        "uri",
+        "is",
+        "check"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "305031f19aef72681a57396e687b5c11021211c0",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-absolute-url#readme",
+      "_id": "is-absolute-url@3.0.1",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-c2QjUwuMxLsld90sj3xYzpFYWJtuxkIn1f5ua9RTEYJt/vV2IsM+Py00/6qjV7qExgifUvt7qfyBGBBKm+2iBg==",
+        "shasum": "e315cbdcbbc3d6789532d591954ac78a0e5049f6",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3065,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdWTyQCRA9TVsSAnZWagAASvIP/3EhjPKy2dFi2ef7hfcZ\nq4aQ6CzAa6ljKwcsQnTua4ZlEmpQG9YhsNclLJFrD/3Wcuq+3Sy28miPHA5a\nxTd8yq+Q7EDCL4oQ42hVpIeN8BrGz6AH0R0hQkHIUmJdjY7FwR4mbqBplJ3W\n/59KDiARGzwSOtW/6TYQVq9g0XIQ5b1dsimvfcsKG4n4EijqJGepWZc9CKcV\n7SyEohqvY+JguJDGpKFiLZUFAlpFiYXT49L8l1A8K0ls3Jc62FvwIzotSanv\no/nYhanIWgmxAaeypYJrXibIwH2fNcsp5MWDHBqHC5R8YvlT1TO5XX1HlJR6\nVMb3hJ6Ls/sAPKZdbKp3aBPHlr97SxIPBFDC2XS/kVDhoahKkOHE/f8LGQR8\nL0HAX3m54QcSEqwdgJOQnVkRqUlkV0fQUigs5/hg2RxJZG8nocc/Sf2U8pme\nrW4X9ZvaopYohMOsVrN8ltwniJ7Pqcdn5IpbTd9ZV4dk9KyykRztOb3rvwx7\n2rTkWsNo3N13ie95N3pwb8ZQmi8xF/BbVwm3VjuhDiLIiO4FZCvRdH+kdSJY\ns4I+g4IPdutJ8PsXsAueqm4YXhI4iLJ1Hk3Zze7MuLWZVjG8XtL9lYPUq+KH\nqZh1rhq/0n+AnTT3mGuN60dGXFABx9SV5oSMfGvKRshZrMm3tNSuRkZ5mDL5\n8VGA\r\n=Vd24\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-absolute-url_3.0.1_1566129296322_0.2570963314369621"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.2": {
+      "name": "is-absolute-url",
+      "version": "3.0.2",
+      "description": "Check if a URL is absolute",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-absolute-url.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "url",
+        "absolute",
+        "relative",
+        "uri",
+        "is",
+        "check"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "219de67a7cd8193a0ae56677930304bbe3a26638",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-absolute-url#readme",
+      "_id": "is-absolute-url@3.0.2",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.11.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-+5g/wLlcm1AcxSP7014m6GvbPHswDx980vD/3bZaap8aGV9Yfs7Q6y6tfaupgZ5O74Byzc8dGrSCJ+bFXx0KdA==",
+        "shasum": "554f2933e7385cc46e94351977ca2081170a206e",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3452,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdexarCRA9TVsSAnZWagAA/KwP/Rpo9pmWlt+h6egxK40D\nkDbe6YhokJJsQejPLcKrO8ajE70zxR2IW4l3PsmuTXQb+2Ydvzd4lhcK2UBp\ndSiUpI9t7/UiIb5DGq0XDwed1W5kcLUQREGBWDq59+ekAaY77KknD29O2HV0\nPrgdlv4/ewYxnoTwPIrghW2rwX7VKr/v2NYAdDTKarW6xKIzaxeEsIbIpdvE\nsWmCQCGkSKJgmOE4CkNX29rdZrdYYBVsmvCFbsCt6HwvPxRIf1L0BACY4BeG\nsSBPMUQfSX1yoCRVNaBUF2Ei9ELdQDRzXg3dZWKKSKVbeSoZ2wqeDlDslNq/\nRxOYThIirtTvJME1xbMfmWS8HDMS8LpsvhCpE+HV0qCXsgxGD6/Csg1+lLFr\ntFRxkgJypwDQTpq/BnXQZU98YT9aAGkDlvftPZfrzZJiYM0Lj/gywh0lv5r5\ndI3M3PbMRWYcfqTIQWsHFsmMc8qolPf2MpncrtQx4WWLqoOR8n7WRE1silMR\nQEQZXhcHH0JHufB/7BCsEEWYSic8TKCPsNLDDyj3Tsfv9RVuvxC/jNW8CWMn\nVV4AOVz63uX/l3rWZaiWr/KC/hoWJPZNQlYM8aVk8ym71+dcHNthpsDWH4lM\nn5zQJ5B8Hwc06DtRLBZUOVS8NlOJxFv70EL4IFfsTQ4xoV0ziU2Xsmkl709Y\n/6r7\r\n=Ve3s\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-absolute-url_3.0.2_1568347818837_0.3173530606423203"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.3": {
+      "name": "is-absolute-url",
+      "version": "3.0.3",
+      "description": "Check if a URL is absolute",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-absolute-url.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "url",
+        "absolute",
+        "relative",
+        "uri",
+        "is",
+        "check"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "8a57ccec064d925640860674cd32e7182eeb3596",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-absolute-url#readme",
+      "_id": "is-absolute-url@3.0.3",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.11.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+        "shasum": "96c6a22b6a23929b11ea0afb1836c36ad4a5d698",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3461,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdkEM9CRA9TVsSAnZWagAA46EP/iBsdfAnzL/SXjoD8dlR\nSu3JHSmU+tN4mxHCOpyQl/0tn8QIxxLIo93zNiKivzYjwZgjZe3LJKOMDu59\nj8AjGLYpYn90vt2TiWRO18ZayYFsA7It0mJQjqigsyYuwWuWY7GoZC+N69FS\nnJApZwdBn5SDiyHrkrlkB/DWR26uXIlOBRjjimbpxTROanE9qeeGCGm2bHF/\nZKK60CEMF7X9MG60CGZYNfljf5fGQJIKC4+F0gQxmchJXHBVRD+vIWIe1GdY\nsjOW/7DBOoxp7ubL5Bb+3/so6jxdG3Tm7RqZ2+H2A71ZEWb8U0SL5INLQneP\n0KZe/WWQ8+gkBvh4DM6WrPpP1/TNKkK8SHhvgQof+ZUAteW3sMLuETUHw7Sg\nQUZv/kfb/CJHgDpPVYFjKts06CDYhrnGnLBOS9lLy8kupzGrZiFuCRZQlOlh\nS8fPYpbO6HEPLnrSy4bPKRfgn8rN6yjjmb2Zunb+EreTWy8e5WSaysf5mfuI\nSSheoe2D124A4yRBKIeVT9aT8AkCbK0y5y/i4MC//+hG1xZ7jTunuKyf1Crk\nz4XqfjXkx6UGtRiCjOq1u/nyVTBA6NTaHbMvE9C5yAIWzhYS4sYmfM6edTcO\n57dCLiBOd66HGGkObFVRNfc3DzgT+u5uL2AVPWQdDuN+G6jrbST9YYGGifF5\nvLPj\r\n=ulJJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-absolute-url_3.0.3_1569735484544_0.16914353628578827"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# is-absolute-url [![Build Status](https://travis-ci.org/sindresorhus/is-absolute-url.svg?branch=master)](https://travis-ci.org/sindresorhus/is-absolute-url)\n\n> Check if a URL is absolute\n\n\n## Install\n\n```\n$ npm install is-absolute-url\n```\n\n\n## Usage\n\n```js\nconst isAbsoluteUrl = require('is-absolute-url');\n\nisAbsoluteUrl('https://sindresorhus.com/foo/bar');\n//=> true\n\nisAbsoluteUrl('//sindresorhus.com');\n//=> false\n\nisAbsoluteUrl('foo/bar');\n//=> false\n```\n\n\n## Related\n\nSee [is-relative-url](https://github.com/sindresorhus/is-relative-url) for the inverse.\n\n\n---\n\n<div align=\"center\">\n\t<b>\n\t\t<a href=\"https://tidelift.com/subscription/pkg/npm-is-absolute-url?utm_source=npm-is-absolute-url&utm_medium=referral&utm_campaign=readme\">Get professional support for this package with a Tidelift subscription</a>\n\t</b>\n\t<br>\n\t<sub>\n\t\tTidelift helps make open source sustainable for maintainers while giving companies<br>assurances about security, maintenance, and licensing for their dependencies.\n\t</sub>\n</div>\n",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-09-29T05:38:08.418Z",
+    "created": "2014-06-29T19:20:33.967Z",
+    "0.1.0": "2014-06-29T19:20:33.967Z",
+    "1.0.0": "2014-08-13T19:20:55.296Z",
+    "2.0.0": "2015-07-03T12:23:23.331Z",
+    "2.1.0": "2016-12-11T16:54:12.315Z",
+    "3.0.0": "2019-04-06T07:24:56.984Z",
+    "3.0.1": "2019-08-18T11:54:56.452Z",
+    "3.0.2": "2019-09-13T04:10:19.096Z",
+    "3.0.3": "2019-09-29T05:38:04.716Z"
+  },
+  "homepage": "https://github.com/sindresorhus/is-absolute-url#readme",
+  "keywords": [
+    "url",
+    "absolute",
+    "relative",
+    "uri",
+    "is",
+    "check"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/is-absolute-url.git"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/is-absolute-url/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "sixertoy": true,
+    "rocket0191": true,
+    "shivayl": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/is-absolute-url.min.json
+++ b/test/fixtures/registry-mocks/content/is-absolute-url.min.json
@@ -1,0 +1,145 @@
+{
+  "name": "is-absolute-url",
+  "dist-tags": {
+    "latest": "3.0.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "is-absolute-url",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "7798f8564fa87273035614420bec41f02d546cfc",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "is-absolute-url",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "2d7ef0fd0bb2a88dac7e92253c6808a0ace24bfb",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "is-absolute-url",
+      "version": "2.0.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "9c4b20b0e5c0cbef9a479a367ede6f991679f359",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.1.0": {
+      "name": "is-absolute-url",
+      "version": "2.1.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "is-absolute-url",
+      "version": "3.0.0",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-3OkP8XrM2Xq4/IxsJnClfMp3OaM3TAatLPLKPeWcxLBTrpe6hihwtX+XZfJTcXg/FTRi4qjy0y/C5qiyNxY24g==",
+        "shasum": "eb21d69df2ed8ef72a3e6f243e216563036a0913",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 2856,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcqFRJCRA9TVsSAnZWagAA7iUP/j27VIC+NSNbjq5d0aE0\nK4kceL2QDMaAZ3varASDuajuziAmSIpW+mexCIWX4SRl97myyyEHrEmRoWuP\nlOrayHUix4w39yghgnUKbWddgkgk3i2/Hhne6B3VPiyXeZc/j13e/oC7y+l1\n2CyeLCOMH7SHQ/7QlRKWV+AG2vA/PkgcI6Km7LX90cKDP0WkJFfpZNgiBqam\n5TYg3btmPBp17DLe456Vtv8wvKZUgPrFlZhifoTzHzDLfZSGmtCkbJ7gs7FF\nhJIGhC5C55aiQfwkWuRQxbvfDE46WIbEmyZVUW9TzbDK7zAlsNWo8ria1Xj0\ny0gqJDy79glBDBPlOfLlVzUi8czZtmfmvQqv7JFmgYfjVv5O26zN295L9BzN\n+eJU6sRRGM8liWcrGzUUifmxM4sEHYED1sE/MpZQ7YfTBWKafABXBCIW1i4T\n8UpEI7Sn1jpjoTOQyqK8c0AyrSPGAvDywiRIwKCvivKJuoAmP1nkPXK9Ecmh\nr9JO+4eVOvGwULzpCYycj2sr8zwjhvF0y5TJ8sY1OYytA/hxMAOwOd2/YAH5\nefqyALjeo7apjWj26KEoy+MnpU6rtCeVgJ2qflFs1gNNS9v7ZxYdyJmppyZ4\nqMX/UH7Dy6Mp0tfz+NIsOUZpkZPIc5ZNABWnSR96XVVWOixstcBIyTffW6yq\nkACC\r\n=LHDl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "3.0.1": {
+      "name": "is-absolute-url",
+      "version": "3.0.1",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-c2QjUwuMxLsld90sj3xYzpFYWJtuxkIn1f5ua9RTEYJt/vV2IsM+Py00/6qjV7qExgifUvt7qfyBGBBKm+2iBg==",
+        "shasum": "e315cbdcbbc3d6789532d591954ac78a0e5049f6",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3065,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdWTyQCRA9TVsSAnZWagAASvIP/3EhjPKy2dFi2ef7hfcZ\nq4aQ6CzAa6ljKwcsQnTua4ZlEmpQG9YhsNclLJFrD/3Wcuq+3Sy28miPHA5a\nxTd8yq+Q7EDCL4oQ42hVpIeN8BrGz6AH0R0hQkHIUmJdjY7FwR4mbqBplJ3W\n/59KDiARGzwSOtW/6TYQVq9g0XIQ5b1dsimvfcsKG4n4EijqJGepWZc9CKcV\n7SyEohqvY+JguJDGpKFiLZUFAlpFiYXT49L8l1A8K0ls3Jc62FvwIzotSanv\no/nYhanIWgmxAaeypYJrXibIwH2fNcsp5MWDHBqHC5R8YvlT1TO5XX1HlJR6\nVMb3hJ6Ls/sAPKZdbKp3aBPHlr97SxIPBFDC2XS/kVDhoahKkOHE/f8LGQR8\nL0HAX3m54QcSEqwdgJOQnVkRqUlkV0fQUigs5/hg2RxJZG8nocc/Sf2U8pme\nrW4X9ZvaopYohMOsVrN8ltwniJ7Pqcdn5IpbTd9ZV4dk9KyykRztOb3rvwx7\n2rTkWsNo3N13ie95N3pwb8ZQmi8xF/BbVwm3VjuhDiLIiO4FZCvRdH+kdSJY\ns4I+g4IPdutJ8PsXsAueqm4YXhI4iLJ1Hk3Zze7MuLWZVjG8XtL9lYPUq+KH\nqZh1rhq/0n+AnTT3mGuN60dGXFABx9SV5oSMfGvKRshZrMm3tNSuRkZ5mDL5\n8VGA\r\n=Vd24\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "3.0.2": {
+      "name": "is-absolute-url",
+      "version": "3.0.2",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-+5g/wLlcm1AcxSP7014m6GvbPHswDx980vD/3bZaap8aGV9Yfs7Q6y6tfaupgZ5O74Byzc8dGrSCJ+bFXx0KdA==",
+        "shasum": "554f2933e7385cc46e94351977ca2081170a206e",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3452,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdexarCRA9TVsSAnZWagAA/KwP/Rpo9pmWlt+h6egxK40D\nkDbe6YhokJJsQejPLcKrO8ajE70zxR2IW4l3PsmuTXQb+2Ydvzd4lhcK2UBp\ndSiUpI9t7/UiIb5DGq0XDwed1W5kcLUQREGBWDq59+ekAaY77KknD29O2HV0\nPrgdlv4/ewYxnoTwPIrghW2rwX7VKr/v2NYAdDTKarW6xKIzaxeEsIbIpdvE\nsWmCQCGkSKJgmOE4CkNX29rdZrdYYBVsmvCFbsCt6HwvPxRIf1L0BACY4BeG\nsSBPMUQfSX1yoCRVNaBUF2Ei9ELdQDRzXg3dZWKKSKVbeSoZ2wqeDlDslNq/\nRxOYThIirtTvJME1xbMfmWS8HDMS8LpsvhCpE+HV0qCXsgxGD6/Csg1+lLFr\ntFRxkgJypwDQTpq/BnXQZU98YT9aAGkDlvftPZfrzZJiYM0Lj/gywh0lv5r5\ndI3M3PbMRWYcfqTIQWsHFsmMc8qolPf2MpncrtQx4WWLqoOR8n7WRE1silMR\nQEQZXhcHH0JHufB/7BCsEEWYSic8TKCPsNLDDyj3Tsfv9RVuvxC/jNW8CWMn\nVV4AOVz63uX/l3rWZaiWr/KC/hoWJPZNQlYM8aVk8ym71+dcHNthpsDWH4lM\nn5zQJ5B8Hwc06DtRLBZUOVS8NlOJxFv70EL4IFfsTQ4xoV0ziU2Xsmkl709Y\n/6r7\r\n=Ve3s\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "3.0.3": {
+      "name": "is-absolute-url",
+      "version": "3.0.3",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+        "shasum": "96c6a22b6a23929b11ea0afb1836c36ad4a5d698",
+        "tarball": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3461,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdkEM9CRA9TVsSAnZWagAA46EP/iBsdfAnzL/SXjoD8dlR\nSu3JHSmU+tN4mxHCOpyQl/0tn8QIxxLIo93zNiKivzYjwZgjZe3LJKOMDu59\nj8AjGLYpYn90vt2TiWRO18ZayYFsA7It0mJQjqigsyYuwWuWY7GoZC+N69FS\nnJApZwdBn5SDiyHrkrlkB/DWR26uXIlOBRjjimbpxTROanE9qeeGCGm2bHF/\nZKK60CEMF7X9MG60CGZYNfljf5fGQJIKC4+F0gQxmchJXHBVRD+vIWIe1GdY\nsjOW/7DBOoxp7ubL5Bb+3/so6jxdG3Tm7RqZ2+H2A71ZEWb8U0SL5INLQneP\n0KZe/WWQ8+gkBvh4DM6WrPpP1/TNKkK8SHhvgQof+ZUAteW3sMLuETUHw7Sg\nQUZv/kfb/CJHgDpPVYFjKts06CDYhrnGnLBOS9lLy8kupzGrZiFuCRZQlOlh\nS8fPYpbO6HEPLnrSy4bPKRfgn8rN6yjjmb2Zunb+EreTWy8e5WSaysf5mfuI\nSSheoe2D124A4yRBKIeVT9aT8AkCbK0y5y/i4MC//+hG1xZ7jTunuKyf1Crk\nz4XqfjXkx6UGtRiCjOq1u/nyVTBA6NTaHbMvE9C5yAIWzhYS4sYmfM6edTcO\n57dCLiBOd66HGGkObFVRNfc3DzgT+u5uL2AVPWQdDuN+G6jrbST9YYGGifF5\nvLPj\r\n=ulJJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "modified": "2019-09-29T05:38:08.418Z"
+}

--- a/test/fixtures/registry-mocks/content/is-plain-object.json
+++ b/test/fixtures/registry-mocks/content/is-plain-object.json
@@ -1,0 +1,1537 @@
+{
+  "_id": "is-plain-object",
+  "_rev": "22-fd35a4548a4a2f81d5fefcb51b7bd92e",
+  "name": "is-plain-object",
+  "description": "Returns true if an object was created by the `Object` constructor, or Object.create(null).",
+  "dist-tags": {
+    "latest": "5.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "is-plain-object",
+      "description": "Return `true` if the given `value` is an object created by the `Object` constructor.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/is-plain-object/blob/master/LICENSE-MIT"
+        }
+      ],
+      "keywords": [
+        "object",
+        "is",
+        "is-object",
+        "isobject",
+        "plain",
+        "value",
+        "typeof",
+        "javascript",
+        "check",
+        "type"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "verb": "~0.2.6",
+        "chai": "~1.9.1",
+        "mocha": "*"
+      },
+      "_id": "is-plain-object@0.1.0",
+      "_shasum": "3ca7db022de72fd12007f1957beb59ea596b979c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3ca7db022de72fd12007f1957beb59ea596b979c",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/is-plain-object/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "keywords": [
+        "object",
+        "is",
+        "is-object",
+        "isobject",
+        "plain",
+        "value",
+        "typeof",
+        "javascript",
+        "check",
+        "type"
+      ],
+      "gitHead": "48f326d18bcf8776c60cdf7c7859d2dc514e6257",
+      "_id": "is-plain-object@1.0.0",
+      "_shasum": "ff5f752db71c3328afd5e685eb6adddd3eaffab7",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ff5f752db71c3328afd5e685eb6adddd3eaffab7",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/is-plain-object/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "browserify": "browserify index.js --standalone isPlainObject | uglifyjs --compress --mangle -o browser/is-plain-object.js",
+        "test_browser": "mocha-phantomjs test/browser.html",
+        "test_node": "mocha test",
+        "test": "npm run test_node && npm run browserify && npm run test_browser"
+      },
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "chai": "*",
+        "mocha": "*",
+        "mocha-phantomjs": "*",
+        "phantomjs": "*",
+        "uglify-js": "*"
+      },
+      "keywords": [
+        "object",
+        "is",
+        "is-object",
+        "isobject",
+        "plain",
+        "value",
+        "typeof",
+        "javascript",
+        "check",
+        "type"
+      ],
+      "gitHead": "b96e86b84e78e21108b1ea824a3e91af1e00164b",
+      "_id": "is-plain-object@2.0.0",
+      "_shasum": "8612587fa90279dc1b6e1cec2056f6c1df7abb2a",
+      "_from": "git://github.com/jonschlinkert/is-plain-object.git",
+      "_resolved": "git://github.com/jonschlinkert/is-plain-object.git#b96e86b84e78e21108b1ea824a3e91af1e00164b",
+      "_fromGithub": true,
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "stevenvachon",
+        "email": "contact@svachon.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "stevenvachon",
+          "email": "contact@svachon.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8612587fa90279dc1b6e1cec2056f6c1df7abb2a",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor.",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonschlinkert/is-plain-object"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "browserify": "browserify index.js --standalone isPlainObject | uglifyjs --compress --mangle -o browser/is-plain-object.js",
+        "test_browser": "mocha-phantomjs test/browser.html",
+        "test_node": "mocha",
+        "test": "npm run test_node && npm run browserify && npm run test_browser"
+      },
+      "dependencies": {
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "chai": "*",
+        "mocha": "*",
+        "mocha-phantomjs": "*",
+        "phantomjs": "*",
+        "uglify-js": "*"
+      },
+      "keywords": [
+        "object",
+        "is",
+        "is-object",
+        "isobject",
+        "plain",
+        "value",
+        "type",
+        "kind",
+        "kind-of",
+        "typeof",
+        "javascript",
+        "check",
+        "type"
+      ],
+      "gitHead": "b96e86b84e78e21108b1ea824a3e91af1e00164b",
+      "_id": "is-plain-object@2.0.1",
+      "_shasum": "4d7ca539bc9db9b737b8acb612f2318ef92f294f",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "stevenvachon",
+          "email": "contact@svachon.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4d7ca539bc9db9b737b8acb612f2318ef92f294f",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor.",
+      "version": "2.0.2",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "browserify": "browserify index.js --standalone isPlainObject | uglifyjs --compress --mangle -o browser/is-plain-object.js",
+        "test_browser": "mocha-phantomjs test/browser.html",
+        "test_node": "mocha",
+        "test": "npm run test_node && npm run browserify && npm run test_browser"
+      },
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^14.3.0",
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.2",
+        "mocha-phantomjs": "^4.1.0",
+        "phantomjs": "^2.1.7",
+        "uglify-js": "^3.0.12"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "isobject",
+            "is-number",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "e6ffcb78603dc3a3826e75852c449639bca627ef",
+      "_id": "is-plain-object@2.0.2",
+      "_shasum": "1d9ab795669937de31998071ca1f701770b375a4",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "stevenvachon",
+          "email": "contact@svachon.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1d9ab795669937de31998071ca1f701770b375a4",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object-2.0.2.tgz_1495914809154_0.5315580435562879"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor.",
+      "version": "2.0.3",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "browserify": "browserify index.js --standalone isPlainObject | uglifyjs --compress --mangle -o browser/is-plain-object.js",
+        "test_browser": "mocha-phantomjs test/browser.html",
+        "test_node": "mocha",
+        "test": "npm run test_node && npm run browserify && npm run test_browser"
+      },
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^14.3.0",
+        "chai": "^4.0.0",
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.2",
+        "mocha-phantomjs": "^4.1.0",
+        "phantomjs": "^2.1.7",
+        "uglify-js": "^3.0.12"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "isobject",
+            "is-number",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "6616250bedd50e6f2378b44637875f22178f7506",
+      "_id": "is-plain-object@2.0.3",
+      "_shasum": "c15bf3e4b66b62d72efaf2925848663ecbc619b6",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "stevenvachon",
+          "email": "contact@svachon.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c15bf3e4b66b62d72efaf2925848663ecbc619b6",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object-2.0.3.tgz_1496153207864_0.18937807087786496"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor.",
+      "version": "2.0.4",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Osman Nuri Okumuş",
+          "url": "http://onokumus.com"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.d.ts",
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "browserify": "browserify index.js --standalone isPlainObject | uglifyjs --compress --mangle -o browser/is-plain-object.js",
+        "test_browser": "mocha-phantomjs test/browser.html",
+        "test_node": "mocha",
+        "test": "npm run test_node && npm run browserify && npm run test_browser"
+      },
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^14.4.0",
+        "chai": "^4.0.2",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.4.2",
+        "mocha-phantomjs": "^4.1.0",
+        "phantomjs": "^2.1.7",
+        "uglify-js": "^3.0.24"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "types": "index.d.ts",
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "is-number",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "81345df0d1700a5c285f379cbdca0e273388910d",
+      "_id": "is-plain-object@2.0.4",
+      "_npmVersion": "5.2.0",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "stevenvachon",
+          "email": "contact@svachon.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+        "shasum": "2c163b3fafb1b606d9d17928f05c2a1c38e07677",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object-2.0.4.tgz_1499812869259_0.27965074591338634"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor.",
+      "version": "3.0.0",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Osman Nuri Okumuş",
+          "url": "http://onokumus.com"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "main": "index.cjs.js",
+      "module": "index.js",
+      "types": "index.d.ts",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "build": "rollup -c",
+        "test_browser": "mocha-headless-chrome --args=disable-web-security -f test/browser.html",
+        "test_node": "mocha -r esm",
+        "test": "npm run test_node && npm run build && npm run test_browser",
+        "prepare": "rollup -c"
+      },
+      "dependencies": {
+        "isobject": "^4.0.0"
+      },
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^2.0.2",
+        "rollup": "^1.10.1",
+        "rollup-plugin-node-resolve": "^4.2.3"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "is-number",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "340bc4ee0eba9322b85bbf732603c3f7fe67851c",
+      "_id": "is-plain-object@3.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.0",
+      "_npmUser": {
+        "name": "trysound",
+        "email": "trysound@yandex.ru"
+      },
+      "dist": {
+        "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+        "shasum": "47bfc5da1b5d50d64110806c199359482e75a928",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 9185,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcyLXkCRA9TVsSAnZWagAAd2IP+wfkoxXYjoEkwNWIUrfy\nzjhbQ5xnTwlZuNoPWZuVdQSYDwufCyh/zWeuiJjsCEkNT/z0QegPdK4PZFIi\n6BNti78yVazpcsonD3njnmoyrV5/8iXyI+C1PRo6nOO6kNHXx0JjAoLRAoVC\nDguYquTDhdo2WlQJ01ln8dSx9ueWQx5QMLE9lBXPzYmrtXbQcLd5Z8uXE4P/\n0vrkIuteL/p7I5RF2iFYjz4sEShk9W+ZNqlAf8Xsaa7yT2B5RRiy/ron5/+g\nLrnPAPn4954fWupxRuivAqgj3CfoOxx6Pl1D+ksK6sNywn6zB2fqTQm8vSLe\nsh6+BrX4ML34PA+2GSMmsv2+pU9Ksc2MwVJYzvIRQYlxMIza6rSMpfoJFiqW\nbiGyVf5+NSozNOnNpqxrv2OYIZnsKk+4ZL8kM5VrMnMAtB0IO8dgPO7uG/pf\n/CpqXJ9b9YKit5JnvuVksepqBIj+j2e40Od4E/wjsNKrIN0J06NksaVTmexo\njebkKSgAqGqqTPeeShtj44dF+Mdu8ChtBE5NYPLzJMDK5gslVb3/IdICzAwg\ncUXCgDR7KfoSio/4bCBB3sx+B4rCwcP3Eoi139qrQeXnl/OVCgINbd7U0u4A\nNIBq4uhTTb7ylFxJAcDBGPfqohPzoUc93pj+tClmPfF/+Bl7KBjZPKdhFI9u\nudtk\r\n=3ByD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        },
+        {
+          "email": "contact@svachon.com",
+          "name": "stevenvachon"
+        },
+        {
+          "email": "trysound@yandex.ru",
+          "name": "trysound"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object_3.0.0_1556657636003_0.8407783091812069"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor.",
+      "version": "3.0.1",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Osman Nuri Okumuş",
+          "url": "http://onokumus.com"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "main": "index.cjs.js",
+      "module": "index.es.js",
+      "types": "index.d.ts",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "build": "rollup -c",
+        "test_browser": "mocha-headless-chrome --args=disable-web-security -f test/browser.html",
+        "test_node": "mocha -r esm",
+        "test": "npm run test_node && npm run build && npm run test_browser",
+        "prepare": "rollup -c"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^8.1.0",
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "isobject": "^4.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^1.10.1"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "is-number",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2014-2017, Jon Schlinkert.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
+      "_id": "is-plain-object@3.0.1",
+      "dist": {
+        "shasum": "662d92d24c0aa4302407b0d45d21f2251c85f85b",
+        "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 9457,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9v38CRA9TVsSAnZWagAAkbEQAJ2Xlwabzov0sVASU7tL\nzQZeGLp+nSkO6NsxaLstwPvOlcwwVyvguew4itIVLHJJ1Hc6c25OejfbJ8j2\nXvOqFWdmtBZovDMD0LzhLe9mEdE7dyLQeuNqcNS94GTaXi0LLRVcK1GxQEM4\ntD30mx2iEdgW7chgYmm/UD1jiRkiyMA8jOt2Cf76+dTxtkqXGAz4hoI6wsId\noH1274RbdaCjEqBmcfWWaWkhAdrb2B3XoWRkdyFAlG/t7kmAUPJ8hS/ztHal\niLCI9uoHs0RLYE+dOe4URvsJi/GJD8pmXVBwr1vWsHJoklWeTly/segTpzu0\njUNRjmNkYPtQq2gh/RVVkzAKWn1A9dQQqaEEp6HsYSteHgS8UVmcffiHMDtB\nak1sgV5wCGYmcB94r6v8wyZXKIztt+ouGJAmCqiSGE/tRxjwSJtvjmnbhNzV\n19+UmP3m/Yy/dQxW2pvRfSMttTWmJo6aGB4n4Y1WwiCDQ0bn3Ij0kQBgy1sf\npz/0yIEfi8Sk1NTRxYhaQ7Q4nztKbui7168X7CWgKetmF2eO4lDAfwArTqrZ\noV5TDctShs6mMWChaIYEB0f39ubmZjjwWArINB1k8sRoicULfiYRtZ6q3sSP\nC5P9ajP2fh8HYyn7C/dalPzirSFx+rT8AY6F34PoGqgg8uY7gS05ZmJTDSlW\nEV/9\r\n=X+uo\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        },
+        {
+          "email": "contact@svachon.com",
+          "name": "stevenvachon"
+        },
+        {
+          "email": "trysound@yandex.ru",
+          "name": "trysound"
+        }
+      ],
+      "_npmUser": {
+        "name": "trysound",
+        "email": "trysound@yandex.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object_3.0.1_1593245179588_0.38683699163270036"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor, or Object.create(null).",
+      "version": "4.0.0",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Osman Nuri Okumuş",
+          "url": "http://onokumus.com"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "main": "index.cjs.js",
+      "module": "index.es.js",
+      "types": "index.d.ts",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "build": "rollup -c",
+        "test_browser": "mocha-headless-chrome --args=disable-web-security -f test/browser.html",
+        "test_node": "mocha -r esm",
+        "test": "npm run test_node && npm run build && npm run test_browser",
+        "prepare": "rollup -c"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^8.1.0",
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "isobject": "^4.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^2.18.1"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "is-number",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2014-2017, Jon Schlinkert.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
+      "_id": "is-plain-object@4.0.0",
+      "dist": {
+        "shasum": "2cd131aa2dc1340ceaee89248f61823706457feb",
+        "integrity": "sha512-WipTQmPd1scuJUgwV/EZ1QbbOpEyHTQEXz4cJvrn+uwwgUtPcd3FD+yvAcKLYA8so2UsjNAq1JBu9rGgmGguVg==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.0.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 9586,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFjJRCRA9TVsSAnZWagAArSEP/0zl2FpPkI11JRXiXaq+\nmc5ciKkpKcuyOFga+lOoKPGM09m0xTFPIhNC968UtoGeyW+vw983F+hHsD3J\nQ+CibN7jmPUYASKdziI5iZj1/I2v2WNXQNPat3XTZEn2ODqzXaV+TVWMneO8\nNDCIXlCm/la8bWMK5BjEWxzybgPSnRNEw+oDOe8+XMwNJU8TO5XmWwOrtYnb\ndGE532K842tgVMRclfhWJVmK0PG9R+DNleiwZyFpEJYF2loZk1SHzMeFrdaW\nMN2rvGXrlNOcFaEnoDhtyJxzB/tOM5he+L1jo2QiRpTMF5BzA8U2Ch5d8+7/\nyO317xt0rmP5SHMEx2WJQ5t6Tjx5AuB3bkZBgJiQekvSTnUXPF2/dicgMbse\nCt8ulAIXWPvAwjNyLvM/FLFbr4w/NxuHwslKQwrYKXvkxQ11aVU1ENfnNzJg\n+XeduOHN+vSeFF3b1RKeV0AKqVaK5GfjHumZwYDqhMTLFy2bX60P7cpw5cVL\ntGk2cMPclT5hp9PT+/A8AqYbX1J4/6QENjqmfklJlmhdbm+vQIUXtr4Ratbx\nSElqBUNxiuj2H6UAiOfJZFOp+XZfiLmSvqMsJLoswe9pWJMBA6xxmFmL5qRW\nyjIeyxz/uY4gXlZSWVXgdR57hwd8HUN8Igyaepz8ulQ4zawyoPxOjPwNOHmJ\nITUZ\r\n=kqQc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        },
+        {
+          "email": "contact@svachon.com",
+          "name": "stevenvachon"
+        },
+        {
+          "email": "trysound@yandex.ru",
+          "name": "trysound"
+        }
+      ],
+      "_npmUser": {
+        "name": "trysound",
+        "email": "trysound@yandex.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object_4.0.0_1595290193115_0.9493888596664919"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.0": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor, or Object.create(null).",
+      "version": "4.1.0",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Osman Nuri Okumuş",
+          "url": "http://onokumus.com"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "main": "index.cjs.js",
+      "module": "index.es.js",
+      "types": "index.d.ts",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "build": "rollup -c",
+        "test_browser": "mocha-headless-chrome --args=disable-web-security -f test/browser.html",
+        "test_node": "mocha -r esm",
+        "test": "npm run test_node && npm run build && npm run test_browser",
+        "prepare": "rollup -c"
+      },
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^2.22.1"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "is-number",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2014-2017, Jon Schlinkert.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
+      "_id": "is-plain-object@4.1.0",
+      "dist": {
+        "shasum": "00196ad308ebb7de9d1fb57ae92ef1c38d5a740e",
+        "integrity": "sha512-1N1OpoS8S4Ua+FsH6Mhvgaj0di3uRXgulcv2dnFu2J/WcEsDNbBoiUX6mYmhQ2cAzZ+B/lTJtX1qUSL5RwsGug==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 8848,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFsqcCRA9TVsSAnZWagAAyIcP/2EOxdbMmCMKyWJOsPse\n+s6cj5zx8u0p6ZPg1MrXp8am9hNfZ12NIyuCUuJ/3vVfHJeAiP+sSNWrlUuJ\n3fyKi7AKddLkUarOU9h6hnNxp0K5CGMrfTPqsnG1HP6Z2gRinOr9CgHOjbPF\nRYbECybxV3uAv4JivKxfgNN+8UaZwn95LnA5DY+oq7/leR2dxnlSS3rh3UVS\nr/kGOqrb2PloXYPPPcO3nJsZWfboApgArqUkVENUPGIzIYiibCsMty/F7rIo\nnZPibVN5Rsm5ZbAtzxMRm8v1S9nHbfC5HEMtTNtkc0f/4LwFHO+G7KxyAMqK\ncTRHdOw4UQM5qUDggxWalf3DoBWA8jwxtJ2gHca+nTPExG7OOOh3x0qJUGBU\nnoRAe87DilT9uzgGVghgOPAoDTVXHAIwcwV6xab0hKN1kMGE3j9yNazwX16s\nFdCDHu8OX0k18bDz23xrKWw4TRrYU75RseQHkazRRr+mq9JzTzu03Ra3eEcS\n5RlOSz0/IV5ZlqooPLqMUxeTKF/fW1pwdpzQUXKoPze8nLAMqqh/fyNHEI0w\nc1uS3qTST24pNv6cCU0j3H7LaWjM5V1zvXolJeDmufl928DLweGnO6vaotQ5\nNQGi6bJzKXUxqzbpOWlaHSbaZrP+8hT/vI8jeM09ifsCKMJxSgw9peTLNQ3x\nF6p3\r\n=5d0P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        },
+        {
+          "email": "contact@svachon.com",
+          "name": "stevenvachon"
+        },
+        {
+          "email": "trysound@yandex.ru",
+          "name": "trysound"
+        }
+      ],
+      "_npmUser": {
+        "name": "trysound",
+        "email": "trysound@yandex.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object_4.1.0_1595329180429_0.6450668912349269"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.1": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor, or Object.create(null).",
+      "version": "4.1.1",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Osman Nuri Okumuş",
+          "url": "http://onokumus.com"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "main": "index.cjs.js",
+      "module": "index.es.js",
+      "types": "index.d.ts",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "build": "rollup -c",
+        "test_browser": "mocha-headless-chrome --args=disable-web-security -f test/browser.html",
+        "test_node": "mocha -r esm",
+        "test": "npm run test_node && npm run build && npm run test_browser",
+        "prepare": "rollup -c"
+      },
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^2.22.1"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "is-number",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2014-2017, Jon Schlinkert.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
+      "_id": "is-plain-object@4.1.1",
+      "dist": {
+        "shasum": "1a14d6452cbd50790edc7fdaa0aed5a40a35ebb5",
+        "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 8836,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfGoXUCRA9TVsSAnZWagAAYKcP/3EnkUPC8tUbqR/CUOpH\nUYQhWAnCjNfSacMHUehZNN9QiauM8Rxcwl8n3/J19kzqt0nyT9wgWiu8+R+F\nHvTJlJyQ0ZbFdiLhE1gm1nx0/OU96OKJi7SkQtZFCRz0eT4tkNA0vVS8uTmT\nS1/LtCzCnpMNB7Iq3V/9RVmkUOV0sox9RiNXDle+aa3T2B87fJwfUzptKATZ\n5OcjbA6qqmECGPmDLNPFdpH9isfyWMUsvHRYGn55fwP38g/yMjZupFtiqWPJ\n22R2jMSTg/ni5yyTpEQlkjH/o2kaqmlrJsgaLX4jbK+hYXKHQzg0loE/0thi\nDnktO4ywGcdQpZnFn3L/WuAMwauAca81Otd4FfwvOCW8EiNhcXTk4EVpCs/E\nhgE+U5ClvIAW5c7SLBQhVV0P2FuaBUZ0cC9rWaA0i1ySPROKFsrcDaCAuS80\nFZ5NClxpLEO0+mosTZ/mAtGLeMHrLlmikizvmHXso2VJIoidmybc78/ZpOcO\nBzroS6/laUWhnRsvV1M0C/hOfluFg34P+egb/VcVnbskjRMaRI6Ra+0h/L5p\npv8tzLFLYmq1J/ggPd6yNrOwS3QGzE0ZuICo6hAXFETVKY7iLB0N471yScM5\nYaB8+luUuAVglF32P6SkyKp2mrqrfIvVoggzmamhodICoU3aLY/UiG6CdLny\nSt+i\r\n=rLPi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        },
+        {
+          "email": "contact@svachon.com",
+          "name": "stevenvachon"
+        },
+        {
+          "email": "trysound@yandex.ru",
+          "name": "trysound"
+        }
+      ],
+      "_npmUser": {
+        "name": "trysound",
+        "email": "trysound@yandex.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object_4.1.1_1595573715637_0.6347161567543831"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.0": {
+      "name": "is-plain-object",
+      "description": "Returns true if an object was created by the `Object` constructor, or Object.create(null).",
+      "version": "5.0.0",
+      "homepage": "https://github.com/jonschlinkert/is-plain-object",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Osman Nuri Okumuş",
+          "url": "http://onokumus.com"
+        },
+        {
+          "name": "Steven Vachon",
+          "url": "https://svachon.com"
+        },
+        {
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        },
+        {
+          "name": "Bogdan Chadkin",
+          "url": "https://github.com/TrySound"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonschlinkert/is-plain-object.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+      },
+      "license": "MIT",
+      "main": "dist/is-plain-object.js",
+      "module": "dist/is-plain-object.mjs",
+      "types": "is-plain-object.d.ts",
+      "exports": {
+        ".": {
+          "import": "./dist/is-plain-object.mjs",
+          "require": "./dist/is-plain-object.js"
+        },
+        "./package.json": "./package.json"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "build": "rollup -c",
+        "test_browser": "mocha-headless-chrome --args=disable-web-security -f test/browser.html",
+        "test_node": "mocha -r esm",
+        "test": "npm run test_node && npm run build && npm run test_browser",
+        "prepare": "rollup -c"
+      },
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^2.22.1"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "kind",
+        "kind-of",
+        "object",
+        "plain",
+        "type",
+        "typeof",
+        "value"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "is-number",
+            "isobject",
+            "kind-of"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "licenseText": "The MIT License (MIT)\n\nCopyright (c) 2014-2017, Jon Schlinkert.\n\nPermission is hereby granted, free of charge, to any person obtaining a copy\nof this software and associated documentation files (the \"Software\"), to deal\nin the Software without restriction, including without limitation the rights\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the Software is\nfurnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in\nall copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\nTHE SOFTWARE.\n",
+      "_id": "is-plain-object@5.0.0",
+      "dist": {
+        "shasum": "4427f50ab3429e9025ea7d52e9043a9ef4159344",
+        "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 9158,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfWQMLCRA9TVsSAnZWagAAbRYQAKQJLFQphXNDxc6H/B1u\n9dBvAqV0kSdebj3S054eyEsQXjJ+WZ2GTQQEiwLenikkNNDUmOkbZxNm2jtw\nzmaZM+RxrYgG8CkDvPO2Iq0KHR5RwbPi6JIiSG/mGb3NkFwCXjdJzFQCujrp\no9fWdALUFfEc3umG4OH4pz2wUkP8zU6RHRfo9lOtEE3zqkyLqHbPSPwfLGcA\nmEmsSPSTFg4+12l7iN1B7UFsyDuLlA2m/t/CLQaPBuum1jjjJpul3Eb4mV2q\ntsi9s8L63EafxM17xR8OQoGowAxw4q3gAADEtx/oR4jld8n2vu3TKDCeG0CP\nlZAEX8psMnqrx+CAiHY2NrC5sXKXx3z6e/h6g0MlJ74wlYZRZYLro+vQDJLM\nOHwfMcGzRKKz/ztHwMl5OaCIx1jURFK8YX0+VZi/VEmNom/LX9tUcpJm8heo\n+4uPTCo78K02AGlcvxNhpPwOI0KfgeZxVQff/D9ZU3AlBqTOqpzVsMAvNswI\nSCus5AV8kwBPyI2IIRZkmlJ5I5S0OS7CUlpJ7QFtaqQmHlq1uxZ2OF3Onrq+\nQa4HxsDPq1T1q1wGMnUJPGZKP1wWTSmQ94Uehz0IN4p7qo6+ifBr5nq6xpxr\ny4eALo3qYuHnQ0amaiOESVMw4zVbAh1f3d6Scp8uyjT22utICnNO0dioz5Sx\nM9nC\r\n=QWWU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "stevenvachon",
+          "email": "contact@svachon.com"
+        },
+        {
+          "name": "trysound",
+          "email": "trysound@yandex.ru"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "trysound",
+        "email": "trysound@yandex.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-plain-object_5.0.0_1599669003462_0.7889028160747054"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# is-plain-object [![NPM version](https://img.shields.io/npm/v/is-plain-object.svg?style=flat)](https://www.npmjs.com/package/is-plain-object) [![NPM monthly downloads](https://img.shields.io/npm/dm/is-plain-object.svg?style=flat)](https://npmjs.org/package/is-plain-object) [![NPM total downloads](https://img.shields.io/npm/dt/is-plain-object.svg?style=flat)](https://npmjs.org/package/is-plain-object) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/is-plain-object.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/is-plain-object)\n\n> Returns true if an object was created by the `Object` constructor, or Object.create(null).\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save is-plain-object\n```\n\nUse [isobject](https://github.com/jonschlinkert/isobject) if you only want to check if the value is an object and not an array or null.\n\n## Usage\n\nwith es modules\n```js\nimport { isPlainObject } from 'is-plain-object';\n```\n\nor with commonjs\n```js\nconst { isPlainObject } = require('is-plain-object');\n```\n\n**true** when created by the `Object` constructor, or Object.create(null).\n\n```js\nisPlainObject(Object.create({}));\n//=> true\nisPlainObject(Object.create(Object.prototype));\n//=> true\nisPlainObject({foo: 'bar'});\n//=> true\nisPlainObject({});\n//=> true\nisPlainObject(null);\n//=> true\n```\n\n**false** when not created by the `Object` constructor.\n\n```js\nisPlainObject(1);\n//=> false\nisPlainObject(['foo', 'bar']);\n//=> false\nisPlainObject([]);\n//=> false\nisPlainObject(new Foo);\n//=> false\nisPlainObject(Object.create(null));\n//=> false\n```\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [is-number](https://www.npmjs.com/package/is-number): Returns true if a number or string value is a finite number. Useful for regex… [more](https://github.com/jonschlinkert/is-number) | [homepage](https://github.com/jonschlinkert/is-number \"Returns true if a number or string value is a finite number. Useful for regex matches, parsing, user input, etc.\")\n* [isobject](https://www.npmjs.com/package/isobject): Returns true if the value is an object and not an array or null. | [homepage](https://github.com/jonschlinkert/isobject \"Returns true if the value is an object and not an array or null.\")\n* [kind-of](https://www.npmjs.com/package/kind-of): Get the native type of a value. | [homepage](https://github.com/jonschlinkert/kind-of \"Get the native type of a value.\")\n\n### Contributors\n\n| **Commits** | **Contributor** |  \n| --- | --- |  \n| 19 | [jonschlinkert](https://github.com/jonschlinkert) |  \n| 6  | [TrySound](https://github.com/TrySound) |  \n| 6  | [stevenvachon](https://github.com/stevenvachon) |  \n| 3  | [onokumus](https://github.com/onokumus) |  \n| 1  | [wtgtybhertgeghgtwtg](https://github.com/wtgtybhertgeghgtwtg) |  \n\n### Author\n\n**Jon Schlinkert**\n\n* [GitHub Profile](https://github.com/jonschlinkert)\n* [Twitter Profile](https://twitter.com/jonschlinkert)\n* [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)\n\n### License\n\nCopyright © 2019, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.8.0, on April 28, 2019._\n",
+  "maintainers": [
+    {
+      "name": "stevenvachon",
+      "email": "contact@svachon.com"
+    },
+    {
+      "name": "trysound",
+      "email": "trysound@yandex.ru"
+    },
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-09-09T16:30:06.726Z",
+    "created": "2014-09-21T22:41:50.073Z",
+    "0.1.0": "2014-09-21T22:41:50.073Z",
+    "1.0.0": "2015-02-25T07:49:39.188Z",
+    "2.0.0": "2015-04-29T12:57:28.225Z",
+    "2.0.1": "2015-05-28T08:02:18.730Z",
+    "2.0.2": "2017-05-27T19:53:30.152Z",
+    "2.0.3": "2017-05-30T14:06:48.757Z",
+    "2.0.4": "2017-07-11T22:41:10.371Z",
+    "3.0.0": "2019-04-30T20:53:56.159Z",
+    "3.0.1": "2020-06-27T08:06:19.703Z",
+    "4.0.0": "2020-07-21T00:09:53.219Z",
+    "4.1.0": "2020-07-21T10:59:40.572Z",
+    "4.1.1": "2020-07-24T06:55:15.761Z",
+    "5.0.0": "2020-09-09T16:30:03.627Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/is-plain-object",
+  "keywords": [
+    "check",
+    "is",
+    "is-object",
+    "isobject",
+    "javascript",
+    "kind",
+    "kind-of",
+    "object",
+    "plain",
+    "type",
+    "typeof",
+    "value"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jonschlinkert/is-plain-object.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/is-plain-object/issues"
+  },
+  "readmeFilename": "README.md",
+  "users": {
+    "dfcreative": true,
+    "arttse": true,
+    "rochejul": true,
+    "d-band": true,
+    "ericmorand": true
+  },
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Jon Schlinkert",
+      "url": "http://twitter.com/jonschlinkert"
+    },
+    {
+      "name": "Osman Nuri Okumuş",
+      "url": "http://onokumus.com"
+    },
+    {
+      "name": "Steven Vachon",
+      "url": "https://svachon.com"
+    },
+    {
+      "url": "https://github.com/wtgtybhertgeghgtwtg"
+    },
+    {
+      "name": "Bogdan Chadkin",
+      "url": "https://github.com/TrySound"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/is-plain-object.min.json
+++ b/test/fixtures/registry-mocks/content/is-plain-object.min.json
@@ -1,0 +1,301 @@
+{
+  "name": "is-plain-object",
+  "dist-tags": {
+    "latest": "5.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "is-plain-object",
+      "version": "0.1.0",
+      "devDependencies": {
+        "verb": "~0.2.6",
+        "chai": "~1.9.1",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "3ca7db022de72fd12007f1957beb59ea596b979c",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "is-plain-object",
+      "version": "1.0.0",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "ff5f752db71c3328afd5e685eb6adddd3eaffab7",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "is-plain-object",
+      "version": "2.0.0",
+      "dependencies": {
+        "isobject": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "chai": "*",
+        "mocha": "*",
+        "mocha-phantomjs": "*",
+        "phantomjs": "*",
+        "uglify-js": "*"
+      },
+      "dist": {
+        "shasum": "8612587fa90279dc1b6e1cec2056f6c1df7abb2a",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.1": {
+      "name": "is-plain-object",
+      "version": "2.0.1",
+      "dependencies": {
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "chai": "*",
+        "mocha": "*",
+        "mocha-phantomjs": "*",
+        "phantomjs": "*",
+        "uglify-js": "*"
+      },
+      "dist": {
+        "shasum": "4d7ca539bc9db9b737b8acb612f2318ef92f294f",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.2": {
+      "name": "is-plain-object",
+      "version": "2.0.2",
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^14.3.0",
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.2",
+        "mocha-phantomjs": "^4.1.0",
+        "phantomjs": "^2.1.7",
+        "uglify-js": "^3.0.12"
+      },
+      "dist": {
+        "shasum": "1d9ab795669937de31998071ca1f701770b375a4",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.3": {
+      "name": "is-plain-object",
+      "version": "2.0.3",
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^14.3.0",
+        "chai": "^4.0.0",
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.2",
+        "mocha-phantomjs": "^4.1.0",
+        "phantomjs": "^2.1.7",
+        "uglify-js": "^3.0.12"
+      },
+      "dist": {
+        "shasum": "c15bf3e4b66b62d72efaf2925848663ecbc619b6",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.4": {
+      "name": "is-plain-object",
+      "version": "2.0.4",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^14.4.0",
+        "chai": "^4.0.2",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.4.2",
+        "mocha-phantomjs": "^4.1.0",
+        "phantomjs": "^2.1.7",
+        "uglify-js": "^3.0.24"
+      },
+      "dist": {
+        "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+        "shasum": "2c163b3fafb1b606d9d17928f05c2a1c38e07677",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "is-plain-object",
+      "version": "3.0.0",
+      "dependencies": {
+        "isobject": "^4.0.0"
+      },
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^2.0.2",
+        "rollup": "^1.10.1",
+        "rollup-plugin-node-resolve": "^4.2.3"
+      },
+      "dist": {
+        "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+        "shasum": "47bfc5da1b5d50d64110806c199359482e75a928",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 9185,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcyLXkCRA9TVsSAnZWagAAd2IP+wfkoxXYjoEkwNWIUrfy\nzjhbQ5xnTwlZuNoPWZuVdQSYDwufCyh/zWeuiJjsCEkNT/z0QegPdK4PZFIi\n6BNti78yVazpcsonD3njnmoyrV5/8iXyI+C1PRo6nOO6kNHXx0JjAoLRAoVC\nDguYquTDhdo2WlQJ01ln8dSx9ueWQx5QMLE9lBXPzYmrtXbQcLd5Z8uXE4P/\n0vrkIuteL/p7I5RF2iFYjz4sEShk9W+ZNqlAf8Xsaa7yT2B5RRiy/ron5/+g\nLrnPAPn4954fWupxRuivAqgj3CfoOxx6Pl1D+ksK6sNywn6zB2fqTQm8vSLe\nsh6+BrX4ML34PA+2GSMmsv2+pU9Ksc2MwVJYzvIRQYlxMIza6rSMpfoJFiqW\nbiGyVf5+NSozNOnNpqxrv2OYIZnsKk+4ZL8kM5VrMnMAtB0IO8dgPO7uG/pf\n/CpqXJ9b9YKit5JnvuVksepqBIj+j2e40Od4E/wjsNKrIN0J06NksaVTmexo\njebkKSgAqGqqTPeeShtj44dF+Mdu8ChtBE5NYPLzJMDK5gslVb3/IdICzAwg\ncUXCgDR7KfoSio/4bCBB3sx+B4rCwcP3Eoi139qrQeXnl/OVCgINbd7U0u4A\nNIBq4uhTTb7ylFxJAcDBGPfqohPzoUc93pj+tClmPfF/+Bl7KBjZPKdhFI9u\nudtk\r\n=3ByD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.1": {
+      "name": "is-plain-object",
+      "version": "3.0.1",
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^8.1.0",
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "isobject": "^4.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^1.10.1"
+      },
+      "dist": {
+        "shasum": "662d92d24c0aa4302407b0d45d21f2251c85f85b",
+        "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 9457,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9v38CRA9TVsSAnZWagAAkbEQAJ2Xlwabzov0sVASU7tL\nzQZeGLp+nSkO6NsxaLstwPvOlcwwVyvguew4itIVLHJJ1Hc6c25OejfbJ8j2\nXvOqFWdmtBZovDMD0LzhLe9mEdE7dyLQeuNqcNS94GTaXi0LLRVcK1GxQEM4\ntD30mx2iEdgW7chgYmm/UD1jiRkiyMA8jOt2Cf76+dTxtkqXGAz4hoI6wsId\noH1274RbdaCjEqBmcfWWaWkhAdrb2B3XoWRkdyFAlG/t7kmAUPJ8hS/ztHal\niLCI9uoHs0RLYE+dOe4URvsJi/GJD8pmXVBwr1vWsHJoklWeTly/segTpzu0\njUNRjmNkYPtQq2gh/RVVkzAKWn1A9dQQqaEEp6HsYSteHgS8UVmcffiHMDtB\nak1sgV5wCGYmcB94r6v8wyZXKIztt+ouGJAmCqiSGE/tRxjwSJtvjmnbhNzV\n19+UmP3m/Yy/dQxW2pvRfSMttTWmJo6aGB4n4Y1WwiCDQ0bn3Ij0kQBgy1sf\npz/0yIEfi8Sk1NTRxYhaQ7Q4nztKbui7168X7CWgKetmF2eO4lDAfwArTqrZ\noV5TDctShs6mMWChaIYEB0f39ubmZjjwWArINB1k8sRoicULfiYRtZ6q3sSP\nC5P9ajP2fh8HYyn7C/dalPzirSFx+rT8AY6F34PoGqgg8uY7gS05ZmJTDSlW\nEV/9\r\n=X+uo\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "4.0.0": {
+      "name": "is-plain-object",
+      "version": "4.0.0",
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^8.1.0",
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "isobject": "^4.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^2.18.1"
+      },
+      "dist": {
+        "shasum": "2cd131aa2dc1340ceaee89248f61823706457feb",
+        "integrity": "sha512-WipTQmPd1scuJUgwV/EZ1QbbOpEyHTQEXz4cJvrn+uwwgUtPcd3FD+yvAcKLYA8so2UsjNAq1JBu9rGgmGguVg==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.0.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 9586,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFjJRCRA9TVsSAnZWagAArSEP/0zl2FpPkI11JRXiXaq+\nmc5ciKkpKcuyOFga+lOoKPGM09m0xTFPIhNC968UtoGeyW+vw983F+hHsD3J\nQ+CibN7jmPUYASKdziI5iZj1/I2v2WNXQNPat3XTZEn2ODqzXaV+TVWMneO8\nNDCIXlCm/la8bWMK5BjEWxzybgPSnRNEw+oDOe8+XMwNJU8TO5XmWwOrtYnb\ndGE532K842tgVMRclfhWJVmK0PG9R+DNleiwZyFpEJYF2loZk1SHzMeFrdaW\nMN2rvGXrlNOcFaEnoDhtyJxzB/tOM5he+L1jo2QiRpTMF5BzA8U2Ch5d8+7/\nyO317xt0rmP5SHMEx2WJQ5t6Tjx5AuB3bkZBgJiQekvSTnUXPF2/dicgMbse\nCt8ulAIXWPvAwjNyLvM/FLFbr4w/NxuHwslKQwrYKXvkxQ11aVU1ENfnNzJg\n+XeduOHN+vSeFF3b1RKeV0AKqVaK5GfjHumZwYDqhMTLFy2bX60P7cpw5cVL\ntGk2cMPclT5hp9PT+/A8AqYbX1J4/6QENjqmfklJlmhdbm+vQIUXtr4Ratbx\nSElqBUNxiuj2H6UAiOfJZFOp+XZfiLmSvqMsJLoswe9pWJMBA6xxmFmL5qRW\nyjIeyxz/uY4gXlZSWVXgdR57hwd8HUN8Igyaepz8ulQ4zawyoPxOjPwNOHmJ\nITUZ\r\n=kqQc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "4.1.0": {
+      "name": "is-plain-object",
+      "version": "4.1.0",
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^2.22.1"
+      },
+      "dist": {
+        "shasum": "00196ad308ebb7de9d1fb57ae92ef1c38d5a740e",
+        "integrity": "sha512-1N1OpoS8S4Ua+FsH6Mhvgaj0di3uRXgulcv2dnFu2J/WcEsDNbBoiUX6mYmhQ2cAzZ+B/lTJtX1qUSL5RwsGug==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 8848,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFsqcCRA9TVsSAnZWagAAyIcP/2EOxdbMmCMKyWJOsPse\n+s6cj5zx8u0p6ZPg1MrXp8am9hNfZ12NIyuCUuJ/3vVfHJeAiP+sSNWrlUuJ\n3fyKi7AKddLkUarOU9h6hnNxp0K5CGMrfTPqsnG1HP6Z2gRinOr9CgHOjbPF\nRYbECybxV3uAv4JivKxfgNN+8UaZwn95LnA5DY+oq7/leR2dxnlSS3rh3UVS\nr/kGOqrb2PloXYPPPcO3nJsZWfboApgArqUkVENUPGIzIYiibCsMty/F7rIo\nnZPibVN5Rsm5ZbAtzxMRm8v1S9nHbfC5HEMtTNtkc0f/4LwFHO+G7KxyAMqK\ncTRHdOw4UQM5qUDggxWalf3DoBWA8jwxtJ2gHca+nTPExG7OOOh3x0qJUGBU\nnoRAe87DilT9uzgGVghgOPAoDTVXHAIwcwV6xab0hKN1kMGE3j9yNazwX16s\nFdCDHu8OX0k18bDz23xrKWw4TRrYU75RseQHkazRRr+mq9JzTzu03Ra3eEcS\n5RlOSz0/IV5ZlqooPLqMUxeTKF/fW1pwdpzQUXKoPze8nLAMqqh/fyNHEI0w\nc1uS3qTST24pNv6cCU0j3H7LaWjM5V1zvXolJeDmufl928DLweGnO6vaotQ5\nNQGi6bJzKXUxqzbpOWlaHSbaZrP+8hT/vI8jeM09ifsCKMJxSgw9peTLNQ3x\nF6p3\r\n=5d0P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "4.1.1": {
+      "name": "is-plain-object",
+      "version": "4.1.1",
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^2.22.1"
+      },
+      "dist": {
+        "shasum": "1a14d6452cbd50790edc7fdaa0aed5a40a35ebb5",
+        "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 8836,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfGoXUCRA9TVsSAnZWagAAYKcP/3EnkUPC8tUbqR/CUOpH\nUYQhWAnCjNfSacMHUehZNN9QiauM8Rxcwl8n3/J19kzqt0nyT9wgWiu8+R+F\nHvTJlJyQ0ZbFdiLhE1gm1nx0/OU96OKJi7SkQtZFCRz0eT4tkNA0vVS8uTmT\nS1/LtCzCnpMNB7Iq3V/9RVmkUOV0sox9RiNXDle+aa3T2B87fJwfUzptKATZ\n5OcjbA6qqmECGPmDLNPFdpH9isfyWMUsvHRYGn55fwP38g/yMjZupFtiqWPJ\n22R2jMSTg/ni5yyTpEQlkjH/o2kaqmlrJsgaLX4jbK+hYXKHQzg0loE/0thi\nDnktO4ywGcdQpZnFn3L/WuAMwauAca81Otd4FfwvOCW8EiNhcXTk4EVpCs/E\nhgE+U5ClvIAW5c7SLBQhVV0P2FuaBUZ0cC9rWaA0i1ySPROKFsrcDaCAuS80\nFZ5NClxpLEO0+mosTZ/mAtGLeMHrLlmikizvmHXso2VJIoidmybc78/ZpOcO\nBzroS6/laUWhnRsvV1M0C/hOfluFg34P+egb/VcVnbskjRMaRI6Ra+0h/L5p\npv8tzLFLYmq1J/ggPd6yNrOwS3QGzE0ZuICo6hAXFETVKY7iLB0N471yScM5\nYaB8+luUuAVglF32P6SkyKp2mrqrfIvVoggzmamhodICoU3aLY/UiG6CdLny\nSt+i\r\n=rLPi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "5.0.0": {
+      "name": "is-plain-object",
+      "version": "5.0.0",
+      "devDependencies": {
+        "chai": "^4.2.0",
+        "esm": "^3.2.22",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^6.1.4",
+        "mocha-headless-chrome": "^3.1.0",
+        "rollup": "^2.22.1"
+      },
+      "dist": {
+        "shasum": "4427f50ab3429e9025ea7d52e9043a9ef4159344",
+        "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+        "tarball": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 9158,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfWQMLCRA9TVsSAnZWagAAbRYQAKQJLFQphXNDxc6H/B1u\n9dBvAqV0kSdebj3S054eyEsQXjJ+WZ2GTQQEiwLenikkNNDUmOkbZxNm2jtw\nzmaZM+RxrYgG8CkDvPO2Iq0KHR5RwbPi6JIiSG/mGb3NkFwCXjdJzFQCujrp\no9fWdALUFfEc3umG4OH4pz2wUkP8zU6RHRfo9lOtEE3zqkyLqHbPSPwfLGcA\nmEmsSPSTFg4+12l7iN1B7UFsyDuLlA2m/t/CLQaPBuum1jjjJpul3Eb4mV2q\ntsi9s8L63EafxM17xR8OQoGowAxw4q3gAADEtx/oR4jld8n2vu3TKDCeG0CP\nlZAEX8psMnqrx+CAiHY2NrC5sXKXx3z6e/h6g0MlJ74wlYZRZYLro+vQDJLM\nOHwfMcGzRKKz/ztHwMl5OaCIx1jURFK8YX0+VZi/VEmNom/LX9tUcpJm8heo\n+4uPTCo78K02AGlcvxNhpPwOI0KfgeZxVQff/D9ZU3AlBqTOqpzVsMAvNswI\nSCus5AV8kwBPyI2IIRZkmlJ5I5S0OS7CUlpJ7QFtaqQmHlq1uxZ2OF3Onrq+\nQa4HxsDPq1T1q1wGMnUJPGZKP1wWTSmQ94Uehz0IN4p7qo6+ifBr5nq6xpxr\ny4eALo3qYuHnQ0amaiOESVMw4zVbAh1f3d6Scp8uyjT22utICnNO0dioz5Sx\nM9nC\r\n=QWWU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2020-09-09T16:30:06.726Z"
+}

--- a/test/fixtures/registry-mocks/content/is-wsl.json
+++ b/test/fixtures/registry-mocks/content/is-wsl.json
@@ -1,0 +1,497 @@
+{
+  "_id": "is-wsl",
+  "_rev": "5-dbb78f90c1b72773c6b55dbfb438d8d1",
+  "name": "is-wsl",
+  "description": "Check if the process is running inside Windows Subsystem for Linux (Bash on Windows)",
+  "dist-tags": {
+    "latest": "2.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "is-wsl",
+      "version": "1.0.0",
+      "description": "Check if the process is running inside Windows Subsystem for Linux (Bash on Windows)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-wsl.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "check",
+        "wsl",
+        "windows",
+        "subsystem",
+        "linux",
+        "detect",
+        "bash",
+        "process",
+        "console",
+        "terminal",
+        "is"
+      ],
+      "devDependencies": {
+        "ava": "*",
+        "proxyquire": "^1.7.11",
+        "xo": "*"
+      },
+      "ava": {
+        "require": "./pre-test"
+      },
+      "gitHead": "c6ca0e95be14195689497e93e4406a55b5971022",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-wsl/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-wsl#readme",
+      "_id": "is-wsl@1.0.0",
+      "_shasum": "48ad3669f346b13c36578715c4f180a6685e3dba",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "48ad3669f346b13c36578715c4f180a6685e3dba",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/is-wsl-1.0.0.tgz_1492350076393_0.24916732753627002"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "is-wsl",
+      "version": "1.1.0",
+      "description": "Check if the process is running inside Windows Subsystem for Linux (Bash on Windows)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-wsl.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "check",
+        "wsl",
+        "windows",
+        "subsystem",
+        "linux",
+        "detect",
+        "bash",
+        "process",
+        "console",
+        "terminal",
+        "is"
+      ],
+      "devDependencies": {
+        "ava": "*",
+        "clear-require": "^2.0.0",
+        "proxyquire": "^1.7.11",
+        "xo": "*"
+      },
+      "gitHead": "60ea5d57a51ee596cb144ef47187c0476a5a421b",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-wsl/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-wsl#readme",
+      "_id": "is-wsl@1.1.0",
+      "_shasum": "1f16e4aa22b04d1336b66188a66af3c600c3a66d",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "1f16e4aa22b04d1336b66188a66af3c600c3a66d",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/is-wsl-1.1.0.tgz_1492407587032_0.143065512413159"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "is-wsl",
+      "version": "2.0.0",
+      "description": "Check if the process is running inside Windows Subsystem for Linux (Bash on Windows)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-wsl.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "check",
+        "wsl",
+        "windows",
+        "subsystem",
+        "linux",
+        "detect",
+        "bash",
+        "process",
+        "console",
+        "terminal",
+        "is"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "clear-module": "^3.2.0",
+        "proxyquire": "^2.1.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "259d6f980602b053133efbf03a8868be649106c9",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-wsl/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-wsl#readme",
+      "_id": "is-wsl@2.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-58xqeym9YpL60zUX4GlBfSLgV0mOL5JRQ6b8HnmmD4crNxprFdL7JGuo9AgtY38+JqseeA6t+XzYCprTkD4nmg==",
+        "shasum": "32849d5bf66413883ce07fada2e924f5505ed493",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3177,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcvsnUCRA9TVsSAnZWagAAkYQQAJiKyFSKTEni5NYMBT/o\nycO6G91B3wbsPbBOzvumTWoQNxhTNUA3vc0/FNRblipfrOiHfpH9TG+9ZF2K\naVRBY8txg8ekXxQF/32XUoYV8+t8yE1XXOMdwLsOWy+5p/auWG7C0i1fghEw\ngkcHaW1y4UZTN+ry5djhylIStzAL+hftB9Cyh03MYN0S56qCK4soK3iG8oR/\nYvs0lY4DcCKZavATkKAT+JZ2TEruQgD91s1lYCUePJKB3KKZ7A+xlilwAjb5\nYethj23pzUObJcBNd5L2Kd3JANOJmal8d1LwBlRClsKUuPog7cTgr0JdrCKT\nnPG/p4CopMFdQmCt4Fal+negehWNvlXtynwwwrPfMYgv9vSjsZY4e1FqWKvA\nWWCqpn41luatUmQa2Zw4Lunfn/gmVqvifIITRLKYTL7OS0Hg7LDGAL+4Jbjm\nzBnEmTwLJb68f5UBGXEOkPA0ThzdH0bPbCLCqc+CEJmANhb+i8oVAD6jQymO\nBmdUGwc/MXdTd4oBoYwRkIzfaXm8V1ixlOpwQzp3KQVK2XPwqf13U9uOBeXf\nwPbFnrXL8365lb86LNwuyTS9AvnA7O80ECBSKUkcnT+aUaejQzhmAbaRzGj+\nah90oaufYLsWuMFBYjHc0aMEhJXZk6ERdCdyJ1Z97rnUwD18/+S0YQ5L80jQ\nIy7n\r\n=yHtf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-wsl_2.0.0_1556007379399_0.8450262724840771"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.1.0": {
+      "name": "is-wsl",
+      "version": "2.1.0",
+      "description": "Check if the process is running inside Windows Subsystem for Linux (Bash on Windows)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-wsl.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "check",
+        "wsl",
+        "windows",
+        "subsystem",
+        "linux",
+        "detect",
+        "bash",
+        "process",
+        "console",
+        "terminal",
+        "is"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "clear-module": "^3.2.0",
+        "proxyquire": "^2.1.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "353c6b259583bbdb0942f59f6bba961dad02a590",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-wsl/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-wsl#readme",
+      "_id": "is-wsl@2.1.0",
+      "_nodeVersion": "8.16.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ==",
+        "shasum": "94369bbeb2249ef07b831b1b08590e686330ccbb",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3623,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdDxrwCRA9TVsSAnZWagAAWLkP/1DU4tT/fgQds9lLSnHi\n/zAk/xDd4CInLOYQYOx350siMRo4V0cBgysYJ7Ur8x6ksk76oYltANPhOy5M\nJTJJ0zotuXT2pQ58d5pAqp+GoCo3WJV1jSBV7wZcvv+ErjLRDhNEse5Zrthh\nJ2JjkuuYJJh/oh9+txI5lHVwYOAsvxsDnrpIU9kHrQC5PM6iYho3nQLQloGm\n02qZZzDwgVr5cW6rtqdgQj4/0DNiyauH/WTCWK45ex+jvZYhI08faX4U8o4C\nRvnMmomF7zGjJxXbFDdgl6g2wE4LA5oDduuX4mV1s/bolxPYxF5GAmYoNsYy\nAEP5jJ2l4HT5ujT6jCJol79yq90gdmGdrCV68F9eXLyP85LqCd3t178lTo3y\nZsrmRlXFOhlkppf92iYZbm9MnxVZDXoTS2bUnNlXGSDTM2hxB19tZLRFw2fV\nysQAKfSnMwzquZg3kToc/MosPboFBPAWTgke8ihH29As1a24+9fuCciDNCM4\n7bH75NHkyRKMf24lDSWrWsKJQO/9Z298zUHEf+QgJUUzck+YFIfVWpMiCTnC\nyUlUt97XYmPPxq80munVI1D/7e8JxeQchavvX2/hnjDtBOLYREJckl+sE+cu\n75KOGFBNRKKmq/S1kmtcfeStmlNXF9xgZ+nZ/zE+0aVSCGZyen9sthDDIpzI\neikw\r\n=3yzQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-wsl_2.1.0_1561271023715_0.7919014380053317"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.1.1": {
+      "name": "is-wsl",
+      "version": "2.1.1",
+      "description": "Check if the process is running inside Windows Subsystem for Linux (Bash on Windows)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-wsl.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "check",
+        "wsl",
+        "windows",
+        "subsystem",
+        "linux",
+        "detect",
+        "bash",
+        "process",
+        "console",
+        "terminal",
+        "is"
+      ],
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "clear-module": "^3.2.0",
+        "proxyquire": "^2.1.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "d51f13a2064d2fc86f5efdadb25ed6427345512e",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-wsl/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-wsl#readme",
+      "_id": "is-wsl@2.1.1",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.11.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+        "shasum": "4a1c152d429df3d441669498e2486d3596ebaf1d",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3604,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdiGOfCRA9TVsSAnZWagAAfGcP+wdOkb2A/dA5usVpcZ1F\nANSg+92PleiO/tQWhqBzkX55AhQixr37ADH4sicsqiZJl5pskBmm1xNsuIrf\nwuUVUYD6JLt93nOGyRAB/t6JnPi3JJWs7lhu/tYitXQZ79z+sibj1r6wSCnk\n/MfIQ4jGWaaIVn1u1tCS14asU5k6HyDGXmZfZjeBdyOcDDyr572BhmblShTK\nCbpBQ3rOLSZgi7koPqcv3fj++zmMI3uagHL7xa8AZfuD68qt6/fiXt4Phef8\n9hAo9anuwIKKqmHWiy5z4XbvAmhH+Pzk/8LtRXARoeuRbBbtjeiFAZ3K9ejI\nVoUFK5XjU68PWYRuEMb7R2NfKth7arMj4s3hwqDu7Cv+wxQDqTHczaaDeupb\nPxys3/1w0cjQgQ/LpXmf4I6oXrYPqPY/jc/V3FPML2t/oFTa+8fbOrhUn0/B\nqZX4LcxQqOdfyVJ1sBM18giRNWREtPu0vLaDqdxXyUTlfiB0j/8EYaN8feXH\n8ClE8myBq+XXG3q7Rt3V2pAxup1lxSjqFRXEn7Gfc5HNsCmbJUqQz8qKwa9S\ngBilmy69rtFA7SednZioryLsiqnk/xq/+oeSd3Z1N3SwEd5yy9i+CFa0pO1B\nOo3GZ3Vm0aQL8yUrnVw0KXaL9Yt9oQ6WLtu58mN2/0QXyMaqwAgDpa+3Ee8K\n10ed\r\n=GBT6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-wsl_2.1.1_1569219486491_0.5998381945097029"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.2.0": {
+      "name": "is-wsl",
+      "version": "2.2.0",
+      "description": "Check if the process is running inside Windows Subsystem for Linux (Bash on Windows)",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/is-wsl.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "check",
+        "wsl",
+        "windows",
+        "subsystem",
+        "linux",
+        "detect",
+        "bash",
+        "process",
+        "console",
+        "terminal",
+        "is"
+      ],
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "clear-module": "^3.2.0",
+        "proxyquire": "^2.1.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "7f3df4886d5f0292bda51cf240218ea643136961",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/is-wsl/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/is-wsl#readme",
+      "_id": "is-wsl@2.2.0",
+      "_nodeVersion": "10.20.1",
+      "_npmVersion": "6.14.4",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+        "shasum": "74a4c76e77ca9fd3f932f290c17ea326cd157271",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3757,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJernlZCRA9TVsSAnZWagAA88MQAKOHBjGtkem2Q7rCeQve\nEF1wYedxEof28RAhQxjDdB0VN80Z9IuUID6Uh8FMVqzdtx9WNCHAnYO5+4+Y\nQtbf13YNCfZZwC/Wx9/WDm1DyaiUbnnbt/XwAFMltipW5mqyJCKLdVierXVJ\nWhKRUGLR8j5HO5ORumqthREtJgptyesXeLBXdHgidHYqvZlsiRa4fFX5C/Ex\niTyPebRsW8f+QAhMR8aAAnsBZhfiNsrUyqWI3zpoo9JDFkPBHLKF2n+wFGpH\n0zRsE5mzlUvOCdHmf+ygKNWNIbhZ3CUHJOwhqf9LPf4EzWieGL8Pzk4g+8gj\nVbSf+oPkm22599G0DxTT+JW2qmx8YG9gYZ5J0hORXASn0GhJVimUQDh+4XyH\nWaZSAtPIKl8fWVf8Ad39jAaSg9Ma2ZxeRgZ9SDcspb5gB81JKg3fonZhkXMT\nDyFNOkXFzzVTrE+s4W/u8B+xDPFzSi/n8TjKzpi+piSHNLPGK9ahq99UKRie\ndTbGKvhLjoDtOxxiyPEmL/1YQ70GL6mDdYWTnj2ymfoQGZ8XPHHS/MVOpj/6\nEqNVgz3YLOBA+5pvLkaum73Fpw7tzZSLxnfjZ/yQKSHn3m39o1oK45VBZMUB\n/I4AKNDCdsCzXJI0+sFNWSKJqzy8vr+AQHPvtblm4Yq/QBf3GG/VaPEpHHXA\nl+5S\r\n=wRN8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/is-wsl_2.2.0_1588492632975_0.7188566750778995"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# is-wsl [![Build Status](https://travis-ci.org/sindresorhus/is-wsl.svg?branch=master)](https://travis-ci.org/sindresorhus/is-wsl)\n\n> Check if the process is running inside [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about) (Bash on Windows)\n\nCan be useful if you need to work around unimplemented or buggy features in WSL. Supports both WSL 1 and WSL 2.\n\n\n## Install\n\n```\n$ npm install is-wsl\n```\n\n\n## Usage\n\n```js\nconst isWsl = require('is-wsl');\n\n// When running inside Windows Subsystem for Linux\nconsole.log(isWsl);\n//=> true\n```\n\n\n---\n\n<div align=\"center\">\n\t<b>\n\t\t<a href=\"https://tidelift.com/subscription/pkg/npm-is-wsl?utm_source=npm-is-wsl&utm_medium=referral&utm_campaign=readme\">Get professional support for this package with a Tidelift subscription</a>\n\t</b>\n\t<br>\n\t<sub>\n\t\tTidelift helps make open source sustainable for maintainers while giving companies<br>assurances about security, maintenance, and licensing for their dependencies.\n\t</sub>\n</div>\n",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-05-03T07:57:15.650Z",
+    "created": "2017-04-16T13:41:16.689Z",
+    "1.0.0": "2017-04-16T13:41:16.689Z",
+    "1.1.0": "2017-04-17T05:39:47.328Z",
+    "2.0.0": "2019-04-23T08:16:19.492Z",
+    "2.1.0": "2019-06-23T06:23:43.801Z",
+    "2.1.1": "2019-09-23T06:18:06.597Z",
+    "2.2.0": "2020-05-03T07:57:13.100Z"
+  },
+  "homepage": "https://github.com/sindresorhus/is-wsl#readme",
+  "keywords": [
+    "check",
+    "wsl",
+    "windows",
+    "subsystem",
+    "linux",
+    "detect",
+    "bash",
+    "process",
+    "console",
+    "terminal",
+    "is"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/is-wsl.git"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/is-wsl/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md"
+}

--- a/test/fixtures/registry-mocks/content/is-wsl.min.json
+++ b/test/fixtures/registry-mocks/content/is-wsl.min.json
@@ -1,0 +1,133 @@
+{
+  "name": "is-wsl",
+  "dist-tags": {
+    "latest": "2.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "is-wsl",
+      "version": "1.0.0",
+      "devDependencies": {
+        "ava": "*",
+        "proxyquire": "^1.7.11",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "48ad3669f346b13c36578715c4f180a6685e3dba",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.1.0": {
+      "name": "is-wsl",
+      "version": "1.1.0",
+      "devDependencies": {
+        "ava": "*",
+        "clear-require": "^2.0.0",
+        "proxyquire": "^1.7.11",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "1f16e4aa22b04d1336b66188a66af3c600c3a66d",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "2.0.0": {
+      "name": "is-wsl",
+      "version": "2.0.0",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "clear-module": "^3.2.0",
+        "proxyquire": "^2.1.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-58xqeym9YpL60zUX4GlBfSLgV0mOL5JRQ6b8HnmmD4crNxprFdL7JGuo9AgtY38+JqseeA6t+XzYCprTkD4nmg==",
+        "shasum": "32849d5bf66413883ce07fada2e924f5505ed493",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3177,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcvsnUCRA9TVsSAnZWagAAkYQQAJiKyFSKTEni5NYMBT/o\nycO6G91B3wbsPbBOzvumTWoQNxhTNUA3vc0/FNRblipfrOiHfpH9TG+9ZF2K\naVRBY8txg8ekXxQF/32XUoYV8+t8yE1XXOMdwLsOWy+5p/auWG7C0i1fghEw\ngkcHaW1y4UZTN+ry5djhylIStzAL+hftB9Cyh03MYN0S56qCK4soK3iG8oR/\nYvs0lY4DcCKZavATkKAT+JZ2TEruQgD91s1lYCUePJKB3KKZ7A+xlilwAjb5\nYethj23pzUObJcBNd5L2Kd3JANOJmal8d1LwBlRClsKUuPog7cTgr0JdrCKT\nnPG/p4CopMFdQmCt4Fal+negehWNvlXtynwwwrPfMYgv9vSjsZY4e1FqWKvA\nWWCqpn41luatUmQa2Zw4Lunfn/gmVqvifIITRLKYTL7OS0Hg7LDGAL+4Jbjm\nzBnEmTwLJb68f5UBGXEOkPA0ThzdH0bPbCLCqc+CEJmANhb+i8oVAD6jQymO\nBmdUGwc/MXdTd4oBoYwRkIzfaXm8V1ixlOpwQzp3KQVK2XPwqf13U9uOBeXf\nwPbFnrXL8365lb86LNwuyTS9AvnA7O80ECBSKUkcnT+aUaejQzhmAbaRzGj+\nah90oaufYLsWuMFBYjHc0aMEhJXZk6ERdCdyJ1Z97rnUwD18/+S0YQ5L80jQ\nIy7n\r\n=yHtf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "2.1.0": {
+      "name": "is-wsl",
+      "version": "2.1.0",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "clear-module": "^3.2.0",
+        "proxyquire": "^2.1.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ==",
+        "shasum": "94369bbeb2249ef07b831b1b08590e686330ccbb",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3623,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdDxrwCRA9TVsSAnZWagAAWLkP/1DU4tT/fgQds9lLSnHi\n/zAk/xDd4CInLOYQYOx350siMRo4V0cBgysYJ7Ur8x6ksk76oYltANPhOy5M\nJTJJ0zotuXT2pQ58d5pAqp+GoCo3WJV1jSBV7wZcvv+ErjLRDhNEse5Zrthh\nJ2JjkuuYJJh/oh9+txI5lHVwYOAsvxsDnrpIU9kHrQC5PM6iYho3nQLQloGm\n02qZZzDwgVr5cW6rtqdgQj4/0DNiyauH/WTCWK45ex+jvZYhI08faX4U8o4C\nRvnMmomF7zGjJxXbFDdgl6g2wE4LA5oDduuX4mV1s/bolxPYxF5GAmYoNsYy\nAEP5jJ2l4HT5ujT6jCJol79yq90gdmGdrCV68F9eXLyP85LqCd3t178lTo3y\nZsrmRlXFOhlkppf92iYZbm9MnxVZDXoTS2bUnNlXGSDTM2hxB19tZLRFw2fV\nysQAKfSnMwzquZg3kToc/MosPboFBPAWTgke8ihH29As1a24+9fuCciDNCM4\n7bH75NHkyRKMf24lDSWrWsKJQO/9Z298zUHEf+QgJUUzck+YFIfVWpMiCTnC\nyUlUt97XYmPPxq80munVI1D/7e8JxeQchavvX2/hnjDtBOLYREJckl+sE+cu\n75KOGFBNRKKmq/S1kmtcfeStmlNXF9xgZ+nZ/zE+0aVSCGZyen9sthDDIpzI\neikw\r\n=3yzQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "2.1.1": {
+      "name": "is-wsl",
+      "version": "2.1.1",
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "clear-module": "^3.2.0",
+        "proxyquire": "^2.1.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+        "shasum": "4a1c152d429df3d441669498e2486d3596ebaf1d",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3604,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdiGOfCRA9TVsSAnZWagAAfGcP+wdOkb2A/dA5usVpcZ1F\nANSg+92PleiO/tQWhqBzkX55AhQixr37ADH4sicsqiZJl5pskBmm1xNsuIrf\nwuUVUYD6JLt93nOGyRAB/t6JnPi3JJWs7lhu/tYitXQZ79z+sibj1r6wSCnk\n/MfIQ4jGWaaIVn1u1tCS14asU5k6HyDGXmZfZjeBdyOcDDyr572BhmblShTK\nCbpBQ3rOLSZgi7koPqcv3fj++zmMI3uagHL7xa8AZfuD68qt6/fiXt4Phef8\n9hAo9anuwIKKqmHWiy5z4XbvAmhH+Pzk/8LtRXARoeuRbBbtjeiFAZ3K9ejI\nVoUFK5XjU68PWYRuEMb7R2NfKth7arMj4s3hwqDu7Cv+wxQDqTHczaaDeupb\nPxys3/1w0cjQgQ/LpXmf4I6oXrYPqPY/jc/V3FPML2t/oFTa+8fbOrhUn0/B\nqZX4LcxQqOdfyVJ1sBM18giRNWREtPu0vLaDqdxXyUTlfiB0j/8EYaN8feXH\n8ClE8myBq+XXG3q7Rt3V2pAxup1lxSjqFRXEn7Gfc5HNsCmbJUqQz8qKwa9S\ngBilmy69rtFA7SednZioryLsiqnk/xq/+oeSd3Z1N3SwEd5yy9i+CFa0pO1B\nOo3GZ3Vm0aQL8yUrnVw0KXaL9Yt9oQ6WLtu58mN2/0QXyMaqwAgDpa+3Ee8K\n10ed\r\n=GBT6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "2.2.0": {
+      "name": "is-wsl",
+      "version": "2.2.0",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "clear-module": "^3.2.0",
+        "proxyquire": "^2.1.0",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+        "shasum": "74a4c76e77ca9fd3f932f290c17ea326cd157271",
+        "tarball": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 3757,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJernlZCRA9TVsSAnZWagAA88MQAKOHBjGtkem2Q7rCeQve\nEF1wYedxEof28RAhQxjDdB0VN80Z9IuUID6Uh8FMVqzdtx9WNCHAnYO5+4+Y\nQtbf13YNCfZZwC/Wx9/WDm1DyaiUbnnbt/XwAFMltipW5mqyJCKLdVierXVJ\nWhKRUGLR8j5HO5ORumqthREtJgptyesXeLBXdHgidHYqvZlsiRa4fFX5C/Ex\niTyPebRsW8f+QAhMR8aAAnsBZhfiNsrUyqWI3zpoo9JDFkPBHLKF2n+wFGpH\n0zRsE5mzlUvOCdHmf+ygKNWNIbhZ3CUHJOwhqf9LPf4EzWieGL8Pzk4g+8gj\nVbSf+oPkm22599G0DxTT+JW2qmx8YG9gYZ5J0hORXASn0GhJVimUQDh+4XyH\nWaZSAtPIKl8fWVf8Ad39jAaSg9Ma2ZxeRgZ9SDcspb5gB81JKg3fonZhkXMT\nDyFNOkXFzzVTrE+s4W/u8B+xDPFzSi/n8TjKzpi+piSHNLPGK9ahq99UKRie\ndTbGKvhLjoDtOxxiyPEmL/1YQ70GL6mDdYWTnj2ymfoQGZ8XPHHS/MVOpj/6\nEqNVgz3YLOBA+5pvLkaum73Fpw7tzZSLxnfjZ/yQKSHn3m39o1oK45VBZMUB\n/I4AKNDCdsCzXJI0+sFNWSKJqzy8vr+AQHPvtblm4Yq/QBf3GG/VaPEpHHXA\nl+5S\r\n=wRN8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "modified": "2020-05-03T07:57:15.650Z"
+}

--- a/test/fixtures/registry-mocks/content/json3.json
+++ b/test/fixtures/registry-mocks/content/json3.json
@@ -1,0 +1,1036 @@
+{
+  "_id": "json3",
+  "_rev": "52-761a0e49ad9e86967e97bdc6bd9d0435",
+  "name": "json3",
+  "description": "A JSON polyfill for older JavaScript platforms.",
+  "dist-tags": {
+    "latest": "3.3.3"
+  },
+  "versions": {
+    "3.1.0": {
+      "name": "json3",
+      "version": "3.1.0",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.com/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "url": "http://kitcambridge.github.com"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "bugs": {
+        "url": "http://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/kitcambridge/json3.git"
+      },
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "kitcambridge@me.com"
+      },
+      "_id": "json3@3.1.0",
+      "dependencies": {},
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-10",
+      "_nodeVersion": "v0.6.7",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "01aaeec7bb56b2a619124d31149d42a96c66dbcf",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.1.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.0": {
+      "name": "json3",
+      "version": "3.2.0",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.com/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "url": "http://kitcambridge.github.com"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "bugs": {
+        "url": "http://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "kitcambridge@me.com"
+      },
+      "_id": "json3@3.2.0",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.12",
+      "_nodeVersion": "v0.6.14",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "751e79f26bdf03e8242bb2bb720c6e501a8cf4bf",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.0.tgz"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.1": {
+      "name": "json3",
+      "version": "3.2.1",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.com/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "url": "http://kitcambridge.github.com"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "bugs": {
+        "url": "http://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "kitcambridge@me.com"
+      },
+      "_id": "json3@3.2.1",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.12",
+      "_nodeVersion": "v0.6.14",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "fc4b6fba9c82806e6b7534df6cb3f7edddfdb59a",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.1.tgz"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.2": {
+      "name": "json3",
+      "version": "3.2.2",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.com/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "url": "http://kitcambridge.github.com"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "bugs": {
+        "url": "http://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "kitcambridge@me.com"
+      },
+      "_id": "json3@3.2.2",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.12",
+      "_nodeVersion": "v0.6.14",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "0f7f1583e5b3f35f1186e0696f72d2deac8e0af7",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.2.tgz"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.4": {
+      "name": "json3",
+      "version": "3.2.4",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.com/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "url": "http://kitcambridge.github.com"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "bugs": {
+        "url": "http://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "kit.cambridge@voxer.com"
+      },
+      "_id": "json3@3.2.4",
+      "dependencies": {},
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.21",
+      "_nodeVersion": "v0.8.2",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "689c589e7ca9340c7ee4949e0d105bc5bf159f21",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.4.tgz"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.5": {
+      "name": "json3",
+      "version": "3.2.5",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.io/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "email": "github@kitcambridge.be",
+        "url": "http://kitcambridge.be/"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Øyvind Sean Kinsey",
+          "email": "oyvind@kinsey.no",
+          "url": "http://fb.me/ok"
+        },
+        {
+          "name": "Mangled Deutz",
+          "email": "olivier@webitup.fr",
+          "url": "http://tech.roxee.tv/"
+        },
+        {
+          "name": "Kiryl Yermakou",
+          "email": "rma4ok@gmail.com",
+          "url": "https://github.com/rma4ok"
+        },
+        {
+          "name": "Oskar Schöldström",
+          "email": "public@oxy.fi",
+          "url": "http://oxy.fi/"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "_id": "json3@3.2.5",
+      "dist": {
+        "shasum": "732ee1f287a6a7ddf8f736dee1d87f27ec2fe989",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "github@kitcambridge.be"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.6": {
+      "name": "json3",
+      "version": "3.2.6",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.io/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "email": "github@kitcambridge.be",
+        "url": "http://kitcambridge.be/"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Mangled Deutz",
+          "email": "olivier@webitup.fr",
+          "url": "http://tech.roxee.tv/"
+        },
+        {
+          "name": "Øyvind Sean Kinsey",
+          "email": "oyvind@kinsey.no",
+          "url": "http://fb.me/ok"
+        },
+        {
+          "name": "Oskar Schöldström",
+          "email": "public@oxy.fi",
+          "url": "http://oxy.fi/"
+        },
+        {
+          "name": "Benjamin Tan",
+          "email": "demoneaux@gmail.com",
+          "url": "http://d10.github.io/"
+        },
+        {
+          "name": "Kiryl Yermakou",
+          "email": "rma4ok@gmail.com",
+          "url": "https://github.com/rma4ok"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "jam": {
+        "main": "./lib/json3.js"
+      },
+      "volo": {
+        "type": "directory",
+        "ignore": [
+          ".*",
+          "build.js",
+          "index.html",
+          "component.json",
+          "bower.json",
+          "benchmark",
+          "page",
+          "test",
+          "vendor"
+        ]
+      },
+      "_id": "json3@3.2.6",
+      "dist": {
+        "shasum": "f6efc93c06a04de9aec53053df2559bb19e2038b",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "github@kitcambridge.be"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.3.0": {
+      "name": "json3",
+      "version": "3.3.0",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.io/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "email": "github@kitcambridge.be",
+        "url": "http://kitcambridge.be/"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Mangled Deutz",
+          "email": "olivier@webitup.fr",
+          "url": "http://tech.roxee.tv/"
+        },
+        {
+          "name": "Øyvind Sean Kinsey",
+          "email": "oyvind@kinsey.no",
+          "url": "http://fb.me/ok"
+        },
+        {
+          "name": "Oskar Schöldström",
+          "email": "public@oxy.fi",
+          "url": "http://oxy.fi/"
+        },
+        {
+          "name": "Benjamin Tan",
+          "email": "demoneaux@gmail.com",
+          "url": "http://d10.github.io/"
+        },
+        {
+          "name": "Kiryl Yermakou",
+          "email": "rma4ok@gmail.com",
+          "url": "https://github.com/rma4ok"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "files": [
+        "README.md",
+        "LICENSE",
+        "lib/json3.js"
+      ],
+      "jam": {
+        "main": "./lib/json3.js",
+        "includes": [
+          "README.md",
+          "LICENSE",
+          "lib/json3.js",
+          "lib/json3.min.js"
+        ]
+      },
+      "volo": {
+        "type": "directory",
+        "ignore": [
+          ".*",
+          "build.js",
+          "index.html",
+          "component.json",
+          "bower.json",
+          "benchmark",
+          "page",
+          "test",
+          "vendor"
+        ]
+      },
+      "_id": "json3@3.3.0",
+      "dist": {
+        "shasum": "0e9e7f6c5d270b758929af4d6fefdc84bd66e259",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "github@kitcambridge.be"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.3.1": {
+      "name": "json3",
+      "version": "3.3.1",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.io/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "email": "github@kitcambridge.be",
+        "url": "http://kitcambridge.be/"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Mangled Deutz",
+          "email": "olivier@webitup.fr",
+          "url": "http://tech.roxee.tv/"
+        },
+        {
+          "name": "Øyvind Sean Kinsey",
+          "email": "oyvind@kinsey.no",
+          "url": "http://fb.me/ok"
+        },
+        {
+          "name": "Oskar Schöldström",
+          "email": "public@oxy.fi",
+          "url": "http://oxy.fi/"
+        },
+        {
+          "name": "Benjamin Tan",
+          "email": "demoneaux@gmail.com",
+          "url": "http://d10.github.io/"
+        },
+        {
+          "name": "Kiryl Yermakou",
+          "email": "rma4ok@gmail.com",
+          "url": "https://github.com/rma4ok"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "files": [
+        "README.md",
+        "LICENSE",
+        "lib/json3.js"
+      ],
+      "jam": {
+        "main": "./lib/json3.js",
+        "includes": [
+          "README.md",
+          "LICENSE",
+          "lib/json3.js",
+          "lib/json3.min.js"
+        ]
+      },
+      "volo": {
+        "type": "directory",
+        "ignore": [
+          ".*",
+          "build.js",
+          "index.html",
+          "component.json",
+          "bower.json",
+          "benchmark",
+          "page",
+          "test",
+          "vendor"
+        ]
+      },
+      "_id": "json3@3.3.1",
+      "dist": {
+        "shasum": "705a82cd8036231f3b3fa8571ef7a5b435cd09f3",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "github@kitcambridge.be"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.3.2": {
+      "name": "json3",
+      "version": "3.3.2",
+      "description": "A modern JSON implementation compatible with nearly all JavaScript platforms.",
+      "homepage": "http://bestiejs.github.io/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://kit.mit-license.org/"
+        }
+      ],
+      "author": {
+        "name": "Kit Cambridge",
+        "email": "github@kitcambridge.be",
+        "url": "http://kitcambridge.be/"
+      },
+      "maintainers": [
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        },
+        {
+          "name": "d10",
+          "email": "demoneaux@gmail.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Mangled Deutz",
+          "email": "olivier@webitup.fr",
+          "url": "http://tech.roxee.tv/"
+        },
+        {
+          "name": "Øyvind Sean Kinsey",
+          "email": "oyvind@kinsey.no",
+          "url": "http://fb.me/ok"
+        },
+        {
+          "name": "Oskar Schöldström",
+          "email": "public@oxy.fi",
+          "url": "http://oxy.fi/"
+        },
+        {
+          "name": "Kiryl Yermakou",
+          "email": "rma4ok@gmail.com",
+          "url": "https://github.com/rma4ok"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "files": [
+        "README.md",
+        "LICENSE",
+        "lib/json3.js",
+        "lib/json3.min.js"
+      ],
+      "jam": {
+        "main": "./lib/json3.js",
+        "includes": [
+          "README.md",
+          "LICENSE",
+          "lib/json3.js",
+          "lib/json3.min.js"
+        ]
+      },
+      "volo": {
+        "type": "directory",
+        "ignore": [
+          ".*",
+          "build.js",
+          "index.html",
+          "component.json",
+          "bower.json",
+          "benchmark",
+          "page",
+          "test",
+          "vendor"
+        ]
+      },
+      "_id": "json3@3.3.2",
+      "dist": {
+        "shasum": "3c0434743df93e2f5c42aee7b19bcb483575f4e1",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "github@kitcambridge.be"
+      },
+      "directories": {},
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.3.3": {
+      "name": "json3",
+      "version": "3.3.3",
+      "description": "A JSON polyfill for older JavaScript platforms.",
+      "homepage": "https://bestiejs.github.io/json3",
+      "main": "./lib/json3",
+      "keywords": [
+        "json",
+        "spec",
+        "ecma",
+        "es5",
+        "lexer",
+        "parser",
+        "stringify"
+      ],
+      "license": "MIT",
+      "author": {
+        "name": "Kit Cambridge",
+        "email": "github@kitcambridge.be",
+        "url": "http://kitcambridge.be/"
+      },
+      "maintainers": [
+        {
+          "name": "d10",
+          "email": "demoneaux@gmail.com"
+        },
+        {
+          "name": "kitcambridge",
+          "email": "kitcambridge@me.com"
+        }
+      ],
+      "contributors": [
+        {
+          "name": "Mangled Deutz",
+          "email": "olivier@webitup.fr",
+          "url": "http://tech.roxee.tv/"
+        },
+        {
+          "name": "Øyvind Sean Kinsey",
+          "email": "oyvind@kinsey.no",
+          "url": "http://fb.me/ok"
+        },
+        {
+          "name": "Oskar Schöldström",
+          "email": "public@oxy.fi",
+          "url": "http://oxy.fi/"
+        },
+        {
+          "name": "Kiryl Yermakou",
+          "email": "rma4ok@gmail.com",
+          "url": "https://github.com/rma4ok"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/bestiejs/json3/issues"
+      },
+      "scripts": {
+        "test": "node test/test_*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/bestiejs/json3.git"
+      },
+      "jam": {
+        "main": "./lib/json3.js",
+        "includes": [
+          "README.md",
+          "LICENSE",
+          "lib/json3.js",
+          "lib/json3.min.js"
+        ]
+      },
+      "volo": {
+        "type": "directory",
+        "ignore": [
+          ".*",
+          "build.js",
+          "index.html",
+          "component.json",
+          "bower.json",
+          "benchmark",
+          "page",
+          "test",
+          "vendor"
+        ]
+      },
+      "devDependencies": {
+        "curl-amd": "~0.8.12",
+        "highlight.js": "~8.3.0",
+        "marked": "~0.3.2",
+        "requirejs": "~2.1.15",
+        "spec": "~1.0.1",
+        "tar": "~1.0.2"
+      },
+      "gitHead": "3014ebd8c43a2a251385bb5ba4c6500edb220e21",
+      "_id": "json3@3.3.3",
+      "_nodeVersion": "11.3.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+        "shasum": "7fc10e375fc5ae42c4705a5cc0aa6f62be305b81",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 77099,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc7G6vCRA9TVsSAnZWagAAiP4QAJoKt7UZQdqOS7A6M4eP\noag8r0BnVkO+dscdp4uDF+T07Kj7jDlENyYJN9gYLt1u3EaXKyEIARu/TjLO\nYalPp5Cr6c3TcioyEe3rl+cjsFVTMaEZxza3ZgvzqoKBl/WvwHrVnATNTR1l\n0ei02ROhMYucInRskEJiSbpCzMgQOGrDW/6XI48vRvFqtBYlW/TJ4Bx7WBQ5\nojFlB+e7XPLqUihdoMd4iSm9xfr1ML6t0VhC6ia31Ac4vbEFdRbu+xUVq20Q\nhhgKT1guH1MCv+nhz5RTGbqW1AyLjnrg8yaxFL8lJAgk7gOR/8rZvtn5suft\n14ve90wqehL9wyvd2brMsJzlyZZAzGz89RT+ijRccjHi0QcKb9E+bs5z7TPl\nmmEwMYo1wQ+Xf85pwxVVFn+rq5ND8+6Qj6ycPvZIimowE9q9OxeobRSGSzgT\nE6dPZtNPIQ9I8l3zjKI/isNES1t40aXWn+jPAvbdbCVbmgqCJYBVJ+xHt5Nz\nAWEtyelEmmW7GI6DQ/2WpRebtMfQm0pBNcwin5Fitfmtxwt9rWjbqID3+Sn1\nc0LiT6T34kYDth4oEaKpzTHaNT0iEiJTcPeE49nCrDbT3QoXNEPxm5rM6zt6\nLCvQgWEooFoJzw2Wh+ltxKDhk6a7d+H3W5FGoIJ6Ak/XL+iLfLqEG3JtFwtK\nQ4k+\r\n=EnTi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "kitcambridge",
+        "email": "github@kitcambridge.be"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/json3_3.3.3_1558998702769_0.7363680341283254"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# 🚨 Unmaintained 🚨\n\n<p class=\"banner\">JSON 3 is **deprecated** and **no longer maintained**. Please don't use it in new projects, and migrate existing projects to use the native `JSON.parse` and `JSON.stringify` instead.</p>\n\nThanks to everyone who contributed patches or found it useful! ❤️\n\n# JSON 3 #\n\n [![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)\n\n**JSON 3** was a JSON polyfill for older JavaScript platforms.\n\n## About ##\n\n[JSON](http://json.org/) is a language-independent data interchange format based on a loose subset of the JavaScript grammar. Originally popularized by [Douglas Crockford](http://www.crockford.com/), the format was standardized in the [fifth edition](http://es5.github.io/) of the ECMAScript specification. The 5.1 edition, ratified in June 2011, incorporates several modifications to the grammar pertaining to the serialization of dates.\n\nJSON 3 exposes two functions: `stringify()` for [serializing](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/JSON/stringify) a JavaScript value to JSON, and `parse()` for [producing](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/JSON/parse) a JavaScript value from a JSON source string. The JSON 3 parser uses recursive descent instead of `eval` and regular expressions, which makes it slower on older platforms compared to [JSON 2](http://json.org/js). The functions behave exactly as described in the ECMAScript spec, **except** for the date serialization discrepancy noted below.\n\nThe project is [hosted on GitHub](http://git.io/json3), along with the [unit tests](http://bestiejs.github.io/json3/test/test_browser.html). It is part of the [BestieJS](https://github.com/bestiejs) family, a collection of best-in-class JavaScript libraries that promote cross-platform support, specification precedents, unit testing, and plenty of documentation.\n\n## Date Serialization\n\n**JSON 3 deviates from the specification in one important way**: it does not define `Date#toISOString()` or `Date#toJSON()`. This preserves CommonJS compatibility and avoids polluting native prototypes. Instead, date serialization is performed internally by the `stringify()` implementation: if a date object does not define a custom `toJSON()` method, it is serialized as a [simplified ISO 8601 date-time string](http://es5.github.com/#x15.9.1.15).\n\n**Several native `Date#toJSON()` implementations produce date time strings that do *not* conform to the grammar outlined in the spec**. In these environments, JSON 3 will override the native `stringify()` implementation. There is an [issue](https://github.com/bestiejs/json3/issues/73) on file to make these tests less strict.\n\nPortions of the date serialization code are adapted from the [`date-shim`](https://github.com/Yaffle/date-shim) project.\n\n# Usage #\n\n## Web Browsers\n\n    <script src=\"//cdnjs.cloudflare.com/ajax/libs/json3/3.3.2/json3.min.js\"></script>\n    <script>\n      JSON.stringify({\"Hello\": 123});\n      // => '{\"Hello\":123}'\n      JSON.parse(\"[[1, 2, 3], 1, 2, 3, 4]\", function (key, value) {\n        if (typeof value == \"number\") {\n          value = value % 2 ? \"Odd\" : \"Even\";\n        }\n        return value;\n      });\n      // => [[\"Odd\", \"Even\", \"Odd\"], \"Odd\", \"Even\", \"Odd\", \"Even\"]\n    </script>\n\n**When used in a web browser**, JSON 3 exposes an additional `JSON3` object containing the `noConflict()` and `runInContext()` functions, as well as aliases to the `stringify()` and `parse()` functions.\n\n### `noConflict` and `runInContext`\n\n* `JSON3.noConflict()` restores the original value of the global `JSON` object and returns a reference to the `JSON3` object.\n* `JSON3.runInContext([context, exports])` initializes JSON 3 using the given `context` object (e.g., `window`, `global`, etc.), or the global object if omitted. If an `exports` object is specified, the `stringify()`, `parse()`, and `runInContext()` functions will be attached to it instead of a new object.\n\n### Asynchronous Module Loaders\n\nJSON 3 is defined as an [anonymous module](https://github.com/amdjs/amdjs-api/wiki/AMD#define-function-) for compatibility with [RequireJS](http://requirejs.org/), [`curl.js`](https://github.com/cujojs/curl), and other asynchronous module loaders.\n\n    <script src=\"//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.js\"></script>\n    <script>\n      require({\n        \"paths\": {\n          \"json3\": \"./path/to/json3\"\n        }\n      }, [\"json3\"], function (JSON) {\n        JSON.parse(\"[1, 2, 3]\");\n        // => [1, 2, 3]\n      });\n    </script>\n\nTo avoid issues with third-party scripts, **JSON 3 is exported to the global scope even when used with a module loader**. If this behavior is undesired, `JSON3.noConflict()` can be used to restore the global `JSON` object to its original value.\n\n**Note:** If you intend to use JSON3 alongside another module, **please do not simply concatenate these modules together**, as that would cause multiple `define` calls in one script, resulting in errors in AMD loaders. The `r.js` build optimizer can be used instead if you need a single compressed file for production.\n\n## CommonJS Environments\n\n    var JSON3 = require(\"./path/to/json3\");\n    JSON3.parse(\"[1, 2, 3]\");\n    // => [1, 2, 3]\n\n## JavaScript Engines\n\n    load(\"path/to/json3.js\");\n    JSON.stringify({\"Hello\": 123, \"Good-bye\": 456}, [\"Hello\"], \"\\t\");\n    // => '{\\n\\t\"Hello\": 123\\n}'\n\n# Compatibility #\n\nJSON 3 has been **tested** with the following web browsers, CommonJS environments, and JavaScript engines.\n\n## Web Browsers\n\n- Windows [Internet Explorer](http://windows.microsoft.com/en-us/internet-explorer/download-ie), version 6.0 and higher\n- Google [Chrome](http://www.google.com/chrome), version 19.0 and higher\n- Mozilla [Firefox](https://www.mozilla.org/en-US/firefox/new/), version 2.0 and higher\n- Apple [Safari](http://www.apple.com/safari/), version 3.0 and higher\n- [Opera](http://www.opera.com/) 8.54 and higher\n- [SeaMonkey](http://www.seamonkey-project.org/) 1.0 and higher\n\n## CommonJS Environments\n\n- [Node](http://nodejs.org/) 0.6.21 and higher\n- [io.js](https://iojs.org/) 1.0.3 and higher\n- [RingoJS](http://ringojs.org/) 0.9 and higher\n- [Narwhal](https://github.com/280north/narwhal) 0.3.2\n\n## JavaScript Engines\n\n- Mozilla [Rhino](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino) 1.7R3 and higher\n- WebKit [JSC](https://trac.webkit.org/wiki/JSC)\n- Google [V8](http://code.google.com/p/v8/)\n\n## Known Incompatibilities\n\n* Attempting to serialize the `arguments` object may produce inconsistent results across environments due to specification version differences. As a workaround, please convert the `arguments` object to an array first: `JSON.stringify([].slice.call(arguments, 0))`.\n\n## Required Native Methods\n\nJSON 3 assumes that the following methods exist and function as described in the ECMAScript specification:\n\n- The `Number`, `String`, `Array`, `Object`, `Date`, `SyntaxError`, and `TypeError` constructors.\n- `String.fromCharCode`\n- `Object#toString`\n- `Object#hasOwnProperty`\n- `Function#call`\n- `Math.floor`\n- `Number#toString`\n- `Date#valueOf`\n- `String.prototype`: `indexOf`, `charCodeAt`, `charAt`, `slice`, `replace`.\n- `Array.prototype`: `push`, `pop`, `join`.\n",
+  "maintainers": [
+    {
+      "email": "github@kitcambridge.be",
+      "name": "kitcambridge"
+    },
+    {
+      "email": "demoneauxt@gmail.com",
+      "name": "d10"
+    },
+    {
+      "email": "demoneaux@gmail.com",
+      "name": "bnjmnt4n"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-14T04:50:57.710Z",
+    "created": "2012-03-23T07:48:29.645Z",
+    "3.1.0": "2012-03-23T07:48:31.966Z",
+    "3.2.0": "2012-04-15T22:19:38.979Z",
+    "3.2.1": "2012-04-27T02:41:21.991Z",
+    "3.2.2": "2012-05-05T20:19:38.310Z",
+    "3.2.4": "2012-10-17T04:44:44.733Z",
+    "3.2.5": "2013-07-25T16:30:40.653Z",
+    "3.2.6": "2013-11-25T08:10:35.434Z",
+    "3.3.0": "2014-01-21T08:24:33.084Z",
+    "3.3.1": "2014-04-09T05:59:46.363Z",
+    "3.3.2": "2014-06-22T21:27:22.857Z",
+    "3.3.3": "2019-05-27T23:11:42.941Z"
+  },
+  "author": {
+    "name": "Kit Cambridge",
+    "email": "github@kitcambridge.be",
+    "url": "http://kitcambridge.be/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/bestiejs/json3.git"
+  },
+  "users": {
+    "mathias": true,
+    "demopark": true,
+    "vutran": true,
+    "staydan": true,
+    "rochejul": true
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://bestiejs.github.io/json3",
+  "keywords": [
+    "json",
+    "spec",
+    "ecma",
+    "es5",
+    "lexer",
+    "parser",
+    "stringify"
+  ],
+  "contributors": [
+    {
+      "name": "Mangled Deutz",
+      "email": "olivier@webitup.fr",
+      "url": "http://tech.roxee.tv/"
+    },
+    {
+      "name": "Øyvind Sean Kinsey",
+      "email": "oyvind@kinsey.no",
+      "url": "http://fb.me/ok"
+    },
+    {
+      "name": "Oskar Schöldström",
+      "email": "public@oxy.fi",
+      "url": "http://oxy.fi/"
+    },
+    {
+      "name": "Kiryl Yermakou",
+      "email": "rma4ok@gmail.com",
+      "url": "https://github.com/rma4ok"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/bestiejs/json3/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/json3.min.json
+++ b/test/fixtures/registry-mocks/content/json3.min.json
@@ -1,0 +1,134 @@
+{
+  "name": "json3",
+  "dist-tags": {
+    "latest": "3.3.3"
+  },
+  "versions": {
+    "3.1.0": {
+      "name": "json3",
+      "version": "3.1.0",
+      "dist": {
+        "shasum": "01aaeec7bb56b2a619124d31149d42a96c66dbcf",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.0": {
+      "name": "json3",
+      "version": "3.2.0",
+      "dist": {
+        "shasum": "751e79f26bdf03e8242bb2bb720c6e501a8cf4bf",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.1": {
+      "name": "json3",
+      "version": "3.2.1",
+      "dist": {
+        "shasum": "fc4b6fba9c82806e6b7534df6cb3f7edddfdb59a",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.2": {
+      "name": "json3",
+      "version": "3.2.2",
+      "dist": {
+        "shasum": "0f7f1583e5b3f35f1186e0696f72d2deac8e0af7",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.4": {
+      "name": "json3",
+      "version": "3.2.4",
+      "dist": {
+        "shasum": "689c589e7ca9340c7ee4949e0d105bc5bf159f21",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.5": {
+      "name": "json3",
+      "version": "3.2.5",
+      "dist": {
+        "shasum": "732ee1f287a6a7ddf8f736dee1d87f27ec2fe989",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.5.tgz"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.2.6": {
+      "name": "json3",
+      "version": "3.2.6",
+      "dist": {
+        "shasum": "f6efc93c06a04de9aec53053df2559bb19e2038b",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.3.0": {
+      "name": "json3",
+      "version": "3.3.0",
+      "dist": {
+        "shasum": "0e9e7f6c5d270b758929af4d6fefdc84bd66e259",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.3.0.tgz"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.3.1": {
+      "name": "json3",
+      "version": "3.3.1",
+      "dist": {
+        "shasum": "705a82cd8036231f3b3fa8571ef7a5b435cd09f3",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.3.1.tgz"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.3.2": {
+      "name": "json3",
+      "version": "3.3.2",
+      "dist": {
+        "shasum": "3c0434743df93e2f5c42aee7b19bcb483575f4e1",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+      },
+      "deprecated": "Please use the native JSON object instead of JSON 3"
+    },
+    "3.3.3": {
+      "name": "json3",
+      "version": "3.3.3",
+      "devDependencies": {
+        "curl-amd": "~0.8.12",
+        "highlight.js": "~8.3.0",
+        "marked": "~0.3.2",
+        "requirejs": "~2.1.15",
+        "spec": "~1.0.1",
+        "tar": "~1.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+        "shasum": "7fc10e375fc5ae42c4705a5cc0aa6f62be305b81",
+        "tarball": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 77099,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc7G6vCRA9TVsSAnZWagAAiP4QAJoKt7UZQdqOS7A6M4eP\noag8r0BnVkO+dscdp4uDF+T07Kj7jDlENyYJN9gYLt1u3EaXKyEIARu/TjLO\nYalPp5Cr6c3TcioyEe3rl+cjsFVTMaEZxza3ZgvzqoKBl/WvwHrVnATNTR1l\n0ei02ROhMYucInRskEJiSbpCzMgQOGrDW/6XI48vRvFqtBYlW/TJ4Bx7WBQ5\nojFlB+e7XPLqUihdoMd4iSm9xfr1ML6t0VhC6ia31Ac4vbEFdRbu+xUVq20Q\nhhgKT1guH1MCv+nhz5RTGbqW1AyLjnrg8yaxFL8lJAgk7gOR/8rZvtn5suft\n14ve90wqehL9wyvd2brMsJzlyZZAzGz89RT+ijRccjHi0QcKb9E+bs5z7TPl\nmmEwMYo1wQ+Xf85pwxVVFn+rq5ND8+6Qj6ycPvZIimowE9q9OxeobRSGSzgT\nE6dPZtNPIQ9I8l3zjKI/isNES1t40aXWn+jPAvbdbCVbmgqCJYBVJ+xHt5Nz\nAWEtyelEmmW7GI6DQ/2WpRebtMfQm0pBNcwin5Fitfmtxwt9rWjbqID3+Sn1\nc0LiT6T34kYDth4oEaKpzTHaNT0iEiJTcPeE49nCrDbT3QoXNEPxm5rM6zt6\nLCvQgWEooFoJzw2Wh+ltxKDhk6a7d+H3W5FGoIJ6Ak/XL+iLfLqEG3JtFwtK\nQ4k+\r\n=EnTi\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-08-14T04:50:57.710Z"
+}

--- a/test/fixtures/registry-mocks/content/killable.json
+++ b/test/fixtures/registry-mocks/content/killable.json
@@ -1,0 +1,160 @@
+{
+  "_id": "killable",
+  "_rev": "4-2bbf1c505f1505f2025d236a24139beb",
+  "name": "killable",
+  "description": "Keeps track of a server's open sockets so they can be destroyed at a moment's notice.",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "killable",
+      "version": "1.0.0",
+      "description": "Keeps track of a server's open sockets so they can be destroyed at a moment's notice.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/marten-de-vries/killable.git"
+      },
+      "keywords": [
+        "express",
+        "http",
+        "server",
+        "socket",
+        "kill",
+        "truncate",
+        "destroy",
+        "restart",
+        "shutdown",
+        "immeadiately"
+      ],
+      "author": {
+        "name": "Marten de Vries"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/marten-de-vries/killable/issues"
+      },
+      "gitHead": "cebeee0433e8bcfae70b313f007f52110e1e113b",
+      "_id": "killable@1.0.0",
+      "scripts": {},
+      "_shasum": "da8b84bd47de5395878f95d64d02f2449fe05e6b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "commandoline",
+        "email": "marten@marten-de-vries.nl"
+      },
+      "maintainers": [
+        {
+          "name": "commandoline",
+          "email": "marten@marten-de-vries.nl"
+        }
+      ],
+      "dist": {
+        "shasum": "da8b84bd47de5395878f95d64d02f2449fe05e6b",
+        "tarball": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "killable",
+      "version": "1.0.1",
+      "description": "Keeps track of a server's open sockets so they can be destroyed at a moment's notice.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/marten-de-vries/killable.git"
+      },
+      "keywords": [
+        "express",
+        "http",
+        "server",
+        "socket",
+        "kill",
+        "truncate",
+        "destroy",
+        "restart",
+        "shutdown",
+        "immeadiately"
+      ],
+      "author": {
+        "name": "Marten de Vries"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/marten-de-vries/killable/issues"
+      },
+      "gitHead": "6f7d56fdd366a08fddbe4ff8438c77e8643a5241",
+      "homepage": "https://github.com/marten-de-vries/killable#readme",
+      "_id": "killable@1.0.1",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.3.0",
+      "_npmUser": {
+        "name": "commandoline",
+        "email": "marten@marten-de-vries.nl"
+      },
+      "dist": {
+        "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
+        "shasum": "4c8ce441187a061c7474fb87ca08e2a638194892",
+        "tarball": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 2914,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbknv3CRA9TVsSAnZWagAAVxMP/149NZG4OszYW5Yqu7CM\nFjDVoZe3Atjq20aLpd9OzHaoK1p2EuGqLbJUSL/LZiQrm7AgzeuFv5olEO7G\nt9ucneVnVhShdutPyNr6wABbh/hFUFcOzLtnRIq02IJnfe8C8mw7itkqZ4tf\ntQvZdeGQdaX5YNwSfeySpGXa6R4Zd5jiVr0UR4qEhCW7XVwGmejGF0BXRlGF\na/X1H2EeRqmuY59ZYSrEiK//5wedH6lt6wyTtYzOLq78+QJUXzRTmgFDUMBc\ntAOzVanELu+hI8EvEW/PaoPnp/qDCuRJSIkxvwVyy5cjgL8zwWBEdaqLDYxe\nMv/ALBHamcaWjIoJzPdKqy3qGWmjaSJARTUE6uMJWswIog8Qo7eoRBtBpjcP\n6vdsZWT/FhSJx5mH7eSdj8+dibXtwf1fBE/hP97reR0V27GKlqgFnh/3zYQB\n6wnJaoQTQkSo3R59g8PwubsAqVlNyAJ5PS5eXzovKQMxQl7jzabC9Wa7Ula+\npyN2UdEF+wEncWOrsxyrbK9RYZby6wx5WxyQwhb7bbYzAYPcYu6ZFWiU0nhO\necH76lcjs5m7nOquwJR/MzncCgA0/yDkyawh67vK2oeS+VX4O7pgJsDJJSUj\nlTLnsXMzJ1FwDR+7YQzQM0gAARDfTyU/9B0QF573N8kZTI3z9eLokggC7wNH\nlMHC\r\n=8k6t\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "commandoline",
+          "email": "marten@marten-de-vries.nl"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/killable_1.0.1_1536326646938_0.1234895972624459"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "killable\n========\n\nKeeps track of a server's open sockets so they can be destroyed at a\nmoment's notice. This way, the server connection can be killed very\nfast.\n\nInstallation\n------------\n\n```\nnpm install killable\n```\n\nExample usage\n-------------\n\nUsing express:\n('server' in the example is just an ``http.server``, so other frameworks\nor pure Node should work just as well.)\n\n```javascript\nvar killable = require('killable');\n\nvar app = require('express')();\nvar server;\n\napp.route('/', function (req, res, next) {\n  res.send('Server is going down NOW!');\n\n  server.kill(function () {\n    //the server is down when this is called. That won't take long.\n  });\n});\n\nvar server = app.listen(8080);\nkillable(server);\n```\n\nAPI\n---\n\nThe ``killable`` module is callable. When you call it on a Node\n``http.Server`` object, it will add a ``server.kill()`` method on it. It\nreturns the server object.\n\n``server.kill([callback])`` closes all open sockets and calls\n``server.close()``, to which the ``callback`` is passed on.\n\nInspired by: http://stackoverflow.com/a/14636625\n\nLicense\n-------\n\nISC\n",
+  "maintainers": [
+    {
+      "name": "commandoline",
+      "email": "marten@marten-de-vries.nl"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-04T09:15:06.934Z",
+    "created": "2014-12-18T16:27:46.796Z",
+    "1.0.0": "2014-12-18T16:27:46.796Z",
+    "1.0.1": "2018-09-07T13:24:07.048Z"
+  },
+  "keywords": [
+    "express",
+    "http",
+    "server",
+    "socket",
+    "kill",
+    "truncate",
+    "destroy",
+    "restart",
+    "shutdown",
+    "immeadiately"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/marten-de-vries/killable.git"
+  },
+  "author": {
+    "name": "Marten de Vries"
+  },
+  "bugs": {
+    "url": "https://github.com/marten-de-vries/killable/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/marten-de-vries/killable#readme",
+  "users": {
+    "daizch": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/killable.min.json
+++ b/test/fixtures/registry-mocks/content/killable.min.json
@@ -1,0 +1,29 @@
+{
+  "name": "killable",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "killable",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "da8b84bd47de5395878f95d64d02f2449fe05e6b",
+        "tarball": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "killable",
+      "version": "1.0.1",
+      "dist": {
+        "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
+        "shasum": "4c8ce441187a061c7474fb87ca08e2a638194892",
+        "tarball": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 2914,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbknv3CRA9TVsSAnZWagAAVxMP/149NZG4OszYW5Yqu7CM\nFjDVoZe3Atjq20aLpd9OzHaoK1p2EuGqLbJUSL/LZiQrm7AgzeuFv5olEO7G\nt9ucneVnVhShdutPyNr6wABbh/hFUFcOzLtnRIq02IJnfe8C8mw7itkqZ4tf\ntQvZdeGQdaX5YNwSfeySpGXa6R4Zd5jiVr0UR4qEhCW7XVwGmejGF0BXRlGF\na/X1H2EeRqmuY59ZYSrEiK//5wedH6lt6wyTtYzOLq78+QJUXzRTmgFDUMBc\ntAOzVanELu+hI8EvEW/PaoPnp/qDCuRJSIkxvwVyy5cjgL8zwWBEdaqLDYxe\nMv/ALBHamcaWjIoJzPdKqy3qGWmjaSJARTUE6uMJWswIog8Qo7eoRBtBpjcP\n6vdsZWT/FhSJx5mH7eSdj8+dibXtwf1fBE/hP97reR0V27GKlqgFnh/3zYQB\n6wnJaoQTQkSo3R59g8PwubsAqVlNyAJ5PS5eXzovKQMxQl7jzabC9Wa7Ula+\npyN2UdEF+wEncWOrsxyrbK9RYZby6wx5WxyQwhb7bbYzAYPcYu6ZFWiU0nhO\necH76lcjs5m7nOquwJR/MzncCgA0/yDkyawh67vK2oeS+VX4O7pgJsDJJSUj\nlTLnsXMzJ1FwDR+7YQzQM0gAARDfTyU/9B0QF573N8kZTI3z9eLokggC7wNH\nlMHC\r\n=8k6t\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-01-04T09:15:06.934Z"
+}

--- a/test/fixtures/registry-mocks/content/loader-utils.json
+++ b/test/fixtures/registry-mocks/content/loader-utils.json
@@ -1,0 +1,2245 @@
+{
+  "_id": "loader-utils",
+  "_rev": "65-be2f88c0515a464cfea2631ddab7ff7c",
+  "name": "loader-utils",
+  "description": "utils for webpack loaders",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "loader-utils",
+      "version": "0.1.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "license": "MIT",
+      "_id": "loader-utils@0.1.0",
+      "dist": {
+        "shasum": "c806ab8550eec0f0b716cc5b07fa7641261399e3",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.1.0.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "loader-utils",
+      "version": "0.1.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "license": "MIT",
+      "_id": "loader-utils@0.1.1",
+      "dist": {
+        "shasum": "2eb185fdec466d145507077f3ea2435e1cf9cc8e",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.1.1.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "loader-utils",
+      "version": "0.1.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "license": "MIT",
+      "_id": "loader-utils@0.1.2",
+      "dist": {
+        "shasum": "94b2b270822ae0f53a6bab74394c1d6f557c296b",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.1.2.tgz"
+      },
+      "_npmVersion": "1.1.63",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "loader-utils",
+      "version": "0.2.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "_id": "loader-utils@0.2.0",
+      "dist": {
+        "shasum": "3ab46086a1397e0fd52470e69106998fd70644a0",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.0.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "loader-utils",
+      "version": "0.2.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "_id": "loader-utils@0.2.1",
+      "dist": {
+        "shasum": "c8d03c4fe8c91e0ae362bd3aeb7fcc445f9b7890",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "loader-utils",
+      "version": "0.2.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "_id": "loader-utils@0.2.2",
+      "dist": {
+        "shasum": "4c0fe718dd3ab62d1d47d03a2b1af54dd7fda382",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "loader-utils",
+      "version": "0.2.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/loader-utils.git"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils",
+      "_id": "loader-utils@0.2.3",
+      "dist": {
+        "shasum": "87fe021587458f10f7eb755c75af60a1fcf4b392",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.4": {
+      "name": "loader-utils",
+      "version": "0.2.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "scripts": {
+        "test": "mocha test index.js"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "bf11c1c2737360c1daf77925cc718fc48e147128",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils",
+      "_id": "loader-utils@0.2.4",
+      "_shasum": "b1fbdd1cf3b57ed111c202ffc193bafd1217f8c5",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b1fbdd1cf3b57ed111c202ffc193bafd1217f8c5",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.5": {
+      "name": "loader-utils",
+      "version": "0.2.5",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x",
+        "big.js": "~2.5.1"
+      },
+      "scripts": {
+        "test": "mocha test index.js"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "db3c7cd123355f61846497ebeef614670c075ed9",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils",
+      "_id": "loader-utils@0.2.5",
+      "_shasum": "8dec38ecbcc3a81a01627f2605bec98390ccd5d0",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8dec38ecbcc3a81a01627f2605bec98390ccd5d0",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.6": {
+      "name": "loader-utils",
+      "version": "0.2.6",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x",
+        "big.js": "~2.5.1"
+      },
+      "scripts": {
+        "test": "mocha test index.js"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "3e9dfceeae52a23e5e027bdb67b30a21b52d2ae2",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils",
+      "_id": "loader-utils@0.2.6",
+      "_shasum": "306b798f6a24a5d78505fdb0db2ddd5bb2b90810",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "306b798f6a24a5d78505fdb0db2ddd5bb2b90810",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.7": {
+      "name": "loader-utils",
+      "version": "0.2.7",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x",
+        "big.js": "~2.5.1"
+      },
+      "scripts": {
+        "test": "mocha test index.js"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "b52bc62f9b2faba9f6c0aea8f9da7211b4e9bdd7",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils",
+      "_id": "loader-utils@0.2.7",
+      "_shasum": "dcbe8eaee038caa32961f206531da23f04e2279d",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dcbe8eaee038caa32961f206531da23f04e2279d",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.8": {
+      "name": "loader-utils",
+      "version": "0.2.8",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "json5": "0.1.x",
+        "big.js": "~2.5.1"
+      },
+      "scripts": {
+        "test": "mocha test index.js"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "289d38652bd4035488ff35dd11130b36b77d1035",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.8",
+      "_shasum": "ad61651fac981a2911e9c9200a838be8974c0cf6",
+      "_from": ".",
+      "_npmVersion": "2.10.0",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ad61651fac981a2911e9c9200a838be8974c0cf6",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.8.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.9": {
+      "name": "loader-utils",
+      "version": "0.2.9",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "a417eea4e36f4fa3001d1a7591093e68cc4f5462",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils",
+      "_id": "loader-utils@0.2.9",
+      "_shasum": "9efc08d1ef20e99145e5e627bd8b945a85ac14dc",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9efc08d1ef20e99145e5e627bd8b945a85ac14dc",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.9.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.10": {
+      "name": "loader-utils",
+      "version": "0.2.10",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "7fd3e9a1c9a0fb8d775f835498b8c0a2002e36a0",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.10",
+      "_shasum": "7ed2258e496644c83680590489bb82f3f57892fc",
+      "_from": ".",
+      "_npmVersion": "2.10.0",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7ed2258e496644c83680590489bb82f3f57892fc",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.10.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.11": {
+      "name": "loader-utils",
+      "version": "0.2.11",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "0adb5e5c06b6fd217b8ec4a5316bb08d3363cd88",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.11",
+      "_shasum": "8a0164e337c21ca099c2b1716366f0db0ec3087f",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8a0164e337c21ca099c2b1716366f0db0ec3087f",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.11.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.12": {
+      "name": "loader-utils",
+      "version": "0.2.12",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "581ccbcb264a9e6d7d667276fbfa609e0ee951f3",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.12",
+      "_shasum": "faa2a501563a3c2c9dda57aa8c39d8be628de7a2",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "faa2a501563a3c2c9dda57aa8c39d8be628de7a2",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.13": {
+      "name": "loader-utils",
+      "version": "0.2.13",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "b16f37eab0655130f82c1b5255373d7b4a372ceb",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.13",
+      "_shasum": "ea0de320be919056362c9972d5072b4596ae9eec",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "ea0de320be919056362c9972d5072b4596ae9eec",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.13.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-0.2.13.tgz_1458846997166_0.9803386435378343"
+      },
+      "directories": {}
+    },
+    "0.2.14": {
+      "name": "loader-utils",
+      "version": "0.2.14",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^1.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "fc647bb47b662771d26529c3157a8d2bc2579844",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.14",
+      "_shasum": "3edab2a123ebb196a1c9d6dd3e83384958843e6f",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "3edab2a123ebb196a1c9d6dd3e83384958843e6f",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-0.2.14.tgz_1460208526883_0.26962931361049414"
+      },
+      "directories": {}
+    },
+    "0.2.15": {
+      "name": "loader-utils",
+      "version": "0.2.15",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "bed965bbcb54fa54beecfee2639e9585ab5ae020",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.15",
+      "_shasum": "c7df3342a9d4e2103dddc97d4060daccc246d6ac",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "c7df3342a9d4e2103dddc97d4060daccc246d6ac",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.15.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-0.2.15.tgz_1463148639681_0.7935674281325191"
+      },
+      "directories": {}
+    },
+    "0.2.16": {
+      "name": "loader-utils",
+      "version": "0.2.16",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "4ea2dfbfe03e3ca70576aff5fe5e4a4235232591",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.16",
+      "_shasum": "f08632066ed8282835dff88dfb52704765adee6d",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "f08632066ed8282835dff88dfb52704765adee6d",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-0.2.16.tgz_1473890187319_0.20624244073405862"
+      },
+      "directories": {}
+    },
+    "0.2.17": {
+      "name": "loader-utils",
+      "version": "0.2.17",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "scripts": {
+        "test": "mocha",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "00b9d0848bd7216e184beacbf6582dc5ee51ff80",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@0.2.17",
+      "_shasum": "f86e6374d43205a6e6c60e9196f17c0299bfb348",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "f86e6374d43205a6e6c60e9196f17c0299bfb348",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-0.2.17.tgz_1487631410094_0.04626395273953676"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "loader-utils",
+      "version": "1.0.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "posttest": "npm run lint",
+        "lint": "eslint --fix *.js test",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": "^4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "main": "lib/index.js",
+      "files": [
+        "lib",
+        "README",
+        "LICENSE"
+      ],
+      "gitHead": "8cda6ab3c53791851b1528b3d7d8d7f537ae344f",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.0.0",
+      "_shasum": "4923aa5442acd8132af59ebc2738a1a828e86184",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "4923aa5442acd8132af59ebc2738a1a828e86184",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-1.0.0.tgz_1487632673669_0.4440648609306663"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "loader-utils",
+      "version": "1.0.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "posttest": "npm run lint",
+        "lint": "eslint --fix *.js test",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": "^4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "main": "lib/index.js",
+      "files": [
+        "lib",
+        "README",
+        "LICENSE"
+      ],
+      "gitHead": "9986c9c281f33f40a11dedbccac41bb6c24bfd9f",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.0.1",
+      "_shasum": "92795b3f71578538b57f7a2ecc71d5b033f0fe29",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "92795b3f71578538b57f7a2ecc71d5b033f0fe29",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-1.0.1.tgz_1487688888715_0.6141277730930597"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "loader-utils",
+      "version": "1.0.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "posttest": "npm run lint",
+        "lint": "eslint --fix *.js test",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "main": "lib/index.js",
+      "files": [
+        "lib",
+        "README",
+        "LICENSE"
+      ],
+      "gitHead": "622de891c53756e3275e7d36197c0fcc2c93149f",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.0.2",
+      "_shasum": "a9f923c865a974623391a8602d031137fad74830",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "a9f923c865a974623391a8602d031137fad74830",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-1.0.2.tgz_1487691451673_0.9973385850898921"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "loader-utils",
+      "version": "1.0.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "posttest": "npm run lint",
+        "lint": "eslint --fix *.js test",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "JSF",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "main": "lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "gitHead": "b3648f53c41b4432e8cde5d90d79a1838ceb5fa0",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.0.3",
+      "_shasum": "566c320c24c33cb3f02db4df83f3dbf60b253de3",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "566c320c24c33cb3f02db4df83f3dbf60b253de3",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-1.0.3.tgz_1488808973512_0.982763821259141"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "loader-utils",
+      "version": "1.0.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "posttest": "npm run lint",
+        "lint": "eslint --fix *.js test",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "publish-patch": "mocha && npm version patch && git push && git push --tags && npm publish"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "main": "lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "gitHead": "dfaa358213c2c96ee07c9fdd4abedd63d4ec528f",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.0.4",
+      "_shasum": "13f56197f1523a305891248b4c7244540848426c",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "13f56197f1523a305891248b4c7244540848426c",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-1.0.4.tgz_1489488966537_0.6818160915281624"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "loader-utils",
+      "version": "1.1.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "scripts": {
+        "test": "mocha",
+        "posttest": "npm run lint",
+        "lint": "eslint lib test",
+        "travis": "npm run cover -- --report lcovonly",
+        "cover": "istanbul cover -x *.runtime.js node_modules/mocha/bin/_mocha",
+        "release": "npm test && standard-version"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4",
+        "standard-version": "^4.0.0"
+      },
+      "main": "lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "gitHead": "a5602addda0c5e98e70d067b8dd050d5e4153f1d",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.1.0",
+      "_shasum": "c98aef488bcceda2ffb5e2de646d6a754429f5cd",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "c98aef488bcceda2ffb5e2de646d6a754429f5cd",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/loader-utils-1.1.0.tgz_1489673126296_0.2887681087013334"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "loader-utils",
+      "version": "1.2.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "scripts": {
+        "lint": "eslint lib test",
+        "pretest": "yarn lint",
+        "test": "jest",
+        "test:ci": "jest --coverage",
+        "release": "yarn test && standard-version"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.15.3",
+        "standard-version": "^4.0.0"
+      },
+      "main": "lib/index.js",
+      "gitHead": "ba4f0d0912b84d974a80ce8a5d2eae69841cd36b",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.2.0",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.1",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-KkQxP+pVgJC6ypy8ePypyhsV/hZeyVlkqiqrxe4pDgCwClbzmr3dGy8LbeSVhmfzYmCpOovdrVs/9chsQXCrLQ==",
+        "shasum": "8194a9bfabc3612e52e556139f67acbf01b267b7",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 25347,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcISHICRA9TVsSAnZWagAA42kP/RrAH166H/qC2XToF46N\nr3WNbGOXa2eGT03IkfWRqSjYH6akAWd9t2S6qAeLgAuTlqiZHNVsJB0+VIyS\nM3hZjh/mptS10uFRRq49N9iNjSy8RL/4kKOn+E6vwL60bJrScjrGdQxn/0So\njTlOByOqT14yEEh/gbphGIF+fXGVTQo/rBVMMnbxuWkhGPq5zVBCQoHYemup\n2m/QwrUVyeaZo+EAVL5mZ2mHvSb1BpTBfGbAcgQdUUYutIjghlogLl737j6J\neSm6ClA86rj9dLHOxIBG9jkt9T+Z6Jb8huDyiZDEQHLY/W7vLHOoMZF16inQ\nBi7EhUWUhs5Hb+fbVHXTHqpB7VIwiIdP72nrGkQvzj2NbVc9suHsOVY+wWNz\nbs8Lm9OCnHxso1KElI7Td6iMDSpn3TYVjVTHK9sqnfthu5dPUPQjZGnUXqA6\nqPU2AbIatCzfHqEnNtKfEGmHWTfsdobicqz67B8/fS/qVAGz6F3T9sm++Oge\n9uImEND7asQHnTGtc0jGRFi78MPu/OpKyPmFO4aZ2pvktiiJ6v/EqpDBbXNq\n9gKo7+UXQI7oaVgJ3H8fmlVnIeX5vesgB97/EtFngiyj5efzFHv11fsb9rNn\nUqgEwYTH1Z2zhj76mxI63DR1baRhl4nFBP/LDd0SdqDxHwGziTmclGyVrlZ7\nxw7C\r\n=Khcs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "bebraw@gmail.com",
+          "name": "bebraw"
+        },
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "j.tangelder@gmail.com",
+          "name": "jtangelder"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loader-utils_1.2.0_1545675208365_0.9149365438295183"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.1": {
+      "name": "loader-utils",
+      "version": "1.2.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "scripts": {
+        "lint": "eslint lib test",
+        "pretest": "yarn lint",
+        "test": "jest",
+        "test:ci": "jest --coverage",
+        "release": "yarn test && standard-version"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.15.3",
+        "standard-version": "^4.0.0"
+      },
+      "main": "lib/index.js",
+      "gitHead": "489ef12a900c9f40c32eb0dceeed1eaab55fcc89",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.2.1",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.1",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-3Zhx4qDqBQ9U8udWB3RMJ29nLu5a3ObNOSzk87woPvge01pi0wABowgv7F79Z4mL0DGtHRi/oOndT34EVhInoQ==",
+        "shasum": "64bbbac69aa5840d03754ba676a963dec568e844",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.1.tgz",
+        "fileCount": 15,
+        "unpackedSize": 26237,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcIiJZCRA9TVsSAnZWagAAr5UQAIUvYJyWoK6CJrmc3s/S\nbsCg86PCgqGRf0Tt9Kc03kUYXpZ1s1cBkGgbvX+SsakxBfaXOdYJV+IsbCtY\nBMMjWVXKtvgeRhtyOZnd/6WzDsb8nRns5BiemZH15fg+x2YDBe09yj//O2Fe\nGdYRo3xm+SvbdKfCaOp2EkFeIrKe4qppJXXR0oaqJxj8fFAMU4zFfK3Zmdtr\n1h1Sv/dLMRae6jipGbYglJYRcRf6Hl8jqk3FRME92hEQyFTMB97vSUxzSFsM\nxMRom/wGqXhFxG5qUOOJjdllo1crO76Bo1mICHunWk/CZo0iNliyKoWKXfbk\naj6zDE31wsU9WceUcHKaUyUonY9ww8SnoLMF589HZ+9UaXNapa8pNrLhohzd\n/Xu51PTS2gbTZJpSzdh/93lueUDceEiWqQRlARWie0iNTdPhIFW++FC0zvxp\nhOOIItORE/8YY8hYTsOd2m6AgXAy86lYImKXELxGyzEiIdhSErFEoNKGJUID\ntwFhZWJPBn+3QpFhYHASMCgi/W13bBoqnDq6lIfrmQJBFmUolLfyvLOroCg8\ndJD+D/XyGnRCtPp0HZUdUS8L6sbCEtFxDwL1+TkCZYd5Zsz1+hCLryZwPfmu\nRD8F1UhJSU4LyhcIwvCfme50qwaDGB6yOuU/NpWmjRU7W/wpXQ6IdZE4Ksvh\nQ2ap\r\n=N2QL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "bebraw@gmail.com",
+          "name": "bebraw"
+        },
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "j.tangelder@gmail.com",
+          "name": "jtangelder"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loader-utils_1.2.1_1545740888656_0.7320917201987636"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.2": {
+      "name": "loader-utils",
+      "version": "1.2.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "scripts": {
+        "lint": "eslint lib test",
+        "pretest": "yarn lint",
+        "test": "jest",
+        "test:ci": "jest --coverage",
+        "release": "yarn test && standard-version"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.15.3",
+        "standard-version": "^4.0.0"
+      },
+      "main": "lib/index.js",
+      "gitHead": "809b690c3b7fcb2e0947f014e86554d2ae1f3f03",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.2.2",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.1",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Xjb++b55GPoVV1ct93EodsswWEErveAqGhhwujIshShtjIKdPpdpveriwNCNsuVo1zQ1ukmPUszK44C9RD7TCg==",
+        "shasum": "fcfcb6b4109b2358c3df160b2254f0496b261a36",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.2.tgz",
+        "fileCount": 15,
+        "unpackedSize": 26548,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcJKm9CRA9TVsSAnZWagAA4e4P/RwxrBXfQSg+BfhrQR+z\nx1zhi/CdNAoGq6QihGbkF86da6mk9nREGpLzDVp6AlM07XZSeipC+CNKDSU1\nNsXy3onFaRFD5pjEyURsqGP2f0ptEG8mPlQtMdkaN2Rz8XhAfHYTHUhit+pS\n33QDHA/tX7h+95aEz7oUfJgEyEVtcuqsIB3otAk++ic1A15ZxCNfmPaN5AuU\n9pECvcxVG/qsYGfIKPww/ypCjRtBrNUJSH5D+7QN0TIe13ecizsWxa9R61vu\nuj8GTjbyWNvqza2itqfTbz49lYkzKNuPWbAMsqMriU3+3AOr9VD0VnB/75ii\nwsOn/8ups+HLNOV5SmNISOGXi/ZzLEflKkKv+l6Aa2tMcegR4aleSdeO1Ytc\njQf0xHRU8JPatQzlFkOG0cmNBR9oKYrQQCIN2JJYGeEHw+mm9MnzGiEa04yB\nwQ90rEaauMsE2LodS8QNe+/zbjnS+1o+/RWYBauIzzsg77ulV4ZNWt4YibIh\ntLle76Dhzo6O7+TOB4uRv8kJ/XIU9oUsBsruEJme4hTbSoGEdp+fYixIAKL5\nzT2Y0zs1oQG+CqHuCxXi2ImyPVVFVUEcntMG1MLXWIL3tlpD3wPCM/VyphRp\np9jO7IeIkZDFFpQOTZM4yr+8DI4eDrafmKHGIZM846FJyHcEsUGclz8VLYXi\n++mp\r\n=U93B\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "bebraw@gmail.com",
+          "name": "bebraw"
+        },
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "j.tangelder@gmail.com",
+          "name": "jtangelder"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loader-utils_1.2.2_1545906620751_0.3714967387139998"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.3": {
+      "name": "loader-utils",
+      "version": "1.2.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "scripts": {
+        "lint": "eslint lib test",
+        "pretest": "yarn lint",
+        "test": "jest",
+        "test:ci": "jest --coverage",
+        "release": "yarn test && standard-version"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.15.3",
+        "standard-version": "^4.0.0"
+      },
+      "main": "lib/index.js",
+      "gitHead": "b91a76c0c98bf71df5a3a1c808ea86268c3716c1",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.2.3",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.1",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+        "shasum": "1ff5dc6911c9f0a062531a4c04b609406108c2c7",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+        "fileCount": 15,
+        "unpackedSize": 26892,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcJMQZCRA9TVsSAnZWagAASckP/jRacPov3Xq8RzE938Wv\n+JE0r/2JrbRt41B1vgVrcYsessd1phyGkha/RGoHl9DLDiptjkOdZ1bgg+HX\ngU0emdTyCm3dX8INN3/fDtPyt8bAmO+PfvW8GvwY+nrrwN8g5PnOMgdUr8+T\nqnEbONrkda4dLkM3MarnBm8PZaAnF1igdCPxyjLQb8mQahgw3CAq38N/uA9a\noxUF04E4OSR2qrz75+ur/0LnEvR8vDJ7TTZ36lpdOF2pTN+/3/f8PxVxnYxo\nwlDYTLozYcK8LgBXmb9k5XqX+dxrmCcj6DIhupXgOQjq7tdHiuTvDAEDR40o\nbYDmn6O5Z3neq3AFGmMo1+WSj1+K7zY8kJeoYDX3V7zxFe0vf4ZgWSuvFueM\nkWqpiu8GkrE7RSbDb7bRZ0piJrtCfQVswGY6nmywBQLXPaztRllDAvHUHonF\nvEG665VBqkeIHaZ8LWKvUQZw/RCg4nvmYLoB0eMfIQi9FDo79atfGQSZMf2B\nMsBzz1GoS5HqICorptFwhTab+6PUUYI7y1VfiVRiP3bn8sPlfW2TL/tivXFs\n/EKIey8yA2JwIfeRrIBu57b5dXuX8edyQSMyx5gp16VeLEvukwdVgUoHzyWN\nnyjQYBhvkP3Au5QkxxlucGxIVrpaEAiOpOGPhN8IgNRxS3ppTi1OvhQsJtuQ\nPDwt\r\n=GdxV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "bebraw@gmail.com",
+          "name": "bebraw"
+        },
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "j.tangelder@gmail.com",
+          "name": "jtangelder"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loader-utils_1.2.3_1545913369202_0.5225895317690739"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.3.0": {
+      "name": "loader-utils",
+      "version": "1.3.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "scripts": {
+        "lint": "eslint lib test",
+        "pretest": "yarn lint",
+        "test": "jest",
+        "test:ci": "jest --coverage",
+        "release": "yarn test && standard-version"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.19.1",
+        "standard-version": "^4.0.0"
+      },
+      "main": "lib/index.js",
+      "gitHead": "06d36cf3a619cab20b08608204cb7ea9bddaceab",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.3.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-3DgDIZM5uYPDORrAT1YvqH/7P4E6Tctk7gaNeNUEEsj+diTu6wGyO9YBLFKJ4kFq+HGn5Au6gg2Hv087U/GBqA==",
+        "shasum": "446ec1ade95d634fd8ad3286ac12ea0306faef3f",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.3.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 27818,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTWsICRA9TVsSAnZWagAA4w8P/iLBAY5kmASDhYwmwzMR\nzhHPktuXwjIdx4erE6FuDIhUJJZcCSvLGdavOZimbrNZKRZ73Aag0BkbXV4x\niAXRM09mfAnKEYYjzPNWNLvBHw2I60WgngLD0FN5+cKzo/cP8CC8ifmLH2D2\nPEa0VOT+7EEMXUXn1+0MhEWJuxXsA2kOMrIfTNN8jwplmscfMb8sDG7djrND\nsDIiks3k8z6xIISwMScGrPYjkzh8lF8wFh5DZKzMtESAJlapU3OFZlmjTriJ\nAcIN7qe5Vg/dzGrLwkgxjBKZoRam9/60JqoQjqd0jCSuZxj/KZhySQ42uJFb\noe0+/ZMMnkK2VY8O3RbcyMPbnvsHuDvbZmuZ6F9xX3T8TFd3VJ4HKhfZ0hKy\n2/NV25Ph7kXsDrsUXMtCUB9FOtcRdesO5uFT6/wX+d3QWagbGs2vpTV3HQRa\nKL5MePmiOrbPD6+6US1R35+uYTscJRRdYpL0J4nMsHJZvQ43j39IPC23HQ2Q\nlujADc+v6KBps+kHlfSu+vwLerUXOepqAnZZYmCLj3eZ5nF91DLsxmLXOsZY\nOXmdO4CQPFTXpQx3UYhST/VeJMsesqmVFQhAAJ62FcganhXR5+ISkiQVCMo9\nwIHPt5STgY9xBZ+ik+hBRmYNkczqQCwcQEjDzmVMYDiAc6Dra+y0kB+hWDxd\noQL9\r\n=4QWF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loader-utils_1.3.0_1582131976553_0.24423840167567645"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.0": {
+      "name": "loader-utils",
+      "version": "1.4.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "scripts": {
+        "lint": "eslint lib test",
+        "pretest": "yarn lint",
+        "test": "jest",
+        "test:ci": "jest --coverage",
+        "release": "yarn test && standard-version"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.19.1",
+        "standard-version": "^4.0.0"
+      },
+      "main": "lib/index.js",
+      "gitHead": "d95b8b53f0ad547133b47ac8226f735c479f76de",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@1.4.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+        "shasum": "c579b5e34cb34b1a74edc6c1fb36bfa371d5a613",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 28893,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTXFiCRA9TVsSAnZWagAA21QQAKRq/Aq+PKQYsMvF49Qz\nkGuo/aAgvcphqUVPgBlk0PFNyYSJzhI42H889XWGQ/HjWSsiYvP0MTHby985\nOcgCQ4TTy3iK9fynC0spDs1/pxIGHWxWYBpQmt15Cn/VlPPbWdjHq0vKIcUY\nrwgYu+E/ylXNiAG9vkldFGNemrD/vCafb3D4h/aPLYYVvWaIzo8Kq+UHMDNw\nURKqD0P6bSIPVglIqK71Ch0XS/6C4m/U45fwmjZITgr7zNfOV4HR10GfupTI\ntAOwlhQjINVGhPCf2mZqHnvNCKD7mJlGgvvoN1zbEu2AD5q27P2xCRKeQA3z\nt8IAzebfSSZYqfBaHQg1F3/xHQrQye8bCQY7jfpL5HBZyxCV3hXbOQ5DFKCU\nFKDGfHmurKAfUkhcGH3J+QLePHjTG3yzso9+2IOWXUbRmLVk9CoT72RioS7v\njVZkPi0XnFDar++XpOrJVdOzkqk9hquOcBQDKkT62OLQ0ZdjJvUyqN7Z19OP\n0gZnyFlWLvIRhs08fn2/b02C8VCVeU+E/gjFlRNA/PHzIA2237DLClSv61tu\nTQPsZXZGBbB6etPshtOjJoFzb9cBvwXp++vS1HcuU18xpsXphckWCsHp4fRP\n6F09g8umNH1t6d5+N/6UPFz7OMH3GXHmZ0SzZe9Fq0Z/SEB3V/71Zf+6ARvv\nsggX\r\n=kKRV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loader-utils_1.4.0_1582133602049_0.6698382604953661"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "loader-utils",
+      "version": "2.0.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "utils for webpack loaders",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "scripts": {
+        "lint": "eslint lib test",
+        "pretest": "yarn lint",
+        "test": "jest",
+        "test:ci": "jest --coverage",
+        "release": "yarn test && standard-version"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/loader-utils.git"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.9",
+        "eslint": "^6.8.0",
+        "eslint-plugin-node": "^11.0.0",
+        "eslint-plugin-prettier": "^3.1.2",
+        "jest": "^25.1.0",
+        "prettier": "^1.19.1",
+        "standard-version": "^7.1.0"
+      },
+      "main": "lib/index.js",
+      "gitHead": "d9f4e23cf411d8556f8bac2d3bf05a6e0103b568",
+      "bugs": {
+        "url": "https://github.com/webpack/loader-utils/issues"
+      },
+      "homepage": "https://github.com/webpack/loader-utils#readme",
+      "_id": "loader-utils@2.0.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.14.2",
+      "dist": {
+        "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+        "shasum": "e4cace5b816d425a166b5f097e10cd12b36064b0",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 29542,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJecLanCRA9TVsSAnZWagAAcUQP/A4EMnQKlU7bQfyGUm3c\n40IQvwykmwyy77Kuosrsh1+5JqcATrTzKBn2x/EeZodZeO3BbKQskiUSVaLn\nOVGYsx1WtD/k/1ubQj/GGJZ2QdThX10OS/b/VD7hSNnLgTqYRgwNBSYjJPR2\nS9esn3mq2XtoZ/qll4tOVIL2sWZMEJ+Rz28u/1WrNB5VH7NKZhW0DbYAcLXF\njXVTovp8s2pQhgFG0jEWHu2lNsZfAeJ2ZRWaGYUjz/Cy1Pj9/SdO8qAI67+D\nLEzy8OGFFmwbCGd+5na5+EVBwKrAaeVJeBrnJeqoayWs/lv3z7qoccODBvbh\nWvG5pKDTbU9MewUqP+Pz09Kw+JY+p5xmRc3AlGd7oP32fhxagx1FSHxdicUe\nSs0NDlsNoXwFsFDj1z6nLI5w/yJqLEC+rw8i3iOSe7i2yc4PpoEwTIoH/sWS\nDL/lO+JyGGsDnuSdDpakFscK2BD2YBWpMKBf+EUYfbKJBj5WJv7qo5EUl27C\nOOZIZNOrpGnDszygH6fIWbrkW/0nnAjg0LdPER7VGtpZldILKdfU6YYm0c50\nalTqRFT1/kKcvuVoUUgnU37POyb77CkiyH+ctcJW4NVjVFr1N+QAggg2BaB4\n58f8/tEl1IJKGP0Mz2VFvMveLFNDXHnwjSiDDY2b+26WOQlpQjNNM928wRME\nIZ7v\r\n=HeY2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loader-utils_2.0.0_1584445095416_0.02652315978988473"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# loader-utils\n\n## Methods\n\n### `getOptions`\n\nRecommended way to retrieve the options of a loader invocation:\n\n```javascript\n// inside your loader\nconst options = loaderUtils.getOptions(this);\n```\n\n1. If `this.query` is a string:\n\t- Tries to parse the query string and returns a new object\n\t- Throws if it's not a valid query string\n2. If `this.query` is object-like, it just returns `this.query`\n3. In any other case, it just returns `null`\n\n**Please note:** The returned `options` object is *read-only*. It may be re-used across multiple invocations.\nIf you pass it on to another library, make sure to make a *deep copy* of it:\n\n```javascript\nconst options = Object.assign(\n\t{},\n\tdefaultOptions,\n\tloaderUtils.getOptions(this) // it is safe to pass null to Object.assign()\n);\n// don't forget nested objects or arrays\noptions.obj = Object.assign({}, options.obj); \noptions.arr = options.arr.slice();\nsomeLibrary(options);\n```\n\n[clone](https://www.npmjs.com/package/clone) is a good library to make a deep copy of the options.\n\n#### Options as query strings\n\nIf the loader options have been passed as loader query string (`loader?some&params`), the string is parsed by using [`parseQuery`](#parsequery).\n\n### `parseQuery`\n\nParses a passed string (e.g. `loaderContext.resourceQuery`) as a query string, and returns an object.\n\n``` javascript\nconst params = loaderUtils.parseQuery(this.resourceQuery); // resource: `file?param1=foo`\nif (params.param1 === \"foo\") {\n\t// do something\n}\n```\n\nThe string is parsed like this:\n\n``` text\n                             -> Error\n?                            -> {}\n?flag                        -> { flag: true }\n?+flag                       -> { flag: true }\n?-flag                       -> { flag: false }\n?xyz=test                    -> { xyz: \"test\" }\n?xyz=1                       -> { xyz: \"1\" } // numbers are NOT parsed\n?xyz[]=a                     -> { xyz: [\"a\"] }\n?flag1&flag2                 -> { flag1: true, flag2: true }\n?+flag1,-flag2               -> { flag1: true, flag2: false }\n?xyz[]=a,xyz[]=b             -> { xyz: [\"a\", \"b\"] }\n?a%2C%26b=c%2C%26d           -> { \"a,&b\": \"c,&d\" }\n?{data:{a:1},isJSON5:true}   -> { data: { a: 1 }, isJSON5: true }\n```\n\n### `stringifyRequest`\n\nTurns a request into a string that can be used inside `require()` or `import` while avoiding absolute paths.\nUse it instead of `JSON.stringify(...)` if you're generating code inside a loader.\n\n**Why is this necessary?** Since webpack calculates the hash before module paths are translated into module ids, we must avoid absolute paths to ensure\nconsistent hashes across different compilations.\n\nThis function:\n\n- resolves absolute requests into relative requests if the request and the module are on the same hard drive\n- replaces `\\` with `/` if the request and the module are on the same hard drive\n- won't change the path at all if the request and the module are on different hard drives\n- applies `JSON.stringify` to the result\n\n```javascript\nloaderUtils.stringifyRequest(this, \"./test.js\");\n// \"\\\"./test.js\\\"\"\n\nloaderUtils.stringifyRequest(this, \".\\\\test.js\");\n// \"\\\"./test.js\\\"\"\n\nloaderUtils.stringifyRequest(this, \"test\");\n// \"\\\"test\\\"\"\n\nloaderUtils.stringifyRequest(this, \"test/lib/index.js\");\n// \"\\\"test/lib/index.js\\\"\"\n\nloaderUtils.stringifyRequest(this, \"otherLoader?andConfig!test?someConfig\");\n// \"\\\"otherLoader?andConfig!test?someConfig\\\"\"\n\nloaderUtils.stringifyRequest(this, require.resolve(\"test\"));\n// \"\\\"../node_modules/some-loader/lib/test.js\\\"\"\n\nloaderUtils.stringifyRequest(this, \"C:\\\\module\\\\test.js\");\n// \"\\\"../../test.js\\\"\" (on Windows, in case the module and the request are on the same drive)\n\nloaderUtils.stringifyRequest(this, \"C:\\\\module\\\\test.js\");\n// \"\\\"C:\\\\module\\\\test.js\\\"\" (on Windows, in case the module and the request are on different drives)\n\nloaderUtils.stringifyRequest(this, \"\\\\\\\\network-drive\\\\test.js\");\n// \"\\\"\\\\\\\\network-drive\\\\\\\\test.js\\\"\" (on Windows, in case the module and the request are on different drives)\n```\n\n### `urlToRequest`\n\nConverts some resource URL to a webpack module request.\n\n> i Before call `urlToRequest` you need call `isUrlRequest` to ensure it is requestable url\n\n```javascript\nconst url = \"path/to/module.js\";\n\nif (loaderUtils.isUrlRequest(url)) {\n  // Logic for requestable url\n  const request = loaderUtils.urlToRequest(url);\n} else {\n  // Logic for not requestable url\n}\n```\n\nSimple example:\n\n```javascript\nconst url = \"path/to/module.js\";\nconst request = loaderUtils.urlToRequest(url); // \"./path/to/module.js\"\n```\n\n#### Module URLs\n\nAny URL containing a `~` will be interpreted as a module request. Anything after the `~` will be considered the request path.\n\n```javascript\nconst url = \"~path/to/module.js\";\nconst request = loaderUtils.urlToRequest(url); // \"path/to/module.js\"\n```\n\n#### Root-relative URLs\n\nURLs that are root-relative (start with `/`) can be resolved relative to some arbitrary path by using the `root` parameter:\n\n```javascript\nconst url = \"/path/to/module.js\";\nconst root = \"./root\";\nconst request = loaderUtils.urlToRequest(url, root); // \"./root/path/to/module.js\"\n```\n\nTo convert a root-relative URL into a module URL, specify a `root` value that starts with `~`:\n\n```javascript\nconst url = \"/path/to/module.js\";\nconst root = \"~\";\nconst request = loaderUtils.urlToRequest(url, root); // \"path/to/module.js\"\n```\n\n### `interpolateName`\n\nInterpolates a filename template using multiple placeholders and/or a regular expression.\nThe template and regular expression are set as query params called `name` and `regExp` on the current loader's context.\n\n```javascript\nconst interpolatedName = loaderUtils.interpolateName(loaderContext, name, options);\n```\n\nThe following tokens are replaced in the `name` parameter:\n\n* `[ext]` the extension of the resource\n* `[name]` the basename of the resource\n* `[path]` the path of the resource relative to the `context` query parameter or option.\n* `[folder]` the folder the resource is in\n* `[query]` the queryof the resource, i.e. `?foo=bar`\n* `[emoji]` a random emoji representation of `options.content`\n* `[emoji:<length>]` same as above, but with a customizable number of emojis\n* `[contenthash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md4 hash)\n* `[<hashType>:contenthash:<digestType>:<length>]` optionally one can configure\n  * other `hashType`s, i. e. `sha1`, `md4`, `md5`, `sha256`, `sha512`\n  * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`\n  * and `length` the length in chars\n* `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md4 hash)\n* `[<hashType>:hash:<digestType>:<length>]` optionally one can configure\n  * other `hashType`s, i. e. `sha1`, `md4`, `md5`, `sha256`, `sha512`\n  * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`\n  * and `length` the length in chars\n* `[N]` the N-th match obtained from matching the current file name against `options.regExp`\n\nIn loader context `[hash]` and `[contenthash]` are the same, but we recommend using `[contenthash]` for avoid misleading.\n\nExamples\n\n``` javascript\n// loaderContext.resourcePath = \"/absolute/path/to/app/js/javascript.js\"\nloaderUtils.interpolateName(loaderContext, \"js/[hash].script.[ext]\", { content: ... });\n// => js/9473fdd0d880a43c21b7778d34872157.script.js\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/js/javascript.js\"\n// loaderContext.resourceQuery = \"?foo=bar\"\nloaderUtils.interpolateName(loaderContext, \"js/[hash].script.[ext][query]\", { content: ... });\n// => js/9473fdd0d880a43c21b7778d34872157.script.js?foo=bar\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/js/javascript.js\"\nloaderUtils.interpolateName(loaderContext, \"js/[contenthash].script.[ext]\", { content: ... });\n// => js/9473fdd0d880a43c21b7778d34872157.script.js\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/page.html\"\nloaderUtils.interpolateName(loaderContext, \"html-[hash:6].html\", { content: ... });\n// => html-9473fd.html\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/flash.txt\"\nloaderUtils.interpolateName(loaderContext, \"[hash]\", { content: ... });\n// => c31e9820c001c9c4a86bce33ce43b679\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/img/image.gif\"\nloaderUtils.interpolateName(loaderContext, \"[emoji]\", { content: ... });\n// => 👍\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/img/image.gif\"\nloaderUtils.interpolateName(loaderContext, \"[emoji:4]\", { content: ... });\n// => 🙍🏢📤🐝\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/img/image.png\"\nloaderUtils.interpolateName(loaderContext, \"[sha512:hash:base64:7].[ext]\", { content: ... });\n// => 2BKDTjl.png\n// use sha512 hash instead of md4 and with only 7 chars of base64\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/img/myself.png\"\n// loaderContext.query.name =\nloaderUtils.interpolateName(loaderContext, \"picture.png\");\n// => picture.png\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/dir/file.png\"\nloaderUtils.interpolateName(loaderContext, \"[path][name].[ext]?[hash]\", { content: ... });\n// => /app/dir/file.png?9473fdd0d880a43c21b7778d34872157\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/js/page-home.js\"\nloaderUtils.interpolateName(loaderContext, \"script-[1].[ext]\", { regExp: \"page-(.*)\\\\.js\", content: ... });\n// => script-home.js\n\n// loaderContext.resourcePath = \"/absolute/path/to/app/js/javascript.js\"\n// loaderContext.resourceQuery = \"?foo=bar\"\nloaderUtils.interpolateName(\n  loaderContext, \n  (resourcePath, resourceQuery) => { \n    // resourcePath - `/app/js/javascript.js`\n    // resourceQuery - `?foo=bar`\n\n    return \"js/[hash].script.[ext]\"; \n  }, \n  { content: ... }\n);\n// => js/9473fdd0d880a43c21b7778d34872157.script.js\n```\n\n### `getHashDigest`\n\n``` javascript\nconst digestString = loaderUtils.getHashDigest(buffer, hashType, digestType, maxLength);\n```\n\n* `buffer` the content that should be hashed\n* `hashType` one of `sha1`, `md4`, `md5`, `sha256`, `sha512` or any other node.js supported hash type\n* `digestType` one of `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`\n* `maxLength` the maximum length in chars\n\n## License\n\nMIT (http://www.opensource.org/licenses/mit-license.php)\n",
+  "maintainers": [
+    {
+      "email": "wiens.joshua@gmail.com",
+      "name": "d3viant0ne"
+    },
+    {
+      "email": "sheo13666q@gmail.com",
+      "name": "evilebottnawi"
+    },
+    {
+      "email": "mail@johannesewald.de",
+      "name": "jhnns"
+    },
+    {
+      "email": "michael.ciniawsky@gmail.com",
+      "name": "michael-ciniawsky"
+    },
+    {
+      "email": "tobias.koppers@googlemail.com",
+      "name": "sokra"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-10T08:03:15.713Z",
+    "created": "2012-11-02T09:04:48.557Z",
+    "0.1.0": "2012-11-02T09:04:51.604Z",
+    "0.1.1": "2012-11-06T15:14:58.115Z",
+    "0.1.2": "2012-11-11T09:32:50.101Z",
+    "0.2.0": "2013-02-01T07:47:44.929Z",
+    "0.2.1": "2013-03-25T22:59:39.122Z",
+    "0.2.2": "2014-03-31T07:42:01.233Z",
+    "0.2.3": "2014-07-07T11:02:24.572Z",
+    "0.2.4": "2014-09-24T19:04:38.525Z",
+    "0.2.5": "2014-10-11T15:38:55.265Z",
+    "0.2.6": "2015-01-11T08:48:46.271Z",
+    "0.2.7": "2015-04-09T21:04:50.152Z",
+    "0.2.8": "2015-05-21T20:32:02.085Z",
+    "0.2.9": "2015-05-22T06:56:37.606Z",
+    "0.2.10": "2015-06-16T18:57:52.693Z",
+    "0.2.11": "2015-07-18T16:26:57.137Z",
+    "0.2.12": "2015-11-23T21:50:32.833Z",
+    "0.2.13": "2016-03-24T19:16:39.586Z",
+    "0.2.14": "2016-04-09T13:28:47.920Z",
+    "0.2.15": "2016-05-13T14:10:41.676Z",
+    "0.2.16": "2016-09-14T21:56:28.432Z",
+    "0.2.17": "2017-02-20T22:56:50.783Z",
+    "1.0.0": "2017-02-20T23:17:55.776Z",
+    "1.0.1": "2017-02-21T14:54:50.645Z",
+    "1.0.2": "2017-02-21T15:37:34.017Z",
+    "1.0.3": "2017-03-06T14:02:55.308Z",
+    "1.0.4": "2017-03-14T10:56:08.427Z",
+    "1.1.0": "2017-03-16T14:05:28.112Z",
+    "1.2.0": "2018-12-24T18:13:28.465Z",
+    "1.2.1": "2018-12-25T12:28:08.826Z",
+    "1.2.2": "2018-12-27T10:30:20.872Z",
+    "1.2.3": "2018-12-27T12:22:49.344Z",
+    "1.3.0": "2020-02-19T17:06:16.671Z",
+    "1.4.0": "2020-02-19T17:33:22.170Z",
+    "2.0.0": "2020-03-17T11:38:15.582Z"
+  },
+  "author": {
+    "name": "Tobias Koppers @sokra"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/webpack/loader-utils#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webpack/loader-utils.git"
+  },
+  "bugs": {
+    "url": "https://github.com/webpack/loader-utils/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "shuoshubao": true,
+    "yanghaojyhangdian": true,
+    "chaoliu": true,
+    "ttionya": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/loader-utils.min.json
+++ b/test/fixtures/registry-mocks/content/loader-utils.min.json
@@ -1,0 +1,663 @@
+{
+  "name": "loader-utils",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "loader-utils",
+      "version": "0.1.0",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "dist": {
+        "shasum": "c806ab8550eec0f0b716cc5b07fa7641261399e3",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "loader-utils",
+      "version": "0.1.1",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "dist": {
+        "shasum": "2eb185fdec466d145507077f3ea2435e1cf9cc8e",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "loader-utils",
+      "version": "0.1.2",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "dist": {
+        "shasum": "94b2b270822ae0f53a6bab74394c1d6f557c296b",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.1.2.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "loader-utils",
+      "version": "0.2.0",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "dist": {
+        "shasum": "3ab46086a1397e0fd52470e69106998fd70644a0",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "loader-utils",
+      "version": "0.2.1",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "dist": {
+        "shasum": "c8d03c4fe8c91e0ae362bd3aeb7fcc445f9b7890",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "loader-utils",
+      "version": "0.2.2",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "dist": {
+        "shasum": "4c0fe718dd3ab62d1d47d03a2b1af54dd7fda382",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.2.tgz"
+      }
+    },
+    "0.2.3": {
+      "name": "loader-utils",
+      "version": "0.2.3",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "dist": {
+        "shasum": "87fe021587458f10f7eb755c75af60a1fcf4b392",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.3.tgz"
+      }
+    },
+    "0.2.4": {
+      "name": "loader-utils",
+      "version": "0.2.4",
+      "dependencies": {
+        "json5": "0.1.x"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "b1fbdd1cf3b57ed111c202ffc193bafd1217f8c5",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.4.tgz"
+      }
+    },
+    "0.2.5": {
+      "name": "loader-utils",
+      "version": "0.2.5",
+      "dependencies": {
+        "json5": "0.1.x",
+        "big.js": "~2.5.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "8dec38ecbcc3a81a01627f2605bec98390ccd5d0",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.5.tgz"
+      }
+    },
+    "0.2.6": {
+      "name": "loader-utils",
+      "version": "0.2.6",
+      "dependencies": {
+        "json5": "0.1.x",
+        "big.js": "~2.5.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "306b798f6a24a5d78505fdb0db2ddd5bb2b90810",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.6.tgz"
+      }
+    },
+    "0.2.7": {
+      "name": "loader-utils",
+      "version": "0.2.7",
+      "dependencies": {
+        "json5": "0.1.x",
+        "big.js": "~2.5.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "dcbe8eaee038caa32961f206531da23f04e2279d",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.7.tgz"
+      }
+    },
+    "0.2.8": {
+      "name": "loader-utils",
+      "version": "0.2.8",
+      "dependencies": {
+        "json5": "0.1.x",
+        "big.js": "~2.5.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "ad61651fac981a2911e9c9200a838be8974c0cf6",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.8.tgz"
+      }
+    },
+    "0.2.9": {
+      "name": "loader-utils",
+      "version": "0.2.9",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "9efc08d1ef20e99145e5e627bd8b945a85ac14dc",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.9.tgz"
+      }
+    },
+    "0.2.10": {
+      "name": "loader-utils",
+      "version": "0.2.10",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "7ed2258e496644c83680590489bb82f3f57892fc",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.10.tgz"
+      }
+    },
+    "0.2.11": {
+      "name": "loader-utils",
+      "version": "0.2.11",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "8a0164e337c21ca099c2b1716366f0db0ec3087f",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.11.tgz"
+      }
+    },
+    "0.2.12": {
+      "name": "loader-utils",
+      "version": "0.2.12",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "faa2a501563a3c2c9dda57aa8c39d8be628de7a2",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz"
+      }
+    },
+    "0.2.13": {
+      "name": "loader-utils",
+      "version": "0.2.13",
+      "dependencies": {
+        "big.js": "^3.0.2",
+        "json5": "^0.4.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "ea0de320be919056362c9972d5072b4596ae9eec",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.13.tgz"
+      }
+    },
+    "0.2.14": {
+      "name": "loader-utils",
+      "version": "0.2.14",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^1.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "3edab2a123ebb196a1c9d6dd3e83384958843e6f",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.14.tgz"
+      }
+    },
+    "0.2.15": {
+      "name": "loader-utils",
+      "version": "0.2.15",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "c7df3342a9d4e2103dddc97d4060daccc246d6ac",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.15.tgz"
+      }
+    },
+    "0.2.16": {
+      "name": "loader-utils",
+      "version": "0.2.16",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "f08632066ed8282835dff88dfb52704765adee6d",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.16.tgz"
+      }
+    },
+    "0.2.17": {
+      "name": "loader-utils",
+      "version": "0.2.17",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "f86e6374d43205a6e6c60e9196f17c0299bfb348",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "loader-utils",
+      "version": "1.0.0",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "4923aa5442acd8132af59ebc2738a1a828e86184",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.0.tgz"
+      },
+      "engines": {
+        "node": "^4.0.0"
+      }
+    },
+    "1.0.1": {
+      "name": "loader-utils",
+      "version": "1.0.1",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "92795b3f71578538b57f7a2ecc71d5b033f0fe29",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.1.tgz"
+      },
+      "engines": {
+        "node": "^4.0.0"
+      }
+    },
+    "1.0.2": {
+      "name": "loader-utils",
+      "version": "1.0.2",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "a9f923c865a974623391a8602d031137fad74830",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.0.3": {
+      "name": "loader-utils",
+      "version": "1.0.3",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "566c320c24c33cb3f02db4df83f3dbf60b253de3",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.0.4": {
+      "name": "loader-utils",
+      "version": "1.0.4",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "13f56197f1523a305891248b4c7244540848426c",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.1.0": {
+      "name": "loader-utils",
+      "version": "1.1.0",
+      "dependencies": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
+      },
+      "devDependencies": {
+        "coveralls": "^2.11.2",
+        "eslint": "^3.15.0",
+        "eslint-plugin-node": "^4.0.1",
+        "istanbul": "^0.3.14",
+        "mocha": "^1.21.4",
+        "standard-version": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "c98aef488bcceda2ffb5e2de646d6a754429f5cd",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.2.0": {
+      "name": "loader-utils",
+      "version": "1.2.0",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.15.3",
+        "standard-version": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-KkQxP+pVgJC6ypy8ePypyhsV/hZeyVlkqiqrxe4pDgCwClbzmr3dGy8LbeSVhmfzYmCpOovdrVs/9chsQXCrLQ==",
+        "shasum": "8194a9bfabc3612e52e556139f67acbf01b267b7",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 25347,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcISHICRA9TVsSAnZWagAA42kP/RrAH166H/qC2XToF46N\nr3WNbGOXa2eGT03IkfWRqSjYH6akAWd9t2S6qAeLgAuTlqiZHNVsJB0+VIyS\nM3hZjh/mptS10uFRRq49N9iNjSy8RL/4kKOn+E6vwL60bJrScjrGdQxn/0So\njTlOByOqT14yEEh/gbphGIF+fXGVTQo/rBVMMnbxuWkhGPq5zVBCQoHYemup\n2m/QwrUVyeaZo+EAVL5mZ2mHvSb1BpTBfGbAcgQdUUYutIjghlogLl737j6J\neSm6ClA86rj9dLHOxIBG9jkt9T+Z6Jb8huDyiZDEQHLY/W7vLHOoMZF16inQ\nBi7EhUWUhs5Hb+fbVHXTHqpB7VIwiIdP72nrGkQvzj2NbVc9suHsOVY+wWNz\nbs8Lm9OCnHxso1KElI7Td6iMDSpn3TYVjVTHK9sqnfthu5dPUPQjZGnUXqA6\nqPU2AbIatCzfHqEnNtKfEGmHWTfsdobicqz67B8/fS/qVAGz6F3T9sm++Oge\n9uImEND7asQHnTGtc0jGRFi78MPu/OpKyPmFO4aZ2pvktiiJ6v/EqpDBbXNq\n9gKo7+UXQI7oaVgJ3H8fmlVnIeX5vesgB97/EtFngiyj5efzFHv11fsb9rNn\nUqgEwYTH1Z2zhj76mxI63DR1baRhl4nFBP/LDd0SdqDxHwGziTmclGyVrlZ7\nxw7C\r\n=Khcs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.2.1": {
+      "name": "loader-utils",
+      "version": "1.2.1",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.15.3",
+        "standard-version": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-3Zhx4qDqBQ9U8udWB3RMJ29nLu5a3ObNOSzk87woPvge01pi0wABowgv7F79Z4mL0DGtHRi/oOndT34EVhInoQ==",
+        "shasum": "64bbbac69aa5840d03754ba676a963dec568e844",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.1.tgz",
+        "fileCount": 15,
+        "unpackedSize": 26237,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcIiJZCRA9TVsSAnZWagAAr5UQAIUvYJyWoK6CJrmc3s/S\nbsCg86PCgqGRf0Tt9Kc03kUYXpZ1s1cBkGgbvX+SsakxBfaXOdYJV+IsbCtY\nBMMjWVXKtvgeRhtyOZnd/6WzDsb8nRns5BiemZH15fg+x2YDBe09yj//O2Fe\nGdYRo3xm+SvbdKfCaOp2EkFeIrKe4qppJXXR0oaqJxj8fFAMU4zFfK3Zmdtr\n1h1Sv/dLMRae6jipGbYglJYRcRf6Hl8jqk3FRME92hEQyFTMB97vSUxzSFsM\nxMRom/wGqXhFxG5qUOOJjdllo1crO76Bo1mICHunWk/CZo0iNliyKoWKXfbk\naj6zDE31wsU9WceUcHKaUyUonY9ww8SnoLMF589HZ+9UaXNapa8pNrLhohzd\n/Xu51PTS2gbTZJpSzdh/93lueUDceEiWqQRlARWie0iNTdPhIFW++FC0zvxp\nhOOIItORE/8YY8hYTsOd2m6AgXAy86lYImKXELxGyzEiIdhSErFEoNKGJUID\ntwFhZWJPBn+3QpFhYHASMCgi/W13bBoqnDq6lIfrmQJBFmUolLfyvLOroCg8\ndJD+D/XyGnRCtPp0HZUdUS8L6sbCEtFxDwL1+TkCZYd5Zsz1+hCLryZwPfmu\nRD8F1UhJSU4LyhcIwvCfme50qwaDGB6yOuU/NpWmjRU7W/wpXQ6IdZE4Ksvh\nQ2ap\r\n=N2QL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.2.2": {
+      "name": "loader-utils",
+      "version": "1.2.2",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.15.3",
+        "standard-version": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Xjb++b55GPoVV1ct93EodsswWEErveAqGhhwujIshShtjIKdPpdpveriwNCNsuVo1zQ1ukmPUszK44C9RD7TCg==",
+        "shasum": "fcfcb6b4109b2358c3df160b2254f0496b261a36",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.2.tgz",
+        "fileCount": 15,
+        "unpackedSize": 26548,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcJKm9CRA9TVsSAnZWagAA4e4P/RwxrBXfQSg+BfhrQR+z\nx1zhi/CdNAoGq6QihGbkF86da6mk9nREGpLzDVp6AlM07XZSeipC+CNKDSU1\nNsXy3onFaRFD5pjEyURsqGP2f0ptEG8mPlQtMdkaN2Rz8XhAfHYTHUhit+pS\n33QDHA/tX7h+95aEz7oUfJgEyEVtcuqsIB3otAk++ic1A15ZxCNfmPaN5AuU\n9pECvcxVG/qsYGfIKPww/ypCjRtBrNUJSH5D+7QN0TIe13ecizsWxa9R61vu\nuj8GTjbyWNvqza2itqfTbz49lYkzKNuPWbAMsqMriU3+3AOr9VD0VnB/75ii\nwsOn/8ups+HLNOV5SmNISOGXi/ZzLEflKkKv+l6Aa2tMcegR4aleSdeO1Ytc\njQf0xHRU8JPatQzlFkOG0cmNBR9oKYrQQCIN2JJYGeEHw+mm9MnzGiEa04yB\nwQ90rEaauMsE2LodS8QNe+/zbjnS+1o+/RWYBauIzzsg77ulV4ZNWt4YibIh\ntLle76Dhzo6O7+TOB4uRv8kJ/XIU9oUsBsruEJme4hTbSoGEdp+fYixIAKL5\nzT2Y0zs1oQG+CqHuCxXi2ImyPVVFVUEcntMG1MLXWIL3tlpD3wPCM/VyphRp\np9jO7IeIkZDFFpQOTZM4yr+8DI4eDrafmKHGIZM846FJyHcEsUGclz8VLYXi\n++mp\r\n=U93B\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.2.3": {
+      "name": "loader-utils",
+      "version": "1.2.3",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^2.0.0",
+        "json5": "^1.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.15.3",
+        "standard-version": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+        "shasum": "1ff5dc6911c9f0a062531a4c04b609406108c2c7",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+        "fileCount": 15,
+        "unpackedSize": 26892,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcJMQZCRA9TVsSAnZWagAASckP/jRacPov3Xq8RzE938Wv\n+JE0r/2JrbRt41B1vgVrcYsessd1phyGkha/RGoHl9DLDiptjkOdZ1bgg+HX\ngU0emdTyCm3dX8INN3/fDtPyt8bAmO+PfvW8GvwY+nrrwN8g5PnOMgdUr8+T\nqnEbONrkda4dLkM3MarnBm8PZaAnF1igdCPxyjLQb8mQahgw3CAq38N/uA9a\noxUF04E4OSR2qrz75+ur/0LnEvR8vDJ7TTZ36lpdOF2pTN+/3/f8PxVxnYxo\nwlDYTLozYcK8LgBXmb9k5XqX+dxrmCcj6DIhupXgOQjq7tdHiuTvDAEDR40o\nbYDmn6O5Z3neq3AFGmMo1+WSj1+K7zY8kJeoYDX3V7zxFe0vf4ZgWSuvFueM\nkWqpiu8GkrE7RSbDb7bRZ0piJrtCfQVswGY6nmywBQLXPaztRllDAvHUHonF\nvEG665VBqkeIHaZ8LWKvUQZw/RCg4nvmYLoB0eMfIQi9FDo79atfGQSZMf2B\nMsBzz1GoS5HqICorptFwhTab+6PUUYI7y1VfiVRiP3bn8sPlfW2TL/tivXFs\n/EKIey8yA2JwIfeRrIBu57b5dXuX8edyQSMyx5gp16VeLEvukwdVgUoHzyWN\nnyjQYBhvkP3Au5QkxxlucGxIVrpaEAiOpOGPhN8IgNRxS3ppTi1OvhQsJtuQ\nPDwt\r\n=GdxV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.3.0": {
+      "name": "loader-utils",
+      "version": "1.3.0",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.19.1",
+        "standard-version": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-3DgDIZM5uYPDORrAT1YvqH/7P4E6Tctk7gaNeNUEEsj+diTu6wGyO9YBLFKJ4kFq+HGn5Au6gg2Hv087U/GBqA==",
+        "shasum": "446ec1ade95d634fd8ad3286ac12ea0306faef3f",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.3.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 27818,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTWsICRA9TVsSAnZWagAA4w8P/iLBAY5kmASDhYwmwzMR\nzhHPktuXwjIdx4erE6FuDIhUJJZcCSvLGdavOZimbrNZKRZ73Aag0BkbXV4x\niAXRM09mfAnKEYYjzPNWNLvBHw2I60WgngLD0FN5+cKzo/cP8CC8ifmLH2D2\nPEa0VOT+7EEMXUXn1+0MhEWJuxXsA2kOMrIfTNN8jwplmscfMb8sDG7djrND\nsDIiks3k8z6xIISwMScGrPYjkzh8lF8wFh5DZKzMtESAJlapU3OFZlmjTriJ\nAcIN7qe5Vg/dzGrLwkgxjBKZoRam9/60JqoQjqd0jCSuZxj/KZhySQ42uJFb\noe0+/ZMMnkK2VY8O3RbcyMPbnvsHuDvbZmuZ6F9xX3T8TFd3VJ4HKhfZ0hKy\n2/NV25Ph7kXsDrsUXMtCUB9FOtcRdesO5uFT6/wX+d3QWagbGs2vpTV3HQRa\nKL5MePmiOrbPD6+6US1R35+uYTscJRRdYpL0J4nMsHJZvQ43j39IPC23HQ2Q\nlujADc+v6KBps+kHlfSu+vwLerUXOepqAnZZYmCLj3eZ5nF91DLsxmLXOsZY\nOXmdO4CQPFTXpQx3UYhST/VeJMsesqmVFQhAAJ62FcganhXR5+ISkiQVCMo9\nwIHPt5STgY9xBZ+ik+hBRmYNkczqQCwcQEjDzmVMYDiAc6Dra+y0kB+hWDxd\noQL9\r\n=4QWF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "1.4.0": {
+      "name": "loader-utils",
+      "version": "1.4.0",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.2",
+        "eslint": "^5.11.0",
+        "eslint-plugin-node": "^8.0.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "jest": "^21.2.1",
+        "prettier": "^1.19.1",
+        "standard-version": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+        "shasum": "c579b5e34cb34b1a74edc6c1fb36bfa371d5a613",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 28893,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTXFiCRA9TVsSAnZWagAA21QQAKRq/Aq+PKQYsMvF49Qz\nkGuo/aAgvcphqUVPgBlk0PFNyYSJzhI42H889XWGQ/HjWSsiYvP0MTHby985\nOcgCQ4TTy3iK9fynC0spDs1/pxIGHWxWYBpQmt15Cn/VlPPbWdjHq0vKIcUY\nrwgYu+E/ylXNiAG9vkldFGNemrD/vCafb3D4h/aPLYYVvWaIzo8Kq+UHMDNw\nURKqD0P6bSIPVglIqK71Ch0XS/6C4m/U45fwmjZITgr7zNfOV4HR10GfupTI\ntAOwlhQjINVGhPCf2mZqHnvNCKD7mJlGgvvoN1zbEu2AD5q27P2xCRKeQA3z\nt8IAzebfSSZYqfBaHQg1F3/xHQrQye8bCQY7jfpL5HBZyxCV3hXbOQ5DFKCU\nFKDGfHmurKAfUkhcGH3J+QLePHjTG3yzso9+2IOWXUbRmLVk9CoT72RioS7v\njVZkPi0XnFDar++XpOrJVdOzkqk9hquOcBQDKkT62OLQ0ZdjJvUyqN7Z19OP\n0gZnyFlWLvIRhs08fn2/b02C8VCVeU+E/gjFlRNA/PHzIA2237DLClSv61tu\nTQPsZXZGBbB6etPshtOjJoFzb9cBvwXp++vS1HcuU18xpsXphckWCsHp4fRP\n6F09g8umNH1t6d5+N/6UPFz7OMH3GXHmZ0SzZe9Fq0Z/SEB3V/71Zf+6ARvv\nsggX\r\n=kKRV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "2.0.0": {
+      "name": "loader-utils",
+      "version": "2.0.0",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "devDependencies": {
+        "coveralls": "^3.0.9",
+        "eslint": "^6.8.0",
+        "eslint-plugin-node": "^11.0.0",
+        "eslint-plugin-prettier": "^3.1.2",
+        "jest": "^25.1.0",
+        "prettier": "^1.19.1",
+        "standard-version": "^7.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+        "shasum": "e4cace5b816d425a166b5f097e10cd12b36064b0",
+        "tarball": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 29542,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJecLanCRA9TVsSAnZWagAAcUQP/A4EMnQKlU7bQfyGUm3c\n40IQvwykmwyy77Kuosrsh1+5JqcATrTzKBn2x/EeZodZeO3BbKQskiUSVaLn\nOVGYsx1WtD/k/1ubQj/GGJZ2QdThX10OS/b/VD7hSNnLgTqYRgwNBSYjJPR2\nS9esn3mq2XtoZ/qll4tOVIL2sWZMEJ+Rz28u/1WrNB5VH7NKZhW0DbYAcLXF\njXVTovp8s2pQhgFG0jEWHu2lNsZfAeJ2ZRWaGYUjz/Cy1Pj9/SdO8qAI67+D\nLEzy8OGFFmwbCGd+5na5+EVBwKrAaeVJeBrnJeqoayWs/lv3z7qoccODBvbh\nWvG5pKDTbU9MewUqP+Pz09Kw+JY+p5xmRc3AlGd7oP32fhxagx1FSHxdicUe\nSs0NDlsNoXwFsFDj1z6nLI5w/yJqLEC+rw8i3iOSe7i2yc4PpoEwTIoH/sWS\nDL/lO+JyGGsDnuSdDpakFscK2BD2YBWpMKBf+EUYfbKJBj5WJv7qo5EUl27C\nOOZIZNOrpGnDszygH6fIWbrkW/0nnAjg0LdPER7VGtpZldILKdfU6YYm0c50\nalTqRFT1/kKcvuVoUUgnU37POyb77CkiyH+ctcJW4NVjVFr1N+QAggg2BaB4\n58f8/tEl1IJKGP0Mz2VFvMveLFNDXHnwjSiDDY2b+26WOQlpQjNNM928wRME\nIZ7v\r\n=HeY2\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    }
+  },
+  "modified": "2020-08-10T08:03:15.713Z"
+}

--- a/test/fixtures/registry-mocks/content/loglevel.json
+++ b/test/fixtures/registry-mocks/content/loglevel.json
@@ -1,0 +1,2116 @@
+{
+  "_id": "loglevel",
+  "_rev": "66-e964045801d9c31cfd516b679041e2f0",
+  "name": "loglevel",
+  "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+  "dist-tags": {
+    "latest": "1.7.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "0.1.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.6",
+        "grunt-contrib-concat": "~0.1.2",
+        "grunt-contrib-uglify": "~0.1.1",
+        "grunt-contrib-jshint": "~0.1.1",
+        "grunt-contrib-watch": "~0.2.0",
+        "grunt-contrib-jasmine": "~0.4.1",
+        "grunt-template-jasmine-requirejs": "~0.1.0",
+        "grunt-open": "~0.2.0",
+        "grunt-contrib-connect": "~0.2.0",
+        "grunt-saucelabs": "~3.0.7"
+      },
+      "keywords": [],
+      "_id": "loglevel@0.1.0",
+      "dist": {
+        "shasum": "94edf0dc6fe70bcd65d472288878275be6120405",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "0.2.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.6",
+        "grunt-contrib-concat": "~0.1.2",
+        "grunt-contrib-uglify": "~0.1.1",
+        "grunt-contrib-jshint": "~0.1.1",
+        "grunt-contrib-watch": "~0.2.0",
+        "grunt-contrib-jasmine": "~0.4.1",
+        "grunt-template-jasmine-requirejs": "~0.1.0",
+        "grunt-open": "~0.2.0",
+        "grunt-contrib-connect": "~0.2.0",
+        "grunt-saucelabs": "~3.0.7"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@0.2.0",
+      "dist": {
+        "shasum": "b8214bc90b1fa7c3e1c9282c50ced4b0eb10f8ce",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "0.3.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.6",
+        "grunt-contrib-concat": "~0.1.2",
+        "grunt-contrib-uglify": "~0.1.1",
+        "grunt-contrib-jshint": "~0.1.1",
+        "grunt-contrib-watch": "~0.2.0",
+        "grunt-contrib-jasmine": "~0.4.1",
+        "grunt-template-jasmine-requirejs": "~0.1.0",
+        "grunt-open": "~0.2.0",
+        "grunt-contrib-connect": "~0.2.0",
+        "grunt-saucelabs": "~3.0.7"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@0.3.0",
+      "dist": {
+        "shasum": "5970fda39aaea5c9aac040605f5e787de196e696",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "0.3.1",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.6",
+        "grunt-contrib-concat": "~0.1.2",
+        "grunt-contrib-uglify": "~0.1.1",
+        "grunt-contrib-jshint": "~0.1.1",
+        "grunt-contrib-watch": "~0.2.0",
+        "grunt-contrib-jasmine": "~0.4.1",
+        "grunt-template-jasmine-requirejs": "~0.1.0",
+        "grunt-open": "~0.2.0",
+        "grunt-contrib-connect": "~0.2.0",
+        "grunt-saucelabs": "~3.0.7"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@0.3.1",
+      "dist": {
+        "shasum": "0737790b40150f0aecc48a207e54ca14fdf88ea9",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "0.4.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.9",
+        "grunt-contrib-concat": "~0.3.0",
+        "grunt-contrib-uglify": "~0.2.4",
+        "grunt-contrib-jshint": "~0.6.4",
+        "grunt-contrib-watch": "~0.5.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-open": "~0.2.2",
+        "grunt-saucelabs": "~4.0.4",
+        "grunt-contrib-connect": "~0.5.0",
+        "grunt-jasmine-node": "~0.1.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@0.4.0",
+      "dist": {
+        "shasum": "649d508ff8998747dc08f55ec3ef3b1b7a3d1971",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "0.5.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.9",
+        "grunt-contrib-concat": "~0.3.0",
+        "grunt-contrib-uglify": "~0.2.4",
+        "grunt-contrib-jshint": "~0.6.4",
+        "grunt-contrib-watch": "~0.5.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-open": "~0.2.2",
+        "grunt-saucelabs": "~4.1.2",
+        "grunt-contrib-connect": "~0.5.0",
+        "grunt-jasmine-node": "~0.1.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@0.5.0",
+      "dist": {
+        "shasum": "f3941921f79f223043904d845497a9e0480fe29a",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "0.6.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "^0.4.1",
+        "grunt-cli": "^0.1.9",
+        "grunt-contrib-concat": "^0.3.0",
+        "grunt-contrib-uglify": "^0.3.0",
+        "grunt-contrib-jshint": "^0.8.0",
+        "grunt-contrib-watch": "^0.5.1",
+        "grunt-contrib-jasmine": "^0.5.2",
+        "grunt-template-jasmine-requirejs": "^0.1.6",
+        "grunt-template-jasmine-istanbul": "^0.2.5",
+        "grunt-open": "^0.2.2",
+        "grunt-saucelabs": "^5.0.0",
+        "grunt-contrib-connect": "^0.6.0",
+        "grunt-jasmine-node": "^0.1.0",
+        "grunt-coveralls": "^0.3.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@0.6.0",
+      "dist": {
+        "shasum": "3dc728ff5a945f9c6652fccd134be9a12a41cc83",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.0.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "qunitjs": "^1.14.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@1.0.0",
+      "dist": {
+        "shasum": "ad593623e855d138d5f9ff5e1c64f4793f603336",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.1.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@1.1.0",
+      "_shasum": "82c94f9b73774b4a1cd2e4ae6562b3a8b676df4b",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "82c94f9b73774b4a1cd2e4ae6562b3a8b676df4b",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.2.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@1.2.0",
+      "dist": {
+        "shasum": "149418e55fb0e0b5fc7ad228c8d315ae1ec19c68",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.3.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "_id": "loglevel@1.3.0",
+      "_shasum": "0be9dbd6bc4079647fbe5c532ee46bf31ec08d58",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0be9dbd6bc4079647fbe5c532ee46bf31ec08d58",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.3.1",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/pimterry/loglevel/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "1999a4378fd4dac3085cef806d0ff85d607cfc9a",
+      "_id": "loglevel@1.3.1",
+      "_shasum": "b116495ab076994d8237e467c14234b10b306730",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b116495ab076994d8237e467c14234b10b306730",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.4.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "02a21113aff7fed6bd8774be843a3500cec2f5d5",
+      "_id": "loglevel@1.4.0",
+      "_shasum": "83ab9fc6ef3e0caf7571b57182b32d8d870309dc",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "83ab9fc6ef3e0caf7571b57182b32d8d870309dc",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.4.1",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "a93aa4f87e63dc57508993e6a8e92996c438decc",
+      "_id": "loglevel@1.4.1",
+      "_shasum": "95b383f91a3c2756fd4ab093667e4309161f2bcd",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.11.0",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "dist": {
+        "shasum": "95b383f91a3c2756fd4ab093667e4309161f2bcd",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/loglevel-1.4.1.tgz_1464707577760_0.3953995918855071"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.5.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "jam": {
+        "dependencies": {},
+        "main": "lib/loglevel.js"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "344fd1b27befbbe7179edfe2522b5f7b37ed0d6d",
+      "_id": "loglevel@1.5.0",
+      "_npmVersion": "5.2.0",
+      "_nodeVersion": "8.1.2",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-OQ2jhWI5G2qsvO0UFNyCQWgKl/tFiwuPIXxELzACeUO2FqstN/R7mmL09+nhv6xOWVPPojQO1A90sCEoJSgBcQ==",
+        "shasum": "3863984a2c326b986fbb965f378758a6dc8a4324",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel-1.5.0.tgz_1505168077497_0.6798963339533657"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.5.1",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "2cd93e88fb275e99aa434f37a2766e4f6252dfd4",
+      "_id": "loglevel@1.5.1",
+      "_shasum": "189078c94ab9053ee215a0acdbf24244ea0f6502",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "8.1.2",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "dist": {
+        "shasum": "189078c94ab9053ee215a0acdbf24244ea0f6502",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel-1.5.1.tgz_1507536604150_0.3011685397941619"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.6.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "7ccfb321978aa15785ee250fba749680c38336ad",
+      "_id": "loglevel@1.6.0",
+      "_shasum": "ae0caa561111498c5ba13723d6fb631d24003934",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "8.8.0",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "dist": {
+        "shasum": "ae0caa561111498c5ba13723d6fb631d24003934",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel-1.6.0.tgz_1510612769633_0.37311658379621804"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.6.1",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "a79c91362b8fc4e14e8bdba51edca76a456f8d26",
+      "_id": "loglevel@1.6.1",
+      "_shasum": "e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "dist": {
+        "shasum": "e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel-1.6.1.tgz_1515616764358_0.792777051217854"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.6.2",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel",
+      "types": "./index.d.ts",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "c54a06fc11f6686b9a250ea5d593a426e1a61978",
+      "_id": "loglevel@1.6.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Jt2MHrCNdtIe1W6co3tF5KXGRkzF+TYffiQstfXa04mrss9IKXzAAXYWak8LbZseAQY03sH2GzMCMU0ZOUc9bg==",
+        "shasum": "668c77948a03dbd22502a3513ace1f62a80cc372",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.2.tgz",
+        "fileCount": 34,
+        "unpackedSize": 129222,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc78fMCRA9TVsSAnZWagAAuwUP/2ltBsOpnPIkRVlmdpMv\npaGgrhl/BTKt8qWVlF7b991fe9Cqo+2yxgJXsqxZn6lqCvf8YaG4vviTpM0x\nKJxDugHVlUXeLcxlCyirGl8lFw3hgsfi7IqW6ucOQUUZQapgeDIl4Ej3t4bR\njjeKX/8ERuXX0y5byO8TUnYwsCGnFfcNy8uEil8WGxjWdNZvVdbvfT9VBMQq\n2Xsl8ep4y9WUOAducXWWraCa2LqcSd4f6bBqBtsE9bEgzHaF4qnr61YwzUCc\nLkZcwcXN1rGdQ3+A4eJGBiiAyjdEFhu3zjiLp6gdTF0Ic0CJW6aJEbnM27xi\n2VrhAL24GwdzakZZgUqv7DpdMFsS3eQexkLm7BVPU3jAVBlGH23SIT+QW5fr\nD2wqHjwriOjOAbneEQBlxsuybWXFcRy12YFqf+FfT1n8nZXNzCNEcKFUeOt8\nt4iJmHFFWxS8DFZMLS4aHYgr33vtx73jOvNqFU5JHXYWS4P9Jg/G4Y49pAzq\nlJlAWvqT2Mt/h3h7qmhy6Ql92/jZX2acunT+hnwfhGycfR1PvHRsfYX79IeY\nHZLgBGNpYlWlUWgRGSal9B7SlHBvJMYTRcXQ1NmQ3OAOS4l3DAZEwzeX9KRw\nScjIdSlCEcHhpo3LfGvIH1VHztzquFRIh2UqTp6sVOSD7FOqABMl8VmxVXLD\nwdEU\r\n=PC9G\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel_1.6.2_1559218124085_0.2409922798385158"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.3": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.6.3",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel",
+      "types": "./index.d.ts",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test && tsc --noEmit ./test/type-test.ts",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "1a069c2a2dfa855f92016def318364b20163df55",
+      "_id": "loglevel@1.6.3",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+        "shasum": "77f2eb64be55a404c9fd04ad16d57c1d6d6b1280",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
+        "fileCount": 35,
+        "unpackedSize": 130345,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/6n5CRA9TVsSAnZWagAA7V4P+QCgW8ecYZtSUWWhr5Kq\nBdB46pSjoTWA6zhN56hbo/F50Ylt7vISCIUtq0BVk1+9ucrpEtlHGAMIwOqv\nWahOASGMTWI4Sr+Dl6aBwXyN1srgKJUOJipFy81vYjDpnrra0E3ASss1VUxN\nUwLUsu9LE5J61fZP+VqgqJHxy7WS/X2+LL/FMG29PL3G19Y7tCIBbZisKkP3\nTqDivtkDeIo/xQeIEo8TaY3h24a4ybARGkJl5zgH7mbCalYb4trq0rIdGdvK\nKfqPr8QHUwpJdy9gogRbVCh99JWRuwrYbNqKChzT2k1kMoCyv8iFTwEN++mS\noxFBuQMUy27aMcPeUxJ5LBvR0qU7Te7lS/WwmHWx2mycm0lskiA3pdD/RzFT\nZIOrIlmWFIinatSP1mDirR1+0JYOyvxi+21cPuBfhKOtONircyFPwzN9GLLY\nAqDj9yuW6rvJG28duo6od2G+vGUqQcZInPRkdqqLGrrpjvbnUVKdTeJL76fm\nU8/5GFicPVyw+zd8gaVltFPdY50isoxMAJPnSVKC/H0dj+ezRRGKxYmvovpV\nWUDEMjsgh7KogEGGHJuuJ54w7Y2ouO42jFhMm94B384NBZhypwqeslV1bdAT\nR3Z9vCHTML6O9e1ZbNZQw4GGcQ7YXL/SUVg5xbs6gEE+g62XjioQSl/xiZxw\nEYnH\r\n=xmw9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel_1.6.3_1560259065206_0.5105774904903855"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.4": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.6.4",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel.js",
+      "types": "./index.d.ts",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test && tsc --noEmit ./test/type-test.ts",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "ee54a76e719da58eb8733f33c0e3d98c25f57269",
+      "_id": "loglevel@1.6.4",
+      "_nodeVersion": "8.16.0",
+      "_npmVersion": "6.10.1",
+      "dist": {
+        "integrity": "sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==",
+        "shasum": "f408f4f006db8354d0577dcf6d33485b3cb90d56",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
+        "fileCount": 35,
+        "unpackedSize": 130436,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdcQsxCRA9TVsSAnZWagAAMmQP/3TqZyIlWGeAw2HeKQaP\nrRTGxnbUqFub0in2G3gXQ2F39qtf5Mf38RWH7ZEe9S3HvmE84Fvo/NzGexfq\n7mJB6MBNMlN8t3VjGl2ex/nKBfLDRw9lls7DJ4/+XA8Mv8RNnaf3TqjXWnDt\nUNsZGPk6FdD7X0Yh+G1PGtawAOpdXSxCWAci43LTAvLEvKaUh9LVr4Gq5NFk\nL7uPdi9GCoolJT4AcmWbUPxF01KTBPk97umjFCb5eOzng891GD3qbp2g120r\nEFTQ3RYTz3twIdC7+QNeqhMCoJ1ta9QgtlHbuF5RDQwQcVYwxU8Vrb+y18xk\nMSspAtWlkTuBFnuTongJ6AW2X6vGbxeOAn/iRjOiuM56QUz3uBAkINXITM4h\nHmkpC6u5UvzqOrmdLkceT/lbh5yGfVMIHP9znJOFzfrBA/E8GL5rVQDoqla2\ncrIXLDZy2XsZHuHvl3qUoDAnKHlAY+Ve2NnyIWsBOcU4I5jGYUsTRffKs4Lz\n8zJff65nyDBYT+6954ri5vAmppAJeAIRvop360iotogF2/HuwUZDdMDm08Ao\nfAXu/CL0FKU9tWyFrD9G/zq9Ep92Oy5Nhe16L8+1xy0MUCIiu0qCcrlRMhl0\nkzpkojeOHBuLRCfm+N8qB2grolNvAA+Ybmorm6yse1MtNl1wDtFk8lICDOYF\ncAIP\r\n=HCAT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel_1.6.4_1567689520297_0.34384390231680007"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.6": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.6.6",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel.js",
+      "types": "./index.d.ts",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test && tsc --noEmit ./test/type-test.ts",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "e9100d4887ad54c2f5f7836caca08f06b23fa3f2",
+      "_id": "loglevel@1.6.6",
+      "_nodeVersion": "6.14.1",
+      "_npmVersion": "6.13.0",
+      "dist": {
+        "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
+        "shasum": "0ee6300cc058db6b3551fa1c4bf73b83bb771312",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
+        "fileCount": 36,
+        "unpackedSize": 132681,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdxFCuCRA9TVsSAnZWagAAXxwP/AxJjKGd+wtkiXs+iM71\nYLdmRxUGZWbBjoaUTfbtN2k6hABqpmDE8wV4kG3MbnjA9v4f3qFcb6yV/kJT\nb3VLL2u2M7eXvjn9n2oc3dJFvV6001gsh2V9+cU4QbTLAy1Ftm0DoGG9A2qw\nzUeYYvgEwNAFO9HRb0zzLsZor7oErELUIplzyF4HMYZz9vqeSoF8DIDHDnQI\nDGa8yk+HJm03wruLYIih0QJ3qDaubP4l6yFoOgrnG2E5JgKi+had0Jp2/Uex\newTUQEUMnjSC+TWx64qcIWUVMh0CgHK4f+yXkY6ewH2WIPFj7MjyUrZfo1B+\ncpILxYGsRyHjbxh97RFK+EqIuJJKWjWLq++P53ZUJoD6FThjKgpZiC/UaH8Y\nXsxg9AKUgXAl8uN4C0jcrBMo9PkFrkDvmDbF3RWNO6is0GMTbje2EbaB2TV2\nAF1VrbAxBhVdkUUIff/trakpLDSTDYlHr23KeT/YETh7WKhm6ysNw6nCYNUd\nklaMAfaHcHhd6woQ146LzJqX3g0cqa4ozbXvh2heK7PDtkY2vlgYsOKqDzm3\nS8BLED2bcy6F20bppKPVqSii5k/QGlj65UlZklXyWcDYiJ7X6C9J8E+2aNoH\nwZ3SkdxrQmu6Fwt61IMQrbU+Uwas1mxFw3zeMIbX+xda15Gxz9YTjVEHZTlM\n3IIf\r\n=B2gb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel_1.6.6_1573146797609_0.462611993637394"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.7": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.6.7",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel.js",
+      "types": "./index.d.ts",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test && tsc --noEmit ./test/type-test.ts",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "f2db6bcfce8f2350b9c760f9ceced62f6e877a0f",
+      "_id": "loglevel@1.6.7",
+      "_nodeVersion": "8.16.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
+        "shasum": "b3e034233188c68b889f5b862415306f565e2c56",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+        "fileCount": 36,
+        "unpackedSize": 133922,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeQWNACRA9TVsSAnZWagAAfjcQAIuPYa47tUUxFK55rpWW\nkMv8vKTOvOgKAGvxk6Ocuu+lI9RITilsVpnQQv7UoDmX05ht90hyqgl3kxvK\nTjUcLMq2i+C+CbXVzR67OotXrbdoAgwuDeCm4fVLRYymY26n+0nTc1PxNLhn\nAeo5qX4hRKcCJ8ekZP+LvWw+YrLpFpBfeJ9ObioROTB1nSTSw9soPP9uHW91\nA6dFfBsR0BA9j7HM7Ue6olFbkd7iJLDrEwjtVbIcul9tDhcl73eIVC3i9fr2\np/ObJlq3S5zPOa63uSarlkcztgYnL21iGUht/VfESO5Ekz71CJm49sh/iF5D\nR4ao432bG6+wGGFJrM0nRqPtnxre7q2HUP4iv/4UGb733Nj3c8G6vTFrSeN3\nxKMRZu1c55HkNIlMi06os8TiPRahILnMvkyO3IGPIbcuJXbZorDMvFvF2ohM\nspfaRF9ebJn/soQ2ISgYiGDxTNeoCNNWVoVwYSFa08/ca9EK8f7vG/1fXf2F\ndkx+M7XeoxbmDJhZMH7qcGPAdZq79UUVkFWvphfqnTO/RVtBh7ExjbAXT3HZ\niI1EEdvCe31RijjqxqQy+859h8vtGcsKfyyNr9sMDi/2a6jVFyFVcg5KdWIr\np7kfd2qJeQzBc3LR6RecSViC0zacd6ZqPeXZscHwpaifwjrR4YWbPcjh88OY\n8/o2\r\n=hgMf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel_1.6.7_1581343551845_0.8017399647946302"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.8": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.6.8",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel.js",
+      "types": "./index.d.ts",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test && tsc --noEmit ./test/type-test.ts",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "ddb2505cbe334d9248e9c1b803f3ebaba129407c",
+      "_id": "loglevel@1.6.8",
+      "_nodeVersion": "8.16.0",
+      "_npmVersion": "6.14.2",
+      "dist": {
+        "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
+        "shasum": "8a25fb75d092230ecd4457270d80b54e28011171",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+        "fileCount": 36,
+        "unpackedSize": 134185,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJelZJYCRA9TVsSAnZWagAAhsEP/0pcXkRXPeHMhwzana4S\n3yylQ8rv1B0yrwuiwJxu1cvn2rxlMmqgjV2cHieVutCwbYJuZfxdU3lzPJjO\nnYl/JU/JwSucxTYPposv3cVjj84OfmuhIGZfCpVRMBZEjB1EWmHPioLwjMQK\nNfB4d7vxjFC1LxrcmuxGn5b+2Nla3CFMtgMWuvwQ0agXARqLuvDcUqrQCpMp\nPcbUA3oLWLz3ssdPLcWkcjymUbbOpiwUtpHbrsyVVc3Dyf9PfEhvQp2BJvl1\niVi6Qd5iXXHFYZfhf4RM2l50DEmVCXdzMkce44fZdfyyAPelpBMw2eb52K5q\nm+2LXG1ge/3Xq0jPrOYTQ8n1m5sa2XD+1H/r6fhUD2kvzW0od2gKAwVxvWh2\nP7mscn/eXHS/XWC2vzoKBkMGRtP0dxNUUpo8C+lEVRIal02GOMcBbkfkm25C\nqNas3aF0YZIiD/0At4iaXAqQiIGMdH0b1pyYzGnj0fNSaV9+/Do6oxK154hp\nvD6A4FMwvZJvdrPmghiVrakZgUEXwJ/T9g0qkfChdHPvKDy1gs+FNYKX1Ajd\noLTCf5CJdWqjbX8MaGGH1zHiE61VNWOqJ+aPiVxqG67Y7uey4G0HzVA7zjkE\neUzyG7qNb7+rKe6nvUT2oPH0N+LkRo3wch5vvEoul4OSCX8/MANXejLKMyfc\nttUF\r\n=W3IL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel_1.6.8_1586860631599_0.5144243548036991"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.0": {
+      "name": "loglevel",
+      "description": "Minimal lightweight logging for JavaScript, adding reliable log level methods to any available console.log methods",
+      "version": "1.7.0",
+      "homepage": "https://github.com/pimterry/loglevel",
+      "author": {
+        "name": "Tim Perry",
+        "email": "pimterry@gmail.com",
+        "url": "http://tim-perry.co.uk"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/pimterry/loglevel.git"
+      },
+      "bugs": {
+        "url": "https://github.com/pimterry/loglevel/issues"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+      },
+      "license": "MIT",
+      "main": "lib/loglevel.js",
+      "types": "./index.d.ts",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "scripts": {
+        "test": "grunt test && tsc --noEmit ./test/type-test.ts",
+        "ci": "grunt ci",
+        "dist": "grunt dist",
+        "watch": "grunt watch"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "browser"
+      ],
+      "gitHead": "7a4112f3ae27d8ecff567b803e292af1e7e5126d",
+      "_id": "loglevel@1.7.0",
+      "_nodeVersion": "8.17.0",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
+        "shasum": "728166855a740d59d38db01cf46f042caa041bb0",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
+        "fileCount": 36,
+        "unpackedSize": 135934,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfRmaCCRA9TVsSAnZWagAAk30P/RDZedPHuTidbE/I67I6\ne+aadlVrrSa3DKdxEwX9MOj8qYQPMSY+O4EkGTPqhYIBIntQ8GYY7UEfbjny\nztWS1wMnTa7eVofG7sXaK8GJYLhtw9DpDvmmnb9iqZ/iEFxMuyhzSDOqO3u2\nFxt8edKUVijAKv1Cdpjmt5HYrXFjOCDyxi7OcDKpuVvwmZQtw1N+jV/0HKCT\n1OnQW6rZfDY8c+1vFFvibmoeFHsDUHhQxWck5SZm43uG+gb7MrJCorqlso+Y\ndwWh3SPB/qrbVjIgZV7e2eMCoQRmhxOfuCcwvHSbeN06Jab/vOwn5fjGzBiO\nH4GJUzgeEXvprWjyplSpFs32fHIV0lw5SKKXhcqbWUMsmbi14CtfbDoa+mHu\ni4BOIIxZy8UBMn5eMfAH0h2iHqY+ocK148cj/QInQ64HyRqsL/T3Pz++z3Zr\nt+DfXP1qTAuGY+fd8pX8ZOUITTOPOV0ck/udh+rA/WRUjt4DCDoqTh8I84O8\nD+rT7ui4+3oYCt8AhdqP3rS99iCW6XFgQIp4Qkg4i/ynGulHOl+fJgt7xmUU\nE4FeGf5NeB5+X5uYntropUThMbl7QUtP9lUf3SCWLwN9wlWGNQM0QtEPHh6v\nbiv3XD/k9l4ySMlWcH7t1/+4PjSDZh9etZ3Nwm3b0SXnK+G6abKLWXJAt7QL\n/QP2\r\n=TAuG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "pimterry",
+          "email": "pimterry@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "pimterry",
+        "email": "pimterry@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/loglevel_1.7.0_1598449281505_0.526581079924987"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "\n# loglevel [![NPM version][npm-image]][npm-url] [![NPM downloads](https://img.shields.io/npm/dw/loglevel.svg)](https://www.npmjs.com/package/loglevel) [![Build status](https://travis-ci.org/pimterry/loglevel.png)](https://travis-ci.org/pimterry/loglevel) [![Coveralls percentage](https://img.shields.io/coveralls/pimterry/loglevel.svg)](https://coveralls.io/r/pimterry/loglevel?branch=master)\n\n[npm-image]: https://img.shields.io/npm/v/loglevel.svg?style=flat\n[npm-url]: https://npmjs.org/package/loglevel\n\n> _Don't debug with logs alone - check out [HTTP Toolkit](https://httptoolkit.tech/javascript): beautiful, powerful & open-source tools for building, testing & debugging HTTP(S)_\n\nMinimal lightweight simple logging for JavaScript. loglevel replaces console.log() and friends with level-based logging and filtering, with none of console's downsides.\n\nThis is a barebones reliable everyday logging library. It does not do fancy things, it does not let you reconfigure appenders or add complex log filtering rules or boil tea (more's the pity), but it does have the all core functionality that you actually use:\n\n## Features\n\n### Simple\n\n* Log things at a given level (trace/debug/info/warn/error) to the console object (as seen in all modern browsers & node.js)\n* Filter logging by level (all the above or 'silent'), so you can disable all but error logging in production, and then run log.setLevel(\"trace\") in your console to turn it all back on for a furious debugging session\n* Single file, no dependencies, weighs in at 1.1KB minified and gzipped\n\n### Effective\n\n* Log methods gracefully fall back to simpler console logging methods if more specific ones aren't available: so calls to log.debug() go to console.debug() if possible, or console.log() if not\n* Logging calls still succeed even if there's no console object at all, so your site doesn't break when people visit with old browsers that don't support the console object (here's looking at you IE) and similar\n* This then comes together giving a consistent reliable API that works in every JavaScript environment with a console available, and never breaks anything anywhere else\n\n### Convenient\n\n* Log output keeps line numbers: most JS logging frameworks call console.log methods through wrapper functions, clobbering your stacktrace and making the extra info many browsers provide useless. We'll have none of that thanks.\n* It works with all the standard JavaScript loading systems out of the box (CommonJS, AMD, or just as a global)\n* Logging is filtered to \"warn\" level by default, to keep your live site clean in normal usage (or you can trivially re-enable everything with an initial log.enableAll() call)\n* Magically handles situations where console logging is not initially available (IE8/9), and automatically enables logging as soon as it does become available (when developer console is opened)\n* TypeScript type definitions included, so no need for extra `@types` packages\n* Extensible, to add other log redirection, filtering, or formatting functionality, while keeping all the above (except you will clobber your stacktrace, see Plugins below)\n\n## Downloading loglevel\n\nIf you're using NPM, you can just run `npm install loglevel`.\n\nAlternatively, loglevel is also available via [Bower](https://github.com/bower/bower) (`bower install loglevel`), as a [Webjar](http://www.webjars.org/), or an [Atmosphere package](https://atmospherejs.com/spacejamio/loglevel) (for Meteor)\n\nAlternatively if you just want to grab the file yourself, you can download either the current stable [production version][min] or the [development version][max] directly, or reference it remotely on unpkg at [`https://unpkg.com/loglevel/dist/loglevel.min.js`][cdn] (this will redirect to a latest version, use the resulting redirected URL if you want to pin that version).\n\nFinally, if you want to tweak loglevel to your own needs or you immediately need the cutting-edge version, clone this repo and see [Developing & Contributing](#developing--contributing) below for build instructions.\n\n[min]: https://raw.github.com/pimterry/loglevel/master/dist/loglevel.min.js\n[max]: https://raw.github.com/pimterry/loglevel/master/dist/loglevel.js\n[cdn]: https://unpkg.com/loglevel/dist/loglevel.min.js\n\n## Setting it up\n\nloglevel supports AMD (e.g. RequireJS), CommonJS (e.g. Node.js) and direct usage (e.g. loading globally with a &lt;script&gt; tag) loading methods. You should be able to do nearly anything, and then skip to the next section anyway and have it work. Just in case though, here's some specific examples that definitely do the right thing:\n\n### CommonsJS (e.g. Node)\n\n```javascript\nvar log = require('loglevel');\nlog.warn(\"unreasonably simple\");\n```\n\n### AMD (e.g. RequireJS)\n\n```javascript\ndefine(['loglevel'], function(log) {\n   log.warn(\"dangerously convenient\");\n});\n```\n\n### Directly in your web page:\n\n```html\n<script src=\"loglevel.min.js\"></script>\n<script>\nlog.warn(\"too easy\");\n</script>\n```\n\n### As an ES6 module:\n\nloglevel is written as a UMD module, with a single object exported. Unfortunately ES6 module loaders & transpilers don't all handle this the same way. Some will treat the object as the default export, while others use it as the root exported object. In addition, loglevel includes `default` property on the root object, designed to help handle this differences. Nonetheless, there's two possible syntaxes that might work for you:\n\nFor most tools, using the default import is the most convenient and flexible option:\n\n```javascript\nimport log from 'loglevel';\nlog.warn(\"module-tastic\");\n```\n\nFor some tools though, it might better to wildcard import the whole object:\n\n```javascript\nimport * as log from 'loglevel';\nlog.warn(\"module-tastic\");\n```\n\nThere's no major difference, unless you're using TypeScript & building a loglevel plugin (in that case, see https://github.com/pimterry/loglevel/issues/149). In general though, just use whichever suits your environment, and everything should work out fine.\n\n### With noConflict():\n\nIf you're using another JavaScript library that exposes a 'log' global, you can run into conflicts with loglevel.  Similarly to jQuery, you can solve this by putting loglevel into no-conflict mode immediately after it is loaded onto the page. This resets to 'log' global to its value before loglevel was loaded (typically `undefined`), and returns the loglevel object, which you can then bind to another name yourself.\n\nFor example:\n\n```html\n<script src=\"loglevel.min.js\"></script>\n<script>\nvar logging = log.noConflict();\n\nlogging.warn(\"still pretty easy\");\n</script>\n```\n\n### TypeScript:\n\nloglevel includes its own type definitions, assuming you're using a modern module environment (e.g. Node.JS, webpack, etc), you should be able to use the ES6 syntax above, and everything will work immediately. If not, file a bug!\n\nIf you really want to use LogLevel as a global however, but from TypeScript, you'll need to declare it as such first. To do that:\n\n* Create a `loglevel.d.ts` file\n* Ensure that file is included in your build (e.g. add it to `include` in your tsconfig, pass it on the command line, or use `///<reference path=\"./loglevel.d.ts\" />`)\n* In that file, add:\n  ```typescript\n  import * as log from 'loglevel';\n  export as namespace log;\n  export = log;\n  ```\n\n## Documentation\n\nThe loglevel API is extremely minimal. All methods are available on the root loglevel object, which it's suggested you name 'log' (this is the default if you import it in globally, and is what's set up in the above examples). The API consists of:\n\n* 5 actual logging methods, ordered and available as:\n  * `log.trace(msg)`\n  * `log.debug(msg)`\n  * `log.info(msg)`\n  * `log.warn(msg)`\n  * `log.error(msg)`\n\n  `log.log(msg)` is also available, as an alias for `log.debug(msg)`, to improve compatibility with `console`, and make migration easier.\n\n  Exact output formatting of these will depend on the console available in the current context of your application. For example, many environments will include a full stack trace with all trace() calls, and icons or similar to highlight other calls.\n\n  These methods should never fail in any environment, even if no console object is currently available, and should always fall back to an available log method even if the specific method called (e.g. warn) isn't available.\n\n  Be aware that all this means that these method won't necessarily always produce exactly the output you expect in every environment; loglevel only guarantees that these methods will never explode on you, and that it will call the most relevant method it can find, with your argument. For example, `log.trace(msg)` in Firefox before version 64 prints the stacktrace by itself, and doesn't include your message (see [#84](https://github.com/pimterry/loglevel/issues/84)).\n\n* A `log.setLevel(level, [persist])` method.\n\n  This disables all logging below the given level, so that after a log.setLevel(\"warn\") call log.warn(\"something\") or log.error(\"something\") will output messages, but log.info(\"something\") will not.\n\n  This can take either a log level name or 'silent' (which disables everything) in one of a few forms:\n  * As a log level from the internal levels list, e.g. log.levels.SILENT ← _for type safety_\n  * As a string, like 'error' (case-insensitive) ← _for a reasonable practical balance_\n  * As a numeric index from 0 (trace) to 5 (silent) ← _deliciously terse, and more easily programmable (...although, why?)_\n\n  Where possible the log level will be persisted. LocalStorage will be used if available, falling back to cookies if not. If neither is available in the current environment (i.e. in Node), or if you pass `false` as the optional 'persist' second argument, persistence will be skipped.\n\n  If log.setLevel() is called when a console object is not available (in IE 8 or 9 before the developer tools have been opened, for example) logging will remain silent until the console becomes available, and then begin logging at the requested level.\n\n* A `log.setDefaultLevel(level)` method.\n\n  This sets the current log level only if one has not been persisted and can’t be loaded. This is useful when initializing scripts; if a developer or user has previously called `setLevel()`, this won’t alter their settings. For example, your application might set the log level to `error` in a production environment, but when debugging an issue, you might call `setLevel(\"trace\")` on the console to see all the logs. If that `error` setting was set using `setDefaultLevel()`, it will still stay as `trace` on subsequent page loads and refreshes instead of resetting to `error`.\n\n  The `level` argument takes is the same values that you might pass to `setLevel()`. Levels set using `setDefaultLevel()` never persist to subsequent page loads.\n\n* `log.enableAll()` and `log.disableAll()` methods.\n\n  These enable or disable all log messages, and are equivalent to log.setLevel(\"trace\") and log.setLevel(\"silent\") respectively.\n\n* A `log.getLevel()` method.\n\n  Returns the current logging level, as a number from 0 (trace) to 5 (silent)\n\n  It's very unlikely you'll need to use this for normal application logging; it's provided partly to help plugin development, and partly to let you optimize logging code as below, where debug data is only generated if the level is set such that it'll actually be logged. This probably doesn't affect you, unless you've run profiling on your code and you have hard numbers telling you that your log data generation is a real performance problem.\n\n  ```javascript\n  if (log.getLevel() <= log.levels.DEBUG) {\n    var logData = runExpensiveDataGeneration();\n    log.debug(logData);\n  }\n  ```\n\n  This notably isn't the right solution to avoid the cost of string concatenation in your logging. Firstly, it's very unlikely that string concatenation in your logging is really an important performance problem. Even if you do genuinely have hard metrics showing that it is though, the better solution that wrapping your log statements in this is to use multiple arguments, as below. The underlying console API will automatically concatenate these for you if logging is enabled, and if it isn't then all log methods are no-ops, and no concatenation will be done at all.\n\n  ```javascript\n  // Prints 'My concatenated log message'\n  log.debug(\"My \", \"concatenated \", \"log message\");\n  ```\n\n* A `log.getLogger(loggerName)` method.\n\n  This gets you a new logger object that works exactly like the root `log` object, but can have its level and logging methods set independently. All loggers must have a name (which is a non-empty string, or a [Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)). Calling `getLogger()` multiple times with the same name will return an identical logger object.\n\n  In large applications, it can be incredibly useful to turn logging on and off for particular modules as you are working with them. Using the `getLogger()` method lets you create a separate logger for each part of your application with its own logging level.\n\n  Likewise, for small, independent modules, using a named logger instead of the default root logger allows developers using your module to selectively turn on deep, trace-level logging when trying to debug problems, while logging only errors or silencing logging altogether under normal circumstances.\n\n  Example usage *(using CommonJS modules, but you could do the same with any module system):*\n\n  ```javascript\n  // In module-one.js:\n  var log = require(\"loglevel\").getLogger(\"module-one\");\n  function doSomethingAmazing() {\n    log.debug(\"Amazing message from module one.\");\n  }\n\n  // In module-two.js:\n  var log = require(\"loglevel\").getLogger(\"module-two\");\n  function doSomethingSpecial() {\n    log.debug(\"Special message from module two.\");\n  }\n\n  // In your main application module:\n  var log = require(\"loglevel\");\n  var moduleOne = require(\"module-one\");\n  var moduleTwo = require(\"module-two\");\n  log.getLogger(\"module-two\").setLevel(\"TRACE\");\n\n  moduleOne.doSomethingAmazing();\n  moduleTwo.doSomethingSpecial();\n  // logs \"Special message from module two.\"\n  // (but nothing from module one.)\n  ```\n\n  Loggers returned by `getLogger()` support all the same properties and methods as the default root logger, excepting `noConflict()` and the `getLogger()` method itself.\n\n  Like the root logger, other loggers can have their logging level saved. If a logger’s level has not been saved, it will inherit the root logger’s level when it is first created. If the root logger’s level changes later, the new level will not affect other loggers that have already been created. Loggers with Symbol names (rather than string names) will be always considered as unique instances, and will never have their logging level saved or restored.\n\n  Likewise, loggers will inherit the root logger’s `methodFactory`. After creation, each logger can have its `methodFactory` independently set. See the *plugins* section below for more about `methodFactory`.\n\n* A `log.getLoggers()` method.\n\n  This will return you the dictionary of all loggers created with `getLogger`, keyed off of their names.\n\n## Plugins\n\n### Existing plugins:\n\n[loglevel-plugin-prefix](https://github.com/kutuluk/loglevel-plugin-prefix) - plugin for loglevel message prefixing.\n\n[loglevel-plugin-remote](https://github.com/kutuluk/loglevel-plugin-remote) - plugin for sending loglevel messages to a remote log server.\n\nServerSend - https://github.com/artemyarulin/loglevel-serverSend - Forward your log messages to a remote server.\n\nDEBUG - https://github.com/vectrlabs/loglevel-debug - Control logging from a DEBUG environmental variable (similar to the classic [Debug](https://github.com/visionmedia/debug) module)\n\n### Writing plugins:\n\nLoglevel provides a simple reliable minimal base for console logging that works everywhere. This means it doesn't include lots of fancy functionality that might be useful in some cases, such as log formatting and redirection (e.g. also sending log messages to a server over AJAX)\n\nIncluding that would increase the size and complexity of the library, but more importantly would remove stacktrace information. Currently log methods are either disabled, or enabled with directly bound versions of the console.log methods (where possible). This means your browser shows the log message as coming from your code at the call to `log.info(\"message!\")` not from within loglevel, since it really calls the bound console method directly, without indirection. The indirection required to dynamically format, further filter, or redirect log messages would stop this.\n\nThere's clearly enough enthusiasm for this even at that cost though that loglevel now includes a plugin API. To use it, redefine log.methodFactory(methodName, logLevel, loggerName) with a function of your own. This will be called for each enabled method each time the level is set (including initially), and should return a function to be used for the given log method, at the given level, for a logger with the given name. If you'd like to retain all the reliability and features of loglevel, it's recommended that this wraps the initially provided value of `log.methodFactory`\n\nFor example, a plugin to prefix all log messages with \"Newsflash: \" would look like:\n\n```javascript\nvar originalFactory = log.methodFactory;\nlog.methodFactory = function (methodName, logLevel, loggerName) {\n    var rawMethod = originalFactory(methodName, logLevel, loggerName);\n\n    return function (message) {\n        rawMethod(\"Newsflash: \" + message);\n    };\n};\nlog.setLevel(log.getLevel()); // Be sure to call setLevel method in order to apply plugin\n```\n\n*(The above supports only a single log.warn(\"\") argument for clarity, but it's easy to extend to a [fuller variadic version](http://jsbin.com/xehoye/edit?html,console))*\n\nIf you develop and release a plugin, please get in contact! I'd be happy to reference it here for future users. Some consistency is helpful; naming your plugin 'loglevel-PLUGINNAME' (e.g. loglevel-newsflash) is preferred, as is giving it the 'loglevel-plugin' keyword in your package.json\n\n## Developing & Contributing\nIn lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality.\n\nBuilds can be run with npm: run `npm run dist` to build a distributable version of the project (in /dist), or `npm test` to just run the tests and linting. During development you can run `npm run watch` and it will monitor source files, and rerun the tests and linting as appropriate when they're changed.\n\n_Also, please don't manually edit files in the \"dist\" subdirectory as they are generated via Grunt. You'll find source code in the \"lib\" subdirectory!_\n\n#### Release process\n\nTo do a release of loglevel:\n\n* Update the version number in package.json and bower.json\n* Run `npm run dist` to build a distributable version in dist/\n* Update the release history in this file (below)\n* Commit the built code, tagging it with the version number and a brief message about the release\n* Push to Github\n* Run `npm publish .` to publish to NPM\n\n## Release History\nv0.1.0 - First working release with apparent compatibility with everything tested\n\nv0.2.0 - Updated release with various tweaks and polish and real proper documentation attached\n\nv0.3.0 - Some bugfixes (#12, #14), cookie-based log level persistence, doc tweaks, support for Bower and JamJS\n\nv0.3.1 - Fixed incorrect text in release build banner, various other minor tweaks\n\nv0.4.0 - Use LocalStorage for level persistence if available, compatibility improvements for IE, improved error messages, multi-environment tests\n\nv0.5.0 - Fix for Modernizr+IE8 issues, improved setLevel error handling, support for auto-activation of desired logging when console eventually turns up in IE8\n\nv0.6.0 - Handle logging in Safari private browsing mode (#33), fix TRACE level persistence bug (#35), plus various minor tweaks\n\nv1.0.0 - Official stable release! Fixed a bug with localStorage in Android webviews, improved CommonJS detection, and added noConflict().\n\nv1.1.0 - Added support for including loglevel with preprocessing and .apply() (#50), and fixed QUnit dep version which made tests potentially unstable.\n\nv1.2.0 - New plugin API! Plus various bits of refactoring and tidy up, nicely simplifying things and trimming the size down.\n\nv1.3.0 - Make persistence optional in setLevel, plus lots of documentation updates and other small tweaks\n\nv1.3.1 - With the new optional persistence, stop unnecessarily persisting the initially set default level (warn)\n\nv1.4.0 - Add getLevel(), setDefaultLevel() and getLogger() functionality for more fine-grained log level control\n\nv1.4.1 - Reorder UMD (#92) to improve bundling tool compatibility\n\nv1.5.0 - Fix log.debug (#111) after V8 changes deprecating console.debug, check for `window` upfront (#104), and add `.log` alias for `.debug` (#64)\n\nv1.5.1 - Fix bug (#112) in level-persistence cookie fallback, which failed if it wasn't the first cookie present\n\nv1.6.0 - Add a name property to loggers and add log.getLoggers() (#114), and recommend unpkg as CDN instead of CDNJS.\n\nv1.6.1 - Various small documentation & test updates\n\nv1.6.2 - Include TypeScript type definitions in the package itself\n\nv1.6.3 - Avoid TypeScript type conflicts with other global `log` types (e.g. `core-js`)\n\nv1.6.4 - Ensure package.json's 'main' is a fully qualified path, to fix webpack issues\n\nv1.6.5 - Ensure the provided message is included when calling trace() in IE11\n\nv1.6.6 - Fix bugs in v1.6.5, which caused issues in node.js & IE < 9\n\nv1.6.7 - Fix a bug in environments with `window` defined but no `window.navigator`\n\nv1.6.8 - Update TypeScript type definitions to include `log.log()`.\n\nv1.7.0 - Add support for Symbol-named loggers, and a `.default` property to help with ES6 module usage.\n\n## `loglevel` for enterprise\n\nAvailable as part of the Tidelift Subscription.\n\nThe maintainers of `loglevel` and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/npm-loglevel?utm_source=npm-loglevel&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)\n\n## License\nCopyright (c) 2013 Tim Perry\nLicensed under the MIT license.\n",
+  "maintainers": [
+    {
+      "name": "pimterry",
+      "email": "pimterry@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-26T13:41:24.016Z",
+    "created": "2013-04-01T21:12:32.487Z",
+    "0.1.0": "2013-04-01T21:12:37.086Z",
+    "0.2.0": "2013-04-01T23:41:28.737Z",
+    "0.3.0": "2013-06-20T11:27:59.408Z",
+    "0.3.1": "2013-07-29T23:18:18.098Z",
+    "0.4.0": "2013-09-22T01:57:13.758Z",
+    "0.5.0": "2013-10-13T17:25:38.084Z",
+    "0.6.0": "2014-03-18T09:23:09.647Z",
+    "1.0.0": "2014-08-03T12:28:39.439Z",
+    "1.1.0": "2014-08-22T12:23:21.311Z",
+    "1.2.0": "2014-10-27T00:06:49.733Z",
+    "1.3.0": "2015-06-03T16:04:50.735Z",
+    "1.3.1": "2015-06-16T09:42:14.420Z",
+    "1.4.0": "2015-08-28T16:05:55.766Z",
+    "1.4.1": "2016-05-31T15:12:58.631Z",
+    "1.5.0": "2017-09-11T22:14:38.671Z",
+    "1.5.1": "2017-10-09T08:10:05.300Z",
+    "1.6.0": "2017-11-13T22:39:30.778Z",
+    "1.6.1": "2018-01-10T20:39:25.502Z",
+    "1.6.2": "2019-05-30T12:08:44.227Z",
+    "1.6.3": "2019-06-11T13:17:45.318Z",
+    "1.6.4": "2019-09-05T13:18:40.460Z",
+    "1.6.5": "2019-11-07T14:40:57.345Z",
+    "1.6.6": "2019-11-07T17:13:17.746Z",
+    "1.6.7": "2020-02-10T14:05:51.949Z",
+    "1.6.8": "2020-04-14T10:37:11.750Z",
+    "1.7.0": "2020-08-26T13:41:21.717Z"
+  },
+  "author": {
+    "name": "Tim Perry",
+    "email": "pimterry@gmail.com",
+    "url": "http://tim-perry.co.uk"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/pimterry/loglevel.git"
+  },
+  "users": {
+    "pimterry": true,
+    "onestone": true,
+    "claudionunezjr": true,
+    "popen2": true,
+    "outofcoffee": true,
+    "nbuchanan": true,
+    "madarche": true,
+    "rocket0191": true,
+    "daniel-lewis-bsc-hons": true,
+    "meeh": true,
+    "danday74": true,
+    "ouq77": true,
+    "azz": true,
+    "allen_lyu": true,
+    "yinotaurus": true
+  },
+  "homepage": "https://github.com/pimterry/loglevel",
+  "keywords": [
+    "log",
+    "logger",
+    "logging",
+    "browser"
+  ],
+  "bugs": {
+    "url": "https://github.com/pimterry/loglevel/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/loglevel.min.json
+++ b/test/fixtures/registry-mocks/content/loglevel.min.json
@@ -1,0 +1,801 @@
+{
+  "name": "loglevel",
+  "dist-tags": {
+    "latest": "1.7.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "loglevel",
+      "version": "0.1.0",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.6",
+        "grunt-contrib-concat": "~0.1.2",
+        "grunt-contrib-uglify": "~0.1.1",
+        "grunt-contrib-jshint": "~0.1.1",
+        "grunt-contrib-watch": "~0.2.0",
+        "grunt-contrib-jasmine": "~0.4.1",
+        "grunt-template-jasmine-requirejs": "~0.1.0",
+        "grunt-open": "~0.2.0",
+        "grunt-contrib-connect": "~0.2.0",
+        "grunt-saucelabs": "~3.0.7"
+      },
+      "dist": {
+        "shasum": "94edf0dc6fe70bcd65d472288878275be6120405",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.2.0": {
+      "name": "loglevel",
+      "version": "0.2.0",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.6",
+        "grunt-contrib-concat": "~0.1.2",
+        "grunt-contrib-uglify": "~0.1.1",
+        "grunt-contrib-jshint": "~0.1.1",
+        "grunt-contrib-watch": "~0.2.0",
+        "grunt-contrib-jasmine": "~0.4.1",
+        "grunt-template-jasmine-requirejs": "~0.1.0",
+        "grunt-open": "~0.2.0",
+        "grunt-contrib-connect": "~0.2.0",
+        "grunt-saucelabs": "~3.0.7"
+      },
+      "dist": {
+        "shasum": "b8214bc90b1fa7c3e1c9282c50ced4b0eb10f8ce",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.3.0": {
+      "name": "loglevel",
+      "version": "0.3.0",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.6",
+        "grunt-contrib-concat": "~0.1.2",
+        "grunt-contrib-uglify": "~0.1.1",
+        "grunt-contrib-jshint": "~0.1.1",
+        "grunt-contrib-watch": "~0.2.0",
+        "grunt-contrib-jasmine": "~0.4.1",
+        "grunt-template-jasmine-requirejs": "~0.1.0",
+        "grunt-open": "~0.2.0",
+        "grunt-contrib-connect": "~0.2.0",
+        "grunt-saucelabs": "~3.0.7"
+      },
+      "dist": {
+        "shasum": "5970fda39aaea5c9aac040605f5e787de196e696",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.3.1": {
+      "name": "loglevel",
+      "version": "0.3.1",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.6",
+        "grunt-contrib-concat": "~0.1.2",
+        "grunt-contrib-uglify": "~0.1.1",
+        "grunt-contrib-jshint": "~0.1.1",
+        "grunt-contrib-watch": "~0.2.0",
+        "grunt-contrib-jasmine": "~0.4.1",
+        "grunt-template-jasmine-requirejs": "~0.1.0",
+        "grunt-open": "~0.2.0",
+        "grunt-contrib-connect": "~0.2.0",
+        "grunt-saucelabs": "~3.0.7"
+      },
+      "dist": {
+        "shasum": "0737790b40150f0aecc48a207e54ca14fdf88ea9",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.4.0": {
+      "name": "loglevel",
+      "version": "0.4.0",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.9",
+        "grunt-contrib-concat": "~0.3.0",
+        "grunt-contrib-uglify": "~0.2.4",
+        "grunt-contrib-jshint": "~0.6.4",
+        "grunt-contrib-watch": "~0.5.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-open": "~0.2.2",
+        "grunt-saucelabs": "~4.0.4",
+        "grunt-contrib-connect": "~0.5.0",
+        "grunt-jasmine-node": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "649d508ff8998747dc08f55ec3ef3b1b7a3d1971",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.5.0": {
+      "name": "loglevel",
+      "version": "0.5.0",
+      "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "~0.1.9",
+        "grunt-contrib-concat": "~0.3.0",
+        "grunt-contrib-uglify": "~0.2.4",
+        "grunt-contrib-jshint": "~0.6.4",
+        "grunt-contrib-watch": "~0.5.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-open": "~0.2.2",
+        "grunt-saucelabs": "~4.1.2",
+        "grunt-contrib-connect": "~0.5.0",
+        "grunt-jasmine-node": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "f3941921f79f223043904d845497a9e0480fe29a",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.6.0": {
+      "name": "loglevel",
+      "version": "0.6.0",
+      "devDependencies": {
+        "grunt": "^0.4.1",
+        "grunt-cli": "^0.1.9",
+        "grunt-contrib-concat": "^0.3.0",
+        "grunt-contrib-uglify": "^0.3.0",
+        "grunt-contrib-jshint": "^0.8.0",
+        "grunt-contrib-watch": "^0.5.1",
+        "grunt-contrib-jasmine": "^0.5.2",
+        "grunt-template-jasmine-requirejs": "^0.1.6",
+        "grunt-template-jasmine-istanbul": "^0.2.5",
+        "grunt-open": "^0.2.2",
+        "grunt-saucelabs": "^5.0.0",
+        "grunt-contrib-connect": "^0.6.0",
+        "grunt-jasmine-node": "^0.1.0",
+        "grunt-coveralls": "^0.3.0"
+      },
+      "dist": {
+        "shasum": "3dc728ff5a945f9c6652fccd134be9a12a41cc83",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-0.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.0.0": {
+      "name": "loglevel",
+      "version": "1.0.0",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "qunitjs": "^1.14.0"
+      },
+      "dist": {
+        "shasum": "ad593623e855d138d5f9ff5e1c64f4793f603336",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.1.0": {
+      "name": "loglevel",
+      "version": "1.1.0",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "82c94f9b73774b4a1cd2e4ae6562b3a8b676df4b",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.2.0": {
+      "name": "loglevel",
+      "version": "1.2.0",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "149418e55fb0e0b5fc7ad228c8d315ae1ec19c68",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.3.0": {
+      "name": "loglevel",
+      "version": "1.3.0",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "0be9dbd6bc4079647fbe5c532ee46bf31ec08d58",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.3.1": {
+      "name": "loglevel",
+      "version": "1.3.1",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "b116495ab076994d8237e467c14234b10b306730",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.4.0": {
+      "name": "loglevel",
+      "version": "1.4.0",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "83ab9fc6ef3e0caf7571b57182b32d8d870309dc",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.4.1": {
+      "name": "loglevel",
+      "version": "1.4.1",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-open": "~0.2.3",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-contrib-clean": "^0.6.0",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "95b383f91a3c2756fd4ab093667e4309161f2bcd",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.5.0": {
+      "name": "loglevel",
+      "version": "1.5.0",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "integrity": "sha512-OQ2jhWI5G2qsvO0UFNyCQWgKl/tFiwuPIXxELzACeUO2FqstN/R7mmL09+nhv6xOWVPPojQO1A90sCEoJSgBcQ==",
+        "shasum": "3863984a2c326b986fbb965f378758a6dc8a4324",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.5.1": {
+      "name": "loglevel",
+      "version": "1.5.1",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "189078c94ab9053ee215a0acdbf24244ea0f6502",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.6.0": {
+      "name": "loglevel",
+      "version": "1.6.0",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "ae0caa561111498c5ba13723d6fb631d24003934",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.6.1": {
+      "name": "loglevel",
+      "version": "1.6.1",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "shasum": "e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.6.2": {
+      "name": "loglevel",
+      "version": "1.6.2",
+      "devDependencies": {
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0"
+      },
+      "dist": {
+        "integrity": "sha512-Jt2MHrCNdtIe1W6co3tF5KXGRkzF+TYffiQstfXa04mrss9IKXzAAXYWak8LbZseAQY03sH2GzMCMU0ZOUc9bg==",
+        "shasum": "668c77948a03dbd22502a3513ace1f62a80cc372",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.2.tgz",
+        "fileCount": 34,
+        "unpackedSize": 129222,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc78fMCRA9TVsSAnZWagAAuwUP/2ltBsOpnPIkRVlmdpMv\npaGgrhl/BTKt8qWVlF7b991fe9Cqo+2yxgJXsqxZn6lqCvf8YaG4vviTpM0x\nKJxDugHVlUXeLcxlCyirGl8lFw3hgsfi7IqW6ucOQUUZQapgeDIl4Ej3t4bR\njjeKX/8ERuXX0y5byO8TUnYwsCGnFfcNy8uEil8WGxjWdNZvVdbvfT9VBMQq\n2Xsl8ep4y9WUOAducXWWraCa2LqcSd4f6bBqBtsE9bEgzHaF4qnr61YwzUCc\nLkZcwcXN1rGdQ3+A4eJGBiiAyjdEFhu3zjiLp6gdTF0Ic0CJW6aJEbnM27xi\n2VrhAL24GwdzakZZgUqv7DpdMFsS3eQexkLm7BVPU3jAVBlGH23SIT+QW5fr\nD2wqHjwriOjOAbneEQBlxsuybWXFcRy12YFqf+FfT1n8nZXNzCNEcKFUeOt8\nt4iJmHFFWxS8DFZMLS4aHYgr33vtx73jOvNqFU5JHXYWS4P9Jg/G4Y49pAzq\nlJlAWvqT2Mt/h3h7qmhy6Ql92/jZX2acunT+hnwfhGycfR1PvHRsfYX79IeY\nHZLgBGNpYlWlUWgRGSal9B7SlHBvJMYTRcXQ1NmQ3OAOS4l3DAZEwzeX9KRw\nScjIdSlCEcHhpo3LfGvIH1VHztzquFRIh2UqTp6sVOSD7FOqABMl8VmxVXLD\nwdEU\r\n=PC9G\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.6.3": {
+      "name": "loglevel",
+      "version": "1.6.3",
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+        "shasum": "77f2eb64be55a404c9fd04ad16d57c1d6d6b1280",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
+        "fileCount": 35,
+        "unpackedSize": 130345,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/6n5CRA9TVsSAnZWagAA7V4P+QCgW8ecYZtSUWWhr5Kq\nBdB46pSjoTWA6zhN56hbo/F50Ylt7vISCIUtq0BVk1+9ucrpEtlHGAMIwOqv\nWahOASGMTWI4Sr+Dl6aBwXyN1srgKJUOJipFy81vYjDpnrra0E3ASss1VUxN\nUwLUsu9LE5J61fZP+VqgqJHxy7WS/X2+LL/FMG29PL3G19Y7tCIBbZisKkP3\nTqDivtkDeIo/xQeIEo8TaY3h24a4ybARGkJl5zgH7mbCalYb4trq0rIdGdvK\nKfqPr8QHUwpJdy9gogRbVCh99JWRuwrYbNqKChzT2k1kMoCyv8iFTwEN++mS\noxFBuQMUy27aMcPeUxJ5LBvR0qU7Te7lS/WwmHWx2mycm0lskiA3pdD/RzFT\nZIOrIlmWFIinatSP1mDirR1+0JYOyvxi+21cPuBfhKOtONircyFPwzN9GLLY\nAqDj9yuW6rvJG28duo6od2G+vGUqQcZInPRkdqqLGrrpjvbnUVKdTeJL76fm\nU8/5GFicPVyw+zd8gaVltFPdY50isoxMAJPnSVKC/H0dj+ezRRGKxYmvovpV\nWUDEMjsgh7KogEGGHJuuJ54w7Y2ouO42jFhMm94B384NBZhypwqeslV1bdAT\nR3Z9vCHTML6O9e1ZbNZQw4GGcQ7YXL/SUVg5xbs6gEE+g62XjioQSl/xiZxw\nEYnH\r\n=xmw9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.6.4": {
+      "name": "loglevel",
+      "version": "1.6.4",
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==",
+        "shasum": "f408f4f006db8354d0577dcf6d33485b3cb90d56",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
+        "fileCount": 35,
+        "unpackedSize": 130436,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdcQsxCRA9TVsSAnZWagAAMmQP/3TqZyIlWGeAw2HeKQaP\nrRTGxnbUqFub0in2G3gXQ2F39qtf5Mf38RWH7ZEe9S3HvmE84Fvo/NzGexfq\n7mJB6MBNMlN8t3VjGl2ex/nKBfLDRw9lls7DJ4/+XA8Mv8RNnaf3TqjXWnDt\nUNsZGPk6FdD7X0Yh+G1PGtawAOpdXSxCWAci43LTAvLEvKaUh9LVr4Gq5NFk\nL7uPdi9GCoolJT4AcmWbUPxF01KTBPk97umjFCb5eOzng891GD3qbp2g120r\nEFTQ3RYTz3twIdC7+QNeqhMCoJ1ta9QgtlHbuF5RDQwQcVYwxU8Vrb+y18xk\nMSspAtWlkTuBFnuTongJ6AW2X6vGbxeOAn/iRjOiuM56QUz3uBAkINXITM4h\nHmkpC6u5UvzqOrmdLkceT/lbh5yGfVMIHP9znJOFzfrBA/E8GL5rVQDoqla2\ncrIXLDZy2XsZHuHvl3qUoDAnKHlAY+Ve2NnyIWsBOcU4I5jGYUsTRffKs4Lz\n8zJff65nyDBYT+6954ri5vAmppAJeAIRvop360iotogF2/HuwUZDdMDm08Ao\nfAXu/CL0FKU9tWyFrD9G/zq9Ep92Oy5Nhe16L8+1xy0MUCIiu0qCcrlRMhl0\nkzpkojeOHBuLRCfm+N8qB2grolNvAA+Ybmorm6yse1MtNl1wDtFk8lICDOYF\ncAIP\r\n=HCAT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "1.6.6": {
+      "name": "loglevel",
+      "version": "1.6.6",
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
+        "shasum": "0ee6300cc058db6b3551fa1c4bf73b83bb771312",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
+        "fileCount": 36,
+        "unpackedSize": 132681,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdxFCuCRA9TVsSAnZWagAAXxwP/AxJjKGd+wtkiXs+iM71\nYLdmRxUGZWbBjoaUTfbtN2k6hABqpmDE8wV4kG3MbnjA9v4f3qFcb6yV/kJT\nb3VLL2u2M7eXvjn9n2oc3dJFvV6001gsh2V9+cU4QbTLAy1Ftm0DoGG9A2qw\nzUeYYvgEwNAFO9HRb0zzLsZor7oErELUIplzyF4HMYZz9vqeSoF8DIDHDnQI\nDGa8yk+HJm03wruLYIih0QJ3qDaubP4l6yFoOgrnG2E5JgKi+had0Jp2/Uex\newTUQEUMnjSC+TWx64qcIWUVMh0CgHK4f+yXkY6ewH2WIPFj7MjyUrZfo1B+\ncpILxYGsRyHjbxh97RFK+EqIuJJKWjWLq++P53ZUJoD6FThjKgpZiC/UaH8Y\nXsxg9AKUgXAl8uN4C0jcrBMo9PkFrkDvmDbF3RWNO6is0GMTbje2EbaB2TV2\nAF1VrbAxBhVdkUUIff/trakpLDSTDYlHr23KeT/YETh7WKhm6ysNw6nCYNUd\nklaMAfaHcHhd6woQ146LzJqX3g0cqa4ozbXvh2heK7PDtkY2vlgYsOKqDzm3\nS8BLED2bcy6F20bppKPVqSii5k/QGlj65UlZklXyWcDYiJ7X6C9J8E+2aNoH\nwZ3SkdxrQmu6Fwt61IMQrbU+Uwas1mxFw3zeMIbX+xda15Gxz9YTjVEHZTlM\n3IIf\r\n=B2gb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+      }
+    },
+    "1.6.7": {
+      "name": "loglevel",
+      "version": "1.6.7",
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
+        "shasum": "b3e034233188c68b889f5b862415306f565e2c56",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+        "fileCount": 36,
+        "unpackedSize": 133922,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeQWNACRA9TVsSAnZWagAAfjcQAIuPYa47tUUxFK55rpWW\nkMv8vKTOvOgKAGvxk6Ocuu+lI9RITilsVpnQQv7UoDmX05ht90hyqgl3kxvK\nTjUcLMq2i+C+CbXVzR67OotXrbdoAgwuDeCm4fVLRYymY26n+0nTc1PxNLhn\nAeo5qX4hRKcCJ8ekZP+LvWw+YrLpFpBfeJ9ObioROTB1nSTSw9soPP9uHW91\nA6dFfBsR0BA9j7HM7Ue6olFbkd7iJLDrEwjtVbIcul9tDhcl73eIVC3i9fr2\np/ObJlq3S5zPOa63uSarlkcztgYnL21iGUht/VfESO5Ekz71CJm49sh/iF5D\nR4ao432bG6+wGGFJrM0nRqPtnxre7q2HUP4iv/4UGb733Nj3c8G6vTFrSeN3\nxKMRZu1c55HkNIlMi06os8TiPRahILnMvkyO3IGPIbcuJXbZorDMvFvF2ohM\nspfaRF9ebJn/soQ2ISgYiGDxTNeoCNNWVoVwYSFa08/ca9EK8f7vG/1fXf2F\ndkx+M7XeoxbmDJhZMH7qcGPAdZq79UUVkFWvphfqnTO/RVtBh7ExjbAXT3HZ\niI1EEdvCe31RijjqxqQy+859h8vtGcsKfyyNr9sMDi/2a6jVFyFVcg5KdWIr\np7kfd2qJeQzBc3LR6RecSViC0zacd6ZqPeXZscHwpaifwjrR4YWbPcjh88OY\n8/o2\r\n=hgMf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+      }
+    },
+    "1.6.8": {
+      "name": "loglevel",
+      "version": "1.6.8",
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
+        "shasum": "8a25fb75d092230ecd4457270d80b54e28011171",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+        "fileCount": 36,
+        "unpackedSize": 134185,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJelZJYCRA9TVsSAnZWagAAhsEP/0pcXkRXPeHMhwzana4S\n3yylQ8rv1B0yrwuiwJxu1cvn2rxlMmqgjV2cHieVutCwbYJuZfxdU3lzPJjO\nnYl/JU/JwSucxTYPposv3cVjj84OfmuhIGZfCpVRMBZEjB1EWmHPioLwjMQK\nNfB4d7vxjFC1LxrcmuxGn5b+2Nla3CFMtgMWuvwQ0agXARqLuvDcUqrQCpMp\nPcbUA3oLWLz3ssdPLcWkcjymUbbOpiwUtpHbrsyVVc3Dyf9PfEhvQp2BJvl1\niVi6Qd5iXXHFYZfhf4RM2l50DEmVCXdzMkce44fZdfyyAPelpBMw2eb52K5q\nm+2LXG1ge/3Xq0jPrOYTQ8n1m5sa2XD+1H/r6fhUD2kvzW0od2gKAwVxvWh2\nP7mscn/eXHS/XWC2vzoKBkMGRtP0dxNUUpo8C+lEVRIal02GOMcBbkfkm25C\nqNas3aF0YZIiD/0At4iaXAqQiIGMdH0b1pyYzGnj0fNSaV9+/Do6oxK154hp\nvD6A4FMwvZJvdrPmghiVrakZgUEXwJ/T9g0qkfChdHPvKDy1gs+FNYKX1Ajd\noLTCf5CJdWqjbX8MaGGH1zHiE61VNWOqJ+aPiVxqG67Y7uey4G0HzVA7zjkE\neUzyG7qNb7+rKe6nvUT2oPH0N+LkRo3wch5vvEoul4OSCX8/MANXejLKMyfc\nttUF\r\n=W3IL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+      }
+    },
+    "1.7.0": {
+      "name": "loglevel",
+      "version": "1.7.0",
+      "devDependencies": {
+        "@types/core-js": "2.5.0",
+        "@types/node": "^12.0.4",
+        "grunt": "~0.4.5",
+        "grunt-cli": "~0.1.13",
+        "grunt-contrib-clean": "^0.6.0",
+        "grunt-contrib-concat": "~0.5.0",
+        "grunt-contrib-connect": "~0.8.0",
+        "grunt-contrib-jasmine": "~0.5.2",
+        "grunt-contrib-jshint": "^1.1.0",
+        "grunt-contrib-qunit": "~0.5.2",
+        "grunt-contrib-uglify": "~0.5.1",
+        "grunt-contrib-watch": "~0.6.1",
+        "grunt-coveralls": "^1.0.0",
+        "grunt-jasmine-node": "~0.2.1",
+        "grunt-open": "~0.2.3",
+        "grunt-preprocess": "^4.0.0",
+        "grunt-saucelabs": "^8.2.0",
+        "grunt-template-jasmine-istanbul": "~0.2.5",
+        "grunt-template-jasmine-requirejs": "~0.1.6",
+        "qunitjs": "1.14.0",
+        "typescript": "^3.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-i2sY04nal5jDcagM3FMfG++T69GEEM8CYuOfeOIvmXzOIcwE9a/CJPR0MFM97pYMj/u10lzz7/zd7+qwhrBTqQ==",
+        "shasum": "728166855a740d59d38db01cf46f042caa041bb0",
+        "tarball": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.0.tgz",
+        "fileCount": 36,
+        "unpackedSize": 135934,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfRmaCCRA9TVsSAnZWagAAk30P/RDZedPHuTidbE/I67I6\ne+aadlVrrSa3DKdxEwX9MOj8qYQPMSY+O4EkGTPqhYIBIntQ8GYY7UEfbjny\nztWS1wMnTa7eVofG7sXaK8GJYLhtw9DpDvmmnb9iqZ/iEFxMuyhzSDOqO3u2\nFxt8edKUVijAKv1Cdpjmt5HYrXFjOCDyxi7OcDKpuVvwmZQtw1N+jV/0HKCT\n1OnQW6rZfDY8c+1vFFvibmoeFHsDUHhQxWck5SZm43uG+gb7MrJCorqlso+Y\ndwWh3SPB/qrbVjIgZV7e2eMCoQRmhxOfuCcwvHSbeN06Jab/vOwn5fjGzBiO\nH4GJUzgeEXvprWjyplSpFs32fHIV0lw5SKKXhcqbWUMsmbi14CtfbDoa+mHu\ni4BOIIxZy8UBMn5eMfAH0h2iHqY+ocK148cj/QInQ64HyRqsL/T3Pz++z3Zr\nt+DfXP1qTAuGY+fd8pX8ZOUITTOPOV0ck/udh+rA/WRUjt4DCDoqTh8I84O8\nD+rT7ui4+3oYCt8AhdqP3rS99iCW6XFgQIp4Qkg4i/ynGulHOl+fJgt7xmUU\nE4FeGf5NeB5+X5uYntropUThMbl7QUtP9lUf3SCWLwN9wlWGNQM0QtEPHh6v\nbiv3XD/k9l4ySMlWcH7t1/+4PjSDZh9etZ3Nwm3b0SXnK+G6abKLWXJAt7QL\n/QP2\r\n=TAuG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+      }
+    }
+  },
+  "modified": "2020-08-26T13:41:24.016Z"
+}

--- a/test/fixtures/registry-mocks/content/map-cache.json
+++ b/test/fixtures/registry-mocks/content/map-cache.json
@@ -1,0 +1,416 @@
+{
+  "_id": "map-cache",
+  "_rev": "8-a86b0fe5901c63a0c560b178c5e5d1c6",
+  "name": "map-cache",
+  "description": "Basic cache object for storing key-value pairs.",
+  "dist-tags": {
+    "latest": "0.2.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "map-cache",
+      "description": "Create a simple cache object for storing key-value pairs.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/map-cache",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/map-cache.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-cache/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/map-cache/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [],
+      "_id": "map-cache@0.1.0",
+      "_shasum": "c10ab293d4605c8b824fddd4869dea9a558c3c33",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c10ab293d4605c8b824fddd4869dea9a558c3c33",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "map-cache",
+      "description": "Basic cache object for storing key-value pairs.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/map-cache",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/map-cache.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-cache/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/map-cache/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "cache",
+        "get",
+        "has",
+        "object",
+        "set",
+        "storage",
+        "store"
+      ],
+      "_id": "map-cache@0.1.1",
+      "_shasum": "568b4ae3233d107317648c60d7b51a80b55cc103",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "568b4ae3233d107317648c60d7b51a80b55cc103",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "map-cache",
+      "description": "Basic cache object for storing key-value pairs.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/map-cache",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/map-cache.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-cache/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "cache",
+        "get",
+        "has",
+        "object",
+        "set",
+        "storage",
+        "store"
+      ],
+      "gitHead": "fd92615eafc29f7898067ed7411dd082af325164",
+      "_id": "map-cache@0.2.0",
+      "_shasum": "3c900dc509c9eda4df063fd6f0f9002d91ab2455",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3c900dc509c9eda4df063fd6f0f9002d91ab2455",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "map-cache",
+      "description": "Basic cache object for storing key-value pairs.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/map-cache",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-cache.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-cache/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "should": "^8.3.0"
+      },
+      "keywords": [
+        "cache",
+        "get",
+        "has",
+        "object",
+        "set",
+        "storage",
+        "store"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "config-cache",
+            "option-cache",
+            "cache-base"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "5f97be81cab9b774bda6106bf6b2f152f96786b2",
+      "_id": "map-cache@0.2.1",
+      "_shasum": "0ac4a21713fe9eb2aa8ddce7db1dff6648b7f713",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0ac4a21713fe9eb2aa8ddce7db1dff6648b7f713",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/map-cache-0.2.1.tgz_1460378062919_0.36677914508618414"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "map-cache",
+      "description": "Basic cache object for storing key-value pairs.",
+      "version": "0.2.2",
+      "homepage": "https://github.com/jonschlinkert/map-cache",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-cache.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-cache/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.9",
+        "should": "^8.3.1"
+      },
+      "keywords": [
+        "cache",
+        "get",
+        "has",
+        "object",
+        "set",
+        "storage",
+        "store"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "config-cache",
+            "option-cache",
+            "cache-base"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "f36c7567cb85b50824db25a2a588c5f7b858823b",
+      "_id": "map-cache@0.2.2",
+      "_shasum": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/map-cache-0.2.2.tgz_1462877475232_0.17523240111768246"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# map-cache [![NPM version](https://img.shields.io/npm/v/map-cache.svg?style=flat)](https://www.npmjs.com/package/map-cache) [![NPM downloads](https://img.shields.io/npm/dm/map-cache.svg?style=flat)](https://npmjs.org/package/map-cache) [![Build Status](https://img.shields.io/travis/jonschlinkert/map-cache.svg?style=flat)](https://travis-ci.org/jonschlinkert/map-cache)\n\nBasic cache object for storing key-value pairs.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install map-cache --save\n```\n\nBased on MapCache in Lo-dash v3.0. [MIT License](https://github.com/lodash/lodash/blob/master/LICENSE.txt)\n\n## Usage\n\n```js\nvar MapCache = require('map-cache');\nvar mapCache = new MapCache();\n```\n\n## API\n\n### [MapCache](index.js#L28)\n\nCreates a cache object to store key/value pairs.\n\n**Example**\n\n```js\nvar cache = new MapCache();\n```\n\n### [.set](index.js#L45)\n\nAdds `value` to `key` on the cache.\n\n**Params**\n\n* `key` **{String}**: The key of the value to cache.\n* `value` **{any}**: The value to cache.\n* `returns` **{Object}**: Returns the `Cache` object for chaining.\n\n**Example**\n\n```js\ncache.set('foo', 'bar');\n```\n\n### [.get](index.js#L65)\n\nGets the cached value for `key`.\n\n**Params**\n\n* `key` **{String}**: The key of the value to get.\n* `returns` **{any}**: Returns the cached value.\n\n**Example**\n\n```js\ncache.get('foo');\n//=> 'bar'\n```\n\n### [.has](index.js#L82)\n\nChecks if a cached value for `key` exists.\n\n**Params**\n\n* `key` **{String}**: The key of the entry to check.\n* `returns` **{Boolean}**: Returns `true` if an entry for `key` exists, else `false`.\n\n**Example**\n\n```js\ncache.has('foo');\n//=> true\n```\n\n### [.del](index.js#L98)\n\nRemoves `key` and its value from the cache.\n\n**Params**\n\n* `key` **{String}**: The key of the value to remove.\n* `returns` **{Boolean}**: Returns `true` if the entry was removed successfully, else `false`.\n\n**Example**\n\n```js\ncache.del('foo');\n```\n\n## Related projects\n\nYou might also be interested in these projects:\n\n* [cache-base](https://www.npmjs.com/package/cache-base): Basic object cache with `get`, `set`, `del`, and `has` methods for node.js/javascript projects. | [homepage](https://github.com/jonschlinkert/cache-base)\n* [config-cache](https://www.npmjs.com/package/config-cache): General purpose JavaScript object storage methods. | [homepage](https://github.com/jonschlinkert/config-cache)\n* [option-cache](https://www.npmjs.com/package/option-cache): Simple API for managing options in JavaScript applications. | [homepage](https://github.com/jonschlinkert/option-cache)\n\n## Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](https://github.com/jonschlinkert/map-cache/issues/new).\n\n## Building docs\n\nGenerate readme and API documentation with [verb](https://github.com/verbose/verb):\n\n```sh\n$ npm install verb && npm run docs\n```\n\nOr, if [verb](https://github.com/verbose/verb) is installed globally:\n\n```sh\n$ verb\n```\n\n## Running tests\n\nInstall dev dependencies:\n\n```sh\n$ npm install -d && npm test\n```\n\n## Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](http://twitter.com/jonschlinkert)\n\n## License\n\nCopyright © 2016, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT license](https://github.com/jonschlinkert/map-cache/blob/master/LICENSE).\n\n***\n\n_This file was generated by [verb](https://github.com/verbose/verb), v0.9.0, on May 10, 2016._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-02-19T08:16:44.327Z",
+    "created": "2015-02-25T10:54:58.270Z",
+    "0.1.0": "2015-02-25T10:54:58.270Z",
+    "0.1.1": "2015-03-18T09:51:35.113Z",
+    "0.2.0": "2015-06-23T17:07:33.511Z",
+    "0.2.1": "2016-04-11T12:34:24.070Z",
+    "0.2.2": "2016-05-10T10:51:16.518Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/map-cache",
+  "keywords": [
+    "cache",
+    "get",
+    "has",
+    "object",
+    "set",
+    "storage",
+    "store"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/map-cache.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/map-cache/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "daizch": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/map-cache.min.json
+++ b/test/fixtures/registry-mocks/content/map-cache.min.json
@@ -1,0 +1,84 @@
+{
+  "name": "map-cache",
+  "dist-tags": {
+    "latest": "0.2.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "map-cache",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "c10ab293d4605c8b824fddd4869dea9a558c3c33",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "map-cache",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "568b4ae3233d107317648c60d7b51a80b55cc103",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "map-cache",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "3c900dc509c9eda4df063fd6f0f9002d91ab2455",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.1": {
+      "name": "map-cache",
+      "version": "0.2.1",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "should": "^8.3.0"
+      },
+      "dist": {
+        "shasum": "0ac4a21713fe9eb2aa8ddce7db1dff6648b7f713",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.2": {
+      "name": "map-cache",
+      "version": "0.2.2",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.9",
+        "should": "^8.3.1"
+      },
+      "dist": {
+        "shasum": "c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf",
+        "tarball": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2019-02-19T08:16:44.327Z"
+}

--- a/test/fixtures/registry-mocks/content/map-visit.json
+++ b/test/fixtures/registry-mocks/content/map-visit.json
@@ -1,0 +1,694 @@
+{
+  "_id": "map-visit",
+  "_rev": "8-bf08c012d8ddcc1e0f98bb4030e5d60f",
+  "name": "map-visit",
+  "description": "Map `visit` over an array of objects.",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "map-visit",
+      "description": "Map `visit` over an array of objects.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/map-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "lodash": "^3.10.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "_id": "map-visit@0.1.0",
+      "_shasum": "d71b0db4c51ea42bdad81d769d6d9689827a13d1",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d71b0db4c51ea42bdad81d769d6d9689827a13d1",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "map-visit",
+      "description": "Map `visit` over an array of objects.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/map-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "lodash": "^3.10.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verbiage": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "object-visit"
+          ]
+        }
+      },
+      "gitHead": "72864009d12c4ddb366a04bbf03c8822a83f75fe",
+      "_id": "map-visit@0.1.1",
+      "_shasum": "655cce40c43c558d1873ee9326e35d07fb51db44",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "655cce40c43c558d1873ee9326e35d07fb51db44",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "map-visit",
+      "description": "Map `visit` over an array of objects.",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/map-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "lazy-cache": "^0.2.3",
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "lodash": "^3.10.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verbiage": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "object-visit"
+          ]
+        }
+      },
+      "gitHead": "4468727c74d2d4c28e8d68f6bb9a8d4703eeeb4d",
+      "_id": "map-visit@0.1.2",
+      "_shasum": "ac3d91d9e81f14c358de82e6e7d3d3f18cd37ae2",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ac3d91d9e81f14c358de82e6e7d3d3f18cd37ae2",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "map-visit",
+      "description": "Map `visit` over an array of objects.",
+      "version": "0.1.3",
+      "homepage": "https://github.com/jonschlinkert/map-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "lazy-cache": "^0.2.3",
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "lodash": "^3.10.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verbiage": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "object-visit"
+          ]
+        }
+      },
+      "gitHead": "fca416c78615b453ca60c0cb7de7f6a5387de9f7",
+      "_id": "map-visit@0.1.3",
+      "_shasum": "d4df0772e9584dcbcb675d62c3cc62d13f5aba43",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d4df0772e9584dcbcb675d62c3cc62d13f5aba43",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "map-visit",
+      "description": "Map `visit` over an array of objects.",
+      "version": "0.1.4",
+      "homepage": "https://github.com/jonschlinkert/map-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "lazy-cache": "^0.2.4",
+        "object-visit": "^0.3.1"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "object-visit"
+          ]
+        }
+      },
+      "gitHead": "ae7d63cd041d641511503af16327b1c8766ce75f",
+      "_id": "map-visit@0.1.4",
+      "_shasum": "4cd79abdc6985324e324204af330d772e48df6bd",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4cd79abdc6985324e324204af330d772e48df6bd",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "map-visit",
+      "description": "Map `visit` over an array of objects.",
+      "version": "0.1.5",
+      "homepage": "https://github.com/jonschlinkert/map-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "lazy-cache": "^2.0.1",
+        "object-visit": "^0.3.4"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "lodash": "^4.14.1",
+        "mocha": "^3.0.1",
+        "should": "^10.0.0"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "object-visit"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "7b0b53047682dda683b4a2f5ab144d7460b02b2b",
+      "_id": "map-visit@0.1.5",
+      "_shasum": "dbe43927ce5525b80dfc1573a44d68c51f26816b",
+      "_from": ".",
+      "_npmVersion": "3.7.5",
+      "_nodeVersion": "5.1.1",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "shasum": "dbe43927ce5525b80dfc1573a44d68c51f26816b",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/map-visit-0.1.5.tgz_1470434073338_0.894326905021444"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "map-visit",
+      "description": "Map `visit` over an array of objects.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/map-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/map-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/map-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "devDependencies": {
+        "clone-deep": "^0.2.4",
+        "extend-shallow": "^2.0.1",
+        "gulp-format-md": "^0.1.12",
+        "lodash": "^4.17.4",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "array",
+        "arrays",
+        "function",
+        "helper",
+        "invoke",
+        "key",
+        "map",
+        "method",
+        "object",
+        "objects",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": [
+            "collection-visit",
+            "object-visit"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "73bcd8385c9520c595a825486f19623a5e0550f0",
+      "_id": "map-visit@1.0.0",
+      "_shasum": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/map-visit-1.0.0.tgz_1491774214052_0.825954457744956"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# map-visit [![NPM version](https://img.shields.io/npm/v/map-visit.svg?style=flat)](https://www.npmjs.com/package/map-visit) [![NPM monthly downloads](https://img.shields.io/npm/dm/map-visit.svg?style=flat)](https://npmjs.org/package/map-visit)  [![NPM total downloads](https://img.shields.io/npm/dt/map-visit.svg?style=flat)](https://npmjs.org/package/map-visit) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/map-visit.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/map-visit)\n\n> Map `visit` over an array of objects.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save map-visit\n```\n\n## Usage\n\n```js\nvar mapVisit = require('map-visit');\n```\n\n## What does this do?\n\n**Assign/Merge/Extend vs. Visit**\n\nLet's say you want to add a `set` method to your application that will:\n\n* set key-value pairs on a `data` object\n* extend objects onto the `data` object\n* extend arrays of objects onto the data object\n\n**Example using `extend`**\n\nHere is one way to accomplish this using Lo-Dash's `extend` (comparable to `Object.assign`):\n\n```js\nvar _ = require('lodash');\n\nvar obj = {\n  data: {},\n  set: function (key, value) {\n    if (Array.isArray(key)) {\n      _.extend.apply(_, [obj.data].concat(key));\n    } else if (typeof key === 'object') {\n      _.extend(obj.data, key);\n    } else {\n      obj.data[key] = value;\n    }\n  }\n};\n\nobj.set('a', 'a');\nobj.set([{b: 'b'}, {c: 'c'}]);\nobj.set({d: {e: 'f'}});\n\nconsole.log(obj.data);\n//=> {a: 'a', b: 'b', c: 'c', d: { e: 'f' }}\n```\n\nThe above approach works fine for most use cases. However, **if you also want to emit an event** each time a property is added to the `data` object, or you want more control over what happens as the object is extended, a better approach would be to use `visit`.\n\n**Example using `visit`**\n\nIn this approach:\n\n* when an array is passed to `set`, the `mapVisit` library calls the `set` method on each object in the array.\n* when an object is passed, `visit` calls `set` on each property in the object.\n\nAs a result, the `data` event will be emitted every time a property is added to `data` (events are just an example, you can use this approach to perform any necessary logic every time the method is called).\n\n```js\nvar mapVisit = require('map-visit');\nvar visit = require('object-visit');\n\nvar obj = {\n  data: {},\n  set: function (key, value) {\n    if (Array.isArray(key)) {\n      mapVisit(obj, 'set', key);\n    } else if (typeof key === 'object') {\n      visit(obj, 'set', key);\n    } else {\n      // simulate an event-emitter\n      console.log('emit', key, value);\n      obj.data[key] = value;\n    }\n  }\n};\n\nobj.set('a', 'a');\nobj.set([{b: 'b'}, {c: 'c'}]);\nobj.set({d: {e: 'f'}});\nobj.set({g: 'h', i: 'j', k: 'l'});\n\nconsole.log(obj.data);\n//=> {a: 'a', b: 'b', c: 'c', d: { e: 'f' }, g: 'h', i: 'j', k: 'l'}\n\n// events would look something like:\n// emit a a\n// emit b b\n// emit c c\n// emit d { e: 'f' }\n// emit g h\n// emit i j\n// emit k l\n```\n\n## About\n\n### Related projects\n\n* [collection-visit](https://www.npmjs.com/package/collection-visit): Visit a method over the items in an object, or map visit over the objects… [more](https://github.com/jonschlinkert/collection-visit) | [homepage](https://github.com/jonschlinkert/collection-visit \"Visit a method over the items in an object, or map visit over the objects in an array.\")\n* [object-visit](https://www.npmjs.com/package/object-visit): Call a specified method on each value in the given object. | [homepage](https://github.com/jonschlinkert/object-visit \"Call a specified method on each value in the given object.\")\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 15 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 7 | [doowb](https://github.com/doowb) |\n\n### Building docs\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n### Running tests\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2017, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.5.0, on April 09, 2017._",
+  "maintainers": [
+    {
+      "name": "doowb",
+      "email": "brian.woodward@gmail.com"
+    },
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-04-09T21:43:35.689Z",
+    "created": "2015-07-04T20:27:34.082Z",
+    "0.1.0": "2015-07-04T20:27:34.082Z",
+    "0.1.1": "2015-08-07T04:07:05.349Z",
+    "0.1.2": "2015-10-06T13:09:05.144Z",
+    "0.1.3": "2015-10-06T13:11:32.060Z",
+    "0.1.4": "2015-11-08T19:04:55.608Z",
+    "0.1.5": "2016-08-05T21:54:35.306Z",
+    "1.0.0": "2017-04-09T21:43:35.689Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/map-visit",
+  "keywords": [
+    "array",
+    "arrays",
+    "function",
+    "helper",
+    "invoke",
+    "key",
+    "map",
+    "method",
+    "object",
+    "objects",
+    "value",
+    "visit",
+    "visitor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/map-visit.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/map-visit/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Brian Woodward",
+      "email": "brian.woodward@gmail.com",
+      "url": "https://twitter.com/doowb"
+    },
+    {
+      "name": "Jon Schlinkert",
+      "email": "jon.schlinkert@sellside.com",
+      "url": "http://twitter.com/jonschlinkert"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/map-visit.min.json
+++ b/test/fixtures/registry-mocks/content/map-visit.min.json
@@ -1,0 +1,148 @@
+{
+  "name": "map-visit",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "map-visit",
+      "version": "0.1.0",
+      "dependencies": {
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "lodash": "^3.10.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "d71b0db4c51ea42bdad81d769d6d9689827a13d1",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "map-visit",
+      "version": "0.1.1",
+      "dependencies": {
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "lodash": "^3.10.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "655cce40c43c558d1873ee9326e35d07fb51db44",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "map-visit",
+      "version": "0.1.2",
+      "dependencies": {
+        "lazy-cache": "^0.2.3",
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "lodash": "^3.10.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "ac3d91d9e81f14c358de82e6e7d3d3f18cd37ae2",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.3": {
+      "name": "map-visit",
+      "version": "0.1.3",
+      "dependencies": {
+        "lazy-cache": "^0.2.3",
+        "object-visit": "^0.1.0"
+      },
+      "devDependencies": {
+        "lodash": "^3.10.0",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "d4df0772e9584dcbcb675d62c3cc62d13f5aba43",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.4": {
+      "name": "map-visit",
+      "version": "0.1.4",
+      "dependencies": {
+        "lazy-cache": "^0.2.4",
+        "object-visit": "^0.3.1"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "4cd79abdc6985324e324204af330d772e48df6bd",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.5": {
+      "name": "map-visit",
+      "version": "0.1.5",
+      "dependencies": {
+        "lazy-cache": "^2.0.1",
+        "object-visit": "^0.3.4"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "lodash": "^4.14.1",
+        "mocha": "^3.0.1",
+        "should": "^10.0.0"
+      },
+      "dist": {
+        "shasum": "dbe43927ce5525b80dfc1573a44d68c51f26816b",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-0.1.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "map-visit",
+      "version": "1.0.0",
+      "dependencies": {
+        "object-visit": "^1.0.0"
+      },
+      "devDependencies": {
+        "clone-deep": "^0.2.4",
+        "extend-shallow": "^2.0.1",
+        "gulp-format-md": "^0.1.12",
+        "lodash": "^4.17.4",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "ecdca8f13144e660f1b5bd41f12f3479d98dfb8f",
+        "tarball": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-04-09T21:43:35.689Z"
+}

--- a/test/fixtures/registry-mocks/content/md5.js.json
+++ b/test/fixtures/registry-mocks/content/md5.js.json
@@ -1,0 +1,721 @@
+{
+  "_id": "md5.js",
+  "_rev": "16-b3e497ac621cc88abe50dfad6a60b40c",
+  "name": "md5.js",
+  "description": "node style md5 on pure JavaScript",
+  "dist-tags": {
+    "latest": "1.3.5"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "md5.js",
+      "version": "1.0.0",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/%3Acrypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "coverage": "nyc node test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^1.0.2",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "38283b6e9b336a9ac5decf50fbdcd76aac90f659",
+      "_id": "md5.js@1.0.0",
+      "_shasum": "448c0d876ece8b09ec9c11949bb565b66fada5df",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "448c0d876ece8b09ec9c11949bb565b66fada5df",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/md5.js-1.0.0.tgz_1459783490482_0.9674298875033855"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "md5.js",
+      "version": "1.1.0",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/%3Acrypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "97132316264039f61357790e269e3bf43682418c",
+      "_id": "md5.js@1.1.0",
+      "_shasum": "23efd65b429ee065b8b4a6631ef04800e2c15802",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "23efd65b429ee065b8b4a6631ef04800e2c15802",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/md5.js-1.1.0.tgz_1460012600943_0.8472151416353881"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "md5.js",
+      "version": "1.2.0",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/%3Acrypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "019eec1246db6e8dd720d7c65e88f8a228674771",
+      "_id": "md5.js@1.2.0",
+      "_shasum": "6c570b36e172f62c8e13c3a1b0f76c95be9c0e6c",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "6c570b36e172f62c8e13c3a1b0f76c95be9c0e6c",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/md5.js-1.2.0.tgz_1460196122796_0.40363837825134397"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "md5.js",
+      "version": "1.3.0",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/%3Acrypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "2ca3bcf04a23a218e7d5c50d0cb47140b731c87e",
+      "_id": "md5.js@1.3.0",
+      "_shasum": "8b02354665ce6c7734aceddcb59d11641c42b785",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "8b02354665ce6c7734aceddcb59d11641c42b785",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/md5.js-1.3.0.tgz_1460270909089_0.9662568017374724"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "md5.js",
+      "version": "1.3.1",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "0d48608c822ff82e38ea9f924fdd7d9021fcc77a",
+      "_id": "md5.js@1.3.1",
+      "_shasum": "d6da45f0e687bb78bae6de19d24d1868d22ca075",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "d6da45f0e687bb78bae6de19d24d1868d22ca075",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/md5.js-1.3.1.tgz_1460437613615_0.4253515535965562"
+      },
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "md5.js",
+      "version": "1.3.2",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "d3cf038feccff55a3dc4dca648710fa57b4501fc",
+      "_id": "md5.js@1.3.2",
+      "_shasum": "b5fc4dba946f9b7cffb291a0bc7e01a321c51339",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "b5fc4dba946f9b7cffb291a0bc7e01a321c51339",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/md5.js-1.3.2.tgz_1460617759954_0.2634202758781612"
+      },
+      "directories": {}
+    },
+    "1.3.3": {
+      "name": "md5.js",
+      "version": "1.3.3",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "1d1db6288b70635bb20209a58214a9843c6e00af",
+      "_id": "md5.js@1.3.3",
+      "_shasum": "05fd01cf2a48e39fe51e64fbebfe650c46cdd58e",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "05fd01cf2a48e39fe51e64fbebfe650c46cdd58e",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/md5.js-1.3.3.tgz_1462358724214_0.19014157797209918"
+      },
+      "directories": {}
+    },
+    "1.3.4": {
+      "name": "md5.js",
+      "version": "1.3.4",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "d5ba10c4dc393a8db6e2f39a2c70c9193964b4ec",
+      "_id": "md5.js@1.3.4",
+      "_shasum": "e9bdbde94a20a5ac18b04340fc5764d5b09d901d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.4.0",
+      "_npmUser": {
+        "name": "fanatid",
+        "email": "fanatid@ya.ru"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e9bdbde94a20a5ac18b04340fc5764d5b09d901d",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/md5.js-1.3.4.tgz_1472409359658_0.7613432689104229"
+      },
+      "directories": {}
+    },
+    "1.3.5": {
+      "name": "md5.js",
+      "version": "1.3.5",
+      "description": "node style md5 on pure JavaScript",
+      "keywords": [
+        "crypto",
+        "md5"
+      ],
+      "homepage": "https://github.com/crypto-browserify/md5.js",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/md5.js/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Kirill Fomichev",
+        "email": "fanatid@ya.ru",
+        "url": "https://github.com/fanatid"
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/md5.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "gitHead": "48df1d6b8c4af2cf52638092d590c528420c61ed",
+      "_id": "md5.js@1.3.5",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+        "shasum": "b5d07b8e3216e3e27cd728d72f70d1e6a342005f",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7671,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbs3Q8CRA9TVsSAnZWagAADJMP/jCAywo2iMaaIo6dYr93\nVtqgE5hCChqlPXQC6PQLoENpTQZrE/2cr+DW16YXFH0TGvxwUGdiqhJsoiqi\nzqHrRm1o267s5dxqD0f0uhDGnz5AuWz/WcDWQRuIQZzrAA53cJ6dgfP5HGcV\n7IrMIyGhWzX6nXB2CoZdp4x8V6cGt+pnC+3bUE6WeSv36cIyn6Srjx4gfbuT\njwUIP0qSeJnaBxTEd/xFAKmypEMeZk5fcGmAqVkzma34MdIwbx/hqwAs1zDE\nKbzU5IelUo+JQQWOEeY627hVwcGQdqMc6Vqcqjca1z+egXOhP1FDeKuhG5za\n1MgC9ilcKUJXicD7fgmqSHWesbxmprrnqo6N+PSZTeKAVU77DgpyVbfyfHrW\nySKp87UVzYKRDbCYzu8kieElRDvsqt718TDLF/XiENLsvOQKVTETJKV42OJE\nba1sRBl2pYeGu6m/PPMgBUpwUrHUnwfEadhBYBZppNutQU/0jfWXLHIuTfTL\nQfELqJZ7cjzmtdCdwvaWYOFWHWlGw6Hp4enIkeDwUN7jZQxecCQMXUMpR380\n8emX+oqGSKfDrxkMAmyVO9hL4rl+oQ94UMD07GM3glQafIBR3/38+mGLsODa\nXKkuUclSaLgg9E/NX+j0gBLbp19CqYHvVWikwSz/bcDdBr2e3DiLlYmxMSxB\nkZ+I\r\n=T1Ev\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "fanatid",
+          "email": "fanatid@ya.ru"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/md5.js_1.3.5_1538487356042_0.034320089519025654"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# md5.js\n\n[![NPM Package](https://img.shields.io/npm/v/md5.js.svg?style=flat-square)](https://www.npmjs.org/package/md5.js)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/md5.js.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/md5.js)\n[![Dependency status](https://img.shields.io/david/crypto-browserify/md5.js.svg?style=flat-square)](https://david-dm.org/crypto-browserify/md5.js#info=dependencies)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nNode style `md5` on pure JavaScript.\n\nFrom [NIST SP 800-131A][1]: *md5 is no longer acceptable where collision resistance is required such as digital signatures.*\n\n## Example\n\n```js\nvar MD5 = require('md5.js')\n\nconsole.log(new MD5().update('42').digest('hex'))\n// => a1d0c6e83f027327d8461063f4ac58a6\n\nvar md5stream = new MD5()\nmd5stream.end('42')\nconsole.log(md5stream.read().toString('hex'))\n// => a1d0c6e83f027327d8461063f4ac58a6\n```\n\n## LICENSE [MIT](LICENSE)\n\n[1]: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf\n",
+  "maintainers": [
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    },
+    {
+      "name": "dcousens",
+      "email": "email@dcousens.com"
+    },
+    {
+      "name": "fanatid",
+      "email": "fanatid@ya.ru"
+    },
+    {
+      "name": "jprichardson",
+      "email": "jprichardson@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-04T18:51:11.997Z",
+    "created": "2016-04-04T15:24:53.141Z",
+    "1.0.0": "2016-04-04T15:24:53.141Z",
+    "1.1.0": "2016-04-07T07:03:23.058Z",
+    "1.2.0": "2016-04-09T10:02:05.112Z",
+    "1.3.0": "2016-04-10T06:48:30.179Z",
+    "1.3.1": "2016-04-12T05:06:56.074Z",
+    "1.3.2": "2016-04-14T07:09:21.713Z",
+    "1.3.3": "2016-05-04T10:45:26.772Z",
+    "1.3.4": "2016-08-28T18:36:01.201Z",
+    "1.3.5": "2018-10-02T13:35:56.206Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/md5.js",
+  "keywords": [
+    "crypto",
+    "md5"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/md5.js.git"
+  },
+  "author": {
+    "name": "Kirill Fomichev",
+    "email": "fanatid@ya.ru",
+    "url": "https://github.com/fanatid"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/md5.js/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "fanatid": true,
+    "rocket0191": true,
+    "liupengbo": true,
+    "xiaobing": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/md5.js.min.json
+++ b/test/fixtures/registry-mocks/content/md5.js.min.json
@@ -1,0 +1,168 @@
+{
+  "name": "md5.js",
+  "dist-tags": {
+    "latest": "1.3.5"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "md5.js",
+      "version": "1.0.0",
+      "dependencies": {
+        "hash-base": "^1.0.2",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "nyc": "^6.1.1",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "448c0d876ece8b09ec9c11949bb565b66fada5df",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "md5.js",
+      "version": "1.1.0",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "23efd65b429ee065b8b4a6631ef04800e2c15802",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "md5.js",
+      "version": "1.2.0",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "6c570b36e172f62c8e13c3a1b0f76c95be9c0e6c",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "md5.js",
+      "version": "1.3.0",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "8b02354665ce6c7734aceddcb59d11641c42b785",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.0.tgz"
+      }
+    },
+    "1.3.1": {
+      "name": "md5.js",
+      "version": "1.3.1",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "d6da45f0e687bb78bae6de19d24d1868d22ca075",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.1.tgz"
+      }
+    },
+    "1.3.2": {
+      "name": "md5.js",
+      "version": "1.3.2",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.8",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "b5fc4dba946f9b7cffb291a0bc7e01a321c51339",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.2.tgz"
+      }
+    },
+    "1.3.3": {
+      "name": "md5.js",
+      "version": "1.3.3",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "05fd01cf2a48e39fe51e64fbebfe650c46cdd58e",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.3.tgz"
+      }
+    },
+    "1.3.4": {
+      "name": "md5.js",
+      "version": "1.3.4",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "e9bdbde94a20a5ac18b04340fc5764d5b09d901d",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz"
+      }
+    },
+    "1.3.5": {
+      "name": "md5.js",
+      "version": "1.3.5",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^7.0.0",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+        "shasum": "b5d07b8e3216e3e27cd728d72f70d1e6a342005f",
+        "tarball": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7671,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbs3Q8CRA9TVsSAnZWagAADJMP/jCAywo2iMaaIo6dYr93\nVtqgE5hCChqlPXQC6PQLoENpTQZrE/2cr+DW16YXFH0TGvxwUGdiqhJsoiqi\nzqHrRm1o267s5dxqD0f0uhDGnz5AuWz/WcDWQRuIQZzrAA53cJ6dgfP5HGcV\n7IrMIyGhWzX6nXB2CoZdp4x8V6cGt+pnC+3bUE6WeSv36cIyn6Srjx4gfbuT\njwUIP0qSeJnaBxTEd/xFAKmypEMeZk5fcGmAqVkzma34MdIwbx/hqwAs1zDE\nKbzU5IelUo+JQQWOEeY627hVwcGQdqMc6Vqcqjca1z+egXOhP1FDeKuhG5za\n1MgC9ilcKUJXicD7fgmqSHWesbxmprrnqo6N+PSZTeKAVU77DgpyVbfyfHrW\nySKp87UVzYKRDbCYzu8kieElRDvsqt718TDLF/XiENLsvOQKVTETJKV42OJE\nba1sRBl2pYeGu6m/PPMgBUpwUrHUnwfEadhBYBZppNutQU/0jfWXLHIuTfTL\nQfELqJZ7cjzmtdCdwvaWYOFWHWlGw6Hp4enIkeDwUN7jZQxecCQMXUMpR380\n8emX+oqGSKfDrxkMAmyVO9hL4rl+oQ94UMD07GM3glQafIBR3/38+mGLsODa\nXKkuUclSaLgg9E/NX+j0gBLbp19CqYHvVWikwSz/bcDdBr2e3DiLlYmxMSxB\nkZ+I\r\n=T1Ev\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-01-04T18:51:11.997Z"
+}

--- a/test/fixtures/registry-mocks/content/media-typer.json
+++ b/test/fixtures/registry-mocks/content/media-typer.json
@@ -1,0 +1,515 @@
+{
+  "_id": "media-typer",
+  "_rev": "16-c93ddf8b74ad3e0914f5d212afeb39a5",
+  "name": "media-typer",
+  "description": "Simple RFC 6838 media type parser and formatter",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "media-typer",
+      "description": "Simple RFC 6838 media type parser and formatter",
+      "version": "0.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/media-typer"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/media-typer/issues"
+      },
+      "homepage": "https://github.com/expressjs/media-typer",
+      "_id": "media-typer@0.0.0",
+      "dist": {
+        "shasum": "4ee71136eb8612cc771ecfa2bf25ddc153084f5c",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "media-typer",
+      "description": "Simple RFC 6838 media type parser and formatter",
+      "version": "0.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/media-typer"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/media-typer/issues"
+      },
+      "homepage": "https://github.com/expressjs/media-typer",
+      "_id": "media-typer@0.1.0",
+      "dist": {
+        "shasum": "00607eec8005776e49ea593202f5469f703e8060",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "media-typer",
+      "description": "Simple RFC 6838 media type parser and formatter",
+      "version": "0.2.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/media-typer"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/media-typer/issues"
+      },
+      "homepage": "https://github.com/expressjs/media-typer",
+      "_id": "media-typer@0.2.0",
+      "dist": {
+        "shasum": "d8a065213adfeaa2e76321a2b6dda36ff6335984",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "media-typer",
+      "description": "Simple RFC 6838 media type parser and formatter",
+      "version": "0.3.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/media-typer"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d49d41ffd0bb5a0655fa44a59df2ec0bfc835b16",
+      "bugs": {
+        "url": "https://github.com/jshttp/media-typer/issues"
+      },
+      "homepage": "https://github.com/jshttp/media-typer",
+      "_id": "media-typer@0.3.0",
+      "_shasum": "8710d7af0aa626f8fffa1ce00168545263255748",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8710d7af0aa626f8fffa1ce00168545263255748",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "media-typer",
+      "description": "Simple RFC 6838 media type parser and formatter",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/media-typer.git"
+      },
+      "devDependencies": {
+        "eslint": "5.7.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "5.2.0",
+        "nyc": "13.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "dbe811acb83855b086667271010d3b105aeb6e34",
+      "bugs": {
+        "url": "https://github.com/jshttp/media-typer/issues"
+      },
+      "homepage": "https://github.com/jshttp/media-typer#readme",
+      "_id": "media-typer@1.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.12.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-MKXtlq1YKUow2wpJlJ7ep1MU6jQR0BaKpkDyrE294cmNSbhoOU1yziJ4UZOU1guFxcEaFt5t4LHsL/t891D6BQ==",
+        "shasum": "ca89611f8e31b936efcb3aa90826772f135e3341",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-1.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8331,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJby98nCRA9TVsSAnZWagAA4d8P/A+KHvncQuvDCGeEBhDT\nNS32nytG/grOSzaMcv/L3KA9zAHBWyYa0EmBQ5Iyvd2A1jk12yKW5FsonQNO\n2Q+FMWW8fzo2pJtV6KB7FGgTJ6oWfViT86c4gjZTnJ6sZBe5z30Ai/5hSk6g\nAv749aM7qgX88RysFGRsbq38rKwmV4LIvLqYFT+knDo+R1A72rFjZLtWSe2a\nfrjdhfz3+f5S0Mj6GWdtgmn6zARFlIi6SyJrrNjoOumQXDRHQt3rgicEgBCR\nztwlnBjFXPCBj6+xK5mIqNP4XJMv1W0DRplP1WWfChTUy+8SU3PMTmE3n0gV\nvx1nBWWrFaZFRsBSp6l6qD5Am4JO/RlFV/GS09OxL93+R/gL+BnGY6uEZhcr\n5d2SDrLAzzznBz6q5KCI3wV8Fx0jNQyibw1XaJ75BL72HsCV1TWU9ZVeGCau\n32/J7ZuRsPkn+adujX6ffIi5+oeFBHkl+NuCvtEZT8nknPw/CsoPYEZ7SA3F\nX+yBPf8fPXiNIk0FrdVtMJvMT2ueaoEw3+hzzmEfwC6Lq25VYTOqdpsbyTiw\n0+Uor6Oe9sYwIZy05pc25PJdJvwHn3LaDLA8Y8PAjntDWNMd8nW2ZnXGVtLE\nia74S0Pqi55M/ARn9DiGe4H/4n77GEQyYuSWIiJheo71mY2/Y8M3OgHGLY4r\nNlif\r\n=3F90\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/media-typer_1.0.0_1540087590178_0.03604841955092852"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.1": {
+      "name": "media-typer",
+      "description": "Simple RFC 6838 media type parser and formatter",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/media-typer.git"
+      },
+      "devDependencies": {
+        "eslint": "5.7.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "5.2.0",
+        "nyc": "13.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "1ee51e645afab21855a35fbf95fe6b1e4c852060",
+      "bugs": {
+        "url": "https://github.com/jshttp/media-typer/issues"
+      },
+      "homepage": "https://github.com/jshttp/media-typer#readme",
+      "_id": "media-typer@1.0.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.12.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-v42gdPIuqYCoDVH5OiaKsVrv6aJqdMWJzl8KCyDs/KeDyBveYp3Wxq4UWJfsWjkSZUNC0xlLfDlLCPa1h/oo+g==",
+        "shasum": "e39d677e19a011c52d2681f430d1adafb299dd41",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-1.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8346,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJby+HDCRA9TVsSAnZWagAALRcP/jsONa6K4aEKiHKqqmU+\nNryRP9TBIgMxtSRaXP2lU+2BqeQRAPFtxa7H4SaFyyM6QLI/I3G3C1LDltXx\nKcmaWPzGHNJZ6aFVqiNgn7nia+/vGiciP/ZeEg1AKy6vFbkKVMuk3AOQVYO0\nMhByAAVLTKBRqMtuMqv2AH7tHQLSMNJCvHQMelQAOruHz8wbE9Pg189uWaud\npm0sD0eqVw6L1VD7A8XtA0TcyidcnytIIgq/uSr6sES6sFIBTtCafbFaz/X3\nrdm4Fiv1jynEN5Q5PWO9sTCIBeJ3gdlTm43EkXS98ggR6pPqYTujTdI15SCJ\nnM1qaMUR3k+2BAZttjD1v+gvtI5U3nl/jgdTWCt0oQlQ3GgO8TjO43RHKYmR\nP4LylGuve7oih6Sf6/MDOi/QPReLiQW4FBdAxCB8jkKjiVV5YEZ4XmlaO2sd\ny/YMcoxBrROebWcjmlFXROfAs2ianwxTD7lhe7YnjghGIf2m+BxFWJF0xLga\n+5op2MR/GCbf93BiV9RguUnfyaRohgmo3acIc4Fm/+M52nMrMS3dyiOxvCRD\n+cjiLJxHUsf192Y9vgbXMxlBqUzr6lGzSQAPpDScImHZzxC6AU3LVNOVCCDU\noMd/a96idMBHmCUC0dXn4WhYGDTjNRAcaj8PTE8vENp66fEbp4/wWFfWVM4h\nuvVC\r\n=0v4D\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/media-typer_1.0.1_1540088258485_0.9356881090496065"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.2": {
+      "name": "media-typer",
+      "description": "Simple RFC 6838 media type parser and formatter",
+      "version": "1.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/media-typer.git"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "95189ea17b0ff63132f027c746ae6eb1b2c783e1",
+      "bugs": {
+        "url": "https://github.com/jshttp/media-typer/issues"
+      },
+      "homepage": "https://github.com/jshttp/media-typer#readme",
+      "_id": "media-typer@1.0.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-/ky7iFD18Y2mN5BdOS4zotSSgu11BsIR2l3L7eK2bTaRWQidoSBmSxGgMFd/XOSGyivlhtQUdDLoUzlr1PWb1g==",
+        "shasum": "e64b0a709d52c158ddedaf38ebebfa00d8e02c14",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-1.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8562,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcukLZCRA9TVsSAnZWagAADM8P/RDVhBWP4o9R/32p6fdI\nVr8PGyNgx0K6s0A6KVOis0x2YwXRHCZKYIP/DXjsstTd4qQ/sT2QQVDTkS8s\ndeTYEQ2W/nvjNymWxPtbkfgZ4fdGFa+QFNoZhQCjg3fbrze2Ym1MPehlAi9G\nw9Li0tIxKQgy9LcXyBC/lPiQdm8Ip5wOvihfVOd4Jm7dyT4NgKem41oKNF8L\nLQIbguAHGE9ET/s8nvLe6WI9IK3CUD7BN4fTLs6ypOJKm3leLDCmzEkwd1Yq\ndvI4WKg/sZ1jYi436OJBaYfzP/kJZDYWT4Hghqh1p4y/WQF3GumRhoPRVSfR\nmBARnlBniHYPoCchPXmSLr4NbKO8ceITFeelxgi42AJzAY4UQU1QP2jjP8LS\nCBo6jmMiePIPLuIN/oOKejtIX8EDsWZelAXDH1jE038PqXp22U2j0KmqPc0m\nmkXBLDOAECvnsqvMqawEJzjJi639EBuRf3tFBnQZGqLoNSDPEtJNJxxMy6zA\nJjjR5zsrlvfX+07NeJHjNB4vutas8sOb/T3aZxc/7VWFgJoDApP+vsoxuQy9\nlvhLPoc+Ew/uXqOt3GwZM27g1caqdVmJolrTzpjKk7GLUR9GoedWcsTCTJZy\nimhjRmbJT24q23z99eeJO1GaraRtxOe3KaLwYpjhTFC1aKJcuH3Yp5CDF3Sp\nYhBE\r\n=e9ga\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/media-typer_1.0.2_1555710681221_0.029165072776340617"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.0": {
+      "name": "media-typer",
+      "description": "Simple RFC 6838 media type parser and formatter",
+      "version": "1.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/media-typer.git"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "1332b73ed8584b7b25d556c55b6de9d64fa3ce2c",
+      "bugs": {
+        "url": "https://github.com/jshttp/media-typer/issues"
+      },
+      "homepage": "https://github.com/jshttp/media-typer#readme",
+      "_id": "media-typer@1.1.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+        "shasum": "6ab74b8f2d3320f2064b2a87a38e7931ff3a5561",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9256,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwSZ1CRA9TVsSAnZWagAAq2YP/iVhvTj/MN3o7Aq8zi5d\ncqBXtKn6MQPCQFT6MlyUSEyXZkR76fZJtpqJLuqMtaICoUcFbt2eAJDqLDY2\nFB0E/q9Fcz/3sz5Smi6q3TBeJhWiMn9VhxkE2WzLBXDl6o9LD0iWAsDgaVse\nSTKTP2wO0xxwUxJKNGWDr9KLCweldS0/5SNMUgGkk7nYfQRaBRiW9t3QI/SW\nYqEllnjxH1r4UZOGSGfX07W5oNhPmBzutKkky+VBQXo51U46qcRV3f6NAObA\nshoOzlCCreCkF3mZuLzG8gfwFULM5b6Xud3/m6Hr1JxH7kVjaa/w2BhUhj3N\nsbgHcBMPHxOqzv1TdA8LAv0J/+sF5brRTLZW8Tp5WKoPvJDp6nG46rmrPm1H\nL7xzDwXKUnL3bZ+KtrSwgXY0viF6uMQlejAjkpXVQki5pc1pOEpnnQ+nfF22\n4myltUfRq5TGBmqqAZV0+Q+vIHf3lMBi/PMVm1ZI1QspY50B08fAr1iH81bI\nCredpoZbf5Avd2eNZnDFQUbzXVh7FW3Q4+q5667AlAvb9b3rZ3wEFgSDW2bS\nnUm/VQFkvRXQl2gM0lQJWd8uOzRFInCH4S4TsPQezBBILBQtmH44qnw/Kqn2\nsDw6GU8MifAKlOfPTl7+WPlALvhmkjrZNK0HukXlowlhisxR1UMLJRGIaWDO\nzTFe\r\n=OUQb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/media-typer_1.1.0_1556162165232_0.28874376896252363"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# media-typer\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nSimple RFC 6838 media type parser.\n\nThis module will parse a given media type into it's component parts, like type,\nsubtype, and suffix. A formatter is also provided to put them back together and\nthe two can be combined to normalize media types into a canonical form.\n\nIf you are looking to parse the string that represents a media type and it's\nparameters in HTTP (for example, the `Content-Type` header), use the\n[content-type module](https://www.npmjs.com/package/content-type).\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install media-typer\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar typer = require('media-typer')\n```\n\n### typer.parse(string)\n\n<!-- eslint-disable no-undef, no-unused-vars -->\n\n```js\nvar obj = typer.parse('image/svg+xml')\n```\n\nParse a media type string. This will return an object with the following\nproperties (examples are shown for the string `'image/svg+xml; charset=utf-8'`):\n\n - `type`: The type of the media type (always lower case). Example: `'image'`\n\n - `subtype`: The subtype of the media type (always lower case). Example: `'svg'`\n\n - `suffix`: The suffix of the media type (always lower case). Example: `'xml'`\n\nIf the given type string is invalid, then a `TypeError` is thrown.\n\n### typer.format(obj)\n\n<!-- eslint-disable no-undef, no-unused-vars -->\n\n```js\nvar obj = typer.format({ type: 'image', subtype: 'svg', suffix: 'xml' })\n```\n\nFormat an object into a media type string. This will return a string of the\nmime type for the given object. For the properties of the object, see the\ndocumentation for `typer.parse(string)`.\n\nIf any of the given object values are invalid, then a `TypeError` is thrown.\n\n### typer.test(string)\n\n<!-- eslint-disable no-undef, no-unused-vars -->\n\n```js\nvar valid = typer.test('image/svg+xml')\n```\n\nValidate a media type string. This will return `true` is the string is a well-\nformatted media type, or `false` otherwise.\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/media-typer/master\n[coveralls-url]: https://coveralls.io/r/jshttp/media-typer?branch=master\n[node-version-image]: https://badgen.net/npm/node/media-typer\n[node-version-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/media-typer\n[npm-url]: https://npmjs.org/package/media-typer\n[npm-version-image]: https://badgen.net/npm/v/media-typer\n[travis-image]: https://badgen.net/travis/jshttp/media-typer/master\n[travis-url]: https://travis-ci.org/jshttp/media-typer\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-25T03:16:08.427Z",
+    "created": "2014-06-13T19:25:11.301Z",
+    "0.0.0": "2014-06-13T19:25:11.301Z",
+    "0.1.0": "2014-06-18T05:02:41.908Z",
+    "0.2.0": "2014-06-18T19:00:35.939Z",
+    "0.3.0": "2014-09-08T04:32:24.363Z",
+    "1.0.0": "2018-10-21T02:06:30.337Z",
+    "1.0.1": "2018-10-21T02:17:38.605Z",
+    "1.0.2": "2019-04-19T21:51:21.389Z",
+    "1.1.0": "2019-04-25T03:16:05.379Z"
+  },
+  "homepage": "https://github.com/jshttp/media-typer#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/media-typer.git"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/media-typer/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "mojaray2k": true,
+    "shanewholloway": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/media-typer.min.json
+++ b/test/fixtures/registry-mocks/content/media-typer.min.json
@@ -1,0 +1,177 @@
+{
+  "name": "media-typer",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "media-typer",
+      "version": "0.0.0",
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "4ee71136eb8612cc771ecfa2bf25ddc153084f5c",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.1.0": {
+      "name": "media-typer",
+      "version": "0.1.0",
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "00607eec8005776e49ea593202f5469f703e8060",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.2.0": {
+      "name": "media-typer",
+      "version": "0.2.0",
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "d8a065213adfeaa2e76321a2b6dda36ff6335984",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.3.0": {
+      "name": "media-typer",
+      "version": "0.3.0",
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4"
+      },
+      "dist": {
+        "shasum": "8710d7af0aa626f8fffa1ce00168545263255748",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.0": {
+      "name": "media-typer",
+      "version": "1.0.0",
+      "devDependencies": {
+        "eslint": "5.7.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "5.2.0",
+        "nyc": "13.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-MKXtlq1YKUow2wpJlJ7ep1MU6jQR0BaKpkDyrE294cmNSbhoOU1yziJ4UZOU1guFxcEaFt5t4LHsL/t891D6BQ==",
+        "shasum": "ca89611f8e31b936efcb3aa90826772f135e3341",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-1.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8331,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJby98nCRA9TVsSAnZWagAA4d8P/A+KHvncQuvDCGeEBhDT\nNS32nytG/grOSzaMcv/L3KA9zAHBWyYa0EmBQ5Iyvd2A1jk12yKW5FsonQNO\n2Q+FMWW8fzo2pJtV6KB7FGgTJ6oWfViT86c4gjZTnJ6sZBe5z30Ai/5hSk6g\nAv749aM7qgX88RysFGRsbq38rKwmV4LIvLqYFT+knDo+R1A72rFjZLtWSe2a\nfrjdhfz3+f5S0Mj6GWdtgmn6zARFlIi6SyJrrNjoOumQXDRHQt3rgicEgBCR\nztwlnBjFXPCBj6+xK5mIqNP4XJMv1W0DRplP1WWfChTUy+8SU3PMTmE3n0gV\nvx1nBWWrFaZFRsBSp6l6qD5Am4JO/RlFV/GS09OxL93+R/gL+BnGY6uEZhcr\n5d2SDrLAzzznBz6q5KCI3wV8Fx0jNQyibw1XaJ75BL72HsCV1TWU9ZVeGCau\n32/J7ZuRsPkn+adujX6ffIi5+oeFBHkl+NuCvtEZT8nknPw/CsoPYEZ7SA3F\nX+yBPf8fPXiNIk0FrdVtMJvMT2ueaoEw3+hzzmEfwC6Lq25VYTOqdpsbyTiw\n0+Uor6Oe9sYwIZy05pc25PJdJvwHn3LaDLA8Y8PAjntDWNMd8nW2ZnXGVtLE\nia74S0Pqi55M/ARn9DiGe4H/4n77GEQyYuSWIiJheo71mY2/Y8M3OgHGLY4r\nNlif\r\n=3F90\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.1": {
+      "name": "media-typer",
+      "version": "1.0.1",
+      "devDependencies": {
+        "eslint": "5.7.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "5.2.0",
+        "nyc": "13.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-v42gdPIuqYCoDVH5OiaKsVrv6aJqdMWJzl8KCyDs/KeDyBveYp3Wxq4UWJfsWjkSZUNC0xlLfDlLCPa1h/oo+g==",
+        "shasum": "e39d677e19a011c52d2681f430d1adafb299dd41",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-1.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8346,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJby+HDCRA9TVsSAnZWagAALRcP/jsONa6K4aEKiHKqqmU+\nNryRP9TBIgMxtSRaXP2lU+2BqeQRAPFtxa7H4SaFyyM6QLI/I3G3C1LDltXx\nKcmaWPzGHNJZ6aFVqiNgn7nia+/vGiciP/ZeEg1AKy6vFbkKVMuk3AOQVYO0\nMhByAAVLTKBRqMtuMqv2AH7tHQLSMNJCvHQMelQAOruHz8wbE9Pg189uWaud\npm0sD0eqVw6L1VD7A8XtA0TcyidcnytIIgq/uSr6sES6sFIBTtCafbFaz/X3\nrdm4Fiv1jynEN5Q5PWO9sTCIBeJ3gdlTm43EkXS98ggR6pPqYTujTdI15SCJ\nnM1qaMUR3k+2BAZttjD1v+gvtI5U3nl/jgdTWCt0oQlQ3GgO8TjO43RHKYmR\nP4LylGuve7oih6Sf6/MDOi/QPReLiQW4FBdAxCB8jkKjiVV5YEZ4XmlaO2sd\ny/YMcoxBrROebWcjmlFXROfAs2ianwxTD7lhe7YnjghGIf2m+BxFWJF0xLga\n+5op2MR/GCbf93BiV9RguUnfyaRohgmo3acIc4Fm/+M52nMrMS3dyiOxvCRD\n+cjiLJxHUsf192Y9vgbXMxlBqUzr6lGzSQAPpDScImHZzxC6AU3LVNOVCCDU\noMd/a96idMBHmCUC0dXn4WhYGDTjNRAcaj8PTE8vENp66fEbp4/wWFfWVM4h\nuvVC\r\n=0v4D\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.2": {
+      "name": "media-typer",
+      "version": "1.0.2",
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-/ky7iFD18Y2mN5BdOS4zotSSgu11BsIR2l3L7eK2bTaRWQidoSBmSxGgMFd/XOSGyivlhtQUdDLoUzlr1PWb1g==",
+        "shasum": "e64b0a709d52c158ddedaf38ebebfa00d8e02c14",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-1.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8562,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcukLZCRA9TVsSAnZWagAADM8P/RDVhBWP4o9R/32p6fdI\nVr8PGyNgx0K6s0A6KVOis0x2YwXRHCZKYIP/DXjsstTd4qQ/sT2QQVDTkS8s\ndeTYEQ2W/nvjNymWxPtbkfgZ4fdGFa+QFNoZhQCjg3fbrze2Ym1MPehlAi9G\nw9Li0tIxKQgy9LcXyBC/lPiQdm8Ip5wOvihfVOd4Jm7dyT4NgKem41oKNF8L\nLQIbguAHGE9ET/s8nvLe6WI9IK3CUD7BN4fTLs6ypOJKm3leLDCmzEkwd1Yq\ndvI4WKg/sZ1jYi436OJBaYfzP/kJZDYWT4Hghqh1p4y/WQF3GumRhoPRVSfR\nmBARnlBniHYPoCchPXmSLr4NbKO8ceITFeelxgi42AJzAY4UQU1QP2jjP8LS\nCBo6jmMiePIPLuIN/oOKejtIX8EDsWZelAXDH1jE038PqXp22U2j0KmqPc0m\nmkXBLDOAECvnsqvMqawEJzjJi639EBuRf3tFBnQZGqLoNSDPEtJNJxxMy6zA\nJjjR5zsrlvfX+07NeJHjNB4vutas8sOb/T3aZxc/7VWFgJoDApP+vsoxuQy9\nlvhLPoc+Ew/uXqOt3GwZM27g1caqdVmJolrTzpjKk7GLUR9GoedWcsTCTJZy\nimhjRmbJT24q23z99eeJO1GaraRtxOe3KaLwYpjhTFC1aKJcuH3Yp5CDF3Sp\nYhBE\r\n=e9ga\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.0": {
+      "name": "media-typer",
+      "version": "1.1.0",
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+        "shasum": "6ab74b8f2d3320f2064b2a87a38e7931ff3a5561",
+        "tarball": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9256,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwSZ1CRA9TVsSAnZWagAAq2YP/iVhvTj/MN3o7Aq8zi5d\ncqBXtKn6MQPCQFT6MlyUSEyXZkR76fZJtpqJLuqMtaICoUcFbt2eAJDqLDY2\nFB0E/q9Fcz/3sz5Smi6q3TBeJhWiMn9VhxkE2WzLBXDl6o9LD0iWAsDgaVse\nSTKTP2wO0xxwUxJKNGWDr9KLCweldS0/5SNMUgGkk7nYfQRaBRiW9t3QI/SW\nYqEllnjxH1r4UZOGSGfX07W5oNhPmBzutKkky+VBQXo51U46qcRV3f6NAObA\nshoOzlCCreCkF3mZuLzG8gfwFULM5b6Xud3/m6Hr1JxH7kVjaa/w2BhUhj3N\nsbgHcBMPHxOqzv1TdA8LAv0J/+sF5brRTLZW8Tp5WKoPvJDp6nG46rmrPm1H\nL7xzDwXKUnL3bZ+KtrSwgXY0viF6uMQlejAjkpXVQki5pc1pOEpnnQ+nfF22\n4myltUfRq5TGBmqqAZV0+Q+vIHf3lMBi/PMVm1ZI1QspY50B08fAr1iH81bI\nCredpoZbf5Avd2eNZnDFQUbzXVh7FW3Q4+q5667AlAvb9b3rZ3wEFgSDW2bS\nnUm/VQFkvRXQl2gM0lQJWd8uOzRFInCH4S4TsPQezBBILBQtmH44qnw/Kqn2\nsDw6GU8MifAKlOfPTl7+WPlALvhmkjrZNK0HukXlowlhisxR1UMLJRGIaWDO\nzTFe\r\n=OUQb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-04-25T03:16:08.427Z"
+}

--- a/test/fixtures/registry-mocks/content/memory-fs.json
+++ b/test/fixtures/registry-mocks/content/memory-fs.json
@@ -1,0 +1,500 @@
+{
+  "_id": "memory-fs",
+  "_rev": "33-25a32bb3f4094e41e2056dcccebe175f",
+  "name": "memory-fs",
+  "description": "A simple in-memory filesystem. Holds data in a javascript object.",
+  "dist-tags": {
+    "latest": "0.5.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "memory-fs",
+      "version": "0.1.0",
+      "description": "A simple in-memory filesystem. Holds data in a javascript object.",
+      "main": "lib/MemoryFileSystem.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "mocha -R spec",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/memory-fs.git"
+      },
+      "keywords": [
+        "fs",
+        "memory"
+      ],
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/memory-fs/issues"
+      },
+      "homepage": "https://github.com/webpack/memory-fs",
+      "devDependencies": {
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "gitHead": "0b1b6ace9cd1b87e388d2b65178c204215ec4da8",
+      "_id": "memory-fs@0.1.0",
+      "_shasum": "247e51c6538d17d412222bd4d5a70c79d83081e8",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "247e51c6538d17d412222bd4d5a70c79d83081e8",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "memory-fs",
+      "version": "0.1.1",
+      "description": "A simple in-memory filesystem. Holds data in a javascript object.",
+      "main": "lib/MemoryFileSystem.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "mocha -R spec",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/memory-fs.git"
+      },
+      "keywords": [
+        "fs",
+        "memory"
+      ],
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/memory-fs/issues"
+      },
+      "homepage": "https://github.com/webpack/memory-fs",
+      "devDependencies": {
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "gitHead": "fe762d8da5c3544432ec487c7fa3ff76e8ed2423",
+      "_id": "memory-fs@0.1.1",
+      "_shasum": "bec997e8654a29753206e3b921809869bec0e943",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bec997e8654a29753206e3b921809869bec0e943",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.1.1.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "memory-fs",
+      "version": "0.2.0",
+      "description": "A simple in-memory filesystem. Holds data in a javascript object.",
+      "main": "lib/MemoryFileSystem.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "mocha -R spec",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/memory-fs.git"
+      },
+      "keywords": [
+        "fs",
+        "memory"
+      ],
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/memory-fs/issues"
+      },
+      "homepage": "https://github.com/webpack/memory-fs",
+      "devDependencies": {
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "gitHead": "b90785340f2adf4eed77c59bdda7742a51d16e5e",
+      "_id": "memory-fs@0.2.0",
+      "_shasum": "f2bb25368bc121e391c2520de92969caee0a0290",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f2bb25368bc121e391c2520de92969caee0a0290",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "memory-fs",
+      "version": "0.3.0",
+      "description": "A simple in-memory filesystem. Holds data in a javascript object.",
+      "main": "lib/MemoryFileSystem.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "mocha",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/memory-fs.git"
+      },
+      "keywords": [
+        "fs",
+        "memory"
+      ],
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/memory-fs/issues"
+      },
+      "homepage": "https://github.com/webpack/memory-fs",
+      "devDependencies": {
+        "bl": "^1.0.0",
+        "codecov.io": "^0.1.4",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "gitHead": "20dcd920d18c1dfa6501d95707fe7fdb6d30b725",
+      "_id": "memory-fs@0.3.0",
+      "_shasum": "7bcc6b629e3a43e871d7e29aca6ae8a7f15cbb20",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "7bcc6b629e3a43e871d7e29aca6ae8a7f15cbb20",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ]
+    },
+    "0.4.0": {
+      "name": "memory-fs",
+      "version": "0.4.0",
+      "description": "A simple in-memory filesystem. Holds data in a javascript object.",
+      "main": "lib/MemoryFileSystem.js",
+      "directories": {
+        "test": "test"
+      },
+      "files": [
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/memory-fs.git"
+      },
+      "keywords": [
+        "fs",
+        "memory"
+      ],
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/memory-fs/issues"
+      },
+      "homepage": "https://github.com/webpack/memory-fs",
+      "devDependencies": {
+        "bl": "^1.0.0",
+        "codecov.io": "^0.1.4",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "gitHead": "bca261622cb9b9bba136300faf87cf9b68b67326",
+      "_id": "memory-fs@0.4.0",
+      "_shasum": "364cb8c6716b5c646b78dbbcecf14989e9b14313",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "364cb8c6716b5c646b78dbbcecf14989e9b14313",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/memory-fs-0.4.0.tgz_1481041955780_0.8974502016790211"
+      }
+    },
+    "0.4.1": {
+      "name": "memory-fs",
+      "version": "0.4.1",
+      "description": "A simple in-memory filesystem. Holds data in a javascript object.",
+      "main": "lib/MemoryFileSystem.js",
+      "directories": {
+        "test": "test"
+      },
+      "files": [
+        "lib/"
+      ],
+      "scripts": {
+        "test": "mocha",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/memory-fs.git"
+      },
+      "keywords": [
+        "fs",
+        "memory"
+      ],
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/memory-fs/issues"
+      },
+      "homepage": "https://github.com/webpack/memory-fs",
+      "devDependencies": {
+        "bl": "^1.0.0",
+        "codecov.io": "^0.1.4",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "gitHead": "1b3c3572b47caa8b6d49b938456cfe180834f377",
+      "_id": "memory-fs@0.4.1",
+      "_shasum": "3a9a20b8462523e447cfbc7e8bb80ed667bfc552",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "3a9a20b8462523e447cfbc7e8bb80ed667bfc552",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/memory-fs-0.4.1.tgz_1481117480286_0.17684827325865626"
+      }
+    },
+    "0.5.0": {
+      "name": "memory-fs",
+      "version": "0.5.0",
+      "description": "A simple in-memory filesystem. Holds data in a javascript object.",
+      "main": "lib/MemoryFileSystem.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "mocha",
+        "lint": "eslint lib/*",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "engines": {
+        "node": ">=4.3.0 <5.0.0 || >=5.10"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/memory-fs.git"
+      },
+      "keywords": [
+        "fs",
+        "memory"
+      ],
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/memory-fs/issues"
+      },
+      "homepage": "https://github.com/webpack/memory-fs",
+      "devDependencies": {
+        "bl": "^1.0.0",
+        "codecov.io": "^0.1.4",
+        "coveralls": "^2.11.2",
+        "eslint": "^4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "3.2.0",
+        "should": "^4.0.4"
+      },
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "gitHead": "3daa18e010ac10b05a3ecaa6342406722a609109",
+      "_id": "memory-fs@0.5.0",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+        "shasum": "324c01288b88652966d161db77838720845a8e3c",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 15236,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdnH+QCRA9TVsSAnZWagAAxgAQAITMbXkDuGeAvUACNwQe\nxVUHQssPTu9dMAZ3aUvK/nP96euAFpgmTjgEbJz6MCdo3+ZlcWbMoTnB18Rc\nQECf3UiI3DJtwa6bkrznHtVXeg5b9ItG0n7ldLGb4eU+TzoxodBEtE9vEKZ2\nrlI3B8d3CudhGJOlCCV25E2u31zUN1071xCeWq7gbXxTuT/1HaTW+7t5cwTq\niywND1x2M9X2h3xGbDk3iShZexjaj5aC+m9fA+pZ/YqYnzzFRpOlxKGopy8A\n0jPT3k3Lzrr8NEtxLRE5v7MWcoeBm4EZ6FpfSt2vWuDIlW7VwpXxkahbv8uT\nHrjZLv57mecSyD1LwvX2S291NN6FLc2DhQx5W2QTCca6S21Vf5CtmKb3AY9L\nTYy7gODP4unusqxOHhZanrLHdWO84mDD7N7n9QjBpv2ueVp+b1jDiVqnMlhC\n+O2NWgRwvcn+iOxCgathl/V+bwD8AlA0ucjXEQpS4oY/mhqe21pRFzfjjSEo\nOM5aWImAz65pFEVB2hMX48CucRkYdyYdGsvPuOd8V3/Ofs+65gX9TS+EA3yQ\nJbWk6/y+zmOKXxZq89eAHbDdhJPLQf/f5sbPtkxJttO8t3Vv0FWM2ox9c02v\nsXsXgM5H/dXexOKFOFlu18RBZ+evLeiq0gBk2yCPaSPRI6pnQtOrI8lg1o3Y\nUKwO\r\n=KroS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/memory-fs_0.5.0_1570537359554_0.6422160851660237"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# memory-fs\n\nA simple in-memory filesystem. Holds data in a javascript object.\n\n``` javascript\nvar MemoryFileSystem = require(\"memory-fs\");\nvar fs = new MemoryFileSystem(); // Optionally pass a javascript object\n\nfs.mkdirpSync(\"/a/test/dir\");\nfs.writeFileSync(\"/a/test/dir/file.txt\", \"Hello World\");\nfs.readFileSync(\"/a/test/dir/file.txt\"); // returns Buffer(\"Hello World\")\n\n// Async variants too\nfs.unlink(\"/a/test/dir/file.txt\", function(err) {\n\t// ...\n});\n\nfs.readdirSync(\"/a/test\"); // returns [\"dir\"]\nfs.statSync(\"/a/test/dir\").isDirectory(); // returns true\nfs.rmdirSync(\"/a/test/dir\");\n\nfs.mkdirpSync(\"C:\\\\use\\\\windows\\\\style\\\\paths\");\n```\n\n## License\n\nCopyright (c) 2012-2014 Tobias Koppers\n\nMIT (http://www.opensource.org/licenses/mit-license.php)\n",
+  "maintainers": [
+    {
+      "name": "sokra",
+      "email": "tobias.koppers@googlemail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-10-08T12:22:44.247Z",
+    "created": "2014-07-01T06:32:03.241Z",
+    "0.1.0": "2014-07-01T06:32:03.241Z",
+    "0.1.1": "2014-12-22T08:17:34.797Z",
+    "0.2.0": "2015-01-16T22:41:46.796Z",
+    "0.3.0": "2015-11-04T23:06:21.535Z",
+    "0.4.0": "2016-12-06T16:32:37.743Z",
+    "0.4.1": "2016-12-07T13:31:22.497Z",
+    "0.5.0": "2019-10-08T12:22:39.687Z"
+  },
+  "homepage": "https://github.com/webpack/memory-fs",
+  "keywords": [
+    "fs",
+    "memory"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webpack/memory-fs.git"
+  },
+  "author": {
+    "name": "Tobias Koppers @sokra"
+  },
+  "bugs": {
+    "url": "https://github.com/webpack/memory-fs/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "rkielty": true,
+    "viz": true,
+    "yhui02": true,
+    "detj": true,
+    "itonyyo": true,
+    "wendellm": true,
+    "scottfreecode": true,
+    "xueboren": true,
+    "krofdrakula": true,
+    "stone_breaker": true,
+    "heartnett": true,
+    "bsara": true,
+    "cryogena": true,
+    "d-band": true,
+    "yeming": true,
+    "shuoshubao": true,
+    "wuxiaword": true,
+    "meeh": true,
+    "lunelson": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/memory-fs.min.json
+++ b/test/fixtures/registry-mocks/content/memory-fs.min.json
@@ -1,0 +1,157 @@
+{
+  "name": "memory-fs",
+  "dist-tags": {
+    "latest": "0.5.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "memory-fs",
+      "version": "0.1.0",
+      "devDependencies": {
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "247e51c6538d17d412222bd4d5a70c79d83081e8",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "memory-fs",
+      "version": "0.1.1",
+      "devDependencies": {
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "bec997e8654a29753206e3b921809869bec0e943",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.1.1.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "memory-fs",
+      "version": "0.2.0",
+      "devDependencies": {
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "f2bb25368bc121e391c2520de92969caee0a0290",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "memory-fs",
+      "version": "0.3.0",
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "devDependencies": {
+        "bl": "^1.0.0",
+        "codecov.io": "^0.1.4",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "7bcc6b629e3a43e871d7e29aca6ae8a7f15cbb20",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "memory-fs",
+      "version": "0.4.0",
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "devDependencies": {
+        "bl": "^1.0.0",
+        "codecov.io": "^0.1.4",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "364cb8c6716b5c646b78dbbcecf14989e9b14313",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.0.tgz"
+      }
+    },
+    "0.4.1": {
+      "name": "memory-fs",
+      "version": "0.4.1",
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "devDependencies": {
+        "bl": "^1.0.0",
+        "codecov.io": "^0.1.4",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.2.13",
+        "mocha": "^1.20.1",
+        "should": "^4.0.4"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "3a9a20b8462523e447cfbc7e8bb80ed667bfc552",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "memory-fs",
+      "version": "0.5.0",
+      "dependencies": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "devDependencies": {
+        "bl": "^1.0.0",
+        "codecov.io": "^0.1.4",
+        "coveralls": "^2.11.2",
+        "eslint": "^4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "3.2.0",
+        "should": "^4.0.4"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+        "shasum": "324c01288b88652966d161db77838720845a8e3c",
+        "tarball": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 15236,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdnH+QCRA9TVsSAnZWagAAxgAQAITMbXkDuGeAvUACNwQe\nxVUHQssPTu9dMAZ3aUvK/nP96euAFpgmTjgEbJz6MCdo3+ZlcWbMoTnB18Rc\nQECf3UiI3DJtwa6bkrznHtVXeg5b9ItG0n7ldLGb4eU+TzoxodBEtE9vEKZ2\nrlI3B8d3CudhGJOlCCV25E2u31zUN1071xCeWq7gbXxTuT/1HaTW+7t5cwTq\niywND1x2M9X2h3xGbDk3iShZexjaj5aC+m9fA+pZ/YqYnzzFRpOlxKGopy8A\n0jPT3k3Lzrr8NEtxLRE5v7MWcoeBm4EZ6FpfSt2vWuDIlW7VwpXxkahbv8uT\nHrjZLv57mecSyD1LwvX2S291NN6FLc2DhQx5W2QTCca6S21Vf5CtmKb3AY9L\nTYy7gODP4unusqxOHhZanrLHdWO84mDD7N7n9QjBpv2ueVp+b1jDiVqnMlhC\n+O2NWgRwvcn+iOxCgathl/V+bwD8AlA0ucjXEQpS4oY/mhqe21pRFzfjjSEo\nOM5aWImAz65pFEVB2hMX48CucRkYdyYdGsvPuOd8V3/Ofs+65gX9TS+EA3yQ\nJbWk6/y+zmOKXxZq89eAHbDdhJPLQf/f5sbPtkxJttO8t3Vv0FWM2ox9c02v\nsXsXgM5H/dXexOKFOFlu18RBZ+evLeiq0gBk2yCPaSPRI6pnQtOrI8lg1o3Y\nUKwO\r\n=KroS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.3.0 <5.0.0 || >=5.10"
+      }
+    }
+  },
+  "modified": "2019-10-08T12:22:44.247Z"
+}

--- a/test/fixtures/registry-mocks/content/merge-descriptors.json
+++ b/test/fixtures/registry-mocks/content/merge-descriptors.json
@@ -1,0 +1,427 @@
+{
+  "_id": "merge-descriptors",
+  "_rev": "72-f8cb24ba4219325106ae367e29330012",
+  "name": "merge-descriptors",
+  "description": "Merge objects using descriptors",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "merge-descriptors",
+      "description": "Merge objects using descriptors",
+      "version": "0.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonathanong/merge-descriptors.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonathanong/merge-descriptors/issues"
+      },
+      "scripts": {
+        "test": "make test;"
+      },
+      "homepage": "https://github.com/jonathanong/merge-descriptors",
+      "_id": "merge-descriptors@0.0.1",
+      "dist": {
+        "shasum": "2ff0980c924cf81d0b5d1fb601177cb8bb56c0d0",
+        "tarball": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.13",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "merge-descriptors",
+      "description": "Merge objects using descriptors",
+      "version": "0.0.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/merge-descriptors.git"
+      },
+      "bugs": {
+        "url": "https://github.com/component/merge-descriptors/issues"
+      },
+      "scripts": {
+        "test": "make test;"
+      },
+      "homepage": "https://github.com/component/merge-descriptors",
+      "_id": "merge-descriptors@0.0.2",
+      "dist": {
+        "shasum": "c36a52a781437513c57275f39dd9d317514ac8c7",
+        "tarball": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "merge-descriptors",
+      "description": "Merge objects using descriptors",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/merge-descriptors.git"
+      },
+      "bugs": {
+        "url": "https://github.com/component/merge-descriptors/issues"
+      },
+      "files": [
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "gitHead": "81d7a3c14099884c391bd237d7d8edf23c6d6f18",
+      "homepage": "https://github.com/component/merge-descriptors",
+      "_id": "merge-descriptors@1.0.0",
+      "scripts": {},
+      "_shasum": "2169cf7538e1b0cc87fb88e1502d8474bbf79864",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2169cf7538e1b0cc87fb88e1502d8474bbf79864",
+        "tarball": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "merge-descriptors",
+      "description": "Merge objects using descriptors",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Mike Grabowski",
+          "email": "grabbou@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/merge-descriptors"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "f26c49c3b423b0b2ac31f6e32a84e1632f2d7ac2",
+      "bugs": {
+        "url": "https://github.com/component/merge-descriptors/issues"
+      },
+      "homepage": "https://github.com/component/merge-descriptors",
+      "_id": "merge-descriptors@1.0.1",
+      "_shasum": "b00aaa556dd8b44568150ec9d1b953f3f90cbb61",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b00aaa556dd8b44568150ec9d1b953f3f90cbb61",
+        "tarball": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# Merge Descriptors\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nMerge objects using descriptors.\n\n```js\nvar thing = {\n  get name() {\n    return 'jon'\n  }\n}\n\nvar animal = {\n\n}\n\nmerge(animal, thing)\n\nanimal.name === 'jon'\n```\n\n## API\n\n### merge(destination, source)\n\nRedefines `destination`'s descriptors with `source`'s.\n\n### merge(destination, source, false)\n\nDefines `source`'s descriptors on `destination` if `destination` does not have\na descriptor by the same name.\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/merge-descriptors.svg\n[npm-url]: https://npmjs.org/package/merge-descriptors\n[travis-image]: https://img.shields.io/travis/component/merge-descriptors/master.svg\n[travis-url]: https://travis-ci.org/component/merge-descriptors\n[coveralls-image]: https://img.shields.io/coveralls/component/merge-descriptors/master.svg\n[coveralls-url]: https://coveralls.io/r/component/merge-descriptors?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/merge-descriptors.svg\n[downloads-url]: https://npmjs.org/package/merge-descriptors\n",
+  "maintainers": [
+    {
+      "email": "julian@juliangruber.com",
+      "name": "juliangruber"
+    },
+    {
+      "email": "tj@vision-media.ca",
+      "name": "tjholowaychuk"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jonathanong"
+    },
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    }
+  ],
+  "time": {
+    "modified": "2018-01-05T19:10:02.085Z",
+    "created": "2013-10-29T20:29:05.974Z",
+    "0.0.1": "2013-10-29T20:29:06.954Z",
+    "0.0.2": "2013-12-14T05:10:12.691Z",
+    "1.0.0": "2015-03-01T21:30:01.609Z",
+    "1.0.1": "2016-01-17T23:50:26.636Z"
+  },
+  "author": {
+    "name": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/component/merge-descriptors"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/component/merge-descriptors",
+  "bugs": {
+    "url": "https://github.com/component/merge-descriptors/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "fatelei": true,
+    "simplyianm": true,
+    "wangnan0610": true,
+    "joshperry": true,
+    "nanhualyq": true,
+    "liushoukai": true,
+    "aitorllj93": true,
+    "456wyc": true,
+    "xu_q90": true,
+    "mojaray2k": true,
+    "magicxiao": true,
+    "leonzhao": true,
+    "duartemendes": true,
+    "ghettovoice": true,
+    "kodekracker": true,
+    "bhaskarmelkani": true,
+    "damon.huang": true,
+    "srksumanth": true
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Mike Grabowski",
+      "email": "grabbou@gmail.com"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/merge-descriptors.min.json
+++ b/test/fixtures/registry-mocks/content/merge-descriptors.min.json
@@ -1,0 +1,45 @@
+{
+  "name": "merge-descriptors",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "merge-descriptors",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "2ff0980c924cf81d0b5d1fb601177cb8bb56c0d0",
+        "tarball": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "merge-descriptors",
+      "version": "0.0.2",
+      "dist": {
+        "shasum": "c36a52a781437513c57275f39dd9d317514ac8c7",
+        "tarball": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "merge-descriptors",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "2169cf7538e1b0cc87fb88e1502d8474bbf79864",
+        "tarball": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "merge-descriptors",
+      "version": "1.0.1",
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "b00aaa556dd8b44568150ec9d1b953f3f90cbb61",
+        "tarball": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2018-01-05T19:10:02.085Z"
+}

--- a/test/fixtures/registry-mocks/content/methods.json
+++ b/test/fixtures/registry-mocks/content/methods.json
@@ -1,0 +1,481 @@
+{
+  "_id": "methods",
+  "_rev": "40-3c86375a6f51b1ac3c7bb6ed5477d00a",
+  "name": "methods",
+  "description": "HTTP methods that node supports",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "methods",
+      "version": "0.0.1",
+      "description": "HTTP methods that node supports",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "keywords": [
+        "http",
+        "methods"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk"
+      },
+      "license": "MIT",
+      "_id": "methods@0.0.1",
+      "dist": {
+        "shasum": "277c90f8bef39709645a8371c51c3b6c648e068c",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "methods",
+      "version": "0.1.0",
+      "description": "HTTP methods that node supports",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "keywords": [
+        "http",
+        "methods"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/node-methods.git"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-methods/issues"
+      },
+      "_id": "methods@0.1.0",
+      "dist": {
+        "shasum": "335d429eefd21b7bacf2e9c922a8d2bd14a30e4f",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "methods",
+      "version": "1.0.0",
+      "description": "HTTP methods that node supports",
+      "main": "index.js",
+      "scripts": {
+        "test": "./node_modules/mocha/bin/mocha"
+      },
+      "keywords": [
+        "http",
+        "methods"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/node-methods.git"
+      },
+      "devDependencies": {
+        "mocha": "1.17.x"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-methods/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-methods",
+      "_id": "methods@1.0.0",
+      "dist": {
+        "shasum": "9a73d86375dfcef26ef61ca3e4b8a2e2538a80e3",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "methods",
+      "version": "1.0.1",
+      "description": "HTTP methods that node supports",
+      "main": "index.js",
+      "scripts": {
+        "test": "./node_modules/mocha/bin/mocha"
+      },
+      "keywords": [
+        "http",
+        "methods"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/node-methods.git"
+      },
+      "devDependencies": {
+        "mocha": "1.17.x"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-methods/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-methods",
+      "_id": "methods@1.0.1",
+      "dist": {
+        "shasum": "75bc91943dffd7da037cf3eeb0ed73a0037cd14b",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "methods",
+      "version": "1.1.0",
+      "description": "HTTP methods that node supports",
+      "main": "index.js",
+      "scripts": {
+        "test": "./node_modules/mocha/bin/mocha"
+      },
+      "keywords": [
+        "http",
+        "methods"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/node-methods.git"
+      },
+      "devDependencies": {
+        "mocha": "1.17.x"
+      },
+      "gitHead": "2a4dd325d18436c33356e6be19e32e08a7c877ab",
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-methods/issues"
+      },
+      "homepage": "https://github.com/visionmedia/node-methods",
+      "_id": "methods@1.1.0",
+      "_shasum": "5dca4ee12df52ff3b056145986a8f01cbc86436f",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5dca4ee12df52ff3b056145986a8f01cbc86436f",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "methods",
+      "description": "HTTP methods that node supports",
+      "version": "1.1.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca",
+          "url": "http://tjholowaychuk.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/methods"
+      },
+      "devDependencies": {
+        "istanbul": "0.3",
+        "mocha": "1"
+      },
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "browser": {
+        "http": false
+      },
+      "keywords": [
+        "http",
+        "methods"
+      ],
+      "gitHead": "6293c6b27c5fb963acf67a347af80ad2ebd7247f",
+      "bugs": {
+        "url": "https://github.com/jshttp/methods/issues"
+      },
+      "homepage": "https://github.com/jshttp/methods",
+      "_id": "methods@1.1.1",
+      "_shasum": "17ea6366066d00c58e375b8ec7dfd0453c89822a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "17ea6366066d00c58e375b8ec7dfd0453c89822a",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "methods",
+      "description": "HTTP methods that node supports",
+      "version": "1.1.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        },
+        {
+          "name": "TJ Holowaychuk",
+          "email": "tj@vision-media.ca",
+          "url": "http://tjholowaychuk.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/methods"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "index.js",
+        "HISTORY.md",
+        "LICENSE"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "browser": {
+        "http": false
+      },
+      "keywords": [
+        "http",
+        "methods"
+      ],
+      "gitHead": "25d257d913f1b94bd2d73581521ff72c81469140",
+      "bugs": {
+        "url": "https://github.com/jshttp/methods/issues"
+      },
+      "homepage": "https://github.com/jshttp/methods",
+      "_id": "methods@1.1.2",
+      "_shasum": "5529a4d67654134edcc5266656835b0f851afcee",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5529a4d67654134edcc5266656835b0f851afcee",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# Methods\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nHTTP verbs that Node.js core's HTTP parser supports.\n\nThis module provides an export that is just like `http.METHODS` from Node.js core,\nwith the following differences:\n\n  * All method names are lower-cased.\n  * Contains a fallback list of methods for Node.js versions that do not have a\n    `http.METHODS` export (0.10 and lower).\n  * Provides the fallback list when using tools like `browserify` without pulling\n    in the `http` shim module.\n\n## Install\n\n```bash\n$ npm install methods\n```\n\n## API\n\n```js\nvar methods = require('methods')\n```\n\n### methods\n\nThis is an array of lower-cased method names that Node.js supports. If Node.js\nprovides the `http.METHODS` export, then this is the same array lower-cased,\notherwise it is a snapshot of the verbs from Node.js 0.10.\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/methods.svg?style=flat\n[npm-url]: https://npmjs.org/package/methods\n[node-version-image]: https://img.shields.io/node/v/methods.svg?style=flat\n[node-version-url]: https://nodejs.org/en/download/\n[travis-image]: https://img.shields.io/travis/jshttp/methods.svg?style=flat\n[travis-url]: https://travis-ci.org/jshttp/methods\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/methods.svg?style=flat\n[coveralls-url]: https://coveralls.io/r/jshttp/methods?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/methods.svg?style=flat\n[downloads-url]: https://npmjs.org/package/methods\n",
+  "maintainers": [
+    {
+      "email": "tj@vision-media.ca",
+      "name": "tjholowaychuk"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jonathanong"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    },
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    }
+  ],
+  "time": {
+    "modified": "2018-01-19T08:49:26.551Z",
+    "created": "2012-06-26T18:34:52.941Z",
+    "0.0.1": "2012-06-26T18:35:02.616Z",
+    "0.1.0": "2013-10-28T19:02:02.097Z",
+    "1.0.0": "2014-05-08T19:17:32.955Z",
+    "1.0.1": "2014-06-02T14:26:09.655Z",
+    "1.1.0": "2014-07-06T02:45:33.027Z",
+    "1.1.1": "2014-12-30T23:51:21.181Z",
+    "1.1.2": "2016-01-18T02:53:56.364Z"
+  },
+  "users": {
+    "m42am": true,
+    "zhangyaochun": true,
+    "simplyianm": true,
+    "moimikey": true,
+    "junjiansyu": true,
+    "nketchum": true,
+    "pgilad": true,
+    "nickeltobias": true,
+    "tobiasnickel": true,
+    "monjer": true,
+    "wangnan0610": true,
+    "yangjiyuan": true,
+    "mojaray2k": true,
+    "daizch": true,
+    "leonzhao": true,
+    "semir2": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jshttp/methods"
+  },
+  "homepage": "https://github.com/jshttp/methods",
+  "keywords": [
+    "http",
+    "methods"
+  ],
+  "bugs": {
+    "url": "https://github.com/jshttp/methods/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    },
+    {
+      "name": "TJ Holowaychuk",
+      "email": "tj@vision-media.ca",
+      "url": "http://tjholowaychuk.com"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/methods.min.json
+++ b/test/fixtures/registry-mocks/content/methods.min.json
@@ -1,0 +1,88 @@
+{
+  "name": "methods",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "methods",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "277c90f8bef39709645a8371c51c3b6c648e068c",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "methods",
+      "version": "0.1.0",
+      "dist": {
+        "shasum": "335d429eefd21b7bacf2e9c922a8d2bd14a30e4f",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-0.1.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "methods",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "1.17.x"
+      },
+      "dist": {
+        "shasum": "9a73d86375dfcef26ef61ca3e4b8a2e2538a80e3",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "methods",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "1.17.x"
+      },
+      "dist": {
+        "shasum": "75bc91943dffd7da037cf3eeb0ed73a0037cd14b",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "methods",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "1.17.x"
+      },
+      "dist": {
+        "shasum": "5dca4ee12df52ff3b056145986a8f01cbc86436f",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "methods",
+      "version": "1.1.1",
+      "devDependencies": {
+        "istanbul": "0.3",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "17ea6366066d00c58e375b8ec7dfd0453c89822a",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.2": {
+      "name": "methods",
+      "version": "1.1.2",
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "5529a4d67654134edcc5266656835b0f851afcee",
+        "tarball": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2018-01-19T08:49:26.551Z"
+}

--- a/test/fixtures/registry-mocks/content/miller-rabin.json
+++ b/test/fixtures/registry-mocks/content/miller-rabin.json
@@ -1,0 +1,884 @@
+{
+  "_id": "miller-rabin",
+  "_rev": "27-5e4af894ce3bc793fe08554b2a2ef730",
+  "name": "miller-rabin",
+  "description": "Miller Rabin algorithm for primality test",
+  "dist-tags": {
+    "latest": "4.0.1"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "miller-rabin",
+      "version": "1.0.1",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "fe668a3fd8cd4298f4b787ba190ead79eefb3116",
+      "_id": "miller-rabin@1.0.1",
+      "_shasum": "48574c577dc24b6ea81cdeb9608840654914962d",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "48574c577dc24b6ea81cdeb9608840654914962d",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "miller-rabin",
+      "version": "1.0.2",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "4a4b1ad8bfa22d262483a67eede00d8d8e9ddbd8",
+      "_id": "miller-rabin@1.0.2",
+      "_shasum": "34602db18c558ba2bb24e30cf5f557e249e34a69",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "34602db18c558ba2bb24e30cf5f557e249e34a69",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "miller-rabin",
+      "version": "1.0.3",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "be0185a44f6afa1991426190ac57386bfc91b799",
+      "_id": "miller-rabin@1.0.3",
+      "_shasum": "7f6c150162cd5e0fd51b9546efddcebaed32ee22",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7f6c150162cd5e0fd51b9546efddcebaed32ee22",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "miller-rabin",
+      "version": "1.1.0",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "d7777bf50806bc02356b59e0f5ce138cdc06bbce",
+      "_id": "miller-rabin@1.1.0",
+      "_shasum": "dfae54be0eb03c2d24ba5bc9612aced3d0a2c5fa",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dfae54be0eb03c2d24ba5bc9612aced3d0a2c5fa",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "miller-rabin",
+      "version": "1.1.1",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "59a943d51ac42931afc3cfc202c443bb39468c62",
+      "_id": "miller-rabin@1.1.1",
+      "_shasum": "00e5be11698e846d7a5a185c5eced425f4379cd5",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "00e5be11698e846d7a5a185c5eced425f4379cd5",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "miller-rabin",
+      "version": "1.1.2",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "bn.js": "^0.16.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "cf572e9ae6004c5600155247eacbb4ed05784d45",
+      "_id": "miller-rabin@1.1.2",
+      "_shasum": "74b9437667b881257b86bf1354cb9ed4231d65c0",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "74b9437667b881257b86bf1354cb9ed4231d65c0",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "miller-rabin",
+      "version": "1.1.3",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "9a7cf7a7d9615a9acbe0fae5384bbd2bdcb96373",
+      "_id": "miller-rabin@1.1.3",
+      "_shasum": "8344ae79438781e215adb97589ef1a6ca7432065",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8344ae79438781e215adb97589ef1a6ca7432065",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "miller-rabin",
+      "version": "1.1.4",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "bacc26fed177a32ceef0b92501de96531fd3538e",
+      "_id": "miller-rabin@1.1.4",
+      "_shasum": "6d8268400e454a347566154c092e6f5627693f37",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6d8268400e454a347566154c092e6f5627693f37",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "miller-rabin",
+      "version": "1.1.5",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/miller-rabin"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "9230dc7d45ba47a7a0a639a56f990ec741fcdd79",
+      "_id": "miller-rabin@1.1.5",
+      "_shasum": "41f506bed994b97e7c184a658ae107dad980526e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "41f506bed994b97e7c184a658ae107dad980526e",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "miller-rabin",
+      "version": "2.0.0",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/miller-rabin.git"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "399935419a163ea0107f9a7328ffff3577627e07",
+      "_id": "miller-rabin@2.0.0",
+      "_shasum": "b6fa65e66064affde1b20b06514964b03f7e3c93",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "1.8.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b6fa65e66064affde1b20b06514964b03f7e3c93",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "miller-rabin",
+      "version": "2.0.1",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/miller-rabin.git"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "ec5836de2a565211217d0531639d70cb4bca6ec3",
+      "_id": "miller-rabin@2.0.1",
+      "_shasum": "8c0e07fef1bc24900a78895434d39ce4024d4648",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "1.8.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8c0e07fef1bc24900a78895434d39ce4024d4648",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "miller-rabin",
+      "version": "3.0.0",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/miller-rabin.git"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": "^3.1.1",
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "ce1b20a2c03e778317f041e7c827af19e574aece",
+      "_id": "miller-rabin@3.0.0",
+      "_shasum": "a95d38440e4e4f792f24afdb51e7a2e765051f3d",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.5.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a95d38440e4e4f792f24afdb51e7a2e765051f3d",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "miller-rabin",
+      "version": "4.0.0",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/miller-rabin.git"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "94b56df9948a1ae592b331afc9559115f3f98fb2",
+      "_id": "miller-rabin@4.0.0",
+      "_shasum": "4a62fb1d42933c05583982f4c716f6fb9e6c6d3d",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "4a62fb1d42933c05583982f4c716f6fb9e6c6d3d",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.1": {
+      "name": "miller-rabin",
+      "version": "4.0.1",
+      "description": "Miller Rabin algorithm for primality test",
+      "main": "lib/mr.js",
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "scripts": {
+        "test": "mocha --reporter=spec test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/miller-rabin.git"
+      },
+      "keywords": [
+        "prime",
+        "miller-rabin",
+        "bignumber"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/miller-rabin/issues"
+      },
+      "homepage": "https://github.com/indutny/miller-rabin",
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "gitHead": "bda17a34d3b33a84a0dbb120ff7f662adea05c01",
+      "_id": "miller-rabin@4.0.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+        "shasum": "f080351c865b0dc562a8462966daa53543c78a4d",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/miller-rabin-4.0.1.tgz_1506550159594_0.8133998683188111"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# Miller-Rabin\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2014.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    },
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-09-27T22:09:20.513Z",
+    "created": "2014-11-05T17:33:19.500Z",
+    "1.0.1": "2014-11-05T17:33:19.500Z",
+    "1.0.2": "2014-11-07T09:49:50.557Z",
+    "1.0.3": "2014-11-07T13:22:05.787Z",
+    "1.1.0": "2014-11-07T14:55:08.026Z",
+    "1.1.1": "2014-11-07T15:10:54.670Z",
+    "1.1.2": "2015-01-02T11:39:58.012Z",
+    "1.1.3": "2015-01-02T16:51:29.402Z",
+    "1.1.4": "2015-01-02T16:53:34.041Z",
+    "1.1.5": "2015-01-05T21:04:57.138Z",
+    "2.0.0": "2015-04-27T09:23:20.946Z",
+    "2.0.1": "2015-04-27T09:28:12.172Z",
+    "2.1.0": "2015-07-28T02:24:52.033Z",
+    "3.0.0": "2015-08-13T11:42:39.666Z",
+    "4.0.0": "2015-10-28T21:08:41.282Z",
+    "4.0.1": "2017-09-27T22:09:20.513Z"
+  },
+  "homepage": "https://github.com/indutny/miller-rabin",
+  "keywords": [
+    "prime",
+    "miller-rabin",
+    "bignumber"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/miller-rabin.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/miller-rabin/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "detj": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/miller-rabin.min.json
+++ b/test/fixtures/registry-mocks/content/miller-rabin.min.json
@@ -1,0 +1,256 @@
+{
+  "name": "miller-rabin",
+  "dist-tags": {
+    "latest": "4.0.1"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "miller-rabin",
+      "version": "1.0.1",
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dist": {
+        "shasum": "48574c577dc24b6ea81cdeb9608840654914962d",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "miller-rabin",
+      "version": "1.0.2",
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dist": {
+        "shasum": "34602db18c558ba2bb24e30cf5f557e249e34a69",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "miller-rabin",
+      "version": "1.0.3",
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dist": {
+        "shasum": "7f6c150162cd5e0fd51b9546efddcebaed32ee22",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.0.3.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "miller-rabin",
+      "version": "1.1.0",
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dist": {
+        "shasum": "dfae54be0eb03c2d24ba5bc9612aced3d0a2c5fa",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "miller-rabin",
+      "version": "1.1.1",
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dist": {
+        "shasum": "00e5be11698e846d7a5a185c5eced425f4379cd5",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "miller-rabin",
+      "version": "1.1.2",
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "bn.js": "^0.16.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.16.0"
+      },
+      "dist": {
+        "shasum": "74b9437667b881257b86bf1354cb9ed4231d65c0",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "miller-rabin",
+      "version": "1.1.3",
+      "dependencies": {
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "bn.js": "^0.15.0",
+        "mocha": "^2.0.1"
+      },
+      "peerDependencies": {
+        "bn.js": "^0.15.0"
+      },
+      "dist": {
+        "shasum": "8344ae79438781e215adb97589ef1a6ca7432065",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.3.tgz"
+      }
+    },
+    "1.1.4": {
+      "name": "miller-rabin",
+      "version": "1.1.4",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "6d8268400e454a347566154c092e6f5627693f37",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.4.tgz"
+      }
+    },
+    "1.1.5": {
+      "name": "miller-rabin",
+      "version": "1.1.5",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "41f506bed994b97e7c184a658ae107dad980526e",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-1.1.5.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "miller-rabin",
+      "version": "2.0.0",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "dist": {
+        "shasum": "b6fa65e66064affde1b20b06514964b03f7e3c93",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "miller-rabin",
+      "version": "2.0.1",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "dist": {
+        "shasum": "8c0e07fef1bc24900a78895434d39ce4024d4648",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-2.0.1.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "miller-rabin",
+      "version": "3.0.0",
+      "dependencies": {
+        "bn.js": "^3.1.1",
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "dist": {
+        "shasum": "a95d38440e4e4f792f24afdb51e7a2e765051f3d",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-3.0.0.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "miller-rabin",
+      "version": "4.0.0",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "dist": {
+        "shasum": "4a62fb1d42933c05583982f4c716f6fb9e6c6d3d",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
+      }
+    },
+    "4.0.1": {
+      "name": "miller-rabin",
+      "version": "4.0.1",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "devDependencies": {
+        "mocha": "^2.0.1"
+      },
+      "bin": {
+        "miller-rabin": "bin/miller-rabin"
+      },
+      "dist": {
+        "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+        "shasum": "f080351c865b0dc562a8462966daa53543c78a4d",
+        "tarball": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2017-09-27T22:09:20.513Z"
+}

--- a/test/fixtures/registry-mocks/content/mime.json
+++ b/test/fixtures/registry-mocks/content/mime.json
@@ -1,0 +1,2935 @@
+{
+  "_id": "mime",
+  "_rev": "257-1abb0bb57a6b230cf472636fc7d9009c",
+  "name": "mime",
+  "description": "A comprehensive library for mime-type mapping",
+  "dist-tags": {
+    "latest": "2.4.6"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "mime",
+      "description": "A super simple utility library for dealing with mime-types",
+      "url": "http://github.com/bentomas/node-mime",
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "author": {
+        "name": "Benjamin Thomas",
+        "email": "benjamin@benjaminthomas.org"
+      },
+      "contributors": [],
+      "dependencies": {},
+      "lib": ".",
+      "main": "mime",
+      "version": "1.0.0",
+      "_id": "mime@1.0.0",
+      "engines": {
+        "node": "*"
+      },
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.0.0.tgz",
+        "shasum": "0650d4779569617b3ee8bec7b8b7522e74af05be"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "mime",
+      "description": "A super simple utility library for dealing with mime-types",
+      "url": "http://github.com/bentomas/node-mime",
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "author": {
+        "name": "Benjamin Thomas",
+        "email": "benjamin@benjaminthomas.org"
+      },
+      "contributors": [],
+      "dependencies": {},
+      "lib": ".",
+      "main": "mime",
+      "version": "1.1.0",
+      "_id": "mime@1.1.0",
+      "engines": {
+        "node": "*"
+      },
+      "_nodeSupported": true,
+      "_npmVersion": "0.2.7-2",
+      "_nodeVersion": "v0.3.1-pre",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.1.0.tgz",
+        "shasum": "a067f5be8a6c9eeb83f3733c8c22dd142a603add"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "mime",
+      "description": "A comprehensive library for mime-type mapping",
+      "url": "http://github.com/bentomas/node-mime",
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "author": {
+        "name": "Benjamin Thomas",
+        "email": "benjamin@benjaminthomas.org"
+      },
+      "contributors": [],
+      "dependencies": {},
+      "lib": ".",
+      "main": "mime",
+      "version": "1.2.1",
+      "_id": "mime@1.2.1",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "0.2.16",
+      "_nodeVersion": "v0.3.1",
+      "directories": {},
+      "modules": {
+        "README.md": "README.md",
+        "index.js": "index.js",
+        "package.json": "package.json",
+        "mime.js": "mime.js",
+        "node.types": "node.types",
+        "mime.types": "mime.types",
+        "test.js": "test.js"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "9876d4db9491091d154288a32893564839b8e04e",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "mime",
+      "description": "A comprehensive library for mime-type mapping",
+      "url": "http://github.com/bentomas/node-mime",
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "author": {
+        "name": "Benjamin Thomas",
+        "email": "benjamin@benjaminthomas.org"
+      },
+      "contributors": [],
+      "dependencies": {},
+      "lib": ".",
+      "main": "mime.js",
+      "version": "1.2.2",
+      "devDependencies": {},
+      "_id": "mime@1.2.2",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.6",
+      "_nodeVersion": "v0.4.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "b9d6355bf53e8d7d56693130e451daff340148cf",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.2.tgz"
+      },
+      "scripts": {},
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "mime",
+      "description": "A comprehensive library for mime-type mapping",
+      "url": "http://github.com/bentomas/node-mime",
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "author": {
+        "name": "Benjamin Thomas",
+        "email": "benjamin@benjaminthomas.org"
+      },
+      "contributors": [],
+      "dependencies": {},
+      "lib": ".",
+      "main": "mime.js",
+      "version": "1.2.3",
+      "_npmJsonOpts": {
+        "file": "/home/kieffer/.npm/mime/1.2.3/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "mime@1.2.3",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.27",
+      "_nodeVersion": "v0.4.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "7717bad7444f42d0c7d98cdc2a7b20068f837b68",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.4": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {},
+      "description": "A comprehensive library for mime-type mapping",
+      "devDependencies": {
+        "async_testing": ""
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git://github.com/bentomas/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.2.4",
+      "_npmJsonOpts": {
+        "file": "/home/kieffer/.npm/mime/1.2.4/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "mime@1.2.4",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.27",
+      "_nodeVersion": "v0.4.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "11b5fdaf29c2509255176b80ad520294f5de92b7",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.5": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {},
+      "description": "A comprehensive library for mime-type mapping",
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git://github.com/bentomas/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.2.5",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "_id": "mime@1.2.5",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "9eed073022a8bf5e16c8566c6867b8832bfbfa13",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.6": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {},
+      "description": "A comprehensive library for mime-type mapping",
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.2.6",
+      "_npmUser": {
+        "name": "bentomas",
+        "email": "benjamin@benjaminthomas.org"
+      },
+      "_id": "mime@1.2.6",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.12",
+      "_nodeVersion": "v0.6.14",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "b1f86c768c025fa87b48075f1709f28aeaf20365",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.7": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {},
+      "description": "A comprehensive library for mime-type mapping",
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.2.7",
+      "_id": "mime@1.2.7",
+      "dist": {
+        "shasum": "c7a13f33a7073d9900f288436b06b3a16200865b",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.8": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {},
+      "description": "A comprehensive library for mime-type mapping",
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.2.8",
+      "_id": "mime@1.2.8",
+      "dist": {
+        "shasum": "59178be248b0e06df58f6e04db3c8ee30084e110",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.9": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {},
+      "description": "A comprehensive library for mime-type mapping",
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.2.9",
+      "_id": "mime@1.2.9",
+      "dist": {
+        "shasum": "009cd40867bd35de521b3b966f04e2f8d4d13d09",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.10": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {},
+      "description": "A comprehensive library for mime-type mapping",
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.2.10",
+      "_id": "mime@1.2.10",
+      "dist": {
+        "shasum": "066380acbc3d78d4f4a51004d8988425dc68b9b1",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.11": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {},
+      "description": "A comprehensive library for mime-type mapping",
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.2.11",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "_id": "mime@1.2.11",
+      "dist": {
+        "shasum": "58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "scripts": {
+        "install": "node build/build.js > types.json",
+        "test": "node build/test.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {
+        "mime-db": "^1.2.0"
+      },
+      "description": "A comprehensive library for mime-type mapping",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://raw.github.com/broofa/node-mime/master/LICENSE"
+        }
+      ],
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.3.0",
+      "gitHead": "2e177718416ed104343446a5eec9861092650aab",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime",
+      "_id": "mime@1.3.0",
+      "_shasum": "447c1ac7a6e4df33e3eebf13419bd736f99067f0",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "shasum": "447c1ac7a6e4df33e3eebf13419bd736f99067f0",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.2": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "scripts": {
+        "install": "node build/build.js > types.json",
+        "test": "node build/test.js"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "dependencies": {
+        "mime-db": "^1.2.0"
+      },
+      "description": "A comprehensive library for mime-type mapping",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://raw.github.com/broofa/node-mime/master/LICENSE"
+        }
+      ],
+      "devDependencies": {},
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.3.2",
+      "gitHead": "ab8f0ab3c8139b849b2caca107553643766f0bc9",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime",
+      "_id": "mime@1.3.2",
+      "_shasum": "10d5293d23d8d4086cd2666a936477a49764c3bf",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "shasum": "10d5293d23d8d4086cd2666a936477a49764c3bf",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.3": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "scripts": {
+        "prepublish": "node build/build.js > types.json",
+        "test": "node build/test.js"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://raw.github.com/broofa/node-mime/master/LICENSE"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mime-db": "^1.2.0"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.3.3",
+      "gitHead": "a80fa147ce33a6ee23336542ff855fa5b3036e07",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime",
+      "_id": "mime@1.3.3",
+      "_shasum": "6b681b6c0c0f6b41aec7eb5ced09f43fc81d6caf",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "shasum": "6b681b6c0c0f6b41aec7eb5ced09f43fc81d6caf",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.4": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "scripts": {
+        "prepublish": "node build/build.js > types.json",
+        "test": "node build/test.js"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://raw.github.com/broofa/node-mime/master/LICENSE"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mime-db": "^1.2.0"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "https://github.com/broofa/node-mime",
+        "type": "git"
+      },
+      "version": "1.3.4",
+      "gitHead": "1628f6e0187095009dcef4805c3a49706f137974",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime",
+      "_id": "mime@1.3.4",
+      "_shasum": "115f9e3b6b3daf2959983cb38f149a2d40eb5d53",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "shasum": "115f9e3b6b3daf2959983cb38f149a2d40eb5d53",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.5": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "mime-db": "^1.22.0"
+      },
+      "scripts": {
+        "prepare": "node build/build.js > types.json",
+        "test": "node build/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.3.5",
+      "gitHead": "902ec070313fd40c9a8135ef4ef401f8a1db9472",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@1.3.5",
+      "_shasum": "dc1ee70b80fee4999cb0775c9f94beefc9a779a3",
+      "_from": ".",
+      "_npmVersion": "4.3.0",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "shasum": "dc1ee70b80fee4999cb0775c9f94beefc9a779a3",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/mime-1.3.5.tgz_1494526697656_0.34659774391911924"
+      },
+      "deprecated": "Breaks custom overrides.  Upgrade to v1.3.6",
+      "directories": {}
+    },
+    "1.3.6": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "mime-db": "^1.22.0"
+      },
+      "scripts": {
+        "prepublish": "node build/build.js > types.json",
+        "test": "node build/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.3.6",
+      "gitHead": "78aa9df74925ee629b9f2c35ec16b099189e9cef",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@1.3.6",
+      "_shasum": "591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0",
+      "_from": ".",
+      "_npmVersion": "4.3.0",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "shasum": "591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/mime-1.3.6.tgz_1494565179088_0.4127067362423986"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "mime-db": "1.30.0"
+      },
+      "scripts": {
+        "prepublish": "node build/build.js > types.json",
+        "test": "node build/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.4.0",
+      "gitHead": "ccbac35bf6c2edfe84e3befbed899e171cb9a6b2",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@1.4.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ==",
+        "shasum": "69e9e0db51d44f2a3b56e48b7817d7d137f1a343",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-1.4.0.tgz_1503936302287_0.8870804917532951"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "0.1.8"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && gren --action=changelog && runmd --output README.md src/README_js.md",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.0.0",
+      "gitHead": "404b573239557eb266501eb70106efa04217a96f",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.0.0",
+      "_shasum": "e58e03970e44e57ed1394893b07e6312f71925e3",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.3",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "shasum": "e58e03970e44e57ed1394893b07e6312f71925e3",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-2.0.0.tgz_1505261064172_0.8468218639027327"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "0.1.8"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && gren --action=changelog && runmd --output README.md src/README_js.md",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.0.1",
+      "gitHead": "a52b627ec9b867e8ae6b8595309b343e7d070df0",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.0.1",
+      "_npmVersion": "5.4.1",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-n2tQ4rs2+GMucMG2YHTwaONXZ/31ZS/vseUOzK5mTecwE91c33tapG51M0kB2R30hi7sY5nKvIkLCdCgUzx6FQ==",
+        "shasum": "73dd0bc6a678836cc8322db5d8e4c3e6f3c06471",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-2.0.1.tgz_1505339730502_0.12810324365273118"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "0.1.8"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "changelog": "gren --action=changelog --tags=all --generate",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.0.2",
+      "gitHead": "4a375abebfa3900921217daa270302e01a1c67ae",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.0.2",
+      "_npmVersion": "5.4.1",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-Oy3+E5KrKoJ99krrYGn+u6jkCEdyFiZX2plVzbuuGLWo5X5K2Oej0KcbF1vHsrB7WFPMSaNqfHjJ6ksLT6kxSg==",
+        "shasum": "097fd2c88c652eae48b2702d7cbf54c08d8ef50a",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-2.0.2.tgz_1505733954150_0.4373962297104299"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "mime-db": "1.30.0"
+      },
+      "scripts": {
+        "prepublish": "node build/build.js > types.json",
+        "test": "node build/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.4.1",
+      "gitHead": "eb24bae372a76acd2c95fd05f8837814c33a9e3d",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@1.4.1",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+        "shasum": "121f9ebc49e3766f311a76e1fa1c8003c4b03aa6",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-1.4.1.tgz_1506364709246_0.33135218149982393"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "0.1.8"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "changelog": "gren --action=changelog --tags=all --generate",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.0.3",
+      "gitHead": "f2d859eb53607b909cca03858429035bb025b21a",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.0.3",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug==",
+        "shasum": "4353337854747c48ea498330dc034f9f4bbbcc0b",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-2.0.3.tgz_1506364719414_0.6998918044846505"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "github-release-notes": "0.13.1",
+        "mime-db": "1.31.0"
+      },
+      "scripts": {
+        "prepublish": "node build/build.js > types.json",
+        "changelog": "gren changelog --tags=all --generate --override",
+        "test": "node build/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.5.0",
+      "gitHead": "949b4519c5a89484d532108f8eaa46c08772d06b",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@1.5.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "7.10.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-v/jMDoK/qKptnTuC3YUNbIj8uUYvTCIHzVu9BHldKSWja48wusAtfjlcBlqnFrqClu3yf69ScDxBPrIyFnF51g==",
+        "shasum": "59c20e03ae116089edeb7d3b34a6788c5b3cccea",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.5.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-1.5.0.tgz_1511386720367_0.24678691499866545"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "contributors": [
+        {
+          "name": "Benjamin Thomas",
+          "email": "benjamin@benjaminthomas.org",
+          "url": "http://github.com/bentomas"
+        }
+      ],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "github-release-notes": "0.13.1",
+        "mime-db": "1.31.0",
+        "mime-score": "1.1.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js",
+        "changelog": "gren changelog --tags=all --generate --override",
+        "test": "node src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "main": "mime.js",
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "1.6.0",
+      "gitHead": "87b396e859aad0cea0845e706613d333c2b0bfdc",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@1.6.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+        "shasum": "32cd9e5c64553bd58d19a568af452acff04981b1",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-1.6.0.tgz_1511571198990_0.8219187778886408"
+      },
+      "directories": {}
+    },
+    "2.0.5": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "changelog": "gren --action=changelog --tags=all --generate",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.0.5",
+      "gitHead": "25141e4ba73de46d089dcd039438df62ee76f23e",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.0.5",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "7.10.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-345FGKrFL5gB4gCt9tdpMJvjYnx6G3z2qBLB7SIHbZui0h1L9GKd6fXqiqa0ShzrIFy1VSydJOCrtRSi907Ggw==",
+        "shasum": "6cce36408c28535b29088d9d263288e72c786775",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-2.0.5.tgz_1513970526401_0.26077263429760933"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.32.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.1.0",
+      "gitHead": "10550a2410e60cd7b34a870a7ac46f36ea526d9d",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.1.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "7.10.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-jPEuocEVyg24I7hWcF6EL5qH0OQ3Ficy95tXA9eNBN6qXsIopYi/CJl3ldTUR+Sljt2rP2SkWpeTcAMon/pjKA==",
+        "shasum": "1022a5ada445aa30686e4059abaea83d0b4e8f9c",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-2.1.0.tgz_1513976718970_0.17231444269418716"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.32.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.2.0",
+      "gitHead": "797e9cee7ac45dfa6bdc8dbe7bc396a1e6f6c581",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.2.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "7.10.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        },
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA==",
+        "shasum": "161e541965551d3b549fa1114391e3a3d55b923b",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime-2.2.0.tgz_1515104848510_0.7507974696345627"
+      },
+      "directories": {}
+    },
+    "2.2.1": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.33.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.2.1",
+      "gitHead": "2aec3b6701bfc21d46ca0d1e8830990e8b867559",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.2.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "7.10.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-8QKdX8CfqnkIn19mnv3Zq78RugzDXZNrcewbZrjf8h0R6aN5Daizum/OoXxqVVhkFW3Ow4LFSn5iOi7qJJOMoA==",
+        "shasum": "3a5e605c59bba00fb731f6a1f84701638131671d",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.2.1.tgz",
+        "fileCount": 16,
+        "unpackedSize": 70404
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.2.1_1522428052314_0.8356571506040067"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.2.2": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.33.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.2.2",
+      "gitHead": "5c22f2180a7213b9e07f26dc9753e34f48121840",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.2.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "7.10.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-A7PDg4s48MkqFEcYg2b069m3DXOEq7hx+9q9rIFrSSYfzsh35GX+LOVMQ8Au0ko7d8bSQCIAuzkjp0vCtwENlQ==",
+        "shasum": "6b4c109d88031d7b5c23635f5b923da336d79121",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.2.2.tgz",
+        "fileCount": 16,
+        "unpackedSize": 70633
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.2.2_1522428150241_0.8170773846359634"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.3.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.33.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.3.0",
+      "gitHead": "27195f8cdd41d3c35d1caf0deb792d68438ed2c9",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.3.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "7.10.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-9dE160rWamibtUmS5kbAuu8Fbk9FihwN7ZYuWXbd6hSFKEKCqRe0hJ8pnqvmNOt5ljmXHmnKTxinIkdM1mKuPw==",
+        "shasum": "e3e1ae7f594b15ef331b79083216b50333ed2ebd",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.3.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 71566
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.3.0_1523452739150_0.6349406966306868"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.3.1": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.33.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.3.1",
+      "gitHead": "9508ad5469f06e570e521086690925275d9b38bf",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.3.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "7.10.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+        "shasum": "b1621c54d63b97c47d3cfe7f7215f7d64517c369",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 71814
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.3.1_1523453415547_0.6151419470390307"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.0": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "^5.9.0",
+        "mime-db": "^1.37.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "5.2.0",
+        "runmd": "1.0.1",
+        "standard-version": "^4.4.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.4.0",
+      "gitHead": "a246724b51217b4319a409fd74801004f5ee4c2d",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.4.0",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "dist": {
+        "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+        "shasum": "e051fd881358585f3279df333fe694da0bcffdd6",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 73137,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb/HUOCRA9TVsSAnZWagAAivMP/3yoL2JUahYb3gcIho77\no1CWe26C8rnZwNnYXzGv9WaaTJ/xfKr6enMW7+G6moemwgX+3h3roAp7eVFz\nGKpkhLNO07geRl0rETZafFaHyxVZd9BuKy+OR/Q/DkjNvza+xeDqJ2SB4wdt\n8WzNT7rH9Espnxvxf9KhA0YWoDUPSOqL/PbAZySuYcmxn4keNJQ+yp0PLDOE\n63shHVVsL7/Vy3qKKUMRAmfwuQCl8CpLL8wi2r/FfNbuvaAKC34d8Y33Aus2\naN2ehHBcUKFjrGor4VwU+G2MYPhGnZovc5w7QIMcBovRRoM8kQKXOyItvF/X\nuW5uzUY9wFRBnkj9tlGTEa4RvFBCp2PvkWpczQsorZZjYbKUC4C9ISSCUzN6\nELoGMxMkQsLIZdwVEFgYUxsN/9Xzjgdac7KEyFw+cQhGfNGrl9rathNWXUEF\nYQn8XMW4jghZ7ZfftVaPARo8mX/Eg1x8VAujrOoupOAPhCgp9sBbb0s00TqW\njdpF5PD3Ny5O6SPFweDwka2WsSV9/elxeDDg8cWTpj+p0SSFbT0d4b/kUWZq\nzgaAWqNSVoC6BpcGS5I7svxJ4dlQbL2BTyu6VXQdzKJ++CGsUn5X+7UBHAe4\nenT4ZUCHJP3mhSNE582PMO/HwNKUYraVHHHAmRfyGBGqnS/mg33WxZrtPgcs\n2zvm\r\n=7Hld\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.4.0_1543271694176_0.25128092892425236"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.1": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "2.4.2",
+        "eslint": "5.16.0",
+        "mime-db": "1.38.0",
+        "mime-score": "1.1.2",
+        "mime-types": "2.1.22",
+        "mocha": "6.0.2",
+        "runmd": "1.2.1",
+        "standard-version": "5.0.2"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "benchmark": "node src/benchmark.js",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.4.1",
+      "gitHead": "e3f7a2bece1e20a4101df4f8b021ce49b26cf76d",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.4.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "dist": {
+        "integrity": "sha512-VRUfmQO0rCd3hKwBymAn3kxYzBHr3I/wdVMywgG3HhXOwrCQgN84ZagpdTm2tZ4TNtwsSmyJWYO88mb5XvzGqQ==",
+        "shasum": "19eb7357bebbda37df585b14038347721558c715",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.1.tgz",
+        "fileCount": 19,
+        "unpackedSize": 74127,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcpQClCRA9TVsSAnZWagAAYVUP/3jqCEnfpQ5MM2Z1eM9X\nvrFQx51FLk41ONqqaw8W82zXdWdQUMmNPMFRrqccP2SLl6tcWPoYZABMTJBB\nQy40c6FE2gSyI5M+S3hUUP8p06UkD0g8uKUr4vCtVflCAQ9O4cdw/LK/Rh7x\n5MrV9NH38H3r4+G7xz5vthmVG3LM/mexaYXyD+7dn7aV4QolPgqslMNoYKjo\n25a/D5ZPvAuQOoVYF2yrHJs17mSiPVnIxA7WwkueF9EKttYOCPZRsEUUxcWC\neXCweZ0GF1a5JuFDpJrK3TctjBxbiFbUgJ5cR6NKTf9rmROTZ/iy2HIenahS\nPpRr/KnynSFosPB2NZnjpU5JXq4rW80dYOgjx36CQ2/8ndTsewL8h9GWUqA/\no/A5TjxG8rfIlva+7K/z0DDrBRke9woHEJl9wOHfuIHuu+2AdxuLd7XKOcEj\ny9ZpvaZnLejPgYxs3DgbOb9jugy0DGGzvkzVBySsc6q/moHNx2epBMcYw0ti\nK9bUFRoqFFbAa6y9DBn0vnONV2+FSCvdXqL528Ygk8HQ3JUEAIZHPP45J6H5\nW/o9dgebeOPRGFFfBgod7o53KbK+Jh3iQ6Gr2AsYYBkYa2cLqQ4jaaIplD3q\naPvaJK9razBBKTB5a9vvXbSNhc7hfp8L0NhiRH6E00olnKggjH3NoYQgm4+/\nOJjP\r\n=UFF/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.4.1_1554317477098_0.19078577985849443"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.2": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "2.4.2",
+        "eslint": "5.16.0",
+        "mime-db": "1.38.0",
+        "mime-score": "1.1.2",
+        "mime-types": "2.1.22",
+        "mocha": "6.0.2",
+        "runmd": "1.2.1",
+        "standard-version": "5.0.2"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "benchmark": "node src/benchmark.js",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.4.2",
+      "gitHead": "30ba26ddf43c11754cbb424d6d679d4c6a11cb34",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.4.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "dist": {
+        "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
+        "shasum": "ce5229a5e99ffc313abac806b482c10e7ba6ac78",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+        "fileCount": 19,
+        "unpackedSize": 74360,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcqkA1CRA9TVsSAnZWagAAggkP/RAyGuatr02wOmMFLwLz\nlC20G3opBTIEuh+hknPf/CcDnEWK+WF3Wc255bEr9z9ocInDa/dj9KpZj1LC\nCfdXWFjDsTHsRYeAUmS770Yc6+8e8GE8vc2UFM7jk6ZnwG9xagV+v8Xm9YAs\nRtd7BN7tXre/fngrG5kcaLHvcDC72+VQ7dkvIDJq0Im9mdI5VmFmP20A60Ng\nkC03fLT2bB53WNLsXGUoX2TEwVF7BW8i5IgLwuVjfCrO3B9n1DToqHht5u9u\n8/K99pwX73Ps/na/iPppvLRcwCFIiL8hcZ7yH95Lr05tFZPiadcJQ5zEyFcj\n2C+kFRpI5FkCVyS356+z2csvWY7XXhclWKxKWHC9/Uxq7qf5QvukQbagwdrh\nLtn9WyRPYf4vZ9BgdAhsAjLfEHOG5aek8hzI2mrJJ60kL/SuKLTVwC7AZkQ2\nwM3lFSp7dWxczqp1tP9E9bOYIj/s7FdeauWpoYSMfTQuDiLCGblR/b6ieB6g\nXVk/2FMtCvAhPlKsBUjP0kG1Y81TbUVgxu30cfjDQWPKZ6v2zLjg+NY8skPS\nMAlLuA3Eju89X7gQykBwlv9RNNXVv1y0D2LlnsIjttPfo3RX+/PmrD1GhN7P\nt9A4GKJ9WTUwK2njcLt8qHHehTTnHF/qM8/idGoez98Z2Z/yGuWRoD8FH4yK\n2Uzj\r\n=chBD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.4.2_1554661428827_0.7122084947285079"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.3": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "2.4.2",
+        "eslint": "5.16.0",
+        "mime-db": "1.38.0",
+        "mime-score": "1.1.2",
+        "mime-types": "2.1.22",
+        "mocha": "6.0.2",
+        "runmd": "1.2.1",
+        "standard-version": "5.0.2"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "benchmark": "node src/benchmark.js",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.4.3",
+      "gitHead": "2f595e4f000daa858f2c2611b56ec221545331f1",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.4.3",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "dist": {
+        "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
+        "shasum": "229687331e86f68924e6cb59e1cdd937f18275fe",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+        "fileCount": 19,
+        "unpackedSize": 74508,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3B0tCRA9TVsSAnZWagAA448QAKQAmUAlViGYaqHe5CyB\n1th8GxX+J9t6msjV0ffe1ZGti+RZWQ30rCRuLCkyg4GxQ0lBkWbzOPe/IA6B\ntq6lQ3UZAU8j/bjApETdsbktCiHFStB8/XPpnh4q3kG3o0BTyGZn2564PR//\nZH+rPhZNmpQe/6oqF3CAUa5ilXxOENGcFWxlwKLzCVULP50TiA+bgSxyMdT2\n/x6SBImaasjkW3XyOjQbjWbxu6JLmiutUGxSkUDXPeKyGbEOCHYwL6bSCbrr\nucdBEZpz9p7v/hdm8J2E1DbJZHhSH79wy1b0jeH1MFUckfLLPgRIxaa4jhZY\nRuL80s4UBPQZqcUEOYwnoiAedUT0u4Yq4d0n807jHKpmQ6Lcjwbr9xxF8Bd9\nlpt6c9V/ckV/2VWi1+44MLDJ/vd+Os4wDs9PWcSaYoD97k/5xjrdj/9Y808S\nzByUs330xcgLtElwgqcAySu3PC122RKQI6g+06JHZR+X2yqpSsQV1PeumBdY\nC4XcXUlxobxVC3rXE7fnXyr53I+Nqi4WdEFYLPwYEGpqG6T7MaQa5B2doqy8\naZ1PSS3klKF2qTpG4vAO9POqZysuxD1epqG+G1gQYuaVWZQeuOtgCcMiG4YR\n0T2N40r+8kAaLNgB9vUcUibm4bHIJwS1KCJ54Pz6ut3XxzfTBlGtZjfIe4nC\nie3z\r\n=kNJP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.4.3_1557929260873_0.13141022034633631"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.4": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "*",
+        "chalk": "*",
+        "eslint": "*",
+        "mime-db": "1.40.0",
+        "mime-score": "*",
+        "mime-types": "2.1.24",
+        "mocha": "6.1.4",
+        "runmd": "*",
+        "standard-version": "6.0.1"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "benchmark": "node src/benchmark.js",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.4.4",
+      "gitHead": "6479a848ac4699e9dc4049409aad99dbebc3f1da",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.4.4",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "dist": {
+        "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+        "shasum": "bd7b91135fc6b01cde3e9bae33d659b63d8857e5",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+        "fileCount": 19,
+        "unpackedSize": 74946,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc+q7iCRA9TVsSAnZWagAAIMMP/1ZtPOiAAL1b2hbekcva\nTgHAroKFU8SdPR3d8nXnDd56g4KbQ5rlWM1EgVlbVSAuuCYQU5R0MKqgaq9P\np27JNBEQTPHsmTAZeN9mZ1R2TTqAwped5RcjOFsrZDYvGPGSOiTKPtv6ZGzg\n/zVJwLNR3DaWNSsu3lnw2/K2kyucZ3xSPRnGgIpzbdJ/pheNbXS6lCA7mWMZ\nDFkhAOB3Z19J3ahFPd/+AdxswtknFOmKEefudXXbdezjYyf355LWz7Cta/OM\nc+B8DRq/TrBqcko2ixY1dJwAs9h8eRnO/QnJT/ysRwFC/YnnrNyq/S77WbfP\nlkW1QZfLFDOt6qsK3ll3VLLf/hxK4Sdsvc+aaFvK4f8rRK8WSppMgPaVLAtV\nilOUETPqj0wp/ycurCxwVJi+Hm8hQyfh05X1glFVUD8YYp9IZIWpOVOqqLdN\n7TL1UDx4oJ0/wpdjy3wSAKfavGk5JuL9TnXa3TbJoRJ8T1FkGhWvAmnRsO20\ncrNCIK1kwl2OBnYjMx54uEs7783DTntg3f/HWGg73tfmv9RLe5ngWYK81FrU\nV5AfTrtiAFyYspJug9uHfRkeoBX5eEhzfOzGyVgcyoMcVMCWY/+dtYMQeAeh\n9ImJrg9jQT7wFMPxeFEaCIYGhnsqjFl7N/8jJwNH6dKfsPxA9KuDf7PVhUG9\ne0MT\r\n=TmH0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.4.4_1559932641676_0.5461150856587325"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.5": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "*",
+        "chalk": "*",
+        "eslint": "*",
+        "mime-db": "1.44.0",
+        "mime-score": "1.2.0",
+        "mime-types": "2.1.27",
+        "mocha": "7.1.2",
+        "runmd": "*",
+        "standard-version": "7.1.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "benchmark": "node src/benchmark.js",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/node-mime.git",
+        "type": "git"
+      },
+      "version": "2.4.5",
+      "gitHead": "32a1681cb917e6ef65a101b7cd93943d151cafb1",
+      "bugs": {
+        "url": "https://github.com/broofa/node-mime/issues"
+      },
+      "homepage": "https://github.com/broofa/node-mime#readme",
+      "_id": "mime@2.4.5",
+      "_nodeVersion": "12.10.0",
+      "_npmVersion": "6.13.6",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "dist": {
+        "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
+        "shasum": "d8de2ecb92982dedbb6541c9b6841d7f218ea009",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
+        "fileCount": 10,
+        "unpackedSize": 57965,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJerKx5CRA9TVsSAnZWagAA4pUP/1WBKA/862DBDbaBOo/I\no6LAeulSAUufwBKXAY6G521veNZtHcKSuzd63y8l+2RCAou5qplQrZLYn/Pk\nXd9lLcHNKk3zamil9sgjJn7biQMmxnFriz/2fO/Q2ZDXNK17nqIfmbz7a9Xs\noZhXsdVfRYY+kD+MEdTO4VAJdxZ/TsZUO6HbBSoyCynG6QxnbxqKKjG9FAgv\nbMYacbihCVXcI2yCa3bo3QWRgJepD8hYPZG0YzW5NDowolOitSHSDIN2HnTJ\nAEmUJuNhktFIiv1BZNbEwqUIZly6JQhlEUweIyaQG0+zFkO7Ea8S4VP4ZnIL\nfpZBAYtuybtgzJaN6poT9AwEgLxFQv8jkbuULA+Ma33WrOINinersZtb+laM\npcjRhq0ItxoYLBkraWYUmAC1g4d3ia39hzO68fLvvw96VkDnJlTGkIubg5UH\nguuGTMFPEJCyCWcT2mXtTwwepWuygSMCAkLlDIisb/4bcxx+8CyagpGdobS0\n1J+GxCbXrocWprb0ZGYaFR3hk9Z2hbKu3JRN1XOgICd5psUbi7tvlonbpmPD\n7r50RZn48VTMyKdmMuonFSZ7QzZBUVecoc91dioLBHPE3yRJ8JPok0/8edk4\nwm2EE7lrO1JNxJq9VvGMaPlDE/LQus34NoBIAnyCodgx0ZcF4hmTJnWlPAaK\nVNqo\r\n=xHhY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.4.5_1588374649078_0.25380674476731957"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.6": {
+      "author": {
+        "name": "Robert Kieffer",
+        "email": "robert@broofa.com",
+        "url": "http://github.com/broofa"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "contributors": [],
+      "description": "A comprehensive library for mime-type mapping",
+      "license": "MIT",
+      "dependencies": {},
+      "devDependencies": {
+        "benchmark": "*",
+        "chalk": "*",
+        "eslint": "*",
+        "mime-db": "1.44.0",
+        "mime-score": "1.2.0",
+        "mime-types": "2.1.27",
+        "mocha": "7.1.2",
+        "runmd": "*",
+        "standard-version": "7.1.0"
+      },
+      "scripts": {
+        "prepare": "node src/build.js && runmd --output README.md src/README_js.md",
+        "release": "standard-version",
+        "benchmark": "node src/benchmark.js",
+        "md": "runmd --watch --output README.md src/README_js.md",
+        "test": "mocha src/test.js"
+      },
+      "keywords": [
+        "util",
+        "mime"
+      ],
+      "name": "mime",
+      "repository": {
+        "url": "git+https://github.com/broofa/mime.git",
+        "type": "git"
+      },
+      "version": "2.4.6",
+      "gitHead": "c8a4810d7697ecee9ecbf52e833548d9d885f0cd",
+      "bugs": {
+        "url": "https://github.com/broofa/mime/issues"
+      },
+      "homepage": "https://github.com/broofa/mime#readme",
+      "_id": "mime@2.4.6",
+      "_nodeVersion": "12.10.0",
+      "_npmVersion": "6.13.6",
+      "_npmUser": {
+        "name": "broofa",
+        "email": "robert@broofa.com"
+      },
+      "dist": {
+        "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+        "shasum": "e5b407c90db442f2beb5b162373d07b69affa4d1",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+        "fileCount": 10,
+        "unpackedSize": 57564,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJezpQLCRA9TVsSAnZWagAAw7QP/1YrEg60oynV6aaZqeGO\nm8DhTTe29D2i7rj4uKotubnKClrS49729E8aO86DBJP0UqNStnobuegOQL6F\nqdLLJgi5B1CCyuezV54uKA5evj6jBObPsfFfWnDDY4jmReRQfS2qPyOzPtdG\nKs8RdF+j9DknwBYjGm2dOGjX94tYZoiLY6ZSPS4mDZ2bAnMt9zKwYONMbvV2\nwzqR2Rawu5CyVOr2UnervidQvy74A0jIXKGBoyhzSJ+VXqevMLiJGWWnGoz+\nSBM25Vg6Rdu1hHnlmiaLoMEN8QF78lmgMcQunA/61nDkAkICGo8QUubp/j18\najUrKY4+y96VIuf15doCrrqQbNIMeCG8gCLZ2deI7A5c96at0xgIa2+67n5E\nz+G5jEvoHzPCYApDpCKg1RD2vIhJv6WywzhlHGXVEL7k/DgUcN/PLENqPykC\nGxgz5MxGU7hVkQYc+EQHnHRLWq8A9/YedNqOYpP5UCJoWfAT9M4ypRjjNa3n\ntgVVzv6cpzwBoBhh/2qV1NSvftnudyRZpj42s8RMQUCJgT/g5hwXZxQ43hg/\nIzrHaEkvXpr/MENUZIRXWUIPx6Iy4EONYox0VJ7P4/7zDO1AboNUGO0s8wD5\n+7mwLy1/ne+8ns7FisY0ArSxjz/egyln9n4MNzItCOwpRvy5F9x1JU7kqruF\n7uCG\r\n=i4GN\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bentomas",
+          "email": "benjamin@benjaminthomas.org"
+        },
+        {
+          "name": "broofa",
+          "email": "robert@broofa.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mime_2.4.6_1590596619489_0.033845580310938095"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "name": "bentomas",
+      "email": "benjamin@benjaminthomas.org"
+    },
+    {
+      "name": "broofa",
+      "email": "robert@broofa.com"
+    }
+  ],
+  "author": {
+    "name": "Robert Kieffer",
+    "email": "robert@broofa.com",
+    "url": "http://github.com/broofa"
+  },
+  "time": {
+    "modified": "2020-05-27T16:23:41.859Z",
+    "created": "2011-01-20T16:27:31.008Z",
+    "1.0.0": "2011-01-20T16:27:31.008Z",
+    "1.1.0": "2011-01-20T16:27:31.008Z",
+    "1.2.1": "2011-01-20T16:27:31.008Z",
+    "1.2.2": "2011-05-09T11:56:13.470Z",
+    "1.2.3": "2011-09-07T13:19:46.375Z",
+    "1.2.4": "2011-09-18T12:00:16.878Z",
+    "1.2.5": "2012-02-16T14:14:57.547Z",
+    "1.2.6": "2012-06-26T15:32:22.315Z",
+    "1.2.7": "2012-07-19T22:34:29.843Z",
+    "1.2.8": "2013-01-10T18:31:25.510Z",
+    "1.2.9": "2013-01-17T16:59:18.360Z",
+    "1.2.10": "2013-07-25T17:03:54.344Z",
+    "1.2.11": "2013-08-15T17:46:51.772Z",
+    "1.3.0": "2015-02-05T19:45:52.999Z",
+    "1.3.1": "2015-02-05T20:08:40.328Z",
+    "1.3.2": "2015-02-05T20:21:14.114Z",
+    "1.3.3": "2015-02-07T00:03:37.869Z",
+    "1.3.4": "2015-02-07T00:04:32.434Z",
+    "1.3.5": "2017-05-11T18:18:17.906Z",
+    "1.3.6": "2017-05-12T04:59:41.167Z",
+    "1.4.0": "2017-08-28T16:05:02.616Z",
+    "2.0.0": "2017-09-13T00:04:24.258Z",
+    "2.0.1": "2017-09-13T21:55:30.616Z",
+    "2.0.2": "2017-09-18T11:25:54.278Z",
+    "1.4.1": "2017-09-25T18:38:29.492Z",
+    "2.0.3": "2017-09-25T18:38:39.500Z",
+    "1.5.0": "2017-11-22T21:38:40.771Z",
+    "1.6.0": "2017-11-25T00:53:19.104Z",
+    "2.0.5": "2017-12-22T19:22:06.502Z",
+    "2.1.0": "2017-12-22T21:05:19.255Z",
+    "2.2.0": "2018-01-04T22:27:28.600Z",
+    "2.2.1": "2018-03-30T16:40:52.382Z",
+    "2.2.2": "2018-03-30T16:42:30.335Z",
+    "2.3.0": "2018-04-11T13:18:59.263Z",
+    "2.3.1": "2018-04-11T13:30:15.691Z",
+    "2.4.0": "2018-11-26T22:34:54.322Z",
+    "2.4.1": "2019-04-03T18:51:17.186Z",
+    "2.4.2": "2019-04-07T18:23:49.030Z",
+    "2.4.3": "2019-05-15T14:07:40.987Z",
+    "2.4.4": "2019-06-07T18:37:21.843Z",
+    "2.4.5": "2020-05-01T23:10:49.282Z",
+    "2.4.6": "2020-05-27T16:23:39.613Z"
+  },
+  "repository": {
+    "url": "git+https://github.com/broofa/mime.git",
+    "type": "git"
+  },
+  "users": {
+    "dresende": true,
+    "broofa": true,
+    "yazgazan": true,
+    "fgribreau": true,
+    "m42am": true,
+    "dannydulai": true,
+    "kastor": true,
+    "meryn": true,
+    "dubban": true,
+    "charmander": true,
+    "spekkionu": true,
+    "einfallstoll": true,
+    "roryrjb": true,
+    "themiddleman": true,
+    "igorissen": true,
+    "aminrx": true,
+    "jmervine": true,
+    "marushkevych": true,
+    "appnus": true,
+    "julien-f": true,
+    "yanickrochon": true,
+    "owaz": true,
+    "shen-weizhong": true,
+    "chaowi": true,
+    "sunrising": true,
+    "pospi": true,
+    "boustanihani": true,
+    "adamlu": true,
+    "hellboy81": true,
+    "joakin": true,
+    "fezvrasta": true,
+    "zhangyaochun": true,
+    "stoneren": true,
+    "jacquesw": true,
+    "zeke": true,
+    "kingcron": true,
+    "robermac": true,
+    "lujcon": true,
+    "yashprit": true,
+    "itonyyo": true,
+    "oheard": true,
+    "moimikey": true,
+    "qqqppp9998": true,
+    "dac2205": true,
+    "staraple": true,
+    "sarwan": true,
+    "jcottam": true,
+    "chriscalo": true,
+    "kappuccino": true,
+    "nfd": true,
+    "mgk": true,
+    "wmcmurray": true,
+    "parkerproject": true,
+    "monkeymonk": true,
+    "gochomugo": true,
+    "ssh0702": true,
+    "krot47": true,
+    "buzz-dee": true,
+    "reecegoddard": true,
+    "mikepol": true,
+    "maur1th": true,
+    "akiva": true,
+    "pandao": true,
+    "kparkov": true,
+    "liushoukai": true,
+    "antanst": true,
+    "stany": true,
+    "softwind": true,
+    "flozz": true,
+    "runningtalus": true,
+    "musichen": true,
+    "kikna": true,
+    "rdesoky": true,
+    "wkaifang": true,
+    "evanyeung": true,
+    "nukisman": true,
+    "gfilip": true,
+    "ifeature": true,
+    "monjer": true,
+    "lijinghust": true,
+    "xinwangwang": true,
+    "roman-io": true,
+    "steel1990": true,
+    "shan": true,
+    "wangnan0610": true,
+    "jahnestacado": true,
+    "xu_q90": true,
+    "ngpixel": true,
+    "uniconstructor": true,
+    "gubi": true,
+    "bhaveshgohel": true,
+    "james3299": true,
+    "zixinliango": true,
+    "ohcoder": true,
+    "ethan_": true,
+    "kistoryg": true,
+    "womcauliff": true,
+    "mojaray2k": true,
+    "fahadjadoon": true,
+    "wgerven": true,
+    "rich-97": true,
+    "kontrax": true,
+    "adhamfarrag": true,
+    "djk": true,
+    "quafoo": true,
+    "potentii": true,
+    "chinawolf_wyp": true,
+    "walexstevens": true,
+    "sibawite": true,
+    "kulyk404": true,
+    "zombieleet": true,
+    "asj1992": true,
+    "wozhizui": true,
+    "royelmi": true,
+    "marcfiedler": true,
+    "zhenguo.zhao": true,
+    "lucazweb": true,
+    "chiaychang": true,
+    "shuoshubao": true,
+    "tianyk": true,
+    "mysticatea": true,
+    "stona": true,
+    "edwardxyt": true,
+    "isenricho": true,
+    "vladimi": true,
+    "losymear": true,
+    "vboctor": true,
+    "enhezzz": true,
+    "windyh": true,
+    "arniu": true,
+    "wolfram77": true,
+    "xiaobing": true,
+    "zuojiang": true
+  },
+  "keywords": [
+    "util",
+    "mime"
+  ],
+  "contributors": [],
+  "bugs": {
+    "url": "https://github.com/broofa/mime/issues"
+  },
+  "readme": "<!--\n  -- This file is auto-generated from src/README_js.md. Changes should be made there.\n  -->\n# Mime\n\nA comprehensive, compact MIME type module.\n\n[![Build Status](https://travis-ci.org/broofa/mime.svg?branch=master)](https://travis-ci.org/broofa/mime)\n\n## Version 2 Notes\n\nVersion 2 is a breaking change from 1.x as the semver implies.  Specifically:\n\n* `lookup()` renamed to `getType()`\n* `extension()` renamed to `getExtension()`\n* `charset()` and `load()` methods have been removed\n\nIf you prefer the legacy version of this module please `npm install mime@^1`.  Version 1 docs may be found [here](https://github.com/broofa/mime/tree/v1.4.0).\n\n## Install\n\n### NPM\n```\nnpm install mime\n```\n\n### Browser\n\nIt is recommended that you use a bundler such as\n[webpack](https://webpack.github.io/) or [browserify](http://browserify.org/) to\npackage your code.  However, browser-ready versions are available via wzrd.in.\nE.g. For the full version:\n\n    <script src=\"https://wzrd.in/standalone/mime@latest\"></script>\n    <script>\n    mime.getType(...); // etc.\n    <script>\n\nOr, for the `mime/lite` version:\n\n    <script src=\"https://wzrd.in/standalone/mime%2flite@latest\"></script>\n    <script>\n    mimelite.getType(...); // (Note `mimelite` here)\n    <script>\n\n## Quick Start\n\nFor the full version (800+ MIME types, 1,000+ extensions):\n\n```javascript\nconst mime = require('mime');\n\nmime.getType('txt');                    // ⇨ 'text/plain'\nmime.getExtension('text/plain');        // ⇨ 'txt'\n```\n\nSee [Mime API](#mime-api) below for API details.\n\n## Lite Version\n\nThere is also a \"lite\" version of this module that omits vendor-specific\n(`*/vnd.*`) and experimental (`*/x-*`) types.  It weighs in at ~2.5KB, compared\nto 8KB for the full version.  To load the lite version:\n\n```javascript\nconst mime = require('mime/lite');\n```\n\n## Mime .vs. mime-types .vs. mime-db modules\n\nFor those of you wondering about the difference between these [popular] NPM modules,\nhere's a brief rundown ...\n\n[`mime-db`](https://github.com/jshttp/mime-db) is \"the source of\ntruth\" for MIME type information.  It is not an API.  Rather, it is a canonical\ndataset of mime type definitions pulled from IANA, Apache, NGINX, and custom mappings\nsubmitted by the Node.js community.\n\n[`mime-types`](https://github.com/jshttp/mime-types) is a thin\nwrapper around mime-db that provides an API drop-in compatible(ish) with `mime @ < v1.3.6` API.\n\n`mime` is, as of v2, a self-contained module bundled with a pre-optimized version\nof the `mime-db` dataset.  It provides a simplified API with the following characteristics:\n\n* Intelligently resolved type conflicts (See [mime-score](https://github.com/broofa/mime-score) for details)\n* Method naming consistent with industry best-practices\n* Compact footprint.  E.g. The minified+compressed sizes of the various modules:\n\nModule | Size\n--- | ---\n`mime-db`  | 18 KB\n`mime-types` | same as mime-db\n`mime` | 8 KB\n`mime/lite` | 2 KB\n\n## Mime API\n\nBoth `require('mime')` and `require('mime/lite')` return instances of the MIME\nclass, documented below.\n\nNote: Inputs to this API are case-insensitive.  Outputs (returned values) will\nbe lowercase.\n\n### new Mime(typeMap, ... more maps)\n\nMost users of this module will not need to create Mime instances directly.\nHowever if you would like to create custom mappings, you may do so as follows\n...\n\n```javascript\n// Require Mime class\nconst Mime = require('mime/Mime');\n\n// Define mime type -> extensions map\nconst typeMap = {\n  'text/abc': ['abc', 'alpha', 'bet'],\n  'text/def': ['leppard']\n};\n\n// Create and use Mime instance\nconst myMime = new Mime(typeMap);\nmyMime.getType('abc');            // ⇨ 'text/abc'\nmyMime.getExtension('text/def');  // ⇨ 'leppard'\n```\n\nIf more than one map argument is provided, each map is `define()`ed (see below), in order.\n\n### mime.getType(pathOrExtension)\n\nGet mime type for the given path or extension.  E.g.\n\n```javascript\nmime.getType('js');             // ⇨ 'application/javascript'\nmime.getType('json');           // ⇨ 'application/json'\n\nmime.getType('txt');            // ⇨ 'text/plain'\nmime.getType('dir/text.txt');   // ⇨ 'text/plain'\nmime.getType('dir\\\\text.txt');  // ⇨ 'text/plain'\nmime.getType('.text.txt');      // ⇨ 'text/plain'\nmime.getType('.txt');           // ⇨ 'text/plain'\n```\n\n`null` is returned in cases where an extension is not detected or recognized\n\n```javascript\nmime.getType('foo/txt');        // ⇨ null\nmime.getType('bogus_type');     // ⇨ null\n```\n\n### mime.getExtension(type)\nGet extension for the given mime type.  Charset options (often included in\nContent-Type headers) are ignored.\n\n```javascript\nmime.getExtension('text/plain');               // ⇨ 'txt'\nmime.getExtension('application/json');         // ⇨ 'json'\nmime.getExtension('text/html; charset=utf8');  // ⇨ 'html'\n```\n\n### mime.define(typeMap[, force = false])\n\nDefine [more] type mappings.\n\n`typeMap` is a map of type -> extensions, as documented in `new Mime`, above.\n\nBy default this method will throw an error if you try to map a type to an\nextension that is already assigned to another type.  Passing `true` for the\n`force` argument will suppress this behavior (overriding any previous mapping).\n\n```javascript\nmime.define({'text/x-abc': ['abc', 'abcd']});\n\nmime.getType('abcd');            // ⇨ 'text/x-abc'\nmime.getExtension('text/x-abc')  // ⇨ 'abc'\n```\n\n## Command Line\n\n    mime [path_or_extension]\n\nE.g.\n\n    > mime scripts/jquery.js\n    application/javascript\n\n----\nMarkdown generated from [src/README_js.md](src/README_js.md) by [![RunMD Logo](http://i.imgur.com/h0FVyzU.png)](https://github.com/broofa/runmd)",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/broofa/mime#readme",
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/mime.min.json
+++ b/test/fixtures/registry-mocks/content/mime.min.json
@@ -1,0 +1,766 @@
+{
+  "name": "mime",
+  "dist-tags": {
+    "latest": "2.4.6"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "mime",
+      "version": "1.0.0",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.0.0.tgz",
+        "shasum": "0650d4779569617b3ee8bec7b8b7522e74af05be"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.1.0": {
+      "name": "mime",
+      "version": "1.1.0",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.1.0.tgz",
+        "shasum": "a067f5be8a6c9eeb83f3733c8c22dd142a603add"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.2.1": {
+      "name": "mime",
+      "version": "1.2.1",
+      "dist": {
+        "shasum": "9876d4db9491091d154288a32893564839b8e04e",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.2.2": {
+      "name": "mime",
+      "version": "1.2.2",
+      "dist": {
+        "shasum": "b9d6355bf53e8d7d56693130e451daff340148cf",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.2.3": {
+      "name": "mime",
+      "version": "1.2.3",
+      "dist": {
+        "shasum": "7717bad7444f42d0c7d98cdc2a7b20068f837b68",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.2.4": {
+      "name": "mime",
+      "version": "1.2.4",
+      "devDependencies": {
+        "async_testing": ""
+      },
+      "dist": {
+        "shasum": "11b5fdaf29c2509255176b80ad520294f5de92b7",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.2.5": {
+      "name": "mime",
+      "version": "1.2.5",
+      "dist": {
+        "shasum": "9eed073022a8bf5e16c8566c6867b8832bfbfa13",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.2.6": {
+      "name": "mime",
+      "version": "1.2.6",
+      "dist": {
+        "shasum": "b1f86c768c025fa87b48075f1709f28aeaf20365",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.2.7": {
+      "name": "mime",
+      "version": "1.2.7",
+      "dist": {
+        "shasum": "c7a13f33a7073d9900f288436b06b3a16200865b",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.7.tgz"
+      }
+    },
+    "1.2.8": {
+      "name": "mime",
+      "version": "1.2.8",
+      "dist": {
+        "shasum": "59178be248b0e06df58f6e04db3c8ee30084e110",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.8.tgz"
+      }
+    },
+    "1.2.9": {
+      "name": "mime",
+      "version": "1.2.9",
+      "dist": {
+        "shasum": "009cd40867bd35de521b3b966f04e2f8d4d13d09",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.9.tgz"
+      }
+    },
+    "1.2.10": {
+      "name": "mime",
+      "version": "1.2.10",
+      "dist": {
+        "shasum": "066380acbc3d78d4f4a51004d8988425dc68b9b1",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.10.tgz"
+      }
+    },
+    "1.2.11": {
+      "name": "mime",
+      "version": "1.2.11",
+      "dist": {
+        "shasum": "58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "mime",
+      "version": "1.3.0",
+      "dependencies": {
+        "mime-db": "^1.2.0"
+      },
+      "dist": {
+        "shasum": "447c1ac7a6e4df33e3eebf13419bd736f99067f0",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.0.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "1.3.2": {
+      "name": "mime",
+      "version": "1.3.2",
+      "dependencies": {
+        "mime-db": "^1.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "shasum": "10d5293d23d8d4086cd2666a936477a49764c3bf",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.2.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "1.3.3": {
+      "name": "mime",
+      "version": "1.3.3",
+      "devDependencies": {
+        "mime-db": "^1.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "shasum": "6b681b6c0c0f6b41aec7eb5ced09f43fc81d6caf",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.3.tgz"
+      }
+    },
+    "1.3.4": {
+      "name": "mime",
+      "version": "1.3.4",
+      "devDependencies": {
+        "mime-db": "^1.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "shasum": "115f9e3b6b3daf2959983cb38f149a2d40eb5d53",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+      }
+    },
+    "1.3.5": {
+      "name": "mime",
+      "version": "1.3.5",
+      "devDependencies": {
+        "mime-db": "^1.22.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "shasum": "dc1ee70b80fee4999cb0775c9f94beefc9a779a3",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.5.tgz"
+      },
+      "deprecated": "Breaks custom overrides.  Upgrade to v1.3.6"
+    },
+    "1.3.6": {
+      "name": "mime",
+      "version": "1.3.6",
+      "devDependencies": {
+        "mime-db": "^1.22.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "shasum": "591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "mime",
+      "version": "1.4.0",
+      "devDependencies": {
+        "mime-db": "1.30.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ==",
+        "shasum": "69e9e0db51d44f2a3b56e48b7817d7d137f1a343",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "mime",
+      "version": "2.0.0",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "0.1.8"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "shasum": "e58e03970e44e57ed1394893b07e6312f71925e3",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "mime",
+      "version": "2.0.1",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "0.1.8"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-n2tQ4rs2+GMucMG2YHTwaONXZ/31ZS/vseUOzK5mTecwE91c33tapG51M0kB2R30hi7sY5nKvIkLCdCgUzx6FQ==",
+        "shasum": "73dd0bc6a678836cc8322db5d8e4c3e6f3c06471",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "2.0.2": {
+      "name": "mime",
+      "version": "2.0.2",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "0.1.8"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-Oy3+E5KrKoJ99krrYGn+u6jkCEdyFiZX2plVzbuuGLWo5X5K2Oej0KcbF1vHsrB7WFPMSaNqfHjJ6ksLT6kxSg==",
+        "shasum": "097fd2c88c652eae48b2702d7cbf54c08d8ef50a",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "1.4.1": {
+      "name": "mime",
+      "version": "1.4.1",
+      "devDependencies": {
+        "mime-db": "1.30.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+        "shasum": "121f9ebc49e3766f311a76e1fa1c8003c4b03aa6",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "mime",
+      "version": "2.0.3",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "0.1.8"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-TrpAd/vX3xaLPDgVRm6JkZwLR0KHfukMdU2wTEbqMDdCnY6Yo3mE+mjs9YE6oMNw2QRfXVeBEYpmpO94BIqiug==",
+        "shasum": "4353337854747c48ea498330dc034f9f4bbbcc0b",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "1.5.0": {
+      "name": "mime",
+      "version": "1.5.0",
+      "devDependencies": {
+        "github-release-notes": "0.13.1",
+        "mime-db": "1.31.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-v/jMDoK/qKptnTuC3YUNbIj8uUYvTCIHzVu9BHldKSWja48wusAtfjlcBlqnFrqClu3yf69ScDxBPrIyFnF51g==",
+        "shasum": "59c20e03ae116089edeb7d3b34a6788c5b3cccea",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.5.0.tgz"
+      }
+    },
+    "1.6.0": {
+      "name": "mime",
+      "version": "1.6.0",
+      "devDependencies": {
+        "github-release-notes": "0.13.1",
+        "mime-db": "1.31.0",
+        "mime-score": "1.1.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+        "shasum": "32cd9e5c64553bd58d19a568af452acff04981b1",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "2.0.5": {
+      "name": "mime",
+      "version": "2.0.5",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "github-release-notes": "0.9.0",
+        "mime-db": "1.30.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-345FGKrFL5gB4gCt9tdpMJvjYnx6G3z2qBLB7SIHbZui0h1L9GKd6fXqiqa0ShzrIFy1VSydJOCrtRSi907Ggw==",
+        "shasum": "6cce36408c28535b29088d9d263288e72c786775",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "2.1.0": {
+      "name": "mime",
+      "version": "2.1.0",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.32.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-jPEuocEVyg24I7hWcF6EL5qH0OQ3Ficy95tXA9eNBN6qXsIopYi/CJl3ldTUR+Sljt2rP2SkWpeTcAMon/pjKA==",
+        "shasum": "1022a5ada445aa30686e4059abaea83d0b4e8f9c",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "2.2.0": {
+      "name": "mime",
+      "version": "2.2.0",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.32.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA==",
+        "shasum": "161e541965551d3b549fa1114391e3a3d55b923b",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "2.2.1": {
+      "name": "mime",
+      "version": "2.2.1",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.33.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-8QKdX8CfqnkIn19mnv3Zq78RugzDXZNrcewbZrjf8h0R6aN5Daizum/OoXxqVVhkFW3Ow4LFSn5iOi7qJJOMoA==",
+        "shasum": "3a5e605c59bba00fb731f6a1f84701638131671d",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.2.1.tgz",
+        "fileCount": 16,
+        "unpackedSize": 70404
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "2.2.2": {
+      "name": "mime",
+      "version": "2.2.2",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.33.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-A7PDg4s48MkqFEcYg2b069m3DXOEq7hx+9q9rIFrSSYfzsh35GX+LOVMQ8Au0ko7d8bSQCIAuzkjp0vCtwENlQ==",
+        "shasum": "6b4c109d88031d7b5c23635f5b923da336d79121",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.2.2.tgz",
+        "fileCount": 16,
+        "unpackedSize": 70633
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "2.3.0": {
+      "name": "mime",
+      "version": "2.3.0",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.33.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-9dE160rWamibtUmS5kbAuu8Fbk9FihwN7ZYuWXbd6hSFKEKCqRe0hJ8pnqvmNOt5ljmXHmnKTxinIkdM1mKuPw==",
+        "shasum": "e3e1ae7f594b15ef331b79083216b50333ed2ebd",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.3.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 71566
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "2.3.1": {
+      "name": "mime",
+      "version": "2.3.1",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "4.6.1",
+        "mime-db": "1.33.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "3.5.3",
+        "runmd": "1.0.1",
+        "standard-version": "4.2.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+        "shasum": "b1621c54d63b97c47d3cfe7f7215f7d64517c369",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 71814
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "2.4.0": {
+      "name": "mime",
+      "version": "2.4.0",
+      "devDependencies": {
+        "chalk": "1.1.3",
+        "eslint": "^5.9.0",
+        "mime-db": "^1.37.0",
+        "mime-score": "1.0.1",
+        "mime-types": "2.1.15",
+        "mocha": "5.2.0",
+        "runmd": "1.0.1",
+        "standard-version": "^4.4.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+        "shasum": "e051fd881358585f3279df333fe694da0bcffdd6",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+        "fileCount": 18,
+        "unpackedSize": 73137,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb/HUOCRA9TVsSAnZWagAAivMP/3yoL2JUahYb3gcIho77\no1CWe26C8rnZwNnYXzGv9WaaTJ/xfKr6enMW7+G6moemwgX+3h3roAp7eVFz\nGKpkhLNO07geRl0rETZafFaHyxVZd9BuKy+OR/Q/DkjNvza+xeDqJ2SB4wdt\n8WzNT7rH9Espnxvxf9KhA0YWoDUPSOqL/PbAZySuYcmxn4keNJQ+yp0PLDOE\n63shHVVsL7/Vy3qKKUMRAmfwuQCl8CpLL8wi2r/FfNbuvaAKC34d8Y33Aus2\naN2ehHBcUKFjrGor4VwU+G2MYPhGnZovc5w7QIMcBovRRoM8kQKXOyItvF/X\nuW5uzUY9wFRBnkj9tlGTEa4RvFBCp2PvkWpczQsorZZjYbKUC4C9ISSCUzN6\nELoGMxMkQsLIZdwVEFgYUxsN/9Xzjgdac7KEyFw+cQhGfNGrl9rathNWXUEF\nYQn8XMW4jghZ7ZfftVaPARo8mX/Eg1x8VAujrOoupOAPhCgp9sBbb0s00TqW\njdpF5PD3Ny5O6SPFweDwka2WsSV9/elxeDDg8cWTpj+p0SSFbT0d4b/kUWZq\nzgaAWqNSVoC6BpcGS5I7svxJ4dlQbL2BTyu6VXQdzKJ++CGsUn5X+7UBHAe4\nenT4ZUCHJP3mhSNE582PMO/HwNKUYraVHHHAmRfyGBGqnS/mg33WxZrtPgcs\n2zvm\r\n=7Hld\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "2.4.1": {
+      "name": "mime",
+      "version": "2.4.1",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "2.4.2",
+        "eslint": "5.16.0",
+        "mime-db": "1.38.0",
+        "mime-score": "1.1.2",
+        "mime-types": "2.1.22",
+        "mocha": "6.0.2",
+        "runmd": "1.2.1",
+        "standard-version": "5.0.2"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-VRUfmQO0rCd3hKwBymAn3kxYzBHr3I/wdVMywgG3HhXOwrCQgN84ZagpdTm2tZ4TNtwsSmyJWYO88mb5XvzGqQ==",
+        "shasum": "19eb7357bebbda37df585b14038347721558c715",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.1.tgz",
+        "fileCount": 19,
+        "unpackedSize": 74127,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcpQClCRA9TVsSAnZWagAAYVUP/3jqCEnfpQ5MM2Z1eM9X\nvrFQx51FLk41ONqqaw8W82zXdWdQUMmNPMFRrqccP2SLl6tcWPoYZABMTJBB\nQy40c6FE2gSyI5M+S3hUUP8p06UkD0g8uKUr4vCtVflCAQ9O4cdw/LK/Rh7x\n5MrV9NH38H3r4+G7xz5vthmVG3LM/mexaYXyD+7dn7aV4QolPgqslMNoYKjo\n25a/D5ZPvAuQOoVYF2yrHJs17mSiPVnIxA7WwkueF9EKttYOCPZRsEUUxcWC\neXCweZ0GF1a5JuFDpJrK3TctjBxbiFbUgJ5cR6NKTf9rmROTZ/iy2HIenahS\nPpRr/KnynSFosPB2NZnjpU5JXq4rW80dYOgjx36CQ2/8ndTsewL8h9GWUqA/\no/A5TjxG8rfIlva+7K/z0DDrBRke9woHEJl9wOHfuIHuu+2AdxuLd7XKOcEj\ny9ZpvaZnLejPgYxs3DgbOb9jugy0DGGzvkzVBySsc6q/moHNx2epBMcYw0ti\nK9bUFRoqFFbAa6y9DBn0vnONV2+FSCvdXqL528Ygk8HQ3JUEAIZHPP45J6H5\nW/o9dgebeOPRGFFfBgod7o53KbK+Jh3iQ6Gr2AsYYBkYa2cLqQ4jaaIplD3q\naPvaJK9razBBKTB5a9vvXbSNhc7hfp8L0NhiRH6E00olnKggjH3NoYQgm4+/\nOJjP\r\n=UFF/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "2.4.2": {
+      "name": "mime",
+      "version": "2.4.2",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "2.4.2",
+        "eslint": "5.16.0",
+        "mime-db": "1.38.0",
+        "mime-score": "1.1.2",
+        "mime-types": "2.1.22",
+        "mocha": "6.0.2",
+        "runmd": "1.2.1",
+        "standard-version": "5.0.2"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
+        "shasum": "ce5229a5e99ffc313abac806b482c10e7ba6ac78",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+        "fileCount": 19,
+        "unpackedSize": 74360,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcqkA1CRA9TVsSAnZWagAAggkP/RAyGuatr02wOmMFLwLz\nlC20G3opBTIEuh+hknPf/CcDnEWK+WF3Wc255bEr9z9ocInDa/dj9KpZj1LC\nCfdXWFjDsTHsRYeAUmS770Yc6+8e8GE8vc2UFM7jk6ZnwG9xagV+v8Xm9YAs\nRtd7BN7tXre/fngrG5kcaLHvcDC72+VQ7dkvIDJq0Im9mdI5VmFmP20A60Ng\nkC03fLT2bB53WNLsXGUoX2TEwVF7BW8i5IgLwuVjfCrO3B9n1DToqHht5u9u\n8/K99pwX73Ps/na/iPppvLRcwCFIiL8hcZ7yH95Lr05tFZPiadcJQ5zEyFcj\n2C+kFRpI5FkCVyS356+z2csvWY7XXhclWKxKWHC9/Uxq7qf5QvukQbagwdrh\nLtn9WyRPYf4vZ9BgdAhsAjLfEHOG5aek8hzI2mrJJ60kL/SuKLTVwC7AZkQ2\nwM3lFSp7dWxczqp1tP9E9bOYIj/s7FdeauWpoYSMfTQuDiLCGblR/b6ieB6g\nXVk/2FMtCvAhPlKsBUjP0kG1Y81TbUVgxu30cfjDQWPKZ6v2zLjg+NY8skPS\nMAlLuA3Eju89X7gQykBwlv9RNNXVv1y0D2LlnsIjttPfo3RX+/PmrD1GhN7P\nt9A4GKJ9WTUwK2njcLt8qHHehTTnHF/qM8/idGoez98Z2Z/yGuWRoD8FH4yK\n2Uzj\r\n=chBD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "2.4.3": {
+      "name": "mime",
+      "version": "2.4.3",
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "chalk": "2.4.2",
+        "eslint": "5.16.0",
+        "mime-db": "1.38.0",
+        "mime-score": "1.1.2",
+        "mime-types": "2.1.22",
+        "mocha": "6.0.2",
+        "runmd": "1.2.1",
+        "standard-version": "5.0.2"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
+        "shasum": "229687331e86f68924e6cb59e1cdd937f18275fe",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+        "fileCount": 19,
+        "unpackedSize": 74508,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3B0tCRA9TVsSAnZWagAA448QAKQAmUAlViGYaqHe5CyB\n1th8GxX+J9t6msjV0ffe1ZGti+RZWQ30rCRuLCkyg4GxQ0lBkWbzOPe/IA6B\ntq6lQ3UZAU8j/bjApETdsbktCiHFStB8/XPpnh4q3kG3o0BTyGZn2564PR//\nZH+rPhZNmpQe/6oqF3CAUa5ilXxOENGcFWxlwKLzCVULP50TiA+bgSxyMdT2\n/x6SBImaasjkW3XyOjQbjWbxu6JLmiutUGxSkUDXPeKyGbEOCHYwL6bSCbrr\nucdBEZpz9p7v/hdm8J2E1DbJZHhSH79wy1b0jeH1MFUckfLLPgRIxaa4jhZY\nRuL80s4UBPQZqcUEOYwnoiAedUT0u4Yq4d0n807jHKpmQ6Lcjwbr9xxF8Bd9\nlpt6c9V/ckV/2VWi1+44MLDJ/vd+Os4wDs9PWcSaYoD97k/5xjrdj/9Y808S\nzByUs330xcgLtElwgqcAySu3PC122RKQI6g+06JHZR+X2yqpSsQV1PeumBdY\nC4XcXUlxobxVC3rXE7fnXyr53I+Nqi4WdEFYLPwYEGpqG6T7MaQa5B2doqy8\naZ1PSS3klKF2qTpG4vAO9POqZysuxD1epqG+G1gQYuaVWZQeuOtgCcMiG4YR\n0T2N40r+8kAaLNgB9vUcUibm4bHIJwS1KCJ54Pz6ut3XxzfTBlGtZjfIe4nC\nie3z\r\n=kNJP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "2.4.4": {
+      "name": "mime",
+      "version": "2.4.4",
+      "devDependencies": {
+        "benchmark": "*",
+        "chalk": "*",
+        "eslint": "*",
+        "mime-db": "1.40.0",
+        "mime-score": "*",
+        "mime-types": "2.1.24",
+        "mocha": "6.1.4",
+        "runmd": "*",
+        "standard-version": "6.0.1"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+        "shasum": "bd7b91135fc6b01cde3e9bae33d659b63d8857e5",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+        "fileCount": 19,
+        "unpackedSize": 74946,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc+q7iCRA9TVsSAnZWagAAIMMP/1ZtPOiAAL1b2hbekcva\nTgHAroKFU8SdPR3d8nXnDd56g4KbQ5rlWM1EgVlbVSAuuCYQU5R0MKqgaq9P\np27JNBEQTPHsmTAZeN9mZ1R2TTqAwped5RcjOFsrZDYvGPGSOiTKPtv6ZGzg\n/zVJwLNR3DaWNSsu3lnw2/K2kyucZ3xSPRnGgIpzbdJ/pheNbXS6lCA7mWMZ\nDFkhAOB3Z19J3ahFPd/+AdxswtknFOmKEefudXXbdezjYyf355LWz7Cta/OM\nc+B8DRq/TrBqcko2ixY1dJwAs9h8eRnO/QnJT/ysRwFC/YnnrNyq/S77WbfP\nlkW1QZfLFDOt6qsK3ll3VLLf/hxK4Sdsvc+aaFvK4f8rRK8WSppMgPaVLAtV\nilOUETPqj0wp/ycurCxwVJi+Hm8hQyfh05X1glFVUD8YYp9IZIWpOVOqqLdN\n7TL1UDx4oJ0/wpdjy3wSAKfavGk5JuL9TnXa3TbJoRJ8T1FkGhWvAmnRsO20\ncrNCIK1kwl2OBnYjMx54uEs7783DTntg3f/HWGg73tfmv9RLe5ngWYK81FrU\nV5AfTrtiAFyYspJug9uHfRkeoBX5eEhzfOzGyVgcyoMcVMCWY/+dtYMQeAeh\n9ImJrg9jQT7wFMPxeFEaCIYGhnsqjFl7N/8jJwNH6dKfsPxA9KuDf7PVhUG9\ne0MT\r\n=TmH0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "2.4.5": {
+      "name": "mime",
+      "version": "2.4.5",
+      "devDependencies": {
+        "benchmark": "*",
+        "chalk": "*",
+        "eslint": "*",
+        "mime-db": "1.44.0",
+        "mime-score": "1.2.0",
+        "mime-types": "2.1.27",
+        "mocha": "7.1.2",
+        "runmd": "*",
+        "standard-version": "7.1.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==",
+        "shasum": "d8de2ecb92982dedbb6541c9b6841d7f218ea009",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.5.tgz",
+        "fileCount": 10,
+        "unpackedSize": 57965,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJerKx5CRA9TVsSAnZWagAA4pUP/1WBKA/862DBDbaBOo/I\no6LAeulSAUufwBKXAY6G521veNZtHcKSuzd63y8l+2RCAou5qplQrZLYn/Pk\nXd9lLcHNKk3zamil9sgjJn7biQMmxnFriz/2fO/Q2ZDXNK17nqIfmbz7a9Xs\noZhXsdVfRYY+kD+MEdTO4VAJdxZ/TsZUO6HbBSoyCynG6QxnbxqKKjG9FAgv\nbMYacbihCVXcI2yCa3bo3QWRgJepD8hYPZG0YzW5NDowolOitSHSDIN2HnTJ\nAEmUJuNhktFIiv1BZNbEwqUIZly6JQhlEUweIyaQG0+zFkO7Ea8S4VP4ZnIL\nfpZBAYtuybtgzJaN6poT9AwEgLxFQv8jkbuULA+Ma33WrOINinersZtb+laM\npcjRhq0ItxoYLBkraWYUmAC1g4d3ia39hzO68fLvvw96VkDnJlTGkIubg5UH\nguuGTMFPEJCyCWcT2mXtTwwepWuygSMCAkLlDIisb/4bcxx+8CyagpGdobS0\n1J+GxCbXrocWprb0ZGYaFR3hk9Z2hbKu3JRN1XOgICd5psUbi7tvlonbpmPD\n7r50RZn48VTMyKdmMuonFSZ7QzZBUVecoc91dioLBHPE3yRJ8JPok0/8edk4\nwm2EE7lrO1JNxJq9VvGMaPlDE/LQus34NoBIAnyCodgx0ZcF4hmTJnWlPAaK\nVNqo\r\n=xHhY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "2.4.6": {
+      "name": "mime",
+      "version": "2.4.6",
+      "devDependencies": {
+        "benchmark": "*",
+        "chalk": "*",
+        "eslint": "*",
+        "mime-db": "1.44.0",
+        "mime-score": "1.2.0",
+        "mime-types": "2.1.27",
+        "mocha": "7.1.2",
+        "runmd": "*",
+        "standard-version": "7.1.0"
+      },
+      "bin": {
+        "mime": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+        "shasum": "e5b407c90db442f2beb5b162373d07b69affa4d1",
+        "tarball": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+        "fileCount": 10,
+        "unpackedSize": 57564,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJezpQLCRA9TVsSAnZWagAAw7QP/1YrEg60oynV6aaZqeGO\nm8DhTTe29D2i7rj4uKotubnKClrS49729E8aO86DBJP0UqNStnobuegOQL6F\nqdLLJgi5B1CCyuezV54uKA5evj6jBObPsfFfWnDDY4jmReRQfS2qPyOzPtdG\nKs8RdF+j9DknwBYjGm2dOGjX94tYZoiLY6ZSPS4mDZ2bAnMt9zKwYONMbvV2\nwzqR2Rawu5CyVOr2UnervidQvy74A0jIXKGBoyhzSJ+VXqevMLiJGWWnGoz+\nSBM25Vg6Rdu1hHnlmiaLoMEN8QF78lmgMcQunA/61nDkAkICGo8QUubp/j18\najUrKY4+y96VIuf15doCrrqQbNIMeCG8gCLZ2deI7A5c96at0xgIa2+67n5E\nz+G5jEvoHzPCYApDpCKg1RD2vIhJv6WywzhlHGXVEL7k/DgUcN/PLENqPykC\nGxgz5MxGU7hVkQYc+EQHnHRLWq8A9/YedNqOYpP5UCJoWfAT9M4ypRjjNa3n\ntgVVzv6cpzwBoBhh/2qV1NSvftnudyRZpj42s8RMQUCJgT/g5hwXZxQ43hg/\nIzrHaEkvXpr/MENUZIRXWUIPx6Iy4EONYox0VJ7P4/7zDO1AboNUGO0s8wD5\n+7mwLy1/ne+8ns7FisY0ArSxjz/egyln9n4MNzItCOwpRvy5F9x1JU7kqruF\n7uCG\r\n=i4GN\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    }
+  },
+  "modified": "2020-05-27T16:23:41.859Z"
+}

--- a/test/fixtures/registry-mocks/content/minimalistic-assert.json
+++ b/test/fixtures/registry-mocks/content/minimalistic-assert.json
@@ -1,0 +1,128 @@
+{
+  "_id": "minimalistic-assert",
+  "_rev": "4-2036693ec3fe63a455dbe8817d7d7e3d",
+  "name": "minimalistic-assert",
+  "description": "minimalistic-assert ===",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "minimalistic-assert",
+      "version": "1.0.0",
+      "description": "minimalistic-assert ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/minimalistic-assert.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/minimalistic-assert/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/minimalistic-assert",
+      "gitHead": "21471ae03175986a30cd3f567ba0bfde5ab10b01",
+      "_id": "minimalistic-assert@1.0.0",
+      "_shasum": "702be2dda6b37f4836bcb3f5db56641b64a1d3d3",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "702be2dda6b37f4836bcb3f5db56641b64a1d3d3",
+        "tarball": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "minimalistic-assert",
+      "version": "1.0.1",
+      "description": "minimalistic-assert ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/calvinmetcalf/minimalistic-assert.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/minimalistic-assert/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/minimalistic-assert",
+      "gitHead": "33113391ad64bea7a3398074a71d0569d4ae038d",
+      "_id": "minimalistic-assert@1.0.1",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+        "shasum": "2e194de044626d4a10e7f7fbc00ce73e83e4d5c7",
+        "tarball": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 1547
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/minimalistic-assert_1.0.1_1523449282967_0.06542122422066798"
+      }
+    }
+  },
+  "readme": "minimalistic-assert\n===\n\nvery minimalistic assert module.\n",
+  "maintainers": [
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    },
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-04-11T12:21:23.597Z",
+    "created": "2015-01-12T16:22:41.555Z",
+    "1.0.0": "2015-01-12T16:22:41.555Z",
+    "1.0.1": "2018-04-11T12:21:23.075Z"
+  },
+  "homepage": "https://github.com/calvinmetcalf/minimalistic-assert",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/calvinmetcalf/minimalistic-assert.git"
+  },
+  "bugs": {
+    "url": "https://github.com/calvinmetcalf/minimalistic-assert/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "readme.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/minimalistic-assert.min.json
+++ b/test/fixtures/registry-mocks/content/minimalistic-assert.min.json
@@ -1,0 +1,28 @@
+{
+  "name": "minimalistic-assert",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "minimalistic-assert",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "702be2dda6b37f4836bcb3f5db56641b64a1d3d3",
+        "tarball": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "minimalistic-assert",
+      "version": "1.0.1",
+      "dist": {
+        "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+        "shasum": "2e194de044626d4a10e7f7fbc00ce73e83e4d5c7",
+        "tarball": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 1547
+      }
+    }
+  },
+  "modified": "2018-04-11T12:21:23.597Z"
+}

--- a/test/fixtures/registry-mocks/content/minimalistic-crypto-utils.json
+++ b/test/fixtures/registry-mocks/content/minimalistic-crypto-utils.json
@@ -1,0 +1,157 @@
+{
+  "_id": "minimalistic-crypto-utils",
+  "_rev": "3-ef9479399ffe73147a240b30ade92920",
+  "name": "minimalistic-crypto-utils",
+  "description": "Minimalistic tools for JS crypto modules",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "minimalistic-crypto-utils",
+      "version": "1.0.0",
+      "description": "Minimalistic tools for JS crypto modules",
+      "main": "lib/utils.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/minimalistic-crypto-utils.git"
+      },
+      "keywords": [
+        "minimalistic",
+        "utils",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/minimalistic-crypto-utils/issues"
+      },
+      "homepage": "https://github.com/indutny/minimalistic-crypto-utils#readme",
+      "devDependencies": {
+        "mocha": "^3.2.0"
+      },
+      "gitHead": "ecca64897b9c0b7928bb66d2088a7118921033f0",
+      "_id": "minimalistic-crypto-utils@1.0.0",
+      "_shasum": "ecaf6d69202974d8b713bf24840f7ba62f2651c8",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "ecaf6d69202974d8b713bf24840f7ba62f2651c8",
+        "tarball": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimalistic-crypto-utils-1.0.0.tgz_1487797996752_0.37201968766748905"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "minimalistic-crypto-utils",
+      "version": "1.0.1",
+      "description": "Minimalistic tools for JS crypto modules",
+      "main": "lib/utils.js",
+      "scripts": {
+        "test": "mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/minimalistic-crypto-utils.git"
+      },
+      "keywords": [
+        "minimalistic",
+        "utils",
+        "crypto"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/minimalistic-crypto-utils/issues"
+      },
+      "homepage": "https://github.com/indutny/minimalistic-crypto-utils#readme",
+      "devDependencies": {
+        "mocha": "^3.2.0"
+      },
+      "gitHead": "f4f2b13a3ac78d8ee6991994bae89ec93304d225",
+      "_id": "minimalistic-crypto-utils@1.0.1",
+      "_shasum": "f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a",
+        "tarball": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/minimalistic-crypto-utils-1.0.1.tgz_1487798457360_0.7726138497237116"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# minimalistic-crypto-utils\n[![Build Status](https://secure.travis-ci.org/indutny/minimalistic-crypto-utils.svg)](http://travis-ci.org/indutny/minimalistic-crypto-utils)\n[![NPM version](https://badge.fury.io/js/minimalistic-crypto-utils.svg)](http://badge.fury.io/js/minimalistic-crypto-utils)\n\nVery minimal utils that are required in order to write reasonable JS-only\ncrypto module.\n\n## Usage\n\n```js\nconst utils = require('minimalistic-crypto-utils');\n\nutils.toArray('abcd', 'hex');\nutils.encode([ 1, 2, 3, 4 ], 'hex');\nutils.toHex([ 1, 2, 3, 4 ]);\n```\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2017.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n\n[0]: http://tools.ietf.org/html/rfc6979\n[1]: https://github.com/indutny/bn.js\n[2]: https://github.com/indutny/hash.js\n[3]: https://github.com/bitchan/eccrypto\n[4]: https://github.com/wanderer/secp256k1-node\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-10-15T15:29:20.163Z",
+    "created": "2017-02-22T21:13:18.587Z",
+    "1.0.0": "2017-02-22T21:13:18.587Z",
+    "1.0.1": "2017-02-22T21:20:57.947Z"
+  },
+  "homepage": "https://github.com/indutny/minimalistic-crypto-utils#readme",
+  "keywords": [
+    "minimalistic",
+    "utils",
+    "crypto"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/minimalistic-crypto-utils.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/minimalistic-crypto-utils/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "heartnett": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/minimalistic-crypto-utils.min.json
+++ b/test/fixtures/registry-mocks/content/minimalistic-crypto-utils.min.json
@@ -1,0 +1,31 @@
+{
+  "name": "minimalistic-crypto-utils",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "minimalistic-crypto-utils",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "ecaf6d69202974d8b713bf24840f7ba62f2651c8",
+        "tarball": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "minimalistic-crypto-utils",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a",
+        "tarball": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2017-10-15T15:29:20.163Z"
+}

--- a/test/fixtures/registry-mocks/content/mississippi.json
+++ b/test/fixtures/registry-mocks/content/mississippi.json
@@ -1,0 +1,624 @@
+{
+  "_id": "mississippi",
+  "_rev": "37-d204ce899b2551e9caa197d1d620344f",
+  "name": "mississippi",
+  "description": "a collection of useful streams",
+  "dist-tags": {
+    "latest": "4.0.0"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "mississippi",
+      "version": "1.0.1",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "gitHead": "e95be0dbf2d35c3a24f79943e7dbf398ae15d30d",
+      "_id": "mississippi@1.0.1",
+      "_shasum": "30765e5d53a2b71137e2f9cc6f58fe5a76d7d121",
+      "_from": ".",
+      "_npmVersion": "2.13.0",
+      "_nodeVersion": "2.4.0",
+      "_npmUser": {
+        "name": "maxogden",
+        "email": "max@maxogden.com"
+      },
+      "maintainers": [
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "30765e5d53a2b71137e2f9cc6f58fe5a76d7d121",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "mississippi",
+      "version": "1.0.2",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "through2": "^2.0.0"
+      },
+      "gitHead": "365e00144f195ad3d7fe3920a765e8fc6b8c5405",
+      "_id": "mississippi@1.0.2",
+      "_shasum": "5c6a78b51939ec3319fc27d7b5fd5f5021a6fbc5",
+      "_from": ".",
+      "_npmVersion": "2.13.0",
+      "_nodeVersion": "2.4.0",
+      "_npmUser": {
+        "name": "maxogden",
+        "email": "max@maxogden.com"
+      },
+      "maintainers": [
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5c6a78b51939ec3319fc27d7b5fd5f5021a6fbc5",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "mississippi",
+      "version": "1.1.0",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "gitHead": "44d3654aa0be48b32c3d504a325ccdfab46ccc94",
+      "_id": "mississippi@1.1.0",
+      "_shasum": "8613c2f3aa54015e212a74522892413ce7fa4578",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "maxogden",
+        "email": "max@maxogden.com"
+      },
+      "dist": {
+        "shasum": "8613c2f3aa54015e212a74522892413ce7fa4578",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "mississippi",
+      "version": "1.1.1",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/maxogden/mississippi.git"
+      },
+      "bugs": {
+        "url": "https://github.com/maxogden/mississippi/issues"
+      },
+      "homepage": "https://github.com/maxogden/mississippi#readme",
+      "gitHead": "95c6eb510f0956e7253d20e8d4bd7d2d7c8fa85e",
+      "_id": "mississippi@1.1.1",
+      "_shasum": "58820f01f7b0abfe6dcef0d658b966072f1a03c7",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "maxogden",
+        "email": "max@maxogden.com"
+      },
+      "dist": {
+        "shasum": "58820f01f7b0abfe6dcef0d658b966072f1a03c7",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "mississippi",
+      "version": "1.2.0",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/maxogden/mississippi.git"
+      },
+      "bugs": {
+        "url": "https://github.com/maxogden/mississippi/issues"
+      },
+      "homepage": "https://github.com/maxogden/mississippi#readme",
+      "gitHead": "4aab2a2d4d98fd5e300a329048eb02a12df44c60",
+      "_id": "mississippi@1.2.0",
+      "_shasum": "cd51bb9bbad3ddb13dee3cf60f1d0929c7a7fa4c",
+      "_from": ".",
+      "_npmVersion": "2.14.15",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "maxogden",
+        "email": "max@maxogden.com"
+      },
+      "dist": {
+        "shasum": "cd51bb9bbad3ddb13dee3cf60f1d0929c7a7fa4c",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "mississippi",
+      "version": "1.3.0",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/maxogden/mississippi.git"
+      },
+      "bugs": {
+        "url": "https://github.com/maxogden/mississippi/issues"
+      },
+      "homepage": "https://github.com/maxogden/mississippi#readme",
+      "gitHead": "dd64841b932d06baf7859ee80db78d139c90b4c7",
+      "_id": "mississippi@1.3.0",
+      "_shasum": "d201583eb12327e3c5c1642a404a9cacf94e34f5",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "maxogden",
+        "email": "max@maxogden.com"
+      },
+      "dist": {
+        "shasum": "d201583eb12327e3c5c1642a404a9cacf94e34f5",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/mississippi-1.3.0.tgz_1484780252704_0.3479328122921288"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "mississippi",
+      "version": "1.3.1",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/maxogden/mississippi.git"
+      },
+      "bugs": {
+        "url": "https://github.com/maxogden/mississippi/issues"
+      },
+      "homepage": "https://github.com/maxogden/mississippi#readme",
+      "gitHead": "169d33f6d04b50cff3fd8d791727e664056e5b3f",
+      "_id": "mississippi@1.3.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "bret",
+        "email": "bcomnes@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+        "shasum": "2a8bb465e86550ac8b36a7b6f45599171d78671e",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mississippi-1.3.1.tgz_1516811503010_0.6841253736056387"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "mississippi",
+      "version": "2.0.0",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^2.0.1",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/maxogden/mississippi.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/maxogden/mississippi/issues"
+      },
+      "homepage": "https://github.com/maxogden/mississippi#readme",
+      "gitHead": "94426b40788f4d7a984b18094238a3b3bc0104de",
+      "_id": "mississippi@2.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "bret",
+        "email": "bcomnes@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+        "shasum": "3442a508fafc28500486feea99409676e4ee5a6f",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mississippi-2.0.0.tgz_1517331003152_0.11919152969494462"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "mississippi",
+      "version": "3.0.0",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/maxogden/mississippi.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/maxogden/mississippi/issues"
+      },
+      "homepage": "https://github.com/maxogden/mississippi#readme",
+      "gitHead": "c3a2f924d72558b167a0ad24b7572eb7c2d7e9f0",
+      "_id": "mississippi@3.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "bret",
+        "email": "bcomnes@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+        "shasum": "ea0a3291f97e0b5e8776b363d5f0a12d94c67022",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16308
+      },
+      "maintainers": [
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mississippi_3.0.0_1519675086561_0.23140610446324694"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "mississippi",
+      "version": "4.0.0",
+      "description": "a collection of useful streams",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "author": {
+        "name": "max ogden"
+      },
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "duplexify": "^4.0.0",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^2.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^3.0.1"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/maxogden/mississippi.git"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/maxogden/mississippi/issues"
+      },
+      "homepage": "https://github.com/maxogden/mississippi#readme",
+      "gitHead": "dbc46ebf1741a71286c66110ca1c90048a349175",
+      "_id": "mississippi@4.0.0",
+      "_nodeVersion": "11.12.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-7PujJ3Te6GGg9lG1nfw5jYCPV6/BsoAT0nCQwb6w+ROuromXYxI6jc/CQSlD82Z/OUMSBX1SoaqhTE+vXiLQzQ==",
+        "shasum": "4440722cc1f495843260e097967d1eeb87cf0122",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-4.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16817,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJck792CRA9TVsSAnZWagAA72EP/j7I3/tsQgK4Ue4O2HHW\ngYQ8S3zvD54hIZ/39QqSDTHAxGpABrpaYaS/ZUuZSJv/R+5VH1dIN8toSB0q\nD6M/s/Y3K+voqXmPQZoTOWWjTvZar2Lw4IfmB0nTRdWWuzr5pyzKrGYokrNW\nXMUTJbYlHUGok6WbeU//xl6zftGXFyOkP/xfQTjDzGdR9yOJb2nqslNRw8fs\nUWxfje76Vy280/YhwrYGHgcdffEMGg8w/LqtomQlIEx0FmSdzmVaVY8/XqLI\n4eF4x+yc+IFVyfKmg2D6bsUp8QfPvN7SEB4RKQ+14YmIxCgK6oUCQ0V33e/r\nC50ya24cGsg4ADymc2zoW8Kx6MXCtJhLQkAqn7d1eKf6q+oHJRxIamrvq2UM\nhDuvpPXM3Px+wxMMgdq+moAv5TNA6GmmGS9qA/2Um/DglsTh0V0WEr/liGH1\nMQC9I884kfvyWWyJOAopL4T+NpNAcu4///sOfpRW8rNRCD7g9QaAvaxsTeqx\nT5OmWAoU0gNhfZ4E7PTWGab8yClURTb+V0wKnKq4sMkmuCxhbE35nCb0dBh9\nrQebsDc0ULJJfwrlWzwHnKiHLG20JhtHEJVMnLsgKTt29SV4/nm6Jr4S+aDm\nfjlpH688vMYcBbIV5mmUJ0M9SBphvhL6ijBd7lEpN+w7ku2Pa8iTMzJWNiDU\nRdcZ\r\n=YlTS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        }
+      ],
+      "_npmUser": {
+        "name": "bret",
+        "email": "bcomnes@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/mississippi_4.0.0_1553186677500_0.6947818043521099"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# mississippi\n\na collection of useful stream utility modules. learn how the modules work using this and then pick the ones you want and use them individually\n\nthe goal of the modules included in mississippi is to make working with streams easy without sacrificing speed, error handling or composability.\n\n## usage\n\n```js\nvar miss = require('mississippi')\n```\n\n## methods\n\n- [pipe](#pipe)\n- [each](#each)\n- [pipeline](#pipeline)\n- [duplex](#duplex)\n- [through](#through)\n- [from](#from)\n- [to](#to)\n- [concat](#concat)\n- [finished](#finished)\n- [parallel](#parallel)\n\n### pipe\n\n##### `miss.pipe(stream1, stream2, stream3, ..., cb)`\n\nPipes streams together and destroys all of them if one of them closes. Calls `cb` with `(error)` if there was an error in any of the streams.\n\nWhen using standard `source.pipe(destination)` the source will _not_ be destroyed if the destination emits close or error. You are also not able to provide a callback to tell when the pipe has finished.\n\n`miss.pipe` does these two things for you, ensuring you handle stream errors 100% of the time (unhandled errors are probably the most common bug in most node streams code)\n\n#### original module\n\n`miss.pipe` is provided by [`require('pump')`](https://www.npmjs.com/package/pump)\n\n#### example\n\n```js\n// lets do a simple file copy\nvar fs = require('fs')\n\nvar read = fs.createReadStream('./original.zip')\nvar write = fs.createWriteStream('./copy.zip')\n\n// use miss.pipe instead of read.pipe(write)\nmiss.pipe(read, write, function (err) {\n  if (err) return console.error('Copy error!', err)\n  console.log('Copied successfully')\n})\n```\n\n### each\n\n##### `miss.each(stream, each, [done])`\n\nIterate the data in `stream` one chunk at a time. Your `each` function will be called with `(data, next)` where data is a data chunk and next is a callback. Call `next` when you are ready to consume the next chunk.\n\nOptionally you can call `next` with an error to destroy the stream. You can also pass the optional third argument, `done`, which is a function that will be called with `(err)` when the stream ends. The `err` argument will be populated with an error if the stream emitted an error.\n\n#### original module\n\n`miss.each` is provided by [`require('stream-each')`](https://www.npmjs.com/package/stream-each)\n\n#### example\n\n```js\nvar fs = require('fs')\nvar split = require('binary-split') // require('split2') would work here as well\n\nvar newLineSeparatedNumbers = fs.createReadStream('numbers.txt')\n\nvar pipeline = miss.pipeline(newLineSeparatedNumbers, split())\nmiss.each(pipeline, eachLine, done)\nvar sum = 0\n\nfunction eachLine (line, next) {\n  sum += parseInt(line.toString())\n  next()\n}\n\nfunction done (err) {\n  if (err) throw err\n  console.log('sum is', sum)\n}\n```\n\n### pipeline\n\n##### `var pipeline = miss.pipeline(stream1, stream2, stream3, ...)`\n\nBuilds a pipeline from all the transform streams passed in as arguments by piping them together and returning a single stream object that lets you write to the first stream and read from the last stream.\n\nIf you are pumping object streams together use `pipeline = miss.pipeline.obj(s1, s2, ...)`.\n\nIf any of the streams in the pipeline emits an error or gets destroyed, or you destroy the stream it returns, all of the streams will be destroyed and cleaned up for you.\n\n#### original module\n\n`miss.pipeline` is provided by [`require('pumpify')`](https://www.npmjs.com/package/pumpify)\n\n#### example\n\n```js\n// first create some transform streams (note: these two modules are fictional)\nvar imageResize = require('image-resizer-stream')({width: 400})\nvar pngOptimizer = require('png-optimizer-stream')({quality: 60})\n\n// instead of doing a.pipe(b), use pipeline\nvar resizeAndOptimize = miss.pipeline(imageResize, pngOptimizer)\n// `resizeAndOptimize` is a transform stream. when you write to it, it writes\n// to `imageResize`. when you read from it, it reads from `pngOptimizer`.\n// it handles piping all the streams together for you\n\n// use it like any other transform stream\nvar fs = require('fs')\n\nvar read = fs.createReadStream('./image.png')\nvar write = fs.createWriteStream('./resized-and-optimized.png')\n\nmiss.pipe(read, resizeAndOptimize, write, function (err) {\n  if (err) return console.error('Image processing error!', err)\n  console.log('Image processed successfully')\n})\n```\n\n### duplex\n\n##### `var duplex = miss.duplex([writable, readable, opts])`\n\nTake two separate streams, a writable and a readable, and turn them into a single [duplex (readable and writable) stream](https://nodejs.org/api/stream.html#stream_class_stream_duplex).\n\nThe returned stream will emit data from the readable. When you write to it it writes to the writable.\n\nYou can either choose to supply the writable and the readable at the time you create the stream, or you can do it later using the `.setWritable` and `.setReadable` methods and data written to the stream in the meantime will be buffered for you.\n\n#### original module\n\n`miss.duplex` is provided by [`require('duplexify')`](https://www.npmjs.com/package/duplexify)\n\n#### example\n\n```js\n// lets spawn a process and take its stdout and stdin and combine them into 1 stream\nvar child = require('child_process')\n\n// @- tells it to read from stdin, --data-binary sets 'raw' binary mode\nvar curl = child.spawn('curl -X POST --data-binary @- http://foo.com')\n\n// duplexCurl will write to stdin and read from stdout\nvar duplexCurl = miss.duplex(curl.stdin, curl.stdout)\n```\n\n### through\n\n##### `var transformer = miss.through([options, transformFunction, flushFunction])`\n\nMake a custom [transform stream](https://nodejs.org/docs/latest/api/stream.html#stream_class_stream_transform).\n\nThe `options` object is passed to the internal transform stream and can be used to create an `objectMode` stream (or use the shortcut `miss.through.obj([...])`)\n\nThe `transformFunction` is called when data is available for the writable side and has the signature `(chunk, encoding, cb)`. Within the function, add data to the readable side any number of times with `this.push(data)`. Call `cb()` to indicate processing of the `chunk` is complete. Or to easily emit a single error or chunk, call `cb(err, chunk)`\n\nThe `flushFunction`, with signature `(cb)`, is called just before the stream is complete and should be used to wrap up stream processing.\n\n#### original module\n\n`miss.through` is provided by [`require('through2')`](https://www.npmjs.com/package/through2)\n\n#### example\n\n```js\nvar fs = require('fs')\n\nvar read = fs.createReadStream('./boring_lowercase.txt')\nvar write = fs.createWriteStream('./AWESOMECASE.TXT')\n\n// Leaving out the options object\nvar uppercaser = miss.through(\n  function (chunk, enc, cb) {\n    cb(null, chunk.toString().toUpperCase())\n  },\n  function (cb) {\n    cb(null, 'ONE LAST BIT OF UPPERCASE')\n  }\n)\n\nmiss.pipe(read, uppercaser, write, function (err) {\n  if (err) return console.error('Trouble uppercasing!')\n  console.log('Splendid uppercasing!')\n})\n```\n\n### from\n\n##### `miss.from([opts], read)`\n\nMake a custom [readable stream](https://nodejs.org/docs/latest/api/stream.html#stream_class_stream_readable).\n\n`opts` contains the options to pass on to the ReadableStream constructor e.g. for creating a readable object stream (or use the shortcut `miss.from.obj([...])`).\n\nReturns a readable stream that calls `read(size, next)` when data is requested from the stream.\n\n- `size` is the recommended amount of data (in bytes) to retrieve.\n- `next(err, chunk)` should be called when you're ready to emit more data.\n\n#### original module\n\n`miss.from` is provided by [`require('from2')`](https://www.npmjs.com/package/from2)\n\n#### example\n\n```js\n\n\nfunction fromString(string) {\n  return miss.from(function(size, next) {\n    // if there's no more content\n    // left in the string, close the stream.\n    if (string.length <= 0) return next(null, null)\n\n    // Pull in a new chunk of text,\n    // removing it from the string.\n    var chunk = string.slice(0, size)\n    string = string.slice(size)\n\n    // Emit \"chunk\" from the stream.\n    next(null, chunk)\n  })\n}\n\n// pipe \"hello world\" out\n// to stdout.\nfromString('hello world').pipe(process.stdout)\n```\n\n### to\n\n##### `miss.to([options], write, [flush])`\n\nMake a custom [writable stream](https://nodejs.org/docs/latest/api/stream.html#stream_class_stream_writable).\n\n`opts` contains the options to pass on to the WritableStream constructor e.g. for creating a writable object stream (or use the shortcut `miss.to.obj([...])`).\n\nReturns a writable stream that calls `write(data, enc, cb)` when data is written to the stream.\n\n- `data` is the received data to write the destination.\n- `enc` encoding of the piece of data received.\n- `cb(err, data)` should be called when you're ready to write more data, or encountered an error.\n\n`flush(cb)` is called before `finish` is emitted and allows for cleanup steps to occur.\n\n#### original module\n\n`miss.to` is provided by [`require('flush-write-stream')`](https://www.npmjs.com/package/flush-write-stream)\n\n#### example\n\n```js\nvar ws = miss.to(write, flush)\n\nws.on('finish', function () {\n  console.log('finished')\n})\n\nws.write('hello')\nws.write('world')\nws.end()\n\nfunction write (data, enc, cb) {\n  // i am your normal ._write method\n  console.log('writing', data.toString())\n  cb()\n}\n\nfunction flush (cb) {\n  // i am called before finish is emitted\n  setTimeout(cb, 1000) // wait 1 sec\n}\n```\n\nIf you run the above it will produce the following output\n\n```\nwriting hello\nwriting world\n(nothing happens for 1 sec)\nfinished\n```\n\n### concat\n\n##### `var concat = miss.concat(cb)`\n\nReturns a writable stream that concatenates all data written to the stream and calls a callback with the single result.\n\nCalling `miss.concat(cb)` returns a writable stream. `cb` is called when the writable stream is finished, e.g. when all data is done being written to it. `cb` is called with a single argument, `(data)`, which will contain the result of concatenating all the data written to the stream.\n\nNote that `miss.concat` will not handle stream errors for you. To handle errors, use `miss.pipe` or handle the `error` event manually.\n\n#### original module\n\n`miss.concat` is provided by [`require('concat-stream')`](https://www.npmjs.com/package/concat-stream)\n\n#### example\n\n```js\nvar fs = require('fs')\n\nvar readStream = fs.createReadStream('cat.png')\nvar concatStream = miss.concat(gotPicture)\n\nfunction callback (err) {\n  if (err) {\n    console.error(err)\n    process.exit(1)\n  }\n}\n\nmiss.pipe(readStream, concatStream, callback)\n\nfunction gotPicture(imageBuffer) {\n  // imageBuffer is all of `cat.png` as a node.js Buffer\n}\n\nfunction handleError(err) {\n  // handle your error appropriately here, e.g.:\n  console.error(err) // print the error to STDERR\n  process.exit(1) // exit program with non-zero exit code\n}\n```\n\n### finished\n\n##### `miss.finished(stream, cb)`\n\nWaits for `stream` to finish or error and then calls `cb` with `(err)`. `cb` will only be called once. `err` will be null if the stream finished without error, or else it will be populated with the error from the streams `error` event.\n\nThis function is useful for simplifying stream handling code as it lets you handle success or error conditions in a single code path. It's used internally `miss.pipe`.\n\n#### original module\n\n`miss.finished` is provided by [`require('end-of-stream')`](https://www.npmjs.com/package/end-of-stream)\n\n#### example\n\n```js\nvar copySource = fs.createReadStream('./movie.mp4')\nvar copyDest = fs.createWriteStream('./movie-copy.mp4')\n\ncopySource.pipe(copyDest)\n\nmiss.finished(copyDest, function(err) {\n  if (err) return console.log('write failed', err)\n  console.log('write success')\n})\n```\n\n### parallel\n\n##### `miss.parallel(concurrency, each)`\n\nThis works like `through` except you can process items in parallel, while still preserving the original input order.\n\nThis is handy if you wanna take advantage of node's async I/O and process streams of items in batches. With this module you can build your very own streaming parallel job queue.\n\nNote that `miss.parallel` preserves input ordering. Passing the option `{ordered:false}` will output the data as soon as it's processed by a transform, without waiting to respect the order (this previously required a separate module [through2-concurrent](https://github.com/almost/through2-concurrent)).\n\n#### original module\n\n`miss.parallel` is provided by [`require('parallel-transform')`](https://npmjs.org/parallel-transform)\n\n#### example\n\nThis example fetches the GET HTTP headers for a stream of input URLs 5 at a time in parallel.\n\n```js\nfunction getResponse (item, cb) {\n  var r = request(item.url)\n  r.on('error', function (err) {\n    cb(err)\n  })\n  r.on('response', function (re) {\n    cb(null, {url: item.url, date: new Date(), status: re.statusCode, headers: re.headers})\n    r.abort()\n  })\n}\n\nmiss.pipe(\n  fs.createReadStream('./urls.txt'), // one url per line\n  split(),\n  miss.parallel(5, getResponse),\n  miss.through(function (row, enc, next) {\n    console.log(JSON.stringify(row))\n    next()\n  })\n)\n```\n\n## see also\n\n- [substack/stream-handbook](https://github.com/substack/stream-handbook)\n- [nodejs.org/api/stream.html](https://nodejs.org/api/stream.html)\n- [awesome-nodejs-streams](https://github.com/thejmazz/awesome-nodejs-streams)\n\n## license\n\nLicensed under the BSD 2-clause license.\n",
+  "maintainers": [
+    {
+      "email": "bcomnes@gmail.com",
+      "name": "bret"
+    },
+    {
+      "email": "max@maxogden.com",
+      "name": "maxogden"
+    }
+  ],
+  "time": {
+    "modified": "2019-03-21T16:44:40.434Z",
+    "created": "2015-08-14T08:36:28.965Z",
+    "1.0.1": "2015-08-14T08:36:28.965Z",
+    "1.0.2": "2015-08-14T08:46:58.926Z",
+    "1.1.0": "2015-10-18T21:50:35.400Z",
+    "1.1.1": "2015-10-18T22:04:23.885Z",
+    "1.2.0": "2016-01-11T01:23:20.896Z",
+    "1.3.0": "2017-01-18T22:57:34.634Z",
+    "1.3.1": "2018-01-24T16:31:44.426Z",
+    "2.0.0": "2018-01-30T16:50:03.240Z",
+    "3.0.0": "2018-02-26T19:58:06.618Z",
+    "4.0.0": "2019-03-21T16:44:37.612Z"
+  },
+  "author": {
+    "name": "max ogden"
+  },
+  "license": "BSD-2-Clause",
+  "readmeFilename": "readme.md",
+  "homepage": "https://github.com/maxogden/mississippi#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maxogden/mississippi.git"
+  },
+  "bugs": {
+    "url": "https://github.com/maxogden/mississippi/issues"
+  },
+  "users": {
+    "ivangaravito": true,
+    "axelav": true,
+    "coalesce": true,
+    "galenandrew": true,
+    "joeybaker": true,
+    "sappharx": true,
+    "joakimbeng": true,
+    "nickeltobias": true,
+    "nickleefly": true,
+    "jgabra": true,
+    "provstevi": true,
+    "rogeruiz": true,
+    "wmhilton": true,
+    "debearloper": true,
+    "shanewholloway": true,
+    "j3kz": true,
+    "nmccready": true,
+    "dpjayasekara": true,
+    "r3nya": true,
+    "max_devjs": true,
+    "norbertparti": true,
+    "mradko": true,
+    "shushanfx": true,
+    "jrop": true,
+    "drewigg": true,
+    "pftom": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/mississippi.min.json
+++ b/test/fixtures/registry-mocks/content/mississippi.min.json
@@ -1,0 +1,203 @@
+{
+  "name": "mississippi",
+  "dist-tags": {
+    "latest": "4.0.0"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "mississippi",
+      "version": "1.0.1",
+      "dist": {
+        "shasum": "30765e5d53a2b71137e2f9cc6f58fe5a76d7d121",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "mississippi",
+      "version": "1.0.2",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "5c6a78b51939ec3319fc27d7b5fd5f5021a6fbc5",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "mississippi",
+      "version": "1.1.0",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "8613c2f3aa54015e212a74522892413ce7fa4578",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "mississippi",
+      "version": "1.1.1",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "58820f01f7b0abfe6dcef0d658b966072f1a03c7",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "mississippi",
+      "version": "1.2.0",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "cd51bb9bbad3ddb13dee3cf60f1d0929c7a7fa4c",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "mississippi",
+      "version": "1.3.0",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "d201583eb12327e3c5c1642a404a9cacf94e34f5",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz"
+      }
+    },
+    "1.3.1": {
+      "name": "mississippi",
+      "version": "1.3.1",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
+        "shasum": "2a8bb465e86550ac8b36a7b6f45599171d78671e",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "mississippi",
+      "version": "2.0.0",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^2.0.1",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+        "shasum": "3442a508fafc28500486feea99409676e4ee5a6f",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "3.0.0": {
+      "name": "mississippi",
+      "version": "3.0.0",
+      "dependencies": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
+        "shasum": "ea0a3291f97e0b5e8776b363d5f0a12d94c67022",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16308
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "4.0.0": {
+      "name": "mississippi",
+      "version": "4.0.0",
+      "dependencies": {
+        "concat-stream": "^2.0.0",
+        "duplexify": "^4.0.0",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^2.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-7PujJ3Te6GGg9lG1nfw5jYCPV6/BsoAT0nCQwb6w+ROuromXYxI6jc/CQSlD82Z/OUMSBX1SoaqhTE+vXiLQzQ==",
+        "shasum": "4440722cc1f495843260e097967d1eeb87cf0122",
+        "tarball": "https://registry.npmjs.org/mississippi/-/mississippi-4.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16817,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJck792CRA9TVsSAnZWagAA72EP/j7I3/tsQgK4Ue4O2HHW\ngYQ8S3zvD54hIZ/39QqSDTHAxGpABrpaYaS/ZUuZSJv/R+5VH1dIN8toSB0q\nD6M/s/Y3K+voqXmPQZoTOWWjTvZar2Lw4IfmB0nTRdWWuzr5pyzKrGYokrNW\nXMUTJbYlHUGok6WbeU//xl6zftGXFyOkP/xfQTjDzGdR9yOJb2nqslNRw8fs\nUWxfje76Vy280/YhwrYGHgcdffEMGg8w/LqtomQlIEx0FmSdzmVaVY8/XqLI\n4eF4x+yc+IFVyfKmg2D6bsUp8QfPvN7SEB4RKQ+14YmIxCgK6oUCQ0V33e/r\nC50ya24cGsg4ADymc2zoW8Kx6MXCtJhLQkAqn7d1eKf6q+oHJRxIamrvq2UM\nhDuvpPXM3Px+wxMMgdq+moAv5TNA6GmmGS9qA/2Um/DglsTh0V0WEr/liGH1\nMQC9I884kfvyWWyJOAopL4T+NpNAcu4///sOfpRW8rNRCD7g9QaAvaxsTeqx\nT5OmWAoU0gNhfZ4E7PTWGab8yClURTb+V0wKnKq4sMkmuCxhbE35nCb0dBh9\nrQebsDc0ULJJfwrlWzwHnKiHLG20JhtHEJVMnLsgKTt29SV4/nm6Jr4S+aDm\nfjlpH688vMYcBbIV5mmUJ0M9SBphvhL6ijBd7lEpN+w7ku2Pa8iTMzJWNiDU\nRdcZ\r\n=YlTS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    }
+  },
+  "modified": "2019-03-21T16:44:40.434Z"
+}

--- a/test/fixtures/registry-mocks/content/move-concurrently.json
+++ b/test/fixtures/registry-mocks/content/move-concurrently.json
@@ -1,0 +1,199 @@
+{
+  "_id": "move-concurrently",
+  "_rev": "21-a3fe36beaf919387ab6677e5571f4786",
+  "name": "move-concurrently",
+  "description": "Promises of moves of files or directories with rename, falling back to recursive rename/copy on EXDEV errors, with configurable concurrency and win32 junction support.",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "move-concurrently",
+      "version": "1.0.0",
+      "description": "Promises of moves of files or directories with rename, falling back to recursive rename/copy on EXDEV errors, with configurable concurrency and win32 junction support.",
+      "main": "move.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [
+        "move"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "copy-concurrently": "^1.0.0",
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "files": [
+        "move.js",
+        "is-windows.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/move-concurrently.git"
+      },
+      "bugs": {
+        "url": "https://github.com/npm/move-concurrently/issues"
+      },
+      "homepage": "https://www.npmjs.com/package/move-concurrently",
+      "gitHead": "eed1d3d3301de07bc21de6209356fd4b4c7c16ec",
+      "_id": "move-concurrently@1.0.0",
+      "_shasum": "7b34a6808475a19b1ea15df9e27e270f0cf013f9",
+      "_from": ".",
+      "_npmVersion": "4.4.3",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "7b34a6808475a19b1ea15df9e27e270f0cf013f9",
+        "tarball": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/move-concurrently-1.0.0.tgz_1489705061152_0.28208360192365944"
+      }
+    },
+    "1.0.1": {
+      "name": "move-concurrently",
+      "version": "1.0.1",
+      "description": "Promises of moves of files or directories with rename, falling back to recursive rename/copy on EXDEV errors, with configurable concurrency and win32 junction support.",
+      "main": "move.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [
+        "move"
+      ],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "copy-concurrently": "^1.0.0",
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "files": [
+        "move.js",
+        "is-windows.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/move-concurrently.git"
+      },
+      "bugs": {
+        "url": "https://github.com/npm/move-concurrently/issues"
+      },
+      "homepage": "https://www.npmjs.com/package/move-concurrently",
+      "gitHead": "8558616a681db87a77b2d9077ce5f855ceb46b87",
+      "_id": "move-concurrently@1.0.1",
+      "_shasum": "be2c005fda32e0b29af1f05d7c4b33214c701f92",
+      "_from": ".",
+      "_npmVersion": "4.4.3",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "be2c005fda32e0b29af1f05d7c4b33214c701f92",
+        "tarball": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/move-concurrently-1.0.1.tgz_1489706667405_0.5766653206665069"
+      }
+    }
+  },
+  "readme": "# move-concurrently\n\nMove files and directories.\n\n```\nconst move = require('move-concurrently')\nmove('/path/to/thing', '/new/path/thing').then(() => {\n  // thing is now moved!\n}).catch(err => {\n  // oh no!\n})\n```\n\nUses `rename` to move things as fast as possible.\n\nIf you `move` across devices or on filesystems that don't support renaming\nlarge directories.  That is, situations that result in `rename` returning\nthe `EXDEV` error, then `move` will fallback to copy + delete.\n\nWhen recursively copying directories it will first try to rename the\ncontents before falling back to copying.  While this will be slightly slower\nin true cross-device scenarios, it is MUCH faster in cases where the\nfilesystem can't handle directory renames.\n\nWhen copying ownership is maintained when running as root.  Permissions are\nalways maintained.  On Windows, if symlinks are unavailable then junctions\nwill be used.\n\n## INTERFACE\n\n### move(from, to, options) → Promise\n\nRecursively moves `from` to `to` and resolves its promise when finished.\nIf `to` already exists then the promise will be rejected with an `EEXIST`\nerror.\n\nStarts by trying to rename `from` to `to`.\n\nOptions are:\n\n* maxConcurrency – (Default: `1`) The maximum number of concurrent copies to do at once.\n* isWindows - (Default: `process.platform === 'win32'`) If true enables Windows symlink semantics. This requires\n  an extra `stat` to determine if the destination of a symlink is a file or directory. If symlinking a directory\n  fails then we'll try making a junction instead.\n\nOptions can also include dependency injection:\n\n* Promise - (Default: `global.Promise`) The promise implementation to use, defaults to Node's.\n* fs - (Default: `require('fs')`) The filesystem module to use.  Can be used\n  to use `graceful-fs` or to inject a mock.\n* writeStreamAtomic - (Default: `require('fs-write-stream-atomic')`) The\n  implementation of `writeStreamAtomic` to use.  Used to inject a mock.\n* getuid - (Default: `process.getuid`) A function that returns the current UID. Used to inject a mock.\n",
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-19T13:50:23.046Z",
+    "created": "2017-03-16T22:57:41.409Z",
+    "1.0.0": "2017-03-16T22:57:41.409Z",
+    "1.0.1": "2017-03-16T23:24:29.189Z"
+  },
+  "homepage": "https://www.npmjs.com/package/move-concurrently",
+  "keywords": [
+    "move"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/move-concurrently.git"
+  },
+  "author": {
+    "name": "Rebecca Turner",
+    "email": "me@re-becca.org",
+    "url": "http://re-becca.org/"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/move-concurrently/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "alshamiri1": true,
+    "gavatron": true,
+    "iarna": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/move-concurrently.min.json
+++ b/test/fixtures/registry-mocks/content/move-concurrently.min.json
@@ -1,0 +1,57 @@
+{
+  "name": "move-concurrently",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "move-concurrently",
+      "version": "1.0.0",
+      "dependencies": {
+        "copy-concurrently": "^1.0.0",
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "7b34a6808475a19b1ea15df9e27e270f0cf013f9",
+        "tarball": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "move-concurrently",
+      "version": "1.0.1",
+      "dependencies": {
+        "copy-concurrently": "^1.0.0",
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tacks": "^1.2.6",
+        "tap": "^10.1.1"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "be2c005fda32e0b29af1f05d7c4b33214c701f92",
+        "tarball": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:50:23.046Z"
+}

--- a/test/fixtures/registry-mocks/content/multicast-dns-service-types.json
+++ b/test/fixtures/registry-mocks/content/multicast-dns-service-types.json
@@ -1,0 +1,211 @@
+{
+  "_id": "multicast-dns-service-types",
+  "_rev": "4-730d3227e01d6fee174d2fbcf8c8ea3a",
+  "name": "multicast-dns-service-types",
+  "description": "Parse and stringify mdns service types",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "multicast-dns-service-types",
+      "version": "1.0.0",
+      "description": "Parse and stringify mdns service types",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns-service-types.git"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "keywords": [
+        "mdns",
+        "bonjour",
+        "zero",
+        "conf"
+      ],
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns-service-types/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns-service-types",
+      "gitHead": "fa2a03f1e7ca819e6bc7e24ac262934f5126f80a",
+      "_id": "multicast-dns-service-types@1.0.0",
+      "_shasum": "5c75f86131b7c55711bb954ac721c8a816411a70",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "1.6.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5c75f86131b7c55711bb954ac721c8a816411a70",
+        "tarball": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "multicast-dns-service-types",
+      "version": "1.0.1",
+      "description": "Parse and stringify mdns service types",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^3.5.0",
+        "tape": "^4.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns-service-types.git"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "keywords": [
+        "mdns",
+        "bonjour",
+        "zero",
+        "conf"
+      ],
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns-service-types/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns-service-types",
+      "gitHead": "3eb979f126eae18d9fae5fb3d3c5a37e8b64d3b7",
+      "_id": "multicast-dns-service-types@1.0.1",
+      "_shasum": "1ebdd242a28c4c94bfbc23c3f060098882b55cb5",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "1.6.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1ebdd242a28c4c94bfbc23c3f060098882b55cb5",
+        "tarball": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "multicast-dns-service-types",
+      "version": "1.1.0",
+      "description": "Parse and stringify mdns service types",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^3.5.0",
+        "tape": "^4.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns-service-types.git"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "keywords": [
+        "mdns",
+        "bonjour",
+        "zero",
+        "conf"
+      ],
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns-service-types/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns-service-types",
+      "gitHead": "4f356bd9d4ee4999b07b8d68b11a4a81611065cf",
+      "_id": "multicast-dns-service-types@1.1.0",
+      "_shasum": "899f11d9686e5e05cb91b35d5f0e63b773cfc901",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "1.6.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "899f11d9686e5e05cb91b35d5f0e63b773cfc901",
+        "tarball": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# multicast-dns-service-types\n\nParse and stringify mdns service types\n\n```\nnpm install multicast-dns-service-types\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/multicast-dns-service-types.svg?style=flat)](http://travis-ci.org/mafintosh/multicast-dns-service-types)\n\n## Usage\n\n``` js\nvar types = require('multicast-dns-service-types')\n\nconsole.log(types.stringify({name: 'http', protocol: 'tcp', subtypes: ['sub1', 'sub2']})) // _http._tcp._sub1._sub2\nconsole.log(types.parse('_http._tcp._sub1._sub2')) // {name: 'http', protocol: 'tcp', subtypes: ['sub1', 'sub2']}\n```\n\nThe following shorthands also exist\n\n``` js\ntypes.stringify(name, protocol, subtypes)\ntypes.tcp(name, subtypes) // set protocol to tcp\ntypes.udp(name, subtypes) // set protocol to udp\n```\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    },
+    {
+      "name": "watson",
+      "email": "w@tson.dk"
+    }
+  ],
+  "time": {
+    "modified": "2016-01-05T14:42:02.468Z",
+    "created": "2015-04-09T17:20:42.239Z",
+    "1.0.0": "2015-04-09T17:20:42.239Z",
+    "1.0.1": "2015-04-09T17:22:41.579Z",
+    "1.1.0": "2015-04-12T04:58:13.281Z"
+  },
+  "homepage": "https://github.com/mafintosh/multicast-dns-service-types",
+  "keywords": [
+    "mdns",
+    "bonjour",
+    "zero",
+    "conf"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mafintosh/multicast-dns-service-types.git"
+  },
+  "author": {
+    "name": "Mathias Buus",
+    "url": "@mafintosh"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/multicast-dns-service-types/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/multicast-dns-service-types.min.json
+++ b/test/fixtures/registry-mocks/content/multicast-dns-service-types.min.json
@@ -1,0 +1,44 @@
+{
+  "name": "multicast-dns-service-types",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "multicast-dns-service-types",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "5c75f86131b7c55711bb954ac721c8a816411a70",
+        "tarball": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "multicast-dns-service-types",
+      "version": "1.0.1",
+      "devDependencies": {
+        "standard": "^3.5.0",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "1ebdd242a28c4c94bfbc23c3f060098882b55cb5",
+        "tarball": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "multicast-dns-service-types",
+      "version": "1.1.0",
+      "devDependencies": {
+        "standard": "^3.5.0",
+        "tape": "^4.0.0"
+      },
+      "dist": {
+        "shasum": "899f11d9686e5e05cb91b35d5f0e63b773cfc901",
+        "tarball": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz"
+      }
+    }
+  },
+  "modified": "2016-01-05T14:42:02.468Z"
+}

--- a/test/fixtures/registry-mocks/content/multicast-dns.json
+++ b/test/fixtures/registry-mocks/content/multicast-dns.json
@@ -1,0 +1,2764 @@
+{
+  "_id": "multicast-dns",
+  "_rev": "54-c0d7bb661bd57b45264196c04d301e17",
+  "name": "multicast-dns",
+  "description": "Low level multicast-dns implementation in pure javascript",
+  "dist-tags": {
+    "latest": "7.2.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "multicast-dns",
+      "version": "0.0.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "ffee0740d1d0f857548e13c4a661c71126c7ff1a",
+      "_id": "multicast-dns@0.0.0",
+      "scripts": {},
+      "_shasum": "b738f4ec1885e1a2c7faf9d017477eba60ab113c",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b738f4ec1885e1a2c7faf9d017477eba60ab113c",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-0.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "multicast-dns",
+      "version": "1.0.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "aa64712139c083cecffa8402d71b63ee658be40b",
+      "_id": "multicast-dns@1.0.0",
+      "scripts": {},
+      "_shasum": "996c737ffc1ed1335dd81fc5a151835037b7de18",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "996c737ffc1ed1335dd81fc5a151835037b7de18",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "multicast-dns",
+      "version": "1.0.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "061ca3d54df75fdcd94638ef0b177fef97ed88e6",
+      "_id": "multicast-dns@1.0.1",
+      "_shasum": "644d4103196bc4245bf718c9a8d0cf19b3f2125c",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "644d4103196bc4245bf718c9a8d0cf19b3f2125c",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "multicast-dns",
+      "version": "1.0.2",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "eeaf652485cbf7148d3570cd1839555cada9b31d",
+      "_id": "multicast-dns@1.0.2",
+      "_shasum": "6e9250bced55632495038f6b092f52a09d1eaaf9",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6e9250bced55632495038f6b092f52a09d1eaaf9",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "multicast-dns",
+      "version": "1.1.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "d1aeea8a82cc572ca960f1bb8a49aa2fe4b3ebc3",
+      "_id": "multicast-dns@1.1.0",
+      "_shasum": "0ac1f270fa78d38ef2182f32f8d734dca64534c3",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0ac1f270fa78d38ef2182f32f8d734dca64534c3",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "multicast-dns",
+      "version": "1.2.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "cf5578e4d584db3d3fa36cf01799ac20532cba85",
+      "_id": "multicast-dns@1.2.0",
+      "_shasum": "a18e6c3ca3258bd117c65f7a0dab16e12e16b03e",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a18e6c3ca3258bd117c65f7a0dab16e12e16b03e",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "multicast-dns",
+      "version": "1.2.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "6860f8f464124301b8a4e175a3a4bfaf7be9c66b",
+      "_id": "multicast-dns@1.2.1",
+      "_shasum": "18ecc801f5f1975007b7afde5ee6db490931723a",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "1.3.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "18ecc801f5f1975007b7afde5ee6db490931723a",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "multicast-dns",
+      "version": "2.0.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "9b099b9922b90bc0b746198447bceb1502f8b8b1",
+      "_id": "multicast-dns@2.0.0",
+      "_shasum": "516fa9e32b077669a718d6e840edfdbdabe05c81",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "1.3.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "516fa9e32b077669a718d6e840edfdbdabe05c81",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "multicast-dns",
+      "version": "2.1.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "e061f37a13437ba55441cec8f6b04cbda1b4cd74",
+      "_id": "multicast-dns@2.1.0",
+      "_shasum": "f0f93e7584bb4e0f59d8f838b2ded055ff77f535",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "1.6.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f0f93e7584bb4e0f59d8f838b2ded055ff77f535",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "multicast-dns",
+      "version": "2.1.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "d9c08827f3b3c2072ce31ab597d114c15aadca70",
+      "_id": "multicast-dns@2.1.1",
+      "_shasum": "1df0728110409a1f866a78776b7993229960d54e",
+      "_from": ".",
+      "_npmVersion": "2.8.4",
+      "_nodeVersion": "1.8.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1df0728110409a1f866a78776b7993229960d54e",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-2.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "multicast-dns",
+      "version": "2.2.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "c70a6a269d477e0cac2b052426b6667cd5aa2722",
+      "_id": "multicast-dns@2.2.0",
+      "_shasum": "2b4c7403d74206ed0c1fd3081ecf23c5d0d06271",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "2b4c7403d74206ed0c1fd3081ecf23c5d0d06271",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-2.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "multicast-dns",
+      "version": "3.0.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "6f876a5171ad5d4f9019f3aabcd5b11ffbadcd3f",
+      "_id": "multicast-dns@3.0.0",
+      "_shasum": "2bd7956425836b90f9ecb85685e2ae2b35dbae19",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "2bd7956425836b90f9ecb85685e2ae2b35dbae19",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "multicast-dns",
+      "version": "4.0.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "c9da742a675923773637a841db7373d00e583d38",
+      "_id": "multicast-dns@4.0.0",
+      "_shasum": "2a9076182c4029812f27e9f07fa37e639849a2ed",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "2a9076182c4029812f27e9f07fa37e639849a2ed",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.1": {
+      "name": "multicast-dns",
+      "version": "4.0.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "f357c39d6b8f640d32d8085b04437477553af668",
+      "_id": "multicast-dns@4.0.1",
+      "_shasum": "abf022fc866727055a9e0c2bc98097f5ebad97a2",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "abf022fc866727055a9e0c2bc98097f5ebad97a2",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-4.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "multicast-dns",
+      "version": "5.0.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "1fa6beb2686749150d7cb4a07ea2207a2b56c008",
+      "_id": "multicast-dns@5.0.0",
+      "_shasum": "2997a51aa027610834d50a325221dacbf86f32dd",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "2997a51aa027610834d50a325221dacbf86f32dd",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.0.1": {
+      "name": "multicast-dns",
+      "version": "5.0.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "0a789b4a131111797e2da180db4918443f2384ae",
+      "_id": "multicast-dns@5.0.1",
+      "_shasum": "b9a44bbc8c3316e70c9a3505134debfd168a0f3e",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "b9a44bbc8c3316e70c9a3505134debfd168a0f3e",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.0.2": {
+      "name": "multicast-dns",
+      "version": "5.0.2",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "a4adef1749c4efc18bd15c4f3669f55558249bc8",
+      "_id": "multicast-dns@5.0.2",
+      "_shasum": "7cb87a2191249bb4d60d6d634bacd251afc1c891",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "7cb87a2191249bb4d60d6d634bacd251afc1c891",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "directories": {}
+    },
+    "5.1.0": {
+      "name": "multicast-dns",
+      "version": "5.1.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "gitHead": "be7cace1419cadc0c4e27a6cf95db6e07588e48a",
+      "_id": "multicast-dns@5.1.0",
+      "_shasum": "68cfa489abdfe1663fdcfffb26aca52a48c9372c",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "68cfa489abdfe1663fdcfffb26aca52a48c9372c",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "directories": {}
+    },
+    "5.2.0": {
+      "name": "multicast-dns",
+      "version": "5.2.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        56.009986032141335,
+        11.961881270211734
+      ],
+      "gitHead": "9c0496bf2985ac27493c1ea999d33b994f19e6a1",
+      "_id": "multicast-dns@5.2.0",
+      "_shasum": "9a30a1e9f36365b17fe23717807ce0f0d4bfdb66",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "9a30a1e9f36365b17fe23717807ce0f0d4bfdb66",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "5.3.0": {
+      "name": "multicast-dns",
+      "version": "5.3.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        56.009986032141335,
+        11.961881270211734
+      ],
+      "gitHead": "fafaff9d3cc2039611f37a204948efe875f2c904",
+      "_id": "multicast-dns@5.3.0",
+      "_shasum": "4f776a5ca7a9db0ebdbe13425044133a550a6477",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "4f776a5ca7a9db0ebdbe13425044133a550a6477",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "directories": {}
+    },
+    "5.3.1": {
+      "name": "multicast-dns",
+      "version": "5.3.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "c716e7ae050ce046a0897fadcb8483805cd9ee63",
+      "_id": "multicast-dns@5.3.1",
+      "_shasum": "4e732552b91e51fea24f971017416f335c8f3f23",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "watson",
+        "email": "w@tson.dk"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "dist": {
+        "shasum": "4e732552b91e51fea24f971017416f335c8f3f23",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "5.4.0": {
+      "name": "multicast-dns",
+      "version": "5.4.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "fb320b61c204439553888595d6e18824b86a96cb",
+      "_id": "multicast-dns@5.4.0",
+      "_shasum": "10469e75f4c0e085991ba317d66736a7cd33f70e",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.2.6",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "10469e75f4c0e085991ba317d66736a7cd33f70e",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/multicast-dns-5.4.0.tgz_1454948282937_0.6237917365506291"
+      },
+      "directories": {}
+    },
+    "5.5.0": {
+      "name": "multicast-dns",
+      "version": "5.5.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "33aec78966aec9ede8b65b6bd1a74562e2cd86be",
+      "_id": "multicast-dns@5.5.0",
+      "_shasum": "539d822df7a6a2c5c63d57f9d6609074282e1bf5",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "539d822df7a6a2c5c63d57f9d6609074282e1bf5",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/multicast-dns-5.5.0.tgz_1455484952792_0.7457283411640674"
+      },
+      "directories": {}
+    },
+    "6.0.0": {
+      "name": "multicast-dns",
+      "version": "6.0.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "e723b98fa977a62b510595b7847275f8e876caa4",
+      "_id": "multicast-dns@6.0.0",
+      "_shasum": "78db2a7348e284847d388d258a938849d0647d3a",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "78db2a7348e284847d388d258a938849d0647d3a",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/multicast-dns-6.0.0.tgz_1455831537592_0.060629300540313125"
+      },
+      "directories": {}
+    },
+    "6.0.1": {
+      "name": "multicast-dns",
+      "version": "6.0.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "696949229edfe98fb3d0c28bd3d4c3a57319f6ab",
+      "_id": "multicast-dns@6.0.1",
+      "_shasum": "069da64a0b695e156ef47c86a94e69e1a17ff2c2",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "069da64a0b695e156ef47c86a94e69e1a17ff2c2",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/multicast-dns-6.0.1.tgz_1456635728829_0.6833660455886275"
+      },
+      "directories": {}
+    },
+    "6.1.0": {
+      "name": "multicast-dns",
+      "version": "6.1.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "a1cabf87e1836a6ec6ebaf943eca8f08d9d66dd0",
+      "_id": "multicast-dns@6.1.0",
+      "_shasum": "8d91824b538556cd34f0adf6f27c60d94b5fb3bf",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "8d91824b538556cd34f0adf6f27c60d94b5fb3bf",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/multicast-dns-6.1.0.tgz_1473749323435_0.28012767573818564"
+      },
+      "directories": {}
+    },
+    "6.1.1": {
+      "name": "multicast-dns",
+      "version": "6.1.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "6b3e4ec0c281e51a87a67a005028a7b12e0c60ff",
+      "_id": "multicast-dns@6.1.1",
+      "_shasum": "6e7de86a570872ab17058adea7160bbeca814dde",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "6e7de86a570872ab17058adea7160bbeca814dde",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/multicast-dns-6.1.1.tgz_1488871059154_0.12876599351875484"
+      },
+      "directories": {}
+    },
+    "6.2.0": {
+      "name": "multicast-dns",
+      "version": "6.2.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "36e6695be993e8d9d50f78adb1787790fef46345",
+      "_id": "multicast-dns@6.2.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-tnQqWkuWYHCOVRveiWQf+5KjHUnEmtxUycTy1esL4prQjXoT4qpndIS4fH63zObmHNxIHke3YHRnQrXYpXHf2A==",
+        "shasum": "13f22d0c32dc5ee82a32878e3c380d875b3eab22",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns-6.2.0.tgz_1511110144726_0.12936242623254657"
+      },
+      "directories": {}
+    },
+    "6.2.1": {
+      "name": "multicast-dns",
+      "version": "6.2.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "39f66d960ede11c642501e48e311d6716eed65b7",
+      "_id": "multicast-dns@6.2.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-uV3/ckdsffHx9IrGQrx613mturMdMqQ06WTq+C09NsStJ9iNG6RcUWgPKs1Rfjy+idZT6tfQoXEusGNnEZhT3w==",
+        "shasum": "c5035defa9219d30640558a49298067352098060",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns-6.2.1.tgz_1511551134752_0.5561937538441271"
+      },
+      "directories": {}
+    },
+    "6.2.2": {
+      "name": "multicast-dns",
+      "version": "6.2.2",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "9751696bc5f62d2861cbc15bd5df16c5053e7412",
+      "_id": "multicast-dns@6.2.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-xTO41ApiRHMVDBYhNL9bEhx7kRf1hq3OqPOnOy8bpTi0JZSxVPDre7ZRpTHLDlxmhf6d/FL+10E8VX1QRd+0DA==",
+        "shasum": "300b6133361f8aaaf2b8d1248e85c363fe5b95a0",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns-6.2.2.tgz_1516231838786_0.7737880831118673"
+      },
+      "directories": {}
+    },
+    "6.2.3": {
+      "name": "multicast-dns",
+      "version": "6.2.3",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "8b510f3b85df6ea8f5c6f1d245621330399f9537",
+      "_id": "multicast-dns@6.2.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+        "shasum": "a0ec7bd9055c4282f790c3c82f4e28db3b31b229",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns-6.2.3.tgz_1517048238726_0.07778409938327968"
+      },
+      "directories": {}
+    },
+    "7.0.0": {
+      "name": "multicast-dns",
+      "version": "7.0.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "446a6f4c25fb39b52ee34aeebd5c5b9b59647488",
+      "_id": "multicast-dns@7.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-BqB5TtIXHo+8gN33N1CA1clsvPsAJlnc6D49SzfQA0xq75cxj15g2y9NaRdf4x2u4v1P66PBC+Wg6YgPO5Bc/g==",
+        "shasum": "68aa14c129377050f36bc318f8ba44101c4b3f38",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20849
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns_7.0.0_1518464661645_0.05552138535960793"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.0.1": {
+      "name": "multicast-dns",
+      "version": "7.0.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "1fa80e31a835b22c65d8c01e917c0ecb4233726c",
+      "_id": "multicast-dns@7.0.1",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.7.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-jx8bO2QZvx5oJXWhiuEb6I8XgufpPXvKFSAoSvurD2nECVhbQQTilY33IfChreWqhqPgzKZbpgsyHapjnRTnlw==",
+        "shasum": "bd600cdb6f1ae6f4defd4b047d95ddbc2dd001aa",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20845,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbc0mZCRA9TVsSAnZWagAAXq4P/j61ylu8jLW/WHvzjruC\nl7VA+lhC+Yv94LiWYvBdrl+fRA7L980/NGCbl+B5FWE5Exl5bFS9zBA/Z9hf\nevARwknnJIcw2aKilNP13ZIxfqV41yZGcdxqouYeQED9G0CBz5q76FgH2o7I\nFg5lZkuEPyCP2wAtVRnA9fGza440lLwl2KfVRwzzNBHje3F4PbujciFkc+gD\nFPNPx4YCMB1Kq3OCnaMU7cADU1qlvrz3W1fqzNPhY/jpFKP5aLb7dJfXIB4q\ndwrCOQDm5dk16Jx8xWml0Qa134aTv1EVOq851ZE61vaJF6UIhdynbhbUGJ6v\nqphQV2eF7iHVqTkhO+K82HmEB7pbWTgqBfck3TROnP27yR8obM6Byg1fFlB/\niy2SyJ7n/LLzsz46EXjf56v6bmK8UIk7oQWjilUBjcVYhewcnCturnCiDFQL\nC0zOT/s4rq1KFjJFz+CcfbUH06qZdZLdo/GKyd5A5O1fFxa5M7hlArUwval9\n/X0BQZ+LQgOwJ9qWWDwOOa9N3h/xBDDC4dKItm2FfPX3N93xKz0AElGknQfU\nBymF/1hvraOkJjw+WpFk+j1RIv26WWnij7hW1tHdOTgE3aH5iNzvtRpStPMU\nQGkRFG3oPHPmJNm3VhNW59GBPxWb0YB0x0XEjeSycdk7v/tse9cx13TqjfIu\n+Gwx\r\n=RyaZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns_7.0.1_1534282137364_0.1577689657919965"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.1.0": {
+      "name": "multicast-dns",
+      "version": "7.1.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "95104bb8be01a70bdc1429a8d2c743b384b32215",
+      "_id": "multicast-dns@7.1.0",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-PHrJGpkPvHHu5GwK5X6XYLPdbujk7X9Ne9aOPJM77fWzzrCwoGnNp1kc8YGjfscgZq0OFi34hk0mhB1rONxm+g==",
+        "shasum": "cb4fe0a47cac8fc444f589f9f89d8bbaceba61a7",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.1.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20916,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbjsQPCRA9TVsSAnZWagAA6lQP/1CKN/2heLDgy4WpFqSZ\n4D/p8ZZm4vCvlt+McFcKz8zYAu+kb2ykWNa8U9jONeAKffeWIT4ghSM3rPkd\noZeVaDoq6lyWhowuDjlwsSxmu0mV9DY+AYm0KYT7d7raATaqMxvmh6oDCN5t\nBlmpsLnyYTmRgIgLk8KPdWwwDRDAgz0XdUB7BN+QmiN9eQYLvVP9iKQ/FEpc\nUKgpogjlMGxJOjhD2qQBlh3aqEECmyHK+9kRT35qMiuwYI6dp1APyCc/WYZQ\nl67vBapxaffbcETHW/BkhKE58/DeAP8JQ8d857AsoSx0vCbOed67ahqZ9gzG\nF5hNnoOYZ4VxFed8F5CdxbsQfkEhXZ8aRUgJ6ilposvK5o8FSUNdDFjWotIG\noWPEI0uBcTWcAQU9XA7u0vj+oQIh8VRO72fz5StJ/4GGVnDnE5+zbKUY4oHq\nSAbaUYz4ADr2cIWiwEertNEd/D+S8z/3iQN9BPP+VX7iMyPN+gAjg4UC3guu\ns3BTwlEiG+WnMtmaPGMxVFit3iDTb/2BAr5JSHhXuLnhIZJscb0P0fxtfbab\nM+7AUuwZT+xgtJvk3oub1vpy4MeHm9R+YjaqPYFcdcWKvHKVL+0mXlmmygxI\nzese2jkC1W7M7bc6XTB1JJrhkuvzkjOuUlRxr51nSvW0VgE1k6C5sfThRR4E\ntrn8\r\n=mEJY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns_7.1.0_1536082958916_0.7453463333182493"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.1.1": {
+      "name": "multicast-dns",
+      "version": "7.1.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "5bf4d6f951f97e1aabfb9e9f6da064c7098827a3",
+      "_id": "multicast-dns@7.1.1",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-/Oxk1oCLB4akIPqBZ8GgvgZhK62b7dlTLSq323QmdsIG2pXdTI6fSmc9dk8904ks2FGSdr3zOCGjcD9MJky/Aw==",
+        "shasum": "974b444bc9ffb92bf19b81eea00b736cceeb9c7b",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.1.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20943,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbjuYaCRA9TVsSAnZWagAAq4EP/2KdCDDiN5hVIlQtkZ9e\ne6BAPLxNDrOUSQTkrZtlGQNZgN+rzLbUmg9DOhaNAXTeFUkZkjBxjRC82u8F\nOfsmz9F+FZbKsr5a/tZhnonN0ga6JUOCoe4s/WDEEmaJOiL5+Ny5X/Ghzhgd\nKayIfto7oV6RU2GV1DStBDvAIwBSErmtVS7SSKKrfX0rTseCsZtffb2oDO5V\nlgiFyw6EHn5u3ya3u6nKDQsgneaZfqUb9BwPDAZJRasptSR/gmiF3P+k6IMW\nSC+6oufa06aQBal5OJ08x933ZTQM2SQXKyh5lTaHyUlnrottDTZBGwdwade7\ncGNSz2NZPLK6h/P4WWSXCCjWzJPu2Tdj1l/ht14mBRpZpf29qBQbFX72rIo+\n4pP799ngwTYwTKSX7P3wPV116fVyWDmyjoVW7ODAegTA/R+i2SZLO+5c1BTo\nrzqalwh2PawoTqGtqm6eX2jRGb69dLKCyVNQ7ypIhqs4O6SIKN9B7NAKaEyH\nMM6x/w9ckWRwp6Pa6LVsCw4f88k+Plg+qW0e3phSOZjgvQSsFwZGyOjdVIlO\nCj5GwzuESLNBWqVtIwh9ArHd7IXRb+qfjGPXvBX7VoM04owijnyrhcMDn9UZ\nkZXTwHnsHFodsnMNHiVVlDcmvXeqSZW1h83AmzlRkWxT36gFjjCH1sZ/zRrX\nzfC3\r\n=yTDB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns_7.1.1_1536091673768_0.9700297707952059"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.2.0": {
+      "name": "multicast-dns",
+      "version": "7.2.0",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "c6787408772f3e32ee8212e8e59b2fca793e3e74",
+      "_id": "multicast-dns@7.2.0",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Tu2QORGOFANB124NWQ/JTRhMf/ODouVLEuvu5Dz8YWEU55zQgRgFGnBHfIh5PbfNDAuaRl7yLB+pgWhSqVxi2Q==",
+        "shasum": "7aa49a7efba931a346011aa02e7d1c314a65ac77",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20966,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbjvrtCRA9TVsSAnZWagAA304P/jKX18bRWHerMpaZs+ER\nipY+F3mfPxLoo8sGLAsiLa84Vt+6aF4KoxrLkKvz7z/DH4EViaUwAoEN3sOn\ndClLmExP73EPSUr3+xv4rKrmbbkYLb4O9YFNOdECbGvAzy06LH9WzkSyysmb\njFfg2tj4Aw/Cpt0vGyLJdUPc4akHPd7QCz9dY9qBqrZQN50EOMDyP06aPJli\nBjPf7HID12ZqSpGy5wqhY8+doW5f6ajS9j221U/qG6OWBjC8h8o1HN3eMtjS\n3gyz7YEtPrlDaC4PqAydHSydvqfzCIGa/uttgDOIkdzLdDu0aLu0vxiowydf\nS0zf9Lz2+caiGM0/04cutTnVIg0Z9CFNiXSOzSjPPPzOriGMn//JPGjyDe+6\natoLLBSYs0i0u7KIeoRQ3BlBcS/4d0S5cxDFjWaNykjJ6X9A3Bi1oooggQZ2\nHYIuGNqPvxIyur9VT+YrdWCz4/U/Kmxa9LEcPLv3XVGTJTAzh1pfCDbuu7ab\nIkXGkXj7jZJts5jIdaGaFLJhACE58Fg7otWZP5g3wAiczb1tKkfvcfdzHf8J\n0Zn4ryKRY+C30yFo20HLLQ0tJkqv0xNUvnIL1sZCy7jPH4w/A12lQFOwTCfS\nc+bQFzbJ/cout43eSX1b5qOQPB6AXJAOcHga9hanThAWKNT0B9OPXluyzFob\nR63o\r\n=QyGg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns_7.2.0_1536097004803_0.7857897042644937"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.2.1": {
+      "name": "multicast-dns",
+      "version": "7.2.1",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "57f4a22174584e1479f5f80ea750bda904c617ad",
+      "_id": "multicast-dns@7.2.1",
+      "_nodeVersion": "12.14.1",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-qJaNecNV4wV5FqZ+aBHOgUcHaJXpEMZhiERmuu7CM0YrCyIsgevVLZJGXeyxMAiofN+jby8oAGr8BpQk6xmptw==",
+        "shasum": "bec7853ee8d88a624a3fbfb5098ca1491c354c70",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 21379,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeRpHzCRA9TVsSAnZWagAAAqIP/jOq2NW/sHLDNl5E4cde\n8uujy3mOyVLRMeFj8doj0G05W7f36vthXsiHrDMjqVKAXrbonG3KcJ+EHkby\nHYZ4+Suzu0FL+dcbzUgEDOi+lHOZwdQAy2tcOZF9NE6RWhu9RkiDc1v6Gn33\nmgIAvckTr4Kh6EwvPi1BogvobaSOvwaYtEXv0d/0rvmhsRXEUsMW98Fu1iGt\niltctwIrI9vD22kDv1jV+1rvbqcggIryqWU7SzuDuC0iYPxIFipOr14KtF79\nSiLof1LPadueSjZhheGb/CAZqXE6j90woh3g6QQO4WBKwCBxdmhDiuVJ9cvQ\nBItYkYHR2c3cgIYDGidtN+2mIW3Y4zG6b/T0PMy4vAQanuR3/lOpDjLsyDig\n6yoMoOsyl5pjc5AzJAL6cHT9q+8i7n7sulYrz5dE44Yjc76gd4Rg8qQFawK2\njbsI81X7rW16nU7G5e6eqE9Ug7rSw1FkeY6cwToatwbb0Brt6EcpVvY97Ns5\nWBfJrqK3s1eWEiHohdG2Nhez4FnoiskGgtL1+pwTjKlaGbHzHHsfKUosURcu\nYWbip6mdsAjuqAv4NcnW6/O+hWvGojbWe8YeMchhU8KSHmE7+mKawsh3Pnot\nhwBTAY+nAjNVTKXyW2xfWg9gX+Jktss0CBd9IAhLZRr13+c0f/DQYY0TwF7Z\nO3s1\r\n=ZoU+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns_7.2.1_1581683187321_0.22578424859357704"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.2.2": {
+      "name": "multicast-dns",
+      "version": "7.2.2",
+      "description": "Low level multicast-dns implementation in pure javascript",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/multicast-dns.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/multicast-dns/issues"
+      },
+      "homepage": "https://github.com/mafintosh/multicast-dns",
+      "keywords": [
+        "multicast",
+        "dns",
+        "mdns",
+        "multicastdns",
+        "dns-sd",
+        "service",
+        "discovery",
+        "bonjour",
+        "avahi"
+      ],
+      "coordinates": [
+        55.6465878,
+        12.5492251
+      ],
+      "gitHead": "52bf467f79da47b4ad2ed27517bd186f4f9e4db1",
+      "_id": "multicast-dns@7.2.2",
+      "_nodeVersion": "13.9.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-XqSMeO8EWV/nOXOpPV8ztIpNweVfE1dSpz6SQvDPp71HD74lMXjt4m/mWB1YBMG0kHtOodxRWc5WOb/UNN1A5g==",
+        "shasum": "5731da04f47d1e435ac457e5ac7b4b39d866a5a1",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 21480,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJefM7cCRA9TVsSAnZWagAAJKIP/icmoVumFASEsRG6HkdN\nuk79TeYrQL8sprlxypImdfxYiPIUExYQx+5TLFUgZ6ESISoH7PSiV6QyVx1P\noRX2n5ZKiVP9jluFiVR8IpleesAqANTjXcKRDUjVCRpsJHrWm93citkAhQAW\n07+4bIlpU/sNL2DX8j9Mlr2b1j7n9aMCK/ikrmPMgrmFca1Eg4b1r16tZMmW\nz56xJTNJB+IA4kgYqqYhEujJ17H/qfPUkeId1zgWB0La3KNvzu+lZop1WNhm\nEpsaIXEoNioa4Cp14BomsQSrS9+2t0j61bO+Pw9N2Ez86Yl3Ux5jlMstj9Sd\n+NUOXsMfyvZ4MZmKkWg8zUtfUehlENNoDRlJ/cg7Kdh2dxsFdlZXzGA2tb8S\nF1pHKuDl3uGKFR9dOZEX9Qb1+vHQOVFBKGMHFhNplLBkZ/q7NmWfxjsisUbi\n+ydIiiMqTom0OdZGUXtI4rus9rjqVhsyoEIZhwy7uXxQVaEKUsrW+TkA/srp\ntq6VHpdcSBJiSrClKF4eGbNn8oTinGKT4ONe5SHWnx6/6//0b5PpW5wgIQUh\n0mTZEvej9ElHyrmWYLsA/Zt0O3aqk3rPFdlmNv0upSXDRevzkA+nRTCUoled\nXSE3NtNi9ISxKsjp1nqsBYT2dAxmBTwBAZthsLuJ61zh5zOwARN74mUcSy2T\nw7vC\r\n=PcXa\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "watson",
+          "email": "w@tson.dk"
+        }
+      ],
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/multicast-dns_7.2.2_1585237724427_0.43089352304777795"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# multicast-dns\n\nLow level multicast-dns implementation in pure javascript\n\n```\nnpm install multicast-dns\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/multicast-dns.svg?style=flat)](http://travis-ci.org/mafintosh/multicast-dns)\n\n## Usage\n\n``` js\nvar mdns = require('multicast-dns')()\n\nmdns.on('response', function(response) {\n  console.log('got a response packet:', response)\n})\n\nmdns.on('query', function(query) {\n  console.log('got a query packet:', query)\n})\n\n// lets query for an A record for 'brunhilde.local'\nmdns.query({\n  questions:[{\n    name: 'brunhilde.local',\n    type: 'A'\n  }]\n})\n```\n\nRunning the above (change `brunhilde.local` to `your-own-hostname.local`) will print an echo of the query packet first\n\n``` js\ngot a query packet: { type: 'query',\n  questions: [ { name: 'brunhilde.local', type: 'A', class: 1 } ],\n  answers: [],\n  authorities: [],\n  additionals: [] }\n```\n\nAnd then a response packet\n\n``` js\ngot a response packet: { type: 'response',\n  questions: [],\n  answers:\n   [ { name: 'brunhilde.local',\n       type: 'A',\n       class: 'IN',\n       ttl: 120,\n       flush: true,\n       data: '192.168.1.5' } ],\n  authorities: [],\n  additionals:\n   [ { name: 'brunhilde.local',\n       type: 'A',\n       class: 'IN',\n       ttl: 120,\n       flush: true,\n       data: '192.168.1.5' },\n     { name: 'brunhilde.local',\n       type: 'AAAA',\n       class: 'IN',\n       ttl: 120,\n       flush: true,\n       data: 'fe80::5ef9:38ff:fe8c:ceaa' } ] }\n```\n\n\n# CLI\n\n```\nnpm install -g multicast-dns\n```\n\n```\nmulticast-dns brunhilde.local\n> 192.168.1.1\n```\n\n# API\n\nA packet has the following format\n\n``` js\n{\n  questions: [{\n    name:'brunhilde.local',\n    type:'A'\n  }],\n  answers: [{\n    name:'brunhilde.local',\n    type:'A',\n    ttl:seconds,\n    data:(record type specific data)\n  }],\n  additionals: [\n    (same format as answers)\n  ],\n  authorities: [\n    (same format as answers)\n  ]\n}\n```\n\nCurrently data from `SRV`, `A`, `PTR`, `TXT`, `AAAA` and `HINFO` records is passed\n\n#### `mdns = multicastdns([options])`\n\nCreates a new `mdns` instance. Options can contain the following\n\n``` js\n{\n  multicast: true // use udp multicasting\n  interface: '192.168.0.2' // explicitly specify a network interface. defaults to all\n  port: 5353, // set the udp port\n  ip: '224.0.0.251', // set the udp ip\n  ttl: 255, // set the multicast ttl\n  loopback: true, // receive your own packets\n  reuseAddr: true // set the reuseAddr option when creating the socket (requires node >=0.11.13)\n}\n```\n\n#### `mdns.on('query', (packet, rinfo))`\n\nEmitted when a query packet is received.\n\n``` js\nmdns.on('query', function(query) {\n  if (query.questions[0] && query.questions[0].name === 'brunhilde.local') {\n    mdns.respond(someResponse) // see below\n  }\n})\n```\n\n#### `mdns.on('response', (packet, rinfo))`\n\nEmitted when a response packet is received.\n\nThe response might not be a response to a query you send as this\nis the result of someone multicasting a response.\n\n#### `mdns.query(packet, [cb])`\n\nSend a dns query. The callback will be called when the packet was sent.\n\nThe following shorthands are equivalent\n\n``` js\nmdns.query('brunhilde.local', 'A')\nmdns.query([{name:'brunhilde.local', type:'A'}])\nmdns.query({\n  questions: [{name:'brunhilde.local', type:'A'}]\n})\n```\n\n#### `mdns.respond(packet, [cb])`\n\nSend a dns response. The callback will be called when the packet was sent.\n\n``` js\n// reply with a SRV and a A record as an answer\nmdns.respond({\n  answers: [{\n    name: 'my-service',\n    type: 'SRV',\n    data: {\n      port:9999,\n      weigth: 0,\n      priority: 10,\n      target: 'my-service.example.com'\n    }\n  }, {\n    name: 'brunhilde.local',\n    type: 'A',\n    ttl: 300,\n    data: '192.168.1.5'\n  }]\n})\n```\n\nThe following shorthands are equivalent\n\n``` js\nmdns.respond([{name:'brunhilde.local', type:'A', data:'192.158.1.5'}])\nmdns.respond({\n  answers: [{name:'brunhilde.local', type:'A', data:'192.158.1.5'}]\n})\n```\n\n#### `mdns.destroy()`\n\nDestroy the mdns instance. Closes the udp socket.\n\n# Development\n\nTo start hacking on this module you can use this example to get started\n\n```\ngit clone git://github.com/mafintosh/multicast-dns.git\nnpm install\nnode example.js\nnode cli.js $(hostname).local\n```\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    },
+    {
+      "name": "watson",
+      "email": "w@tson.dk"
+    }
+  ],
+  "time": {
+    "modified": "2020-03-26T15:48:46.915Z",
+    "created": "2015-01-08T23:35:59.537Z",
+    "0.0.0": "2015-01-08T23:35:59.537Z",
+    "1.0.0": "2015-01-08T23:36:54.558Z",
+    "1.0.1": "2015-01-09T00:20:30.385Z",
+    "1.0.2": "2015-01-09T11:38:19.975Z",
+    "1.1.0": "2015-01-09T11:42:50.369Z",
+    "1.2.0": "2015-01-12T15:15:38.120Z",
+    "1.2.1": "2015-02-22T13:47:41.451Z",
+    "2.0.0": "2015-02-22T15:51:52.753Z",
+    "2.1.0": "2015-04-07T18:03:56.870Z",
+    "2.1.1": "2015-05-03T14:58:58.132Z",
+    "2.2.0": "2015-06-12T01:38:35.083Z",
+    "3.0.0": "2015-07-02T21:11:53.216Z",
+    "4.0.0": "2015-11-08T21:51:51.096Z",
+    "4.0.1": "2015-12-22T20:42:01.142Z",
+    "5.0.0": "2015-12-22T21:32:52.108Z",
+    "5.0.1": "2016-01-05T14:45:30.487Z",
+    "5.0.2": "2016-01-05T15:07:51.495Z",
+    "5.1.0": "2016-01-05T15:11:42.237Z",
+    "5.2.0": "2016-01-09T20:38:22.760Z",
+    "5.3.0": "2016-01-31T13:01:41.003Z",
+    "5.3.1": "2016-01-31T13:27:11.621Z",
+    "5.4.0": "2016-02-08T16:18:04.295Z",
+    "5.5.0": "2016-02-14T21:22:34.959Z",
+    "6.0.0": "2016-02-18T21:39:01.902Z",
+    "6.0.1": "2016-02-28T05:02:09.884Z",
+    "6.1.0": "2016-09-13T06:48:45.227Z",
+    "6.1.1": "2017-03-07T07:17:39.877Z",
+    "6.2.0": "2017-11-19T16:49:05.691Z",
+    "6.2.1": "2017-11-24T19:18:55.673Z",
+    "6.2.2": "2018-01-17T23:30:39.662Z",
+    "6.2.3": "2018-01-27T10:17:19.030Z",
+    "7.0.0": "2018-02-12T19:44:22.323Z",
+    "7.0.1": "2018-08-14T21:28:57.488Z",
+    "7.1.0": "2018-09-04T17:42:39.027Z",
+    "7.1.1": "2018-09-04T20:07:53.882Z",
+    "7.2.0": "2018-09-04T21:36:44.966Z",
+    "7.2.1": "2020-02-14T12:26:27.485Z",
+    "7.2.2": "2020-03-26T15:48:44.510Z"
+  },
+  "homepage": "https://github.com/mafintosh/multicast-dns",
+  "keywords": [
+    "multicast",
+    "dns",
+    "mdns",
+    "multicastdns",
+    "dns-sd",
+    "service",
+    "discovery",
+    "bonjour",
+    "avahi"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mafintosh/multicast-dns.git"
+  },
+  "author": {
+    "name": "Mathias Buus",
+    "url": "@mafintosh"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/multicast-dns/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "131": true,
+    "goliatone": true,
+    "nneves": true,
+    "manikantag": true,
+    "shanewholloway": true,
+    "netoperatorwibby": true,
+    "damienc": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/multicast-dns.min.json
+++ b/test/fixtures/registry-mocks/content/multicast-dns.min.json
@@ -1,0 +1,708 @@
+{
+  "name": "multicast-dns",
+  "dist-tags": {
+    "latest": "7.2.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "multicast-dns",
+      "version": "0.0.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "dist": {
+        "shasum": "b738f4ec1885e1a2c7faf9d017477eba60ab113c",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-0.0.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "multicast-dns",
+      "version": "1.0.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "dist": {
+        "shasum": "996c737ffc1ed1335dd81fc5a151835037b7de18",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "multicast-dns",
+      "version": "1.0.1",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "644d4103196bc4245bf718c9a8d0cf19b3f2125c",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "multicast-dns",
+      "version": "1.0.2",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "6e9250bced55632495038f6b092f52a09d1eaaf9",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "multicast-dns",
+      "version": "1.1.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "0ac1f270fa78d38ef2182f32f8d734dca64534c3",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "multicast-dns",
+      "version": "1.2.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "a18e6c3ca3258bd117c65f7a0dab16e12e16b03e",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "multicast-dns",
+      "version": "1.2.1",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "18ecc801f5f1975007b7afde5ee6db490931723a",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-1.2.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "multicast-dns",
+      "version": "2.0.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3"
+      },
+      "dist": {
+        "shasum": "516fa9e32b077669a718d6e840edfdbdabe05c81",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-2.0.0.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "multicast-dns",
+      "version": "2.1.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "f0f93e7584bb4e0f59d8f838b2ded055ff77f535",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-2.1.0.tgz"
+      }
+    },
+    "2.1.1": {
+      "name": "multicast-dns",
+      "version": "2.1.1",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "1df0728110409a1f866a78776b7993229960d54e",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-2.1.1.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "multicast-dns",
+      "version": "2.2.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "2b4c7403d74206ed0c1fd3081ecf23c5d0d06271",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-2.2.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "multicast-dns",
+      "version": "3.0.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "2bd7956425836b90f9ecb85685e2ae2b35dbae19",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-3.0.0.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "multicast-dns",
+      "version": "4.0.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "2a9076182c4029812f27e9f07fa37e639849a2ed",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-4.0.0.tgz"
+      }
+    },
+    "4.0.1": {
+      "name": "multicast-dns",
+      "version": "4.0.1",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "abf022fc866727055a9e0c2bc98097f5ebad97a2",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-4.0.1.tgz"
+      }
+    },
+    "5.0.0": {
+      "name": "multicast-dns",
+      "version": "5.0.0",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^3.3.2",
+        "tape": "^3.0.3"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "2997a51aa027610834d50a325221dacbf86f32dd",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.0.0.tgz"
+      }
+    },
+    "5.0.1": {
+      "name": "multicast-dns",
+      "version": "5.0.1",
+      "dependencies": {
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "b9a44bbc8c3316e70c9a3505134debfd168a0f3e",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.0.1.tgz"
+      }
+    },
+    "5.0.2": {
+      "name": "multicast-dns",
+      "version": "5.0.2",
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "7cb87a2191249bb4d60d6d634bacd251afc1c891",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.0.2.tgz"
+      }
+    },
+    "5.1.0": {
+      "name": "multicast-dns",
+      "version": "5.1.0",
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "68cfa489abdfe1663fdcfffb26aca52a48c9372c",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.1.0.tgz"
+      }
+    },
+    "5.2.0": {
+      "name": "multicast-dns",
+      "version": "5.2.0",
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "9a30a1e9f36365b17fe23717807ce0f0d4bfdb66",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.2.0.tgz"
+      }
+    },
+    "5.3.0": {
+      "name": "multicast-dns",
+      "version": "5.3.0",
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "4f776a5ca7a9db0ebdbe13425044133a550a6477",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.3.0.tgz"
+      }
+    },
+    "5.3.1": {
+      "name": "multicast-dns",
+      "version": "5.3.1",
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "4e732552b91e51fea24f971017416f335c8f3f23",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.3.1.tgz"
+      }
+    },
+    "5.4.0": {
+      "name": "multicast-dns",
+      "version": "5.4.0",
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "10469e75f4c0e085991ba317d66736a7cd33f70e",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.4.0.tgz"
+      }
+    },
+    "5.5.0": {
+      "name": "multicast-dns",
+      "version": "5.5.0",
+      "dependencies": {
+        "thunky": "^0.1.0",
+        "ip": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "539d822df7a6a2c5c63d57f9d6609074282e1bf5",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-5.5.0.tgz"
+      }
+    },
+    "6.0.0": {
+      "name": "multicast-dns",
+      "version": "6.0.0",
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "78db2a7348e284847d388d258a938849d0647d3a",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.0.0.tgz"
+      }
+    },
+    "6.0.1": {
+      "name": "multicast-dns",
+      "version": "6.0.1",
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "069da64a0b695e156ef47c86a94e69e1a17ff2c2",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.0.1.tgz"
+      }
+    },
+    "6.1.0": {
+      "name": "multicast-dns",
+      "version": "6.1.0",
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "8d91824b538556cd34f0adf6f27c60d94b5fb3bf",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.0.tgz"
+      }
+    },
+    "6.1.1": {
+      "name": "multicast-dns",
+      "version": "6.1.1",
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "shasum": "6e7de86a570872ab17058adea7160bbeca814dde",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz"
+      }
+    },
+    "6.2.0": {
+      "name": "multicast-dns",
+      "version": "6.2.0",
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-tnQqWkuWYHCOVRveiWQf+5KjHUnEmtxUycTy1esL4prQjXoT4qpndIS4fH63zObmHNxIHke3YHRnQrXYpXHf2A==",
+        "shasum": "13f22d0c32dc5ee82a32878e3c380d875b3eab22",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.0.tgz"
+      }
+    },
+    "6.2.1": {
+      "name": "multicast-dns",
+      "version": "6.2.1",
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-uV3/ckdsffHx9IrGQrx613mturMdMqQ06WTq+C09NsStJ9iNG6RcUWgPKs1Rfjy+idZT6tfQoXEusGNnEZhT3w==",
+        "shasum": "c5035defa9219d30640558a49298067352098060",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.1.tgz"
+      }
+    },
+    "6.2.2": {
+      "name": "multicast-dns",
+      "version": "6.2.2",
+      "dependencies": {
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tape": "^4.4.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-xTO41ApiRHMVDBYhNL9bEhx7kRf1hq3OqPOnOy8bpTi0JZSxVPDre7ZRpTHLDlxmhf6d/FL+10E8VX1QRd+0DA==",
+        "shasum": "300b6133361f8aaaf2b8d1248e85c363fe5b95a0",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.2.tgz"
+      }
+    },
+    "6.2.3": {
+      "name": "multicast-dns",
+      "version": "6.2.3",
+      "dependencies": {
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+        "shasum": "a0ec7bd9055c4282f790c3c82f4e28db3b31b229",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz"
+      }
+    },
+    "7.0.0": {
+      "name": "multicast-dns",
+      "version": "7.0.0",
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-BqB5TtIXHo+8gN33N1CA1clsvPsAJlnc6D49SzfQA0xq75cxj15g2y9NaRdf4x2u4v1P66PBC+Wg6YgPO5Bc/g==",
+        "shasum": "68aa14c129377050f36bc318f8ba44101c4b3f38",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20849
+      }
+    },
+    "7.0.1": {
+      "name": "multicast-dns",
+      "version": "7.0.1",
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-jx8bO2QZvx5oJXWhiuEb6I8XgufpPXvKFSAoSvurD2nECVhbQQTilY33IfChreWqhqPgzKZbpgsyHapjnRTnlw==",
+        "shasum": "bd600cdb6f1ae6f4defd4b047d95ddbc2dd001aa",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.0.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20845,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbc0mZCRA9TVsSAnZWagAAXq4P/j61ylu8jLW/WHvzjruC\nl7VA+lhC+Yv94LiWYvBdrl+fRA7L980/NGCbl+B5FWE5Exl5bFS9zBA/Z9hf\nevARwknnJIcw2aKilNP13ZIxfqV41yZGcdxqouYeQED9G0CBz5q76FgH2o7I\nFg5lZkuEPyCP2wAtVRnA9fGza440lLwl2KfVRwzzNBHje3F4PbujciFkc+gD\nFPNPx4YCMB1Kq3OCnaMU7cADU1qlvrz3W1fqzNPhY/jpFKP5aLb7dJfXIB4q\ndwrCOQDm5dk16Jx8xWml0Qa134aTv1EVOq851ZE61vaJF6UIhdynbhbUGJ6v\nqphQV2eF7iHVqTkhO+K82HmEB7pbWTgqBfck3TROnP27yR8obM6Byg1fFlB/\niy2SyJ7n/LLzsz46EXjf56v6bmK8UIk7oQWjilUBjcVYhewcnCturnCiDFQL\nC0zOT/s4rq1KFjJFz+CcfbUH06qZdZLdo/GKyd5A5O1fFxa5M7hlArUwval9\n/X0BQZ+LQgOwJ9qWWDwOOa9N3h/xBDDC4dKItm2FfPX3N93xKz0AElGknQfU\nBymF/1hvraOkJjw+WpFk+j1RIv26WWnij7hW1tHdOTgE3aH5iNzvtRpStPMU\nQGkRFG3oPHPmJNm3VhNW59GBPxWb0YB0x0XEjeSycdk7v/tse9cx13TqjfIu\n+Gwx\r\n=RyaZ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.1.0": {
+      "name": "multicast-dns",
+      "version": "7.1.0",
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-PHrJGpkPvHHu5GwK5X6XYLPdbujk7X9Ne9aOPJM77fWzzrCwoGnNp1kc8YGjfscgZq0OFi34hk0mhB1rONxm+g==",
+        "shasum": "cb4fe0a47cac8fc444f589f9f89d8bbaceba61a7",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.1.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20916,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbjsQPCRA9TVsSAnZWagAA6lQP/1CKN/2heLDgy4WpFqSZ\n4D/p8ZZm4vCvlt+McFcKz8zYAu+kb2ykWNa8U9jONeAKffeWIT4ghSM3rPkd\noZeVaDoq6lyWhowuDjlwsSxmu0mV9DY+AYm0KYT7d7raATaqMxvmh6oDCN5t\nBlmpsLnyYTmRgIgLk8KPdWwwDRDAgz0XdUB7BN+QmiN9eQYLvVP9iKQ/FEpc\nUKgpogjlMGxJOjhD2qQBlh3aqEECmyHK+9kRT35qMiuwYI6dp1APyCc/WYZQ\nl67vBapxaffbcETHW/BkhKE58/DeAP8JQ8d857AsoSx0vCbOed67ahqZ9gzG\nF5hNnoOYZ4VxFed8F5CdxbsQfkEhXZ8aRUgJ6ilposvK5o8FSUNdDFjWotIG\noWPEI0uBcTWcAQU9XA7u0vj+oQIh8VRO72fz5StJ/4GGVnDnE5+zbKUY4oHq\nSAbaUYz4ADr2cIWiwEertNEd/D+S8z/3iQN9BPP+VX7iMyPN+gAjg4UC3guu\ns3BTwlEiG+WnMtmaPGMxVFit3iDTb/2BAr5JSHhXuLnhIZJscb0P0fxtfbab\nM+7AUuwZT+xgtJvk3oub1vpy4MeHm9R+YjaqPYFcdcWKvHKVL+0mXlmmygxI\nzese2jkC1W7M7bc6XTB1JJrhkuvzkjOuUlRxr51nSvW0VgE1k6C5sfThRR4E\ntrn8\r\n=mEJY\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.1.1": {
+      "name": "multicast-dns",
+      "version": "7.1.1",
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-/Oxk1oCLB4akIPqBZ8GgvgZhK62b7dlTLSq323QmdsIG2pXdTI6fSmc9dk8904ks2FGSdr3zOCGjcD9MJky/Aw==",
+        "shasum": "974b444bc9ffb92bf19b81eea00b736cceeb9c7b",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.1.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20943,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbjuYaCRA9TVsSAnZWagAAq4EP/2KdCDDiN5hVIlQtkZ9e\ne6BAPLxNDrOUSQTkrZtlGQNZgN+rzLbUmg9DOhaNAXTeFUkZkjBxjRC82u8F\nOfsmz9F+FZbKsr5a/tZhnonN0ga6JUOCoe4s/WDEEmaJOiL5+Ny5X/Ghzhgd\nKayIfto7oV6RU2GV1DStBDvAIwBSErmtVS7SSKKrfX0rTseCsZtffb2oDO5V\nlgiFyw6EHn5u3ya3u6nKDQsgneaZfqUb9BwPDAZJRasptSR/gmiF3P+k6IMW\nSC+6oufa06aQBal5OJ08x933ZTQM2SQXKyh5lTaHyUlnrottDTZBGwdwade7\ncGNSz2NZPLK6h/P4WWSXCCjWzJPu2Tdj1l/ht14mBRpZpf29qBQbFX72rIo+\n4pP799ngwTYwTKSX7P3wPV116fVyWDmyjoVW7ODAegTA/R+i2SZLO+5c1BTo\nrzqalwh2PawoTqGtqm6eX2jRGb69dLKCyVNQ7ypIhqs4O6SIKN9B7NAKaEyH\nMM6x/w9ckWRwp6Pa6LVsCw4f88k+Plg+qW0e3phSOZjgvQSsFwZGyOjdVIlO\nCj5GwzuESLNBWqVtIwh9ArHd7IXRb+qfjGPXvBX7VoM04owijnyrhcMDn9UZ\nkZXTwHnsHFodsnMNHiVVlDcmvXeqSZW1h83AmzlRkWxT36gFjjCH1sZ/zRrX\nzfC3\r\n=yTDB\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.2.0": {
+      "name": "multicast-dns",
+      "version": "7.2.0",
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-Tu2QORGOFANB124NWQ/JTRhMf/ODouVLEuvu5Dz8YWEU55zQgRgFGnBHfIh5PbfNDAuaRl7yLB+pgWhSqVxi2Q==",
+        "shasum": "7aa49a7efba931a346011aa02e7d1c314a65ac77",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 20966,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbjvrtCRA9TVsSAnZWagAA304P/jKX18bRWHerMpaZs+ER\nipY+F3mfPxLoo8sGLAsiLa84Vt+6aF4KoxrLkKvz7z/DH4EViaUwAoEN3sOn\ndClLmExP73EPSUr3+xv4rKrmbbkYLb4O9YFNOdECbGvAzy06LH9WzkSyysmb\njFfg2tj4Aw/Cpt0vGyLJdUPc4akHPd7QCz9dY9qBqrZQN50EOMDyP06aPJli\nBjPf7HID12ZqSpGy5wqhY8+doW5f6ajS9j221U/qG6OWBjC8h8o1HN3eMtjS\n3gyz7YEtPrlDaC4PqAydHSydvqfzCIGa/uttgDOIkdzLdDu0aLu0vxiowydf\nS0zf9Lz2+caiGM0/04cutTnVIg0Z9CFNiXSOzSjPPPzOriGMn//JPGjyDe+6\natoLLBSYs0i0u7KIeoRQ3BlBcS/4d0S5cxDFjWaNykjJ6X9A3Bi1oooggQZ2\nHYIuGNqPvxIyur9VT+YrdWCz4/U/Kmxa9LEcPLv3XVGTJTAzh1pfCDbuu7ab\nIkXGkXj7jZJts5jIdaGaFLJhACE58Fg7otWZP5g3wAiczb1tKkfvcfdzHf8J\n0Zn4ryKRY+C30yFo20HLLQ0tJkqv0xNUvnIL1sZCy7jPH4w/A12lQFOwTCfS\nc+bQFzbJ/cout43eSX1b5qOQPB6AXJAOcHga9hanThAWKNT0B9OPXluyzFob\nR63o\r\n=QyGg\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.2.1": {
+      "name": "multicast-dns",
+      "version": "7.2.1",
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-qJaNecNV4wV5FqZ+aBHOgUcHaJXpEMZhiERmuu7CM0YrCyIsgevVLZJGXeyxMAiofN+jby8oAGr8BpQk6xmptw==",
+        "shasum": "bec7853ee8d88a624a3fbfb5098ca1491c354c70",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 21379,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeRpHzCRA9TVsSAnZWagAAAqIP/jOq2NW/sHLDNl5E4cde\n8uujy3mOyVLRMeFj8doj0G05W7f36vthXsiHrDMjqVKAXrbonG3KcJ+EHkby\nHYZ4+Suzu0FL+dcbzUgEDOi+lHOZwdQAy2tcOZF9NE6RWhu9RkiDc1v6Gn33\nmgIAvckTr4Kh6EwvPi1BogvobaSOvwaYtEXv0d/0rvmhsRXEUsMW98Fu1iGt\niltctwIrI9vD22kDv1jV+1rvbqcggIryqWU7SzuDuC0iYPxIFipOr14KtF79\nSiLof1LPadueSjZhheGb/CAZqXE6j90woh3g6QQO4WBKwCBxdmhDiuVJ9cvQ\nBItYkYHR2c3cgIYDGidtN+2mIW3Y4zG6b/T0PMy4vAQanuR3/lOpDjLsyDig\n6yoMoOsyl5pjc5AzJAL6cHT9q+8i7n7sulYrz5dE44Yjc76gd4Rg8qQFawK2\njbsI81X7rW16nU7G5e6eqE9Ug7rSw1FkeY6cwToatwbb0Brt6EcpVvY97Ns5\nWBfJrqK3s1eWEiHohdG2Nhez4FnoiskGgtL1+pwTjKlaGbHzHHsfKUosURcu\nYWbip6mdsAjuqAv4NcnW6/O+hWvGojbWe8YeMchhU8KSHmE7+mKawsh3Pnot\nhwBTAY+nAjNVTKXyW2xfWg9gX+Jktss0CBd9IAhLZRr13+c0f/DQYY0TwF7Z\nO3s1\r\n=ZoU+\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.2.2": {
+      "name": "multicast-dns",
+      "version": "7.2.2",
+      "dependencies": {
+        "dns-packet": "^4.0.0",
+        "thunky": "^1.0.2"
+      },
+      "devDependencies": {
+        "standard": "^10.0.3",
+        "tape": "^4.8.0"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-XqSMeO8EWV/nOXOpPV8ztIpNweVfE1dSpz6SQvDPp71HD74lMXjt4m/mWB1YBMG0kHtOodxRWc5WOb/UNN1A5g==",
+        "shasum": "5731da04f47d1e435ac457e5ac7b4b39d866a5a1",
+        "tarball": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 21480,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJefM7cCRA9TVsSAnZWagAAJKIP/icmoVumFASEsRG6HkdN\nuk79TeYrQL8sprlxypImdfxYiPIUExYQx+5TLFUgZ6ESISoH7PSiV6QyVx1P\noRX2n5ZKiVP9jluFiVR8IpleesAqANTjXcKRDUjVCRpsJHrWm93citkAhQAW\n07+4bIlpU/sNL2DX8j9Mlr2b1j7n9aMCK/ikrmPMgrmFca1Eg4b1r16tZMmW\nz56xJTNJB+IA4kgYqqYhEujJ17H/qfPUkeId1zgWB0La3KNvzu+lZop1WNhm\nEpsaIXEoNioa4Cp14BomsQSrS9+2t0j61bO+Pw9N2Ez86Yl3Ux5jlMstj9Sd\n+NUOXsMfyvZ4MZmKkWg8zUtfUehlENNoDRlJ/cg7Kdh2dxsFdlZXzGA2tb8S\nF1pHKuDl3uGKFR9dOZEX9Qb1+vHQOVFBKGMHFhNplLBkZ/q7NmWfxjsisUbi\n+ydIiiMqTom0OdZGUXtI4rus9rjqVhsyoEIZhwy7uXxQVaEKUsrW+TkA/srp\ntq6VHpdcSBJiSrClKF4eGbNn8oTinGKT4ONe5SHWnx6/6//0b5PpW5wgIQUh\n0mTZEvej9ElHyrmWYLsA/Zt0O3aqk3rPFdlmNv0upSXDRevzkA+nRTCUoled\nXSE3NtNi9ISxKsjp1nqsBYT2dAxmBTwBAZthsLuJ61zh5zOwARN74mUcSy2T\nw7vC\r\n=PcXa\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-03-26T15:48:46.915Z"
+}

--- a/test/fixtures/registry-mocks/content/nan.json
+++ b/test/fixtures/registry-mocks/content/nan.json
@@ -1,0 +1,6948 @@
+{
+  "_id": "nan",
+  "_rev": "188-b2575055e6a6d3775653cfc14186e192",
+  "name": "nan",
+  "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 14 compatibility",
+  "dist-tags": {
+    "latest": "2.14.2"
+  },
+  "versions": {
+    "0.3.0-wip": {
+      "name": "nan",
+      "version": "0.3.0-wip",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.3.0-wip",
+      "dist": {
+        "shasum": "fd51b1e427db1e5952abbc5eaa053a50bddb795f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.0-wip.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0-wip2": {
+      "name": "nan",
+      "version": "0.3.0-wip2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.3.0-wip2",
+      "dist": {
+        "shasum": "0455cc096df55927852e524f195b42631317d21c",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.0-wip2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "nan",
+      "version": "0.3.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.3.0",
+      "dist": {
+        "shasum": "8c053549c789b3a1c6169f9bf7949750c6117054",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "nan",
+      "version": "0.3.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.3.1",
+      "dist": {
+        "shasum": "672523b3fbdbc8e73213dc1951b636e98b3b176f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "nan",
+      "version": "0.3.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.3.2",
+      "dist": {
+        "shasum": "0df1935cab15369075ef160ad2894107aa14dc2d",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "nan",
+      "version": "0.4.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.4.0",
+      "dist": {
+        "shasum": "c099837dd37983b0fbe8cbc800bf56e07e36acd9",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "nan",
+      "version": "0.4.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.4.1",
+      "dist": {
+        "shasum": "6bca2af7af5ae7f76e9aa96c80897605bcd0407f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "nan",
+      "version": "0.4.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@0.4.2",
+      "dist": {
+        "shasum": "e23acfd4811f60ca5cf98c06c1fea8682539d351",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.13",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.3": {
+      "name": "nan",
+      "version": "0.4.3",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.4.3",
+      "dist": {
+        "shasum": "6f4274c4fa753be8c562822501a7e925ad2af035",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.4": {
+      "name": "nan",
+      "version": "0.4.4",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": ".index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@0.4.4",
+      "dist": {
+        "shasum": "9db58eae63cee119807a0d01afd0655d956bea75",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.13",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "nan",
+      "version": "0.5.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@0.5.0",
+      "dist": {
+        "shasum": "fff2b55c761245ef11965d03214d8b4836ef8d79",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "nan",
+      "version": "0.5.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.5.1",
+      "dist": {
+        "shasum": "3dbf3b1a8ab63beb34e39210266c269a0c5d2df2",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.5.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "nan",
+      "version": "0.5.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@0.5.2",
+      "dist": {
+        "shasum": "217df903f50b0647d97c5f28f1c5d12cb0803e09",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.5.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "nan",
+      "version": "0.6.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@0.6.0",
+      "dist": {
+        "shasum": "a54ebe59717b467c77425302bd7c17574c887aaa",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "nan",
+      "version": "0.7.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "_id": "nan@0.7.0",
+      "dist": {
+        "shasum": "3c9cc0a4e021c9cc2b699df1d94944e51c5352b9",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "nan",
+      "version": "0.7.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@0.7.1",
+      "dist": {
+        "shasum": "fc576184a1037b3e5675f2ba3740dee2044ff8f4",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.7.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "nan",
+      "version": "0.8.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@0.8.0",
+      "dist": {
+        "shasum": "022a8fa5e9fe8420964ac1fb3dc94e17f449f5fd",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "nan",
+      "version": "1.0.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.0.0",
+      "dist": {
+        "shasum": "ae24f8850818d662fcab5acf7f3b95bfaa2ccf38",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "nan",
+      "version": "1.1.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.1.0",
+      "dist": {
+        "shasum": "6ca1ab85dc2cd75d6e7d5cbf3d9491bbb97d4aa5",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "nan",
+      "version": "1.1.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.1.1",
+      "dist": {
+        "shasum": "1057b5526920e77f268d8e5e1d274a6c19251d18",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "nan",
+      "version": "1.1.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.1.2",
+      "dist": {
+        "shasum": "bbd48552fc0758673ebe8fada360b60278a6636b",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "nan",
+      "version": "1.2.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.2.0",
+      "dist": {
+        "shasum": "9c4d63ce9e4f8e95de2d574e18f7925554a8a8ef",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "nan",
+      "version": "1.3.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.1",
+        "tap": "~0.4.12",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "e482fbe142e58373d5a24f4e5a60c61e22a13f83",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.3.0",
+      "_shasum": "9a5b8d5ef97a10df3050e59b2c362d3baf779742",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "9a5b8d5ef97a10df3050e59b2c362d3baf779742",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "nan",
+      "version": "1.4.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "7eb51725bc0aae4de3cebe3554df304f36fb074c",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.4.0",
+      "_shasum": "d49a8e21da02b88f8b175a5300bdfd5e9a5d5362",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "d49a8e21da02b88f8b175a5300bdfd5e9a5d5362",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "nan",
+      "version": "1.4.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.4.1",
+      "_shasum": "0a2bb562c558b440005b1f7eb8b31ccbdb565d5f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "0a2bb562c558b440005b1f7eb8b31ccbdb565d5f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "nan",
+      "version": "1.5.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "6fea75acc8f78124756ff4d8e536b6196aca3d37",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.5.0",
+      "_shasum": "2b3c05bc361f52e50aea2c49077783aa67c5b7fb",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "2b3c05bc361f52e50aea2c49077783aa67c5b7fb",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.2": {
+      "name": "nan",
+      "version": "1.4.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "769993a03894c421384564c1ea00a109667aede8",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.4.2",
+      "_shasum": "394c45ae2e3493a35f9adf96d33ee01098ff38d9",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "394c45ae2e3493a35f9adf96d33ee01098ff38d9",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.3": {
+      "name": "nan",
+      "version": "1.4.3",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "75121a4413c4729170ec97c73c4826600f4a763e",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.4.3",
+      "_shasum": "c56b5404698063696f597435f9163c312aea5009",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "c56b5404698063696f597435f9163c312aea5009",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "nan",
+      "version": "1.5.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "d05708b0aa6afebe9363b9f34cc5958d2af771f3",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.5.1",
+      "_shasum": "a565e4d4143cb49afdd3fe07e4c8aeaa1e7e0603",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "a565e4d4143cb49afdd3fe07e4c8aeaa1e7e0603",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "nan",
+      "version": "1.5.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "f93a47f06efedd72b37c1a3250040aed496b6e8d",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.5.2",
+      "_shasum": "17da56116d035c6a25f18e9d6b356d4199744aa8",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "17da56116d035c6a25f18e9d6b356d4199744aa8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "nan",
+      "version": "1.6.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "e4a76669d7ca47081bbf666434784e9bfbbb633b",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.6.0",
+      "_shasum": "a3b14a6608a31d9c2c062ca5f2c5ae77e9399f95",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "a3b14a6608a31d9c2c062ca5f2c5ae77e9399f95",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.3": {
+      "name": "nan",
+      "version": "1.5.3",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "28ea7e1b769f790c69deaf141b47e4d41e176e8b",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.5.3",
+      "_shasum": "4cd0ecc133b7b0700a492a646add427ae8a318eb",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "1.0.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "4cd0ecc133b7b0700a492a646add427ae8a318eb",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "nan",
+      "version": "1.6.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "87c127bba328c8229f2e8e3875b19422888abe5f",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.6.1",
+      "_shasum": "69bc50b2d727f3df01145a963f7d2e4da5ff9184",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "1.0.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "69bc50b2d727f3df01145a963f7d2e4da5ff9184",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "nan",
+      "version": "1.6.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "ab0e5eed8d4aa36111bf8f44cf75644ece327e98",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.6.2",
+      "_shasum": "2657d1c43b00f1e847e083832285b7d8f5ba8ec8",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "2657d1c43b00f1e847e083832285b7d8f5ba8ec8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "nan",
+      "version": "1.7.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/rvagg/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "550efb5dde5cb6bf79db87ab48dce850e56e971a",
+      "bugs": {
+        "url": "https://github.com/rvagg/nan/issues"
+      },
+      "homepage": "https://github.com/rvagg/nan",
+      "_id": "nan@1.7.0",
+      "_shasum": "755b997404e83cbe7bc08bc3c5c56291bce87438",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "755b997404e83cbe7bc08bc3c5c56291bce87438",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "nan",
+      "version": "1.8.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iojs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "2aef83e5b6b5f7a59bb0b5a820e55ce934eabbba",
+      "bugs": {
+        "url": "https://github.com/iojs/nan/issues"
+      },
+      "homepage": "https://github.com/iojs/nan#readme",
+      "_id": "nan@1.8.0",
+      "_shasum": "0b46b0463a4b6439f72f5a2143775e69827e02e6",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "0b46b0463a4b6439f72f5a2143775e69827e02e6",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.1": {
+      "name": "nan",
+      "version": "1.8.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iojs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "2a07f672c08f8dd65aeb35d94df40f6e96126666",
+      "bugs": {
+        "url": "https://github.com/iojs/nan/issues"
+      },
+      "homepage": "https://github.com/iojs/nan#readme",
+      "_id": "nan@1.8.1",
+      "_shasum": "6b2f119c88942f7e24f97b0cfde135ff96d4a66d",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "6b2f119c88942f7e24f97b0cfde135ff96d4a66d",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.2": {
+      "name": "nan",
+      "version": "1.8.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iojs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "76495edfd7b642532e6f9f412403e6e2392df94b",
+      "bugs": {
+        "url": "https://github.com/iojs/nan/issues"
+      },
+      "homepage": "https://github.com/iojs/nan#readme",
+      "_id": "nan@1.8.2",
+      "_shasum": "131518535fa0c49e91f2d1a776f65bb04577dea0",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "131518535fa0c49e91f2d1a776f65bb04577dea0",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.3": {
+      "name": "nan",
+      "version": "1.8.3",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iojs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "93784ad3aa9355b515bdd7efaceb67b42140b8f2",
+      "bugs": {
+        "url": "https://github.com/iojs/nan/issues"
+      },
+      "homepage": "https://github.com/iojs/nan#readme",
+      "_id": "nan@1.8.3",
+      "_shasum": "2f4ec4932c7a2250b5ef4b4597fc5e76af021229",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "2f4ec4932c7a2250b5ef4b4597fc5e76af021229",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.4": {
+      "name": "nan",
+      "version": "1.8.4",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iojs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "ed3bbf4ced0cf7937b4e4164766797f71aa97f3d",
+      "bugs": {
+        "url": "https://github.com/iojs/nan/issues"
+      },
+      "homepage": "https://github.com/iojs/nan#readme",
+      "_id": "nan@1.8.4",
+      "_shasum": "3c76b5382eab33e44b758d2813ca9d92e9342f34",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "3c76b5382eab33e44b758d2813ca9d92e9342f34",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.0": {
+      "name": "nan",
+      "version": "1.9.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "399b3a54ada39a7cf7a11978ea727eae3686666e",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@1.9.0",
+      "_shasum": "1a9cd2755609766f5c291e4194fce39fde286515",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "1a9cd2755609766f5c291e4194fce39fde286515",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "nan",
+      "version": "2.0.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "4ed41d760313b648b4d212d6ff5374668757be4f",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.0",
+      "_shasum": "bcdd32340befef23a588ea66b2f38902a2b82e42",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "bcdd32340befef23a588ea66b2f38902a2b82e42",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "nan",
+      "version": "2.0.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "b8bfceff634d009fbc399bbae4321afecf5f2254",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.1",
+      "_shasum": "acbeda51fbff253fe1438f71c6df758a58a6c30b",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "acbeda51fbff253fe1438f71c6df758a58a6c30b",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "nan",
+      "version": "2.0.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "e6fe13be317181468258cf6e1724efcf4482d44a",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.2",
+      "_shasum": "326b3076add027caa3878aa68aef18516694d9ec",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "326b3076add027caa3878aa68aef18516694d9ec",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "nan",
+      "version": "2.0.3",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "719ba85039fc9fe3ca169c2eade76d250f0f208a",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.3",
+      "_shasum": "39252b7a399715750b76abc3c4625076a5420a51",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "39252b7a399715750b76abc3c4625076a5420a51",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "nan",
+      "version": "2.0.4",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "736a7d4f1692591d9256b88ed5484736134bd107",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.4",
+      "_shasum": "f81d4c18aa3c8300dec2f336c52fb827cadfa719",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "f81d4c18aa3c8300dec2f336c52fb827cadfa719",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.5": {
+      "name": "nan",
+      "version": "2.0.5",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "d13a2e9ce762fd130877b53c71d35963fa2cf689",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.5",
+      "_shasum": "365888014be1fd178db0cbfa258edf7b0cb1c408",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "365888014be1fd178db0cbfa258edf7b0cb1c408",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.6": {
+      "name": "nan",
+      "version": "2.0.6",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "b6bc21134b818708db918b62d7764ea713f46d52",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.6",
+      "_shasum": "1bf60f2a4f91da0d426516f136f51725a092c316",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "1bf60f2a4f91da0d426516f136f51725a092c316",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.7": {
+      "name": "nan",
+      "version": "2.0.7",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "c68f4bee08ceca279f264903f2b91b54e6e5e168",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.7",
+      "_shasum": "c726ce45dbd863b46234e4dfe5bf02d0cb309cd8",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "c726ce45dbd863b46234e4dfe5bf02d0cb309cd8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.7.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.8": {
+      "name": "nan",
+      "version": "2.0.8",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8->0.12 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "505803bbd83dbd43c06e179b78b690e52e17d317",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.8",
+      "_shasum": "c15fd99dd4cc323d1c2f94ac426313680e606392",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.2.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "c15fd99dd4cc323d1c2f94ac426313680e606392",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.8.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.9": {
+      "name": "nan",
+      "version": "2.0.9",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 4 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "pangyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.0.9",
+      "_shasum": "d02a770f46778842cceb94e17cab31ffc7234a05",
+      "_resolved": "file:nan-2.0.9.tgz",
+      "_from": "nan-2.0.9.tgz",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "dist": {
+        "shasum": "d02a770f46778842cceb94e17cab31ffc7234a05",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "nan",
+      "version": "2.1.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 4 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.1.0",
+      "_shasum": "020a7ccedc63fdee85f85967d5607849e74abbe8",
+      "_resolved": "file:nan-2.1.0.tgz",
+      "_from": "nan-2.1.0.tgz",
+      "_npmVersion": "3.3.5",
+      "_nodeVersion": "4.1.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "020a7ccedc63fdee85f85967d5607849e74abbe8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "nan",
+      "version": "2.2.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 4 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.2.0",
+      "_shasum": "779c07135629503cf6a7b7e6aab33049b3c3853c",
+      "_resolved": "file:nan-2.2.0.tgz",
+      "_from": "nan-2.2.0.tgz",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "779c07135629503cf6a7b7e6aab33049b3c3853c",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "directories": {}
+    },
+    "2.2.1": {
+      "name": "nan",
+      "version": "2.2.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 4 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.2.1",
+      "_shasum": "d68693f6b34bb41d66bc68b3a4f9defc79d7149b",
+      "_resolved": "file:nan-2.2.1.tgz",
+      "_from": "nan-2.2.1.tgz",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "d68693f6b34bb41d66bc68b3a4f9defc79d7149b",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/nan-2.2.1.tgz_1459265439909_0.12396649201400578"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "nan",
+      "version": "2.3.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 6 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.3.0",
+      "_shasum": "e3e5ce03d1811ca92641d0a77934336473ee66be",
+      "_resolved": "file:nan-2.3.0.tgz",
+      "_from": "nan-2.3.0.tgz",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "e3e5ce03d1811ca92641d0a77934336473ee66be",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/nan-2.3.0.tgz_1461751797395_0.23794877855107188"
+      },
+      "directories": {}
+    },
+    "2.3.1": {
+      "name": "nan",
+      "version": "2.3.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 6 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.3.1",
+      "_shasum": "a4d3e9bfeee09d782d37db161b517221138c2a85",
+      "_resolved": "file:nan-2.3.1.tgz",
+      "_from": "nan-2.3.1.tgz",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "a4d3e9bfeee09d782d37db161b517221138c2a85",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/nan-2.3.1.tgz_1461774167709_0.5660416295286268"
+      },
+      "directories": {}
+    },
+    "2.3.2": {
+      "name": "nan",
+      "version": "2.3.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 6 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.3.2",
+      "_shasum": "4d4ecf17e1da4e989efb4f273d8d00201cad087e",
+      "_resolved": "file:nan-2.3.2.tgz",
+      "_from": "nan-2.3.2.tgz",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "4d4ecf17e1da4e989efb4f273d8d00201cad087e",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/nan-2.3.2.tgz_1461778534440_0.04312888509593904"
+      },
+      "directories": {}
+    },
+    "2.3.3": {
+      "name": "nan",
+      "version": "2.3.3",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 6 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.3.3",
+      "_shasum": "64dd83c9704a83648b6c72b401f6384bd94ef16f",
+      "_resolved": "file:nan-2.3.3.tgz",
+      "_from": "nan-2.3.3.tgz",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "64dd83c9704a83648b6c72b401f6384bd94ef16f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/nan-2.3.3.tgz_1462313618725_0.044748055282980204"
+      },
+      "directories": {}
+    },
+    "2.3.4": {
+      "name": "nan",
+      "version": "2.3.4",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 6 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.3.4",
+      "_shasum": "a7d5eb1cb727f8123a2dda6a883c006b30896718",
+      "_resolved": "file:nan-2.3.4.tgz",
+      "_from": "nan-2.3.4.tgz",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "a7d5eb1cb727f8123a2dda6a883c006b30896718",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/nan-2.3.4.tgz_1464646356651_0.48181944130919874"
+      },
+      "directories": {}
+    },
+    "2.3.5": {
+      "name": "nan",
+      "version": "2.3.5",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 6 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.3.5",
+      "_shasum": "822a0dc266290ce4cd3a12282ca3e7e364668a08",
+      "_resolved": "file:nan-2.3.5.tgz",
+      "_from": "nan-2.3.5.tgz",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "822a0dc266290ce4cd3a12282ca3e7e364668a08",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/nan-2.3.5.tgz_1464707164994_0.4295874561648816"
+      },
+      "directories": {}
+    },
+    "2.4.0": {
+      "name": "nan",
+      "version": "2.4.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 6 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.4.0",
+      "_shasum": "fb3c59d45fe4effe215f0b890f8adf6eb32d2232",
+      "_resolved": "file:nan-2.4.0.tgz",
+      "_from": "nan-2.4.0.tgz",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "fb3c59d45fe4effe215f0b890f8adf6eb32d2232",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/nan-2.4.0.tgz_1468158679820_0.6951719264034182"
+      },
+      "directories": {}
+    },
+    "2.5.0": {
+      "name": "nan",
+      "version": "2.5.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 7 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.5.0",
+      "_shasum": "aa8f1e34531d807e9e27755b234b4a6ec0c152a8",
+      "_resolved": "file:nan-2.5.0.tgz",
+      "_from": "nan-2.5.0.tgz",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "aa8f1e34531d807e9e27755b234b4a6ec0c152a8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/nan-2.5.0.tgz_1482346189010_0.8120697599370033"
+      },
+      "directories": {}
+    },
+    "2.5.1": {
+      "name": "nan",
+      "version": "2.5.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 7 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.5.1",
+      "_shasum": "d5b01691253326a97a2bbee9e61c55d8d60351e2",
+      "_resolved": "file:nan-2.5.1.tgz",
+      "_from": "nan-2.5.1.tgz",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "d5b01691253326a97a2bbee9e61c55d8d60351e2",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/nan-2.5.1.tgz_1485124061146_0.7941144248470664"
+      },
+      "directories": {}
+    },
+    "2.6.0": {
+      "name": "nan",
+      "version": "2.6.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 7 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.6.0",
+      "_shasum": "b9b0a907d796d0d336fd73afce24f5e1aa929934",
+      "_resolved": "file:nan-2.6.0.tgz",
+      "_from": "nan-2.6.0.tgz",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "b9b0a907d796d0d336fd73afce24f5e1aa929934",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/nan-2.6.0.tgz_1491431846889_0.2909555535297841"
+      },
+      "directories": {}
+    },
+    "2.6.1": {
+      "name": "nan",
+      "version": "2.6.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 7 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "a80a0e652da1c010bf8aba3c725b667fadb53261",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.6.1",
+      "_shasum": "8c84f7b14c96b89f57fbc838012180ec8ca39a01",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.2",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "8c84f7b14c96b89f57fbc838012180ec8ca39a01",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/nan-2.6.1.tgz_1491457816058_0.0568844648078084"
+      },
+      "directories": {}
+    },
+    "2.6.2": {
+      "name": "nan",
+      "version": "2.6.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 7 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "f0b2f64c1e5317888f2e12fdefb2f105e7018552",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.6.2",
+      "_shasum": "e4ff34e6c95fdfb5aecc08de6596f43605a7db45",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "e4ff34e6c95fdfb5aecc08de6596f43605a7db45",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/nan-2.6.2.tgz_1492029516320_0.2352329883724451"
+      },
+      "directories": {}
+    },
+    "2.7.0": {
+      "name": "nan",
+      "version": "2.7.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 8 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2013 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.7.0",
+      "_shasum": "d95bf721ec877e08db276ed3fc6eb78f9083ad46",
+      "_resolved": "file:nan-2.7.0.tgz",
+      "_from": "nan-2.7.0.tgz",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "d95bf721ec877e08db276ed3fc6eb78f9083ad46",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan-2.7.0.tgz_1504053769999_0.18853025324642658"
+      },
+      "directories": {}
+    },
+    "2.8.0": {
+      "name": "nan",
+      "version": "2.8.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 9 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.8.0",
+      "_shasum": "ed715f3fe9de02b57a5e6252d90a96675e1f085a",
+      "_resolved": "file:nan-2.8.0.tgz",
+      "_from": "nan-2.8.0.tgz",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.12.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "shasum": "ed715f3fe9de02b57a5e6252d90a96675e1f085a",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan-2.8.0.tgz_1510745663002_0.45465062628500164"
+      },
+      "directories": {}
+    },
+    "2.9.1": {
+      "name": "nan",
+      "version": "2.9.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 9 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.9.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-c609vVPyCEuuzqOjx3hwsSZMXLg5QTzbTfgBmEx6N444ymBt1+Yg/rTGr2+4S3VJ3btXI8m1TZ7nLcYcRTZYuQ==",
+        "shasum": "af88fcaee5292992c5b755121ceeaa74536fc228",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.9.1.tgz",
+        "fileCount": 45,
+        "unpackedSize": 404355
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.9.1_1519319649692_0.4583243317207173"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.9.2": {
+      "name": "nan",
+      "version": "2.9.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 9 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.9.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+        "shasum": "f564d75f5f8f36a6d9456cca7a6c4fe488ab7866",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+        "fileCount": 45,
+        "unpackedSize": 404456
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.9.2_1519342457594_0.2577351460235977"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.10.0": {
+      "name": "nan",
+      "version": "2.10.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 9 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.10.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+        "shasum": "96d0cd610ebd58d4b4de9cc0c6828cda99c7548f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 409953
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.10.0_1521216708687_0.31611161513830033"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.11.0": {
+      "name": "nan",
+      "version": "2.11.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 9 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.11.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+        "shasum": "574e360e4d954ab16966ec102c0c049fd961a099",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 412174,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgU8BCRA9TVsSAnZWagAAJNIP/2+bZl2y/eC/prNgAOPV\nOOAp8aPI1FAe9jcly9hjQqplKPvIY8XXP5WK6pq+ce1l5vyvHdtcQum977I7\nMLH3MiEj31aIcNrI0/G9LTMqmHMct+qKK4OjyjhupRFuQCHI+BPXGTrQVZ2S\nkUi76QwLOXMnu9rRwmVS+rEjRu+W0TT+sQb4sspBdhG/4qnyp/rp+L2Shdv8\nLlRB4EC7j8N6aosWBrhyVBPX59yliFn0z7mAuFswqdcm4TI3rtTXn1yIDkaW\nyukbkwOBAtL1dKfV7rlmjiS2Retp9FdF3X5D4tVdwbKSd3+5uMYUmz5CsoLI\nbY9uOdjHZGByFfVbMI8qZA6vf0HNZ2/0O7n+f1qGOVFCS4JvjHqgZa6eLjCD\nntdvJmAruNmtIhlXMmq+rUIyA6H4KaaDI2gSggeFVacpuTnFUKW6HN/fGQpB\n2COAPd6cjFJJ47v/YdKBzGZLuUXQ21Je2xxLeGYSd253XSQcu4rPYFTdSSTF\nbuLmG7SObSG/F9hDntzUpCP2hDn5ekmGJwZMRH2h9RuuVMISx3P48Zht6htZ\nTfE8KmOR0ncQtf94jX6KmqFJZjkrZatCCJmTkWWJGjch1/qP/qb1mLjo0hAz\niqq3pAGb2PwF1lRSAAbdqjDIUbGdO1a3NEkvDBH9JtafBBV5ZiEsNBzqhsXs\nEmh8\r\n=CVBp\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.11.0_1535201025004_0.7520281082678468"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.11.1": {
+      "name": "nan",
+      "version": "2.11.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 10 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "85a74a1a724ddffdb81f709b745d5707a8a0f699",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.11.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+        "shasum": "90e22bccb8ca57ea4cd37cc83d3819b52eea6766",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+        "fileCount": 47,
+        "unpackedSize": 487268,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbrzNSCRA9TVsSAnZWagAA0vgQAJoa+4F+vH2jgoMAIh2M\nduUOqUMSIKBSqcO1+OzZj8Xi1NTQXKnuxwUpcLfG7kUFSTXMNQ5pqXv4om8/\nViw9to8ZE5wAlK3Uqejk5qaQgVNmxeWtO91R85q3KNI6l1Z4qaRVJN13GwnS\nS1iwDlG/3dKLWAAcoJjP20uCHSvFmEsR+FJy0G5y76s+QSJNFI0TmZRXpowJ\nTezFZsBU/EFRBKKIv//nNvuSxh1/TITrD72sshjpjWdwWqJK0T9emtuBOGFT\nhjsYWGeykfu3HjxBwrzG4hNhyO7nQCl59TRoiPKyqNb70W9RvjJAcldwcMqX\nBddgZ5lZq4+qw+KBGnkoHvO5cS6CQoe3cgFNILGq1NNbPc22Kwp5CVdy1TXv\nC7BcutM20izHrQeBnilZTy+PFBx3eNixWJHFyVDZeGrF47t2jqKvcLEm1eF8\n7pA6/VxXDvE2D+MBjfpAWfSbZ0bR0jhDYvly+1DufutyCd+G6JzR04FsGg1y\nk873NoJ6P9WlZhzvnLBaoWOaQP8XOcxcugSQPP8lTA4hDmQwXY9K8Rwi6Ry2\nw+wGn2WAUQXQhKHJto6dJiIZyJ/yt0h5rjGnwzraXReQQXcTif2dSkvpAgPK\nRXVMRKQIh3us3mU6rSXwg08T4NopJLDLdEuwYYvoKy7xPZLx5uzP/phWLJsb\nG33O\r\n=ig8G\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.11.1_1538208593407_0.7919453530392533"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.12.0": {
+      "name": "nan",
+      "version": "2.12.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 11 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "e8f8519db5f784b6b581b94d14bfe8df7cba91d2",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.12.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-zT5nC0JhbljmyEf+Z456nvm7iO7XgRV2hYxoBtPpnyp+0Q4aCoP6uWNn76v/I6k2kCYNLWqWbwBWQcjsNI/bjw==",
+        "shasum": "9d443fdb5e13a20770cc5e602eee59760a685885",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.12.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 414432,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcFk+qCRA9TVsSAnZWagAAKTYP/ifKNoarxTcvHhn31rYR\nU2Gr9fmUnNnakkjaUwsJofQvqrBJDMzmT5t0gbHSrFRsTr8Jx2WgmIotef84\njyZfNqI09UM2xHXOKqUiZTcQlAQ9VErtHi2PDWr/A1i1qv/3AGPxYRMpbWR1\nTgI2bC1YGAq87470BB41C0BRfEXd2c6DffBYFEgkWoyDiAHrSltNwziENf9B\nV05ovWxdIf3ugIpgSKPYms+ff+lM4G7AcdDmg5zHw1PwmUcMN4hNRFROD+dN\nWGpNzVCyEZ7aIa1iwOcMzRm8s0OtUCo+pxq/nzOB0Oo9jtuEkH/hwSZbw0OL\n/wY57CsIAkbDj8/QBLDfQRjOWJ7pINiaY9smRmZzFkGnr216ZhvYAPaFpzeQ\nV+ioAr8mXnlJVQcoo0EXBave1DWt7ucZm3y9Hc0HeE267sJQMkwDJnGZxFDE\ntSq4RZwT8Kjzl4fDmWWEisIJAoOCYvgzF0sYvCODbMOJ9NQtwt7X8ZzPnrkQ\nBuB8D7HtcsUPgPAglq+XbjxKRTx4HP3HnMWieLNwLrBWhJG6QG25eabMpoYC\nV0DeDFYx6YebK01kmAmnZ8uxx1uBScKD91FwxijkWfwSPakxrX97aocYFXJw\naOFtkc0/vf6p/o3cpXKNwZ5dALAiqU2qPENY6kEwsV6eyX4RzCSKQBKN+cbc\nW3aJ\r\n=bGq5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.12.0_1544966058111_0.3054513371345562"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.12.1": {
+      "name": "nan",
+      "version": "2.12.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 11 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "1b77c1186c7f36b17f73256c5b04c496a12adf4b",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.12.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+        "shasum": "7b1aa193e9aa86057e3c7bbd0ac448e770925552",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+        "fileCount": 46,
+        "unpackedSize": 414999,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcGWAzCRA9TVsSAnZWagAAkoMQAJgEI+g1PFR6UlfI3nbv\n7HlsOR47Y2VNinIsyoQECyE1QNoaPH9f/1TflublZFh6pOCWyClc6MaFEP2e\nbQf7qkHTJfjviaLSUc0pqzve3DxKVoXbvRANhxBoWipHXkFTvQoPWc3f3LYx\nEvNlyOX9L6nHMaeMNooeD5Fcj5ZtGyc80IWouGTatOVLoQO1n5JAEb9PHuJD\nwgHfZHnkNOYO1YQ/9VeRVQ9K5z8mgcQhcBfKaSJrc9DolihwuvJ+iy4RWx3C\nHWpYzpJzo/xDNtX5LH9sZaezljt/vI1wacGdVGtXBM5GVTkb1pIDhDG5n8Vo\ntUHdVwLL7+sH/kjyurKU9L5spbkAJEgmpS8lerx+tD8HqOtv6R8EqPhADm6F\nI1bpMzoul8ALiUat+MUF81KivuwEJ0ydTED5tKnTno7btU0M2cC8otbXpXvg\nngVSotsAs9IVifZAGHwk0rmTckj1pdxL6WR+4/o+7y4c9xXBI6DNbS/DfuQe\nfSTgg8TJRVLlf/7vAE64L3q16EdCt9h5qdbfgvpK0Ww9fg/3vw9UuIvz/1z2\nMWXOWFVDZDSpFPXf8lanaes9IKdhO3arZJHlRnmFZ/HjCzzG5YHpy8Qsg7wT\n1jo0m/kdnW7onz9aoSZ40D6oGDLdp32QoJH2JFrhVl0fh7hetr8905KMkVpu\nZnpp\r\n=tMc9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.12.1_1545166898928_0.20846162122668432"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.13.0": {
+      "name": "nan",
+      "version": "2.13.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 11 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "24c6357e53f02c5344847e8f64bb02db45ba5627",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.13.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-5DDQvN0luhXdut8SCwzm/ZuAX2W+fwhqNzfq7CZ+OJzQ6NwpcqmIGyLD1R8MEt7BeErzcsI0JLr4pND2pNp2Cw==",
+        "shasum": "7bdfc27dd3c060c46e60b62c72b74012d1a4cd68",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.13.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 416211,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJciYbLCRA9TVsSAnZWagAADc0QAKNxJUs+1fHRtmFMIAv7\nXb2ObCu8VH6wPDDvhpqr+pFIQIocBsmqNdr8rD7d2WlVxThrmDQ2pkVqQOVC\nGgSjChjFVcUA/6kcFYfbX+OzS8aZirFKdr2a5RDrsK6QvaoAmw0MhMU5u3RN\nnLuvjfnlFQCm6yLfUZSRYKK70EA3n5IbjidWNMuqPvKJ3M4mXa/naSVNGqGA\nCJsUufCaMRl4P120+4+250RS8nJO55PWeHsRIwgudoQyxEc5ItH0QeGw6tNe\nrHv9lM1Yf0AQ8Zlkl0RbvX7vcMTo6wTGWGVCklP7ApBzL90oasoJ4U0TWsGc\nJUcdUKVD04xoVvuXch4YL9UWcmH4R35L3eOHAOknQiv2TqXzi6vdePCdpE1M\nNAuyCEvuvruDMLLUSQJ1ch98mvscKIfZwOOcmSIbdPzY99lPDdWgpkPNamMF\n9eM19nBvuJaKLssjIcpTcKYEERlhiWTZ6kMhc4i/w+3zySO7T6usBYsZjNyT\nEaf6WWrBLrYtRnio7hSAgiIayHmbgritN8ErvP7/SkJYtAp/Zm88elQxtRcE\nivBnVnATCcdXQBtn9O1B8mhJEefIrNVlR90L8nfoo9q5ntthGVysyqgKmReA\noHjmrlK3Gl6eY2gdK8WAA4fYZmxnRtzrci8Y1yrn4mvbBjKsU8CPwZ+WtweA\nLB6a\r\n=S1LC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.13.0_1552516810400_0.9078450704100733"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.13.1": {
+      "name": "nan",
+      "version": "2.13.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 11 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "19f08c2394b19a5dbe854020fed0446606d68955",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.13.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==",
+        "shasum": "a15bee3790bde247e8f38f1d446edcdaeb05f2dd",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
+        "fileCount": 46,
+        "unpackedSize": 416465,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcis3lCRA9TVsSAnZWagAA99kP/iAWCAc0pkQp7r4B/2f3\n2VQBLO8I5QThewxHroCALastX+4feQXXBreL5nrkuZy0Qki0EfzSZsTaDJz9\nslPnBF9MrT00o2vx6OKhxae9G6n0gZ5Mx+TqxiKdAl9op3RjqRtZHAygheSF\n0HdrtlRAZxplrMH9d/qvuEF20KmT2hjQ/epD90g0bH5hM3g7KzqgLIuZ7V/+\nbz6SEv+bI/l10jo7BYo89tjr12RreCkFy9RbvyqjXDHBCbM9wn9zczWH5WCJ\nh6/n1d9zxnj63xJ5AFYRpWPJ24kndw6jtvR4g3fa+R8gNnhKP5xXpoePtLfZ\nO+0/zANjDQf7qXeAsk6SywbFlAiFE2QftuJqTphOG26hrbWGURsNHsOy2Q94\nU7Q+vy8fehSJ48cHwhTuoc1TLTwKQWH/+daIuaslALmPvWtIi6ZJrf9Jrulp\nCO3GY+JTZmQKBnFvXGhRG6QjdfzGu05D4XTBesqVj+MVf7weXs548NPUitIg\n/qwjADZRrlCNijCC39JSgGuDf2xJzqg/APk5Mmy13piX4m2zyc2Q27fagPgb\nzcNYj5OZLHnotgbBBaukJOBob/n0+/OzUVBdLItwMNPE7IfJNo1+4gdVYG1+\n4rzVugjlQg5Nne0Ifts1vzDVUJ1A6DoxAeEz9Zn7ghTiDgQXSW550ziDDsCY\nWEfj\r\n=Qy+m\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.13.1_1552600548761_0.5425426860056854"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.13.2": {
+      "name": "nan",
+      "version": "2.13.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 11 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "c428b85786c41e4d55c11c02fe04ef1adba80934",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.13.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+        "shasum": "f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+        "fileCount": 46,
+        "unpackedSize": 416510,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcl5T0CRA9TVsSAnZWagAAiQ4QAKLRrhcLF7X35CmFE7Q1\n9kSj7Madc0MFOwpqAMjTALGe/zlu5sjAFu6aRRDLhLKOVel7PsX+FuNENv4A\nCTz5VQu8Q7Gx3uCq+1R5RReogxyQzhQR0gpJS2b3tm/nza8cBSLBS5G7F5HN\n5bD0V0b2lTDAaqsfUVRq0ocuXRY5uu79JfCnF4w0I+W4AfUKVIMI1xXjSiJo\n3kTXdMbjDXkCzy6picwLGte0EYMy005XcB4o0U9l1xkvQ/ebn9lsQHD+MGOX\nz0zLyMT+ZwnUD7XMdHmdLYQBRC4pkekHzGhB6lzNietmaIXgQboTkd86AjqQ\niYifuF7yNL3CipBgcdBE5B1gPIx22TfGjSnIFXuYjbtYWIbxkOWU42c5E2hy\nDS3WOkcHNu75ygW4gNcH4QPcHD3foFS3nPl5pShW9u1PpKKSuQiezPk0VMxP\n0hNmP5s3pp82I8cLPhs/qc55NCecGJnu82PM/osXOV9Tn7VBGstIXOKElyV0\nPevcUfnviqUyHwn6itFajsvoTUFLTQSz/YYCeOI1nXgoca/5cwOy2Ta2bYxT\nlEDSWve7kONxW0WRUcYQlz6iz7vrwu+xADX0wEwPImttEUuJ7h7zhU4scGAT\n7x4jTEYIQy5OZOjWrMZPlRyD/PBYq8UCQ3nic21IRc1B81/OVxrJ3Dcw3Pgd\n49k2\r\n=DnIP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.13.2_1553437939841_0.6110006893669775"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.14.0": {
+      "name": "nan",
+      "version": "2.14.0",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 11 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "1dcc61bd06d84e389bfd5311b2b1492a14c74201",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.14.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+        "shasum": "7818f722027b2459a86f0295d434d1fc2336c52c",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 417060,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3bXpCRA9TVsSAnZWagAApycP/2mhtcraLrh5RRziC2xM\nUKDaEjBIznHn7PqDWecW3HW/CGrUfmuxpDCBlE2fBm2cxF26nB/CV6xoD2W1\nkyu4MkRcKiAvNW0h4a5sTwXey0U6xc8JRBhBTWgfiY2aQoA4fIO5akmbIa/w\nyT6tspFQ0BQWKBrxlSOqfQ/lARU4Dzy2eiKu1aWMffQecgqOPTrlb5/QxFsr\nUmfdePyO2odVrjDiiNJsfkHeMh66ED4n7szrRjwkz7FTkoEF0dMOw/bWJU2X\nEYVziHG7rm9B4Blzv6KtqG4Y9Gty8epOG+itSLQcc088H86TXYXJn6y75+lf\n1Lw5E9lxw5XLfVnE7uzr0NVHhcj/M3RaGzXySi7v2AWMbF6wqxtAdebdNaew\nIpc3+NVj2OjA/79bzzhU76MG0PrYURE8UmVugHZHGp9L1PraD/jWqCT1JMGE\n1qGu2dSlsqoyNe9Y1pTs/kc+I4KLjwDqo14NyQQk8quvkyHrQ66oO5lAPN4U\n5ms7vR+FOZYrtX7jQDTAs9N169N0IxhGwgsUH4zRza2RkkdTzsjyEnPhqlrI\n6tIrfYldrudrGtcNmLJqY7fTUA86L3f7SQvlnpfsDPUFagfwQr4Uz9JE8q1k\nhbe8CqTuhbET2AZNFlBxf0ii3ipwNXXJtB/0hIVQCfud1vbdS1IuOibc2/YY\n6ep0\r\n=AZxH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.14.0_1558033896058_0.6879275796293267"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.14.1": {
+      "name": "nan",
+      "version": "2.14.1",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 14 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "eaae2683a3df542376797a11385b87b9c0d071c5",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.14.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+        "shasum": "d7be34dfa3105b91494c3147089315eff8874b01",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+        "fileCount": 46,
+        "unpackedSize": 417637,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJen0KtCRA9TVsSAnZWagAAEJAP/AuPED/luXpLqjqUtyRc\nm1zYL5L3e5XyxkCZ+/Agc1gi/p1SG0zFo5XrgabTVcPsyZ2RwAyB+hUCDlC7\nHRp/VbfR/lvEGvcznzsjm4pcn+8oIM5vR+RM035LR+RsvZ+TxBVc4P6Oe9vT\njwsPquNy/PJseIygzNvteINOr5iGUVVOq61pkqzmUP3WrydxVYY6kLn1y+F2\nM1poBixx4NOHdhTuv65B7N7hK7A5YDVZhetGEA8tDEF4KCOB2vgx/kWdaz2k\nA/r94QRILObXIFriUM0CNI5p/gBEIEJ9art5U7eiQwvDJXKmAkSR2nSsJMf7\nusH4+Ot40dVCUbLw/kGYpPAJ+BTdPpFqmW5UFkheCaq/Neihkioj6RDJ8eco\n8Oh4xVPLH9/cT1IhvYlKRmuWyPKU57y9saEvB1PWcUecp/fkc1Aonptak6dK\n87DAk9+85S/mwhQExlwc9SSBsPXIyY6UjSmwfEUPuY9BlD8SmLasdkIPFC8V\nEcjzebcVo8kd5nOz/9PrwZE5Gkfs4B5SpJTK92ZLYOIEcht2l4CvglELBxbj\n5Hd+scHKmWvHyrShBkRie2BDQXzroDbGYqoKHuzAOgv075APk9yvEYOnqP/4\nzz68DIGbYgNwPCLEEO4q34fdX/1SHtZ+Yb+sN+AqULIVHjmzAKKkcDgsLNmK\nqOt2\r\n=EVf+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.14.1_1587495596751_0.585087272794657"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.14.2": {
+      "name": "nan",
+      "version": "2.14.2",
+      "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 14 compatibility",
+      "main": "include_dirs.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodejs/nan.git"
+      },
+      "scripts": {
+        "test": "tap --gc --stderr test/js/*-test.js",
+        "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
+        "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
+        "docs": "doc/.build.sh"
+      },
+      "contributors": [
+        {
+          "name": "Rod Vagg",
+          "email": "r@va.gg",
+          "url": "https://github.com/rvagg"
+        },
+        {
+          "name": "Benjamin Byholm",
+          "email": "bbyholm@abo.fi",
+          "url": "https://github.com/kkoopa/"
+        },
+        {
+          "name": "Trevor Norris",
+          "email": "trev.norris@gmail.com",
+          "url": "https://github.com/trevnorris"
+        },
+        {
+          "name": "Nathan Rajlich",
+          "email": "nathan@tootallnate.net",
+          "url": "https://github.com/TooTallNate"
+        },
+        {
+          "name": "Brett Lawson",
+          "email": "brett19@gmail.com",
+          "url": "https://github.com/brett19"
+        },
+        {
+          "name": "Ben Noordhuis",
+          "email": "info@bnoordhuis.nl",
+          "url": "https://github.com/bnoordhuis"
+        },
+        {
+          "name": "David Siegel",
+          "email": "david@artcom.de",
+          "url": "https://github.com/agnat"
+        },
+        {
+          "name": "Michael Ira Krufky",
+          "email": "mkrufky@gmail.com",
+          "url": "https://github.com/mkrufky"
+        }
+      ],
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "license": "MIT",
+      "gitHead": "7c3fc6884666bd19b597ea58a99f51f2f4860c4e",
+      "bugs": {
+        "url": "https://github.com/nodejs/nan/issues"
+      },
+      "homepage": "https://github.com/nodejs/nan#readme",
+      "_id": "nan@2.14.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.0",
+      "_npmUser": {
+        "name": "kkoopa",
+        "email": "bbyholm@abo.fi"
+      },
+      "dist": {
+        "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+        "shasum": "f5376400695168f4cc694ac9393d0c9585eeea19",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+        "fileCount": 46,
+        "unpackedSize": 417991,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfhaJzCRA9TVsSAnZWagAAqa0P/33rKLxI1mx53dz2Z6/B\nQQAJOUcgZgpIdY7LkaDGw6oTRyYoDg9uq1aOW7uL6OTJGZb/0UH3LS/gs5CK\nUk1CnYitqHSmyzOCO6tZyQmiFqYqLJf5drQn+uV9sU3bi2+u42Z03vTv5v+j\nEwRLH3TfeMbrEOgDdBuo6RB+jgaZHKyEXsvCe6NXXAaAQ8as82vtDOA1FOzq\nhB91RTYgS57lF3g/ciWg/Bvb7o2Fwep7+Ah/22Cpz9UC8fm8QGz4/lQRba3m\n504ah7HXRoF79+HqvntRKF0j8fJ8fpX3cu7wQ5UND8bj/VhhNpKZtM/tCv98\nq00KMaWYNqD+NJYKULLS658iJVjpPNr9UElb3+jNDCoX+UEvdOckuJKwo5u0\n7HRmqpE6Pb0MGfVqhHK6K3buwg+eccMcCKPiHHaiZvqa/jD0savGNx2ylMVD\niTpyl8XV+ZU9vfR1tJ3OFYzOGfXOGG5LqOut/hT0qjBLTWXL3ajPcxCNdJRH\nWSrDJ7Y3da/KkyMdX37t39Q6JkQbD2hz2nGNIr1pe36CNqx8FMOvnHG2Gwuy\nGFdcABFLpkppKhHmRebaRlQXJ416KHzxUkD+A/5DcUb7ChoJgn4j6TN7ewVb\nNOb7UllppKKHOseXgre8uJM1vVslNLVsBYzfgv58uhSTbMvo5QBuK/QHKilw\nRoBa\r\n=4oJR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "kkoopa",
+          "email": "bbyholm@abo.fi"
+        },
+        {
+          "name": "rvagg",
+          "email": "r@va.gg"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/nan_2.14.2_1602593394727_0.8742800087816833"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "Native Abstractions for Node.js\n===============================\n\n**A header file filled with macro and utility goodness for making add-on development for Node.js easier across versions 0.8, 0.10, 0.12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13 and 14.**\n\n***Current version: 2.14.2***\n\n*(See [CHANGELOG.md](https://github.com/nodejs/nan/blob/master/CHANGELOG.md) for complete ChangeLog)*\n\n[![NPM](https://nodei.co/npm/nan.png?downloads=true&downloadRank=true)](https://nodei.co/npm/nan/) [![NPM](https://nodei.co/npm-dl/nan.png?months=6&height=3)](https://nodei.co/npm/nan/)\n\n[![Build Status](https://api.travis-ci.org/nodejs/nan.svg?branch=master)](https://travis-ci.org/nodejs/nan)\n[![Build status](https://ci.appveyor.com/api/projects/status/kh73pbm9dsju7fgh)](https://ci.appveyor.com/project/RodVagg/nan)\n\nThanks to the crazy changes in V8 (and some in Node core), keeping native addons compiling happily across versions, particularly 0.10 to 0.12 to 4.0, is a minor nightmare. The goal of this project is to store all logic necessary to develop native Node.js addons without having to inspect `NODE_MODULE_VERSION` and get yourself into a macro-tangle.\n\nThis project also contains some helper utilities that make addon development a bit more pleasant.\n\n * **[News & Updates](#news)**\n * **[Usage](#usage)**\n * **[Example](#example)**\n * **[API](#api)**\n * **[Tests](#tests)**\n * **[Known issues](#issues)**\n * **[Governance & Contributing](#governance)**\n\n<a name=\"news\"></a>\n\n## News & Updates\n\n<a name=\"usage\"></a>\n\n## Usage\n\nSimply add **NAN** as a dependency in the *package.json* of your Node addon:\n\n``` bash\n$ npm install --save nan\n```\n\nPull in the path to **NAN** in your *binding.gyp* so that you can use `#include <nan.h>` in your *.cpp* files:\n\n``` python\n\"include_dirs\" : [\n    \"<!(node -e \\\"require('nan')\\\")\"\n]\n```\n\nThis works like a `-I<path-to-NAN>` when compiling your addon.\n\n<a name=\"example\"></a>\n\n## Example\n\nJust getting started with Nan? Take a look at the **[Node Add-on Examples](https://github.com/nodejs/node-addon-examples)**.\n\nRefer to a [quick-start **Nan** Boilerplate](https://github.com/fcanas/node-native-boilerplate) for a ready-to-go project that utilizes basic Nan functionality.\n\nFor a simpler example, see the **[async pi estimation example](https://github.com/nodejs/nan/tree/master/examples/async_pi_estimate)** in the examples directory for full code and an explanation of what this Monte Carlo Pi estimation example does. Below are just some parts of the full example that illustrate the use of **NAN**.\n\nYet another example is **[nan-example-eol](https://github.com/CodeCharmLtd/nan-example-eol)**. It shows newline detection implemented as a native addon.\n\nAlso take a look at our comprehensive **[C++ test suite](https://github.com/nodejs/nan/tree/master/test/cpp)** which has a plethora of code snippets for your pasting pleasure.\n\n<a name=\"api\"></a>\n\n## API\n\nAdditional to the NAN documentation below, please consult:\n\n* [The V8 Getting Started * Guide](https://v8.dev/docs/embed)\n* [V8 API Documentation](https://v8docs.nodesource.com/)\n* [Node Add-on Documentation](https://nodejs.org/api/addons.html)\n\n<!-- START API -->\n\n### JavaScript-accessible methods\n\nA _template_ is a blueprint for JavaScript functions and objects in a context. You can use a template to wrap C++ functions and data structures within JavaScript objects so that they can be manipulated from JavaScript. See the V8 Embedders Guide section on [Templates](https://github.com/v8/v8/wiki/Embedder%27s-Guide#templates) for further information.\n\nIn order to expose functionality to JavaScript via a template, you must provide it to V8 in a form that it understands. Across the versions of V8 supported by NAN, JavaScript-accessible method signatures vary widely, NAN fully abstracts method declaration and provides you with an interface that is similar to the most recent V8 API but is backward-compatible with older versions that still use the now-deceased `v8::Argument` type.\n\n* **Method argument types**\n - <a href=\"doc/methods.md#api_nan_function_callback_info\"><b><code>Nan::FunctionCallbackInfo</code></b></a>\n - <a href=\"doc/methods.md#api_nan_property_callback_info\"><b><code>Nan::PropertyCallbackInfo</code></b></a>\n - <a href=\"doc/methods.md#api_nan_return_value\"><b><code>Nan::ReturnValue</code></b></a>\n* **Method declarations**\n - <a href=\"doc/methods.md#api_nan_method\"><b>Method declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_getter\"><b>Getter declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_setter\"><b>Setter declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_property_getter\"><b>Property getter declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_property_setter\"><b>Property setter declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_property_enumerator\"><b>Property enumerator declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_property_deleter\"><b>Property deleter declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_property_query\"><b>Property query declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_index_getter\"><b>Index getter declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_index_setter\"><b>Index setter declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_index_enumerator\"><b>Index enumerator declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_index_deleter\"><b>Index deleter declaration</b></a>\n - <a href=\"doc/methods.md#api_nan_index_query\"><b>Index query declaration</b></a>\n* Method and template helpers\n - <a href=\"doc/methods.md#api_nan_set_method\"><b><code>Nan::SetMethod()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_prototype_method\"><b><code>Nan::SetPrototypeMethod()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_accessor\"><b><code>Nan::SetAccessor()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_named_property_handler\"><b><code>Nan::SetNamedPropertyHandler()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_indexed_property_handler\"><b><code>Nan::SetIndexedPropertyHandler()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_template\"><b><code>Nan::SetTemplate()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_prototype_template\"><b><code>Nan::SetPrototypeTemplate()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_instance_template\"><b><code>Nan::SetInstanceTemplate()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_call_handler\"><b><code>Nan::SetCallHandler()</code></b></a>\n - <a href=\"doc/methods.md#api_nan_set_call_as_function_handler\"><b><code>Nan::SetCallAsFunctionHandler()</code></b></a>\n\n### Scopes\n\nA _local handle_ is a pointer to an object. All V8 objects are accessed using handles, they are necessary because of the way the V8 garbage collector works.\n\nA handle scope can be thought of as a container for any number of handles. When you've finished with your handles, instead of deleting each one individually you can simply delete their scope.\n\nThe creation of `HandleScope` objects is different across the supported versions of V8. Therefore, NAN provides its own implementations that can be used safely across these.\n\n - <a href=\"doc/scopes.md#api_nan_handle_scope\"><b><code>Nan::HandleScope</code></b></a>\n - <a href=\"doc/scopes.md#api_nan_escapable_handle_scope\"><b><code>Nan::EscapableHandleScope</code></b></a>\n\nAlso see the V8 Embedders Guide section on [Handles and Garbage Collection](https://github.com/v8/v8/wiki/Embedder%27s%20Guide#handles-and-garbage-collection).\n\n### Persistent references\n\nAn object reference that is independent of any `HandleScope` is a _persistent_ reference. Where a `Local` handle only lives as long as the `HandleScope` in which it was allocated, a `Persistent` handle remains valid until it is explicitly disposed.\n\nDue to the evolution of the V8 API, it is necessary for NAN to provide a wrapper implementation of the `Persistent` classes to supply compatibility across the V8 versions supported.\n\n - <a href=\"doc/persistent.md#api_nan_persistent_base\"><b><code>Nan::PersistentBase & v8::PersistentBase</code></b></a>\n - <a href=\"doc/persistent.md#api_nan_non_copyable_persistent_traits\"><b><code>Nan::NonCopyablePersistentTraits & v8::NonCopyablePersistentTraits</code></b></a>\n - <a href=\"doc/persistent.md#api_nan_copyable_persistent_traits\"><b><code>Nan::CopyablePersistentTraits & v8::CopyablePersistentTraits</code></b></a>\n - <a href=\"doc/persistent.md#api_nan_persistent\"><b><code>Nan::Persistent</code></b></a>\n - <a href=\"doc/persistent.md#api_nan_global\"><b><code>Nan::Global</code></b></a>\n - <a href=\"doc/persistent.md#api_nan_weak_callback_info\"><b><code>Nan::WeakCallbackInfo</code></b></a>\n - <a href=\"doc/persistent.md#api_nan_weak_callback_type\"><b><code>Nan::WeakCallbackType</code></b></a>\n\nAlso see the V8 Embedders Guide section on [Handles and Garbage Collection](https://developers.google.com/v8/embed#handles).\n\n### New\n\nNAN provides a `Nan::New()` helper for the creation of new JavaScript objects in a way that's compatible across the supported versions of V8.\n\n - <a href=\"doc/new.md#api_nan_new\"><b><code>Nan::New()</code></b></a>\n - <a href=\"doc/new.md#api_nan_undefined\"><b><code>Nan::Undefined()</code></b></a>\n - <a href=\"doc/new.md#api_nan_null\"><b><code>Nan::Null()</code></b></a>\n - <a href=\"doc/new.md#api_nan_true\"><b><code>Nan::True()</code></b></a>\n - <a href=\"doc/new.md#api_nan_false\"><b><code>Nan::False()</code></b></a>\n - <a href=\"doc/new.md#api_nan_empty_string\"><b><code>Nan::EmptyString()</code></b></a>\n\n\n### Converters\n\nNAN contains functions that convert `v8::Value`s to other `v8::Value` types and native types. Since type conversion is not guaranteed to succeed, they return `Nan::Maybe` types. These converters can be used in place of `value->ToX()` and `value->XValue()` (where `X` is one of the types, e.g. `Boolean`) in a way that provides a consistent interface across V8 versions. Newer versions of V8 use the new `v8::Maybe` and `v8::MaybeLocal` types for these conversions, older versions don't have this functionality so it is provided by NAN.\n\n - <a href=\"doc/converters.md#api_nan_to\"><b><code>Nan::To()</code></b></a>\n\n### Maybe Types\n\nThe `Nan::MaybeLocal` and `Nan::Maybe` types are monads that encapsulate `v8::Local` handles that _may be empty_.\n\n* **Maybe Types**\n  - <a href=\"doc/maybe_types.md#api_nan_maybe_local\"><b><code>Nan::MaybeLocal</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_maybe\"><b><code>Nan::Maybe</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_nothing\"><b><code>Nan::Nothing</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_just\"><b><code>Nan::Just</code></b></a>\n* **Maybe Helpers**\n  - <a href=\"doc/maybe_types.md#api_nan_call\"><b><code>Nan::Call()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_to_detail_string\"><b><code>Nan::ToDetailString()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_to_array_index\"><b><code>Nan::ToArrayIndex()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_equals\"><b><code>Nan::Equals()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_new_instance\"><b><code>Nan::NewInstance()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_function\"><b><code>Nan::GetFunction()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_set\"><b><code>Nan::Set()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_define_own_property\"><b><code>Nan::DefineOwnProperty()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_force_set\"><del><b><code>Nan::ForceSet()</code></b></del></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get\"><b><code>Nan::Get()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_property_attribute\"><b><code>Nan::GetPropertyAttributes()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_has\"><b><code>Nan::Has()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_delete\"><b><code>Nan::Delete()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_property_names\"><b><code>Nan::GetPropertyNames()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_own_property_names\"><b><code>Nan::GetOwnPropertyNames()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_set_prototype\"><b><code>Nan::SetPrototype()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_object_proto_to_string\"><b><code>Nan::ObjectProtoToString()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_has_own_property\"><b><code>Nan::HasOwnProperty()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_has_real_named_property\"><b><code>Nan::HasRealNamedProperty()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_has_real_indexed_property\"><b><code>Nan::HasRealIndexedProperty()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_has_real_named_callback_property\"><b><code>Nan::HasRealNamedCallbackProperty()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_real_named_property_in_prototype_chain\"><b><code>Nan::GetRealNamedPropertyInPrototypeChain()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_real_named_property\"><b><code>Nan::GetRealNamedProperty()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_call_as_function\"><b><code>Nan::CallAsFunction()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_call_as_constructor\"><b><code>Nan::CallAsConstructor()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_source_line\"><b><code>Nan::GetSourceLine()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_line_number\"><b><code>Nan::GetLineNumber()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_start_column\"><b><code>Nan::GetStartColumn()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_end_column\"><b><code>Nan::GetEndColumn()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_clone_element_at\"><b><code>Nan::CloneElementAt()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_has_private\"><b><code>Nan::HasPrivate()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_get_private\"><b><code>Nan::GetPrivate()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_set_private\"><b><code>Nan::SetPrivate()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_delete_private\"><b><code>Nan::DeletePrivate()</code></b></a>\n  - <a href=\"doc/maybe_types.md#api_nan_make_maybe\"><b><code>Nan::MakeMaybe()</code></b></a>\n\n### Script\n\nNAN provides a `v8::Script` helpers as the API has changed over the supported versions of V8.\n\n - <a href=\"doc/script.md#api_nan_compile_script\"><b><code>Nan::CompileScript()</code></b></a>\n - <a href=\"doc/script.md#api_nan_run_script\"><b><code>Nan::RunScript()</code></b></a>\n\n\n### JSON\n\nThe _JSON_ object provides the C++ versions of the methods offered by the `JSON` object in javascript. V8 exposes these methods via the `v8::JSON` object.\n\n - <a href=\"doc/json.md#api_nan_json_parse\"><b><code>Nan::JSON.Parse</code></b></a>\n - <a href=\"doc/json.md#api_nan_json_stringify\"><b><code>Nan::JSON.Stringify</code></b></a>\n\nRefer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-8.16/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.\n\n### Errors\n\nNAN includes helpers for creating, throwing and catching Errors as much of this functionality varies across the supported versions of V8 and must be abstracted.\n\nNote that an Error object is simply a specialized form of `v8::Value`.\n\nAlso consult the V8 Embedders Guide section on [Exceptions](https://developers.google.com/v8/embed#exceptions) for more information.\n\n - <a href=\"doc/errors.md#api_nan_error\"><b><code>Nan::Error()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_range_error\"><b><code>Nan::RangeError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_reference_error\"><b><code>Nan::ReferenceError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_syntax_error\"><b><code>Nan::SyntaxError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_type_error\"><b><code>Nan::TypeError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_throw_error\"><b><code>Nan::ThrowError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_throw_range_error\"><b><code>Nan::ThrowRangeError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_throw_reference_error\"><b><code>Nan::ThrowReferenceError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_throw_syntax_error\"><b><code>Nan::ThrowSyntaxError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_throw_type_error\"><b><code>Nan::ThrowTypeError()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_fatal_exception\"><b><code>Nan::FatalException()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_errno_exception\"><b><code>Nan::ErrnoException()</code></b></a>\n - <a href=\"doc/errors.md#api_nan_try_catch\"><b><code>Nan::TryCatch</code></b></a>\n\n\n### Buffers\n\nNAN's `node::Buffer` helpers exist as the API has changed across supported Node versions. Use these methods to ensure compatibility.\n\n - <a href=\"doc/buffers.md#api_nan_new_buffer\"><b><code>Nan::NewBuffer()</code></b></a>\n - <a href=\"doc/buffers.md#api_nan_copy_buffer\"><b><code>Nan::CopyBuffer()</code></b></a>\n - <a href=\"doc/buffers.md#api_nan_free_callback\"><b><code>Nan::FreeCallback()</code></b></a>\n\n### Nan::Callback\n\n`Nan::Callback` makes it easier to use `v8::Function` handles as callbacks. A class that wraps a `v8::Function` handle, protecting it from garbage collection and making it particularly useful for storage and use across asynchronous execution.\n\n - <a href=\"doc/callback.md#api_nan_callback\"><b><code>Nan::Callback</code></b></a>\n\n### Asynchronous work helpers\n\n`Nan::AsyncWorker`, `Nan::AsyncProgressWorker` and `Nan::AsyncProgressQueueWorker` are helper classes that make working with asynchronous code easier.\n\n - <a href=\"doc/asyncworker.md#api_nan_async_worker\"><b><code>Nan::AsyncWorker</code></b></a>\n - <a href=\"doc/asyncworker.md#api_nan_async_progress_worker\"><b><code>Nan::AsyncProgressWorkerBase &amp; Nan::AsyncProgressWorker</code></b></a>\n - <a href=\"doc/asyncworker.md#api_nan_async_progress_queue_worker\"><b><code>Nan::AsyncProgressQueueWorker</code></b></a>\n - <a href=\"doc/asyncworker.md#api_nan_async_queue_worker\"><b><code>Nan::AsyncQueueWorker</code></b></a>\n\n### Strings & Bytes\n\nMiscellaneous string & byte encoding and decoding functionality provided for compatibility across supported versions of V8 and Node. Implemented by NAN to ensure that all encoding types are supported, even for older versions of Node where they are missing.\n\n - <a href=\"doc/string_bytes.md#api_nan_encoding\"><b><code>Nan::Encoding</code></b></a>\n - <a href=\"doc/string_bytes.md#api_nan_encode\"><b><code>Nan::Encode()</code></b></a>\n - <a href=\"doc/string_bytes.md#api_nan_decode_bytes\"><b><code>Nan::DecodeBytes()</code></b></a>\n - <a href=\"doc/string_bytes.md#api_nan_decode_write\"><b><code>Nan::DecodeWrite()</code></b></a>\n\n\n### Object Wrappers\n\nThe `ObjectWrap` class can be used to make wrapped C++ objects and a factory of wrapped objects.\n\n - <a href=\"doc/object_wrappers.md#api_nan_object_wrap\"><b><code>Nan::ObjectWrap</code></b></a>\n\n\n### V8 internals\n\nThe hooks to access V8 internals—including GC and statistics—are different across the supported versions of V8, therefore NAN provides its own hooks that call the appropriate V8 methods.\n\n - <a href=\"doc/v8_internals.md#api_nan_gc_callback\"><b><code>NAN_GC_CALLBACK()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_add_gc_epilogue_callback\"><b><code>Nan::AddGCEpilogueCallback()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_remove_gc_epilogue_callback\"><b><code>Nan::RemoveGCEpilogueCallback()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_add_gc_prologue_callback\"><b><code>Nan::AddGCPrologueCallback()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_remove_gc_prologue_callback\"><b><code>Nan::RemoveGCPrologueCallback()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_get_heap_statistics\"><b><code>Nan::GetHeapStatistics()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_set_counter_function\"><b><code>Nan::SetCounterFunction()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_set_create_histogram_function\"><b><code>Nan::SetCreateHistogramFunction()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_set_add_histogram_sample_function\"><b><code>Nan::SetAddHistogramSampleFunction()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_idle_notification\"><b><code>Nan::IdleNotification()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_low_memory_notification\"><b><code>Nan::LowMemoryNotification()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_context_disposed_notification\"><b><code>Nan::ContextDisposedNotification()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_get_internal_field_pointer\"><b><code>Nan::GetInternalFieldPointer()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_set_internal_field_pointer\"><b><code>Nan::SetInternalFieldPointer()</code></b></a>\n - <a href=\"doc/v8_internals.md#api_nan_adjust_external_memory\"><b><code>Nan::AdjustExternalMemory()</code></b></a>\n\n\n### Miscellaneous V8 Helpers\n\n - <a href=\"doc/v8_misc.md#api_nan_utf8_string\"><b><code>Nan::Utf8String</code></b></a>\n - <a href=\"doc/v8_misc.md#api_nan_get_current_context\"><b><code>Nan::GetCurrentContext()</code></b></a>\n - <a href=\"doc/v8_misc.md#api_nan_set_isolate_data\"><b><code>Nan::SetIsolateData()</code></b></a>\n - <a href=\"doc/v8_misc.md#api_nan_get_isolate_data\"><b><code>Nan::GetIsolateData()</code></b></a>\n - <a href=\"doc/v8_misc.md#api_nan_typedarray_contents\"><b><code>Nan::TypedArrayContents</code></b></a>\n\n\n### Miscellaneous Node Helpers\n\n - <a href=\"doc/node_misc.md#api_nan_asyncresource\"><b><code>Nan::AsyncResource</code></b></a>\n - <a href=\"doc/node_misc.md#api_nan_make_callback\"><b><code>Nan::MakeCallback()</code></b></a>\n - <a href=\"doc/node_misc.md#api_nan_module_init\"><b><code>NAN_MODULE_INIT()</code></b></a>\n - <a href=\"doc/node_misc.md#api_nan_export\"><b><code>Nan::Export()</code></b></a>\n\n<!-- END API -->\n\n\n<a name=\"tests\"></a>\n\n### Tests\n\nTo run the NAN tests do:\n\n``` sh\nnpm install\nnpm run-script rebuild-tests\nnpm test\n```\n\nOr just:\n\n``` sh\nnpm install\nmake test\n```\n\n<a name=\"issues\"></a>\n\n## Known issues\n\n### Compiling against Node.js 0.12 on OSX\n\nWith new enough compilers available on OSX, the versions of V8 headers corresponding to Node.js 0.12\ndo not compile anymore. The error looks something like:\n\n```\n❯   CXX(target) Release/obj.target/accessors/cpp/accessors.o\nIn file included from ../cpp/accessors.cpp:9:\nIn file included from ../../nan.h:51:\nIn file included from /Users/ofrobots/.node-gyp/0.12.18/include/node/node.h:61:\n/Users/ofrobots/.node-gyp/0.12.18/include/node/v8.h:5800:54: error: 'CreateHandle' is a protected member of 'v8::HandleScope'\n  return Handle<T>(reinterpret_cast<T*>(HandleScope::CreateHandle(\n                                        ~~~~~~~~~~~~~^~~~~~~~~~~~\n```\n\nThis can be worked around by patching your local versions of v8.h corresponding to Node 0.12 to make\n`v8::Handle` a friend of `v8::HandleScope`. Since neither Node.js not V8 support this release line anymore\nthis patch cannot be released by either project in an official release.\n\nFor this reason, we do not test against Node.js 0.12 on OSX in this project's CI. If you need to support\nthat configuration, you will need to either get an older compiler, or apply a source patch to the version\nof V8 headers as a workaround.\n\n<a name=\"governance\"></a>\n\n## Governance & Contributing\n\nNAN is governed by the [Node.js Addon API Working Group](https://github.com/nodejs/CTC/blob/master/WORKING_GROUPS.md#addon-api)\n\n### Addon API Working Group (WG)\n\nThe NAN project is jointly governed by a Working Group which is responsible for high-level guidance of the project.\n\nMembers of the WG are also known as Collaborators, there is no distinction between the two, unlike other Node.js projects.\n\nThe WG has final authority over this project including:\n\n* Technical direction\n* Project governance and process (including this policy)\n* Contribution policy\n* GitHub repository hosting\n* Maintaining the list of additional Collaborators\n\nFor the current list of WG members, see the project [README.md](./README.md#collaborators).\n\nIndividuals making significant and valuable contributions are made members of the WG and given commit-access to the project. These individuals are identified by the WG and their addition to the WG is discussed via GitHub and requires unanimous consensus amongst those WG members participating in the discussion with a quorum of 50% of WG members required for acceptance of the vote.\n\n_Note:_ If you make a significant contribution and are not considered for commit-access log an issue or contact a WG member directly.\n\nFor the current list of WG members / Collaborators, see the project [README.md](./README.md#collaborators).\n\n### Consensus Seeking Process\n\nThe WG follows a [Consensus Seeking](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making) decision making model.\n\nModifications of the contents of the NAN repository are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the WG. All pull requests must be reviewed and accepted by a WG member with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing WG member, an additional WG member is required for sign-off. Consensus should be sought if additional WG members participate and there is disagreement around a particular modification.\n\nIf a change proposal cannot reach a consensus, a WG member can call for a vote amongst the members of the WG. Simple majority wins.\n\n<a id=\"developers-certificate-of-origin\"></a>\n\n## Developer's Certificate of Origin 1.1\n\nBy making a contribution to this project, I certify that:\n\n* (a) The contribution was created in whole or in part by me and I\n  have the right to submit it under the open source license\n  indicated in the file; or\n\n* (b) The contribution is based upon previous work that, to the best\n  of my knowledge, is covered under an appropriate open source\n  license and I have the right under that license to submit that\n  work with modifications, whether created in whole or in part\n  by me, under the same open source license (unless I am\n  permitted to submit under a different license), as indicated\n  in the file; or\n\n* (c) The contribution was provided directly to me by some other\n  person who certified (a), (b) or (c) and I have not modified\n  it.\n\n* (d) I understand and agree that this project and the contribution\n  are public and that a record of the contribution (including all\n  personal information I submit with it, including my sign-off) is\n  maintained indefinitely and may be redistributed consistent with\n  this project or the open source license(s) involved.\n\n<a name=\"collaborators\"></a>\n\n### WG Members / Collaborators\n\n<table><tbody>\n<tr><th align=\"left\">Rod Vagg</th><td><a href=\"https://github.com/rvagg\">GitHub/rvagg</a></td><td><a href=\"http://twitter.com/rvagg\">Twitter/@rvagg</a></td></tr>\n<tr><th align=\"left\">Benjamin Byholm</th><td><a href=\"https://github.com/kkoopa/\">GitHub/kkoopa</a></td><td>-</td></tr>\n<tr><th align=\"left\">Trevor Norris</th><td><a href=\"https://github.com/trevnorris\">GitHub/trevnorris</a></td><td><a href=\"http://twitter.com/trevnorris\">Twitter/@trevnorris</a></td></tr>\n<tr><th align=\"left\">Nathan Rajlich</th><td><a href=\"https://github.com/TooTallNate\">GitHub/TooTallNate</a></td><td><a href=\"http://twitter.com/TooTallNate\">Twitter/@TooTallNate</a></td></tr>\n<tr><th align=\"left\">Brett Lawson</th><td><a href=\"https://github.com/brett19\">GitHub/brett19</a></td><td><a href=\"http://twitter.com/brett19x\">Twitter/@brett19x</a></td></tr>\n<tr><th align=\"left\">Ben Noordhuis</th><td><a href=\"https://github.com/bnoordhuis\">GitHub/bnoordhuis</a></td><td><a href=\"http://twitter.com/bnoordhuis\">Twitter/@bnoordhuis</a></td></tr>\n<tr><th align=\"left\">David Siegel</th><td><a href=\"https://github.com/agnat\">GitHub/agnat</a></td><td><a href=\"http://twitter.com/agnat\">Twitter/@agnat</a></td></tr>\n<tr><th align=\"left\">Michael Ira Krufky</th><td><a href=\"https://github.com/mkrufky\">GitHub/mkrufky</a></td><td><a href=\"http://twitter.com/mkrufky\">Twitter/@mkrufky</a></td></tr>\n</tbody></table>\n\n## Licence &amp; copyright\n\nCopyright (c) 2018 NAN WG Members / Collaborators (listed above).\n\nNative Abstractions for Node.js is licensed under an MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE file for more details.\n",
+  "maintainers": [
+    {
+      "name": "kkoopa",
+      "email": "bbyholm@abo.fi"
+    },
+    {
+      "name": "rvagg",
+      "email": "r@va.gg"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-13T12:49:57.248Z",
+    "created": "2013-08-16T10:54:38.330Z",
+    "0.3.0-wip": "2013-08-16T10:54:45.384Z",
+    "0.3.0-wip2": "2013-08-16T11:38:17.241Z",
+    "0.3.0": "2013-08-19T11:56:01.536Z",
+    "0.3.1": "2013-08-20T09:17:59.275Z",
+    "0.3.2": "2013-08-30T12:53:23.650Z",
+    "0.4.0": "2013-09-02T11:49:34.846Z",
+    "0.4.1": "2013-09-16T13:35:24.529Z",
+    "0.4.2": "2013-11-02T02:40:01.651Z",
+    "0.4.3": "2013-11-02T02:56:46.951Z",
+    "0.4.4": "2013-11-02T03:39:07.560Z",
+    "0.5.0": "2013-11-11T02:36:36.947Z",
+    "0.5.1": "2013-11-11T21:43:27.912Z",
+    "0.5.2": "2013-11-16T10:25:47.488Z",
+    "0.6.0": "2013-11-21T01:22:46.218Z",
+    "0.7.0": "2013-12-16T14:55:11.928Z",
+    "0.7.1": "2014-01-09T12:23:38.047Z",
+    "0.8.0": "2014-01-09T12:30:42.175Z",
+    "1.0.0": "2014-05-04T12:20:09.986Z",
+    "1.1.0": "2014-05-25T01:13:41.611Z",
+    "1.1.1": "2014-05-28T10:20:37.994Z",
+    "1.1.2": "2014-05-28T13:07:41.871Z",
+    "1.2.0": "2014-06-04T21:24:39.703Z",
+    "1.3.0": "2014-08-02T12:07:40.701Z",
+    "1.4.0": "2014-11-01T22:48:41.300Z",
+    "1.4.1": "2014-11-08T16:19:39.727Z",
+    "1.5.0": "2015-01-14T19:39:39.575Z",
+    "1.4.2": "2015-01-15T03:53:24.469Z",
+    "1.4.3": "2015-01-15T03:54:10.813Z",
+    "1.5.1": "2015-01-15T03:54:54.300Z",
+    "1.5.2": "2015-01-22T23:54:56.053Z",
+    "1.6.0": "2015-01-23T00:29:18.252Z",
+    "1.5.3": "2015-01-23T00:40:19.788Z",
+    "1.6.1": "2015-01-23T00:48:11.043Z",
+    "1.6.2": "2015-02-06T18:39:26.282Z",
+    "1.7.0": "2015-02-28T12:18:10.217Z",
+    "1.8.0": "2015-04-23T14:29:59.549Z",
+    "1.8.1": "2015-04-23T17:59:00.393Z",
+    "1.8.2": "2015-04-23T19:54:07.123Z",
+    "1.8.3": "2015-04-26T14:29:27.155Z",
+    "1.8.4": "2015-04-26T14:32:39.821Z",
+    "1.9.0": "2015-07-31T11:18:16.059Z",
+    "2.0.0": "2015-07-31T11:56:05.961Z",
+    "2.0.1": "2015-08-06T11:17:23.696Z",
+    "2.0.2": "2015-08-06T11:41:46.078Z",
+    "2.0.3": "2015-08-06T23:20:47.997Z",
+    "2.0.4": "2015-08-07T00:05:12.716Z",
+    "2.0.5": "2015-08-10T14:53:43.186Z",
+    "2.0.6": "2015-08-26T07:48:29.905Z",
+    "2.0.7": "2015-08-26T07:52:04.898Z",
+    "2.0.8": "2015-08-28T08:02:26.997Z",
+    "2.0.9": "2015-09-08T22:57:25.991Z",
+    "2.1.0": "2015-10-08T14:39:47.658Z",
+    "2.2.0": "2016-01-09T15:12:57.471Z",
+    "2.2.1": "2016-03-29T15:30:42.770Z",
+    "2.3.0": "2016-04-27T10:10:00.078Z",
+    "2.3.1": "2016-04-27T16:22:50.179Z",
+    "2.3.2": "2016-04-27T17:35:35.526Z",
+    "2.3.3": "2016-05-03T22:13:40.112Z",
+    "2.3.4": "2016-05-30T22:12:38.756Z",
+    "2.3.5": "2016-05-31T15:06:07.585Z",
+    "2.4.0": "2016-07-10T13:51:21.410Z",
+    "2.5.0": "2016-12-21T18:49:51.532Z",
+    "2.5.1": "2017-01-22T22:27:41.920Z",
+    "2.6.0": "2017-04-05T22:37:27.792Z",
+    "2.6.1": "2017-04-06T05:50:18.273Z",
+    "2.6.2": "2017-04-12T20:38:38.470Z",
+    "2.7.0": "2017-08-30T00:42:51.289Z",
+    "2.8.0": "2017-11-15T11:34:24.395Z",
+    "2.9.1": "2018-02-22T17:14:09.800Z",
+    "2.9.2": "2018-02-22T23:34:17.650Z",
+    "2.10.0": "2018-03-16T16:11:48.820Z",
+    "2.11.0": "2018-08-25T12:43:45.113Z",
+    "2.11.1": "2018-09-29T08:09:53.621Z",
+    "2.12.0": "2018-12-16T13:14:18.284Z",
+    "2.12.1": "2018-12-18T21:01:39.060Z",
+    "2.13.0": "2019-03-13T22:40:10.625Z",
+    "2.13.1": "2019-03-14T21:55:48.868Z",
+    "2.13.2": "2019-03-24T14:32:19.987Z",
+    "2.14.0": "2019-05-16T19:11:36.198Z",
+    "2.14.1": "2020-04-21T18:59:56.894Z",
+    "2.14.2": "2020-10-13T12:49:54.960Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/nodejs/nan.git"
+  },
+  "users": {
+    "ceejbot": true,
+    "fivdi": true,
+    "dozoisch": true,
+    "daviddias": true,
+    "ecomfe": true,
+    "magemagic": true,
+    "slickmonk": true,
+    "hal9zillion": true,
+    "wouldgo": true,
+    "estliberitas": true,
+    "coderaiser": true,
+    "yashprit": true,
+    "foliveira": true,
+    "mortiy": true,
+    "yunnysunny": true,
+    "theheros": true,
+    "y-a-v-a": true,
+    "matteo.collina": true,
+    "blitzprog": true,
+    "guananddu": true,
+    "monolithed": true,
+    "markthethomas": true,
+    "jalcine": true,
+    "chesstrian": true,
+    "kriswill": true,
+    "panlw": true,
+    "koslun": true,
+    "fatelei": true,
+    "pandao": true,
+    "js3692": true,
+    "detj": true,
+    "magicxiao85": true,
+    "liushoukai": true,
+    "djk": true,
+    "shanewholloway": true,
+    "taoyuan": true,
+    "emarcs": true,
+    "javascript": true,
+    "rexpan": true,
+    "horpto": true,
+    "wangnan0610": true,
+    "lukicdarkoo": true,
+    "highlanderkev": true,
+    "nohomey": true,
+    "mojaray2k": true,
+    "braviel": true,
+    "crycode": true,
+    "ga1989": true,
+    "andr": true,
+    "sopov": true,
+    "mkrufky": true,
+    "shuoshubao": true,
+    "xtx1130": true,
+    "xrush": true,
+    "usex": true,
+    "nbuchanan": true,
+    "steel1990": true,
+    "atesgoral": true,
+    "abetomo": true,
+    "nicknaso": true,
+    "chaoliu": true,
+    "faraoman": true,
+    "semenovem": true,
+    "debashish": true
+  },
+  "homepage": "https://github.com/nodejs/nan#readme",
+  "contributors": [
+    {
+      "name": "Rod Vagg",
+      "email": "r@va.gg",
+      "url": "https://github.com/rvagg"
+    },
+    {
+      "name": "Benjamin Byholm",
+      "email": "bbyholm@abo.fi",
+      "url": "https://github.com/kkoopa/"
+    },
+    {
+      "name": "Trevor Norris",
+      "email": "trev.norris@gmail.com",
+      "url": "https://github.com/trevnorris"
+    },
+    {
+      "name": "Nathan Rajlich",
+      "email": "nathan@tootallnate.net",
+      "url": "https://github.com/TooTallNate"
+    },
+    {
+      "name": "Brett Lawson",
+      "email": "brett19@gmail.com",
+      "url": "https://github.com/brett19"
+    },
+    {
+      "name": "Ben Noordhuis",
+      "email": "info@bnoordhuis.nl",
+      "url": "https://github.com/bnoordhuis"
+    },
+    {
+      "name": "David Siegel",
+      "email": "david@artcom.de",
+      "url": "https://github.com/agnat"
+    },
+    {
+      "name": "Michael Ira Krufky",
+      "email": "mkrufky@gmail.com",
+      "url": "https://github.com/mkrufky"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/nodejs/nan/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/nan.min.json
+++ b/test/fixtures/registry-mocks/content/nan.min.json
@@ -1,0 +1,1181 @@
+{
+  "name": "nan",
+  "dist-tags": {
+    "latest": "2.14.2"
+  },
+  "versions": {
+    "0.3.0-wip": {
+      "name": "nan",
+      "version": "0.3.0-wip",
+      "dist": {
+        "shasum": "fd51b1e427db1e5952abbc5eaa053a50bddb795f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.0-wip.tgz"
+      }
+    },
+    "0.3.0-wip2": {
+      "name": "nan",
+      "version": "0.3.0-wip2",
+      "dist": {
+        "shasum": "0455cc096df55927852e524f195b42631317d21c",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.0-wip2.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "nan",
+      "version": "0.3.0",
+      "dist": {
+        "shasum": "8c053549c789b3a1c6169f9bf7949750c6117054",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "nan",
+      "version": "0.3.1",
+      "dist": {
+        "shasum": "672523b3fbdbc8e73213dc1951b636e98b3b176f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.1.tgz"
+      }
+    },
+    "0.3.2": {
+      "name": "nan",
+      "version": "0.3.2",
+      "dist": {
+        "shasum": "0df1935cab15369075ef160ad2894107aa14dc2d",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "nan",
+      "version": "0.4.0",
+      "dist": {
+        "shasum": "c099837dd37983b0fbe8cbc800bf56e07e36acd9",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.0.tgz"
+      }
+    },
+    "0.4.1": {
+      "name": "nan",
+      "version": "0.4.1",
+      "dist": {
+        "shasum": "6bca2af7af5ae7f76e9aa96c80897605bcd0407f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.1.tgz"
+      }
+    },
+    "0.4.2": {
+      "name": "nan",
+      "version": "0.4.2",
+      "dist": {
+        "shasum": "e23acfd4811f60ca5cf98c06c1fea8682539d351",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.2.tgz"
+      }
+    },
+    "0.4.3": {
+      "name": "nan",
+      "version": "0.4.3",
+      "dist": {
+        "shasum": "6f4274c4fa753be8c562822501a7e925ad2af035",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.3.tgz"
+      }
+    },
+    "0.4.4": {
+      "name": "nan",
+      "version": "0.4.4",
+      "dist": {
+        "shasum": "9db58eae63cee119807a0d01afd0655d956bea75",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.4.4.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "nan",
+      "version": "0.5.0",
+      "dist": {
+        "shasum": "fff2b55c761245ef11965d03214d8b4836ef8d79",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.5.0.tgz"
+      }
+    },
+    "0.5.1": {
+      "name": "nan",
+      "version": "0.5.1",
+      "dist": {
+        "shasum": "3dbf3b1a8ab63beb34e39210266c269a0c5d2df2",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.5.1.tgz"
+      }
+    },
+    "0.5.2": {
+      "name": "nan",
+      "version": "0.5.2",
+      "dist": {
+        "shasum": "217df903f50b0647d97c5f28f1c5d12cb0803e09",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.5.2.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "nan",
+      "version": "0.6.0",
+      "dist": {
+        "shasum": "a54ebe59717b467c77425302bd7c17574c887aaa",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.6.0.tgz"
+      }
+    },
+    "0.7.0": {
+      "name": "nan",
+      "version": "0.7.0",
+      "dist": {
+        "shasum": "3c9cc0a4e021c9cc2b699df1d94944e51c5352b9",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.7.0.tgz"
+      }
+    },
+    "0.7.1": {
+      "name": "nan",
+      "version": "0.7.1",
+      "dist": {
+        "shasum": "fc576184a1037b3e5675f2ba3740dee2044ff8f4",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.7.1.tgz"
+      }
+    },
+    "0.8.0": {
+      "name": "nan",
+      "version": "0.8.0",
+      "dist": {
+        "shasum": "022a8fa5e9fe8420964ac1fb3dc94e17f449f5fd",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-0.8.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "nan",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "ae24f8850818d662fcab5acf7f3b95bfaa2ccf38",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "nan",
+      "version": "1.1.0",
+      "dist": {
+        "shasum": "6ca1ab85dc2cd75d6e7d5cbf3d9491bbb97d4aa5",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "nan",
+      "version": "1.1.1",
+      "dist": {
+        "shasum": "1057b5526920e77f268d8e5e1d274a6c19251d18",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "nan",
+      "version": "1.1.2",
+      "dist": {
+        "shasum": "bbd48552fc0758673ebe8fada360b60278a6636b",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.1.2.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "nan",
+      "version": "1.2.0",
+      "dist": {
+        "shasum": "9c4d63ce9e4f8e95de2d574e18f7925554a8a8ef",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "nan",
+      "version": "1.3.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.1",
+        "tap": "~0.4.12",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "9a5b8d5ef97a10df3050e59b2c362d3baf779742",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.3.0.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "nan",
+      "version": "1.4.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "d49a8e21da02b88f8b175a5300bdfd5e9a5d5362",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.4.0.tgz"
+      }
+    },
+    "1.4.1": {
+      "name": "nan",
+      "version": "1.4.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "0a2bb562c558b440005b1f7eb8b31ccbdb565d5f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.4.1.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "nan",
+      "version": "1.5.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "2b3c05bc361f52e50aea2c49077783aa67c5b7fb",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.5.0.tgz"
+      }
+    },
+    "1.4.2": {
+      "name": "nan",
+      "version": "1.4.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "394c45ae2e3493a35f9adf96d33ee01098ff38d9",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.4.2.tgz"
+      }
+    },
+    "1.4.3": {
+      "name": "nan",
+      "version": "1.4.3",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "c56b5404698063696f597435f9163c312aea5009",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz"
+      }
+    },
+    "1.5.1": {
+      "name": "nan",
+      "version": "1.5.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.4.13",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "a565e4d4143cb49afdd3fe07e4c8aeaa1e7e0603",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.5.1.tgz"
+      }
+    },
+    "1.5.2": {
+      "name": "nan",
+      "version": "1.5.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "17da56116d035c6a25f18e9d6b356d4199744aa8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.5.2.tgz"
+      }
+    },
+    "1.6.0": {
+      "name": "nan",
+      "version": "1.6.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "a3b14a6608a31d9c2c062ca5f2c5ae77e9399f95",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.6.0.tgz"
+      }
+    },
+    "1.5.3": {
+      "name": "nan",
+      "version": "1.5.3",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "4cd0ecc133b7b0700a492a646add427ae8a318eb",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
+      }
+    },
+    "1.6.1": {
+      "name": "nan",
+      "version": "1.6.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "69bc50b2d727f3df01145a963f7d2e4da5ff9184",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.6.1.tgz"
+      }
+    },
+    "1.6.2": {
+      "name": "nan",
+      "version": "1.6.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "2657d1c43b00f1e847e083832285b7d8f5ba8ec8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.6.2.tgz"
+      }
+    },
+    "1.7.0": {
+      "name": "nan",
+      "version": "1.7.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.5.0",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "755b997404e83cbe7bc08bc3c5c56291bce87438",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.7.0.tgz"
+      }
+    },
+    "1.8.0": {
+      "name": "nan",
+      "version": "1.8.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "0b46b0463a4b6439f72f5a2143775e69827e02e6",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.0.tgz"
+      }
+    },
+    "1.8.1": {
+      "name": "nan",
+      "version": "1.8.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "6b2f119c88942f7e24f97b0cfde135ff96d4a66d",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.1.tgz"
+      }
+    },
+    "1.8.2": {
+      "name": "nan",
+      "version": "1.8.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "131518535fa0c49e91f2d1a776f65bb04577dea0",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.2.tgz"
+      }
+    },
+    "1.8.3": {
+      "name": "nan",
+      "version": "1.8.3",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "2f4ec4932c7a2250b5ef4b4597fc5e76af021229",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.3.tgz"
+      }
+    },
+    "1.8.4": {
+      "name": "nan",
+      "version": "1.8.4",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~1.0.2",
+        "pangyp": "~2.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "3c76b5382eab33e44b758d2813ca9d92e9342f34",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+      }
+    },
+    "1.9.0": {
+      "name": "nan",
+      "version": "1.9.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "1a9cd2755609766f5c291e4194fce39fde286515",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-1.9.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "nan",
+      "version": "2.0.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "bcdd32340befef23a588ea66b2f38902a2b82e42",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "nan",
+      "version": "2.0.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "acbeda51fbff253fe1438f71c6df758a58a6c30b",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "nan",
+      "version": "2.0.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "326b3076add027caa3878aa68aef18516694d9ec",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "nan",
+      "version": "2.0.3",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "39252b7a399715750b76abc3c4625076a5420a51",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.3.tgz"
+      }
+    },
+    "2.0.4": {
+      "name": "nan",
+      "version": "2.0.4",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "f81d4c18aa3c8300dec2f336c52fb827cadfa719",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.4.tgz"
+      }
+    },
+    "2.0.5": {
+      "name": "nan",
+      "version": "2.0.5",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "365888014be1fd178db0cbfa258edf7b0cb1c408",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.5.tgz"
+      }
+    },
+    "2.0.6": {
+      "name": "nan",
+      "version": "2.0.6",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "1bf60f2a4f91da0d426516f136f51725a092c316",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.6.tgz"
+      }
+    },
+    "2.0.7": {
+      "name": "nan",
+      "version": "2.0.7",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "c726ce45dbd863b46234e4dfe5bf02d0cb309cd8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.7.tgz"
+      }
+    },
+    "2.0.8": {
+      "name": "nan",
+      "version": "2.0.8",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "c15fd99dd4cc323d1c2f94ac426313680e606392",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.8.tgz"
+      }
+    },
+    "2.0.9": {
+      "name": "nan",
+      "version": "2.0.9",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~2.0.2",
+        "pangyp": "~2.2.0",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "d02a770f46778842cceb94e17cab31ffc7234a05",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "nan",
+      "version": "2.1.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "020a7ccedc63fdee85f85967d5607849e74abbe8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "nan",
+      "version": "2.2.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "779c07135629503cf6a7b7e6aab33049b3c3853c",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+      }
+    },
+    "2.2.1": {
+      "name": "nan",
+      "version": "2.2.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "d68693f6b34bb41d66bc68b3a4f9defc79d7149b",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.2.1.tgz"
+      }
+    },
+    "2.3.0": {
+      "name": "nan",
+      "version": "2.3.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "e3e5ce03d1811ca92641d0a77934336473ee66be",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.0.tgz"
+      }
+    },
+    "2.3.1": {
+      "name": "nan",
+      "version": "2.3.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "a4d3e9bfeee09d782d37db161b517221138c2a85",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.1.tgz"
+      }
+    },
+    "2.3.2": {
+      "name": "nan",
+      "version": "2.3.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "4d4ecf17e1da4e989efb4f273d8d00201cad087e",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.2.tgz"
+      }
+    },
+    "2.3.3": {
+      "name": "nan",
+      "version": "2.3.3",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "64dd83c9704a83648b6c72b401f6384bd94ef16f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.3.tgz"
+      }
+    },
+    "2.3.4": {
+      "name": "nan",
+      "version": "2.3.4",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "a7d5eb1cb727f8123a2dda6a883c006b30896718",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.4.tgz"
+      }
+    },
+    "2.3.5": {
+      "name": "nan",
+      "version": "2.3.5",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "822a0dc266290ce4cd3a12282ca3e7e364668a08",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz"
+      }
+    },
+    "2.4.0": {
+      "name": "nan",
+      "version": "2.4.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "fb3c59d45fe4effe215f0b890f8adf6eb32d2232",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+      }
+    },
+    "2.5.0": {
+      "name": "nan",
+      "version": "2.5.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "aa8f1e34531d807e9e27755b234b4a6ec0c152a8",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz"
+      }
+    },
+    "2.5.1": {
+      "name": "nan",
+      "version": "2.5.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "d5b01691253326a97a2bbee9e61c55d8d60351e2",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz"
+      }
+    },
+    "2.6.0": {
+      "name": "nan",
+      "version": "2.6.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "b9b0a907d796d0d336fd73afce24f5e1aa929934",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.6.0.tgz"
+      }
+    },
+    "2.6.1": {
+      "name": "nan",
+      "version": "2.6.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "8c84f7b14c96b89f57fbc838012180ec8ca39a01",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.6.1.tgz"
+      }
+    },
+    "2.6.2": {
+      "name": "nan",
+      "version": "2.6.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "e4ff34e6c95fdfb5aecc08de6596f43605a7db45",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+      }
+    },
+    "2.7.0": {
+      "name": "nan",
+      "version": "2.7.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "node-gyp": "~3.0.1",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "d95bf721ec877e08db276ed3fc6eb78f9083ad46",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
+      }
+    },
+    "2.8.0": {
+      "name": "nan",
+      "version": "2.8.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "ed715f3fe9de02b57a5e6252d90a96675e1f085a",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz"
+      }
+    },
+    "2.9.1": {
+      "name": "nan",
+      "version": "2.9.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-c609vVPyCEuuzqOjx3hwsSZMXLg5QTzbTfgBmEx6N444ymBt1+Yg/rTGr2+4S3VJ3btXI8m1TZ7nLcYcRTZYuQ==",
+        "shasum": "af88fcaee5292992c5b755121ceeaa74536fc228",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.9.1.tgz",
+        "fileCount": 45,
+        "unpackedSize": 404355
+      }
+    },
+    "2.9.2": {
+      "name": "nan",
+      "version": "2.9.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+        "shasum": "f564d75f5f8f36a6d9456cca7a6c4fe488ab7866",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+        "fileCount": 45,
+        "unpackedSize": 404456
+      }
+    },
+    "2.10.0": {
+      "name": "nan",
+      "version": "2.10.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+        "shasum": "96d0cd610ebd58d4b4de9cc0c6828cda99c7548f",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 409953
+      }
+    },
+    "2.11.0": {
+      "name": "nan",
+      "version": "2.11.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
+        "shasum": "574e360e4d954ab16966ec102c0c049fd961a099",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 412174,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgU8BCRA9TVsSAnZWagAAJNIP/2+bZl2y/eC/prNgAOPV\nOOAp8aPI1FAe9jcly9hjQqplKPvIY8XXP5WK6pq+ce1l5vyvHdtcQum977I7\nMLH3MiEj31aIcNrI0/G9LTMqmHMct+qKK4OjyjhupRFuQCHI+BPXGTrQVZ2S\nkUi76QwLOXMnu9rRwmVS+rEjRu+W0TT+sQb4sspBdhG/4qnyp/rp+L2Shdv8\nLlRB4EC7j8N6aosWBrhyVBPX59yliFn0z7mAuFswqdcm4TI3rtTXn1yIDkaW\nyukbkwOBAtL1dKfV7rlmjiS2Retp9FdF3X5D4tVdwbKSd3+5uMYUmz5CsoLI\nbY9uOdjHZGByFfVbMI8qZA6vf0HNZ2/0O7n+f1qGOVFCS4JvjHqgZa6eLjCD\nntdvJmAruNmtIhlXMmq+rUIyA6H4KaaDI2gSggeFVacpuTnFUKW6HN/fGQpB\n2COAPd6cjFJJ47v/YdKBzGZLuUXQ21Je2xxLeGYSd253XSQcu4rPYFTdSSTF\nbuLmG7SObSG/F9hDntzUpCP2hDn5ekmGJwZMRH2h9RuuVMISx3P48Zht6htZ\nTfE8KmOR0ncQtf94jX6KmqFJZjkrZatCCJmTkWWJGjch1/qP/qb1mLjo0hAz\niqq3pAGb2PwF1lRSAAbdqjDIUbGdO1a3NEkvDBH9JtafBBV5ZiEsNBzqhsXs\nEmh8\r\n=CVBp\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.11.1": {
+      "name": "nan",
+      "version": "2.11.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+        "shasum": "90e22bccb8ca57ea4cd37cc83d3819b52eea6766",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+        "fileCount": 47,
+        "unpackedSize": 487268,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbrzNSCRA9TVsSAnZWagAA0vgQAJoa+4F+vH2jgoMAIh2M\nduUOqUMSIKBSqcO1+OzZj8Xi1NTQXKnuxwUpcLfG7kUFSTXMNQ5pqXv4om8/\nViw9to8ZE5wAlK3Uqejk5qaQgVNmxeWtO91R85q3KNI6l1Z4qaRVJN13GwnS\nS1iwDlG/3dKLWAAcoJjP20uCHSvFmEsR+FJy0G5y76s+QSJNFI0TmZRXpowJ\nTezFZsBU/EFRBKKIv//nNvuSxh1/TITrD72sshjpjWdwWqJK0T9emtuBOGFT\nhjsYWGeykfu3HjxBwrzG4hNhyO7nQCl59TRoiPKyqNb70W9RvjJAcldwcMqX\nBddgZ5lZq4+qw+KBGnkoHvO5cS6CQoe3cgFNILGq1NNbPc22Kwp5CVdy1TXv\nC7BcutM20izHrQeBnilZTy+PFBx3eNixWJHFyVDZeGrF47t2jqKvcLEm1eF8\n7pA6/VxXDvE2D+MBjfpAWfSbZ0bR0jhDYvly+1DufutyCd+G6JzR04FsGg1y\nk873NoJ6P9WlZhzvnLBaoWOaQP8XOcxcugSQPP8lTA4hDmQwXY9K8Rwi6Ry2\nw+wGn2WAUQXQhKHJto6dJiIZyJ/yt0h5rjGnwzraXReQQXcTif2dSkvpAgPK\nRXVMRKQIh3us3mU6rSXwg08T4NopJLDLdEuwYYvoKy7xPZLx5uzP/phWLJsb\nG33O\r\n=ig8G\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.12.0": {
+      "name": "nan",
+      "version": "2.12.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-zT5nC0JhbljmyEf+Z456nvm7iO7XgRV2hYxoBtPpnyp+0Q4aCoP6uWNn76v/I6k2kCYNLWqWbwBWQcjsNI/bjw==",
+        "shasum": "9d443fdb5e13a20770cc5e602eee59760a685885",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.12.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 414432,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcFk+qCRA9TVsSAnZWagAAKTYP/ifKNoarxTcvHhn31rYR\nU2Gr9fmUnNnakkjaUwsJofQvqrBJDMzmT5t0gbHSrFRsTr8Jx2WgmIotef84\njyZfNqI09UM2xHXOKqUiZTcQlAQ9VErtHi2PDWr/A1i1qv/3AGPxYRMpbWR1\nTgI2bC1YGAq87470BB41C0BRfEXd2c6DffBYFEgkWoyDiAHrSltNwziENf9B\nV05ovWxdIf3ugIpgSKPYms+ff+lM4G7AcdDmg5zHw1PwmUcMN4hNRFROD+dN\nWGpNzVCyEZ7aIa1iwOcMzRm8s0OtUCo+pxq/nzOB0Oo9jtuEkH/hwSZbw0OL\n/wY57CsIAkbDj8/QBLDfQRjOWJ7pINiaY9smRmZzFkGnr216ZhvYAPaFpzeQ\nV+ioAr8mXnlJVQcoo0EXBave1DWt7ucZm3y9Hc0HeE267sJQMkwDJnGZxFDE\ntSq4RZwT8Kjzl4fDmWWEisIJAoOCYvgzF0sYvCODbMOJ9NQtwt7X8ZzPnrkQ\nBuB8D7HtcsUPgPAglq+XbjxKRTx4HP3HnMWieLNwLrBWhJG6QG25eabMpoYC\nV0DeDFYx6YebK01kmAmnZ8uxx1uBScKD91FwxijkWfwSPakxrX97aocYFXJw\naOFtkc0/vf6p/o3cpXKNwZ5dALAiqU2qPENY6kEwsV6eyX4RzCSKQBKN+cbc\nW3aJ\r\n=bGq5\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.12.1": {
+      "name": "nan",
+      "version": "2.12.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+        "shasum": "7b1aa193e9aa86057e3c7bbd0ac448e770925552",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+        "fileCount": 46,
+        "unpackedSize": 414999,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcGWAzCRA9TVsSAnZWagAAkoMQAJgEI+g1PFR6UlfI3nbv\n7HlsOR47Y2VNinIsyoQECyE1QNoaPH9f/1TflublZFh6pOCWyClc6MaFEP2e\nbQf7qkHTJfjviaLSUc0pqzve3DxKVoXbvRANhxBoWipHXkFTvQoPWc3f3LYx\nEvNlyOX9L6nHMaeMNooeD5Fcj5ZtGyc80IWouGTatOVLoQO1n5JAEb9PHuJD\nwgHfZHnkNOYO1YQ/9VeRVQ9K5z8mgcQhcBfKaSJrc9DolihwuvJ+iy4RWx3C\nHWpYzpJzo/xDNtX5LH9sZaezljt/vI1wacGdVGtXBM5GVTkb1pIDhDG5n8Vo\ntUHdVwLL7+sH/kjyurKU9L5spbkAJEgmpS8lerx+tD8HqOtv6R8EqPhADm6F\nI1bpMzoul8ALiUat+MUF81KivuwEJ0ydTED5tKnTno7btU0M2cC8otbXpXvg\nngVSotsAs9IVifZAGHwk0rmTckj1pdxL6WR+4/o+7y4c9xXBI6DNbS/DfuQe\nfSTgg8TJRVLlf/7vAE64L3q16EdCt9h5qdbfgvpK0Ww9fg/3vw9UuIvz/1z2\nMWXOWFVDZDSpFPXf8lanaes9IKdhO3arZJHlRnmFZ/HjCzzG5YHpy8Qsg7wT\n1jo0m/kdnW7onz9aoSZ40D6oGDLdp32QoJH2JFrhVl0fh7hetr8905KMkVpu\nZnpp\r\n=tMc9\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.13.0": {
+      "name": "nan",
+      "version": "2.13.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-5DDQvN0luhXdut8SCwzm/ZuAX2W+fwhqNzfq7CZ+OJzQ6NwpcqmIGyLD1R8MEt7BeErzcsI0JLr4pND2pNp2Cw==",
+        "shasum": "7bdfc27dd3c060c46e60b62c72b74012d1a4cd68",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.13.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 416211,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJciYbLCRA9TVsSAnZWagAADc0QAKNxJUs+1fHRtmFMIAv7\nXb2ObCu8VH6wPDDvhpqr+pFIQIocBsmqNdr8rD7d2WlVxThrmDQ2pkVqQOVC\nGgSjChjFVcUA/6kcFYfbX+OzS8aZirFKdr2a5RDrsK6QvaoAmw0MhMU5u3RN\nnLuvjfnlFQCm6yLfUZSRYKK70EA3n5IbjidWNMuqPvKJ3M4mXa/naSVNGqGA\nCJsUufCaMRl4P120+4+250RS8nJO55PWeHsRIwgudoQyxEc5ItH0QeGw6tNe\nrHv9lM1Yf0AQ8Zlkl0RbvX7vcMTo6wTGWGVCklP7ApBzL90oasoJ4U0TWsGc\nJUcdUKVD04xoVvuXch4YL9UWcmH4R35L3eOHAOknQiv2TqXzi6vdePCdpE1M\nNAuyCEvuvruDMLLUSQJ1ch98mvscKIfZwOOcmSIbdPzY99lPDdWgpkPNamMF\n9eM19nBvuJaKLssjIcpTcKYEERlhiWTZ6kMhc4i/w+3zySO7T6usBYsZjNyT\nEaf6WWrBLrYtRnio7hSAgiIayHmbgritN8ErvP7/SkJYtAp/Zm88elQxtRcE\nivBnVnATCcdXQBtn9O1B8mhJEefIrNVlR90L8nfoo9q5ntthGVysyqgKmReA\noHjmrlK3Gl6eY2gdK8WAA4fYZmxnRtzrci8Y1yrn4mvbBjKsU8CPwZ+WtweA\nLB6a\r\n=S1LC\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.13.1": {
+      "name": "nan",
+      "version": "2.13.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==",
+        "shasum": "a15bee3790bde247e8f38f1d446edcdaeb05f2dd",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
+        "fileCount": 46,
+        "unpackedSize": 416465,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcis3lCRA9TVsSAnZWagAA99kP/iAWCAc0pkQp7r4B/2f3\n2VQBLO8I5QThewxHroCALastX+4feQXXBreL5nrkuZy0Qki0EfzSZsTaDJz9\nslPnBF9MrT00o2vx6OKhxae9G6n0gZ5Mx+TqxiKdAl9op3RjqRtZHAygheSF\n0HdrtlRAZxplrMH9d/qvuEF20KmT2hjQ/epD90g0bH5hM3g7KzqgLIuZ7V/+\nbz6SEv+bI/l10jo7BYo89tjr12RreCkFy9RbvyqjXDHBCbM9wn9zczWH5WCJ\nh6/n1d9zxnj63xJ5AFYRpWPJ24kndw6jtvR4g3fa+R8gNnhKP5xXpoePtLfZ\nO+0/zANjDQf7qXeAsk6SywbFlAiFE2QftuJqTphOG26hrbWGURsNHsOy2Q94\nU7Q+vy8fehSJ48cHwhTuoc1TLTwKQWH/+daIuaslALmPvWtIi6ZJrf9Jrulp\nCO3GY+JTZmQKBnFvXGhRG6QjdfzGu05D4XTBesqVj+MVf7weXs548NPUitIg\n/qwjADZRrlCNijCC39JSgGuDf2xJzqg/APk5Mmy13piX4m2zyc2Q27fagPgb\nzcNYj5OZLHnotgbBBaukJOBob/n0+/OzUVBdLItwMNPE7IfJNo1+4gdVYG1+\n4rzVugjlQg5Nne0Ifts1vzDVUJ1A6DoxAeEz9Zn7ghTiDgQXSW550ziDDsCY\nWEfj\r\n=Qy+m\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.13.2": {
+      "name": "nan",
+      "version": "2.13.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+        "shasum": "f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+        "fileCount": 46,
+        "unpackedSize": 416510,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcl5T0CRA9TVsSAnZWagAAiQ4QAKLRrhcLF7X35CmFE7Q1\n9kSj7Madc0MFOwpqAMjTALGe/zlu5sjAFu6aRRDLhLKOVel7PsX+FuNENv4A\nCTz5VQu8Q7Gx3uCq+1R5RReogxyQzhQR0gpJS2b3tm/nza8cBSLBS5G7F5HN\n5bD0V0b2lTDAaqsfUVRq0ocuXRY5uu79JfCnF4w0I+W4AfUKVIMI1xXjSiJo\n3kTXdMbjDXkCzy6picwLGte0EYMy005XcB4o0U9l1xkvQ/ebn9lsQHD+MGOX\nz0zLyMT+ZwnUD7XMdHmdLYQBRC4pkekHzGhB6lzNietmaIXgQboTkd86AjqQ\niYifuF7yNL3CipBgcdBE5B1gPIx22TfGjSnIFXuYjbtYWIbxkOWU42c5E2hy\nDS3WOkcHNu75ygW4gNcH4QPcHD3foFS3nPl5pShW9u1PpKKSuQiezPk0VMxP\n0hNmP5s3pp82I8cLPhs/qc55NCecGJnu82PM/osXOV9Tn7VBGstIXOKElyV0\nPevcUfnviqUyHwn6itFajsvoTUFLTQSz/YYCeOI1nXgoca/5cwOy2Ta2bYxT\nlEDSWve7kONxW0WRUcYQlz6iz7vrwu+xADX0wEwPImttEUuJ7h7zhU4scGAT\n7x4jTEYIQy5OZOjWrMZPlRyD/PBYq8UCQ3nic21IRc1B81/OVxrJ3Dcw3Pgd\n49k2\r\n=DnIP\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.14.0": {
+      "name": "nan",
+      "version": "2.14.0",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+        "shasum": "7818f722027b2459a86f0295d434d1fc2336c52c",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+        "fileCount": 46,
+        "unpackedSize": 417060,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3bXpCRA9TVsSAnZWagAApycP/2mhtcraLrh5RRziC2xM\nUKDaEjBIznHn7PqDWecW3HW/CGrUfmuxpDCBlE2fBm2cxF26nB/CV6xoD2W1\nkyu4MkRcKiAvNW0h4a5sTwXey0U6xc8JRBhBTWgfiY2aQoA4fIO5akmbIa/w\nyT6tspFQ0BQWKBrxlSOqfQ/lARU4Dzy2eiKu1aWMffQecgqOPTrlb5/QxFsr\nUmfdePyO2odVrjDiiNJsfkHeMh66ED4n7szrRjwkz7FTkoEF0dMOw/bWJU2X\nEYVziHG7rm9B4Blzv6KtqG4Y9Gty8epOG+itSLQcc088H86TXYXJn6y75+lf\n1Lw5E9lxw5XLfVnE7uzr0NVHhcj/M3RaGzXySi7v2AWMbF6wqxtAdebdNaew\nIpc3+NVj2OjA/79bzzhU76MG0PrYURE8UmVugHZHGp9L1PraD/jWqCT1JMGE\n1qGu2dSlsqoyNe9Y1pTs/kc+I4KLjwDqo14NyQQk8quvkyHrQ66oO5lAPN4U\n5ms7vR+FOZYrtX7jQDTAs9N169N0IxhGwgsUH4zRza2RkkdTzsjyEnPhqlrI\n6tIrfYldrudrGtcNmLJqY7fTUA86L3f7SQvlnpfsDPUFagfwQr4Uz9JE8q1k\nhbe8CqTuhbET2AZNFlBxf0ii3ipwNXXJtB/0hIVQCfud1vbdS1IuOibc2/YY\n6ep0\r\n=AZxH\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.14.1": {
+      "name": "nan",
+      "version": "2.14.1",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+        "shasum": "d7be34dfa3105b91494c3147089315eff8874b01",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+        "fileCount": 46,
+        "unpackedSize": 417637,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJen0KtCRA9TVsSAnZWagAAEJAP/AuPED/luXpLqjqUtyRc\nm1zYL5L3e5XyxkCZ+/Agc1gi/p1SG0zFo5XrgabTVcPsyZ2RwAyB+hUCDlC7\nHRp/VbfR/lvEGvcznzsjm4pcn+8oIM5vR+RM035LR+RsvZ+TxBVc4P6Oe9vT\njwsPquNy/PJseIygzNvteINOr5iGUVVOq61pkqzmUP3WrydxVYY6kLn1y+F2\nM1poBixx4NOHdhTuv65B7N7hK7A5YDVZhetGEA8tDEF4KCOB2vgx/kWdaz2k\nA/r94QRILObXIFriUM0CNI5p/gBEIEJ9art5U7eiQwvDJXKmAkSR2nSsJMf7\nusH4+Ot40dVCUbLw/kGYpPAJ+BTdPpFqmW5UFkheCaq/Neihkioj6RDJ8eco\n8Oh4xVPLH9/cT1IhvYlKRmuWyPKU57y9saEvB1PWcUecp/fkc1Aonptak6dK\n87DAk9+85S/mwhQExlwc9SSBsPXIyY6UjSmwfEUPuY9BlD8SmLasdkIPFC8V\nEcjzebcVo8kd5nOz/9PrwZE5Gkfs4B5SpJTK92ZLYOIEcht2l4CvglELBxbj\n5Hd+scHKmWvHyrShBkRie2BDQXzroDbGYqoKHuzAOgv075APk9yvEYOnqP/4\nzz68DIGbYgNwPCLEEO4q34fdX/1SHtZ+Yb+sN+AqULIVHjmzAKKkcDgsLNmK\nqOt2\r\n=EVf+\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.14.2": {
+      "name": "nan",
+      "version": "2.14.2",
+      "devDependencies": {
+        "bindings": "~1.2.1",
+        "commander": "^2.8.1",
+        "glob": "^5.0.14",
+        "request": "=2.81.0",
+        "node-gyp": "~3.6.2",
+        "readable-stream": "^2.1.4",
+        "tap": "~0.7.1",
+        "xtend": "~4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+        "shasum": "f5376400695168f4cc694ac9393d0c9585eeea19",
+        "tarball": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+        "fileCount": 46,
+        "unpackedSize": 417991,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfhaJzCRA9TVsSAnZWagAAqa0P/33rKLxI1mx53dz2Z6/B\nQQAJOUcgZgpIdY7LkaDGw6oTRyYoDg9uq1aOW7uL6OTJGZb/0UH3LS/gs5CK\nUk1CnYitqHSmyzOCO6tZyQmiFqYqLJf5drQn+uV9sU3bi2+u42Z03vTv5v+j\nEwRLH3TfeMbrEOgDdBuo6RB+jgaZHKyEXsvCe6NXXAaAQ8as82vtDOA1FOzq\nhB91RTYgS57lF3g/ciWg/Bvb7o2Fwep7+Ah/22Cpz9UC8fm8QGz4/lQRba3m\n504ah7HXRoF79+HqvntRKF0j8fJ8fpX3cu7wQ5UND8bj/VhhNpKZtM/tCv98\nq00KMaWYNqD+NJYKULLS658iJVjpPNr9UElb3+jNDCoX+UEvdOckuJKwo5u0\n7HRmqpE6Pb0MGfVqhHK6K3buwg+eccMcCKPiHHaiZvqa/jD0savGNx2ylMVD\niTpyl8XV+ZU9vfR1tJ3OFYzOGfXOGG5LqOut/hT0qjBLTWXL3ajPcxCNdJRH\nWSrDJ7Y3da/KkyMdX37t39Q6JkQbD2hz2nGNIr1pe36CNqx8FMOvnHG2Gwuy\nGFdcABFLpkppKhHmRebaRlQXJ416KHzxUkD+A/5DcUb7ChoJgn4j6TN7ewVb\nNOb7UllppKKHOseXgre8uJM1vVslNLVsBYzfgv58uhSTbMvo5QBuK/QHKilw\nRoBa\r\n=4oJR\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-13T12:49:57.248Z"
+}

--- a/test/fixtures/registry-mocks/content/negotiator.json
+++ b/test/fixtures/registry-mocks/content/negotiator.json
@@ -1,0 +1,1807 @@
+{
+  "_id": "negotiator",
+  "_rev": "66-03748b238505fbb99d2686a410fe9884",
+  "name": "negotiator",
+  "description": "HTTP content negotiation",
+  "dist-tags": {
+    "latest": "0.6.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.1.0",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node > 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "iconv": "1.1.x",
+        "gzip-buffer": "x.x.x"
+      },
+      "dependencies": {
+        "underscore": "1.2.x",
+        "coffee-script": "1.2.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "_id": "negotiator@0.1.0",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-alpha-6",
+      "_nodeVersion": "v0.6.5",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "eceb71a868cb56ae156cc563a1a881669d4e9650",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.2.3",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "_id": "negotiator@0.2.3",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-alpha-6",
+      "_nodeVersion": "v0.6.5",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e93dd1d816112185f752cbb4c4c1df8cfca4f399",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.4": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.2.4",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "_id": "negotiator@0.2.4",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-alpha-6",
+      "_nodeVersion": "v0.6.5",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "8c82cc553bbfc8ada49a969ead7bcfac3fb190f7",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.5": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.2.5",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "_id": "negotiator@0.2.5",
+      "dependencies": {},
+      "dist": {
+        "shasum": "12ec7b4a9f3b4c894c31d8c4ec015925ba547eec",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.6": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.2.6",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "_id": "negotiator@0.2.6",
+      "dependencies": {},
+      "dist": {
+        "shasum": "28db6bc2e442c8655325d156ff74055dc0db289c",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.7": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.2.7",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "_id": "negotiator@0.2.7",
+      "dependencies": {},
+      "dist": {
+        "shasum": "f31240c6a4aed34c1c2f22f2ce325a5414a00a9e",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.8": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.2.8",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "_id": "negotiator@0.2.8",
+      "dependencies": {},
+      "dist": {
+        "shasum": "adfd207a3875c4d37095729c2e7c283c5ba2ee72",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.3.0",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "_id": "negotiator@0.3.0",
+      "dependencies": {},
+      "dist": {
+        "shasum": "706d692efeddf574d57ea9fb1ab89a4fa7ee8f60",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.0",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "bugs": {
+        "url": "https://github.com/federomero/negotiator/issues"
+      },
+      "homepage": "https://github.com/federomero/negotiator",
+      "dependencies": {},
+      "_id": "negotiator@0.4.0",
+      "dist": {
+        "shasum": "06992a7c3d6014cace59f6368a5803452a6ae5c1",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.1",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "bugs": {
+        "url": "https://github.com/federomero/negotiator/issues"
+      },
+      "homepage": "https://github.com/federomero/negotiator",
+      "dependencies": {},
+      "_id": "negotiator@0.4.1",
+      "dist": {
+        "shasum": "7806f0041eca5b05bb00758d8ad7611ff18f357c",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.2",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "bugs": {
+        "url": "https://github.com/federomero/negotiator/issues"
+      },
+      "homepage": "https://github.com/federomero/negotiator",
+      "dependencies": {},
+      "_id": "negotiator@0.4.2",
+      "dist": {
+        "shasum": "8c43ea7e4c40ddfe40c3c0234c4ef77500b8fd37",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.3": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.3",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "bugs": {
+        "url": "https://github.com/federomero/negotiator/issues"
+      },
+      "homepage": "https://github.com/federomero/negotiator",
+      "dependencies": {},
+      "_id": "negotiator@0.4.3",
+      "dist": {
+        "shasum": "9d6b5cf549547ca06a3971a81f80d25f3cf9db02",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.4": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.4",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "bugs": {
+        "url": "https://github.com/federomero/negotiator/issues"
+      },
+      "homepage": "https://github.com/federomero/negotiator",
+      "dependencies": {},
+      "_id": "negotiator@0.4.4",
+      "dist": {
+        "shasum": "321ec00f2d3a9f597c62581082030b49c39fd199",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.5": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.5",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "bugs": {
+        "url": "https://github.com/federomero/negotiator/issues"
+      },
+      "homepage": "https://github.com/federomero/negotiator",
+      "dependencies": {},
+      "_id": "negotiator@0.4.5",
+      "dist": {
+        "shasum": "0e738eb225e3a166ee7d69ebcfdc702ba236a77b",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.6": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.6",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "bugs": {
+        "url": "https://github.com/federomero/negotiator/issues"
+      },
+      "homepage": "https://github.com/federomero/negotiator",
+      "dependencies": {},
+      "_id": "negotiator@0.4.6",
+      "dist": {
+        "shasum": "f45faf9fa833ed3ca51250ea9a7ddfc4267a44b3",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.7": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.7",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/federomero/negotiator.git"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "engine": "node >= 0.6",
+      "license": "MIT",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "scripts": {
+        "test": "nodeunit test"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "main": "lib/negotiator.js",
+      "bugs": {
+        "url": "https://github.com/federomero/negotiator/issues"
+      },
+      "homepage": "https://github.com/federomero/negotiator",
+      "dependencies": {},
+      "_id": "negotiator@0.4.7",
+      "dist": {
+        "shasum": "a4160f7177ec806738631d0d3052325da42abdc8",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "federomero",
+        "email": "federomero@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.8": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.8",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/negotiator"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "istanbul": "~0.3.2",
+        "nodeunit": "0.8.x"
+      },
+      "scripts": {
+        "test": "nodeunit test",
+        "test-cov": "istanbul cover ./node_modules/nodeunit/bin/nodeunit test"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "main": "lib/negotiator.js",
+      "files": [
+        "lib",
+        "LICENSE"
+      ],
+      "gitHead": "4b0bc3f2fec38a839556bd4674f79024929ba256",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator",
+      "_id": "negotiator@0.4.8",
+      "_shasum": "96010b23b63c387f47a4bed96762a831cda39eab",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "96010b23b63c387f47a4bed96762a831cda39eab",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.8.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.9": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.4.9",
+      "author": {
+        "name": "Federico Romero",
+        "email": "federico.romero@outboxlabs.com"
+      },
+      "contributors": [
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/negotiator"
+      },
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "license": "MIT",
+      "devDependencies": {
+        "istanbul": "~0.3.2",
+        "nodeunit": "0.8.x"
+      },
+      "scripts": {
+        "test": "nodeunit test",
+        "test-cov": "istanbul cover ./node_modules/nodeunit/bin/nodeunit test"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "main": "lib/negotiator.js",
+      "files": [
+        "lib",
+        "LICENSE"
+      ],
+      "gitHead": "1e90abd710b662db80f1ea244e647cce3bd74504",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator",
+      "_id": "negotiator@0.4.9",
+      "_shasum": "92e46b6db53c7e421ed64a2bc94f08be7630df3f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "92e46b6db53c7e421ed64a2bc94f08be7630df3f",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.5.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Federico Romero",
+          "email": "federico.romero@outboxlabs.com"
+        },
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/negotiator"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "nodeunit": "0.9.0"
+      },
+      "files": [
+        "lib/",
+        "HISTORY.md",
+        "LICENSE",
+        "index.js",
+        "README.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "nodeunit test",
+        "test-cov": "istanbul cover ./node_modules/nodeunit/bin/nodeunit test"
+      },
+      "gitHead": "79110a26fa939a77df65f8651a5d4d071f77a14a",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator",
+      "_id": "negotiator@0.5.0",
+      "_shasum": "bb77b3139d80d9b1ee8c913520a18b0d475b1b90",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bb77b3139d80d9b1ee8c913520a18b0d475b1b90",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.5.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Federico Romero",
+          "email": "federico.romero@outboxlabs.com"
+        },
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/negotiator"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "nodeunit": "0.9.0",
+        "tap": "0.5.0"
+      },
+      "files": [
+        "lib/",
+        "HISTORY.md",
+        "LICENSE",
+        "index.js",
+        "README.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "nodeunit test",
+        "test-cov": "istanbul cover ./node_modules/nodeunit/bin/nodeunit test"
+      },
+      "gitHead": "bfee971fe0503518cc93d1956518212203b7e68c",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator",
+      "_id": "negotiator@0.5.1",
+      "_shasum": "498f661c522470153c6086ac83019cb3eb66f61c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "498f661c522470153c6086ac83019cb3eb66f61c",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.5.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Federico Romero",
+          "email": "federico.romero@outboxlabs.com"
+        },
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/negotiator"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "lib/",
+        "HISTORY.md",
+        "LICENSE",
+        "index.js",
+        "README.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "a317a47bcd5efadd0561b1f2da0a7e1bea09b8c2",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator",
+      "_id": "negotiator@0.5.2",
+      "_shasum": "17bf5c8322f6c8284a8f3c7dfec356106438a41a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "17bf5c8322f6c8284a8f3c7dfec356106438a41a",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.3": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.5.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Federico Romero",
+          "email": "federico.romero@outboxlabs.com"
+        },
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/negotiator"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "lib/",
+        "HISTORY.md",
+        "LICENSE",
+        "index.js",
+        "README.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "cbb717b3f164f25820f90b160cda6d0166b9d922",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator",
+      "_id": "negotiator@0.5.3",
+      "_shasum": "269d5c476810ec92edbe7b6c2f28316384f9a7e8",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "269d5c476810ec92edbe7b6c2f28316384f9a7e8",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.6.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Federico Romero",
+          "email": "federico.romero@outboxlabs.com"
+        },
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/negotiator"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "lib/",
+        "HISTORY.md",
+        "LICENSE",
+        "index.js",
+        "README.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d904ca6a639487b4e27c009e33183570aae4e789",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator",
+      "_id": "negotiator@0.6.0",
+      "_shasum": "33593a5a2b0ce30c985840c6f56b6fb1ea9e3a55",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "33593a5a2b0ce30c985840c6f56b6fb1ea9e3a55",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.6.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Federico Romero",
+          "email": "federico.romero@outboxlabs.com"
+        },
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/negotiator.git"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "lib/",
+        "HISTORY.md",
+        "LICENSE",
+        "index.js",
+        "README.md"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "751c381c32707f238143cd65d78520e16f4ef9e5",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator#readme",
+      "_id": "negotiator@0.6.1",
+      "_shasum": "2b327184e8992101177b28563fb5e7102acd0ca9",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "2b327184e8992101177b28563fb5e7102acd0ca9",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "federomero",
+          "email": "federomero@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/negotiator-0.6.1.tgz_1462250848695_0.027451182017102838"
+      },
+      "directories": {}
+    },
+    "0.6.2": {
+      "name": "negotiator",
+      "description": "HTTP content negotiation",
+      "version": "0.6.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Federico Romero",
+          "email": "federico.romero@outboxlabs.com"
+        },
+        {
+          "name": "Isaac Z. Schlueter",
+          "email": "i@izs.me",
+          "url": "http://blog.izs.me/"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "content negotiation",
+        "accept",
+        "accept-language",
+        "accept-encoding",
+        "accept-charset"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/negotiator.git"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "99f418e11907b60e63f0addc09fc596ddc7be5be",
+      "bugs": {
+        "url": "https://github.com/jshttp/negotiator/issues"
+      },
+      "homepage": "https://github.com/jshttp/negotiator#readme",
+      "_id": "negotiator@0.6.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+        "shasum": "feacf7ccf525a77ae9634436a64883ffeca346fb",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 28102,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcx5cnCRA9TVsSAnZWagAAP20P/0MCkOVbsy3QpadyxP2l\nfQaJNj3676xMnX1jvmbttyR2pejPTOeACkojxti4dkza3VoK5i0P2vxXVjjC\nFTS+joLUaqyS/urJFhQOxICR37l1s849MnXrwV/+mIo7kytMelYJcTbPj3ov\np6OYauZfzPlnFP3zxBYaPmIOKSILILVoVGPSwkRrJlgJUgdqzaMKSUTfTCzq\nELh0wT834veFEnFIeu84Z4NWf6QPrWLwO8Fi6clDpTc0TYJl4xi0cEo9euSB\nQdKVK2gwPCLq6vV3TZoPHCs4/8XLX9zSZLqrAeiK6gC8rrJiGIEFTVLgUXIc\nDb7bKpcOlpvRBBGwtoa0crIGWEFZ5HCTLeDL3ZyfafZ6XqTYeOrYUpvmhv+A\nU6abBAxcE2FGdWkYuSMrbSU1KplzubcLEthVfVilREcQl7V/INK1rRzC/YPb\nlvXd0VqHH+JzsIqe5okX6prnQmKJ6I9Xtu2y7/ocI1WkikaU3bFjbIwke40w\nLTjqvSGCmc9End3k50XOG/AwhitANuOMugJ8iYwn1DwT995tj6IW8Am+C2gR\n0lceIeUnOq5VxtDYN/q2rfVg/cHcr9srAnPdGp4dwcSLTwWX9/vDKB6piasF\nZnYHmofBFT2ensRv1qYU4nlDZPULH5T+rPFVhZgGUCpJzzc2wAMTpFcQixQ3\nCEXq\r\n=qmZ/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/negotiator_0.6.2_1556584230489_0.2011163414894186"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# negotiator\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nAn HTTP content negotiator for Node.js\n\n## Installation\n\n```sh\n$ npm install negotiator\n```\n\n## API\n\n```js\nvar Negotiator = require('negotiator')\n```\n\n### Accept Negotiation\n\n```js\navailableMediaTypes = ['text/html', 'text/plain', 'application/json']\n\n// The negotiator constructor receives a request object\nnegotiator = new Negotiator(request)\n\n// Let's say Accept header is 'text/html, application/*;q=0.2, image/jpeg;q=0.8'\n\nnegotiator.mediaTypes()\n// -> ['text/html', 'image/jpeg', 'application/*']\n\nnegotiator.mediaTypes(availableMediaTypes)\n// -> ['text/html', 'application/json']\n\nnegotiator.mediaType(availableMediaTypes)\n// -> 'text/html'\n```\n\nYou can check a working example at `examples/accept.js`.\n\n#### Methods\n\n##### mediaType()\n\nReturns the most preferred media type from the client.\n\n##### mediaType(availableMediaType)\n\nReturns the most preferred media type from a list of available media types.\n\n##### mediaTypes()\n\nReturns an array of preferred media types ordered by the client preference.\n\n##### mediaTypes(availableMediaTypes)\n\nReturns an array of preferred media types ordered by priority from a list of\navailable media types.\n\n### Accept-Language Negotiation\n\n```js\nnegotiator = new Negotiator(request)\n\navailableLanguages = ['en', 'es', 'fr']\n\n// Let's say Accept-Language header is 'en;q=0.8, es, pt'\n\nnegotiator.languages()\n// -> ['es', 'pt', 'en']\n\nnegotiator.languages(availableLanguages)\n// -> ['es', 'en']\n\nlanguage = negotiator.language(availableLanguages)\n// -> 'es'\n```\n\nYou can check a working example at `examples/language.js`.\n\n#### Methods\n\n##### language()\n\nReturns the most preferred language from the client.\n\n##### language(availableLanguages)\n\nReturns the most preferred language from a list of available languages.\n\n##### languages()\n\nReturns an array of preferred languages ordered by the client preference.\n\n##### languages(availableLanguages)\n\nReturns an array of preferred languages ordered by priority from a list of\navailable languages.\n\n### Accept-Charset Negotiation\n\n```js\navailableCharsets = ['utf-8', 'iso-8859-1', 'iso-8859-5']\n\nnegotiator = new Negotiator(request)\n\n// Let's say Accept-Charset header is 'utf-8, iso-8859-1;q=0.8, utf-7;q=0.2'\n\nnegotiator.charsets()\n// -> ['utf-8', 'iso-8859-1', 'utf-7']\n\nnegotiator.charsets(availableCharsets)\n// -> ['utf-8', 'iso-8859-1']\n\nnegotiator.charset(availableCharsets)\n// -> 'utf-8'\n```\n\nYou can check a working example at `examples/charset.js`.\n\n#### Methods\n\n##### charset()\n\nReturns the most preferred charset from the client.\n\n##### charset(availableCharsets)\n\nReturns the most preferred charset from a list of available charsets.\n\n##### charsets()\n\nReturns an array of preferred charsets ordered by the client preference.\n\n##### charsets(availableCharsets)\n\nReturns an array of preferred charsets ordered by priority from a list of\navailable charsets.\n\n### Accept-Encoding Negotiation\n\n```js\navailableEncodings = ['identity', 'gzip']\n\nnegotiator = new Negotiator(request)\n\n// Let's say Accept-Encoding header is 'gzip, compress;q=0.2, identity;q=0.5'\n\nnegotiator.encodings()\n// -> ['gzip', 'identity', 'compress']\n\nnegotiator.encodings(availableEncodings)\n// -> ['gzip', 'identity']\n\nnegotiator.encoding(availableEncodings)\n// -> 'gzip'\n```\n\nYou can check a working example at `examples/encoding.js`.\n\n#### Methods\n\n##### encoding()\n\nReturns the most preferred encoding from the client.\n\n##### encoding(availableEncodings)\n\nReturns the most preferred encoding from a list of available encodings.\n\n##### encodings()\n\nReturns an array of preferred encodings ordered by the client preference.\n\n##### encodings(availableEncodings)\n\nReturns an array of preferred encodings ordered by priority from a list of\navailable encodings.\n\n## See Also\n\nThe [accepts](https://npmjs.org/package/accepts#readme) module builds on\nthis module and provides an alternative interface, mime type validation,\nand more.\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/negotiator.svg\n[npm-url]: https://npmjs.org/package/negotiator\n[node-version-image]: https://img.shields.io/node/v/negotiator.svg\n[node-version-url]: https://nodejs.org/en/download/\n[travis-image]: https://img.shields.io/travis/jshttp/negotiator/master.svg\n[travis-url]: https://travis-ci.org/jshttp/negotiator\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/negotiator/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/negotiator?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/negotiator.svg\n[downloads-url]: https://npmjs.org/package/negotiator\n",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-30T00:30:33.236Z",
+    "created": "2012-01-26T17:25:16.828Z",
+    "0.1.0": "2012-01-26T17:25:19.965Z",
+    "0.2.3": "2012-04-24T21:37:45.030Z",
+    "0.2.4": "2012-06-02T21:48:39.123Z",
+    "0.2.5": "2012-08-11T18:16:30.819Z",
+    "0.2.6": "2013-06-05T14:20:08.959Z",
+    "0.2.7": "2013-08-11T04:12:25.408Z",
+    "0.2.8": "2013-09-19T18:33:09.169Z",
+    "0.3.0": "2013-10-18T20:12:14.807Z",
+    "0.4.0": "2014-01-09T15:23:11.532Z",
+    "0.4.1": "2014-01-16T17:02:25.226Z",
+    "0.4.2": "2014-03-01T03:06:59.978Z",
+    "0.4.3": "2014-04-16T14:12:01.576Z",
+    "0.4.4": "2014-05-29T15:19:30.693Z",
+    "0.4.5": "2014-05-29T15:53:13.591Z",
+    "0.4.6": "2014-06-11T19:36:14.258Z",
+    "0.4.7": "2014-06-24T22:32:21.627Z",
+    "0.4.8": "2014-09-28T21:46:31.730Z",
+    "0.4.9": "2014-10-15T04:39:00.364Z",
+    "0.5.0": "2014-12-19T04:05:15.020Z",
+    "0.5.1": "2015-02-15T01:54:09.606Z",
+    "0.5.2": "2015-05-07T05:18:55.668Z",
+    "0.5.3": "2015-05-11T02:19:32.641Z",
+    "0.6.0": "2015-09-30T01:21:40.970Z",
+    "0.6.1": "2016-05-03T04:47:29.814Z",
+    "0.6.2": "2019-04-30T00:30:30.629Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/negotiator.git"
+  },
+  "users": {
+    "isaacs": true,
+    "kubakubula": true,
+    "kylemathews": true,
+    "calebmer": true,
+    "snowdream": true,
+    "chrisyipw": true,
+    "magicadiii": true,
+    "mojaray2k": true,
+    "nisimjoseph": true,
+    "chosan": true,
+    "vparaskevas": true
+  },
+  "homepage": "https://github.com/jshttp/negotiator#readme",
+  "keywords": [
+    "http",
+    "content negotiation",
+    "accept",
+    "accept-language",
+    "accept-encoding",
+    "accept-charset"
+  ],
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Federico Romero",
+      "email": "federico.romero@outboxlabs.com"
+    },
+    {
+      "name": "Isaac Z. Schlueter",
+      "email": "i@izs.me",
+      "url": "http://blog.izs.me/"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/jshttp/negotiator/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/negotiator.min.json
+++ b/test/fixtures/registry-mocks/content/negotiator.min.json
@@ -1,0 +1,381 @@
+{
+  "name": "negotiator",
+  "dist-tags": {
+    "latest": "0.6.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "negotiator",
+      "version": "0.1.0",
+      "dependencies": {
+        "underscore": "1.2.x",
+        "coffee-script": "1.2.x"
+      },
+      "devDependencies": {
+        "nodeunit": "0.6.x",
+        "iconv": "1.1.x",
+        "gzip-buffer": "x.x.x"
+      },
+      "dist": {
+        "shasum": "eceb71a868cb56ae156cc563a1a881669d4e9650",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.3": {
+      "name": "negotiator",
+      "version": "0.2.3",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "e93dd1d816112185f752cbb4c4c1df8cfca4f399",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.4": {
+      "name": "negotiator",
+      "version": "0.2.4",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "8c82cc553bbfc8ada49a969ead7bcfac3fb190f7",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.5": {
+      "name": "negotiator",
+      "version": "0.2.5",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "12ec7b4a9f3b4c894c31d8c4ec015925ba547eec",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.6": {
+      "name": "negotiator",
+      "version": "0.2.6",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "28db6bc2e442c8655325d156ff74055dc0db289c",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.7": {
+      "name": "negotiator",
+      "version": "0.2.7",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "f31240c6a4aed34c1c2f22f2ce325a5414a00a9e",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.8": {
+      "name": "negotiator",
+      "version": "0.2.8",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "adfd207a3875c4d37095729c2e7c283c5ba2ee72",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.2.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.3.0": {
+      "name": "negotiator",
+      "version": "0.3.0",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "706d692efeddf574d57ea9fb1ab89a4fa7ee8f60",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.0": {
+      "name": "negotiator",
+      "version": "0.4.0",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "06992a7c3d6014cace59f6368a5803452a6ae5c1",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.1": {
+      "name": "negotiator",
+      "version": "0.4.1",
+      "devDependencies": {
+        "nodeunit": "0.6.x"
+      },
+      "dist": {
+        "shasum": "7806f0041eca5b05bb00758d8ad7611ff18f357c",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.2": {
+      "name": "negotiator",
+      "version": "0.4.2",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "dist": {
+        "shasum": "8c43ea7e4c40ddfe40c3c0234c4ef77500b8fd37",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.3": {
+      "name": "negotiator",
+      "version": "0.4.3",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "dist": {
+        "shasum": "9d6b5cf549547ca06a3971a81f80d25f3cf9db02",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.4": {
+      "name": "negotiator",
+      "version": "0.4.4",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "dist": {
+        "shasum": "321ec00f2d3a9f597c62581082030b49c39fd199",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.5": {
+      "name": "negotiator",
+      "version": "0.4.5",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "dist": {
+        "shasum": "0e738eb225e3a166ee7d69ebcfdc702ba236a77b",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.6": {
+      "name": "negotiator",
+      "version": "0.4.6",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "dist": {
+        "shasum": "f45faf9fa833ed3ca51250ea9a7ddfc4267a44b3",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.7": {
+      "name": "negotiator",
+      "version": "0.4.7",
+      "devDependencies": {
+        "nodeunit": "0.8.x"
+      },
+      "dist": {
+        "shasum": "a4160f7177ec806738631d0d3052325da42abdc8",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.8": {
+      "name": "negotiator",
+      "version": "0.4.8",
+      "devDependencies": {
+        "istanbul": "~0.3.2",
+        "nodeunit": "0.8.x"
+      },
+      "dist": {
+        "shasum": "96010b23b63c387f47a4bed96762a831cda39eab",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.4.9": {
+      "name": "negotiator",
+      "version": "0.4.9",
+      "devDependencies": {
+        "istanbul": "~0.3.2",
+        "nodeunit": "0.8.x"
+      },
+      "dist": {
+        "shasum": "92e46b6db53c7e421ed64a2bc94f08be7630df3f",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.0": {
+      "name": "negotiator",
+      "version": "0.5.0",
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "nodeunit": "0.9.0"
+      },
+      "dist": {
+        "shasum": "bb77b3139d80d9b1ee8c913520a18b0d475b1b90",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.1": {
+      "name": "negotiator",
+      "version": "0.5.1",
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "nodeunit": "0.9.0",
+        "tap": "0.5.0"
+      },
+      "dist": {
+        "shasum": "498f661c522470153c6086ac83019cb3eb66f61c",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.2": {
+      "name": "negotiator",
+      "version": "0.5.2",
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "17bf5c8322f6c8284a8f3c7dfec356106438a41a",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.5.3": {
+      "name": "negotiator",
+      "version": "0.5.3",
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "269d5c476810ec92edbe7b6c2f28316384f9a7e8",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.6.0": {
+      "name": "negotiator",
+      "version": "0.6.0",
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "33593a5a2b0ce30c985840c6f56b6fb1ea9e3a55",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.6.1": {
+      "name": "negotiator",
+      "version": "0.6.1",
+      "devDependencies": {
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "2b327184e8992101177b28563fb5e7102acd0ca9",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "0.6.2": {
+      "name": "negotiator",
+      "version": "0.6.2",
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+        "shasum": "feacf7ccf525a77ae9634436a64883ffeca346fb",
+        "tarball": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 28102,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcx5cnCRA9TVsSAnZWagAAP20P/0MCkOVbsy3QpadyxP2l\nfQaJNj3676xMnX1jvmbttyR2pejPTOeACkojxti4dkza3VoK5i0P2vxXVjjC\nFTS+joLUaqyS/urJFhQOxICR37l1s849MnXrwV/+mIo7kytMelYJcTbPj3ov\np6OYauZfzPlnFP3zxBYaPmIOKSILILVoVGPSwkRrJlgJUgdqzaMKSUTfTCzq\nELh0wT834veFEnFIeu84Z4NWf6QPrWLwO8Fi6clDpTc0TYJl4xi0cEo9euSB\nQdKVK2gwPCLq6vV3TZoPHCs4/8XLX9zSZLqrAeiK6gC8rrJiGIEFTVLgUXIc\nDb7bKpcOlpvRBBGwtoa0crIGWEFZ5HCTLeDL3ZyfafZ6XqTYeOrYUpvmhv+A\nU6abBAxcE2FGdWkYuSMrbSU1KplzubcLEthVfVilREcQl7V/INK1rRzC/YPb\nlvXd0VqHH+JzsIqe5okX6prnQmKJ6I9Xtu2y7/ocI1WkikaU3bFjbIwke40w\nLTjqvSGCmc9End3k50XOG/AwhitANuOMugJ8iYwn1DwT995tj6IW8Am+C2gR\n0lceIeUnOq5VxtDYN/q2rfVg/cHcr9srAnPdGp4dwcSLTwWX9/vDKB6piasF\nZnYHmofBFT2ensRv1qYU4nlDZPULH5T+rPFVhZgGUCpJzzc2wAMTpFcQixQ3\nCEXq\r\n=qmZ/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2019-04-30T00:30:33.236Z"
+}

--- a/test/fixtures/registry-mocks/content/node-forge.json
+++ b/test/fixtures/registry-mocks/content/node-forge.json
@@ -1,0 +1,13817 @@
+{
+  "_id": "node-forge",
+  "_rev": "249-bb666a6368a9075775bc6f7521e87354",
+  "name": "node-forge",
+  "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+  "dist-tags": {
+    "latest": "0.10.0"
+  },
+  "versions": {
+    "0.1.2": {
+      "name": "node-forge",
+      "version": "0.1.2",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.2",
+      "dist": {
+        "shasum": "93e77ac7bbd1a38996db0269eb9f8f38f522dc64",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.24",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "node-forge",
+      "version": "0.1.3",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.3",
+      "dist": {
+        "shasum": "343fcca300e0ac8773ba0d7462eeba2434b838c4",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "node-forge",
+      "version": "0.1.4",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.4",
+      "dist": {
+        "shasum": "e81f075a5ddc12c0a0d3e74b67db879f4ec55f2c",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "node-forge",
+      "version": "0.1.5",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.5",
+      "dist": {
+        "shasum": "67b979a91e4e2814c3ab965ea04fff9a939b0d02",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.6": {
+      "name": "node-forge",
+      "version": "0.1.6",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.6",
+      "dist": {
+        "shasum": "59bf151a367a3d99b576521e4399aa6a26db1c96",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.7": {
+      "name": "node-forge",
+      "version": "0.1.7",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.7",
+      "dist": {
+        "shasum": "01db370faa5caeb016c137a6b2109f9cf33ae31c",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.8": {
+      "name": "node-forge",
+      "version": "0.1.8",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.8",
+      "dist": {
+        "shasum": "0fa179f093602309c8095e297d5685f06d6a8229",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.9": {
+      "name": "node-forge",
+      "version": "0.1.9",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.9",
+      "dist": {
+        "shasum": "bad01ae0faded777814951b1f265b220f7935151",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.10": {
+      "name": "node-forge",
+      "version": "0.1.10",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.10",
+      "dist": {
+        "shasum": "6cc72542a5ed7d68ff95731b59fa3e5c8e52ba19",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.11": {
+      "name": "node-forge",
+      "version": "0.1.11",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.11",
+      "dist": {
+        "shasum": "acd749b5a01a589c3979060df3a12d85a3a7775e",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.12": {
+      "name": "node-forge",
+      "version": "0.1.12",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.12",
+      "dist": {
+        "shasum": "21b211edd605178948e1e5661e5ae3874f008bf1",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.12.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.13": {
+      "name": "node-forge",
+      "version": "0.1.13",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.13",
+      "dist": {
+        "shasum": "2f90b2f43ceae08f2182a5f9e1f53b6d5f136be3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.13.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.14": {
+      "name": "node-forge",
+      "version": "0.1.14",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.14",
+      "dist": {
+        "shasum": "0e602a32c14c95a49911b7fcbb8630c9df400e07",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.14.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.15": {
+      "name": "node-forge",
+      "version": "0.1.15",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.1.15",
+      "dist": {
+        "shasum": "fd83a7dd7d71065628b09e707a10c28358215b02",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.15.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "node-forge",
+      "version": "0.2.0",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.0",
+      "dist": {
+        "shasum": "fb3182d7774d2559f1020be7e8e7dbc586c3f053",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "node-forge",
+      "version": "0.2.1",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.1",
+      "dist": {
+        "shasum": "9177d7592aac79e45fa557f343b751cc1cf5df65",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "node-forge",
+      "version": "0.2.2",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.2",
+      "dist": {
+        "shasum": "2f019e468f75300e5f551666e0cfccc2982d6a91",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "node-forge",
+      "version": "0.2.3",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.3",
+      "dist": {
+        "shasum": "5b3f4a9af5bbdb2b0bc0fc8c8bb6cb0c5ca053c1",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.4": {
+      "name": "node-forge",
+      "version": "0.2.4",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.4",
+      "dist": {
+        "shasum": "741a5b53115d0510d2bfb9c5e74b00cdce4fef34",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.5": {
+      "name": "node-forge",
+      "version": "0.2.5",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.5",
+      "dist": {
+        "shasum": "88a3b40fa80415f32fe448ce88609e88e8713d4f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.6": {
+      "name": "node-forge",
+      "version": "0.2.6",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.6",
+      "dist": {
+        "shasum": "47c7a1543a82bcf3603c4637923072c0b6d70bd3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.7": {
+      "name": "node-forge",
+      "version": "0.2.7",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.7",
+      "dist": {
+        "shasum": "b8820076c7a7adf78a54714ee0512ab5ed15551c",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.8": {
+      "name": "node-forge",
+      "version": "0.2.8",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.8",
+      "dist": {
+        "shasum": "39a3531d9a293d2ccfb359de8aca6de928bbbf4a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.9": {
+      "name": "node-forge",
+      "version": "0.2.9",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.9",
+      "dist": {
+        "shasum": "ffddde6e011b66ad5fdf070ebcacbd690d864399",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.10": {
+      "name": "node-forge",
+      "version": "0.2.10",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.10",
+      "dist": {
+        "shasum": "1eeeb82504e99e2b5b186aee377b378967448f32",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.11": {
+      "name": "node-forge",
+      "version": "0.2.11",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.11",
+      "dist": {
+        "shasum": "85c73643bc8d6a0c46f7ba73ff141220be87a047",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.12": {
+      "name": "node-forge",
+      "version": "0.2.12",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.12",
+      "dist": {
+        "shasum": "0d6e031a8e42a86332b6dd7c1d004ef1d83a7a0f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.12.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.13": {
+      "name": "node-forge",
+      "version": "0.2.13",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.13",
+      "dist": {
+        "shasum": "a75be7b64b5a1bd1839ad1cafdd7d1da7d06d3bb",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.13.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.14": {
+      "name": "node-forge",
+      "version": "0.2.14",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.14",
+      "dist": {
+        "shasum": "5751bf2c73c0c081fd64a75d1a9e4a316276e389",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.14.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.15": {
+      "name": "node-forge",
+      "version": "0.2.15",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.15",
+      "dist": {
+        "shasum": "ccbbfc4060d8a685b893669f5239a2c2f86c40b3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.15.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.17": {
+      "name": "node-forge",
+      "version": "0.2.17",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.17",
+      "dist": {
+        "shasum": "103e31d2acf038c864acde74ce7773619dc02977",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.17.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.18": {
+      "name": "node-forge",
+      "version": "0.2.18",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.18",
+      "dist": {
+        "shasum": "54231bd51f5b675361405e95f2320cb5250a8a51",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.18.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.19": {
+      "name": "node-forge",
+      "version": "0.2.19",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.19",
+      "dist": {
+        "shasum": "8f2581bc3823dc1d55976b12dcd9517c4953e146",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.19.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.20": {
+      "name": "node-forge",
+      "version": "0.2.20",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.20",
+      "dist": {
+        "shasum": "4518f2d70ba13bb76a2edc9222c78b73e70ef5f1",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.20.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.21": {
+      "name": "node-forge",
+      "version": "0.2.21",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.21",
+      "dist": {
+        "shasum": "b8ffd1f9d5a6c21ab1a95f42e8e60917b0318318",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.21.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.22": {
+      "name": "node-forge",
+      "version": "0.2.22",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "_id": "node-forge@0.2.22",
+      "dist": {
+        "shasum": "695a7656efd52cf16d445325220a7af320413b22",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.22.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.23": {
+      "name": "node-forge",
+      "version": "0.2.23",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "nodejs ./node_modules/requirejs/bin/r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "nodejs ./node_modules/requirejs/bin/r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.23",
+      "dist": {
+        "shasum": "54f286b2d5b5f0ecb56f9524db4c07d33d165b8e",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.23.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.24": {
+      "name": "node-forge",
+      "version": "0.2.24",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "./node_modules/requirejs/bin/r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "./node_modules/requirejs/bin/r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.24",
+      "dist": {
+        "shasum": "fa6f846f42fa93f63a0a30c9fbff7b4e130e0858",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.24.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.25": {
+      "name": "node-forge",
+      "version": "0.2.25",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "bin": {
+        "r.js": "./node_modules/.bin/r.js"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.25",
+      "dist": {
+        "shasum": "ec3fa50aa67c93d5f3c13535f7e90daaca8d2c3a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.25.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.26": {
+      "name": "node-forge",
+      "version": "0.2.26",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.26",
+      "dist": {
+        "shasum": "0a82185f1fd4c09a71ff53651b4edc889d9aa750",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.26.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.27": {
+      "name": "node-forge",
+      "version": "0.2.27",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.27",
+      "dist": {
+        "shasum": "ce1c3b2692bbb2febb4378a139d4ea31d605dbc6",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.27.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.28": {
+      "name": "node-forge",
+      "version": "0.2.28",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.28",
+      "dist": {
+        "shasum": "5a84f55dfeb9798b732cfcd5ca1a19d95b714955",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.28.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.29": {
+      "name": "node-forge",
+      "version": "0.2.29",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.29",
+      "dist": {
+        "shasum": "9323e87d00087d6eafdab796ae9e9456cd93e254",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.29.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.30": {
+      "name": "node-forge",
+      "version": "0.2.30",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.30",
+      "dist": {
+        "shasum": "11bf6a92c0b2502901f3e4cd9e19cf5bd6eaf73b",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.30.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.31": {
+      "name": "node-forge",
+      "version": "0.2.31",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.31",
+      "dist": {
+        "shasum": "07a05d70431bcd0ab27f2ae81a6e4b4b3050e58b",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.31.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.32": {
+      "name": "node-forge",
+      "version": "0.2.32",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.32",
+      "dist": {
+        "shasum": "e8a5ec998a4177232dbc77cece8c83d5e125a51f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.32.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.33": {
+      "name": "node-forge",
+      "version": "0.2.33",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.33",
+      "dist": {
+        "shasum": "abdff447a8df35ace4d98f64b171e3b9ce0d5eab",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.33.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.34": {
+      "name": "node-forge",
+      "version": "0.2.34",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.34",
+      "dist": {
+        "shasum": "371ed438501a3dd4da22a8b77dfe3fd5e2a4db91",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.34.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.35": {
+      "name": "node-forge",
+      "version": "0.2.35",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.35",
+      "dist": {
+        "shasum": "0ff787d01785302a08c6545ca9f5884d1f69232a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.35.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.36": {
+      "name": "node-forge",
+      "version": "0.2.36",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.36",
+      "dist": {
+        "shasum": "0af19a90fe05e62fdee6911e7f14869b65aa1b12",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.36.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.37": {
+      "name": "node-forge",
+      "version": "0.2.37",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.2.37",
+      "dist": {
+        "shasum": "25b7c4d37886b521ea35e84b65db6cb082476451",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.37.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "node-forge",
+      "version": "0.3.0",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilties.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.3.0",
+      "_shasum": "c428ed8d858c549ea146eac8123703c636b21965",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c428ed8d858c549ea146eac8123703c636b21965",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.1-dev": {
+      "name": "node-forge",
+      "version": "0.4.1-dev",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.4.1-dev",
+      "_shasum": "0fa5f8a8bbcec4b37468288b8b2002d4ed31c90f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0fa5f8a8bbcec4b37468288b8b2002d4ed31c90f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.4.1-dev.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "node-forge",
+      "version": "0.4.1",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.4.1",
+      "_shasum": "7291ec39fc7b87a03dfcdcbb9424c56f1e85dcb8",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7291ec39fc7b87a03dfcdcbb9424c56f1e85dcb8",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "node-forge",
+      "version": "0.4.2",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.4.2",
+      "_shasum": "9a51624c92971297cffea0aca93a0006df7e80ae",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9a51624c92971297cffea0aca93a0006df7e80ae",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.3": {
+      "name": "node-forge",
+      "version": "0.4.3",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js"
+      },
+      "_id": "node-forge@0.4.3",
+      "_shasum": "853508f1dde1d0ca35f37e3f5d583884d860544d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "853508f1dde1d0ca35f37e3f5d583884d860544d",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "node-forge",
+      "version": "0.5.1",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.5.1",
+      "_shasum": "57378aed99ea926548082f91f2fcb6e079787458",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "57378aed99ea926548082f91f2fcb6e079787458",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "node-forge",
+      "version": "0.5.2",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.5.2",
+      "_shasum": "ae0fd9fb5c475e9f4fb17a15de975559f23b52bf",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ae0fd9fb5c475e9f4fb17a15de975559f23b52bf",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.3": {
+      "name": "node-forge",
+      "version": "0.5.3",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.5.3",
+      "_shasum": "71876ff874170d9b8b8e7ba87ce4681f9c583774",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "71876ff874170d9b8b8e7ba87ce4681f9c583774",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.4": {
+      "name": "node-forge",
+      "version": "0.5.4",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.5.4",
+      "_shasum": "5365ac6bc216e20ea8a1e8f7d02c3004117d853d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5365ac6bc216e20ea8a1e8f7d02c3004117d853d",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.5": {
+      "name": "node-forge",
+      "version": "0.5.5",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.5.5",
+      "_shasum": "69a63dfb964b97ceef71c9c6be3c9658d3bbc102",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "69a63dfb964b97ceef71c9c6be3c9658d3bbc102",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "node-forge",
+      "version": "0.6.0",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.0",
+      "_shasum": "c2817b8c9e49dcd0aa1fe682cfe6f79fd399ca05",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c2817b8c9e49dcd0aa1fe682cfe6f79fd399ca05",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "node-forge",
+      "version": "0.6.1",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.1",
+      "_shasum": "c4ef9a1b263adea62f7aebc9c60f42daf32ec6f0",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c4ef9a1b263adea62f7aebc9c60f42daf32ec6f0",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.2": {
+      "name": "node-forge",
+      "version": "0.6.2",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.2",
+      "_shasum": "ec1786750aa9cae7d3f2710e1e94f86f3f1f8ba3",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ec1786750aa9cae7d3f2710e1e94f86f3f1f8ba3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.3": {
+      "name": "node-forge",
+      "version": "0.6.3",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.3",
+      "_shasum": "a1888494d21d062f36966b25465d0e837905e357",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a1888494d21d062f36966b25465d0e837905e357",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.4": {
+      "name": "node-forge",
+      "version": "0.6.4",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.4",
+      "_shasum": "99d7e14cfbf91b98b424dc7286472566c863cb5f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "99d7e14cfbf91b98b424dc7286472566c863cb5f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.5": {
+      "name": "node-forge",
+      "version": "0.6.5",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.5",
+      "_shasum": "e43148f439c9bd6d6813a8bac11646de0d6ddf73",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e43148f439c9bd6d6813a8bac11646de0d6ddf73",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.6": {
+      "name": "node-forge",
+      "version": "0.6.6",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.6",
+      "_shasum": "a40c787b3f0a67a33a7b5bced11aa015cabb5cbd",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a40c787b3f0a67a33a7b5bced11aa015cabb5cbd",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.7": {
+      "name": "node-forge",
+      "version": "0.6.7",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.7",
+      "_shasum": "ce15c75077935c498a0fd97581ad5c156c8a69ae",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ce15c75077935c498a0fd97581ad5c156c8a69ae",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.8": {
+      "name": "node-forge",
+      "version": "0.6.8",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "_id": "node-forge@0.6.8",
+      "_shasum": "8543bd6687c71682bb36bc4c4ec02b041fd99e1d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8543bd6687c71682bb36bc4c4ec02b041fd99e1d",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.8.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.9": {
+      "name": "node-forge",
+      "version": "0.6.9",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "acf490b4dc41e8607d69e8060b0bb427e63b394f",
+      "_id": "node-forge@0.6.9",
+      "_shasum": "225f4e620b306db80ad70604bf0493324bd56af4",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "225f4e620b306db80ad70604bf0493324bd56af4",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.9.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.10": {
+      "name": "node-forge",
+      "version": "0.6.10",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "9a827d8aa66ddc1ad95a7cb8b327046c11efd41a",
+      "_id": "node-forge@0.6.10",
+      "_shasum": "372d73307fa244442659ef1ad5593a263a321fbb",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "372d73307fa244442659ef1ad5593a263a321fbb",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.10.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.11": {
+      "name": "node-forge",
+      "version": "0.6.11",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "58e3b120644be14cec94201bdb1a01f3c05e580e",
+      "_id": "node-forge@0.6.11",
+      "_shasum": "2c7d5de441bbb45b4aa86d177465af4022c9b27f",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2c7d5de441bbb45b4aa86d177465af4022c9b27f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.11.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.12": {
+      "name": "node-forge",
+      "version": "0.6.12",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "0f8a9a54c736f2e69f8410f38ddd7143469eaabe",
+      "_id": "node-forge@0.6.12",
+      "_shasum": "61494dfc34479e11aef0a3f836b2d7224ae47084",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "61494dfc34479e11aef0a3f836b2d7224ae47084",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.12.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.13": {
+      "name": "node-forge",
+      "version": "0.6.13",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "525a310837ea93154a9842ec96d9a20f459a313f",
+      "_id": "node-forge@0.6.13",
+      "_shasum": "5e83d55637e3a937db982f1a83c457ff7d6351de",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5e83d55637e3a937db982f1a83c457ff7d6351de",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.13.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.14": {
+      "name": "node-forge",
+      "version": "0.6.14",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "dccb01e429f93d0abdb3ff07436b3e4b3a294e08",
+      "_id": "node-forge@0.6.14",
+      "_shasum": "75ebdcac5ecfeb2961669676d3f49edda01da456",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "75ebdcac5ecfeb2961669676d3f49edda01da456",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.14.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.16": {
+      "name": "node-forge",
+      "version": "0.6.16",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "bca3e277a09dc6c1f93198d0a27de2b9237e94dd",
+      "_id": "node-forge@0.6.16",
+      "_shasum": "aae85babf97034d46f1b74a39bfe5891282ae842",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "aae85babf97034d46f1b74a39bfe5891282ae842",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.16.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.18": {
+      "name": "node-forge",
+      "version": "0.6.18",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "5c936892d85cad97798c85e3e9bb2e36ddda2c6c",
+      "_id": "node-forge@0.6.18",
+      "_shasum": "2cc198672e94c7c4336e846e23d2a358d16d06d5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2cc198672e94c7c4336e846e23d2a358d16d06d5",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.18.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.19": {
+      "name": "node-forge",
+      "version": "0.6.19",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "87f580455049e54115fa7e2d5158bb7ca61d912c",
+      "_id": "node-forge@0.6.19",
+      "_shasum": "2a99a77875debda12444ac391fc5c72a200962a5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2a99a77875debda12444ac391fc5c72a200962a5",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.19.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.20": {
+      "name": "node-forge",
+      "version": "0.6.20",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "7a305eec3d5879ce5c06ccc1b2bb10c89c0dadd8",
+      "_id": "node-forge@0.6.20",
+      "_shasum": "4574775d9093581b8fc9193b4e647a25bc4c38ce",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4574775d9093581b8fc9193b4e647a25bc4c38ce",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.20.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.21": {
+      "name": "node-forge",
+      "version": "0.6.21",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "gitHead": "875d46d0ef05f1b2a8a93b533a882c3a862f7fcf",
+      "_id": "node-forge@0.6.21",
+      "_shasum": "7dadde911be009c7aae9150e780aea21d4f8bd09",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7dadde911be009c7aae9150e780aea21d4f8bd09",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.21.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.22": {
+      "name": "node-forge",
+      "version": "0.6.22",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "7f6cef2f4e50d18219795a2a1c25f79bcdc1b135",
+      "_id": "node-forge@0.6.22",
+      "_shasum": "1e71e952e137a70ff8aa1d966dcd58d8eb4497ef",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1e71e952e137a70ff8aa1d966dcd58d8eb4497ef",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.22.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.23": {
+      "name": "node-forge",
+      "version": "0.6.23",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "f40097f78e5343c6d26523600b69d348232cf076",
+      "_id": "node-forge@0.6.23",
+      "_shasum": "f03cf65ebd5d4d9dd2f7becb57ceaf78ed94a2bf",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f03cf65ebd5d4d9dd2f7becb57ceaf78ed94a2bf",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.23.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.24": {
+      "name": "node-forge",
+      "version": "0.6.24",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "e62d8db230a21899a167a618837b9cf32bf1698f",
+      "_id": "node-forge@0.6.24",
+      "_shasum": "49a8d3b19d92b644adf0f6ae25c5ddf9d5d6a994",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "49a8d3b19d92b644adf0f6ae25c5ddf9d5d6a994",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.24.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.25": {
+      "name": "node-forge",
+      "version": "0.6.25",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "ba72d2b8afba1f86cd8d2f5e9e8296b6b67805a9",
+      "_id": "node-forge@0.6.25",
+      "_shasum": "1d4bdc4267525aa70ef951b016241f4381358007",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1d4bdc4267525aa70ef951b016241f4381358007",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.25.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.26": {
+      "name": "node-forge",
+      "version": "0.6.26",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "a698f003f4a04d975410037215698fbd4a718a5f",
+      "_id": "node-forge@0.6.26",
+      "_shasum": "989d7028e14b134111a2c5c0333df9bca89ec407",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "989d7028e14b134111a2c5c0333df9bca89ec407",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.26.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.27": {
+      "name": "node-forge",
+      "version": "0.6.27",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "82728c8e5b408d5089ef6821083d724a7cbf752c",
+      "_id": "node-forge@0.6.27",
+      "_shasum": "943c403d926204cdb03ba19802701fc3aa573223",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "943c403d926204cdb03ba19802701fc3aa573223",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.27.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.28": {
+      "name": "node-forge",
+      "version": "0.6.28",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "8e493fdf64e208ccd753da15e26afcf8f72f824b",
+      "_id": "node-forge@0.6.28",
+      "_shasum": "3e8b53d85fb5793d1790409d9c395d119ec18f32",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3e8b53d85fb5793d1790409d9c395d119ec18f32",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.28.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.29": {
+      "name": "node-forge",
+      "version": "0.6.29",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "58788ea285cc9e0696b7cd7db432396036826239",
+      "_id": "node-forge@0.6.29",
+      "_shasum": "0f0f38ebe0de37cd506e6aa39458c953012fc65e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0f0f38ebe0de37cd506e6aa39458c953012fc65e",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.29.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.30": {
+      "name": "node-forge",
+      "version": "0.6.30",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "c1371c62bb7675e3ec362a7959ba37d39524aa9c",
+      "_id": "node-forge@0.6.30",
+      "_shasum": "0804e7a120648a11191c99af9ab767a54b6ff7bb",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0804e7a120648a11191c99af9ab767a54b6ff7bb",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.30.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.31": {
+      "name": "node-forge",
+      "version": "0.6.31",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "7ffe33a8c952eb0a4e31762cabe43d40b7ef7101",
+      "_id": "node-forge@0.6.31",
+      "_shasum": "1c2ca64c5e47de9ad3638720033fd8c3b94d9c1b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1c2ca64c5e47de9ad3638720033fd8c3b94d9c1b",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.31.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.32": {
+      "name": "node-forge",
+      "version": "0.6.32",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "74dc542208cf64526f21e7ecd059b51b505ba188",
+      "_id": "node-forge@0.6.32",
+      "_shasum": "04d1299a0a36d196c1eb8660056fe87169f8a581",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "04d1299a0a36d196c1eb8660056fe87169f8a581",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.32.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.33": {
+      "name": "node-forge",
+      "version": "0.6.33",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "90bb96b8ff545eb884a2ef716b2ae208334f8848",
+      "_id": "node-forge@0.6.33",
+      "_shasum": "463811879f573d45155ad6a9f43dc296e8e85ebc",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "463811879f573d45155ad6a9f43dc296e8e85ebc",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.34": {
+      "name": "node-forge",
+      "version": "0.6.34",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "f7e6f8d02cf2111eb6c28f11758330fd08d2cebd",
+      "_id": "node-forge@0.6.34",
+      "_shasum": "7e01d3477e73bf83a17daf5ea5bfc5af4d8199ab",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e01d3477e73bf83a17daf5ea5bfc5af4d8199ab",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.34.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.35": {
+      "name": "node-forge",
+      "version": "0.6.35",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "e2107549cf5d261629d3a72ef5ca76d3e6a28df0",
+      "_id": "node-forge@0.6.35",
+      "_shasum": "7a2e207b7d4feebc978e8936042f1891267f2acf",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7a2e207b7d4feebc978e8936042f1891267f2acf",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.35.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.37": {
+      "name": "node-forge",
+      "version": "0.6.37",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "e8e6ecbab88370be2dd561e30b54bf0fdd1045d7",
+      "_id": "node-forge@0.6.37",
+      "_shasum": "32ea701c683fc300f1458e9490dc194a766f3641",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "32ea701c683fc300f1458e9490dc194a766f3641",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.37.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.38": {
+      "name": "node-forge",
+      "version": "0.6.38",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "http://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/digitalbazaar/forge"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "113a8c25d7627c42d57eb771b04724f6717b01b5",
+      "_id": "node-forge@0.6.38",
+      "_shasum": "184473ee3ad1e412100dc6fdfc44ff92309e57c8",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "184473ee3ad1e412100dc6fdfc44ff92309e57c8",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.38.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.39": {
+      "name": "node-forge",
+      "version": "0.6.39",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "4dd7e02669a5706e9c71dce67f2127299b24efe0",
+      "_id": "node-forge@0.6.39",
+      "_shasum": "2184e89dba9b44b3aa54cd4bf1e7334f247cf9ce",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.2.6",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2184e89dba9b44b3aa54cd4bf1e7334f247cf9ce",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.39.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.39.tgz_1455289318649_0.6288448101840913"
+      },
+      "directories": {}
+    },
+    "0.6.40": {
+      "name": "node-forge",
+      "version": "0.6.40",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "df2e93eee6b76e29987969dbfb39875a95b4f003",
+      "_id": "node-forge@0.6.40",
+      "_shasum": "5cd0993ccc48046e59348811ac83b73006b45f55",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.1.0",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "dist": {
+        "shasum": "5cd0993ccc48046e59348811ac83b73006b45f55",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.40.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.40.tgz_1467135203861_0.9434924686793238"
+      },
+      "directories": {}
+    },
+    "0.6.41": {
+      "name": "node-forge",
+      "version": "0.6.41",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "licenses": [
+        {
+          "type": "BSD",
+          "url": "https://github.com/digitalbazaar/forge/raw/master/LICENSE"
+        }
+      ],
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "7ab3d030a321b462dda870ba8963aa94e653ad19",
+      "_id": "node-forge@0.6.41",
+      "_shasum": "e2f45b5c9f7a3919198fc8fc08a10f8f70381997",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.1.0",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "dist": {
+        "shasum": "e2f45b5c9f7a3919198fc8fc08a10f8f70381997",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.41.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.41.tgz_1468595590453_0.5868177814409137"
+      },
+      "directories": {}
+    },
+    "0.6.42": {
+      "name": "node-forge",
+      "version": "0.6.42",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "467500ca5e8293e7b02817f2d9157fa9d0c66d79",
+      "_id": "node-forge@0.6.42",
+      "_shasum": "add1fc36947d12e56ef9f647b09e2a60f2c8ee5e",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "dist": {
+        "shasum": "add1fc36947d12e56ef9f647b09e2a60f2c8ee5e",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.42.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.42.tgz_1470324784072_0.952621589647606"
+      },
+      "directories": {}
+    },
+    "0.6.43": {
+      "name": "node-forge",
+      "version": "0.6.43",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "7b4fb9da74c3692b516c61b7ea68dd91191a7bbb",
+      "_id": "node-forge@0.6.43",
+      "_shasum": "70c40ca7ed9f0f4aa35b424507ca9e45246bfe09",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "dist": {
+        "shasum": "70c40ca7ed9f0f4aa35b424507ca9e45246bfe09",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.43.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.43.tgz_1475854004862_0.9579732301644981"
+      },
+      "directories": {}
+    },
+    "0.6.44": {
+      "name": "node-forge",
+      "version": "0.6.44",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "f9dcb9e3bd92afd77ae959933c99c174e613abae",
+      "_id": "node-forge@0.6.44",
+      "_shasum": "7058595c2d42821c6a3ace6e5a2ec47a24ac8733",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "dist": {
+        "shasum": "7058595c2d42821c6a3ace6e5a2ec47a24ac8733",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.44.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.44.tgz_1476803800835_0.26680224551819265"
+      },
+      "directories": {}
+    },
+    "0.6.45": {
+      "name": "node-forge",
+      "version": "0.6.45",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "d1b19f9500e548fef0f731e9b3a3f3d4c00d31e7",
+      "_id": "node-forge@0.6.45",
+      "_shasum": "86962a681134bc2fe5ec8fd31970d495aa9d3837",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "dlongley",
+        "email": "dlongley@digitalbazaar.com"
+      },
+      "dist": {
+        "shasum": "86962a681134bc2fe5ec8fd31970d495aa9d3837",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.45.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.45.tgz_1477763378013_0.055795623920857906"
+      },
+      "directories": {}
+    },
+    "0.6.46": {
+      "name": "node-forge",
+      "version": "0.6.46",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "5261b178defc1f92f1b642165d5662b66eab6285",
+      "_id": "node-forge@0.6.46",
+      "_shasum": "04a8a1c336eb72ef6f434ba7c854d608916c328d",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "04a8a1c336eb72ef6f434ba7c854d608916c328d",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.46.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.46.tgz_1481134512958_0.8900855523534119"
+      },
+      "directories": {}
+    },
+    "0.6.47": {
+      "name": "node-forge",
+      "version": "0.6.47",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "js/forge.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "c9f06ad0c56d3ec67fbd74a9e7fac4619b8f563c",
+      "_id": "node-forge@0.6.47",
+      "_shasum": "84a239c1eabfd9bbe3a9b7308d52102fdba1da81",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "84a239c1eabfd9bbe3a9b7308d52102fdba1da81",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.47.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.47.tgz_1484364539778_0.8238722428213805"
+      },
+      "directories": {}
+    },
+    "0.6.48": {
+      "name": "node-forge",
+      "version": "0.6.48",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "js/forge.js",
+      "files": [
+        "js/*.js",
+        "swf/*.swf",
+        "minify.js",
+        "start.frag",
+        "end.frag"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "34d3c83412bd3a26e5e76055c9b6544b635d7148",
+      "_id": "node-forge@0.6.48",
+      "_shasum": "6986ea43bdd3cadc47a19db97759055edf753c01",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6986ea43bdd3cadc47a19db97759055edf753c01",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.48.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.48.tgz_1485306916670_0.8487077408935875"
+      },
+      "directories": {}
+    },
+    "0.6.49": {
+      "name": "node-forge",
+      "version": "0.6.49",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "js/forge.js",
+      "files": [
+        "js/*.js",
+        "swf/*.swf",
+        "minify.js",
+        "start.frag",
+        "end.frag"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "bundle": "r.js -o minify.js optimize=none out=js/forge.bundle.js",
+        "minify": "r.js -o minify.js",
+        "jscs": "jscs *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js",
+        "jshint": "jshint *.js js/*.js minify.js nodejs/*.js nodejs/test/*.js nodejs/ui/*.js tests/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "gitHead": "69e348726e9f6e835696e9b7024ee08695809532",
+      "_id": "node-forge@0.6.49",
+      "_shasum": "f1ee95d5d74623938fe19d698aa5a26d54d2f60f",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.5",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f1ee95d5d74623938fe19d698aa5a26d54d2f60f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.49.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.6.49.tgz_1486436375266_0.3795410143211484"
+      },
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "node-forge",
+      "version": "0.7.0",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^13.1.1",
+        "commander": "^2.9.0",
+        "express": "^4.14.1",
+        "istanbul": "^0.4.5",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.4",
+        "karma": "^1.4.1",
+        "karma-browserify": "^5.1.1",
+        "karma-chrome-launcher": "^2.0.0",
+        "karma-edge-launcher": "^0.2.0",
+        "karma-firefox-launcher": "^1.0.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.2",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.1.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.2",
+        "mocha": "^3.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "opts": "^1.2.2",
+        "webpack": "^2.2.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "files": [
+        "lib/*.js",
+        "flash/swf/*.swf",
+        "dist/*.min.js",
+        "dist/*.min.js.map"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "mocha -t 30000 -R spec tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -u exports -t 30000 -R spec tests/unit/index.js",
+        "coverage-lcov": "rm -rf coverage && ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -u exports -t 30000 -R spec tests/unit/index.js",
+        "coverage-report": "istanbul report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "df77afbcca98b068ddd618d1698e841d6060c0de",
+      "_id": "node-forge@0.7.0",
+      "_shasum": "5e0782a44e5e093fae3676d59f84ecfb38a4baad",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.5",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5e0782a44e5e093fae3676d59f84ecfb38a4baad",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.7.0.tgz_1486507027363_0.07054512039758265"
+      },
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "node-forge",
+      "version": "0.7.1",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^13.1.1",
+        "commander": "^2.9.0",
+        "express": "^4.14.1",
+        "istanbul": "^0.4.5",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.4",
+        "karma": "^1.4.1",
+        "karma-browserify": "^5.1.1",
+        "karma-chrome-launcher": "^2.0.0",
+        "karma-edge-launcher": "^0.2.0",
+        "karma-firefox-launcher": "^1.0.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.2",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.1.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.2",
+        "mocha": "^3.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "opts": "^1.2.2",
+        "webpack": "^2.2.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "files": [
+        "lib/*.js",
+        "flash/swf/*.swf",
+        "dist/*.min.js",
+        "dist/*.min.js.map"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "mocha -t 30000 -R spec tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -u exports -t 30000 -R spec tests/unit/index.js",
+        "coverage-lcov": "rm -rf coverage && ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- -u exports -t 30000 -R spec tests/unit/index.js",
+        "coverage-report": "istanbul report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "11e0cdccf190ff74e2b38d7fff06afebda29f5f5",
+      "_id": "node-forge@0.7.1",
+      "_shasum": "9da611ea08982f4b94206b3beb4cc9665f20c300",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9da611ea08982f4b94206b3beb4cc9665f20c300",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-forge-0.7.1.tgz_1490651543791_0.5024964583572"
+      },
+      "directories": {}
+    },
+    "0.7.2": {
+      "name": "node-forge",
+      "version": "0.7.2",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.12",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.4.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "files": [
+        "lib/*.js",
+        "flash/swf/*.swf",
+        "dist/*.min.js",
+        "dist/*.min.js.map"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "31b810ecf6e8b4fa97e080369078faee42695630",
+      "_id": "node-forge@0.7.2",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-XTBoBY8NoeGAqQywTM8BjBz/Ro37eTmVF657yf6JumfOhxW9eET43Hve5+6L4+lo3hTDx7kTbC1WfasTHinDpg==",
+        "shasum": "3703b27f61a4c7613f046377643038b99e6a7891",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.2.tgz",
+        "fileCount": 60,
+        "unpackedSize": 1613053
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.7.2_1519757373069_0.8295629776227034"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.7.3": {
+      "name": "node-forge",
+      "version": "0.7.3",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.12",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.4.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "files": [
+        "lib/*.js",
+        "flash/swf/*.swf",
+        "dist/*.min.js",
+        "dist/*.min.js.map"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "5eb308ad390ba0f06bb8facbac16259f89a42f86",
+      "_id": "node-forge@0.7.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-UGP1kI3GWGcvOgODS7o1YodpkE9RzJHMv1nlSH35iBjPZM/702cWZ1Z2wFBGYkgvzG0vfMp7scs9+gKjHQ3DlA==",
+        "shasum": "03188af9dd2401c55e040150ba3c708575678e1a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.3.tgz",
+        "fileCount": 60,
+        "unpackedSize": 1613135
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.7.3_1520290172341_0.6190146886310097"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.7.4": {
+      "name": "node-forge",
+      "version": "0.7.4",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.13",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.5.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "files": [
+        "lib/*.js",
+        "flash/swf/*.swf",
+        "dist/*.min.js",
+        "dist/*.min.js.map"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "9396c419496e9d203fe548db5df828ee045fba61",
+      "_id": "node-forge@0.7.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA==",
+        "shasum": "8e6e9f563a1e32213aa7508cded22aa791dbf986",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1670853
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.7.4_1520452786594_0.5983816848149388"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.7.5": {
+      "name": "node-forge",
+      "version": "0.7.5",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.13",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.5.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "files": [
+        "lib/*.js",
+        "flash/swf/*.swf",
+        "dist/*.min.js",
+        "dist/*.min.js.map"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "c3d63fbbee1e9f68108bd499ceaeb01b5800e95c",
+      "_id": "node-forge@0.7.5",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
+        "shasum": "6c152c345ce11c52f465c2abd957e8639cd674df",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1670906
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.7.5_1522455886607_0.17227011795546154"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.7.6": {
+      "name": "node-forge",
+      "version": "0.7.6",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.13",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.5.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "files": [
+        "lib/*.js",
+        "flash/swf/*.swf",
+        "dist/*.min.js",
+        "dist/*.min.js.map"
+      ],
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "fb69220891a5ee58e017b48a1813208d968e6bac",
+      "_id": "node-forge@0.7.6",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "8.11.3",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
+        "shasum": "fdf3b418aee1f94f0ef642cd63486c77ca9724ac",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1672108,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbc0dvCRA9TVsSAnZWagAAI7UQAIXe+9wh1JqYxR6FI4Xz\nMw2dZBss88XHNlZaAVKSWckN5MwzJf24cYM3y8omsf+4NyExu51TckjP59wr\nmcD3P11+TFMFLt67WdPdJh7x25fmNqUiOvHLVFuCXnTe1P5rbMvAyE9oAm1Q\nVYmh6UIkb1mkx5D7IflAs5ChzMqLPH+wU+sQcXy3whPRJrUrrSfqxvZdW4JC\njJacKy9L2MbuJvjuc0p/ybKxg1wTpTqmEgQNdew0vhv1fgHQhwWK9qJS7yGZ\nKjkYzJkC298lNYZkSAKHweQnf/1VMSemSyVmvB15LnTnf+hzYZzuyuFp4DjX\nfvlS+LJZ8QAehj8z8Afgwf+XYBx2MgAPifbS9vLqbuCyrEXPsrLBZw0K+Q27\nwV3orjYS9cwZpzJIN1HAl09uu9SSz0Rn1YapI/LHTyVXplyVuo32bBNiE1/L\n9wSFzRPkCtUazUjU5s/TUSUNpAyFtGphsC5B00tcuL17SmWz7zs/XGZCv8Gn\n4I3h3vLZ0ORieAVAHJa0KlaY97PNhAGzBh/zZHKoWn4GCQIlSBs8NQ/QtKf+\nPNsNtWpZReR3cW0r1y0AlTE0GEffHP6dL3zKGhHmR/1dMcuf5ut+7t+Iqg4X\nOdxqasvAkfCnB9mgAQoqx4vxoyu6XC8WA4/95UdL410VRZOcMvkEDfAOMPHh\nMaSb\r\n=Dfnj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.7.6_1534281582679_0.3437719028713917"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.8.0": {
+      "name": "node-forge",
+      "version": "0.8.0",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^13.1.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "06de7f43c9befb3ae8d43a34bcf4e049f1deb23c",
+      "_id": "node-forge@0.8.0",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.7.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-DVrvVeXwnSSX0Bgi9jy8p4IXQKLhGRQltG+UTR3Oci3Wb/zIROMoxw9im/K5s6KnNMheSWgG8K4qz8Njccdj3g==",
+        "shasum": "b897a89f25fe85ed7d0e3bd0c744c62931254dca",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.0.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1682003,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcU8GVCRA9TVsSAnZWagAAp5IP/iTJX0RuIWBRwruMqnwi\nvoIPCKQYGJ4StEXvq4/PwIDt9J+yVfdbsvULhj0ImDJVOElsQ8UMeBGXjRFa\nKx6SRGmRwj59kfQBod4kP5n7v43GGqXv11Xpy/xpMvmqORFOyd1ACU8q55iO\nv4iWyj5cn0MjjUcoMCexo51cc2bTxXJO3VQcZ2ri9rUavckuFRS9svAonLKP\nQFv+eDdOKZXqPcdscWIviOVT8hzqN0+JcguqH3xyCd3sk6a0tfsfNwy9DtuD\noVcc/VqoenhENzSf2PII9MO4c1wPHzGGy7l7rPXkY0RQE3bzicsKSrUl2GOV\nZUvJ+aQAES8KsJD864sCAvNIfVpgj265hVFIQVE2nGhVb7vbTeeCpLTqFvwx\ng2r4Mj8xiw/n+T3hBGb/DqJjFcuo03v+NmW2CLfvVg9lFK6suPsRt00fIueE\nHujPqMX/9Dj9gcczYNDat8Hh9us8yAsbfqRsBkqxaCl3uRedEqI36CYVFIn+\naU5rT49c4xzRE6OhZ1aJob4Ot46AMENzp3FrTUALeMGARCp3yGNq8OA8Kj1Z\nV6QpuFOklU6KWpUKIpEMg4chCjzN1OdpaJB/VLXrO2aVGpWOjOxV9WPCtF2f\nry32xPIbabQo57zjbR3+nOGcNlIXLDrLS0nINU6ePzOuiAUHjiU7gzAaLYgo\n1F5w\r\n=k3zn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.8.0_1548992916705_0.22920316992040335"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.8.1": {
+      "name": "node-forge",
+      "version": "0.8.1",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^13.1.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "jshint": "jshint *.js lib/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jscs": "jscs *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js",
+        "_jshint": "jshint *.js lib/*.js tests/*.js tests/unit/*.js tests/legacy/*.js tests/issues/*.js tests/websockets/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "1160fc4cc78e43630d42c8a68868cb518872089a",
+      "_id": "node-forge@0.8.1",
+      "_nodeVersion": "10.15.1",
+      "_npmVersion": "6.8.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-C/42HVb5eRtnDgRKOFx4bJH6LwbGQwbEHOC/trQwQSR6xWAUR/jlWoUJnxOmFTvdmDIZtjl2VH4dl3VpQuIz5g==",
+        "shasum": "67aeb9df7bb78d15444ec04a0162d2c565559c37",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.1.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1682101,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJccb6LCRA9TVsSAnZWagAArLsP/jb58LOJu/8hmDJETqoT\n+RYoSNV99RV2cGaJ5pVpVbCT3HuV0r+TAJwo0rQN5wT3zso+yUgOianp9cq4\nKpWXi8YoDP5syNybHSLhu5gK2QF9X0LtDTyi8aBj0OQaE4yPjhglSrHPA0FR\nJm1aEpzmi6nmu0LCdoJCNkbm/OCw+Tjc4iiaSB/OnDXxmW0FH+NvMhg5wmxs\nkq+B3rxJ7AMunGd+Pt5X5ZCBF/ToTQSahvAIsr6GZ1WqKyOQaIVr99lZBXhp\nGe9XtGVPgW2a4a4eCxj6ukTKyjeBOx0TDVWxweYLc7B5eVAt8IH0Fl2iQBHL\nQtqLoLCOH3dATJjYKO8OEtcKnH5ZXbZIrRCkPxc+nCDBWqRI5c3JvdAJUZHd\npE8H2FGC0Bb4qRmztzAmAweJmjk7gmDxd63DcZ8pTOfPrKz06DtdR4cG0KDl\n+gg/7HWFxT97m8R7MBJH55bs5cxu/vZdW9NPaqWOteoRXJ49Z/dmVg1srMIR\nSv0ZmtMCKWVOGgEm05ud1BX3NSu+8QbMIrPGo1TcprMELoUZVjQ1F1DOwivS\nqcHKXect53hL1EReG/+HqjBbcbu59QBIeyGS4lw3bvuCcBPUdWktpAiQiBTI\ntOONRa2w3vU8OU8iblQWFDD1icn9thGkIVv+e4wZ0nj7yYeuPruZrJ7XmVJ4\n0lBC\r\n=p/hY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.8.1_1550958218022_0.6010955185159634"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.8.2": {
+      "name": "node-forge",
+      "version": "0.8.2",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.14.1",
+        "eslint-config-digitalbazaar": "^1.7.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^13.3.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "lint": "eslint *.js lib/*.js tests/*.js tests/**/*.js examples/*.js flash/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "6139558173a632068a2a1494c85ec053f5115f80",
+      "_id": "node-forge@0.8.2",
+      "_nodeVersion": "10.15.3",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-mXQ9GBq1N3uDCyV1pdSzgIguwgtVpM7f5/5J4ipz12PKWElmPpVWLDuWl8iXmhysr21+WmX/OJ5UKx82wjomgg==",
+        "shasum": "b4bcc59fb12ce77a8825fc6a783dfe3182499c5a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.2.tgz",
+        "fileCount": 63,
+        "unpackedSize": 1683275,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJckA8jCRA9TVsSAnZWagAA+J4P+wfwEfdE9TJmt3AE0m2Y\ngpiRfdebftyJoqyBBFTpLwiDEm9rpvQV9abqHLfIGf2NP2cPFNQds/Ud0ve2\nUL0DJgB5FCVUMZVQbwpfZYek6/44SfSDpoBlh6/KYyAEovbHK0zOSQIt6dl6\nG3KG35eF2/mEmRyAWHPVACn6F1cAP5b8CEA8gwCFA2S2XQoymCTglh2tZbkU\ne3wAAx0/bTxiBlU/2GGjkHVLPNN2b+S/YNZcSKIHxW44HYsU/w3uHt3Yw+n2\nM0ByuWoFVmnTwRLWePmEthKUmd4P23d3wePGPC6Cav4qmTWyV/i0MyMkg6+1\n5H+TcprrRgndf9pzecNZuhg/7z7rgUJhFrFE7QvBQAoEUIokfcz9KJpQdJNI\nhTI/P7C7QTnZFcqr6hns9NhbXQ36AbiKkTTbhdcuqY6FQAr+ofqoDmCNf3rZ\nq74bf72p9mTW0GBuWj0YGA7/iqif11IVUZMsNHh5gE5bMdH7J8FGA4eXqPpa\niV6wmj8fpCt8xLyJJm0QUjGUbsVpBmzYX7foqAgkTj9Al9IIO0cGkWff385Y\ntDo+rMHjInasVuy4YhZcQa2RyFeCvZXPmpHgmJR7rM5TeZiNxfkh6nmsRj5G\n/cdGHGDTidLkeaoTCLBGnATU594No7wWtM7VgOPz4SceVA9IbtyExST30WQZ\n2YM3\r\n=LFRj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.8.2_1552944929975_0.2245718149916811"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.8.3": {
+      "name": "node-forge",
+      "version": "0.8.3",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": "*"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "lint": "eslint *.js lib/*.js tests/*.js tests/**/*.js examples/*.js flash/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "86dff53db42829473df18cdd3059f065d4eae5cc",
+      "_id": "node-forge@0.8.3",
+      "_nodeVersion": "10.15.3",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-5lv9UKmvTBog+m4AWL8XpZnr3WbNKxYL2M77i903ylY/huJIooSTDHyUWQ/OppFuKQpAGMk6qNtDymSJNRIEIg==",
+        "shasum": "c714c51d9f95b13fee8039bf78da3195efef5b64",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.3.tgz",
+        "fileCount": 63,
+        "unpackedSize": 1683334,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3GsoCRA9TVsSAnZWagAAqGMP/1rBJge9gtod9zd1nVNk\nE+cRFQgFyadnnJfG4eD2gE2hUHKjf9rnG36vgCU82CM5NhvDKgDXA5zb9XSV\nKQ8UTRz5GVrFxO9MVllqXVVnc0dGc6YLS6eThO1pUzr4+WzV44nQY4RCgwZl\n3vPnTS2Ra+CCkw3STeA/XUVM/KlJRS5JtIiF+Whvx1lvt+To5uNsiKJ7lGF6\nEkDDwp8Gbi2o9DsYnubXd7D40a22waTIHE8UB5qgIxWvGGHopYHmouPoPUO0\nSZ4DICJSzcuRL+SU2fiSM+OG8VFPV3PtA3B72k/gdQKq8J+rmiv9nv809vsa\nVuU4hQKfsh3K5rG/1mM4EOl3taxcyY0/8hra9S94YvrE6RjVRl5Dbl+4Y27X\nADCnQ6H9gFvgCzlekk2oKNGoyYRbo6in0WGu1icfmTbwV19EiCA9S1ZIrKDO\nQooghSAiHgKvMBiG4as+ipFjNZm3A/OE9a+v+RMThpW7/GHjovojXHvPt8cC\n8SD1HTx9adc3BG3EtkumA4+4ROmZb6MvoFSzoTIdcRzIVR23JVuGLEbNfLUs\nQ+egA6XktNnc5R/lZ4AbfikXHHbbpnqwt5ybHTcKf+Cr+EC7aj9vBNHVCt4b\nU6k85cHM5puTFvKKRRh+JqNbnBW4e6LpmqD8Ue1SPLO0INQjMcA8apNgjaOV\ngR7Q\r\n=qmNw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.8.3_1557949223256_0.6245297058715329"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.8.4": {
+      "name": "node-forge",
+      "version": "0.8.4",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": ">= 4.5.0"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "lint": "eslint *.js lib/*.js tests/*.js tests/**/*.js examples/*.js flash/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "1aaf497a7c2866fd5f01cf43678073f619681fbd",
+      "_id": "node-forge@0.8.4",
+      "_nodeVersion": "10.15.3",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-UOfdpxivIYY4g5tqp5FNRNgROVNxRACUxxJREntJLFaJr1E0UEqFtUIk0F/jYx/E+Y6sVXd0KDi/m5My0yGCVw==",
+        "shasum": "d6738662b661be19e2711ef01aa3b18212f13030",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.4.tgz",
+        "fileCount": 63,
+        "unpackedSize": 1683492,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc5bEdCRA9TVsSAnZWagAAvc8P/2VWgfbRU0QQOxGLL91R\nMXVPc3lSUO0gDYfcdpbV4o9OaD8yCVdFf3iCB+PZuc1lJZR1yYhcUr2V++o0\n/eok00FowKMAl32GIu+yTCPmD6WUe+8GgONh7noRlXLID2oqUoBf/H5a39G/\nI+8PitKLfa9zIBDv+4h4nRnnessE/V4owD3YRzx8ULEsCfqP+EqR7BHrAX+N\nSe7tByZGS3YWiFlqJFVPr5sUthhmavQTCTV0PynvDHupNndKEdg9AH1yIY9S\nEnroZX9ZKtA93gW8zed1V4QE6LGE5ICB6AwBMZx1MbibdLYgvgoCjOFuuTn3\nO1eKgEUmJ9uO8VrH4oggLm+T+vGlp9ua5cFYh3nDW+6PntcyoCEd1qKI3IK9\nGVokq73YHdpgajIEHlJk2s2FxFyj7N2Hf/hefGkKFn2QibU43g/VRtAiKHEC\nDy+it0KUPkXMrWOYVE7Yg6a1O9aC2uFaANceLCGIorFzV83yvJ/MoaUxYiSS\nlFxsk6cs/BxX+oZvi3lIkdMgwbrlY7Gt1pu511LcW6rFkO0HwqyZbeEUSrgJ\nZA8XbxSBVxmFUm8pTYB3LxpZtshUx25RTIh7Xw7Tjy9Aljn1HJzC7lottXll\nFn9o60Z9V6/QD4HbD4AbIgxIXFHK0NlforHxsmxvT6vab7cg08YMHksvsGiV\n5F7C\r\n=LqNU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.8.4_1558556956438_0.08524181859470281"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.8.5": {
+      "name": "node-forge",
+      "version": "0.8.5",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": ">= 4.5.0"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "lint": "eslint *.js lib/*.js tests/*.js tests/**/*.js examples/*.js flash/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "7192006e1916ce87498f6ef9bd86c080a5c48614",
+      "_id": "node-forge@0.8.5",
+      "_nodeVersion": "10.15.3",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+        "shasum": "57906f07614dc72762c84cef442f427c0e1b86ee",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+        "fileCount": 63,
+        "unpackedSize": 1683543,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdCYwGCRA9TVsSAnZWagAAFfMP/19ZJSZCzdBJON3sp1xs\ncPXCXlrmcSW/MD2WWwUSbKxhSvSlAveu+rcUVyHzpACqGJ0jpd35MPBwik8n\nvjOevroZ+I6oJP2/1qLBm3ACcqRqmo3AlJII49st/DMrho1BkDb3erLIDptS\nS6Q6b6DGjnYrsmDhkbCU7N5hHxtOAoUBLgBL/kT8RlcmPJ32IsiXij5XX7Bw\n/5P1GdUm+L7BVmML6oyyBLmW32nO5zSbsKgCo5Ya4oCkQFdh5Lwh/27HooSG\ne9sWsVMVgbyLlRBFLkT40Ob+A+1VH99PvW9W5Aee11wPOsLdussGRqFkMbSK\nivpnlx04mWBz2BICYbTnGBTJeP8Xr6GZPkn2/GjGeFsOVKfIVaku1mGM06k7\n/DOdzjQ43eiim6UxSNOQ1blDOtPHCtPf4+S8tTGugIXETS1FuC9eV6YAUA1a\nISqSp7erjbJPZHQ44WcFvxNoH6b06fxAXTm5RiCf1N0SL3m0Lqp/cc5hOFpt\n9w78dd4XYFiRKtllSyd6ohoYIkA69qMd/z0sHoYx08XdEZQAhFZp/noFeK7G\nwdgZsO5x+1Yvw21QLiPEye8zWr97Sgc6xSdwNxO5LHBqm2t3x2Ds5UhDBZfX\nDXwCJOhifL7tmSBht6OJGdAy870+60496wSz0IlWvd61L+AN3b9UshRhS0ST\nziah\r\n=3EYK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.8.5_1560906757066_0.041806662772238656"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.9.0": {
+      "name": "node-forge",
+      "version": "0.9.0",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": ">= 4.5.0"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "lint": "eslint *.js lib/*.js tests/*.js tests/**/*.js examples/*.js flash/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "5513f7788764fd9c8e21523fa6ab40a3928f2ed6",
+      "_id": "node-forge@0.9.0",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.11.2",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+        "shasum": "d624050edbb44874adca12bb9a52ec63cb782579",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+        "fileCount": 64,
+        "unpackedSize": 1694489,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdcHSoCRA9TVsSAnZWagAATboP/1/g4u3BCXBSYCfj66bV\nwz++KdipCtHSMszMZ/fsXVaI7vovim/UmziBJTMznPJSCkPOxtK2eWDj8KfJ\njF2kiQ55fJRXQjq8TjWvh++DsLfizE6usW/NqRExc2YKvv6GdU8fFFRv6jO5\n+u4psrZfiWqfSQiOHBtXdqHM3/HZSLQUPO0BGvppr2bwXxXL5kx/vKSP/aCC\nyIXHuQf8cVr2DA737kcqT740FmYfZgooBOevGteiwILO64iumki76JUMDEjX\nEPvA1IbY0rMT8m4ffixeew68HKL2dfSR6YcQrI357+xsyfftzKQiOjnUATJW\n62ncaFrT/lfNmC2oPTDFwRgA98jbkVZx9RlVq73Z9pt0WVPBmMZmsscrjtov\nZzWtsliHJDdoQuZtfXGqZkuzrUrkNXlLZO5qzH2ibVFVtV0BeEjmsEabIrZy\ngBBirjoAZnuzbfncsFaI2T1xf2dzun9Bc2YvNILrYFXqXV59ReD0gs5yqRSp\nyphViHeRysr0ZcIGqKTAt+WAJwJ7jfZUlGCxjEoefg2hXZ+wRR7mbsCxU+X7\nSZi1SvAz4QQccx/TU/gDDYRIrs37yzl/9gtPL2b1L7jJ3U6q6WdGwSjgREtE\nqZRkj1hjnMKHUGbtnThtAh1S7+6opRKdTsXfM4WCyzcKCNpkRyYaCpbBd3x/\nJ0Q3\r\n=Fwfk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.9.0_1567650982933_0.009304061406716357"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.9.1": {
+      "name": "node-forge",
+      "version": "0.9.1",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": ">= 4.5.0"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "lint": "eslint *.js lib/*.js tests/*.js tests/**/*.js examples/*.js flash/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "197218e159cbf82c611da91994c1126e2cfa35c3",
+      "_id": "node-forge@0.9.1",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.11.3",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+        "shasum": "775368e6846558ab6676858a4d8c6e8d16c677b5",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+        "fileCount": 64,
+        "unpackedSize": 1695226,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdjQusCRA9TVsSAnZWagAA8ZAQAKEmnXGsyp1On4tQPdrM\ncsGC94EyVqIuoq8aC9apAibz/FtpAMpL+PdnSiyuCCcM87eggsGG1s1V7akX\nor+eGk7EACWwxs702jL5500H3uO1G3zlqCOjA/rYcbx3iR0cvpHjK4vrM/jB\nwCvcR4921WC1JAUqMUjXLWcdg+5NYlu01cid+DgNgQUT6Jm2Dy0j9BczObmQ\n9SLrJJMLLOLwcKNbebtYk8vuoMtLws+gZOdQaXFn6LhnWGRVYtPS86IBi/NR\nBd7YstSex8ooD6dRP0uNmu41leYDUPHUOjKJm1SG5q30Mac3fgxzaZbbZ2TY\nAlyncClDmKXbuMUMeEzglbUHkKARv3kIRxlSaoZYyP2cdcUMFpI/0pkMPCHr\nmTqyLZPxwkkY0C7+qXpq5UW+dj6msl5s9K1wpB+ucnw/FYkTUbMIPQUh0gtt\nsjfwHVG7NacT9WTEjP8BGkNSUtWpfl55EARR4BS7P7tRZCLFLbgjitlMApJz\nMA4aTcLXKjcHlZ6qWuwHtp69WFIp7rLqhJQVwd4IjGYvFprTsvQlZcm3cZTm\nh8KQhTWAnK88/UvqRy/x52DFXvos28ySKQIvD4fL1aYwC4hMMorB/GkMxSj1\nR+vzVcaLWdpGnWXKSEwQFajT2vWuaL+SmeJiOWu2NE6fvVtvCHjlmPBkjNh/\nE4OD\r\n=/Q02\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.9.1_1569524651992_0.3427633754251329"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.9.2": {
+      "name": "node-forge",
+      "version": "0.9.2",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": ">= 4.5.0"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "lint": "eslint *.js lib/*.js tests/*.js tests/**/*.js examples/*.js flash/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "bf049a46d94d22da095f3c294ad5fbdcaa3f3f16",
+      "_id": "node-forge@0.9.2",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.5",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw==",
+        "shasum": "b35a44c28889b2ea55cabf8c79e3563f9676190a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.2.tgz",
+        "fileCount": 64,
+        "unpackedSize": 1696489,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfTvPACRA9TVsSAnZWagAAsVMQAJlBrEcSSmTSJyrU4weU\ndw+na7c+N0/t7g9Z5exXrlAXouKAJldGgBaBT3r0Kd+HYjPe85BV8PCQgvJh\nbPYZAbb6uquD2nDK/jobjT+SJuORYvXJA+7yO63ILQn+jucideCkhKvZbJLe\nTnlmowYbvGgAtXjpYgog2VIGR1dhsf5+o4zPMz+DyuKKqPKev3K8App8uJIx\ngzC0vIbsH3tMvEP9Y8Ztryh6gmL2vCA7nVltNNngtDspAUwHlVJOn0E/NkZB\n8MfI4yLE6O9GmSUsV6RldmZEMIZwr1fG/+NHLQVqK9j/eezf0V6K2atGWiL/\nlSF6/lAcVQX7R20OE8hHu5JM6g1KhVsZqYPZ9hVBwZcMBGgH6C8aISmoOWmn\n6FPnaCmBvUTBQoCguMoMmvfcWCxMIavsUQ+tE20UXPDqWgRzPWtffDYOBKeW\nI7Dc7UamsmT7e4z/ADtUEQU4aMv+vVy51kbtl5FLEuvwq+OV29qSKTtgqxCZ\n1g/bqYtQ8VFP6ER3U8g24C2n7uGqVbv9tLOd353aO9Xa7Gjr6xZ+/ywfbV/W\n2/Cu9dRVSJut11kQSV2TG/XbbykvSFXg45KHgJko/j36EKVl8qagnrXa4aRI\nbDzQ7Gp1iAis8Hu4PNvscMqFHkGHv1x2e/+ZCPZTpKnqkiCbM8840A9O8OgO\n0zlB\r\n=q/R7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.9.2_1599009727256_0.6000255483250756"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.10.0": {
+      "name": "node-forge",
+      "version": "0.10.0",
+      "description": "JavaScript implementations of network transports, cryptography, ciphers, PKI, message digests, and various utilities.",
+      "homepage": "https://github.com/digitalbazaar/forge",
+      "author": {
+        "name": "Digital Bazaar, Inc.",
+        "email": "support@digitalbazaar.com",
+        "url": "http://digitalbazaar.com/"
+      },
+      "contributors": [
+        {
+          "name": "Dave Longley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "David I. Lehn",
+          "email": "dlehn@digitalbazaar.com"
+        },
+        {
+          "name": "Stefan Siegl",
+          "email": "stesie@brokenpipe.de"
+        },
+        {
+          "name": "Christoph Dorn",
+          "email": "christoph@christophdorn.com"
+        }
+      ],
+      "devDependencies": {
+        "browserify": "^16.5.2",
+        "commander": "^2.20.0",
+        "cross-env": "^5.2.1",
+        "eslint": "^7.8.1",
+        "eslint-config-digitalbazaar": "^2.5.0",
+        "express": "^4.16.2",
+        "karma": "^4.4.1",
+        "karma-browserify": "^7.0.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.3.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^2.0.2",
+        "karma-sourcemap-loader": "^0.3.8",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^4.0.2",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^15.1.0",
+        "opts": "^1.2.7",
+        "webpack": "^4.44.1",
+        "webpack-cli": "^3.3.12",
+        "worker-loader": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/digitalbazaar/forge.git"
+      },
+      "bugs": {
+        "url": "https://github.com/digitalbazaar/forge/issues",
+        "email": "support@digitalbazaar.com"
+      },
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "main": "lib/index.js",
+      "engines": {
+        "node": ">= 6.0.0"
+      },
+      "keywords": [
+        "aes",
+        "asn",
+        "asn.1",
+        "cbc",
+        "crypto",
+        "cryptography",
+        "csr",
+        "des",
+        "gcm",
+        "hmac",
+        "http",
+        "https",
+        "md5",
+        "network",
+        "pkcs",
+        "pki",
+        "prng",
+        "rc2",
+        "rsa",
+        "sha1",
+        "sha256",
+        "sha384",
+        "sha512",
+        "ssh",
+        "tls",
+        "x.509",
+        "x509"
+      ],
+      "scripts": {
+        "prepublish": "npm run build",
+        "build": "webpack",
+        "test-build": "webpack --config webpack-tests.config.js",
+        "test": "cross-env NODE_ENV=test mocha -t 30000 -R ${REPORTER:-spec} tests/unit/index.js",
+        "test-karma": "karma start",
+        "test-karma-sauce": "karma start karma-sauce.conf",
+        "test-server": "node tests/server.js",
+        "test-server-ws": "node tests/websockets/server-ws.js",
+        "test-server-webid": "node tests/websockets/server-webid.js",
+        "coverage": "rm -rf coverage && nyc --reporter=lcov --reporter=text-summary npm test",
+        "coverage-report": "nyc report",
+        "lint": "eslint *.js lib/*.js tests/*.js tests/**/*.js examples/*.js flash/*.js"
+      },
+      "nyc": {
+        "exclude": [
+          "tests"
+        ]
+      },
+      "jspm": {
+        "format": "amd"
+      },
+      "browser": {
+        "buffer": false,
+        "crypto": false,
+        "process": false
+      },
+      "gitHead": "8018c3ea6f8e75d2df1b9ce4ec9c536db3db37e6",
+      "_id": "node-forge@0.10.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.5",
+      "_npmUser": {
+        "name": "davidlehn",
+        "email": "dil@lehn.org"
+      },
+      "dist": {
+        "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+        "shasum": "32dea2afb3e9926f02ee5ce8794902691a676bf3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+        "fileCount": 64,
+        "unpackedSize": 1691149,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfTv5BCRA9TVsSAnZWagAAR/gP/0/MfddmfY6ND+zP36FY\nf1XeGUoBRCa5F/GI0jVCPgxvNZMb9OvLbFTigBPPQyHu5gDcB5Vq64ieL58/\n3SOn5FeIWoSLTxM7CR4Nzq6eQ2mxybhAV18vL1Dash9cqM/gT191J0A7tQKC\ncB4vsNIZzXerfCvMb/m8D+/Neb/FRBHCmlc4KXXWBEKLI/a6iUuHfPtxM+nt\nKNBE+yiKdpqzAMu/x2jmAj5ABhWdUDfnq1Pgl4ocogGknD40VS9VxftnT2r6\nfIatERkqIWbqahotZ/PA8c+xrgAeXzsrQL6A1xqSODs06koIjo+BkDAwo2gG\nr4/FhLARFHCBPc8wg/wAyhxsytjIGYjZj4WEshQPzuJYd0WspqfFXzlT5rvm\nGkfNKTpBUjWM06+6JdkUgQqb8RwXNnxHBD4d+JLmGb5n9X/hlA8l0+F0EKjy\nhKgMzt9VDtfHehP662F6B3QPDF/xH5zDH0yxYCWN15IjXATGRaXsqqZms21U\nPBSbr4Uhrw+uAa65FeMN685MW9GszsIJsFrvkSsZNkSF8A6PpbAf3E53zWUR\nrDp6Bpapd47+yaF3oKA/fl4geLUEVBC7YPd6xuHwwI+n16UIryaQdPN1Z4bc\nhI4LQ0s2ZvYT0pmedX9nOLeFL0g6iLrTGLXBeJRQPRMVIJBa7C245qlAuyFq\nioPC\r\n=cJdv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "davidlehn",
+          "email": "dil@lehn.org"
+        },
+        {
+          "name": "dlongley",
+          "email": "dlongley@digitalbazaar.com"
+        },
+        {
+          "name": "msporny",
+          "email": "msporny@digitalbazaar.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-forge_0.10.0_1599012416809_0.001104495454428367"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Forge\n\n[![npm package](https://nodei.co/npm/node-forge.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/node-forge/)\n\n[![Build status](https://img.shields.io/travis/digitalbazaar/forge.svg?branch=master)](https://travis-ci.org/digitalbazaar/forge)\n\nA native implementation of [TLS][] (and various other cryptographic tools) in\n[JavaScript][].\n\nIntroduction\n------------\n\nThe Forge software is a fully native implementation of the [TLS][] protocol\nin JavaScript, a set of cryptography utilities, and a set of tools for\ndeveloping Web Apps that utilize many network resources.\n\nPerformance\n------------\n\nForge is fast. Benchmarks against other popular JavaScript cryptography\nlibraries can be found here:\n\n* http://dominictarr.github.io/crypto-bench/\n* http://cryptojs.altervista.org/test/simulate-threading-speed_test.html\n\nDocumentation\n-------------\n\n* [Introduction](#introduction)\n* [Performance](#performance)\n* [Installation](#installation)\n* [Testing](#testing)\n* [Contributing](#contributing)\n\n### API\n\n* [Options](#options)\n\n### Transports\n\n* [TLS](#tls)\n* [HTTP](#http)\n* [SSH](#ssh)\n* [XHR](#xhr)\n* [Sockets](#socket)\n\n### Ciphers\n\n* [CIPHER](#cipher)\n* [AES](#aes)\n* [DES](#des)\n* [RC2](#rc2)\n\n### PKI\n\n* [ED25519](#ed25519)\n* [RSA](#rsa)\n* [RSA-KEM](#rsakem)\n* [X.509](#x509)\n* [PKCS#5](#pkcs5)\n* [PKCS#7](#pkcs7)\n* [PKCS#8](#pkcs8)\n* [PKCS#10](#pkcs10)\n* [PKCS#12](#pkcs12)\n* [ASN.1](#asn)\n\n### Message Digests\n\n* [SHA1](#sha1)\n* [SHA256](#sha256)\n* [SHA384](#sha384)\n* [SHA512](#sha512)\n* [MD5](#md5)\n* [HMAC](#hmac)\n\n### Utilities\n\n* [Prime](#prime)\n* [PRNG](#prng)\n* [Tasks](#task)\n* [Utilities](#util)\n* [Logging](#log)\n* [Debugging](#debug)\n* [Flash Networking Support](#flash)\n\n### Other\n\n* [Security Considerations](#security-considerations)\n* [Library Background](#library-background)\n* [Contact](#contact)\n* [Donations](#donations)\n\n---------------------------------------\n\nInstallation\n------------\n\n**Note**: Please see the [Security Considerations](#security-considerations)\nsection before using packaging systems and pre-built files.\n\nForge uses a [CommonJS][] module structure with a build process for browser\nbundles. The older [0.6.x][] branch with standalone files is available but will\nnot be regularly updated.\n\n### Node.js\n\nIf you want to use forge with [Node.js][], it is available through `npm`:\n\nhttps://npmjs.org/package/node-forge\n\nInstallation:\n\n    npm install node-forge\n\nYou can then use forge as a regular module:\n\n```js\nvar forge = require('node-forge');\n```\n\nThe npm package includes pre-built `forge.min.js`, `forge.all.min.js`, and\n`prime.worker.min.js` using the [UMD][] format.\n\n### Bundle / Bower\n\nEach release is published in a separate repository as pre-built and minimized\nbasic forge bundles using the [UMD][] format.\n\nhttps://github.com/digitalbazaar/forge-dist\n\nThis bundle can be used in many environments. In particular it can be installed\nwith [Bower][]:\n\n    bower install forge\n\n### jsDelivr CDN\n\nTo use it via [jsDelivr](https://www.jsdelivr.com/package/npm/node-forge) include this in your html:\n\n```html\n<script src=\"https://cdn.jsdelivr.net/npm/node-forge@0.7.0/dist/forge.min.js\"></script>\n```\n\n### unpkg CDN\n\nTo use it via [unpkg](https://unpkg.com/#/) include this in your html:\n\n```html\n<script src=\"https://unpkg.com/node-forge@0.7.0/dist/forge.min.js\"></script>\n```\n\n### Development Requirements\n\nThe core JavaScript has the following requirements to build and test:\n\n* Building a browser bundle:\n  * Node.js\n  * npm\n* Testing\n  * Node.js\n  * npm\n  * Chrome, Firefox, Safari (optional)\n\nSome special networking features can optionally use a Flash component.  See the\n[Flash README](./flash/README.md) for details.\n\n### Building for a web browser\n\nTo create single file bundles for use with browsers run the following:\n\n    npm install\n    npm run build\n\nThis will create single non-minimized and minimized files that can be\nincluded in the browser:\n\n    dist/forge.js\n    dist/forge.min.js\n\nA bundle that adds some utilities and networking support is also available:\n\n    dist/forge.all.js\n    dist/forge.all.min.js\n\nInclude the file via:\n\n```html\n<script src=\"YOUR_SCRIPT_PATH/forge.js\"></script>\n```\nor\n```html\n<script src=\"YOUR_SCRIPT_PATH/forge.min.js\"></script>\n```\n\nThe above bundles will synchronously create a global 'forge' object.\n\n**Note**: These bundles will not include any WebWorker scripts (eg:\n`dist/prime.worker.js`), so these will need to be accessible from the browser\nif any WebWorkers are used.\n\n### Building a custom browser bundle\n\nThe build process uses [webpack][] and the [config](./webpack.config.js) file\ncan be modified to generate a file or files that only contain the parts of\nforge you need.\n\n[Browserify][] override support is also present in `package.json`.\n\nTesting\n-------\n\n### Prepare to run tests\n\n    npm install\n\n### Running automated tests with Node.js\n\nForge natively runs in a [Node.js][] environment:\n\n    npm test\n\n### Running automated tests with Headless Chrome\n\nAutomated testing is done via [Karma][]. By default it will run the tests with\nHeadless Chrome.\n\n    npm run test-karma\n\nIs 'mocha' reporter output too verbose? Other reporters are available. Try\n'dots', 'progress', or 'tap'.\n\n    npm run test-karma -- --reporters progress\n\nBy default [webpack][] is used. [Browserify][] can also be used.\n\n    BUNDLER=browserify npm run test-karma\n\n### Running automated tests with one or more browsers\n\nYou can also specify one or more browsers to use.\n\n    npm run test-karma -- --browsers Chrome,Firefox,Safari,ChromeHeadless\n\nThe reporter option and `BUNDLER` environment variable can also be used.\n\n### Running manual tests in a browser\n\nTesting in a browser uses [webpack][] to combine forge and all tests and then\nloading the result in a browser. A simple web server is provided that will\noutput the HTTP or HTTPS URLs to load. It also will start a simple Flash Policy\nServer. Unit tests and older legacy tests are provided. Custom ports can be\nused by running `node tests/server.js` manually.\n\nTo run the unit tests in a browser a special forge build is required:\n\n    npm run test-build\n\nTo run legacy browser based tests the main forge build is required:\n\n    npm run build\n\nThe tests are run with a custom server that prints out the URLs to use:\n\n    npm run test-server\n\n### Running other tests\n\nThere are some other random tests and benchmarks available in the tests\ndirectory.\n\n### Coverage testing\n\nTo perform coverage testing of the unit tests, run the following. The results\nwill be put in the `coverage/` directory. Note that coverage testing can slow\ndown some tests considerably.\n\n    npm install\n    npm run coverage\n\nContributing\n------------\n\nAny contributions (eg: PRs) that are accepted will be brought under the same\nlicense used by the rest of the Forge project. This license allows Forge to\nbe used under the terms of either the BSD License or the GNU General Public\nLicense (GPL) Version 2.\n\nSee: [LICENSE](https://github.com/digitalbazaar/forge/blob/cbebca3780658703d925b61b2caffb1d263a6c1d/LICENSE)\n\nIf a contribution contains 3rd party source code with its own license, it\nmay retain it, so long as that license is compatible with the Forge license.\n\nAPI\n---\n\n<a name=\"options\" />\n\n### Options\n\nIf at any time you wish to disable the use of native code, where available,\nfor particular forge features like its secure random number generator, you\nmay set the ```forge.options.usePureJavaScript``` flag to ```true```. It is\nnot recommended that you set this flag as native code is typically more\nperformant and may have stronger security properties. It may be useful to\nset this flag to test certain features that you plan to run in environments\nthat are different from your testing environment.\n\nTo disable native code when including forge in the browser:\n\n```js\n// run this *after* including the forge script\nforge.options.usePureJavaScript = true;\n```\n\nTo disable native code when using Node.js:\n\n```js\nvar forge = require('node-forge');\nforge.options.usePureJavaScript = true;\n```\n\nTransports\n----------\n\n<a name=\"tls\" />\n\n### TLS\n\nProvides a native javascript client and server-side [TLS][] implementation.\n\n__Examples__\n\n```js\n// create TLS client\nvar client = forge.tls.createConnection({\n  server: false,\n  caStore: /* Array of PEM-formatted certs or a CA store object */,\n  sessionCache: {},\n  // supported cipher suites in order of preference\n  cipherSuites: [\n    forge.tls.CipherSuites.TLS_RSA_WITH_AES_128_CBC_SHA,\n    forge.tls.CipherSuites.TLS_RSA_WITH_AES_256_CBC_SHA],\n  virtualHost: 'example.com',\n  verify: function(connection, verified, depth, certs) {\n    if(depth === 0) {\n      var cn = certs[0].subject.getField('CN').value;\n      if(cn !== 'example.com') {\n        verified = {\n          alert: forge.tls.Alert.Description.bad_certificate,\n          message: 'Certificate common name does not match hostname.'\n        };\n      }\n    }\n    return verified;\n  },\n  connected: function(connection) {\n    console.log('connected');\n    // send message to server\n    connection.prepare(forge.util.encodeUtf8('Hi server!'));\n    /* NOTE: experimental, start heartbeat retransmission timer\n    myHeartbeatTimer = setInterval(function() {\n      connection.prepareHeartbeatRequest(forge.util.createBuffer('1234'));\n    }, 5*60*1000);*/\n  },\n  /* provide a client-side cert if you want\n  getCertificate: function(connection, hint) {\n    return myClientCertificate;\n  },\n  /* the private key for the client-side cert if provided */\n  getPrivateKey: function(connection, cert) {\n    return myClientPrivateKey;\n  },\n  tlsDataReady: function(connection) {\n    // TLS data (encrypted) is ready to be sent to the server\n    sendToServerSomehow(connection.tlsData.getBytes());\n    // if you were communicating with the server below, you'd do:\n    // server.process(connection.tlsData.getBytes());\n  },\n  dataReady: function(connection) {\n    // clear data from the server is ready\n    console.log('the server sent: ' +\n      forge.util.decodeUtf8(connection.data.getBytes()));\n    // close connection\n    connection.close();\n  },\n  /* NOTE: experimental\n  heartbeatReceived: function(connection, payload) {\n    // restart retransmission timer, look at payload\n    clearInterval(myHeartbeatTimer);\n    myHeartbeatTimer = setInterval(function() {\n      connection.prepareHeartbeatRequest(forge.util.createBuffer('1234'));\n    }, 5*60*1000);\n    payload.getBytes();\n  },*/\n  closed: function(connection) {\n    console.log('disconnected');\n  },\n  error: function(connection, error) {\n    console.log('uh oh', error);\n  }\n});\n\n// start the handshake process\nclient.handshake();\n\n// when encrypted TLS data is received from the server, process it\nclient.process(encryptedBytesFromServer);\n\n// create TLS server\nvar server = forge.tls.createConnection({\n  server: true,\n  caStore: /* Array of PEM-formatted certs or a CA store object */,\n  sessionCache: {},\n  // supported cipher suites in order of preference\n  cipherSuites: [\n    forge.tls.CipherSuites.TLS_RSA_WITH_AES_128_CBC_SHA,\n    forge.tls.CipherSuites.TLS_RSA_WITH_AES_256_CBC_SHA],\n  // require a client-side certificate if you want\n  verifyClient: true,\n  verify: function(connection, verified, depth, certs) {\n    if(depth === 0) {\n      var cn = certs[0].subject.getField('CN').value;\n      if(cn !== 'the-client') {\n        verified = {\n          alert: forge.tls.Alert.Description.bad_certificate,\n          message: 'Certificate common name does not match expected client.'\n        };\n      }\n    }\n    return verified;\n  },\n  connected: function(connection) {\n    console.log('connected');\n    // send message to client\n    connection.prepare(forge.util.encodeUtf8('Hi client!'));\n    /* NOTE: experimental, start heartbeat retransmission timer\n    myHeartbeatTimer = setInterval(function() {\n      connection.prepareHeartbeatRequest(forge.util.createBuffer('1234'));\n    }, 5*60*1000);*/\n  },\n  getCertificate: function(connection, hint) {\n    return myServerCertificate;\n  },\n  getPrivateKey: function(connection, cert) {\n    return myServerPrivateKey;\n  },\n  tlsDataReady: function(connection) {\n    // TLS data (encrypted) is ready to be sent to the client\n    sendToClientSomehow(connection.tlsData.getBytes());\n    // if you were communicating with the client above you'd do:\n    // client.process(connection.tlsData.getBytes());\n  },\n  dataReady: function(connection) {\n    // clear data from the client is ready\n    console.log('the client sent: ' +\n      forge.util.decodeUtf8(connection.data.getBytes()));\n    // close connection\n    connection.close();\n  },\n  /* NOTE: experimental\n  heartbeatReceived: function(connection, payload) {\n    // restart retransmission timer, look at payload\n    clearInterval(myHeartbeatTimer);\n    myHeartbeatTimer = setInterval(function() {\n      connection.prepareHeartbeatRequest(forge.util.createBuffer('1234'));\n    }, 5*60*1000);\n    payload.getBytes();\n  },*/\n  closed: function(connection) {\n    console.log('disconnected');\n  },\n  error: function(connection, error) {\n    console.log('uh oh', error);\n  }\n});\n\n// when encrypted TLS data is received from the client, process it\nserver.process(encryptedBytesFromClient);\n```\n\nConnect to a TLS server using node's net.Socket:\n\n```js\nvar socket = new net.Socket();\n\nvar client = forge.tls.createConnection({\n  server: false,\n  verify: function(connection, verified, depth, certs) {\n    // skip verification for testing\n    console.log('[tls] server certificate verified');\n    return true;\n  },\n  connected: function(connection) {\n    console.log('[tls] connected');\n    // prepare some data to send (note that the string is interpreted as\n    // 'binary' encoded, which works for HTTP which only uses ASCII, use\n    // forge.util.encodeUtf8(str) otherwise\n    client.prepare('GET / HTTP/1.0\\r\\n\\r\\n');\n  },\n  tlsDataReady: function(connection) {\n    // encrypted data is ready to be sent to the server\n    var data = connection.tlsData.getBytes();\n    socket.write(data, 'binary'); // encoding should be 'binary'\n  },\n  dataReady: function(connection) {\n    // clear data from the server is ready\n    var data = connection.data.getBytes();\n    console.log('[tls] data received from the server: ' + data);\n  },\n  closed: function() {\n    console.log('[tls] disconnected');\n  },\n  error: function(connection, error) {\n    console.log('[tls] error', error);\n  }\n});\n\nsocket.on('connect', function() {\n  console.log('[socket] connected');\n  client.handshake();\n});\nsocket.on('data', function(data) {\n  client.process(data.toString('binary')); // encoding should be 'binary'\n});\nsocket.on('end', function() {\n  console.log('[socket] disconnected');\n});\n\n// connect to google.com\nsocket.connect(443, 'google.com');\n\n// or connect to gmail's imap server (but don't send the HTTP header above)\n//socket.connect(993, 'imap.gmail.com');\n```\n\n<a name=\"http\" />\n\n### HTTP\n\nProvides a native [JavaScript][] mini-implementation of an http client that\nuses pooled sockets.\n\n__Examples__\n\n```js\n// create an HTTP GET request\nvar request = forge.http.createRequest({method: 'GET', path: url.path});\n\n// send the request somewhere\nsendSomehow(request.toString());\n\n// receive response\nvar buffer = forge.util.createBuffer();\nvar response = forge.http.createResponse();\nvar someAsyncDataHandler = function(bytes) {\n  if(!response.bodyReceived) {\n    buffer.putBytes(bytes);\n    if(!response.headerReceived) {\n      if(response.readHeader(buffer)) {\n        console.log('HTTP response header: ' + response.toString());\n      }\n    }\n    if(response.headerReceived && !response.bodyReceived) {\n      if(response.readBody(buffer)) {\n        console.log('HTTP response body: ' + response.body);\n      }\n    }\n  }\n};\n```\n\n<a name=\"ssh\" />\n\n### SSH\n\nProvides some SSH utility functions.\n\n__Examples__\n\n```js\n// encodes (and optionally encrypts) a private RSA key as a Putty PPK file\nforge.ssh.privateKeyToPutty(privateKey, passphrase, comment);\n\n// encodes a public RSA key as an OpenSSH file\nforge.ssh.publicKeyToOpenSSH(key, comment);\n\n// encodes a private RSA key as an OpenSSH file\nforge.ssh.privateKeyToOpenSSH(privateKey, passphrase);\n\n// gets the SSH public key fingerprint in a byte buffer\nforge.ssh.getPublicKeyFingerprint(key);\n\n// gets a hex-encoded, colon-delimited SSH public key fingerprint\nforge.ssh.getPublicKeyFingerprint(key, {encoding: 'hex', delimiter: ':'});\n```\n\n<a name=\"xhr\" />\n\n### XHR\n\nProvides an XmlHttpRequest implementation using forge.http as a backend.\n\n__Examples__\n\n```js\n// TODO\n```\n\n<a name=\"socket\" />\n\n### Sockets\n\nProvides an interface to create and use raw sockets provided via Flash.\n\n__Examples__\n\n```js\n// TODO\n```\n\nCiphers\n-------\n\n<a name=\"cipher\" />\n\n### CIPHER\n\nProvides a basic API for block encryption and decryption. There is built-in\nsupport for the ciphers: [AES][], [3DES][], and [DES][], and for the modes\nof operation: [ECB][], [CBC][], [CFB][], [OFB][], [CTR][], and [GCM][].\n\nThese algorithms are currently supported:\n\n* AES-ECB\n* AES-CBC\n* AES-CFB\n* AES-OFB\n* AES-CTR\n* AES-GCM\n* 3DES-ECB\n* 3DES-CBC\n* DES-ECB\n* DES-CBC\n\nWhen using an [AES][] algorithm, the key size will determine whether\nAES-128, AES-192, or AES-256 is used (all are supported). When a [DES][]\nalgorithm is used, the key size will determine whether [3DES][] or regular\n[DES][] is used. Use a [3DES][] algorithm to enforce Triple-DES.\n\n__Examples__\n\n```js\n// generate a random key and IV\n// Note: a key size of 16 bytes will use AES-128, 24 => AES-192, 32 => AES-256\nvar key = forge.random.getBytesSync(16);\nvar iv = forge.random.getBytesSync(16);\n\n/* alternatively, generate a password-based 16-byte key\nvar salt = forge.random.getBytesSync(128);\nvar key = forge.pkcs5.pbkdf2('password', salt, numIterations, 16);\n*/\n\n// encrypt some bytes using CBC mode\n// (other modes include: ECB, CFB, OFB, CTR, and GCM)\n// Note: CBC and ECB modes use PKCS#7 padding as default\nvar cipher = forge.cipher.createCipher('AES-CBC', key);\ncipher.start({iv: iv});\ncipher.update(forge.util.createBuffer(someBytes));\ncipher.finish();\nvar encrypted = cipher.output;\n// outputs encrypted hex\nconsole.log(encrypted.toHex());\n\n// decrypt some bytes using CBC mode\n// (other modes include: CFB, OFB, CTR, and GCM)\nvar decipher = forge.cipher.createDecipher('AES-CBC', key);\ndecipher.start({iv: iv});\ndecipher.update(encrypted);\nvar result = decipher.finish(); // check 'result' for true/false\n// outputs decrypted hex\nconsole.log(decipher.output.toHex());\n\n// decrypt bytes using CBC mode and streaming\n// Performance can suffer for large multi-MB inputs due to buffer\n// manipulations. Stream processing in chunks can offer significant\n// improvement. CPU intensive update() calls could also be performed with\n// setImmediate/setTimeout to avoid blocking the main browser UI thread (not\n// shown here). Optimal block size depends on the JavaScript VM and other\n// factors. Encryption can use a simple technique for increased performance.\nvar encryptedBytes = encrypted.bytes();\nvar decipher = forge.cipher.createDecipher('AES-CBC', key);\ndecipher.start({iv: iv});\nvar length = encryptedBytes.length;\nvar chunkSize = 1024 * 64;\nvar index = 0;\nvar decrypted = '';\ndo {\n  decrypted += decipher.output.getBytes();\n  var buf = forge.util.createBuffer(encryptedBytes.substr(index, chunkSize));\n  decipher.update(buf);\n  index += chunkSize;\n} while(index < length);\nvar result = decipher.finish();\nassert(result);\ndecrypted += decipher.output.getBytes();\nconsole.log(forge.util.bytesToHex(decrypted));\n\n// encrypt some bytes using GCM mode\nvar cipher = forge.cipher.createCipher('AES-GCM', key);\ncipher.start({\n  iv: iv, // should be a 12-byte binary-encoded string or byte buffer\n  additionalData: 'binary-encoded string', // optional\n  tagLength: 128 // optional, defaults to 128 bits\n});\ncipher.update(forge.util.createBuffer(someBytes));\ncipher.finish();\nvar encrypted = cipher.output;\nvar tag = cipher.mode.tag;\n// outputs encrypted hex\nconsole.log(encrypted.toHex());\n// outputs authentication tag\nconsole.log(tag.toHex());\n\n// decrypt some bytes using GCM mode\nvar decipher = forge.cipher.createDecipher('AES-GCM', key);\ndecipher.start({\n  iv: iv,\n  additionalData: 'binary-encoded string', // optional\n  tagLength: 128, // optional, defaults to 128 bits\n  tag: tag // authentication tag from encryption\n});\ndecipher.update(encrypted);\nvar pass = decipher.finish();\n// pass is false if there was a failure (eg: authentication tag didn't match)\nif(pass) {\n  // outputs decrypted hex\n  console.log(decipher.output.toHex());\n}\n```\n\nUsing forge in Node.js to match openssl's \"enc\" command line tool (**Note**: OpenSSL \"enc\" uses a non-standard file format with a custom key derivation function and a fixed iteration count of 1, which some consider less secure than alternatives such as [OpenPGP](https://tools.ietf.org/html/rfc4880)/[GnuPG](https://www.gnupg.org/)):\n\n```js\nvar forge = require('node-forge');\nvar fs = require('fs');\n\n// openssl enc -des3 -in input.txt -out input.enc\nfunction encrypt(password) {\n  var input = fs.readFileSync('input.txt', {encoding: 'binary'});\n\n  // 3DES key and IV sizes\n  var keySize = 24;\n  var ivSize = 8;\n\n  // get derived bytes\n  // Notes:\n  // 1. If using an alternative hash (eg: \"-md sha1\") pass\n  //   \"forge.md.sha1.create()\" as the final parameter.\n  // 2. If using \"-nosalt\", set salt to null.\n  var salt = forge.random.getBytesSync(8);\n  // var md = forge.md.sha1.create(); // \"-md sha1\"\n  var derivedBytes = forge.pbe.opensslDeriveBytes(\n    password, salt, keySize + ivSize/*, md*/);\n  var buffer = forge.util.createBuffer(derivedBytes);\n  var key = buffer.getBytes(keySize);\n  var iv = buffer.getBytes(ivSize);\n\n  var cipher = forge.cipher.createCipher('3DES-CBC', key);\n  cipher.start({iv: iv});\n  cipher.update(forge.util.createBuffer(input, 'binary'));\n  cipher.finish();\n\n  var output = forge.util.createBuffer();\n\n  // if using a salt, prepend this to the output:\n  if(salt !== null) {\n    output.putBytes('Salted__'); // (add to match openssl tool output)\n    output.putBytes(salt);\n  }\n  output.putBuffer(cipher.output);\n\n  fs.writeFileSync('input.enc', output.getBytes(), {encoding: 'binary'});\n}\n\n// openssl enc -d -des3 -in input.enc -out input.dec.txt\nfunction decrypt(password) {\n  var input = fs.readFileSync('input.enc', {encoding: 'binary'});\n\n  // parse salt from input\n  input = forge.util.createBuffer(input, 'binary');\n  // skip \"Salted__\" (if known to be present)\n  input.getBytes('Salted__'.length);\n  // read 8-byte salt\n  var salt = input.getBytes(8);\n\n  // Note: if using \"-nosalt\", skip above parsing and use\n  // var salt = null;\n\n  // 3DES key and IV sizes\n  var keySize = 24;\n  var ivSize = 8;\n\n  var derivedBytes = forge.pbe.opensslDeriveBytes(\n    password, salt, keySize + ivSize);\n  var buffer = forge.util.createBuffer(derivedBytes);\n  var key = buffer.getBytes(keySize);\n  var iv = buffer.getBytes(ivSize);\n\n  var decipher = forge.cipher.createDecipher('3DES-CBC', key);\n  decipher.start({iv: iv});\n  decipher.update(input);\n  var result = decipher.finish(); // check 'result' for true/false\n\n  fs.writeFileSync(\n    'input.dec.txt', decipher.output.getBytes(), {encoding: 'binary'});\n}\n```\n\n<a name=\"aes\" />\n\n### AES\n\nProvides [AES][] encryption and decryption in [CBC][], [CFB][], [OFB][],\n[CTR][], and [GCM][] modes. See [CIPHER](#cipher) for examples.\n\n<a name=\"des\" />\n\n### DES\n\nProvides [3DES][] and [DES][] encryption and decryption in [ECB][] and\n[CBC][] modes. See [CIPHER](#cipher) for examples.\n\n<a name=\"rc2\" />\n\n### RC2\n\n__Examples__\n\n```js\n// generate a random key and IV\nvar key = forge.random.getBytesSync(16);\nvar iv = forge.random.getBytesSync(8);\n\n// encrypt some bytes\nvar cipher = forge.rc2.createEncryptionCipher(key);\ncipher.start(iv);\ncipher.update(forge.util.createBuffer(someBytes));\ncipher.finish();\nvar encrypted = cipher.output;\n// outputs encrypted hex\nconsole.log(encrypted.toHex());\n\n// decrypt some bytes\nvar cipher = forge.rc2.createDecryptionCipher(key);\ncipher.start(iv);\ncipher.update(encrypted);\ncipher.finish();\n// outputs decrypted hex\nconsole.log(cipher.output.toHex());\n```\n\nPKI\n---\n\nProvides [X.509][] certificate support, ED25519 key generation and\nsigning/verifying, and RSA public and private key encoding, decoding,\nencryption/decryption, and signing/verifying.\n\n<a name=\"ed25519\" />\n\n### ED25519\n\nSpecial thanks to [TweetNaCl.js][] for providing the bulk of the implementation.\n\n__Examples__\n\n```js\nvar ed25519 = forge.pki.ed25519;\n\n// generate a random ED25519 keypair\nvar keypair = ed25519.generateKeyPair();\n// `keypair.publicKey` is a node.js Buffer or Uint8Array\n// `keypair.privateKey` is a node.js Buffer or Uint8Array\n\n// generate a random ED25519 keypair based on a random 32-byte seed\nvar seed = forge.random.getBytesSync(32);\nvar keypair = ed25519.generateKeyPair({seed: seed});\n\n// generate a random ED25519 keypair based on a \"password\" 32-byte seed\nvar password = 'Mai9ohgh6ahxee0jutheew0pungoozil';\nvar seed = new forge.util.ByteBuffer(password, 'utf8');\nvar keypair = ed25519.generateKeyPair({seed: seed});\n\n// sign a UTF-8 message\nvar signature = ED25519.sign({\n  message: 'test',\n  // also accepts `binary` if you want to pass a binary string\n  encoding: 'utf8',\n  // node.js Buffer, Uint8Array, forge ByteBuffer, binary string\n  privateKey: privateKey\n});\n// `signature` is a node.js Buffer or Uint8Array\n\n// sign a message passed as a buffer\nvar signature = ED25519.sign({\n  // also accepts a forge ByteBuffer or Uint8Array\n  message: Buffer.from('test', 'utf8'),\n  privateKey: privateKey\n});\n\n// sign a message digest (shorter \"message\" == better performance)\nvar md = forge.md.sha256.create();\nmd.update('test', 'utf8');\nvar signature = ED25519.sign({\n  md: md,\n  privateKey: privateKey\n});\n\n// verify a signature on a UTF-8 message\nvar verified = ED25519.verify({\n  message: 'test',\n  encoding: 'utf8',\n  // node.js Buffer, Uint8Array, forge ByteBuffer, or binary string\n  signature: signature,\n  // node.js Buffer, Uint8Array, forge ByteBuffer, or binary string\n  publicKey: publicKey\n});\n// `verified` is true/false\n\n// sign a message passed as a buffer\nvar verified = ED25519.verify({\n  // also accepts a forge ByteBuffer or Uint8Array\n  message: Buffer.from('test', 'utf8'),\n  // node.js Buffer, Uint8Array, forge ByteBuffer, or binary string\n  signature: signature,\n  // node.js Buffer, Uint8Array, forge ByteBuffer, or binary string\n  publicKey: publicKey\n});\n\n// verify a signature on a message digest\nvar md = forge.md.sha256.create();\nmd.update('test', 'utf8');\nvar verified = ED25519.verify({\n  md: md,\n  // node.js Buffer, Uint8Array, forge ByteBuffer, or binary string\n  signature: signature,\n  // node.js Buffer, Uint8Array, forge ByteBuffer, or binary string\n  publicKey: publicKey\n});\n```\n\n<a name=\"rsa\" />\n\n### RSA\n\n__Examples__\n\n```js\nvar rsa = forge.pki.rsa;\n\n// generate an RSA key pair synchronously\n// *NOT RECOMMENDED*: Can be significantly slower than async and may block\n// JavaScript execution. Will use native Node.js 10.12.0+ API if possible.\nvar keypair = rsa.generateKeyPair({bits: 2048, e: 0x10001});\n\n// generate an RSA key pair asynchronously (uses web workers if available)\n// use workers: -1 to run a fast core estimator to optimize # of workers\n// *RECOMMENDED*: Can be significantly faster than sync. Will use native\n// Node.js 10.12.0+ or WebCrypto API if possible.\nrsa.generateKeyPair({bits: 2048, workers: 2}, function(err, keypair) {\n  // keypair.privateKey, keypair.publicKey\n});\n\n// generate an RSA key pair in steps that attempt to run for a specified period\n// of time on the main JS thread\nvar state = rsa.createKeyPairGenerationState(2048, 0x10001);\nvar step = function() {\n  // run for 100 ms\n  if(!rsa.stepKeyPairGenerationState(state, 100)) {\n    setTimeout(step, 1);\n  }\n  else {\n    // done, turn off progress indicator, use state.keys\n  }\n};\n// turn on progress indicator, schedule generation to run\nsetTimeout(step);\n\n// sign data with a private key and output DigestInfo DER-encoded bytes\n// (defaults to RSASSA PKCS#1 v1.5)\nvar md = forge.md.sha1.create();\nmd.update('sign this', 'utf8');\nvar signature = privateKey.sign(md);\n\n// verify data with a public key\n// (defaults to RSASSA PKCS#1 v1.5)\nvar verified = publicKey.verify(md.digest().bytes(), signature);\n\n// sign data using RSASSA-PSS where PSS uses a SHA-1 hash, a SHA-1 based\n// masking function MGF1, and a 20 byte salt\nvar md = forge.md.sha1.create();\nmd.update('sign this', 'utf8');\nvar pss = forge.pss.create({\n  md: forge.md.sha1.create(),\n  mgf: forge.mgf.mgf1.create(forge.md.sha1.create()),\n  saltLength: 20\n  // optionally pass 'prng' with a custom PRNG implementation\n  // optionalls pass 'salt' with a forge.util.ByteBuffer w/custom salt\n});\nvar signature = privateKey.sign(md, pss);\n\n// verify RSASSA-PSS signature\nvar pss = forge.pss.create({\n  md: forge.md.sha1.create(),\n  mgf: forge.mgf.mgf1.create(forge.md.sha1.create()),\n  saltLength: 20\n  // optionally pass 'prng' with a custom PRNG implementation\n});\nvar md = forge.md.sha1.create();\nmd.update('sign this', 'utf8');\npublicKey.verify(md.digest().getBytes(), signature, pss);\n\n// encrypt data with a public key (defaults to RSAES PKCS#1 v1.5)\nvar encrypted = publicKey.encrypt(bytes);\n\n// decrypt data with a private key (defaults to RSAES PKCS#1 v1.5)\nvar decrypted = privateKey.decrypt(encrypted);\n\n// encrypt data with a public key using RSAES PKCS#1 v1.5\nvar encrypted = publicKey.encrypt(bytes, 'RSAES-PKCS1-V1_5');\n\n// decrypt data with a private key using RSAES PKCS#1 v1.5\nvar decrypted = privateKey.decrypt(encrypted, 'RSAES-PKCS1-V1_5');\n\n// encrypt data with a public key using RSAES-OAEP\nvar encrypted = publicKey.encrypt(bytes, 'RSA-OAEP');\n\n// decrypt data with a private key using RSAES-OAEP\nvar decrypted = privateKey.decrypt(encrypted, 'RSA-OAEP');\n\n// encrypt data with a public key using RSAES-OAEP/SHA-256\nvar encrypted = publicKey.encrypt(bytes, 'RSA-OAEP', {\n  md: forge.md.sha256.create()\n});\n\n// decrypt data with a private key using RSAES-OAEP/SHA-256\nvar decrypted = privateKey.decrypt(encrypted, 'RSA-OAEP', {\n  md: forge.md.sha256.create()\n});\n\n// encrypt data with a public key using RSAES-OAEP/SHA-256/MGF1-SHA-1\n// compatible with Java's RSA/ECB/OAEPWithSHA-256AndMGF1Padding\nvar encrypted = publicKey.encrypt(bytes, 'RSA-OAEP', {\n  md: forge.md.sha256.create(),\n  mgf1: {\n    md: forge.md.sha1.create()\n  }\n});\n\n// decrypt data with a private key using RSAES-OAEP/SHA-256/MGF1-SHA-1\n// compatible with Java's RSA/ECB/OAEPWithSHA-256AndMGF1Padding\nvar decrypted = privateKey.decrypt(encrypted, 'RSA-OAEP', {\n  md: forge.md.sha256.create(),\n  mgf1: {\n    md: forge.md.sha1.create()\n  }\n});\n\n```\n\n<a name=\"rsakem\" />\n\n### RSA-KEM\n\n__Examples__\n\n```js\n// generate an RSA key pair asynchronously (uses web workers if available)\n// use workers: -1 to run a fast core estimator to optimize # of workers\nforge.rsa.generateKeyPair({bits: 2048, workers: -1}, function(err, keypair) {\n  // keypair.privateKey, keypair.publicKey\n});\n\n// generate and encapsulate a 16-byte secret key\nvar kdf1 = new forge.kem.kdf1(forge.md.sha1.create());\nvar kem = forge.kem.rsa.create(kdf1);\nvar result = kem.encrypt(keypair.publicKey, 16);\n// result has 'encapsulation' and 'key'\n\n// encrypt some bytes\nvar iv = forge.random.getBytesSync(12);\nvar someBytes = 'hello world!';\nvar cipher = forge.cipher.createCipher('AES-GCM', result.key);\ncipher.start({iv: iv});\ncipher.update(forge.util.createBuffer(someBytes));\ncipher.finish();\nvar encrypted = cipher.output.getBytes();\nvar tag = cipher.mode.tag.getBytes();\n\n// send 'encrypted', 'iv', 'tag', and result.encapsulation to recipient\n\n// decrypt encapsulated 16-byte secret key\nvar kdf1 = new forge.kem.kdf1(forge.md.sha1.create());\nvar kem = forge.kem.rsa.create(kdf1);\nvar key = kem.decrypt(keypair.privateKey, result.encapsulation, 16);\n\n// decrypt some bytes\nvar decipher = forge.cipher.createDecipher('AES-GCM', key);\ndecipher.start({iv: iv, tag: tag});\ndecipher.update(forge.util.createBuffer(encrypted));\nvar pass = decipher.finish();\n// pass is false if there was a failure (eg: authentication tag didn't match)\nif(pass) {\n  // outputs 'hello world!'\n  console.log(decipher.output.getBytes());\n}\n\n```\n\n<a name=\"x509\" />\n\n### X.509\n\n__Examples__\n\n```js\nvar pki = forge.pki;\n\n// convert a PEM-formatted public key to a Forge public key\nvar publicKey = pki.publicKeyFromPem(pem);\n\n// convert a Forge public key to PEM-format\nvar pem = pki.publicKeyToPem(publicKey);\n\n// convert an ASN.1 SubjectPublicKeyInfo to a Forge public key\nvar publicKey = pki.publicKeyFromAsn1(subjectPublicKeyInfo);\n\n// convert a Forge public key to an ASN.1 SubjectPublicKeyInfo\nvar subjectPublicKeyInfo = pki.publicKeyToAsn1(publicKey);\n\n// gets a SHA-1 RSAPublicKey fingerprint a byte buffer\npki.getPublicKeyFingerprint(key);\n\n// gets a SHA-1 SubjectPublicKeyInfo fingerprint a byte buffer\npki.getPublicKeyFingerprint(key, {type: 'SubjectPublicKeyInfo'});\n\n// gets a hex-encoded, colon-delimited SHA-1 RSAPublicKey public key fingerprint\npki.getPublicKeyFingerprint(key, {encoding: 'hex', delimiter: ':'});\n\n// gets a hex-encoded, colon-delimited SHA-1 SubjectPublicKeyInfo public key fingerprint\npki.getPublicKeyFingerprint(key, {\n  type: 'SubjectPublicKeyInfo',\n  encoding: 'hex',\n  delimiter: ':'\n});\n\n// gets a hex-encoded, colon-delimited MD5 RSAPublicKey public key fingerprint\npki.getPublicKeyFingerprint(key, {\n  md: forge.md.md5.create(),\n  encoding: 'hex',\n  delimiter: ':'\n});\n\n// creates a CA store\nvar caStore = pki.createCaStore([/* PEM-encoded cert */, ...]);\n\n// add a certificate to the CA store\ncaStore.addCertificate(certObjectOrPemString);\n\n// gets the issuer (its certificate) for the given certificate\nvar issuerCert = caStore.getIssuer(subjectCert);\n\n// verifies a certificate chain against a CA store\npki.verifyCertificateChain(caStore, chain, customVerifyCallback);\n\n// signs a certificate using the given private key\ncert.sign(privateKey);\n\n// signs a certificate using SHA-256 instead of SHA-1\ncert.sign(privateKey, forge.md.sha256.create());\n\n// verifies an issued certificate using the certificates public key\nvar verified = issuer.verify(issued);\n\n// generate a keypair and create an X.509v3 certificate\nvar keys = pki.rsa.generateKeyPair(2048);\nvar cert = pki.createCertificate();\ncert.publicKey = keys.publicKey;\n// alternatively set public key from a csr\n//cert.publicKey = csr.publicKey;\n// NOTE: serialNumber is the hex encoded value of an ASN.1 INTEGER.\n// Conforming CAs should ensure serialNumber is:\n// - no more than 20 octets\n// - non-negative (prefix a '00' if your value starts with a '1' bit)\ncert.serialNumber = '01';\ncert.validity.notBefore = new Date();\ncert.validity.notAfter = new Date();\ncert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);\nvar attrs = [{\n  name: 'commonName',\n  value: 'example.org'\n}, {\n  name: 'countryName',\n  value: 'US'\n}, {\n  shortName: 'ST',\n  value: 'Virginia'\n}, {\n  name: 'localityName',\n  value: 'Blacksburg'\n}, {\n  name: 'organizationName',\n  value: 'Test'\n}, {\n  shortName: 'OU',\n  value: 'Test'\n}];\ncert.setSubject(attrs);\n// alternatively set subject from a csr\n//cert.setSubject(csr.subject.attributes);\ncert.setIssuer(attrs);\ncert.setExtensions([{\n  name: 'basicConstraints',\n  cA: true\n}, {\n  name: 'keyUsage',\n  keyCertSign: true,\n  digitalSignature: true,\n  nonRepudiation: true,\n  keyEncipherment: true,\n  dataEncipherment: true\n}, {\n  name: 'extKeyUsage',\n  serverAuth: true,\n  clientAuth: true,\n  codeSigning: true,\n  emailProtection: true,\n  timeStamping: true\n}, {\n  name: 'nsCertType',\n  client: true,\n  server: true,\n  email: true,\n  objsign: true,\n  sslCA: true,\n  emailCA: true,\n  objCA: true\n}, {\n  name: 'subjectAltName',\n  altNames: [{\n    type: 6, // URI\n    value: 'http://example.org/webid#me'\n  }, {\n    type: 7, // IP\n    ip: '127.0.0.1'\n  }]\n}, {\n  name: 'subjectKeyIdentifier'\n}]);\n/* alternatively set extensions from a csr\nvar extensions = csr.getAttribute({name: 'extensionRequest'}).extensions;\n// optionally add more extensions\nextensions.push.apply(extensions, [{\n  name: 'basicConstraints',\n  cA: true\n}, {\n  name: 'keyUsage',\n  keyCertSign: true,\n  digitalSignature: true,\n  nonRepudiation: true,\n  keyEncipherment: true,\n  dataEncipherment: true\n}]);\ncert.setExtensions(extensions);\n*/\n// self-sign certificate\ncert.sign(keys.privateKey);\n\n// convert a Forge certificate to PEM\nvar pem = pki.certificateToPem(cert);\n\n// convert a Forge certificate from PEM\nvar cert = pki.certificateFromPem(pem);\n\n// convert an ASN.1 X.509x3 object to a Forge certificate\nvar cert = pki.certificateFromAsn1(obj);\n\n// convert a Forge certificate to an ASN.1 X.509v3 object\nvar asn1Cert = pki.certificateToAsn1(cert);\n```\n\n<a name=\"pkcs5\" />\n\n### PKCS#5\n\nProvides the password-based key-derivation function from [PKCS#5][].\n\n__Examples__\n\n```js\n// generate a password-based 16-byte key\n// note an optional message digest can be passed as the final parameter\nvar salt = forge.random.getBytesSync(128);\nvar derivedKey = forge.pkcs5.pbkdf2('password', salt, numIterations, 16);\n\n// generate key asynchronously\n// note an optional message digest can be passed before the callback\nforge.pkcs5.pbkdf2('password', salt, numIterations, 16, function(err, derivedKey) {\n  // do something w/derivedKey\n});\n```\n\n<a name=\"pkcs7\" />\n\n### PKCS#7\n\nProvides cryptographically protected messages from [PKCS#7][].\n\n__Examples__\n\n```js\n// convert a message from PEM\nvar p7 = forge.pkcs7.messageFromPem(pem);\n// look at p7.recipients\n\n// find a recipient by the issuer of a certificate\nvar recipient = p7.findRecipient(cert);\n\n// decrypt\np7.decrypt(p7.recipients[0], privateKey);\n\n// create a p7 enveloped message\nvar p7 = forge.pkcs7.createEnvelopedData();\n\n// add a recipient\nvar cert = forge.pki.certificateFromPem(certPem);\np7.addRecipient(cert);\n\n// set content\np7.content = forge.util.createBuffer('Hello');\n\n// encrypt\np7.encrypt();\n\n// convert message to PEM\nvar pem = forge.pkcs7.messageToPem(p7);\n\n// create a degenerate PKCS#7 certificate container\n// (CRLs not currently supported, only certificates)\nvar p7 = forge.pkcs7.createSignedData();\np7.addCertificate(certOrCertPem1);\np7.addCertificate(certOrCertPem2);\nvar pem = forge.pkcs7.messageToPem(p7);\n\n// create PKCS#7 signed data with authenticatedAttributes\n// attributes include: PKCS#9 content-type, message-digest, and signing-time\nvar p7 = forge.pkcs7.createSignedData();\np7.content = forge.util.createBuffer('Some content to be signed.', 'utf8');\np7.addCertificate(certOrCertPem);\np7.addSigner({\n  key: privateKeyAssociatedWithCert,\n  certificate: certOrCertPem,\n  digestAlgorithm: forge.pki.oids.sha256,\n  authenticatedAttributes: [{\n    type: forge.pki.oids.contentType,\n    value: forge.pki.oids.data\n  }, {\n    type: forge.pki.oids.messageDigest\n    // value will be auto-populated at signing time\n  }, {\n    type: forge.pki.oids.signingTime,\n    // value can also be auto-populated at signing time\n    value: new Date()\n  }]\n});\np7.sign();\nvar pem = forge.pkcs7.messageToPem(p7);\n\n// PKCS#7 Sign in detached mode.\n// Includes the signature and certificate without the signed data.\np7.sign({detached: true});\n\n```\n\n<a name=\"pkcs8\" />\n\n### PKCS#8\n\n__Examples__\n\n```js\nvar pki = forge.pki;\n\n// convert a PEM-formatted private key to a Forge private key\nvar privateKey = pki.privateKeyFromPem(pem);\n\n// convert a Forge private key to PEM-format\nvar pem = pki.privateKeyToPem(privateKey);\n\n// convert an ASN.1 PrivateKeyInfo or RSAPrivateKey to a Forge private key\nvar privateKey = pki.privateKeyFromAsn1(rsaPrivateKey);\n\n// convert a Forge private key to an ASN.1 RSAPrivateKey\nvar rsaPrivateKey = pki.privateKeyToAsn1(privateKey);\n\n// wrap an RSAPrivateKey ASN.1 object in a PKCS#8 ASN.1 PrivateKeyInfo\nvar privateKeyInfo = pki.wrapRsaPrivateKey(rsaPrivateKey);\n\n// convert a PKCS#8 ASN.1 PrivateKeyInfo to PEM\nvar pem = pki.privateKeyInfoToPem(privateKeyInfo);\n\n// encrypts a PrivateKeyInfo using a custom password and\n// outputs an EncryptedPrivateKeyInfo\nvar encryptedPrivateKeyInfo = pki.encryptPrivateKeyInfo(\n  privateKeyInfo, 'myCustomPasswordHere', {\n    algorithm: 'aes256', // 'aes128', 'aes192', 'aes256', '3des'\n  });\n\n// decrypts an ASN.1 EncryptedPrivateKeyInfo that was encrypted\n// with a custom password\nvar privateKeyInfo = pki.decryptPrivateKeyInfo(\n  encryptedPrivateKeyInfo, 'myCustomPasswordHere');\n\n// converts an EncryptedPrivateKeyInfo to PEM\nvar pem = pki.encryptedPrivateKeyToPem(encryptedPrivateKeyInfo);\n\n// converts a PEM-encoded EncryptedPrivateKeyInfo to ASN.1 format\nvar encryptedPrivateKeyInfo = pki.encryptedPrivateKeyFromPem(pem);\n\n// wraps and encrypts a Forge private key and outputs it in PEM format\nvar pem = pki.encryptRsaPrivateKey(privateKey, 'password');\n\n// encrypts a Forge private key and outputs it in PEM format using OpenSSL's\n// proprietary legacy format + encapsulated PEM headers (DEK-Info)\nvar pem = pki.encryptRsaPrivateKey(privateKey, 'password', {legacy: true});\n\n// decrypts a PEM-formatted, encrypted private key\nvar privateKey = pki.decryptRsaPrivateKey(pem, 'password');\n\n// sets an RSA public key from a private key\nvar publicKey = pki.setRsaPublicKey(privateKey.n, privateKey.e);\n```\n\n<a name=\"pkcs10\" />\n\n### PKCS#10\n\nProvides certification requests or certificate signing requests (CSR) from\n[PKCS#10][].\n\n__Examples__\n\n```js\n// generate a key pair\nvar keys = forge.pki.rsa.generateKeyPair(1024);\n\n// create a certification request (CSR)\nvar csr = forge.pki.createCertificationRequest();\ncsr.publicKey = keys.publicKey;\ncsr.setSubject([{\n  name: 'commonName',\n  value: 'example.org'\n}, {\n  name: 'countryName',\n  value: 'US'\n}, {\n  shortName: 'ST',\n  value: 'Virginia'\n}, {\n  name: 'localityName',\n  value: 'Blacksburg'\n}, {\n  name: 'organizationName',\n  value: 'Test'\n}, {\n  shortName: 'OU',\n  value: 'Test'\n}]);\n// set (optional) attributes\ncsr.setAttributes([{\n  name: 'challengePassword',\n  value: 'password'\n}, {\n  name: 'unstructuredName',\n  value: 'My Company, Inc.'\n}, {\n  name: 'extensionRequest',\n  extensions: [{\n    name: 'subjectAltName',\n    altNames: [{\n      // 2 is DNS type\n      type: 2,\n      value: 'test.domain.com'\n    }, {\n      type: 2,\n      value: 'other.domain.com',\n    }, {\n      type: 2,\n      value: 'www.domain.net'\n    }]\n  }]\n}]);\n\n// sign certification request\ncsr.sign(keys.privateKey);\n\n// verify certification request\nvar verified = csr.verify();\n\n// convert certification request to PEM-format\nvar pem = forge.pki.certificationRequestToPem(csr);\n\n// convert a Forge certification request from PEM-format\nvar csr = forge.pki.certificationRequestFromPem(pem);\n\n// get an attribute\ncsr.getAttribute({name: 'challengePassword'});\n\n// get extensions array\ncsr.getAttribute({name: 'extensionRequest'}).extensions;\n\n```\n\n<a name=\"pkcs12\" />\n\n### PKCS#12\n\nProvides the cryptographic archive file format from [PKCS#12][].\n\n**Note for Chrome/Firefox/iOS/similar users**: If you have trouble importing\na PKCS#12 container, try using the TripleDES algorithm. It can be passed\nto `forge.pkcs12.toPkcs12Asn1` using the `{algorithm: '3des'}` option.\n\n__Examples__\n\n```js\n// decode p12 from base64\nvar p12Der = forge.util.decode64(p12b64);\n// get p12 as ASN.1 object\nvar p12Asn1 = forge.asn1.fromDer(p12Der);\n// decrypt p12 using the password 'password'\nvar p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, 'password');\n// decrypt p12 using non-strict parsing mode (resolves some ASN.1 parse errors)\nvar p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, false, 'password');\n// decrypt p12 using literally no password (eg: Mac OS X/apple push)\nvar p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1);\n// decrypt p12 using an \"empty\" password (eg: OpenSSL with no password input)\nvar p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, '');\n// p12.safeContents is an array of safe contents, each of\n// which contains an array of safeBags\n\n// get bags by friendlyName\nvar bags = p12.getBags({friendlyName: 'test'});\n// bags are key'd by attribute type (here \"friendlyName\")\n// and the key values are an array of matching objects\nvar cert = bags.friendlyName[0];\n\n// get bags by localKeyId\nvar bags = p12.getBags({localKeyId: buffer});\n// bags are key'd by attribute type (here \"localKeyId\")\n// and the key values are an array of matching objects\nvar cert = bags.localKeyId[0];\n\n// get bags by localKeyId (input in hex)\nvar bags = p12.getBags({localKeyIdHex: '7b59377ff142d0be4565e9ac3d396c01401cd879'});\n// bags are key'd by attribute type (here \"localKeyId\", *not* \"localKeyIdHex\")\n// and the key values are an array of matching objects\nvar cert = bags.localKeyId[0];\n\n// get bags by type\nvar bags = p12.getBags({bagType: forge.pki.oids.certBag});\n// bags are key'd by bagType and each bagType key's value\n// is an array of matches (in this case, certificate objects)\nvar cert = bags[forge.pki.oids.certBag][0];\n\n// get bags by friendlyName and filter on bag type\nvar bags = p12.getBags({\n  friendlyName: 'test',\n  bagType: forge.pki.oids.certBag\n});\n\n// get key bags\nvar bags = p12.getBags({bagType: forge.pki.oids.keyBag});\n// get key\nvar bag = bags[forge.pki.oids.keyBag][0];\nvar key = bag.key;\n// if the key is in a format unrecognized by forge then\n// bag.key will be `null`, use bag.asn1 to get the ASN.1\n// representation of the key\nif(bag.key === null) {\n  var keyAsn1 = bag.asn1;\n  // can now convert back to DER/PEM/etc for export\n}\n\n// generate a p12 using AES (default)\nvar p12Asn1 = forge.pkcs12.toPkcs12Asn1(\n  privateKey, certificateChain, 'password');\n\n// generate a p12 that can be imported by Chrome/Firefox/iOS\n// (requires the use of Triple DES instead of AES)\nvar p12Asn1 = forge.pkcs12.toPkcs12Asn1(\n  privateKey, certificateChain, 'password',\n  {algorithm: '3des'});\n\n// base64-encode p12\nvar p12Der = forge.asn1.toDer(p12Asn1).getBytes();\nvar p12b64 = forge.util.encode64(p12Der);\n\n// create download link for p12\nvar a = document.createElement('a');\na.download = 'example.p12';\na.setAttribute('href', 'data:application/x-pkcs12;base64,' + p12b64);\na.appendChild(document.createTextNode('Download'));\n```\n\n<a name=\"asn\" />\n\n### ASN.1\n\nProvides [ASN.1][] DER encoding and decoding.\n\n__Examples__\n\n```js\nvar asn1 = forge.asn1;\n\n// create a SubjectPublicKeyInfo\nvar subjectPublicKeyInfo =\n  asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [\n    // AlgorithmIdentifier\n    asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [\n      // algorithm\n      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.OID, false,\n        asn1.oidToDer(pki.oids['rsaEncryption']).getBytes()),\n      // parameters (null)\n      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.NULL, false, '')\n    ]),\n    // subjectPublicKey\n    asn1.create(asn1.Class.UNIVERSAL, asn1.Type.BITSTRING, false, [\n      // RSAPublicKey\n      asn1.create(asn1.Class.UNIVERSAL, asn1.Type.SEQUENCE, true, [\n        // modulus (n)\n        asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,\n          _bnToBytes(key.n)),\n        // publicExponent (e)\n        asn1.create(asn1.Class.UNIVERSAL, asn1.Type.INTEGER, false,\n          _bnToBytes(key.e))\n      ])\n    ])\n  ]);\n\n// serialize an ASN.1 object to DER format\nvar derBuffer = asn1.toDer(subjectPublicKeyInfo);\n\n// deserialize to an ASN.1 object from a byte buffer filled with DER data\nvar object = asn1.fromDer(derBuffer);\n\n// convert an OID dot-separated string to a byte buffer\nvar derOidBuffer = asn1.oidToDer('1.2.840.113549.1.1.5');\n\n// convert a byte buffer with a DER-encoded OID to a dot-separated string\nconsole.log(asn1.derToOid(derOidBuffer));\n// output: 1.2.840.113549.1.1.5\n\n// validates that an ASN.1 object matches a particular ASN.1 structure and\n// captures data of interest from that structure for easy access\nvar publicKeyValidator = {\n  name: 'SubjectPublicKeyInfo',\n  tagClass: asn1.Class.UNIVERSAL,\n  type: asn1.Type.SEQUENCE,\n  constructed: true,\n  captureAsn1: 'subjectPublicKeyInfo',\n  value: [{\n    name: 'SubjectPublicKeyInfo.AlgorithmIdentifier',\n    tagClass: asn1.Class.UNIVERSAL,\n    type: asn1.Type.SEQUENCE,\n    constructed: true,\n    value: [{\n      name: 'AlgorithmIdentifier.algorithm',\n      tagClass: asn1.Class.UNIVERSAL,\n      type: asn1.Type.OID,\n      constructed: false,\n      capture: 'publicKeyOid'\n    }]\n  }, {\n    // subjectPublicKey\n    name: 'SubjectPublicKeyInfo.subjectPublicKey',\n    tagClass: asn1.Class.UNIVERSAL,\n    type: asn1.Type.BITSTRING,\n    constructed: false,\n    value: [{\n      // RSAPublicKey\n      name: 'SubjectPublicKeyInfo.subjectPublicKey.RSAPublicKey',\n      tagClass: asn1.Class.UNIVERSAL,\n      type: asn1.Type.SEQUENCE,\n      constructed: true,\n      optional: true,\n      captureAsn1: 'rsaPublicKey'\n    }]\n  }]\n};\n\nvar capture = {};\nvar errors = [];\nif(!asn1.validate(\n  publicKeyValidator, subjectPublicKeyInfo, validator, capture, errors)) {\n  throw 'ASN.1 object is not a SubjectPublicKeyInfo.';\n}\n// capture.subjectPublicKeyInfo contains the full ASN.1 object\n// capture.rsaPublicKey contains the full ASN.1 object for the RSA public key\n// capture.publicKeyOid only contains the value for the OID\nvar oid = asn1.derToOid(capture.publicKeyOid);\nif(oid !== pki.oids['rsaEncryption']) {\n  throw 'Unsupported OID.';\n}\n\n// pretty print an ASN.1 object to a string for debugging purposes\nasn1.prettyPrint(object);\n```\n\nMessage Digests\n----------------\n\n<a name=\"sha1\" />\n\n### SHA1\n\nProvides [SHA-1][] message digests.\n\n__Examples__\n\n```js\nvar md = forge.md.sha1.create();\nmd.update('The quick brown fox jumps over the lazy dog');\nconsole.log(md.digest().toHex());\n// output: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12\n```\n\n<a name=\"sha256\" />\n\n### SHA256\n\nProvides [SHA-256][] message digests.\n\n__Examples__\n\n```js\nvar md = forge.md.sha256.create();\nmd.update('The quick brown fox jumps over the lazy dog');\nconsole.log(md.digest().toHex());\n// output: d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592\n```\n\n<a name=\"sha384\" />\n\n### SHA384\n\nProvides [SHA-384][] message digests.\n\n__Examples__\n\n```js\nvar md = forge.md.sha384.create();\nmd.update('The quick brown fox jumps over the lazy dog');\nconsole.log(md.digest().toHex());\n// output: ca737f1014a48f4c0b6dd43cb177b0afd9e5169367544c494011e3317dbf9a509cb1e5dc1e85a941bbee3d7f2afbc9b1\n```\n\n<a name=\"sha512\" />\n\n### SHA512\n\nProvides [SHA-512][] message digests.\n\n__Examples__\n\n```js\n// SHA-512\nvar md = forge.md.sha512.create();\nmd.update('The quick brown fox jumps over the lazy dog');\nconsole.log(md.digest().toHex());\n// output: 07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6\n\n// SHA-512/224\nvar md = forge.md.sha512.sha224.create();\nmd.update('The quick brown fox jumps over the lazy dog');\nconsole.log(md.digest().toHex());\n// output: 944cd2847fb54558d4775db0485a50003111c8e5daa63fe722c6aa37\n\n// SHA-512/256\nvar md = forge.md.sha512.sha256.create();\nmd.update('The quick brown fox jumps over the lazy dog');\nconsole.log(md.digest().toHex());\n// output: dd9d67b371519c339ed8dbd25af90e976a1eeefd4ad3d889005e532fc5bef04d\n```\n\n<a name=\"md5\" />\n\n### MD5\n\nProvides [MD5][] message digests.\n\n__Examples__\n\n```js\nvar md = forge.md.md5.create();\nmd.update('The quick brown fox jumps over the lazy dog');\nconsole.log(md.digest().toHex());\n// output: 9e107d9d372bb6826bd81d3542a419d6\n```\n\n<a name=\"hmac\" />\n\n### HMAC\n\nProvides [HMAC][] w/any supported message digest algorithm.\n\n__Examples__\n\n```js\nvar hmac = forge.hmac.create();\nhmac.start('sha1', 'Jefe');\nhmac.update('what do ya want for nothing?');\nconsole.log(hmac.digest().toHex());\n// output: effcdf6ae5eb2fa2d27416d5f184df9c259a7c79\n```\n\nUtilities\n---------\n\n<a name=\"prime\" />\n\n### Prime\n\nProvides an API for generating large, random, probable primes.\n\n__Examples__\n\n```js\n// generate a random prime on the main JS thread\nvar bits = 1024;\nforge.prime.generateProbablePrime(bits, function(err, num) {\n  console.log('random prime', num.toString(16));\n});\n\n// generate a random prime using Web Workers (if available, otherwise\n// falls back to the main thread)\nvar bits = 1024;\nvar options = {\n  algorithm: {\n    name: 'PRIMEINC',\n    workers: -1 // auto-optimize # of workers\n  }\n};\nforge.prime.generateProbablePrime(bits, options, function(err, num) {\n  console.log('random prime', num.toString(16));\n});\n```\n\n<a name=\"prng\" />\n\n### PRNG\n\nProvides a [Fortuna][]-based cryptographically-secure pseudo-random number\ngenerator, to be used with a cryptographic function backend, e.g. [AES][]. An\nimplementation using [AES][] as a backend is provided. An API for collecting\nentropy is given, though if window.crypto.getRandomValues is available, it will\nbe used automatically.\n\n__Examples__\n\n```js\n// get some random bytes synchronously\nvar bytes = forge.random.getBytesSync(32);\nconsole.log(forge.util.bytesToHex(bytes));\n\n// get some random bytes asynchronously\nforge.random.getBytes(32, function(err, bytes) {\n  console.log(forge.util.bytesToHex(bytes));\n});\n\n// collect some entropy if you'd like\nforge.random.collect(someRandomBytes);\njQuery().mousemove(function(e) {\n  forge.random.collectInt(e.clientX, 16);\n  forge.random.collectInt(e.clientY, 16);\n});\n\n// specify a seed file for use with the synchronous API if you'd like\nforge.random.seedFileSync = function(needed) {\n  // get 'needed' number of random bytes from somewhere\n  return fetchedRandomBytes;\n};\n\n// specify a seed file for use with the asynchronous API if you'd like\nforge.random.seedFile = function(needed, callback) {\n  // get the 'needed' number of random bytes from somewhere\n  callback(null, fetchedRandomBytes);\n});\n\n// register the main thread to send entropy or a Web Worker to receive\n// entropy on demand from the main thread\nforge.random.registerWorker(self);\n\n// generate a new instance of a PRNG with no collected entropy\nvar myPrng = forge.random.createInstance();\n```\n\n<a name=\"task\" />\n\n### Tasks\n\nProvides queuing and synchronizing tasks in a web application.\n\n__Examples__\n\n```js\n// TODO\n```\n\n<a name=\"util\" />\n\n### Utilities\n\nProvides utility functions, including byte buffer support, base64,\nbytes to/from hex, zlib inflate/deflate, etc.\n\n__Examples__\n\n```js\n// encode/decode base64\nvar encoded = forge.util.encode64(str);\nvar str = forge.util.decode64(encoded);\n\n// encode/decode UTF-8\nvar encoded = forge.util.encodeUtf8(str);\nvar str = forge.util.decodeUtf8(encoded);\n\n// bytes to/from hex\nvar bytes = forge.util.hexToBytes(hex);\nvar hex = forge.util.bytesToHex(bytes);\n\n// create an empty byte buffer\nvar buffer = forge.util.createBuffer();\n// create a byte buffer from raw binary bytes\nvar buffer = forge.util.createBuffer(input, 'raw');\n// create a byte buffer from utf8 bytes\nvar buffer = forge.util.createBuffer(input, 'utf8');\n\n// get the length of the buffer in bytes\nbuffer.length();\n// put bytes into the buffer\nbuffer.putBytes(bytes);\n// put a 32-bit integer into the buffer\nbuffer.putInt32(10);\n// buffer to hex\nbuffer.toHex();\n// get a copy of the bytes in the buffer\nbytes.bytes(/* count */);\n// empty this buffer and get its contents\nbytes.getBytes(/* count */);\n\n// convert a forge buffer into a Node.js Buffer\n// make sure you specify the encoding as 'binary'\nvar forgeBuffer = forge.util.createBuffer();\nvar nodeBuffer = Buffer.from(forgeBuffer.getBytes(), 'binary');\n\n// convert a Node.js Buffer into a forge buffer\n// make sure you specify the encoding as 'binary'\nvar nodeBuffer = Buffer.from('CAFE', 'hex');\nvar forgeBuffer = forge.util.createBuffer(nodeBuffer.toString('binary'));\n\n// parse a URL\nvar parsed = forge.util.parseUrl('http://example.com/foo?bar=baz');\n// parsed.scheme, parsed.host, parsed.port, parsed.path, parsed.fullHost\n```\n\n<a name=\"log\" />\n\n### Logging\n\nProvides logging to a javascript console using various categories and\nlevels of verbosity.\n\n__Examples__\n\n```js\n// TODO\n```\n\n<a name=\"debug\" />\n\n### Debugging\n\nProvides storage of debugging information normally inaccessible in\nclosures for viewing/investigation.\n\n__Examples__\n\n```js\n// TODO\n```\n\n<a name=\"flash\" />\n\n### Flash Networking Support\n\nThe [flash README](./flash/README.md) provides details on rebuilding the\noptional Flash component used for networking. It also provides details on\nPolicy Server support.\n\nSecurity Considerations\n-----------------------\n\nWhen using this code please keep the following in mind:\n\n- Cryptography is hard. Please review and test this code before depending on it\n  for critical functionality.\n- The nature of JavaScript is that execution of this code depends on trusting a\n  very large set of JavaScript tools and systems. Consider runtime variations,\n  runtime characteristics, runtime optimization, code optimization, code\n  minimization, code obfuscation, bundling tools, possible bugs, the Forge code\n  itself, and so on.\n- If using pre-built bundles from [Bower][] or similar be aware someone else\n  ran the tools to create those files.\n- Use a secure transport channel such as [TLS][] to load scripts and consider\n  using additional security mechanisms such as [Subresource Integrity][] script\n  attributes.\n- Use \"native\" functionality where possible. This can be critical when dealing\n  with performance and random number generation. Note that the JavaScript\n  random number algorithms should perform well if given suitable entropy.\n- Understand possible attacks against cryptographic systems. For instance side\n  channel and timing attacks may be possible due to the difficulty in\n  implementing constant time algorithms in pure JavaScript.\n- Certain features in this library are less susceptible to attacks depending on\n  usage. This primarily includes features that deal with data format\n  manipulation or those that are not involved in communication.\n\nLibrary Background\n------------------\n\n* https://digitalbazaar.com/2010/07/20/javascript-tls-1/\n* https://digitalbazaar.com/2010/07/20/javascript-tls-2/\n\nContact\n-------\n\n* Code: https://github.com/digitalbazaar/forge\n* Bugs: https://github.com/digitalbazaar/forge/issues\n* Email: support@digitalbazaar.com\n* IRC: [#forgejs][] on [freenode][]\n\nDonations\n---------\n\nFinancial support is welcome and helps contribute to futher development:\n\n* For [PayPal][] please send to paypal@digitalbazaar.com.\n* Something else? Please contact support@digitalbazaar.com.\n\n[#forgejs]: https://webchat.freenode.net/?channels=#forgejs\n[0.6.x]: https://github.com/digitalbazaar/forge/tree/0.6.x\n[3DES]: https://en.wikipedia.org/wiki/Triple_DES\n[AES]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard\n[ASN.1]: https://en.wikipedia.org/wiki/ASN.1\n[Bower]: https://bower.io/\n[Browserify]: http://browserify.org/\n[CBC]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation\n[CFB]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation\n[CTR]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation\n[CommonJS]: https://en.wikipedia.org/wiki/CommonJS\n[DES]: https://en.wikipedia.org/wiki/Data_Encryption_Standard\n[ECB]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation\n[Fortuna]: https://en.wikipedia.org/wiki/Fortuna_(PRNG)\n[GCM]: https://en.wikipedia.org/wiki/GCM_mode\n[HMAC]: https://en.wikipedia.org/wiki/HMAC\n[JavaScript]: https://en.wikipedia.org/wiki/JavaScript\n[Karma]: https://karma-runner.github.io/\n[MD5]: https://en.wikipedia.org/wiki/MD5\n[Node.js]: https://nodejs.org/\n[OFB]: https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation\n[PKCS#10]: https://en.wikipedia.org/wiki/Certificate_signing_request\n[PKCS#12]: https://en.wikipedia.org/wiki/PKCS_%E2%99%AF12\n[PKCS#5]: https://en.wikipedia.org/wiki/PKCS\n[PKCS#7]: https://en.wikipedia.org/wiki/Cryptographic_Message_Syntax\n[PayPal]: https://www.paypal.com/\n[RC2]: https://en.wikipedia.org/wiki/RC2\n[SHA-1]: https://en.wikipedia.org/wiki/SHA-1\n[SHA-256]: https://en.wikipedia.org/wiki/SHA-256\n[SHA-384]: https://en.wikipedia.org/wiki/SHA-384\n[SHA-512]: https://en.wikipedia.org/wiki/SHA-512\n[Subresource Integrity]: https://www.w3.org/TR/SRI/\n[TLS]: https://en.wikipedia.org/wiki/Transport_Layer_Security\n[UMD]: https://github.com/umdjs/umd\n[X.509]: https://en.wikipedia.org/wiki/X.509\n[freenode]: https://freenode.net/\n[unpkg]: https://unpkg.com/\n[webpack]: https://webpack.github.io/\n[TweetNaCl.js]: https://github.com/dchest/tweetnacl-js\n",
+  "maintainers": [
+    {
+      "name": "davidlehn",
+      "email": "dil@lehn.org"
+    },
+    {
+      "name": "dlongley",
+      "email": "dlongley@digitalbazaar.com"
+    },
+    {
+      "name": "msporny",
+      "email": "msporny@digitalbazaar.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-09-02T02:07:00.558Z",
+    "created": "2013-06-19T17:20:36.004Z",
+    "0.1.2": "2013-06-19T17:20:37.534Z",
+    "0.1.3-dev": "2013-06-24T19:57:36.482Z",
+    "0.1.3": "2013-06-24T20:31:14.220Z",
+    "0.1.4": "2013-06-26T20:17:24.622Z",
+    "0.1.5": "2013-07-23T19:40:58.216Z",
+    "0.1.6": "2013-07-29T16:10:41.320Z",
+    "0.1.7": "2013-07-30T03:32:00.067Z",
+    "0.1.8": "2013-07-30T04:47:38.433Z",
+    "0.1.9": "2013-07-30T15:27:10.279Z",
+    "0.1.10": "2013-07-30T21:11:10.167Z",
+    "0.1.11": "2013-08-01T04:43:56.185Z",
+    "0.1.12": "2013-08-01T18:05:26.464Z",
+    "0.1.13": "2013-08-02T02:49:23.586Z",
+    "0.1.14": "2013-08-02T03:41:38.897Z",
+    "0.1.15": "2013-08-06T05:19:31.752Z",
+    "0.2.0": "2013-08-14T19:50:15.868Z",
+    "0.2.1": "2013-08-15T21:08:04.623Z",
+    "0.2.2": "2013-08-16T01:26:36.650Z",
+    "0.2.3": "2013-08-17T00:56:02.065Z",
+    "0.2.4": "2013-08-19T16:09:37.841Z",
+    "0.2.5": "2013-09-13T01:10:10.077Z",
+    "0.2.6": "2013-09-15T18:41:11.958Z",
+    "0.2.7": "2013-09-18T18:06:51.801Z",
+    "0.2.8": "2013-09-19T17:16:51.784Z",
+    "0.2.9": "2013-09-19T17:59:06.196Z",
+    "0.2.10": "2013-09-19T18:06:45.826Z",
+    "0.2.11": "2013-09-20T16:35:14.846Z",
+    "0.2.12": "2013-09-25T17:12:15.456Z",
+    "0.2.13": "2013-09-28T02:02:12.285Z",
+    "0.2.14": "2013-09-28T19:05:04.715Z",
+    "0.2.15": "2013-10-16T00:46:44.189Z",
+    "0.2.17": "2013-10-23T14:46:08.348Z",
+    "0.2.18": "2013-11-15T19:03:38.490Z",
+    "0.2.19": "2013-11-27T16:49:06.053Z",
+    "0.2.20": "2013-11-30T02:58:31.932Z",
+    "0.2.21": "2013-12-02T16:51:06.106Z",
+    "0.2.22": "2013-12-11T02:11:04.171Z",
+    "0.2.23": "2014-01-08T17:33:20.480Z",
+    "0.2.24": "2014-01-15T18:30:06.407Z",
+    "0.2.25": "2014-01-15T18:54:27.739Z",
+    "0.2.26": "2014-01-15T22:47:07.848Z",
+    "0.2.27": "2014-01-22T02:42:10.823Z",
+    "0.2.28": "2014-01-29T02:34:14.065Z",
+    "0.2.29": "2014-02-05T16:12:15.221Z",
+    "0.2.30": "2014-02-16T22:11:28.390Z",
+    "0.2.31": "2014-03-10T14:00:34.135Z",
+    "0.2.32": "2014-03-19T01:37:46.528Z",
+    "0.2.33": "2014-03-20T01:59:21.607Z",
+    "0.2.34": "2014-03-21T18:09:06.487Z",
+    "0.2.35": "2014-03-27T01:10:30.715Z",
+    "0.2.36": "2014-04-03T15:39:06.688Z",
+    "0.2.37": "2014-04-12T01:40:25.925Z",
+    "0.3.0": "2014-05-13T17:19:20.729Z",
+    "0.4.1-dev": "2014-05-16T20:54:26.398Z",
+    "0.4.1": "2014-05-16T22:53:53.773Z",
+    "0.4.2": "2014-05-16T23:02:24.510Z",
+    "0.4.3": "2014-05-16T23:53:45.078Z",
+    "0.5.1": "2014-05-21T05:28:18.904Z",
+    "0.5.2": "2014-05-21T14:47:59.173Z",
+    "0.5.3": "2014-05-21T19:53:49.076Z",
+    "0.5.4": "2014-05-26T18:50:48.459Z",
+    "0.5.5": "2014-05-27T16:29:32.396Z",
+    "0.6.0": "2014-06-09T16:27:48.649Z",
+    "0.6.1": "2014-06-09T18:39:11.607Z",
+    "0.6.2": "2014-06-09T23:35:05.035Z",
+    "0.6.3": "2014-06-10T15:41:38.703Z",
+    "0.6.4": "2014-06-10T15:49:24.317Z",
+    "0.6.5": "2014-06-11T21:52:39.136Z",
+    "0.6.6": "2014-06-12T01:59:27.638Z",
+    "0.6.7": "2014-06-16T14:53:59.305Z",
+    "0.6.8": "2014-06-23T02:45:41.175Z",
+    "0.6.9": "2014-07-03T15:21:19.973Z",
+    "0.6.10": "2014-07-07T15:29:18.488Z",
+    "0.6.11": "2014-07-08T19:55:57.666Z",
+    "0.6.12": "2014-07-21T20:25:08.423Z",
+    "0.6.13": "2014-09-26T16:42:43.346Z",
+    "0.6.14": "2014-09-26T19:20:05.666Z",
+    "0.6.16": "2014-10-24T16:21:12.452Z",
+    "0.6.18": "2014-11-12T02:05:36.284Z",
+    "0.6.19": "2014-12-01T17:34:43.285Z",
+    "0.6.20": "2014-12-01T19:42:31.476Z",
+    "0.6.21": "2015-03-09T14:52:42.694Z",
+    "0.6.22": "2015-04-02T21:59:31.346Z",
+    "0.6.23": "2015-04-08T02:01:49.004Z",
+    "0.6.24": "2015-04-15T20:17:10.990Z",
+    "0.6.25": "2015-04-16T14:57:42.929Z",
+    "0.6.26": "2015-04-23T14:53:22.110Z",
+    "0.6.27": "2015-05-18T21:25:30.126Z",
+    "0.6.28": "2015-05-19T18:45:05.010Z",
+    "0.6.29": "2015-05-20T02:51:21.071Z",
+    "0.6.30": "2015-05-27T17:23:01.533Z",
+    "0.6.31": "2015-06-24T14:16:22.921Z",
+    "0.6.32": "2015-06-25T02:58:51.917Z",
+    "0.6.33": "2015-06-26T00:00:26.040Z",
+    "0.6.34": "2015-06-30T20:59:51.595Z",
+    "0.6.35": "2015-09-26T14:46:19.481Z",
+    "0.6.37": "2015-10-23T04:50:52.586Z",
+    "0.6.38": "2015-11-10T18:08:42.478Z",
+    "0.6.39": "2016-02-12T15:02:00.672Z",
+    "0.6.40": "2016-06-28T17:33:27.208Z",
+    "0.6.41": "2016-07-15T15:13:13.370Z",
+    "0.6.42": "2016-08-04T15:33:06.558Z",
+    "0.6.43": "2016-10-07T15:26:46.982Z",
+    "0.6.44": "2016-10-18T15:16:43.200Z",
+    "0.6.45": "2016-10-29T17:49:38.914Z",
+    "0.6.46": "2016-12-07T18:15:15.865Z",
+    "0.6.47": "2017-01-14T03:29:01.866Z",
+    "0.6.48": "2017-01-25T01:15:19.205Z",
+    "0.6.49": "2017-02-07T02:59:37.748Z",
+    "0.7.0": "2017-02-07T22:37:08.261Z",
+    "0.7.1": "2017-03-27T21:52:26.323Z",
+    "0.7.2": "2018-02-27T18:49:33.210Z",
+    "0.7.3": "2018-03-05T22:49:32.451Z",
+    "0.7.4": "2018-03-07T19:59:46.832Z",
+    "0.7.5": "2018-03-31T00:24:46.810Z",
+    "0.7.6": "2018-08-14T21:19:42.799Z",
+    "0.8.0": "2019-02-01T03:48:36.968Z",
+    "0.8.1": "2019-02-23T21:43:38.214Z",
+    "0.8.2": "2019-03-18T21:35:30.096Z",
+    "0.8.3": "2019-05-15T19:40:23.429Z",
+    "0.8.4": "2019-05-22T20:29:16.685Z",
+    "0.8.5": "2019-06-19T01:12:37.260Z",
+    "0.9.0": "2019-09-05T02:36:23.139Z",
+    "0.9.1": "2019-09-26T19:04:12.148Z",
+    "0.9.2": "2020-09-02T01:22:07.505Z",
+    "0.10.0": "2020-09-02T02:06:56.960Z"
+  },
+  "author": {
+    "name": "Digital Bazaar, Inc.",
+    "email": "support@digitalbazaar.com",
+    "url": "http://digitalbazaar.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/digitalbazaar/forge.git"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/digitalbazaar/forge",
+  "keywords": [
+    "aes",
+    "asn",
+    "asn.1",
+    "cbc",
+    "crypto",
+    "cryptography",
+    "csr",
+    "des",
+    "gcm",
+    "hmac",
+    "http",
+    "https",
+    "md5",
+    "network",
+    "pkcs",
+    "pki",
+    "prng",
+    "rc2",
+    "rsa",
+    "sha1",
+    "sha256",
+    "sha384",
+    "sha512",
+    "ssh",
+    "tls",
+    "x.509",
+    "x509"
+  ],
+  "contributors": [
+    {
+      "name": "Dave Longley",
+      "email": "dlongley@digitalbazaar.com"
+    },
+    {
+      "name": "David I. Lehn",
+      "email": "dlehn@digitalbazaar.com"
+    },
+    {
+      "name": "Stefan Siegl",
+      "email": "stesie@brokenpipe.de"
+    },
+    {
+      "name": "Christoph Dorn",
+      "email": "christoph@christophdorn.com"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/digitalbazaar/forge/issues",
+    "email": "support@digitalbazaar.com"
+  },
+  "users": {
+    "heckj": true,
+    "evgenus": true,
+    "joshperry": true,
+    "mhfrantz": true,
+    "detj": true,
+    "lichenhao": true,
+    "matthewfincher": true,
+    "alnyli07": true,
+    "linuxwizard": true,
+    "patoi": true,
+    "gfilip": true,
+    "figroc": true,
+    "sqrtthree": true,
+    "vtocco": true,
+    "shanewholloway": true,
+    "olamedia": true,
+    "starfox64": true,
+    "ph4r05": true,
+    "jankeromnes": true,
+    "manikantag": true,
+    "lucifier129": true,
+    "daizch": true,
+    "sopepos": true,
+    "tsxuehu": true,
+    "may": true,
+    "hgonlywj": true,
+    "akamaozu": true,
+    "aquafadas": true,
+    "janx": true,
+    "bouchezb": true,
+    "cr8tiv": true,
+    "josudoey": true,
+    "stovmascript": true,
+    "knksmith57": true,
+    "vjenks": true,
+    "aditya_1806": true
+  },
+  "license": "(BSD-3-Clause OR GPL-2.0)"
+}

--- a/test/fixtures/registry-mocks/content/node-forge.min.json
+++ b/test/fixtures/registry-mocks/content/node-forge.min.json
@@ -1,0 +1,2234 @@
+{
+  "name": "node-forge",
+  "dist-tags": {
+    "latest": "0.10.0"
+  },
+  "versions": {
+    "0.1.2": {
+      "name": "node-forge",
+      "version": "0.1.2",
+      "dist": {
+        "shasum": "93e77ac7bbd1a38996db0269eb9f8f38f522dc64",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.3": {
+      "name": "node-forge",
+      "version": "0.1.3",
+      "dist": {
+        "shasum": "343fcca300e0ac8773ba0d7462eeba2434b838c4",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.4": {
+      "name": "node-forge",
+      "version": "0.1.4",
+      "dist": {
+        "shasum": "e81f075a5ddc12c0a0d3e74b67db879f4ec55f2c",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.5": {
+      "name": "node-forge",
+      "version": "0.1.5",
+      "dist": {
+        "shasum": "67b979a91e4e2814c3ab965ea04fff9a939b0d02",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.6": {
+      "name": "node-forge",
+      "version": "0.1.6",
+      "dist": {
+        "shasum": "59bf151a367a3d99b576521e4399aa6a26db1c96",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.7": {
+      "name": "node-forge",
+      "version": "0.1.7",
+      "dist": {
+        "shasum": "01db370faa5caeb016c137a6b2109f9cf33ae31c",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.8": {
+      "name": "node-forge",
+      "version": "0.1.8",
+      "dist": {
+        "shasum": "0fa179f093602309c8095e297d5685f06d6a8229",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.9": {
+      "name": "node-forge",
+      "version": "0.1.9",
+      "dist": {
+        "shasum": "bad01ae0faded777814951b1f265b220f7935151",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.9.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.10": {
+      "name": "node-forge",
+      "version": "0.1.10",
+      "dist": {
+        "shasum": "6cc72542a5ed7d68ff95731b59fa3e5c8e52ba19",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.10.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.11": {
+      "name": "node-forge",
+      "version": "0.1.11",
+      "dist": {
+        "shasum": "acd749b5a01a589c3979060df3a12d85a3a7775e",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.11.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.12": {
+      "name": "node-forge",
+      "version": "0.1.12",
+      "dist": {
+        "shasum": "21b211edd605178948e1e5661e5ae3874f008bf1",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.12.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.13": {
+      "name": "node-forge",
+      "version": "0.1.13",
+      "dist": {
+        "shasum": "2f90b2f43ceae08f2182a5f9e1f53b6d5f136be3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.13.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.14": {
+      "name": "node-forge",
+      "version": "0.1.14",
+      "dist": {
+        "shasum": "0e602a32c14c95a49911b7fcbb8630c9df400e07",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.14.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.15": {
+      "name": "node-forge",
+      "version": "0.1.15",
+      "dist": {
+        "shasum": "fd83a7dd7d71065628b09e707a10c28358215b02",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.1.15.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.0": {
+      "name": "node-forge",
+      "version": "0.2.0",
+      "dist": {
+        "shasum": "fb3182d7774d2559f1020be7e8e7dbc586c3f053",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.1": {
+      "name": "node-forge",
+      "version": "0.2.1",
+      "dist": {
+        "shasum": "9177d7592aac79e45fa557f343b751cc1cf5df65",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.2": {
+      "name": "node-forge",
+      "version": "0.2.2",
+      "dist": {
+        "shasum": "2f019e468f75300e5f551666e0cfccc2982d6a91",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.3": {
+      "name": "node-forge",
+      "version": "0.2.3",
+      "dist": {
+        "shasum": "5b3f4a9af5bbdb2b0bc0fc8c8bb6cb0c5ca053c1",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.4": {
+      "name": "node-forge",
+      "version": "0.2.4",
+      "dist": {
+        "shasum": "741a5b53115d0510d2bfb9c5e74b00cdce4fef34",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.5": {
+      "name": "node-forge",
+      "version": "0.2.5",
+      "dist": {
+        "shasum": "88a3b40fa80415f32fe448ce88609e88e8713d4f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.6": {
+      "name": "node-forge",
+      "version": "0.2.6",
+      "dist": {
+        "shasum": "47c7a1543a82bcf3603c4637923072c0b6d70bd3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.7": {
+      "name": "node-forge",
+      "version": "0.2.7",
+      "dist": {
+        "shasum": "b8820076c7a7adf78a54714ee0512ab5ed15551c",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.8": {
+      "name": "node-forge",
+      "version": "0.2.8",
+      "dist": {
+        "shasum": "39a3531d9a293d2ccfb359de8aca6de928bbbf4a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.9": {
+      "name": "node-forge",
+      "version": "0.2.9",
+      "dist": {
+        "shasum": "ffddde6e011b66ad5fdf070ebcacbd690d864399",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.9.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.10": {
+      "name": "node-forge",
+      "version": "0.2.10",
+      "dist": {
+        "shasum": "1eeeb82504e99e2b5b186aee377b378967448f32",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.10.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.11": {
+      "name": "node-forge",
+      "version": "0.2.11",
+      "dist": {
+        "shasum": "85c73643bc8d6a0c46f7ba73ff141220be87a047",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.11.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.12": {
+      "name": "node-forge",
+      "version": "0.2.12",
+      "dist": {
+        "shasum": "0d6e031a8e42a86332b6dd7c1d004ef1d83a7a0f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.12.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.13": {
+      "name": "node-forge",
+      "version": "0.2.13",
+      "dist": {
+        "shasum": "a75be7b64b5a1bd1839ad1cafdd7d1da7d06d3bb",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.13.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.14": {
+      "name": "node-forge",
+      "version": "0.2.14",
+      "dist": {
+        "shasum": "5751bf2c73c0c081fd64a75d1a9e4a316276e389",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.14.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.15": {
+      "name": "node-forge",
+      "version": "0.2.15",
+      "dist": {
+        "shasum": "ccbbfc4060d8a685b893669f5239a2c2f86c40b3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.15.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.17": {
+      "name": "node-forge",
+      "version": "0.2.17",
+      "dist": {
+        "shasum": "103e31d2acf038c864acde74ce7773619dc02977",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.17.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.18": {
+      "name": "node-forge",
+      "version": "0.2.18",
+      "dist": {
+        "shasum": "54231bd51f5b675361405e95f2320cb5250a8a51",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.18.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.19": {
+      "name": "node-forge",
+      "version": "0.2.19",
+      "dist": {
+        "shasum": "8f2581bc3823dc1d55976b12dcd9517c4953e146",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.19.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.20": {
+      "name": "node-forge",
+      "version": "0.2.20",
+      "dist": {
+        "shasum": "4518f2d70ba13bb76a2edc9222c78b73e70ef5f1",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.20.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.21": {
+      "name": "node-forge",
+      "version": "0.2.21",
+      "dist": {
+        "shasum": "b8ffd1f9d5a6c21ab1a95f42e8e60917b0318318",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.21.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.22": {
+      "name": "node-forge",
+      "version": "0.2.22",
+      "dist": {
+        "shasum": "695a7656efd52cf16d445325220a7af320413b22",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.22.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.23": {
+      "name": "node-forge",
+      "version": "0.2.23",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "54f286b2d5b5f0ecb56f9524db4c07d33d165b8e",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.23.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.24": {
+      "name": "node-forge",
+      "version": "0.2.24",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "fa6f846f42fa93f63a0a30c9fbff7b4e130e0858",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.24.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.25": {
+      "name": "node-forge",
+      "version": "0.2.25",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "bin": {
+        "r.js": "./node_modules/.bin/r.js"
+      },
+      "dist": {
+        "shasum": "ec3fa50aa67c93d5f3c13535f7e90daaca8d2c3a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.25.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.26": {
+      "name": "node-forge",
+      "version": "0.2.26",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "0a82185f1fd4c09a71ff53651b4edc889d9aa750",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.26.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.27": {
+      "name": "node-forge",
+      "version": "0.2.27",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "ce1c3b2692bbb2febb4378a139d4ea31d605dbc6",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.27.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.28": {
+      "name": "node-forge",
+      "version": "0.2.28",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "5a84f55dfeb9798b732cfcd5ca1a19d95b714955",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.28.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.29": {
+      "name": "node-forge",
+      "version": "0.2.29",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "9323e87d00087d6eafdab796ae9e9456cd93e254",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.29.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.30": {
+      "name": "node-forge",
+      "version": "0.2.30",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "11bf6a92c0b2502901f3e4cd9e19cf5bd6eaf73b",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.30.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.31": {
+      "name": "node-forge",
+      "version": "0.2.31",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "07a05d70431bcd0ab27f2ae81a6e4b4b3050e58b",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.31.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.32": {
+      "name": "node-forge",
+      "version": "0.2.32",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "e8a5ec998a4177232dbc77cece8c83d5e125a51f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.32.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.33": {
+      "name": "node-forge",
+      "version": "0.2.33",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "abdff447a8df35ace4d98f64b171e3b9ce0d5eab",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.33.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.34": {
+      "name": "node-forge",
+      "version": "0.2.34",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "371ed438501a3dd4da22a8b77dfe3fd5e2a4db91",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.34.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.35": {
+      "name": "node-forge",
+      "version": "0.2.35",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "0ff787d01785302a08c6545ca9f5884d1f69232a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.35.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.36": {
+      "name": "node-forge",
+      "version": "0.2.36",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "0af19a90fe05e62fdee6911e7f14869b65aa1b12",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.36.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.37": {
+      "name": "node-forge",
+      "version": "0.2.37",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "25b7c4d37886b521ea35e84b65db6cb082476451",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.2.37.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.3.0": {
+      "name": "node-forge",
+      "version": "0.3.0",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "c428ed8d858c549ea146eac8123703c636b21965",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.3.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.1-dev": {
+      "name": "node-forge",
+      "version": "0.4.1-dev",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "0fa5f8a8bbcec4b37468288b8b2002d4ed31c90f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.4.1-dev.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.1": {
+      "name": "node-forge",
+      "version": "0.4.1",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "7291ec39fc7b87a03dfcdcbb9424c56f1e85dcb8",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.4.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.2": {
+      "name": "node-forge",
+      "version": "0.4.2",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "9a51624c92971297cffea0aca93a0006df7e80ae",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.4.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.3": {
+      "name": "node-forge",
+      "version": "0.4.3",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "853508f1dde1d0ca35f37e3f5d583884d860544d",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.4.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.5.1": {
+      "name": "node-forge",
+      "version": "0.5.1",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "57378aed99ea926548082f91f2fcb6e079787458",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.5.2": {
+      "name": "node-forge",
+      "version": "0.5.2",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "ae0fd9fb5c475e9f4fb17a15de975559f23b52bf",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.5.3": {
+      "name": "node-forge",
+      "version": "0.5.3",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "71876ff874170d9b8b8e7ba87ce4681f9c583774",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.5.4": {
+      "name": "node-forge",
+      "version": "0.5.4",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "5365ac6bc216e20ea8a1e8f7d02c3004117d853d",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.5.5": {
+      "name": "node-forge",
+      "version": "0.5.5",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "69a63dfb964b97ceef71c9c6be3c9658d3bbc102",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.5.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.0": {
+      "name": "node-forge",
+      "version": "0.6.0",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "c2817b8c9e49dcd0aa1fe682cfe6f79fd399ca05",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.1": {
+      "name": "node-forge",
+      "version": "0.6.1",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "c4ef9a1b263adea62f7aebc9c60f42daf32ec6f0",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.2": {
+      "name": "node-forge",
+      "version": "0.6.2",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "ec1786750aa9cae7d3f2710e1e94f86f3f1f8ba3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.3": {
+      "name": "node-forge",
+      "version": "0.6.3",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "a1888494d21d062f36966b25465d0e837905e357",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.4": {
+      "name": "node-forge",
+      "version": "0.6.4",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "99d7e14cfbf91b98b424dc7286472566c863cb5f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.5": {
+      "name": "node-forge",
+      "version": "0.6.5",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "e43148f439c9bd6d6813a8bac11646de0d6ddf73",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.6": {
+      "name": "node-forge",
+      "version": "0.6.6",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "a40c787b3f0a67a33a7b5bced11aa015cabb5cbd",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.6.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.7": {
+      "name": "node-forge",
+      "version": "0.6.7",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "ce15c75077935c498a0fd97581ad5c156c8a69ae",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.7.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.8": {
+      "name": "node-forge",
+      "version": "0.6.8",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "8543bd6687c71682bb36bc4c4ec02b041fd99e1d",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.8.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.9": {
+      "name": "node-forge",
+      "version": "0.6.9",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "225f4e620b306db80ad70604bf0493324bd56af4",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.9.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.10": {
+      "name": "node-forge",
+      "version": "0.6.10",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "372d73307fa244442659ef1ad5593a263a321fbb",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.10.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.11": {
+      "name": "node-forge",
+      "version": "0.6.11",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "2c7d5de441bbb45b4aa86d177465af4022c9b27f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.11.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.12": {
+      "name": "node-forge",
+      "version": "0.6.12",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "61494dfc34479e11aef0a3f836b2d7224ae47084",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.12.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.13": {
+      "name": "node-forge",
+      "version": "0.6.13",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "5e83d55637e3a937db982f1a83c457ff7d6351de",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.13.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.14": {
+      "name": "node-forge",
+      "version": "0.6.14",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "75ebdcac5ecfeb2961669676d3f49edda01da456",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.14.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.16": {
+      "name": "node-forge",
+      "version": "0.6.16",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "aae85babf97034d46f1b74a39bfe5891282ae842",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.16.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.18": {
+      "name": "node-forge",
+      "version": "0.6.18",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "2cc198672e94c7c4336e846e23d2a358d16d06d5",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.18.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.19": {
+      "name": "node-forge",
+      "version": "0.6.19",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "2a99a77875debda12444ac391fc5c72a200962a5",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.19.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.20": {
+      "name": "node-forge",
+      "version": "0.6.20",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "4574775d9093581b8fc9193b4e647a25bc4c38ce",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.20.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.21": {
+      "name": "node-forge",
+      "version": "0.6.21",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "7dadde911be009c7aae9150e780aea21d4f8bd09",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.21.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.22": {
+      "name": "node-forge",
+      "version": "0.6.22",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "1e71e952e137a70ff8aa1d966dcd58d8eb4497ef",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.22.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.23": {
+      "name": "node-forge",
+      "version": "0.6.23",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "f03cf65ebd5d4d9dd2f7becb57ceaf78ed94a2bf",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.23.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.24": {
+      "name": "node-forge",
+      "version": "0.6.24",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "49a8d3b19d92b644adf0f6ae25c5ddf9d5d6a994",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.24.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.25": {
+      "name": "node-forge",
+      "version": "0.6.25",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "1d4bdc4267525aa70ef951b016241f4381358007",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.25.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.26": {
+      "name": "node-forge",
+      "version": "0.6.26",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "989d7028e14b134111a2c5c0333df9bca89ec407",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.26.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.27": {
+      "name": "node-forge",
+      "version": "0.6.27",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "943c403d926204cdb03ba19802701fc3aa573223",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.27.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.28": {
+      "name": "node-forge",
+      "version": "0.6.28",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "3e8b53d85fb5793d1790409d9c395d119ec18f32",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.28.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.29": {
+      "name": "node-forge",
+      "version": "0.6.29",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "0f0f38ebe0de37cd506e6aa39458c953012fc65e",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.29.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.30": {
+      "name": "node-forge",
+      "version": "0.6.30",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "0804e7a120648a11191c99af9ab767a54b6ff7bb",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.30.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.31": {
+      "name": "node-forge",
+      "version": "0.6.31",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "1c2ca64c5e47de9ad3638720033fd8c3b94d9c1b",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.31.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.32": {
+      "name": "node-forge",
+      "version": "0.6.32",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "04d1299a0a36d196c1eb8660056fe87169f8a581",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.32.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.33": {
+      "name": "node-forge",
+      "version": "0.6.33",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "463811879f573d45155ad6a9f43dc296e8e85ebc",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.34": {
+      "name": "node-forge",
+      "version": "0.6.34",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "7e01d3477e73bf83a17daf5ea5bfc5af4d8199ab",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.34.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.35": {
+      "name": "node-forge",
+      "version": "0.6.35",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "7a2e207b7d4feebc978e8936042f1891267f2acf",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.35.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.37": {
+      "name": "node-forge",
+      "version": "0.6.37",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "32ea701c683fc300f1458e9490dc194a766f3641",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.37.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.38": {
+      "name": "node-forge",
+      "version": "0.6.38",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "184473ee3ad1e412100dc6fdfc44ff92309e57c8",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.38.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.39": {
+      "name": "node-forge",
+      "version": "0.6.39",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "2184e89dba9b44b3aa54cd4bf1e7334f247cf9ce",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.39.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.40": {
+      "name": "node-forge",
+      "version": "0.6.40",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "5cd0993ccc48046e59348811ac83b73006b45f55",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.40.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.41": {
+      "name": "node-forge",
+      "version": "0.6.41",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "e2f45b5c9f7a3919198fc8fc08a10f8f70381997",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.41.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.42": {
+      "name": "node-forge",
+      "version": "0.6.42",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "add1fc36947d12e56ef9f647b09e2a60f2c8ee5e",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.42.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.43": {
+      "name": "node-forge",
+      "version": "0.6.43",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "70c40ca7ed9f0f4aa35b424507ca9e45246bfe09",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.43.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.44": {
+      "name": "node-forge",
+      "version": "0.6.44",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "7058595c2d42821c6a3ace6e5a2ec47a24ac8733",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.44.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.45": {
+      "name": "node-forge",
+      "version": "0.6.45",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "86962a681134bc2fe5ec8fd31970d495aa9d3837",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.45.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.46": {
+      "name": "node-forge",
+      "version": "0.6.46",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "04a8a1c336eb72ef6f434ba7c854d608916c328d",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.46.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.47": {
+      "name": "node-forge",
+      "version": "0.6.47",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "84a239c1eabfd9bbe3a9b7308d52102fdba1da81",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.47.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.48": {
+      "name": "node-forge",
+      "version": "0.6.48",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "6986ea43bdd3cadc47a19db97759055edf753c01",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.48.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.49": {
+      "name": "node-forge",
+      "version": "0.6.49",
+      "devDependencies": {
+        "almond": "~0.2.6",
+        "jscs": "^1.8.1",
+        "requirejs": "~2.1.8"
+      },
+      "dist": {
+        "shasum": "f1ee95d5d74623938fe19d698aa5a26d54d2f60f",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.49.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.7.0": {
+      "name": "node-forge",
+      "version": "0.7.0",
+      "devDependencies": {
+        "browserify": "^13.1.1",
+        "commander": "^2.9.0",
+        "express": "^4.14.1",
+        "istanbul": "^0.4.5",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.4",
+        "karma": "^1.4.1",
+        "karma-browserify": "^5.1.1",
+        "karma-chrome-launcher": "^2.0.0",
+        "karma-edge-launcher": "^0.2.0",
+        "karma-firefox-launcher": "^1.0.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.2",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.1.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.2",
+        "mocha": "^3.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "opts": "^1.2.2",
+        "webpack": "^2.2.0"
+      },
+      "dist": {
+        "shasum": "5e0782a44e5e093fae3676d59f84ecfb38a4baad",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.7.1": {
+      "name": "node-forge",
+      "version": "0.7.1",
+      "devDependencies": {
+        "browserify": "^13.1.1",
+        "commander": "^2.9.0",
+        "express": "^4.14.1",
+        "istanbul": "^0.4.5",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.4",
+        "karma": "^1.4.1",
+        "karma-browserify": "^5.1.1",
+        "karma-chrome-launcher": "^2.0.0",
+        "karma-edge-launcher": "^0.2.0",
+        "karma-firefox-launcher": "^1.0.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.2",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.1.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.2",
+        "mocha": "^3.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "opts": "^1.2.2",
+        "webpack": "^2.2.0"
+      },
+      "dist": {
+        "shasum": "9da611ea08982f4b94206b3beb4cc9665f20c300",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.7.2": {
+      "name": "node-forge",
+      "version": "0.7.2",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.12",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.4.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-XTBoBY8NoeGAqQywTM8BjBz/Ro37eTmVF657yf6JumfOhxW9eET43Hve5+6L4+lo3hTDx7kTbC1WfasTHinDpg==",
+        "shasum": "3703b27f61a4c7613f046377643038b99e6a7891",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.2.tgz",
+        "fileCount": 60,
+        "unpackedSize": 1613053
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.7.3": {
+      "name": "node-forge",
+      "version": "0.7.3",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.12",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.4.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-UGP1kI3GWGcvOgODS7o1YodpkE9RzJHMv1nlSH35iBjPZM/702cWZ1Z2wFBGYkgvzG0vfMp7scs9+gKjHQ3DlA==",
+        "shasum": "03188af9dd2401c55e040150ba3c708575678e1a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.3.tgz",
+        "fileCount": 60,
+        "unpackedSize": 1613135
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.7.4": {
+      "name": "node-forge",
+      "version": "0.7.4",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.13",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.5.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-8Df0906+tq/omxuCZD6PqhPaQDYuyJ1d+VITgxoIA8zvQd1ru+nMJcDChHH324MWitIgbVkAkQoGEEVJNpn/PA==",
+        "shasum": "8e6e9f563a1e32213aa7508cded22aa791dbf986",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.4.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1670853
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.7.5": {
+      "name": "node-forge",
+      "version": "0.7.5",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.13",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.5.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
+        "shasum": "6c152c345ce11c52f465c2abd957e8639cd674df",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1670906
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.7.6": {
+      "name": "node-forge",
+      "version": "0.7.6",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^2.0.0",
+        "karma-browserify": "^5.2.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-phantomjs-launcher": "^1.0.2",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^2.0.13",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^11.5.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
+        "shasum": "fdf3b418aee1f94f0ef642cd63486c77ca9724ac",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1672108,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbc0dvCRA9TVsSAnZWagAAI7UQAIXe+9wh1JqYxR6FI4Xz\nMw2dZBss88XHNlZaAVKSWckN5MwzJf24cYM3y8omsf+4NyExu51TckjP59wr\nmcD3P11+TFMFLt67WdPdJh7x25fmNqUiOvHLVFuCXnTe1P5rbMvAyE9oAm1Q\nVYmh6UIkb1mkx5D7IflAs5ChzMqLPH+wU+sQcXy3whPRJrUrrSfqxvZdW4JC\njJacKy9L2MbuJvjuc0p/ybKxg1wTpTqmEgQNdew0vhv1fgHQhwWK9qJS7yGZ\nKjkYzJkC298lNYZkSAKHweQnf/1VMSemSyVmvB15LnTnf+hzYZzuyuFp4DjX\nfvlS+LJZ8QAehj8z8Afgwf+XYBx2MgAPifbS9vLqbuCyrEXPsrLBZw0K+Q27\nwV3orjYS9cwZpzJIN1HAl09uu9SSz0Rn1YapI/LHTyVXplyVuo32bBNiE1/L\n9wSFzRPkCtUazUjU5s/TUSUNpAyFtGphsC5B00tcuL17SmWz7zs/XGZCv8Gn\n4I3h3vLZ0ORieAVAHJa0KlaY97PNhAGzBh/zZHKoWn4GCQIlSBs8NQ/QtKf+\nPNsNtWpZReR3cW0r1y0AlTE0GEffHP6dL3zKGhHmR/1dMcuf5ut+7t+Iqg4X\nOdxqasvAkfCnB9mgAQoqx4vxoyu6XC8WA4/95UdL410VRZOcMvkEDfAOMPHh\nMaSb\r\n=Dfnj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.8.0": {
+      "name": "node-forge",
+      "version": "0.8.0",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^13.1.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-DVrvVeXwnSSX0Bgi9jy8p4IXQKLhGRQltG+UTR3Oci3Wb/zIROMoxw9im/K5s6KnNMheSWgG8K4qz8Njccdj3g==",
+        "shasum": "b897a89f25fe85ed7d0e3bd0c744c62931254dca",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.0.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1682003,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcU8GVCRA9TVsSAnZWagAAp5IP/iTJX0RuIWBRwruMqnwi\nvoIPCKQYGJ4StEXvq4/PwIDt9J+yVfdbsvULhj0ImDJVOElsQ8UMeBGXjRFa\nKx6SRGmRwj59kfQBod4kP5n7v43GGqXv11Xpy/xpMvmqORFOyd1ACU8q55iO\nv4iWyj5cn0MjjUcoMCexo51cc2bTxXJO3VQcZ2ri9rUavckuFRS9svAonLKP\nQFv+eDdOKZXqPcdscWIviOVT8hzqN0+JcguqH3xyCd3sk6a0tfsfNwy9DtuD\noVcc/VqoenhENzSf2PII9MO4c1wPHzGGy7l7rPXkY0RQE3bzicsKSrUl2GOV\nZUvJ+aQAES8KsJD864sCAvNIfVpgj265hVFIQVE2nGhVb7vbTeeCpLTqFvwx\ng2r4Mj8xiw/n+T3hBGb/DqJjFcuo03v+NmW2CLfvVg9lFK6suPsRt00fIueE\nHujPqMX/9Dj9gcczYNDat8Hh9us8yAsbfqRsBkqxaCl3uRedEqI36CYVFIn+\naU5rT49c4xzRE6OhZ1aJob4Ot46AMENzp3FrTUALeMGARCp3yGNq8OA8Kj1Z\nV6QpuFOklU6KWpUKIpEMg4chCjzN1OdpaJB/VLXrO2aVGpWOjOxV9WPCtF2f\nry32xPIbabQo57zjbR3+nOGcNlIXLDrLS0nINU6ePzOuiAUHjiU7gzAaLYgo\n1F5w\r\n=k3zn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.8.1": {
+      "name": "node-forge",
+      "version": "0.8.1",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "express": "^4.16.2",
+        "jscs": "^3.0.7",
+        "jshint": "^2.9.5",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^13.1.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-C/42HVb5eRtnDgRKOFx4bJH6LwbGQwbEHOC/trQwQSR6xWAUR/jlWoUJnxOmFTvdmDIZtjl2VH4dl3VpQuIz5g==",
+        "shasum": "67aeb9df7bb78d15444ec04a0162d2c565559c37",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.1.tgz",
+        "fileCount": 62,
+        "unpackedSize": 1682101,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJccb6LCRA9TVsSAnZWagAArLsP/jb58LOJu/8hmDJETqoT\n+RYoSNV99RV2cGaJ5pVpVbCT3HuV0r+TAJwo0rQN5wT3zso+yUgOianp9cq4\nKpWXi8YoDP5syNybHSLhu5gK2QF9X0LtDTyi8aBj0OQaE4yPjhglSrHPA0FR\nJm1aEpzmi6nmu0LCdoJCNkbm/OCw+Tjc4iiaSB/OnDXxmW0FH+NvMhg5wmxs\nkq+B3rxJ7AMunGd+Pt5X5ZCBF/ToTQSahvAIsr6GZ1WqKyOQaIVr99lZBXhp\nGe9XtGVPgW2a4a4eCxj6ukTKyjeBOx0TDVWxweYLc7B5eVAt8IH0Fl2iQBHL\nQtqLoLCOH3dATJjYKO8OEtcKnH5ZXbZIrRCkPxc+nCDBWqRI5c3JvdAJUZHd\npE8H2FGC0Bb4qRmztzAmAweJmjk7gmDxd63DcZ8pTOfPrKz06DtdR4cG0KDl\n+gg/7HWFxT97m8R7MBJH55bs5cxu/vZdW9NPaqWOteoRXJ49Z/dmVg1srMIR\nSv0ZmtMCKWVOGgEm05ud1BX3NSu+8QbMIrPGo1TcprMELoUZVjQ1F1DOwivS\nqcHKXect53hL1EReG/+HqjBbcbu59QBIeyGS4lw3bvuCcBPUdWktpAiQiBTI\ntOONRa2w3vU8OU8iblQWFDD1icn9thGkIVv+e4wZ0nj7yYeuPruZrJ7XmVJ4\n0lBC\r\n=p/hY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.8.2": {
+      "name": "node-forge",
+      "version": "0.8.2",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.14.1",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.14.1",
+        "eslint-config-digitalbazaar": "^1.7.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.0.1",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^13.3.0",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-mXQ9GBq1N3uDCyV1pdSzgIguwgtVpM7f5/5J4ipz12PKWElmPpVWLDuWl8iXmhysr21+WmX/OJ5UKx82wjomgg==",
+        "shasum": "b4bcc59fb12ce77a8825fc6a783dfe3182499c5a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.2.tgz",
+        "fileCount": 63,
+        "unpackedSize": 1683275,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJckA8jCRA9TVsSAnZWagAA+J4P+wfwEfdE9TJmt3AE0m2Y\ngpiRfdebftyJoqyBBFTpLwiDEm9rpvQV9abqHLfIGf2NP2cPFNQds/Ud0ve2\nUL0DJgB5FCVUMZVQbwpfZYek6/44SfSDpoBlh6/KYyAEovbHK0zOSQIt6dl6\nG3KG35eF2/mEmRyAWHPVACn6F1cAP5b8CEA8gwCFA2S2XQoymCTglh2tZbkU\ne3wAAx0/bTxiBlU/2GGjkHVLPNN2b+S/YNZcSKIHxW44HYsU/w3uHt3Yw+n2\nM0ByuWoFVmnTwRLWePmEthKUmd4P23d3wePGPC6Cav4qmTWyV/i0MyMkg6+1\n5H+TcprrRgndf9pzecNZuhg/7z7rgUJhFrFE7QvBQAoEUIokfcz9KJpQdJNI\nhTI/P7C7QTnZFcqr6hns9NhbXQ36AbiKkTTbhdcuqY6FQAr+ofqoDmCNf3rZ\nq74bf72p9mTW0GBuWj0YGA7/iqif11IVUZMsNHh5gE5bMdH7J8FGA4eXqPpa\niV6wmj8fpCt8xLyJJm0QUjGUbsVpBmzYX7foqAgkTj9Al9IIO0cGkWff385Y\ntDo+rMHjInasVuy4YhZcQa2RyFeCvZXPmpHgmJR7rM5TeZiNxfkh6nmsRj5G\n/cdGHGDTidLkeaoTCLBGnATU594No7wWtM7VgOPz4SceVA9IbtyExST30WQZ\n2YM3\r\n=LFRj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.8.3": {
+      "name": "node-forge",
+      "version": "0.8.3",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-5lv9UKmvTBog+m4AWL8XpZnr3WbNKxYL2M77i903ylY/huJIooSTDHyUWQ/OppFuKQpAGMk6qNtDymSJNRIEIg==",
+        "shasum": "c714c51d9f95b13fee8039bf78da3195efef5b64",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.3.tgz",
+        "fileCount": 63,
+        "unpackedSize": 1683334,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3GsoCRA9TVsSAnZWagAAqGMP/1rBJge9gtod9zd1nVNk\nE+cRFQgFyadnnJfG4eD2gE2hUHKjf9rnG36vgCU82CM5NhvDKgDXA5zb9XSV\nKQ8UTRz5GVrFxO9MVllqXVVnc0dGc6YLS6eThO1pUzr4+WzV44nQY4RCgwZl\n3vPnTS2Ra+CCkw3STeA/XUVM/KlJRS5JtIiF+Whvx1lvt+To5uNsiKJ7lGF6\nEkDDwp8Gbi2o9DsYnubXd7D40a22waTIHE8UB5qgIxWvGGHopYHmouPoPUO0\nSZ4DICJSzcuRL+SU2fiSM+OG8VFPV3PtA3B72k/gdQKq8J+rmiv9nv809vsa\nVuU4hQKfsh3K5rG/1mM4EOl3taxcyY0/8hra9S94YvrE6RjVRl5Dbl+4Y27X\nADCnQ6H9gFvgCzlekk2oKNGoyYRbo6in0WGu1icfmTbwV19EiCA9S1ZIrKDO\nQooghSAiHgKvMBiG4as+ipFjNZm3A/OE9a+v+RMThpW7/GHjovojXHvPt8cC\n8SD1HTx9adc3BG3EtkumA4+4ROmZb6MvoFSzoTIdcRzIVR23JVuGLEbNfLUs\nQ+egA6XktNnc5R/lZ4AbfikXHHbbpnqwt5ybHTcKf+Cr+EC7aj9vBNHVCt4b\nU6k85cHM5puTFvKKRRh+JqNbnBW4e6LpmqD8Ue1SPLO0INQjMcA8apNgjaOV\ngR7Q\r\n=qmNw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.8.4": {
+      "name": "node-forge",
+      "version": "0.8.4",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-UOfdpxivIYY4g5tqp5FNRNgROVNxRACUxxJREntJLFaJr1E0UEqFtUIk0F/jYx/E+Y6sVXd0KDi/m5My0yGCVw==",
+        "shasum": "d6738662b661be19e2711ef01aa3b18212f13030",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.4.tgz",
+        "fileCount": 63,
+        "unpackedSize": 1683492,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc5bEdCRA9TVsSAnZWagAAvc8P/2VWgfbRU0QQOxGLL91R\nMXVPc3lSUO0gDYfcdpbV4o9OaD8yCVdFf3iCB+PZuc1lJZR1yYhcUr2V++o0\n/eok00FowKMAl32GIu+yTCPmD6WUe+8GgONh7noRlXLID2oqUoBf/H5a39G/\nI+8PitKLfa9zIBDv+4h4nRnnessE/V4owD3YRzx8ULEsCfqP+EqR7BHrAX+N\nSe7tByZGS3YWiFlqJFVPr5sUthhmavQTCTV0PynvDHupNndKEdg9AH1yIY9S\nEnroZX9ZKtA93gW8zed1V4QE6LGE5ICB6AwBMZx1MbibdLYgvgoCjOFuuTn3\nO1eKgEUmJ9uO8VrH4oggLm+T+vGlp9ua5cFYh3nDW+6PntcyoCEd1qKI3IK9\nGVokq73YHdpgajIEHlJk2s2FxFyj7N2Hf/hefGkKFn2QibU43g/VRtAiKHEC\nDy+it0KUPkXMrWOYVE7Yg6a1O9aC2uFaANceLCGIorFzV83yvJ/MoaUxYiSS\nlFxsk6cs/BxX+oZvi3lIkdMgwbrlY7Gt1pu511LcW6rFkO0HwqyZbeEUSrgJ\nZA8XbxSBVxmFUm8pTYB3LxpZtshUx25RTIh7Xw7Tjy9Aljn1HJzC7lottXll\nFn9o60Z9V6/QD4HbD4AbIgxIXFHK0NlforHxsmxvT6vab7cg08YMHksvsGiV\n5F7C\r\n=LqNU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "0.8.5": {
+      "name": "node-forge",
+      "version": "0.8.5",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+        "shasum": "57906f07614dc72762c84cef442f427c0e1b86ee",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+        "fileCount": 63,
+        "unpackedSize": 1683543,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdCYwGCRA9TVsSAnZWagAAFfMP/19ZJSZCzdBJON3sp1xs\ncPXCXlrmcSW/MD2WWwUSbKxhSvSlAveu+rcUVyHzpACqGJ0jpd35MPBwik8n\nvjOevroZ+I6oJP2/1qLBm3ACcqRqmo3AlJII49st/DMrho1BkDb3erLIDptS\nS6Q6b6DGjnYrsmDhkbCU7N5hHxtOAoUBLgBL/kT8RlcmPJ32IsiXij5XX7Bw\n/5P1GdUm+L7BVmML6oyyBLmW32nO5zSbsKgCo5Ya4oCkQFdh5Lwh/27HooSG\ne9sWsVMVgbyLlRBFLkT40Ob+A+1VH99PvW9W5Aee11wPOsLdussGRqFkMbSK\nivpnlx04mWBz2BICYbTnGBTJeP8Xr6GZPkn2/GjGeFsOVKfIVaku1mGM06k7\n/DOdzjQ43eiim6UxSNOQ1blDOtPHCtPf4+S8tTGugIXETS1FuC9eV6YAUA1a\nISqSp7erjbJPZHQ44WcFvxNoH6b06fxAXTm5RiCf1N0SL3m0Lqp/cc5hOFpt\n9w78dd4XYFiRKtllSyd6ohoYIkA69qMd/z0sHoYx08XdEZQAhFZp/noFeK7G\nwdgZsO5x+1Yvw21QLiPEye8zWr97Sgc6xSdwNxO5LHBqm2t3x2Ds5UhDBZfX\nDXwCJOhifL7tmSBht6OJGdAy870+60496wSz0IlWvd61L+AN3b9UshRhS0ST\nziah\r\n=3EYK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "0.9.0": {
+      "name": "node-forge",
+      "version": "0.9.0",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+        "shasum": "d624050edbb44874adca12bb9a52ec63cb782579",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
+        "fileCount": 64,
+        "unpackedSize": 1694489,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdcHSoCRA9TVsSAnZWagAATboP/1/g4u3BCXBSYCfj66bV\nwz++KdipCtHSMszMZ/fsXVaI7vovim/UmziBJTMznPJSCkPOxtK2eWDj8KfJ\njF2kiQ55fJRXQjq8TjWvh++DsLfizE6usW/NqRExc2YKvv6GdU8fFFRv6jO5\n+u4psrZfiWqfSQiOHBtXdqHM3/HZSLQUPO0BGvppr2bwXxXL5kx/vKSP/aCC\nyIXHuQf8cVr2DA737kcqT740FmYfZgooBOevGteiwILO64iumki76JUMDEjX\nEPvA1IbY0rMT8m4ffixeew68HKL2dfSR6YcQrI357+xsyfftzKQiOjnUATJW\n62ncaFrT/lfNmC2oPTDFwRgA98jbkVZx9RlVq73Z9pt0WVPBmMZmsscrjtov\nZzWtsliHJDdoQuZtfXGqZkuzrUrkNXlLZO5qzH2ibVFVtV0BeEjmsEabIrZy\ngBBirjoAZnuzbfncsFaI2T1xf2dzun9Bc2YvNILrYFXqXV59ReD0gs5yqRSp\nyphViHeRysr0ZcIGqKTAt+WAJwJ7jfZUlGCxjEoefg2hXZ+wRR7mbsCxU+X7\nSZi1SvAz4QQccx/TU/gDDYRIrs37yzl/9gtPL2b1L7jJ3U6q6WdGwSjgREtE\nqZRkj1hjnMKHUGbtnThtAh1S7+6opRKdTsXfM4WCyzcKCNpkRyYaCpbBd3x/\nJ0Q3\r\n=Fwfk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "0.9.1": {
+      "name": "node-forge",
+      "version": "0.9.1",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+        "shasum": "775368e6846558ab6676858a4d8c6e8d16c677b5",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+        "fileCount": 64,
+        "unpackedSize": 1695226,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdjQusCRA9TVsSAnZWagAA8ZAQAKEmnXGsyp1On4tQPdrM\ncsGC94EyVqIuoq8aC9apAibz/FtpAMpL+PdnSiyuCCcM87eggsGG1s1V7akX\nor+eGk7EACWwxs702jL5500H3uO1G3zlqCOjA/rYcbx3iR0cvpHjK4vrM/jB\nwCvcR4921WC1JAUqMUjXLWcdg+5NYlu01cid+DgNgQUT6Jm2Dy0j9BczObmQ\n9SLrJJMLLOLwcKNbebtYk8vuoMtLws+gZOdQaXFn6LhnWGRVYtPS86IBi/NR\nBd7YstSex8ooD6dRP0uNmu41leYDUPHUOjKJm1SG5q30Mac3fgxzaZbbZ2TY\nAlyncClDmKXbuMUMeEzglbUHkKARv3kIRxlSaoZYyP2cdcUMFpI/0pkMPCHr\nmTqyLZPxwkkY0C7+qXpq5UW+dj6msl5s9K1wpB+ucnw/FYkTUbMIPQUh0gtt\nsjfwHVG7NacT9WTEjP8BGkNSUtWpfl55EARR4BS7P7tRZCLFLbgjitlMApJz\nMA4aTcLXKjcHlZ6qWuwHtp69WFIp7rLqhJQVwd4IjGYvFprTsvQlZcm3cZTm\nh8KQhTWAnK88/UvqRy/x52DFXvos28ySKQIvD4fL1aYwC4hMMorB/GkMxSj1\nR+vzVcaLWdpGnWXKSEwQFajT2vWuaL+SmeJiOWu2NE6fvVtvCHjlmPBkjNh/\nE4OD\r\n=/Q02\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "0.9.2": {
+      "name": "node-forge",
+      "version": "0.9.2",
+      "devDependencies": {
+        "browserify": "^16.1.0",
+        "commander": "^2.20.0",
+        "cross-env": "^5.1.3",
+        "eslint": "^5.16.0",
+        "eslint-config-digitalbazaar": "^2.0.0",
+        "express": "^4.16.2",
+        "karma": "^3.1.4",
+        "karma-browserify": "^6.0.0",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^1.2.0",
+        "karma-sourcemap-loader": "^0.3.7",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^3.0.5",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^14.1.1",
+        "opts": "^1.2.2",
+        "webpack": "^3.11.0",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw==",
+        "shasum": "b35a44c28889b2ea55cabf8c79e3563f9676190a",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.2.tgz",
+        "fileCount": 64,
+        "unpackedSize": 1696489,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfTvPACRA9TVsSAnZWagAAsVMQAJlBrEcSSmTSJyrU4weU\ndw+na7c+N0/t7g9Z5exXrlAXouKAJldGgBaBT3r0Kd+HYjPe85BV8PCQgvJh\nbPYZAbb6uquD2nDK/jobjT+SJuORYvXJA+7yO63ILQn+jucideCkhKvZbJLe\nTnlmowYbvGgAtXjpYgog2VIGR1dhsf5+o4zPMz+DyuKKqPKev3K8App8uJIx\ngzC0vIbsH3tMvEP9Y8Ztryh6gmL2vCA7nVltNNngtDspAUwHlVJOn0E/NkZB\n8MfI4yLE6O9GmSUsV6RldmZEMIZwr1fG/+NHLQVqK9j/eezf0V6K2atGWiL/\nlSF6/lAcVQX7R20OE8hHu5JM6g1KhVsZqYPZ9hVBwZcMBGgH6C8aISmoOWmn\n6FPnaCmBvUTBQoCguMoMmvfcWCxMIavsUQ+tE20UXPDqWgRzPWtffDYOBKeW\nI7Dc7UamsmT7e4z/ADtUEQU4aMv+vVy51kbtl5FLEuvwq+OV29qSKTtgqxCZ\n1g/bqYtQ8VFP6ER3U8g24C2n7uGqVbv9tLOd353aO9Xa7Gjr6xZ+/ywfbV/W\n2/Cu9dRVSJut11kQSV2TG/XbbykvSFXg45KHgJko/j36EKVl8qagnrXa4aRI\nbDzQ7Gp1iAis8Hu4PNvscMqFHkGHv1x2e/+ZCPZTpKnqkiCbM8840A9O8OgO\n0zlB\r\n=q/R7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "0.10.0": {
+      "name": "node-forge",
+      "version": "0.10.0",
+      "devDependencies": {
+        "browserify": "^16.5.2",
+        "commander": "^2.20.0",
+        "cross-env": "^5.2.1",
+        "eslint": "^7.8.1",
+        "eslint-config-digitalbazaar": "^2.5.0",
+        "express": "^4.16.2",
+        "karma": "^4.4.1",
+        "karma-browserify": "^7.0.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-edge-launcher": "^0.4.2",
+        "karma-firefox-launcher": "^1.3.0",
+        "karma-ie-launcher": "^1.0.0",
+        "karma-mocha": "^1.3.0",
+        "karma-mocha-reporter": "^2.2.5",
+        "karma-safari-launcher": "^1.0.0",
+        "karma-sauce-launcher": "^2.0.2",
+        "karma-sourcemap-loader": "^0.3.8",
+        "karma-tap-reporter": "0.0.6",
+        "karma-webpack": "^4.0.2",
+        "mocha": "^5.2.0",
+        "mocha-lcov-reporter": "^1.2.0",
+        "nodejs-websocket": "^1.7.1",
+        "nyc": "^15.1.0",
+        "opts": "^1.2.7",
+        "webpack": "^4.44.1",
+        "webpack-cli": "^3.3.12",
+        "worker-loader": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+        "shasum": "32dea2afb3e9926f02ee5ce8794902691a676bf3",
+        "tarball": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+        "fileCount": 64,
+        "unpackedSize": 1691149,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfTv5BCRA9TVsSAnZWagAAR/gP/0/MfddmfY6ND+zP36FY\nf1XeGUoBRCa5F/GI0jVCPgxvNZMb9OvLbFTigBPPQyHu5gDcB5Vq64ieL58/\n3SOn5FeIWoSLTxM7CR4Nzq6eQ2mxybhAV18vL1Dash9cqM/gT191J0A7tQKC\ncB4vsNIZzXerfCvMb/m8D+/Neb/FRBHCmlc4KXXWBEKLI/a6iUuHfPtxM+nt\nKNBE+yiKdpqzAMu/x2jmAj5ABhWdUDfnq1Pgl4ocogGknD40VS9VxftnT2r6\nfIatERkqIWbqahotZ/PA8c+xrgAeXzsrQL6A1xqSODs06koIjo+BkDAwo2gG\nr4/FhLARFHCBPc8wg/wAyhxsytjIGYjZj4WEshQPzuJYd0WspqfFXzlT5rvm\nGkfNKTpBUjWM06+6JdkUgQqb8RwXNnxHBD4d+JLmGb5n9X/hlA8l0+F0EKjy\nhKgMzt9VDtfHehP662F6B3QPDF/xH5zDH0yxYCWN15IjXATGRaXsqqZms21U\nPBSbr4Uhrw+uAa65FeMN685MW9GszsIJsFrvkSsZNkSF8A6PpbAf3E53zWUR\nrDp6Bpapd47+yaF3oKA/fl4geLUEVBC7YPd6xuHwwI+n16UIryaQdPN1Z4bc\nhI4LQ0s2ZvYT0pmedX9nOLeFL0g6iLrTGLXBeJRQPRMVIJBa7C245qlAuyFq\nioPC\r\n=cJdv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    }
+  },
+  "modified": "2020-09-02T02:07:00.558Z"
+}

--- a/test/fixtures/registry-mocks/content/node-libs-browser.json
+++ b/test/fixtures/registry-mocks/content/node-libs-browser.json
@@ -1,0 +1,1730 @@
+{
+  "_id": "node-libs-browser",
+  "_rev": "49-31fd5a4d725356caf2cd30333ef9a6ab",
+  "name": "node-libs-browser",
+  "description": "The node core libs for in browser usage.",
+  "dist-tags": {
+    "latest": "2.2.1",
+    "0.x-latest": "0.7.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "node-libs-browser",
+      "version": "0.1.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "0.1.6",
+        "vm-browserify": "0.0.1",
+        "crypto-browserify": "0.2.1",
+        "http-browserify": "0.1.6",
+        "buffer-browserify": "0.0.4",
+        "zlib-browserify": "0.0.1"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "1.8.x",
+        "should": "1.1.x",
+        "chai": "1.5.x",
+        "mocha-loader": "0.5.x",
+        "json-loader": "0.5.x"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "_id": "node-libs-browser@0.1.0",
+      "dist": {
+        "shasum": "f283a8bbd690605ea7bd950eee843dce0f3cac4a",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "node-libs-browser",
+      "version": "0.1.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "0.1.6",
+        "vm-browserify": "0.0.1",
+        "crypto-browserify": "0.2.1",
+        "http-browserify": "0.1.6",
+        "buffer-browserify": "0.0.4",
+        "zlib-browserify": "0.0.1"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "1.8.x",
+        "should": "1.1.x",
+        "chai": "1.5.x",
+        "mocha-loader": "0.5.x",
+        "json-loader": "0.5.x"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "_id": "node-libs-browser@0.1.1",
+      "dist": {
+        "shasum": "ed88d15779d843d20d120d55649b062af5cd4a0d",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "node-libs-browser",
+      "version": "0.1.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "0.1.6",
+        "vm-browserify": "0.0.1",
+        "crypto-browserify": "0.2.1",
+        "http-browserify": "0.1.6",
+        "buffer-browserify": "0.0.4",
+        "zlib-browserify": "0.0.1"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "devDependencies": {
+        "mocha": "1.8.x",
+        "should": "1.1.x",
+        "chai": "1.5.x",
+        "mocha-loader": "0.5.x",
+        "json-loader": "0.5.x"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec"
+      },
+      "_id": "node-libs-browser@0.1.2",
+      "dist": {
+        "shasum": "f9347dbfdecd36bdbebccb4f898310283ffcbf29",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "node-libs-browser",
+      "version": "0.2.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "~1.0.3",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "~2.1.0",
+        "http-browserify": "~1.3.2",
+        "zlib-browserify": "0.0.3",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "~1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "~1.0.1",
+        "stream-browserify": "~0.1.3",
+        "string_decoder": "~0.10.25",
+        "punycode": "~1.2.4",
+        "events": "~1.0.0",
+        "util": "~0.10.3",
+        "assert": "~1.1.1",
+        "buffer": "~2.1.5",
+        "url": "~0.7.9",
+        "process": "~0.6.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "_id": "node-libs-browser@0.2.0",
+      "dist": {
+        "shasum": "66414bb5a51724ac8964307380c15323750be232",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "node-libs-browser",
+      "version": "0.2.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "~1.0.3",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "~2.1.0",
+        "http-browserify": "~1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "~1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "~1.0.1",
+        "stream-browserify": "~0.1.3",
+        "string_decoder": "~0.10.25",
+        "punycode": "~1.2.4",
+        "events": "~1.0.0",
+        "util": "~0.10.3",
+        "assert": "~1.1.1",
+        "buffer": "~2.1.5",
+        "url": "~0.7.9",
+        "process": "~0.6.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "_id": "node-libs-browser@0.2.1",
+      "dist": {
+        "shasum": "c1cc27f16d454edec77e70aa4661feb3b5faf03a",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "node-libs-browser",
+      "version": "0.3.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "~1.1.0",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "~2.1.0",
+        "http-browserify": "~1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "~1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "~1.0.1",
+        "stream-browserify": "~1.0.0",
+        "string_decoder": "~0.10.25",
+        "punycode": "~1.2.4",
+        "events": "~1.0.0",
+        "util": "~0.10.3",
+        "assert": "~1.1.1",
+        "buffer": "~2.3.0",
+        "url": "~0.10.1",
+        "process": "~0.7.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "_id": "node-libs-browser@0.3.0",
+      "dist": {
+        "shasum": "7bc86ce1e7823d0e33cd0d3adb52fb683dc02ec7",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "node-libs-browser",
+      "version": "0.3.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "^1.1.0",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "^2.1.0",
+        "http-browserify": "^1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "^1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "^1.0.1",
+        "stream-browserify": "^1.0.0",
+        "readable-stream": "^1.0.27",
+        "string_decoder": "~0.10.25",
+        "punycode": "^1.2.4",
+        "events": "^1.0.0",
+        "util": "~0.10.3",
+        "assert": "^1.1.1",
+        "buffer": "^2.3.0",
+        "url": "~0.10.1",
+        "process": "~0.7.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "_id": "node-libs-browser@0.3.1",
+      "dist": {
+        "shasum": "a6c318d1eb43bd740c72193bafb6236a11aa7088",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "node-libs-browser",
+      "version": "0.4.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "^1.1.0",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "^3.0.0",
+        "http-browserify": "^1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "^1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "^1.0.1",
+        "stream-browserify": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "string_decoder": "~0.10.25",
+        "punycode": "^1.2.4",
+        "events": "^1.0.0",
+        "util": "~0.10.3",
+        "assert": "^1.1.1",
+        "buffer": "^2.3.0",
+        "url": "~0.10.1",
+        "process": "~0.7.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "gitHead": "0875a372931394d53d2db8bb7655bb26dee157c3",
+      "_id": "node-libs-browser@0.4.0",
+      "scripts": {},
+      "_shasum": "c7541dfa495220991e0ff18c0a32486c62161540",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c7541dfa495220991e0ff18c0a32486c62161540",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "node-libs-browser",
+      "version": "0.4.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "console-browserify": "^1.1.0",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "3.3.0",
+        "http-browserify": "^1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "^1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "^1.0.1",
+        "stream-browserify": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "string_decoder": "~0.10.25",
+        "punycode": "^1.2.4",
+        "events": "^1.0.0",
+        "util": "~0.10.3",
+        "assert": "^1.1.1",
+        "buffer": "^2.3.0",
+        "url": "~0.10.1",
+        "process": "~0.8.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "gitHead": "403da8d8b845f5d84a69c495d98d0150aedf5ef1",
+      "_id": "node-libs-browser@0.4.1",
+      "scripts": {},
+      "_shasum": "9d063c7f3bdc2eab8d184578b5bcb5785e63ad3a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9d063c7f3bdc2eab8d184578b5bcb5785e63ad3a",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "node-libs-browser",
+      "version": "0.4.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "^3.9.13",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "~0.10.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "gitHead": "279075c8e444ca4f5dfa38258a7f8e4083782fa5",
+      "_id": "node-libs-browser@0.4.2",
+      "scripts": {},
+      "_shasum": "09a2ae0684094c246743f6ce968ad44b7f20e6b2",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "09a2ae0684094c246743f6ce968ad44b7f20e6b2",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.3": {
+      "name": "node-libs-browser",
+      "version": "0.4.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "~0.10.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "gitHead": "0a54c5fd9b15261fb3785bda6eebaeda216a83c0",
+      "_id": "node-libs-browser@0.4.3",
+      "scripts": {},
+      "_shasum": "4c6f784411ecc1b383c8d5fb6c2490ae5a546099",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4c6f784411ecc1b383c8d5fb6c2490ae5a546099",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "node-libs-browser",
+      "version": "0.5.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "gitHead": "e0864478d2b51c3c1f6bcbdffe50e54eb0be2d6c",
+      "_id": "node-libs-browser@0.5.0",
+      "scripts": {},
+      "_shasum": "6960d54ad3b72fbb3b1740a0008501a41482aa34",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6960d54ad3b72fbb3b1740a0008501a41482aa34",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "node-libs-browser",
+      "version": "0.5.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "setimmediate": "^1.0.2",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "6870205c186fe8c64626d4b93001896aee2bedc5",
+      "_id": "node-libs-browser@0.5.1",
+      "_shasum": "69e2e009201e8561bdc4a27d4c988ecadbeea67f",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "69e2e009201e8561bdc4a27d4c988ecadbeea67f",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "node-libs-browser",
+      "version": "0.5.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "5c1097b23f2800975848dd928cf505b83709f616",
+      "_id": "node-libs-browser@0.5.2",
+      "_shasum": "5cb4574607d67d15a650ab5a17ffd7b1a3dc86f7",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5cb4574607d67d15a650ab5a17ffd7b1a3dc86f7",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.3": {
+      "name": "node-libs-browser",
+      "version": "0.5.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "aba1c1f71bc60dcf5677cda9d861b0642756189a",
+      "_id": "node-libs-browser@0.5.3",
+      "_shasum": "55efa888ec907acdb8cffc4e7a51712780e13b6a",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "55efa888ec907acdb8cffc4e7a51712780e13b6a",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "node-libs-browser",
+      "version": "1.0.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.1",
+        "os-browserify": "~0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.11.0",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "a6cef60acb59be7627d228e42201b9e55f46761b",
+      "_id": "node-libs-browser@1.0.0",
+      "_shasum": "ff8ad6c2cfa78043bdd0091ec07f0aaa581620fc",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "ff8ad6c2cfa78043bdd0091ec07f0aaa581620fc",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "node-libs-browser",
+      "version": "0.6.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^4.9.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "c853a6fd3b4749ae4f14c466e86e7d23bbc347ca",
+      "_id": "node-libs-browser@0.6.0",
+      "_shasum": "244806d44d319e048bc8607b5cc4eaf9a29d2e3c",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "244806d44d319e048bc8607b5cc4eaf9a29d2e3c",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-libs-browser-0.6.0.tgz_1471502106946_0.1987982855644077"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "node-libs-browser",
+      "version": "1.1.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "3bbff0dd6ffe32e2bdb759a062eecf5d994fb524",
+      "_id": "node-libs-browser@1.1.0",
+      "_shasum": "fd43c7b99be25dd36eaf4e8f76ca3f678997f847",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "fd43c7b99be25dd36eaf4e8f76ca3f678997f847",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-libs-browser-1.1.0.tgz_1479858635984_0.5259804422967136"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "node-libs-browser",
+      "version": "1.1.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "a382585981cc53528cc4dde54be75a2950b3cb61",
+      "_id": "node-libs-browser@1.1.1",
+      "_shasum": "2a38243abedd7dffcd07a97c9aca5668975a6fea",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "2a38243abedd7dffcd07a97c9aca5668975a6fea",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-libs-browser-1.1.1.tgz_1479893095797_0.08319727424532175"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "node-libs-browser",
+      "version": "2.0.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "2e543a33d51382dda4f3c2e68f20f6c11a19fe4d",
+      "_id": "node-libs-browser@2.0.0",
+      "_shasum": "a3a59ec97024985b46e958379646f96c4b616646",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "a3a59ec97024985b46e958379646f96c4b616646",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/node-libs-browser-2.0.0.tgz_1479893265735_0.15596941602416337"
+      },
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "node-libs-browser",
+      "version": "0.7.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.9.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "3.3.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "628ad33f9301a213b03456aeec13d831bd561af3",
+      "_id": "node-libs-browser@0.7.0",
+      "_shasum": "3e272c0819e308935e26674408d7af0e1491b83b",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "shasum": "3e272c0819e308935e26674408d7af0e1491b83b",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/node-libs-browser-0.7.0.tgz_1479993224871_0.8378041384276003"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "node-libs-browser",
+      "version": "2.1.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "files": [
+        "index.js",
+        "mock/"
+      ],
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "98c49c3cd6360bd8acc20f54dee2b957a8a14754",
+      "_id": "node-libs-browser@2.1.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.0",
+      "_npmUser": {
+        "name": "jhnns",
+        "email": "mail@johannesewald.de"
+      },
+      "dist": {
+        "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+        "shasum": "5f94263d404f6e44767d726901fff05478d600df",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-libs-browser-2.1.0.tgz_1510782294900_0.290951925329864"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "node-libs-browser",
+      "version": "2.2.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "0.0.4"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "be2518915c17dc9e6c517044c8a5114484180db5",
+      "_id": "node-libs-browser@2.2.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.12.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+        "shasum": "c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 10520,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQHNDCRA9TVsSAnZWagAAuFIP/RQDZUPcIYkMH3w3K0qY\n0mM4cBGu8I1+goAQAyLD10ksMfCZXjv6LCYqJtnXj0PFZ5DbYTrzfqcEdq5/\nfrSA55duyMnl88kkJ3vJ9+LSdjLHo0q/DP6/LTp0VpRf5v/xlenbFTWoRWVt\nWuTQPX3oJ55JkS5VaxBAvlAuCPjTJa3qRpxwxsWqCOAUmpcJEKUudLaMtEdY\nNgT5N9Y0Aes0WT0ljfh6ydstB1cUKJRljukrmV9RXzgqynhiHEaCOtpSFB/q\nN00OiyT9CL+5WJKq7Ajokrpv733IvHWYuZIP+WNPPqG+RzH7lsF+wrfmdDjN\nEStbLz5Xrsv9FwuBp8vY3ZmESbZnrRRIGhnZEtk8M3/yBfRdL0vXOUe7mtRK\ncMe2Hieah5m94wp7kQ1NeAV2eKgkW8xC1IVK5ywduJrsQhZTYpISuOQjypZv\nw/Yxd+ib2Ji66zOZX16XD5WeKgI6AEtSmwlb7BMjfrQ1SyA1hsIerU4pkNaX\nePQ9l9cYXnMPel7rFtZwojH3pCLGnZhuhyCmtMTY5HpkQtm9u4DqnklyT0dD\nmT8plY40ADIKOcj1QDPZOtBp7fhtYeaDXTawjMX4VanBnGABV40rB6cHj/ay\nxsW8gCxBJHRx1cP6F5VmIEcuLW5A0dH+j4CJQNg1GN30sU3lT6L+BXW4iPoo\nl/Lc\r\n=+EgN\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-libs-browser_2.2.0_1547727682409_0.2909451176763844"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.2.1": {
+      "name": "node-libs-browser",
+      "version": "2.2.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "The node core libs for in browser usage.",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/node-libs-browser.git"
+      },
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.1",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "^1.0.1"
+      },
+      "homepage": "http://github.com/webpack/node-libs-browser",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/node-libs-browser/issues"
+      },
+      "gitHead": "214057f118bad5da8b99db33fd16a5b6ceb42d9b",
+      "_id": "node-libs-browser@2.2.1",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+        "shasum": "b64f513d18338625f90346d27b0d235e631f6425",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 10783,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAWmwCRA9TVsSAnZWagAAHp4P/iXoDhW3nWMWtvRZHWq/\nY3L0LdNU/pQBisdt9K9ZFOsx3pXRbi1KweBCAkKXDJ0YtT/v11Ae8TYXNdZ6\nOitbB/O388f/pajhoZT4FI2dyvZhluL1OH5AhESc90huiej6EP4ynhHJUg5y\nqKaZ+QMzv9oSKaxoFKhmAjfOkTwHT9Ig5BmNwxvGTxDh4Wjzu3v2WDCFs+zS\ne2LLq9JVnNI95ndvLJnsC8DWm77Lzjxrf6Wo4GqqNCP0+XM00xoHmVA4PMYl\natc7R++D0LkfRTu5Rf7L8NeZ1bwz0Vgkn5XSr1S2GKMvxA4ujgKyl2rAKcxD\nUV+xKTEl6GDkaOvX5KPYQH4uAiJV21riy8fG9JkrgF9ZNdgvGyWCy5ujBaWB\nI3CwV6fvmmukN84ROcDN7eJ3QpImJ8zkVasfgNFL3iSOXtPZnshwdtwOtUEG\nKVaaazc6cfksQJYbkw9pKn9nUu80YqnaUSq26B0aw9C3KaO+tEzpDIIo5V7h\nT8/mQz3Tu9OXZNtgxL2IbTw7S7r068tTwmyIu+2qaMPjQsMcLT90h8UgUez3\n9fVXdfWVTpvFvs5hCY8C/ZSqya7ic+549UFH0bzOMymJuiAkAT1J8KMIevES\nAj8fprYHMs+rqVkEeBNM5o4oib+mAAa4d5pRkDVGRGWPkIJsUBcpK8eoPTWR\nPhN+\r\n=H6/8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/node-libs-browser_2.2.1_1560373679933_0.04253978108351042"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# node-libs-browser\n\nThe node core libs for in-browser usage.\n\nNOTE: This library is deprecated and won't accept Pull Requests that include Breaking Changes or new Features. Only bugfixes are accepted.\n\n[![dependencies status](http://david-dm.org/webpack/node-libs-browser.png)](http://david-dm.org/webpack/node-libs-browser)\n\nExports a hash [object] of absolute paths to each lib, keyed by lib names. Modules without browser replacements are `null`.\n\nSome modules have mocks in the `mock` directory. These are replacements with minimal functionality.\n\n| lib name | browser implementation | mock implementation |\n|:--------:|:----------------------:|:-------------------:|\n| assert | [defunctzombie/commonjs-assert](https://github.com/defunctzombie/commonjs-assert) | --- |\n| buffer | [feross/buffer](https://github.com/feross/buffer) | [buffer.js](https://github.com/webpack/node-libs-browser/blob/master/mock/buffer.js) |\n| child_process | --- | --- |\n| cluster | --- | --- |\n| console | [Raynos/console-browserify](https://github.com/Raynos/console-browserify) | [console.js](https://github.com/webpack/node-libs-browser/blob/master/mock/console.js) |\n| constants | [juliangruber/constants-browserify](https://github.com/juliangruber/constants-browserify) | --- |\n| crypto | [crypto-browserify/crypto-browserify](https://github.com/crypto-browserify/crypto-browserify) | --- |\n| dgram | --- | --- |\n| dns | --- | [dns.js](https://github.com/webpack/node-libs-browser/blob/master/mock/dns.js) |\n| domain | [bevry/domain-browser](https://github.com/bevry/domain-browser) | --- |\n| events | [Gozala/events](https://github.com/Gozala/events) | --- |\n| fs | --- | --- |\n| http | [jhiesey/stream-http](https://github.com/jhiesey/stream-http) | --- |\n| https | [substack/https-browserify](https://github.com/substack/https-browserify) | --- |\n| module | --- | --- |\n| net | --- | [net.js](https://github.com/webpack/node-libs-browser/blob/master/mock/net.js) |\n| os | [CoderPuppy/os-browserify](https://github.com/CoderPuppy/os-browserify) | --- |\n| path | [substack/path-browserify](https://github.com/substack/path-browserify) | --- |\n| process | [shtylman/node-process](https://github.com/shtylman/node-process) | [process.js](https://github.com/webpack/node-libs-browser/blob/master/mock/process.js) |\n| punycode | [bestiejs/punycode.js](https://github.com/bestiejs/punycode.js) | --- |\n| querystring | [mike-spainhower/querystring](https://github.com/mike-spainhower/querystring) | --- |\n| readline | --- | --- |\n| repl | --- | --- |\n| stream | [substack/stream-browserify](https://github.com/substack/stream-browserify) | --- |\n| string_decoder | [rvagg/string_decoder](https://github.com/rvagg/string_decoder) | --- |\n| sys | [defunctzombie/node-util](https://github.com/defunctzombie/node-util) | --- |\n| timers | [jryans/timers-browserify](https://github.com/jryans/timers-browserify) | --- | \n| tls | --- | [tls.js](https://github.com/webpack/node-libs-browser/blob/master/mock/tls.js) |\n| tty | [substack/tty-browserify](https://github.com/substack/tty-browserify) | [tty.js](https://github.com/webpack/node-libs-browser/blob/master/mock/tty.js) |\n| url | [defunctzombie/node-url](https://github.com/defunctzombie/node-url) | --- |\n| util | [defunctzombie/node-util](https://github.com/defunctzombie/node-util) | --- |\n| vm | [substack/vm-browserify](https://github.com/substack/vm-browserify) | --- |\n| zlib | [devongovett/browserify-zlib](https://github.com/devongovett/browserify-zlib) | --- |\n\n## Outdated versions \n\n### `buffer`\n\nThe current `buffer` implementation uses feross/buffer@4.x because feross/buffer@5.x relies on [typed arrays](https://github.com/feross/buffer/commit/5daca86b7cd5d2b8ccb167534d47421029f639e9#commitcomment-19698936).\nThis will be dropped as soon as IE9 is not a typical browser target anymore.\n\n### `punycode`\n\nThe current `punycode` implementation uses bestiejs/punycode.js@1.x because bestiejs/punycode.js@2.x requires modern JS engines that understand `const` and `let`.\nIt will be removed someday since it has already been [deprecated from the node API](https://nodejs.org/api/punycode.html).\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "jhnns",
+      "email": "mail@johannesewald.de"
+    },
+    {
+      "name": "sokra",
+      "email": "tobias.koppers@googlemail.com"
+    },
+    {
+      "name": "thelarkinn",
+      "email": "sean.larkin@cuw.edu"
+    }
+  ],
+  "time": {
+    "modified": "2019-06-12T21:08:03.397Z",
+    "created": "2013-02-25T10:31:59.987Z",
+    "0.1.0": "2013-02-25T10:32:03.272Z",
+    "0.1.1": "2013-02-25T10:47:01.515Z",
+    "0.1.2": "2013-02-25T17:18:07.680Z",
+    "0.2.0": "2014-03-18T21:39:34.168Z",
+    "0.2.1": "2014-04-18T16:59:17.020Z",
+    "0.3.0": "2014-05-21T05:47:56.550Z",
+    "0.3.1": "2014-05-21T05:58:51.487Z",
+    "0.4.0": "2014-07-25T16:40:17.240Z",
+    "0.4.1": "2014-11-18T21:44:06.357Z",
+    "0.4.2": "2015-03-04T21:20:05.932Z",
+    "0.4.3": "2015-03-05T08:17:53.280Z",
+    "0.5.0": "2015-05-10T09:57:03.948Z",
+    "0.5.1": "2015-05-21T19:36:18.545Z",
+    "0.5.2": "2015-05-21T19:40:02.327Z",
+    "0.5.3": "2015-09-16T20:22:27.473Z",
+    "1.0.0": "2016-01-23T12:28:26.951Z",
+    "0.6.0": "2016-08-18T06:35:08.727Z",
+    "1.1.0": "2016-11-22T23:50:37.969Z",
+    "1.1.1": "2016-11-23T09:24:57.884Z",
+    "2.0.0": "2016-11-23T09:27:46.260Z",
+    "0.7.0": "2016-11-24T13:13:46.849Z",
+    "2.1.0": "2017-11-15T21:44:55.018Z",
+    "2.2.0": "2019-01-17T12:21:22.714Z",
+    "2.2.1": "2019-06-12T21:08:00.062Z"
+  },
+  "author": {
+    "name": "Tobias Koppers @sokra"
+  },
+  "homepage": "http://github.com/webpack/node-libs-browser",
+  "readmeFilename": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webpack/node-libs-browser.git"
+  },
+  "bugs": {
+    "url": "https://github.com/webpack/node-libs-browser/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "crazyjingling": true,
+    "ikeyan": true,
+    "mfellner": true,
+    "hugov": true,
+    "tomekf": true,
+    "sternelee": true,
+    "alanmcbee": true,
+    "kkho595": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/node-libs-browser.min.json
+++ b/test/fixtures/registry-mocks/content/node-libs-browser.min.json
@@ -1,0 +1,779 @@
+{
+  "name": "node-libs-browser",
+  "dist-tags": {
+    "latest": "2.2.1",
+    "0.x-latest": "0.7.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "node-libs-browser",
+      "version": "0.1.0",
+      "dependencies": {
+        "console-browserify": "0.1.6",
+        "vm-browserify": "0.0.1",
+        "crypto-browserify": "0.2.1",
+        "http-browserify": "0.1.6",
+        "buffer-browserify": "0.0.4",
+        "zlib-browserify": "0.0.1"
+      },
+      "devDependencies": {
+        "mocha": "1.8.x",
+        "should": "1.1.x",
+        "chai": "1.5.x",
+        "mocha-loader": "0.5.x",
+        "json-loader": "0.5.x"
+      },
+      "dist": {
+        "shasum": "f283a8bbd690605ea7bd950eee843dce0f3cac4a",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "node-libs-browser",
+      "version": "0.1.1",
+      "dependencies": {
+        "console-browserify": "0.1.6",
+        "vm-browserify": "0.0.1",
+        "crypto-browserify": "0.2.1",
+        "http-browserify": "0.1.6",
+        "buffer-browserify": "0.0.4",
+        "zlib-browserify": "0.0.1"
+      },
+      "devDependencies": {
+        "mocha": "1.8.x",
+        "should": "1.1.x",
+        "chai": "1.5.x",
+        "mocha-loader": "0.5.x",
+        "json-loader": "0.5.x"
+      },
+      "dist": {
+        "shasum": "ed88d15779d843d20d120d55649b062af5cd4a0d",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "node-libs-browser",
+      "version": "0.1.2",
+      "dependencies": {
+        "console-browserify": "0.1.6",
+        "vm-browserify": "0.0.1",
+        "crypto-browserify": "0.2.1",
+        "http-browserify": "0.1.6",
+        "buffer-browserify": "0.0.4",
+        "zlib-browserify": "0.0.1"
+      },
+      "devDependencies": {
+        "mocha": "1.8.x",
+        "should": "1.1.x",
+        "chai": "1.5.x",
+        "mocha-loader": "0.5.x",
+        "json-loader": "0.5.x"
+      },
+      "dist": {
+        "shasum": "f9347dbfdecd36bdbebccb4f898310283ffcbf29",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.1.2.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "node-libs-browser",
+      "version": "0.2.0",
+      "dependencies": {
+        "console-browserify": "~1.0.3",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "~2.1.0",
+        "http-browserify": "~1.3.2",
+        "zlib-browserify": "0.0.3",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "~1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "~1.0.1",
+        "stream-browserify": "~0.1.3",
+        "string_decoder": "~0.10.25",
+        "punycode": "~1.2.4",
+        "events": "~1.0.0",
+        "util": "~0.10.3",
+        "assert": "~1.1.1",
+        "buffer": "~2.1.5",
+        "url": "~0.7.9",
+        "process": "~0.6.0"
+      },
+      "dist": {
+        "shasum": "66414bb5a51724ac8964307380c15323750be232",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "node-libs-browser",
+      "version": "0.2.1",
+      "dependencies": {
+        "console-browserify": "~1.0.3",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "~2.1.0",
+        "http-browserify": "~1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "~1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "~1.0.1",
+        "stream-browserify": "~0.1.3",
+        "string_decoder": "~0.10.25",
+        "punycode": "~1.2.4",
+        "events": "~1.0.0",
+        "util": "~0.10.3",
+        "assert": "~1.1.1",
+        "buffer": "~2.1.5",
+        "url": "~0.7.9",
+        "process": "~0.6.0"
+      },
+      "dist": {
+        "shasum": "c1cc27f16d454edec77e70aa4661feb3b5faf03a",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.2.1.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "node-libs-browser",
+      "version": "0.3.0",
+      "dependencies": {
+        "console-browserify": "~1.1.0",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "~2.1.0",
+        "http-browserify": "~1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "~1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "~1.0.1",
+        "stream-browserify": "~1.0.0",
+        "string_decoder": "~0.10.25",
+        "punycode": "~1.2.4",
+        "events": "~1.0.0",
+        "util": "~0.10.3",
+        "assert": "~1.1.1",
+        "buffer": "~2.3.0",
+        "url": "~0.10.1",
+        "process": "~0.7.0"
+      },
+      "dist": {
+        "shasum": "7bc86ce1e7823d0e33cd0d3adb52fb683dc02ec7",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "node-libs-browser",
+      "version": "0.3.1",
+      "dependencies": {
+        "console-browserify": "^1.1.0",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "^2.1.0",
+        "http-browserify": "^1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "^1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "^1.0.1",
+        "stream-browserify": "^1.0.0",
+        "readable-stream": "^1.0.27",
+        "string_decoder": "~0.10.25",
+        "punycode": "^1.2.4",
+        "events": "^1.0.0",
+        "util": "~0.10.3",
+        "assert": "^1.1.1",
+        "buffer": "^2.3.0",
+        "url": "~0.10.1",
+        "process": "~0.7.0"
+      },
+      "dist": {
+        "shasum": "a6c318d1eb43bd740c72193bafb6236a11aa7088",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.3.1.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "node-libs-browser",
+      "version": "0.4.0",
+      "dependencies": {
+        "console-browserify": "^1.1.0",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "^3.0.0",
+        "http-browserify": "^1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "^1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "^1.0.1",
+        "stream-browserify": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "string_decoder": "~0.10.25",
+        "punycode": "^1.2.4",
+        "events": "^1.0.0",
+        "util": "~0.10.3",
+        "assert": "^1.1.1",
+        "buffer": "^2.3.0",
+        "url": "~0.10.1",
+        "process": "~0.7.0"
+      },
+      "dist": {
+        "shasum": "c7541dfa495220991e0ff18c0a32486c62161540",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.0.tgz"
+      }
+    },
+    "0.4.1": {
+      "name": "node-libs-browser",
+      "version": "0.4.1",
+      "dependencies": {
+        "console-browserify": "^1.1.0",
+        "vm-browserify": "0.0.4",
+        "crypto-browserify": "3.3.0",
+        "http-browserify": "^1.3.2",
+        "browserify-zlib": "~0.1.4",
+        "https-browserify": "0.0.0",
+        "tty-browserify": "0.0.0",
+        "constants-browserify": "0.0.1",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "domain-browser": "^1.1.1",
+        "querystring-es3": "~0.2.0",
+        "timers-browserify": "^1.0.1",
+        "stream-browserify": "^1.0.0",
+        "readable-stream": "^1.1.13",
+        "string_decoder": "~0.10.25",
+        "punycode": "^1.2.4",
+        "events": "^1.0.0",
+        "util": "~0.10.3",
+        "assert": "^1.1.1",
+        "buffer": "^2.3.0",
+        "url": "~0.10.1",
+        "process": "~0.8.0"
+      },
+      "dist": {
+        "shasum": "9d063c7f3bdc2eab8d184578b5bcb5785e63ad3a",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.1.tgz"
+      }
+    },
+    "0.4.2": {
+      "name": "node-libs-browser",
+      "version": "0.4.2",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "^3.9.13",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "~0.10.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "09a2ae0684094c246743f6ce968ad44b7f20e6b2",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.2.tgz"
+      }
+    },
+    "0.4.3": {
+      "name": "node-libs-browser",
+      "version": "0.4.3",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "~0.10.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "4c6f784411ecc1b383c8d5fb6c2490ae5a546099",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.3.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "node-libs-browser",
+      "version": "0.5.0",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "6960d54ad3b72fbb3b1740a0008501a41482aa34",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.0.tgz"
+      }
+    },
+    "0.5.1": {
+      "name": "node-libs-browser",
+      "version": "0.5.1",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "setimmediate": "^1.0.2",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "69e2e009201e8561bdc4a27d4c988ecadbeea67f",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.1.tgz"
+      }
+    },
+    "0.5.2": {
+      "name": "node-libs-browser",
+      "version": "0.5.2",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "5cb4574607d67d15a650ab5a17ffd7b1a3dc86f7",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.2.tgz"
+      }
+    },
+    "0.5.3": {
+      "name": "node-libs-browser",
+      "version": "0.5.3",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^3.0.3",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "55efa888ec907acdb8cffc4e7a51712780e13b6a",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "node-libs-browser",
+      "version": "1.0.0",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.1",
+        "os-browserify": "~0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.11.0",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "ff8ad6c2cfa78043bdd0091ec07f0aaa581620fc",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-1.0.0.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "node-libs-browser",
+      "version": "0.6.0",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "~0.1.4",
+        "buffer": "^4.9.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "0.0.1",
+        "crypto-browserify": "~3.2.6",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "http-browserify": "^1.3.2",
+        "https-browserify": "0.0.0",
+        "os-browserify": "~0.1.2",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "~0.2.0",
+        "readable-stream": "^1.1.13",
+        "stream-browserify": "^1.0.0",
+        "string_decoder": "~0.10.25",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.0",
+        "url": "~0.10.1",
+        "util": "~0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "244806d44d319e048bc8607b5cc4eaf9a29d2e3c",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.6.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "node-libs-browser",
+      "version": "1.1.0",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "fd43c7b99be25dd36eaf4e8f76ca3f678997f847",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "node-libs-browser",
+      "version": "1.1.1",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "2a38243abedd7dffcd07a97c9aca5668975a6fea",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-1.1.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "node-libs-browser",
+      "version": "2.0.0",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "a3a59ec97024985b46e958379646f96c4b616646",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz"
+      }
+    },
+    "0.7.0": {
+      "name": "node-libs-browser",
+      "version": "0.7.0",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.9.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "3.3.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "0.0.1",
+        "os-browserify": "^0.2.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "shasum": "3e272c0819e308935e26674408d7af0e1491b83b",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "node-libs-browser",
+      "version": "2.1.0",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
+        "shasum": "5f94263d404f6e44767d726901fff05478d600df",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "node-libs-browser",
+      "version": "2.2.0",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "0.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+        "shasum": "c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 10520,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQHNDCRA9TVsSAnZWagAAuFIP/RQDZUPcIYkMH3w3K0qY\n0mM4cBGu8I1+goAQAyLD10ksMfCZXjv6LCYqJtnXj0PFZ5DbYTrzfqcEdq5/\nfrSA55duyMnl88kkJ3vJ9+LSdjLHo0q/DP6/LTp0VpRf5v/xlenbFTWoRWVt\nWuTQPX3oJ55JkS5VaxBAvlAuCPjTJa3qRpxwxsWqCOAUmpcJEKUudLaMtEdY\nNgT5N9Y0Aes0WT0ljfh6ydstB1cUKJRljukrmV9RXzgqynhiHEaCOtpSFB/q\nN00OiyT9CL+5WJKq7Ajokrpv733IvHWYuZIP+WNPPqG+RzH7lsF+wrfmdDjN\nEStbLz5Xrsv9FwuBp8vY3ZmESbZnrRRIGhnZEtk8M3/yBfRdL0vXOUe7mtRK\ncMe2Hieah5m94wp7kQ1NeAV2eKgkW8xC1IVK5ywduJrsQhZTYpISuOQjypZv\nw/Yxd+ib2Ji66zOZX16XD5WeKgI6AEtSmwlb7BMjfrQ1SyA1hsIerU4pkNaX\nePQ9l9cYXnMPel7rFtZwojH3pCLGnZhuhyCmtMTY5HpkQtm9u4DqnklyT0dD\nmT8plY40ADIKOcj1QDPZOtBp7fhtYeaDXTawjMX4VanBnGABV40rB6cHj/ay\nxsW8gCxBJHRx1cP6F5VmIEcuLW5A0dH+j4CJQNg1GN30sU3lT6L+BXW4iPoo\nl/Lc\r\n=+EgN\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.2.1": {
+      "name": "node-libs-browser",
+      "version": "2.2.1",
+      "dependencies": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.1",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "^1.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+        "shasum": "b64f513d18338625f90346d27b0d235e631f6425",
+        "tarball": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 10783,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAWmwCRA9TVsSAnZWagAAHp4P/iXoDhW3nWMWtvRZHWq/\nY3L0LdNU/pQBisdt9K9ZFOsx3pXRbi1KweBCAkKXDJ0YtT/v11Ae8TYXNdZ6\nOitbB/O388f/pajhoZT4FI2dyvZhluL1OH5AhESc90huiej6EP4ynhHJUg5y\nqKaZ+QMzv9oSKaxoFKhmAjfOkTwHT9Ig5BmNwxvGTxDh4Wjzu3v2WDCFs+zS\ne2LLq9JVnNI95ndvLJnsC8DWm77Lzjxrf6Wo4GqqNCP0+XM00xoHmVA4PMYl\natc7R++D0LkfRTu5Rf7L8NeZ1bwz0Vgkn5XSr1S2GKMvxA4ujgKyl2rAKcxD\nUV+xKTEl6GDkaOvX5KPYQH4uAiJV21riy8fG9JkrgF9ZNdgvGyWCy5ujBaWB\nI3CwV6fvmmukN84ROcDN7eJ3QpImJ8zkVasfgNFL3iSOXtPZnshwdtwOtUEG\nKVaaazc6cfksQJYbkw9pKn9nUu80YqnaUSq26B0aw9C3KaO+tEzpDIIo5V7h\nT8/mQz3Tu9OXZNtgxL2IbTw7S7r068tTwmyIu+2qaMPjQsMcLT90h8UgUez3\n9fVXdfWVTpvFvs5hCY8C/ZSqya7ic+549UFH0bzOMymJuiAkAT1J8KMIevES\nAj8fprYHMs+rqVkEeBNM5o4oib+mAAa4d5pRkDVGRGWPkIJsUBcpK8eoPTWR\nPhN+\r\n=H6/8\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-06-12T21:08:03.397Z"
+}

--- a/test/fixtures/registry-mocks/content/object-copy.json
+++ b/test/fixtures/registry-mocks/content/object-copy.json
@@ -1,0 +1,202 @@
+{
+  "_id": "object-copy",
+  "_rev": "2-855916efe3abb123539dd32015338ded",
+  "name": "object-copy",
+  "description": "Copy static properties, prototype properties, and descriptors from one object to another.",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "object-copy",
+      "description": "Copy static properties, prototype properties, and descriptors from one object to another.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/object-copy",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-copy.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-copy/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "*",
+        "mocha": "*"
+      },
+      "keywords": [
+        "copy",
+        "object"
+      ],
+      "verb": {
+        "layout": "default",
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb"
+        ]
+      },
+      "gitHead": "15b972a4a7137f6bf47886c68e73a2fffa8eacf2",
+      "_id": "object-copy@0.1.0",
+      "_shasum": "7e7d858b781bd7c991a41ba975ed3812754e998c",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e7d858b781bd7c991a41ba975ed3812754e998c",
+        "tarball": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/object-copy-0.1.0.tgz_1465495667685_0.612287495052442"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "object-copy",
+      "description": "Copy static properties, prototype properties, and descriptors from one object to another.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/object-copy",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-copy.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-copy/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "copy-descriptor": "^0.1.1",
+        "define-property": "^1.0.0",
+        "kind-of": "^5.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.2"
+      },
+      "keywords": [
+        "copy",
+        "object"
+      ],
+      "verb": {
+        "layout": "default",
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "copy-descriptor",
+            "define-property",
+            "kind-of"
+          ]
+        },
+        "reflinks": [
+          "verb"
+        ]
+      },
+      "gitHead": "de31ea69653f62d98e3dad3496af541fc279aa05",
+      "_id": "object-copy@1.0.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-aOrmvYlQQ7sB/vVo65iqSvGBbqXPLkz90viy6/Tg9sLvwalib9wguMIuGViFEC5S5KJkEAdSKOTobbtxnLCUQg==",
+        "shasum": "b87092f787590dedca2d134493f46c1d3351956c",
+        "tarball": "https://registry.npmjs.org/object-copy/-/object-copy-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/object-copy-1.0.0.tgz_1498391294174_0.4766365101095289"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# object-copy [![NPM version](https://img.shields.io/npm/v/object-copy.svg?style=flat)](https://www.npmjs.com/package/object-copy) [![NPM monthly downloads](https://img.shields.io/npm/dm/object-copy.svg?style=flat)](https://npmjs.org/package/object-copy) [![NPM total downloads](https://img.shields.io/npm/dt/object-copy.svg?style=flat)](https://npmjs.org/package/object-copy) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/object-copy.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/object-copy)\n\n> Copy static properties, prototype properties, and descriptors from one object to another.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save object-copy\n```\n\n## Usage\n\n```js\nvar copy = require('object-copy');\n```\n\n## API\n\n### [copy](index.js#L32)\n\nCopy static properties, prototype properties, and descriptors from one object to another.\n\n**Params**\n\n* `receiver` **{Object}**\n* `provider` **{Object}**\n* `omit` **{String|Array}**: (optional) One or more properties to omit\n* `filter` **{Function}**: (optional) Called on each key before copying the property. If the function returns false, the property will not be copied.\n* `returns` **{Object}**\n\n**Example**\n\n```js\nfunction App() {}\nvar proto = App.prototype;\nApp.prototype.set = function() {};\nApp.prototype.get = function() {};\n\nvar obj = {};\ncopy(obj, proto);\n\n// filter out keys\ncopy(obj, proto, function(key) {\n  return key !== 'index';\n});\n```\n\n## About\n\n### Related projects\n\n* [copy-descriptor](https://www.npmjs.com/package/copy-descriptor): Copy a descriptor from object A to object B | [homepage](https://github.com/jonschlinkert/copy-descriptor \"Copy a descriptor from object A to object B\")\n* [define-property](https://www.npmjs.com/package/define-property): Define a non-enumerable property on an object. | [homepage](https://github.com/jonschlinkert/define-property \"Define a non-enumerable property on an object.\")\n* [kind-of](https://www.npmjs.com/package/kind-of): Get the native type of a value. | [homepage](https://github.com/jonschlinkert/kind-of \"Get the native type of a value.\")\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Building docs\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n### Running tests\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2017, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on June 25, 2017._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-06-25T11:48:15.080Z",
+    "created": "2016-06-09T18:07:50.184Z",
+    "0.1.0": "2016-06-09T18:07:50.184Z",
+    "1.0.0": "2017-06-25T11:48:15.080Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/object-copy",
+  "keywords": [
+    "copy",
+    "object"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/object-copy.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/object-copy/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/object-copy.min.json
+++ b/test/fixtures/registry-mocks/content/object-copy.min.json
@@ -1,0 +1,50 @@
+{
+  "name": "object-copy",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "object-copy",
+      "version": "0.1.0",
+      "dependencies": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "*",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "7e7d858b781bd7c991a41ba975ed3812754e998c",
+        "tarball": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "object-copy",
+      "version": "1.0.0",
+      "dependencies": {
+        "copy-descriptor": "^0.1.1",
+        "define-property": "^1.0.0",
+        "kind-of": "^5.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-aOrmvYlQQ7sB/vVo65iqSvGBbqXPLkz90viy6/Tg9sLvwalib9wguMIuGViFEC5S5KJkEAdSKOTobbtxnLCUQg==",
+        "shasum": "b87092f787590dedca2d134493f46c1d3351956c",
+        "tarball": "https://registry.npmjs.org/object-copy/-/object-copy-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-06-25T11:48:15.080Z"
+}

--- a/test/fixtures/registry-mocks/content/object-is.json
+++ b/test/fixtures/registry-mocks/content/object-is.json
@@ -1,0 +1,890 @@
+{
+  "_id": "object-is",
+  "_rev": "15-60766fbbce0d2de38c4cfc08895bf36e",
+  "name": "object-is",
+  "description": "ES2015-compliant shim for Object.is - differentiates between -0 and +0",
+  "dist-tags": {
+    "latest": "1.1.3"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "object-is",
+      "version": "0.0.0",
+      "description": "ES6-compliant shim for Object.is - differentiates between -0 and +0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js",
+        "coverage": "covert test.js",
+        "coverage-quiet": "covert test.js --quiet"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/ljharb/object-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/ljharb/object-is/issues"
+      },
+      "homepage": "https://github.com/ljharb/object-is",
+      "keywords": [
+        "is",
+        "Object.is",
+        "equality",
+        "sameValueZero",
+        "ES6",
+        "shim",
+        "polyfill"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.4.2",
+        "covert": "~0.3.1"
+      },
+      "testling": {
+        "files": "test.js",
+        "browsers": [
+          "iexplore/6.0..latest",
+          "firefox/3.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/10.0..12.0",
+          "opera/15.0..latest",
+          "opera/next",
+          "safari/4.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "_id": "object-is@0.0.0",
+      "dist": {
+        "shasum": "65adab52f96f7071047ab2edf8d5e0d4230dc1b4",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "object-is",
+      "version": "1.0.0",
+      "description": "ES6-compliant shim for Object.is - differentiates between -0 and +0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "test": "node test.js && npm run coverage",
+        "coverage": "covert test.js",
+        "coverage-quiet": "covert test.js --quiet"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/ljharb/object-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/ljharb/object-is/issues"
+      },
+      "homepage": "https://github.com/ljharb/object-is",
+      "keywords": [
+        "is",
+        "Object.is",
+        "equality",
+        "sameValueZero",
+        "ES6",
+        "shim",
+        "polyfill"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.13.1",
+        "covert": "~0.4.0"
+      },
+      "testling": {
+        "files": "test.js",
+        "browsers": [
+          "iexplore/6.0..latest",
+          "firefox/3.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/10.0..12.0",
+          "opera/15.0..latest",
+          "opera/next",
+          "safari/4.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "gitHead": "8811835bff203cf0dc0dee1342beeb749ea63e10",
+      "_id": "object-is@1.0.0",
+      "_shasum": "c4d85931da0009435ec9825ddbe578a7ff82c001",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c4d85931da0009435ec9825ddbe578a7ff82c001",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "object-is",
+      "version": "1.0.1",
+      "description": "ES6-compliant shim for Object.is - differentiates between -0 and +0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run lint && node test.js && npm run coverage-quiet",
+        "coverage": "covert test.js",
+        "coverage-quiet": "covert test.js --quiet",
+        "lint": "jscs *.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/ljharb/object-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/ljharb/object-is/issues"
+      },
+      "homepage": "https://github.com/ljharb/object-is",
+      "keywords": [
+        "is",
+        "Object.is",
+        "equality",
+        "sameValueZero",
+        "ES6",
+        "shim",
+        "polyfill"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.14.0",
+        "covert": "~1.0.0",
+        "jscs": "~1.5.9"
+      },
+      "testling": {
+        "files": "test.js",
+        "browsers": [
+          "iexplore/6.0..latest",
+          "firefox/3.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/10.0..12.0",
+          "opera/15.0..latest",
+          "opera/next",
+          "safari/4.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "gitHead": "a51367e2c85f408211982ccb3ed2f1cc2da70d05",
+      "_id": "object-is@1.0.1",
+      "_shasum": "0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "object-is",
+      "version": "1.0.2",
+      "description": "ES2015-compliant shim for Object.is - differentiates between -0 and +0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\"",
+        "pretest": "npm run lint",
+        "tests-only": "node test",
+        "test": "npm run tests-only",
+        "posttest": "npx aud",
+        "coverage": "covert test",
+        "lint": "eslint ."
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/object-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/es-shims/object-is/issues"
+      },
+      "homepage": "https://github.com/es-shims/object-is",
+      "keywords": [
+        "is",
+        "Object.is",
+        "equality",
+        "sameValueZero",
+        "ES6",
+        "ES2015",
+        "shim",
+        "polyfill"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "@ljharb/eslint-config": "^15.0.2",
+        "auto-changelog": "^1.16.2",
+        "covert": "^1.1.1",
+        "eslint": "^6.7.2",
+        "has-symbols": "^1.0.1",
+        "tape": "^4.11.0"
+      },
+      "testling": {
+        "files": "test.js",
+        "browsers": [
+          "iexplore/6.0..latest",
+          "firefox/3.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/10.0..12.0",
+          "opera/15.0..latest",
+          "opera/next",
+          "safari/4.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false
+      },
+      "gitHead": "082fdb0ca51a1a363d6fdb533f988f0fabe7d10a",
+      "_id": "object-is@1.0.2",
+      "_nodeVersion": "13.3.0",
+      "_npmVersion": "6.13.1",
+      "dist": {
+        "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+        "shasum": "6b80eb84fe451498f65007982f035a5b445edec4",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 16498,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd9ytSCRA9TVsSAnZWagAA5koP/3OpM9HTrTeBXLXbtfBO\nWMzdrsFzD/67aiRs7jejkQqPHbUKc3l/gdB12zUSFGsFb3wP9LPTYB6dyQ94\nd8j6SuInoodlidjxrDrq2LD4LxKwcN0CW+iw8/DzwmxG0017KLLam/ykbPzQ\nvnI3PM8fMiUdXdwkUoqIr/louLr3SmyJ9fO1NcFGgNFG88gl/W8QOoa6Oz08\nOy3jjBdJSyVLvf5tl1yX1C+F0fn7F5Fhtt2AL0IBok+wTIHNWr8Oh1Mmo6jg\n+BGJEAtWRBYdyuUG+agL1JQ+crnoMjnrwJ57aAN6satjUFyH4UT2/i7Y8UNI\n4T1raOrZQiZNRSCh3DVfcr58xFjrPmlYSKbpcY04QMnkqQjewFK4QfR+Wq5p\nzbSnWug8oIiHZ0j7CWvI0VtSOQRF4gez4qnvgnufTHujPPoff8B17NTIwZgs\n/zRQyLaez0/tnXw8ayvjicdu0EQIZjF2Lcalten1D8TftE+lmdzgvx3KXDLj\nRQPQQD/v9O/dXU7cqi0mN7mTK8NgzSkzCCEVnmiIwVOxlxa31Q3ublkdcsSK\n7PPQJelesj0a9fju6Et+0Yl6meKImOYhyYI5nv+IBADHll4bNiTkwY+Gbgnc\n7+igavjjbJTfCu7qEQAuGgRseLxGLkk8FDPsZQ3pmhAiuXacc3UYsY00F4Ms\nmqCI\r\n=2AeM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb+esshims@gmail.com",
+          "name": "es-shims-owner"
+        },
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/object-is_1.0.2_1576479570145_0.7229938222854198"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.0": {
+      "name": "object-is",
+      "version": "1.1.0",
+      "description": "ES2015-compliant shim for Object.is - differentiates between -0 and +0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "tests-only": "node test",
+        "test": "npm run tests-only",
+        "posttest": "npx aud --production",
+        "coverage": "covert test",
+        "prelint": "es-shim-api",
+        "lint": "eslint .",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/object-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/es-shims/object-is/issues"
+      },
+      "homepage": "https://github.com/es-shims/object-is",
+      "keywords": [
+        "is",
+        "Object.is",
+        "equality",
+        "sameValueZero",
+        "ES6",
+        "ES2015",
+        "shim",
+        "polyfill",
+        "es-shim API"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^16.0.0",
+        "aud": "^1.1.0",
+        "auto-changelog": "^2.0.0",
+        "covert": "^1.1.1",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^5.0.0-next.5"
+      },
+      "testling": {
+        "files": "test.js",
+        "browsers": [
+          "iexplore/6.0..latest",
+          "firefox/3.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/10.0..12.0",
+          "opera/15.0..latest",
+          "opera/next",
+          "safari/4.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false
+      },
+      "gitHead": "2c559ab591dc6b43df491f8b9eac5db5d401681f",
+      "_id": "object-is@1.1.0",
+      "_nodeVersion": "13.12.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-wznR5+ya11MdnkLq+oYePGjW2ge4RY5DVSwa3iKuDCpvLsYGnp24Qy5EzVRgyMHEuEkKd+dX/1JpAT6QxZXq2g==",
+        "shasum": "57e5e236f2831066c82948cbd735c24a9e54084d",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.1.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 18380,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeld/nCRA9TVsSAnZWagAAH1QP/R4suubDK/XkvmV4tKLp\ngmPRaaVtuSHa736FsJa8u0tp8SLhOiD0jPNF6AbOi/PIFQOGOZeS3epN9Y/K\nqNrq6UeQL4gM28xuF4OSACzAUTw+LeiUGMItu19x7Qwlm351yuzb1pg9dRDD\nnmJLxs3J8H25xN0SM7asC+o7zUtHpDVxITrgPrTubmPwR/D3ZVBvdtE7nUc8\n0Ai/++V7M/nj65iT2PV13By+E78cyL0H+PJEcJQAddlgI8z1STySWcCFY1eg\nHrjudeh8xmPnb9gX7HFgPS5jtaF+bhnI4ehTH1hdWBsSsQ4d3QJjkz1ql4vN\niQPOm92+z2xF/ajgq8PBEUZ3JDaK2PoXouGAPgtKW/uxxapqMIxm4j32TpAd\nz4ZTsZamK4uI0uA5rSFz2TN0YLycIA+gZ2SWEeSoHJyAYOF4+ER+k3SOywxo\n1stnhn1bTgPY1qUNweff0AxVb6tnS/vDzuaHbB8SKJBcgbi4DcGzBM1si2gy\nR/dzHX8HRH43BJIQxaLD0BLXgd1GX3dBtIRaqq1+omrOPIZPt/V20Bw9rlTt\nnW+qtOFbedNwZ5PxkTdmt5iARNzH9uWrzxCVkTx57jD1gMrXid74ra7Unvat\nqvXRdBE3GBg7lydyJnrk78n93JkqLBDGKT2HJqY77BOUD0vMbIRLj1xGvmjE\n19tO\r\n=ptum\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/object-is_1.1.0_1586880486475_0.3625097471806267"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.1": {
+      "name": "object-is",
+      "version": "1.1.1",
+      "description": "ES2015-compliant shim for Object.is - differentiates between -0 and +0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "tests-only": "node test",
+        "test": "npm run tests-only",
+        "posttest": "npx aud --production",
+        "coverage": "covert test",
+        "prelint": "es-shim-api",
+        "lint": "eslint .",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/object-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/es-shims/object-is/issues"
+      },
+      "homepage": "https://github.com/es-shims/object-is",
+      "keywords": [
+        "is",
+        "Object.is",
+        "equality",
+        "sameValueZero",
+        "ES6",
+        "ES2015",
+        "shim",
+        "polyfill",
+        "es-shim API"
+      ],
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^16.0.0",
+        "aud": "^1.1.0",
+        "auto-changelog": "^2.0.0",
+        "covert": "^1.1.1",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^5.0.0-next.5"
+      },
+      "testling": {
+        "files": "test.js",
+        "browsers": [
+          "iexplore/6.0..latest",
+          "firefox/3.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/10.0..12.0",
+          "opera/15.0..latest",
+          "opera/next",
+          "safari/4.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false
+      },
+      "gitHead": "2d6ac911b256eafb6b54dda4e993931070da230e",
+      "_id": "object-is@1.1.1",
+      "_nodeVersion": "13.13.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-9wFT2CEamBmkYN6TEqnXCOzexDKR/N3hyUOQwtxIxZCZOyvlTUhKUejftM6+nciflJX0x2VLh7wNFWvIpmKGNw==",
+        "shasum": "9314b6dc7f649891a1fc7f499a6cd3b0a6c01543",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.1.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 25554,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJelhFcCRA9TVsSAnZWagAAnXMP/34zIHmloOiJ5GCE49aI\nVW3IijmBH61f+Tf45EbOFFQw6v3X9SDgdge6ZogwHvbWjPA97s5dU5DfjnIo\nP1khJdlU/IWdrTRVpAg6KZgX8S9dZ4GBNcgKi71d5IcnLflCBHPUpDliuDZK\nqkPIz0apz4IHSXkopyFyyrYFzpFwc0Gtj9hpXSnMZk1cpLpBGptSJWdHgPJl\nAWzPgeaNIAMMZVt0Y0L5m7Vet3dHGmnxiCqnUu4fbJbdIr1/DHZiRQf3WAgP\n8myP0F+HmPtb5jqAqzZmHqcMpPL9byRDnmASpvz1T2ZX0tPXfK4yuOPjozJA\n+oukV1AAT99WOLG+FOhfCeG5lKQX4PH0OhBk7k+NsuC6A27AcfPT8GGo5t7R\n030PGVQOLdxu7S9DIK7ekoBGyeUmuP36a3t4GFGLVTqIWsnsovm6v0qXNYte\nwh94oGgFfBFFnFSu75nmcp0AM0Sj+wE6RUv4vUcTlQH6/Sc60Aq1PmRBkA/d\nGURbHEjUPzWV81+gw/22EtMrpl9bUenoAzcdscR5aTEv6kBLXXHfoF9wV/et\n9qwYm+4tWNV63+AOVL1OCWZM8WQLAS9j5/8DHrrvpBBgF5kSfJ03O/7aAonR\nf5G+W+/O5YA5AWb/gHalJlW5FjwYdZuF8gabMPC6bH+DwY3NHMrogIH0034N\nAzoE\r\n=Ya0T\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/object-is_1.1.1_1586893147687_0.7202577943507198"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.2": {
+      "name": "object-is",
+      "version": "1.1.2",
+      "description": "ES2015-compliant shim for Object.is - differentiates between -0 and +0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "tests-only": "node test",
+        "test": "npm run tests-only",
+        "posttest": "npx aud --production",
+        "coverage": "covert test",
+        "prelint": "es-shim-api --bound",
+        "lint": "eslint .",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/object-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/es-shims/object-is/issues"
+      },
+      "homepage": "https://github.com/es-shims/object-is",
+      "keywords": [
+        "is",
+        "Object.is",
+        "equality",
+        "sameValueZero",
+        "ES6",
+        "ES2015",
+        "shim",
+        "polyfill",
+        "es-shim API"
+      ],
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^16.0.0",
+        "aud": "^1.1.0",
+        "auto-changelog": "^2.0.0",
+        "covert": "^1.1.1",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^5.0.0-next.5"
+      },
+      "testling": {
+        "files": "test.js",
+        "browsers": [
+          "iexplore/6.0..latest",
+          "firefox/3.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/10.0..12.0",
+          "opera/15.0..latest",
+          "opera/next",
+          "safari/4.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false
+      },
+      "gitHead": "f320ccf74845a3d4a7da7b03153c60c28955eb57",
+      "_id": "object-is@1.1.2",
+      "_nodeVersion": "13.13.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+        "shasum": "c5d2e87ff9e119f78b7a088441519e2eec1573b6",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 25937,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJelhQ5CRA9TVsSAnZWagAAexQP/1ltZexI1kiaTRK+P31+\niU5Fqfyh+OFkM7Cib8fYLTVv+Ed63TCKfxdxg9NTT+8pf3rklsYhlpIn02kZ\nHWJidKNaJQSjxLVkS51o42rXSlpxH4URWhbE/cPfUpJKusBGZNTvVbtBiUks\nhZfkrYwE33ggybAikJ2HeoLDTBZpUtv5mJNHgsdtT/MKAE4ckg0e8NtHyOSn\nFp2quuIRXFsdLTDUrKzHLEb6J4X3MicBNelq8vwaZAxuPf2ZedY8t7vT5GWc\nxn2PP+auXyjAz8ieemKwB4XfJeqErzj7j9uJ5nAwjbg8/LVmYybR273G/zuW\nGZ83XCOHX/gGvXLD/wrbH7jyIt5TTsYna6QMpPJK3HU85g/3h/+5bU1IGzhS\npDHc7qdvS4friP+/YrZ67kQPY4cRdbQX/TGUMTPZznRxVIHmd3ptCASa/6Hf\nS+OTXKV6qwF35PfXoW6XHUwsFMsyKy/NOL/MH8J3WQ03AavqcOIFRp8SKK6N\nuPHOSSWJGj6aJuCNcWVwi1O4q9A5MejVJFxT4TqPM0r6O1qGrfFKuGpa8I1N\ngYxlEDk8xQbrLK0zSYMsgNggqOZr0+iGh+r0MT8EeD9/CRw53cBmZxKibgES\nMvvSJCF1rCrCZH10mq0JXFqqk8/QzaJsce9ChXLnE4hPkPcgtI7KdjNNVNYa\nh0zJ\r\n=RjDk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/object-is_1.1.2_1586893880595_0.14621663101190285"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.3": {
+      "name": "object-is",
+      "version": "1.1.3",
+      "description": "ES2015-compliant shim for Object.is - differentiates between -0 and +0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "prepublish": "safe-publish-latest",
+        "pretest": "npm run lint",
+        "tests-only": "node test",
+        "test": "npm run tests-only",
+        "posttest": "npx aud --production",
+        "coverage": "covert test",
+        "prelint": "es-shim-api --bound",
+        "lint": "eslint .",
+        "version": "auto-changelog && git add CHANGELOG.md",
+        "postversion": "auto-changelog && git add CHANGELOG.md && git commit --no-edit --amend && git tag -f \"v$(node -e \"console.log(require('./package.json').version)\")\""
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/object-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/es-shims/object-is/issues"
+      },
+      "homepage": "https://github.com/es-shims/object-is",
+      "keywords": [
+        "is",
+        "Object.is",
+        "equality",
+        "sameValueZero",
+        "ES6",
+        "ES2015",
+        "shim",
+        "polyfill",
+        "es-shim API"
+      ],
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^17.2.0",
+        "aud": "^1.1.2",
+        "auto-changelog": "^2.2.1",
+        "covert": "^1.1.1",
+        "eslint": "^7.10.0",
+        "has-symbols": "^1.0.1",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^5.0.1"
+      },
+      "testling": {
+        "files": "test.js",
+        "browsers": [
+          "iexplore/6.0..latest",
+          "firefox/3.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/10.0..12.0",
+          "opera/15.0..latest",
+          "opera/next",
+          "safari/4.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "auto-changelog": {
+        "output": "CHANGELOG.md",
+        "template": "keepachangelog",
+        "unreleased": false,
+        "commitLimit": false,
+        "backfillLimit": false,
+        "hideCredit": true
+      },
+      "gitHead": "ba25251d13d0d0646b9896985eb48dd92706161a",
+      "_id": "object-is@1.1.3",
+      "_nodeVersion": "14.12.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
+        "shasum": "2e3b9e65560137455ee3bd62aec4d90a2ea1cc81",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+        "fileCount": 13,
+        "unpackedSize": 19659,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfdPl8CRA9TVsSAnZWagAARM8P/26bP/SmvdymZv18pA6s\nb1Pc6DegdmeFZQuCyesCeyrRl+0huTNbNI2teo1dMU6xwgF7a4H1/YMZuf1L\nWve7FMHX2NHkVtmNOGpqoTJT4om7oapeSr+gCLjuc7FxI6dALJyb0CNMkNJp\nRHj3aSCCepNm8uSSix8HJzvpxFx/xZRXpeYMxlpmRuCdqhnDqwenW9+SpCJi\njNvTlV2Xp8F8ZR0SnGN8nBmOihNhjywrEC65r6zJJaoyuE3rCNLMBcndGqFt\nghZFqUF4uduLaWwcJ/mjn1GVNtDgEH6rP6pv4o6mdJ/RdyueHlVL/CZdED7b\n6DgK5AFg9qPKVflF36L8cNrWaEAdO50vIXxD08XSj1UFjCHcVmqK34kvRyMk\nqqv/UjQWLFCpVe1vFiVhjXjbc7RwRtZGYdYldN+OT1jpRSwBOBfOTpIdWoOI\nrEYGNXHAM4D4SlPdaKKdKrCHVlGMzd3Lw9V9Ma8dWCC9zHPjde+wyjmHKzKa\nsf8Me4HmnrnJ5waKLOLO5y8K1n74vf3yhxmv6zgiLXPqxO/R9+q37U9SgeSk\nYspmBT48FzNE0CRxeEfYyUO+vs0XQzOF7GZp1sZ/wa/SsX6jWpcBcE6VGUK0\nUroX0uno0TdCJsi9jcovue75ix+Mp5F+KvqzM5oReFVyYxvd0atNh3dxFwdD\ndWo5\r\n=Y2R/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        },
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/object-is_1.1.3_1601501563862_0.400024732395988"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "#object-is <sup>[![Version Badge][2]][1]</sup>\n\n[![Build Status][3]][4]\n[![dependency status][5]][6]\n[![dev dependency status][7]][8]\n[![License][license-image]][license-url]\n[![Downloads][downloads-image]][downloads-url]\n\n[![npm badge][11]][1]\n\nES2015-compliant shim for Object.is - differentiates between -0 and +0, and can compare to NaN.\n\nEssentially, Object.is returns the same value as === - but true for NaN, and false for -0 and +0.\n\n## Example\n\n```js\nObject.is = require('object-is');\nvar assert = require('assert');\n\nassert.ok(Object.is());\nassert.ok(Object.is(undefined));\nassert.ok(Object.is(undefined, undefined));\nassert.ok(Object.is(null, null));\nassert.ok(Object.is(true, true));\nassert.ok(Object.is(false, false));\nassert.ok(Object.is('foo', 'foo'));\n\nvar arr = [1, 2];\nassert.ok(Object.is(arr, arr));\nassert.notOk(Object.is(arr, [1, 2]));\n\nassert.ok(Object.is(0, 0));\nassert.ok(Object.is(-0, -0));\nassert.notOk(Object.is(0, -0));\n\nassert.ok(Object.is(NaN, NaN));\nassert.ok(Object.is(Infinity, Infinity));\nassert.ok(Object.is(-Infinity, -Infinity));\n```\n\n## Tests\nSimply clone the repo, `npm install`, and run `npm test`\n\n[1]: https://npmjs.org/package/object-is\n[2]: http://versionbadg.es/es-shims/object-is.svg\n[3]: https://travis-ci.org/es-shims/object-is.svg\n[4]: https://travis-ci.org/es-shims/object-is\n[5]: https://david-dm.org/es-shims/object-is.svg\n[6]: https://david-dm.org/es-shims/object-is\n[7]: https://david-dm.org/es-shims/object-is/dev-status.svg\n[8]: https://david-dm.org/es-shims/object-is#info=devDependencies\n[11]: https://nodei.co/npm/object-is.png?downloads=true&stars=true\n[license-image]: http://img.shields.io/npm/l/object-is.svg\n[license-url]: LICENSE\n[downloads-image]: http://img.shields.io/npm/dm/object-is.svg\n[downloads-url]: http://npm-stat.com/charts.html?package=object-is\n\n",
+  "maintainers": [
+    {
+      "name": "substack",
+      "email": "substack@gmail.com"
+    },
+    {
+      "name": "ljharb",
+      "email": "ljharb@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-09-30T21:32:47.394Z",
+    "created": "2014-02-18T06:25:04.343Z",
+    "0.0.0": "2014-02-18T06:25:04.343Z",
+    "1.0.0": "2014-08-01T07:19:38.410Z",
+    "1.0.1": "2014-08-28T09:21:04.558Z",
+    "1.0.2": "2019-12-16T06:59:30.404Z",
+    "1.1.0": "2020-04-14T16:08:06.579Z",
+    "1.1.1": "2020-04-14T19:39:07.796Z",
+    "1.1.2": "2020-04-14T19:51:20.748Z",
+    "1.1.3": "2020-09-30T21:32:44.018Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/es-shims/object-is",
+  "keywords": [
+    "is",
+    "Object.is",
+    "equality",
+    "sameValueZero",
+    "ES6",
+    "ES2015",
+    "shim",
+    "polyfill",
+    "es-shim API"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/es-shims/object-is.git"
+  },
+  "author": {
+    "name": "Jordan Harband"
+  },
+  "bugs": {
+    "url": "https://github.com/es-shims/object-is/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "emiljohansson": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/object-is.min.json
+++ b/test/fixtures/registry-mocks/content/object-is.min.json
@@ -1,0 +1,208 @@
+{
+  "name": "object-is",
+  "dist-tags": {
+    "latest": "1.1.3"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "object-is",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tape": "~2.4.2",
+        "covert": "~0.3.1"
+      },
+      "dist": {
+        "shasum": "65adab52f96f7071047ab2edf8d5e0d4230dc1b4",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.0.0": {
+      "name": "object-is",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "~2.13.1",
+        "covert": "~0.4.0"
+      },
+      "dist": {
+        "shasum": "c4d85931da0009435ec9825ddbe578a7ff82c001",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.0.1": {
+      "name": "object-is",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tape": "~2.14.0",
+        "covert": "~1.0.0",
+        "jscs": "~1.5.9"
+      },
+      "dist": {
+        "shasum": "0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.0.2": {
+      "name": "object-is",
+      "version": "1.0.2",
+      "devDependencies": {
+        "@ljharb/eslint-config": "^15.0.2",
+        "auto-changelog": "^1.16.2",
+        "covert": "^1.1.1",
+        "eslint": "^6.7.2",
+        "has-symbols": "^1.0.1",
+        "tape": "^4.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
+        "shasum": "6b80eb84fe451498f65007982f035a5b445edec4",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 16498,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd9ytSCRA9TVsSAnZWagAA5koP/3OpM9HTrTeBXLXbtfBO\nWMzdrsFzD/67aiRs7jejkQqPHbUKc3l/gdB12zUSFGsFb3wP9LPTYB6dyQ94\nd8j6SuInoodlidjxrDrq2LD4LxKwcN0CW+iw8/DzwmxG0017KLLam/ykbPzQ\nvnI3PM8fMiUdXdwkUoqIr/louLr3SmyJ9fO1NcFGgNFG88gl/W8QOoa6Oz08\nOy3jjBdJSyVLvf5tl1yX1C+F0fn7F5Fhtt2AL0IBok+wTIHNWr8Oh1Mmo6jg\n+BGJEAtWRBYdyuUG+agL1JQ+crnoMjnrwJ57aAN6satjUFyH4UT2/i7Y8UNI\n4T1raOrZQiZNRSCh3DVfcr58xFjrPmlYSKbpcY04QMnkqQjewFK4QfR+Wq5p\nzbSnWug8oIiHZ0j7CWvI0VtSOQRF4gez4qnvgnufTHujPPoff8B17NTIwZgs\n/zRQyLaez0/tnXw8ayvjicdu0EQIZjF2Lcalten1D8TftE+lmdzgvx3KXDLj\nRQPQQD/v9O/dXU7cqi0mN7mTK8NgzSkzCCEVnmiIwVOxlxa31Q3ublkdcsSK\n7PPQJelesj0a9fju6Et+0Yl6meKImOYhyYI5nv+IBADHll4bNiTkwY+Gbgnc\n7+igavjjbJTfCu7qEQAuGgRseLxGLkk8FDPsZQ3pmhAiuXacc3UYsY00F4Ms\nmqCI\r\n=2AeM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "1.1.0": {
+      "name": "object-is",
+      "version": "1.1.0",
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^16.0.0",
+        "aud": "^1.1.0",
+        "auto-changelog": "^2.0.0",
+        "covert": "^1.1.1",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^5.0.0-next.5"
+      },
+      "dist": {
+        "integrity": "sha512-wznR5+ya11MdnkLq+oYePGjW2ge4RY5DVSwa3iKuDCpvLsYGnp24Qy5EzVRgyMHEuEkKd+dX/1JpAT6QxZXq2g==",
+        "shasum": "57e5e236f2831066c82948cbd735c24a9e54084d",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.1.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 18380,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeld/nCRA9TVsSAnZWagAAH1QP/R4suubDK/XkvmV4tKLp\ngmPRaaVtuSHa736FsJa8u0tp8SLhOiD0jPNF6AbOi/PIFQOGOZeS3epN9Y/K\nqNrq6UeQL4gM28xuF4OSACzAUTw+LeiUGMItu19x7Qwlm351yuzb1pg9dRDD\nnmJLxs3J8H25xN0SM7asC+o7zUtHpDVxITrgPrTubmPwR/D3ZVBvdtE7nUc8\n0Ai/++V7M/nj65iT2PV13By+E78cyL0H+PJEcJQAddlgI8z1STySWcCFY1eg\nHrjudeh8xmPnb9gX7HFgPS5jtaF+bhnI4ehTH1hdWBsSsQ4d3QJjkz1ql4vN\niQPOm92+z2xF/ajgq8PBEUZ3JDaK2PoXouGAPgtKW/uxxapqMIxm4j32TpAd\nz4ZTsZamK4uI0uA5rSFz2TN0YLycIA+gZ2SWEeSoHJyAYOF4+ER+k3SOywxo\n1stnhn1bTgPY1qUNweff0AxVb6tnS/vDzuaHbB8SKJBcgbi4DcGzBM1si2gy\nR/dzHX8HRH43BJIQxaLD0BLXgd1GX3dBtIRaqq1+omrOPIZPt/V20Bw9rlTt\nnW+qtOFbedNwZ5PxkTdmt5iARNzH9uWrzxCVkTx57jD1gMrXid74ra7Unvat\nqvXRdBE3GBg7lydyJnrk78n93JkqLBDGKT2HJqY77BOUD0vMbIRLj1xGvmjE\n19tO\r\n=ptum\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "1.1.1": {
+      "name": "object-is",
+      "version": "1.1.1",
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^16.0.0",
+        "aud": "^1.1.0",
+        "auto-changelog": "^2.0.0",
+        "covert": "^1.1.1",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^5.0.0-next.5"
+      },
+      "dist": {
+        "integrity": "sha512-9wFT2CEamBmkYN6TEqnXCOzexDKR/N3hyUOQwtxIxZCZOyvlTUhKUejftM6+nciflJX0x2VLh7wNFWvIpmKGNw==",
+        "shasum": "9314b6dc7f649891a1fc7f499a6cd3b0a6c01543",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.1.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 25554,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJelhFcCRA9TVsSAnZWagAAnXMP/34zIHmloOiJ5GCE49aI\nVW3IijmBH61f+Tf45EbOFFQw6v3X9SDgdge6ZogwHvbWjPA97s5dU5DfjnIo\nP1khJdlU/IWdrTRVpAg6KZgX8S9dZ4GBNcgKi71d5IcnLflCBHPUpDliuDZK\nqkPIz0apz4IHSXkopyFyyrYFzpFwc0Gtj9hpXSnMZk1cpLpBGptSJWdHgPJl\nAWzPgeaNIAMMZVt0Y0L5m7Vet3dHGmnxiCqnUu4fbJbdIr1/DHZiRQf3WAgP\n8myP0F+HmPtb5jqAqzZmHqcMpPL9byRDnmASpvz1T2ZX0tPXfK4yuOPjozJA\n+oukV1AAT99WOLG+FOhfCeG5lKQX4PH0OhBk7k+NsuC6A27AcfPT8GGo5t7R\n030PGVQOLdxu7S9DIK7ekoBGyeUmuP36a3t4GFGLVTqIWsnsovm6v0qXNYte\nwh94oGgFfBFFnFSu75nmcp0AM0Sj+wE6RUv4vUcTlQH6/Sc60Aq1PmRBkA/d\nGURbHEjUPzWV81+gw/22EtMrpl9bUenoAzcdscR5aTEv6kBLXXHfoF9wV/et\n9qwYm+4tWNV63+AOVL1OCWZM8WQLAS9j5/8DHrrvpBBgF5kSfJ03O/7aAonR\nf5G+W+/O5YA5AWb/gHalJlW5FjwYdZuF8gabMPC6bH+DwY3NHMrogIH0034N\nAzoE\r\n=Ya0T\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "1.1.2": {
+      "name": "object-is",
+      "version": "1.1.2",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^16.0.0",
+        "aud": "^1.1.0",
+        "auto-changelog": "^2.0.0",
+        "covert": "^1.1.1",
+        "eslint": "^6.8.0",
+        "has-symbols": "^1.0.1",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^5.0.0-next.5"
+      },
+      "dist": {
+        "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+        "shasum": "c5d2e87ff9e119f78b7a088441519e2eec1573b6",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 25937,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJelhQ5CRA9TVsSAnZWagAAexQP/1ltZexI1kiaTRK+P31+\niU5Fqfyh+OFkM7Cib8fYLTVv+Ed63TCKfxdxg9NTT+8pf3rklsYhlpIn02kZ\nHWJidKNaJQSjxLVkS51o42rXSlpxH4URWhbE/cPfUpJKusBGZNTvVbtBiUks\nhZfkrYwE33ggybAikJ2HeoLDTBZpUtv5mJNHgsdtT/MKAE4ckg0e8NtHyOSn\nFp2quuIRXFsdLTDUrKzHLEb6J4X3MicBNelq8vwaZAxuPf2ZedY8t7vT5GWc\nxn2PP+auXyjAz8ieemKwB4XfJeqErzj7j9uJ5nAwjbg8/LVmYybR273G/zuW\nGZ83XCOHX/gGvXLD/wrbH7jyIt5TTsYna6QMpPJK3HU85g/3h/+5bU1IGzhS\npDHc7qdvS4friP+/YrZ67kQPY4cRdbQX/TGUMTPZznRxVIHmd3ptCASa/6Hf\nS+OTXKV6qwF35PfXoW6XHUwsFMsyKy/NOL/MH8J3WQ03AavqcOIFRp8SKK6N\nuPHOSSWJGj6aJuCNcWVwi1O4q9A5MejVJFxT4TqPM0r6O1qGrfFKuGpa8I1N\ngYxlEDk8xQbrLK0zSYMsgNggqOZr0+iGh+r0MT8EeD9/CRw53cBmZxKibgES\nMvvSJCF1rCrCZH10mq0JXFqqk8/QzaJsce9ChXLnE4hPkPcgtI7KdjNNVNYa\nh0zJ\r\n=RjDk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "1.1.3": {
+      "name": "object-is",
+      "version": "1.1.3",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^17.2.0",
+        "aud": "^1.1.2",
+        "auto-changelog": "^2.2.1",
+        "covert": "^1.1.1",
+        "eslint": "^7.10.0",
+        "has-symbols": "^1.0.1",
+        "safe-publish-latest": "^1.1.4",
+        "tape": "^5.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
+        "shasum": "2e3b9e65560137455ee3bd62aec4d90a2ea1cc81",
+        "tarball": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+        "fileCount": 13,
+        "unpackedSize": 19659,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfdPl8CRA9TVsSAnZWagAARM8P/26bP/SmvdymZv18pA6s\nb1Pc6DegdmeFZQuCyesCeyrRl+0huTNbNI2teo1dMU6xwgF7a4H1/YMZuf1L\nWve7FMHX2NHkVtmNOGpqoTJT4om7oapeSr+gCLjuc7FxI6dALJyb0CNMkNJp\nRHj3aSCCepNm8uSSix8HJzvpxFx/xZRXpeYMxlpmRuCdqhnDqwenW9+SpCJi\njNvTlV2Xp8F8ZR0SnGN8nBmOihNhjywrEC65r6zJJaoyuE3rCNLMBcndGqFt\nghZFqUF4uduLaWwcJ/mjn1GVNtDgEH6rP6pv4o6mdJ/RdyueHlVL/CZdED7b\n6DgK5AFg9qPKVflF36L8cNrWaEAdO50vIXxD08XSj1UFjCHcVmqK34kvRyMk\nqqv/UjQWLFCpVe1vFiVhjXjbc7RwRtZGYdYldN+OT1jpRSwBOBfOTpIdWoOI\nrEYGNXHAM4D4SlPdaKKdKrCHVlGMzd3Lw9V9Ma8dWCC9zHPjde+wyjmHKzKa\nsf8Me4HmnrnJ5waKLOLO5y8K1n74vf3yhxmv6zgiLXPqxO/R9+q37U9SgeSk\nYspmBT48FzNE0CRxeEfYyUO+vs0XQzOF7GZp1sZ/wa/SsX6jWpcBcE6VGUK0\nUroX0uno0TdCJsi9jcovue75ix+Mp5F+KvqzM5oReFVyYxvd0atNh3dxFwdD\ndWo5\r\n=Y2R/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  },
+  "modified": "2020-09-30T21:32:47.394Z"
+}

--- a/test/fixtures/registry-mocks/content/object-visit.json
+++ b/test/fixtures/registry-mocks/content/object-visit.json
@@ -1,0 +1,871 @@
+{
+  "_id": "object-visit",
+  "_rev": "12-57dcdb9eec6d537ae639a0cef5eb9f6e",
+  "name": "object-visit",
+  "description": "Call a specified method on each value in the given object.",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "object-visit",
+      "description": "Call the given method on each value in the given object.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "gitHead": "c4bc5a072871a8f0b5f49dfeeae2402dd4a1ba91",
+      "_id": "object-visit@0.1.0",
+      "_shasum": "b1bb6749f228ee76e0c42f3851d28a14d233ce26",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b1bb6749f228ee76e0c42f3851d28a14d233ce26",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "object-visit",
+      "description": "Call the given method on each value in the given object.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "map-visit"
+          ]
+        }
+      },
+      "gitHead": "b4bd9cedc4fa269c38ae0b78b98fcf207a52b71f",
+      "_id": "object-visit@0.2.0",
+      "_shasum": "5e803d935fd3a950e02305a64ef1842f1a8fcf7c",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5e803d935fd3a950e02305a64ef1842f1a8fcf7c",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "object-visit",
+      "description": "Call the given method on each value in the given object.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "map-visit"
+          ]
+        }
+      },
+      "gitHead": "3e97cb456f8713aa5abf347734186e00677bc32c",
+      "_id": "object-visit@0.2.1",
+      "_shasum": "23c9002c355707862d00a0a188a05132de9fad5a",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "23c9002c355707862d00a0a188a05132de9fad5a",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "object-visit",
+      "description": "Call the given method on each value in the given object.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "expected": "^0.1.0",
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "base-methods",
+            "collection-visit",
+            "map-visit"
+          ]
+        }
+      },
+      "gitHead": "3e97cb456f8713aa5abf347734186e00677bc32c",
+      "_id": "object-visit@0.3.0",
+      "_shasum": "97e850c2f93aaa74d262e9ea18163ca85b7114c7",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "97e850c2f93aaa74d262e9ea18163ca85b7114c7",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "object-visit",
+      "description": "Call the given method on each value in the given object.",
+      "version": "0.3.1",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "expected": "^0.1.0",
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "base-methods",
+            "collection-visit",
+            "map-visit"
+          ]
+        }
+      },
+      "gitHead": "bc4cae5b50afac7c249d6b6f093f02aaa1f23232",
+      "_id": "object-visit@0.3.1",
+      "_shasum": "af58f53489f9e76d43a505f9a9eff329da957690",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "af58f53489f9e76d43a505f9a9eff329da957690",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "object-visit",
+      "description": "Call a specified method on each value in the given object.",
+      "version": "0.3.2",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "expected": "^0.1.0",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.0.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-mocha": "^2.1.3",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "map-visit",
+            "define-property",
+            "base-methods"
+          ]
+        }
+      },
+      "gitHead": "88635e3412829826c2ef4b510d17cad134010ccf",
+      "_id": "object-visit@0.3.2",
+      "_shasum": "d1fdd3e550e4d78df6d16e84aa0e837b49b9042c",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d1fdd3e550e4d78df6d16e84aa0e837b49b9042c",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.3": {
+      "name": "object-visit",
+      "description": "Call a specified method on each value in the given object.",
+      "version": "0.3.3",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.0.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-mocha": "^2.1.3",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "map-visit",
+            "define-property",
+            "base-methods"
+          ]
+        }
+      },
+      "gitHead": "88635e3412829826c2ef4b510d17cad134010ccf",
+      "_id": "object-visit@0.3.3",
+      "_shasum": "acef7115e63b8449238f44d4c78cb594b3d1a95d",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "acef7115e63b8449238f44d4c78cb594b3d1a95d",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.4": {
+      "name": "object-visit",
+      "description": "Call a specified method on each value in the given object.",
+      "version": "0.3.4",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.0.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-mocha": "^2.1.3",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "collection-visit",
+            "map-visit",
+            "define-property",
+            "base-methods"
+          ]
+        }
+      },
+      "gitHead": "7d5e941d09644b30f92a341632e17d47e1001c8b",
+      "_id": "object-visit@0.3.4",
+      "_shasum": "ae15cf86f0b2fdd551771636448452c54c3da829",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ae15cf86f0b2fdd551771636448452c54c3da829",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "object-visit",
+      "description": "Call a specified method on each value in the given object.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "base-methods",
+            "collection-visit",
+            "define-property",
+            "map-visit"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "daffde04ce16ca0ef46fe29f65e7576f123dfe60",
+      "_id": "object-visit@1.0.0",
+      "_shasum": "632f78e50663d161e4780cf4d4ac5e806ef5d541",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "632f78e50663d161e4780cf4d4ac5e806ef5d541",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/object-visit-1.0.0.tgz_1491772180437_0.023425929713994265"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "object-visit",
+      "description": "Call a specified method on each value in the given object.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jonschlinkert/object-visit",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object-visit.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object-visit/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "context",
+        "function",
+        "helper",
+        "key",
+        "method",
+        "object",
+        "value",
+        "visit",
+        "visitor"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "base-methods",
+            "collection-visit",
+            "define-property",
+            "map-visit"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "2220cd6ea35008481c9e252488bcbde9ebca0983",
+      "_id": "object-visit@1.0.1",
+      "_shasum": "f79c4493af0c5377b59fe39d395e41042dd045bb",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f79c4493af0c5377b59fe39d395e41042dd045bb",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/object-visit-1.0.1.tgz_1496118320846_0.49384314101189375"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# object-visit [![NPM version](https://img.shields.io/npm/v/object-visit.svg?style=flat)](https://www.npmjs.com/package/object-visit) [![NPM monthly downloads](https://img.shields.io/npm/dm/object-visit.svg?style=flat)](https://npmjs.org/package/object-visit) [![NPM total downloads](https://img.shields.io/npm/dt/object-visit.svg?style=flat)](https://npmjs.org/package/object-visit) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/object-visit.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/object-visit)\n\n> Call a specified method on each value in the given object.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save object-visit\n```\n\n## Usage\n\n```js\nvar visit = require('object-visit');\n\nvar ctx = {\n  data: {},\n  set: function (key, value) {\n    if (typeof key === 'object') {\n      visit(ctx, 'set', key);\n    } else {\n      ctx.data[key] = value;\n    }\n  }\n};\n\nctx.set('a', 'a');\nctx.set('b', 'b');\nctx.set('c', 'c');\nctx.set({d: {e: 'f'}});\n\nconsole.log(ctx.data);\n//=> {a: 'a', b: 'b', c: 'c', d: { e: 'f' }};\n```\n\n## About\n\n### Related projects\n\n* [base-methods](https://www.npmjs.com/package/base-methods): base-methods is the foundation for creating modular, unit testable and highly pluggable node.js applications, starting… [more](https://github.com/jonschlinkert/base-methods) | [homepage](https://github.com/jonschlinkert/base-methods \"base-methods is the foundation for creating modular, unit testable and highly pluggable node.js applications, starting with a handful of common methods, like `set`, `get`, `del` and `use`.\")\n* [collection-visit](https://www.npmjs.com/package/collection-visit): Visit a method over the items in an object, or map visit over the objects… [more](https://github.com/jonschlinkert/collection-visit) | [homepage](https://github.com/jonschlinkert/collection-visit \"Visit a method over the items in an object, or map visit over the objects in an array.\")\n* [define-property](https://www.npmjs.com/package/define-property): Define a non-enumerable property on an object. | [homepage](https://github.com/jonschlinkert/define-property \"Define a non-enumerable property on an object.\")\n* [map-visit](https://www.npmjs.com/package/map-visit): Map `visit` over an array of objects. | [homepage](https://github.com/jonschlinkert/map-visit \"Map `visit` over an array of objects.\")\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Building docs\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n### Running tests\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2017, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on May 30, 2017._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-05-30T04:25:21.809Z",
+    "created": "2015-07-04T19:57:29.483Z",
+    "0.1.0": "2015-07-04T19:57:29.483Z",
+    "0.2.0": "2015-08-29T23:36:08.120Z",
+    "0.2.1": "2015-08-30T02:45:56.001Z",
+    "0.2.2": "2015-10-06T13:48:19.559Z",
+    "0.3.0": "2015-10-06T13:49:10.813Z",
+    "0.3.1": "2015-10-10T10:59:18.322Z",
+    "0.3.2": "2015-11-08T19:10:32.876Z",
+    "0.3.3": "2015-11-09T22:33:36.207Z",
+    "0.3.4": "2015-11-09T22:38:19.120Z",
+    "1.0.0": "2017-04-09T21:09:41.085Z",
+    "1.0.1": "2017-05-30T04:25:21.809Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/object-visit",
+  "keywords": [
+    "context",
+    "function",
+    "helper",
+    "key",
+    "method",
+    "object",
+    "value",
+    "visit",
+    "visitor"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/object-visit.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/object-visit/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/object-visit.min.json
+++ b/test/fixtures/registry-mocks/content/object-visit.min.json
@@ -1,0 +1,217 @@
+{
+  "name": "object-visit",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "object-visit",
+      "version": "0.1.0",
+      "dependencies": {
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "b1bb6749f228ee76e0c42f3851d28a14d233ce26",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "object-visit",
+      "version": "0.2.0",
+      "dependencies": {
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "5e803d935fd3a950e02305a64ef1842f1a8fcf7c",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.1": {
+      "name": "object-visit",
+      "version": "0.2.1",
+      "dependencies": {
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "23c9002c355707862d00a0a188a05132de9fad5a",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.0": {
+      "name": "object-visit",
+      "version": "0.3.0",
+      "dependencies": {
+        "expected": "^0.1.0",
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "97e850c2f93aaa74d262e9ea18163ca85b7114c7",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.1": {
+      "name": "object-visit",
+      "version": "0.3.1",
+      "dependencies": {
+        "expected": "^0.1.0",
+        "isobject": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "af58f53489f9e76d43a505f9a9eff329da957690",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.2": {
+      "name": "object-visit",
+      "version": "0.3.2",
+      "dependencies": {
+        "expected": "^0.1.0",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.0.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-mocha": "^2.1.3",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "d1fdd3e550e4d78df6d16e84aa0e837b49b9042c",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.3": {
+      "name": "object-visit",
+      "version": "0.3.3",
+      "dependencies": {
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.0.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-mocha": "^2.1.3",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "acef7115e63b8449238f44d4c78cb594b3d1a95d",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.4": {
+      "name": "object-visit",
+      "version": "0.3.4",
+      "dependencies": {
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.0.0",
+        "gulp-istanbul": "^0.10.1",
+        "gulp-mocha": "^2.1.3",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "ae15cf86f0b2fdd551771636448452c54c3da829",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-0.3.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "object-visit",
+      "version": "1.0.0",
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "632f78e50663d161e4780cf4d4ac5e806ef5d541",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "object-visit",
+      "version": "1.0.1",
+      "dependencies": {
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "f79c4493af0c5377b59fe39d395e41042dd045bb",
+        "tarball": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-05-30T04:25:21.809Z"
+}

--- a/test/fixtures/registry-mocks/content/object.pick.json
+++ b/test/fixtures/registry-mocks/content/object.pick.json
@@ -1,0 +1,639 @@
+{
+  "_id": "object.pick",
+  "_rev": "16-2e4fd7c25dd8c656915c94ad111fa920",
+  "name": "object.pick",
+  "description": "Returns a filtered copy of an object with only the specified keys, similar to `_.pick` from lodash / underscore.",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "versions": {
+    "0.1.1": {
+      "name": "object.pick",
+      "description": "Returns a filtered copy of an object with only the specified keys, exactly like `pick` from lo-dash / underscore.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/object.pick",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/object.pick.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object.pick/issues"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jonschlinkert/object.pick/blob/master/LICENSE-MIT"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6"
+      },
+      "keywords": [
+        "check",
+        "is",
+        "is-object",
+        "isobject",
+        "javascript",
+        "key",
+        "keys",
+        "object",
+        "pick",
+        "plain",
+        "prop",
+        "properties",
+        "property",
+        "props",
+        "type",
+        "type-of",
+        "typeof",
+        "util",
+        "utilities",
+        "utility",
+        "utils",
+        "value"
+      ],
+      "_id": "object.pick@0.1.1",
+      "_shasum": "aff20a2eaac790890126cf1d2d45e8891eebccb4",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "aff20a2eaac790890126cf1d2d45e8891eebccb4",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "object.pick",
+      "description": "Returns a filtered copy of an object with only the specified keys, like `pick` from lo-dash / underscore.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/object.pick",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/object.pick.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object.pick/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/object.pick/blob/master/LICENSE-MIT"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "object",
+        "pick"
+      ],
+      "gitHead": "9260c87ecb178ffa029ca29857eb8fdc2953b0e6",
+      "_id": "object.pick@1.0.0",
+      "_shasum": "787a26e906343210bcd30d5682ffcc7e4200f43f",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "787a26e906343210bcd30d5682ffcc7e4200f43f",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "object.pick",
+      "description": "Returns a filtered copy of an object with only the specified keys, like `pick` from lo-dash / underscore.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jonschlinkert/object.pick",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/object.pick.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object.pick/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/object.pick/blob/master/LICENSE-MIT"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "object",
+        "pick"
+      ],
+      "gitHead": "06e63ba38b592176795ee432d24203f0f81ccd52",
+      "_id": "object.pick@1.0.1",
+      "_shasum": "6459751a70786162cbc29c43b21a9112b878ec03",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6459751a70786162cbc29c43b21a9112b878ec03",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "object.pick",
+      "description": "Returns a filtered copy of an object with only the specified keys, like `pick` from lo-dash / underscore.",
+      "version": "1.1.0",
+      "homepage": "https://github.com/jonschlinkert/object.pick",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/object.pick.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object.pick/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/object.pick/blob/master/LICENSE-MIT"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha -R spec"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "object",
+        "pick"
+      ],
+      "gitHead": "c8d951b04c40749462cf8c654004ef3944667df1",
+      "_id": "object.pick@1.1.0",
+      "_shasum": "306406de02ac3fe77eea3c5ed8b708df45f4109f",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "306406de02ac3fe77eea3c5ed8b708df45f4109f",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "object.pick",
+      "description": "Returns a filtered copy of an object with only the specified keys, like `pick` from lo-dash / underscore.",
+      "version": "1.1.1",
+      "homepage": "https://github.com/jonschlinkert/object.pick",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/object.pick.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object.pick/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/object.pick/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "keywords": [
+        "object",
+        "pick"
+      ],
+      "gitHead": "c8d951b04c40749462cf8c654004ef3944667df1",
+      "_id": "object.pick@1.1.1",
+      "_shasum": "d578036575c77945fda736c88b9ea432eaf21e7a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d578036575c77945fda736c88b9ea432eaf21e7a",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "object.pick",
+      "description": "Returns a filtered copy of an object with only the specified keys, similar to `_.pick` from lodash / underscore.",
+      "version": "1.1.2",
+      "homepage": "https://github.com/jonschlinkert/object.pick",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object.pick.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object.pick/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5",
+        "vinyl": "^1.1.1"
+      },
+      "keywords": [
+        "object",
+        "pick"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "get-value",
+            "set-value",
+            "mixin-deep",
+            "extend-shallow"
+          ],
+          "highlight": "object.omit"
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "e32be6263a9e6ffd9bc5364b9b423e75b8d7c8e0",
+      "_id": "object.pick@1.1.2",
+      "_shasum": "c24da6ce45f10c5aabe71797d16a839cd5969b1e",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c24da6ce45f10c5aabe71797d16a839cd5969b1e",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.1.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/object.pick-1.1.2.tgz_1458549449575_0.7406595365609974"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "object.pick",
+      "description": "Returns a filtered copy of an object with only the specified keys, similar to `_.pick` from lodash / underscore.",
+      "version": "1.2.0",
+      "homepage": "https://github.com/jonschlinkert/object.pick",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object.pick.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object.pick/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^2.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.1.2",
+        "vinyl": "^2.0.0"
+      },
+      "keywords": [
+        "object",
+        "pick"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "extend-shallow",
+            "get-value",
+            "mixin-deep",
+            "set-value"
+          ],
+          "highlight": "object.omit"
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "c9e87ae572c41bf8fb3fb44a940586b38997f629",
+      "_id": "object.pick@1.2.0",
+      "_shasum": "b5392bee9782da6d9fb7d6afaf539779f1234c2b",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b5392bee9782da6d9fb7d6afaf539779f1234c2b",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/object.pick-1.2.0.tgz_1477549306086_0.7492839891929179"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "object.pick",
+      "description": "Returns a filtered copy of an object with only the specified keys, similar to `_.pick` from lodash / underscore.",
+      "version": "1.3.0",
+      "homepage": "https://github.com/jonschlinkert/object.pick",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/object.pick.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/object.pick/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.1.2",
+        "vinyl": "^2.0.0"
+      },
+      "keywords": [
+        "object",
+        "pick"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "extend-shallow",
+            "get-value",
+            "mixin-deep",
+            "set-value"
+          ],
+          "highlight": "object.omit"
+        },
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "f9d89d96a8d5ec671dc39e2c2319d8aaa04dd2cc",
+      "_id": "object.pick@1.3.0",
+      "_shasum": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "0.10.48",
+      "_npmUser": {
+        "name": "phated",
+        "email": "blaine.bublitz@gmail.com"
+      },
+      "maintainers": [
+        {
+          "email": "blaine.bublitz@gmail.com",
+          "name": "phated"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "dist": {
+        "shasum": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/object.pick-1.3.0.tgz_1503110073929_0.8448499809019268"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# object.pick [![NPM version](https://img.shields.io/npm/v/object.pick.svg?style=flat)](https://www.npmjs.com/package/object.pick) [![NPM monthly downloads](https://img.shields.io/npm/dm/object.pick.svg?style=flat)](https://npmjs.org/package/object.pick)  [![NPM total downloads](https://img.shields.io/npm/dt/object.pick.svg?style=flat)](https://npmjs.org/package/object.pick) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/object.pick.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/object.pick)\n\n> Returns a filtered copy of an object with only the specified keys, similar to `_.pick` from lodash / underscore.\n\nYou might also be interested in [object.omit](https://github.com/jonschlinkert/object.omit).\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save object.pick\n```\n\n## benchmarks\n\nThis is the [fastest implementation](http://jsperf.com/pick-props) I tested. Pull requests welcome!\n\n## Usage\n\n```js\nvar pick = require('object.pick');\n\npick({a: 'a', b: 'b'}, 'a')\n//=> {a: 'a'}\n\npick({a: 'a', b: 'b', c: 'c'}, ['a', 'b'])\n//=> {a: 'a', b: 'b'}\n```\n\n## About\n\n### Related projects\n\n* [extend-shallow](https://www.npmjs.com/package/extend-shallow): Extend an object with the properties of additional objects. node.js/javascript util. | [homepage](https://github.com/jonschlinkert/extend-shallow \"Extend an object with the properties of additional objects. node.js/javascript util.\")\n* [get-value](https://www.npmjs.com/package/get-value): Use property paths (`a.b.c`) to get a nested value from an object. | [homepage](https://github.com/jonschlinkert/get-value \"Use property paths (`a.b.c`) to get a nested value from an object.\")\n* [mixin-deep](https://www.npmjs.com/package/mixin-deep): Deeply mix the properties of objects into the first object. Like merge-deep, but doesn't clone. | [homepage](https://github.com/jonschlinkert/mixin-deep \"Deeply mix the properties of objects into the first object. Like merge-deep, but doesn't clone.\")\n* [set-value](https://www.npmjs.com/package/set-value): Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths. | [homepage](https://github.com/jonschlinkert/set-value \"Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths.\")\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Building docs\n\n_(This document was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme) (a [verb](https://github.com/verbose/verb) generator), please don't edit the readme directly. Any changes to the readme must be made in [.verb.md](.verb.md).)_\n\nTo generate the readme and API documentation with [verb](https://github.com/verbose/verb):\n\n```sh\n$ npm install -g verb verb-generate-readme && verb\n```\n\n### Running tests\n\nInstall dev dependencies:\n\n```sh\n$ npm install -d && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](http://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2016, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT license](https://github.com/jonschlinkert/object.pick/blob/master/LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.2.0, on October 27, 2016._",
+  "maintainers": [
+    {
+      "email": "blaine.bublitz@gmail.com",
+      "name": "phated"
+    },
+    {
+      "email": "github@sellside.com",
+      "name": "jonschlinkert"
+    }
+  ],
+  "time": {
+    "modified": "2017-10-21T06:45:24.588Z",
+    "created": "2014-10-06T04:29:00.412Z",
+    "0.1.1": "2014-10-06T04:29:00.412Z",
+    "1.0.0": "2014-12-20T08:17:40.858Z",
+    "1.0.1": "2014-12-20T08:19:10.969Z",
+    "1.1.0": "2014-12-20T08:31:19.812Z",
+    "1.1.1": "2015-02-14T04:45:03.769Z",
+    "1.1.2": "2016-03-21T08:37:31.996Z",
+    "1.2.0": "2016-10-27T06:21:48.316Z",
+    "1.3.0": "2017-08-19T02:34:34.023Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/object.pick",
+  "keywords": [
+    "object",
+    "pick"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/object.pick.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/object.pick/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "users": {
+    "icerainnuaa": true,
+    "rocket0191": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/object.pick.min.json
+++ b/test/fixtures/registry-mocks/content/object.pick.min.json
@@ -1,0 +1,142 @@
+{
+  "name": "object.pick",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "versions": {
+    "0.1.1": {
+      "name": "object.pick",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4",
+        "verb": ">= 0.2.6"
+      },
+      "dist": {
+        "shasum": "aff20a2eaac790890126cf1d2d45e8891eebccb4",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "object.pick",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "787a26e906343210bcd30d5682ffcc7e4200f43f",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "object.pick",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "6459751a70786162cbc29c43b21a9112b878ec03",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.0": {
+      "name": "object.pick",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "306406de02ac3fe77eea3c5ed8b708df45f4109f",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.1": {
+      "name": "object.pick",
+      "version": "1.1.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "^4.0.4"
+      },
+      "dist": {
+        "shasum": "d578036575c77945fda736c88b9ea432eaf21e7a",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.1.2": {
+      "name": "object.pick",
+      "version": "1.1.2",
+      "dependencies": {
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5",
+        "vinyl": "^1.1.1"
+      },
+      "dist": {
+        "shasum": "c24da6ce45f10c5aabe71797d16a839cd5969b1e",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.2.0": {
+      "name": "object.pick",
+      "version": "1.2.0",
+      "dependencies": {
+        "isobject": "^2.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.1.2",
+        "vinyl": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "b5392bee9782da6d9fb7d6afaf539779f1234c2b",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.3.0": {
+      "name": "object.pick",
+      "version": "1.3.0",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.1.2",
+        "vinyl": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "87a10ac4c1694bd2e1cbf53591a66141fb5dd747",
+        "tarball": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-10-21T06:45:24.588Z"
+}

--- a/test/fixtures/registry-mocks/content/obuf.json
+++ b/test/fixtures/registry-mocks/content/obuf.json
@@ -1,0 +1,565 @@
+{
+  "_id": "obuf",
+  "_rev": "12-933b69a61011599aec7bd072a68398f9",
+  "name": "obuf",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "obuf",
+      "version": "0.1.0",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/offset-buffer"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "2099db18818abf1e01c8b4e415fe9405cfe2c863",
+      "_id": "obuf@0.1.0",
+      "_shasum": "4761976805f7b1306c127525c8200d46a054df2c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4761976805f7b1306c127525c8200d46a054df2c",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "obuf",
+      "version": "0.1.1",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indutny/offset-buffer"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "958af0d99c9a4b05b586cdf29eb0216e5711028a",
+      "_id": "obuf@0.1.1",
+      "_shasum": "be0444a2ccc1d55ae85a23d9628aeec7b6331166",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "be0444a2ccc1d55ae85a23d9628aeec7b6331166",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "obuf",
+      "version": "1.0.0",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "dde321d47819f0f513446e4ca5c66ccca969b3b6",
+      "_id": "obuf@1.0.0",
+      "_shasum": "ca8b9275ea3cf4fe210d87a070b4a3572f8a96ea",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ca8b9275ea3cf4fe210d87a070b4a3572f8a96ea",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "obuf",
+      "version": "1.0.1",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "c13950a3453bed889bbad3be436b0abb6aa9e3fc",
+      "_id": "obuf@1.0.1",
+      "_shasum": "ff94cb1621eab2952755e8e5ef44ea6e389f3669",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ff94cb1621eab2952755e8e5ef44ea6e389f3669",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "obuf",
+      "version": "1.0.2",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "c4f93e589c06d5245e34788225d021996043cfa8",
+      "_id": "obuf@1.0.2",
+      "_shasum": "66e11f272f1cb8d912f8efdb294f3552a31f7b2a",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "66e11f272f1cb8d912f8efdb294f3552a31f7b2a",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "obuf",
+      "version": "1.0.3",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "361c727115bb55d930b832daff70dd99b48391ba",
+      "_id": "obuf@1.0.3",
+      "_shasum": "d8d59659f4689b49589db57f6eeead4464251d0c",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d8d59659f4689b49589db57f6eeead4464251d0c",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "obuf",
+      "version": "1.0.4",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "f14f76d0928ebf139c875a612f180f824a627323",
+      "_id": "obuf@1.0.4",
+      "_shasum": "530a9c3aa6b40c94515ce174701b333ae7ed8757",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "530a9c3aa6b40c94515ce174701b333ae7ed8757",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "obuf",
+      "version": "1.1.0",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "ff67970a49ca530cab48f3356428fbda399094a4",
+      "_id": "obuf@1.1.0",
+      "_shasum": "2592ef8d00e52bf50a4b13a994e1aa3024e4d630",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2592ef8d00e52bf50a4b13a994e1aa3024e4d630",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "obuf",
+      "version": "1.1.1",
+      "description": "",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "f14ad53be824cdfc805c0375c36cbf40d8d25f0a",
+      "_id": "obuf@1.1.1",
+      "_shasum": "104124b6c602c6796881a042541d36db43a5264e",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "104124b6c602c6796881a042541d36db43a5264e",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "obuf",
+      "version": "1.1.2",
+      "description": "Byte buffer specialized for data in chunks with special cases for dropping bytes in the front, merging bytes in to various integer types and abandoning buffer without penalty for previous chunk merges.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+      },
+      "keywords": [
+        "Offset",
+        "Buffer",
+        "reader"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/offset-buffer/issues"
+      },
+      "homepage": "https://github.com/indutny/offset-buffer",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "bac901d63eee226effb9149bf9511aac8d5853f0",
+      "_id": "obuf@1.1.2",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.6.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+        "shasum": "09bea3343d41859ebd446292d11c9d4db619084e",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19129
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/obuf_1.1.2_1520717598316_0.09991861763110621"
+      }
+    }
+  },
+  "readme": "# obuf - Offset buffer implementation.\n\nByte buffer specialized for data in chunks with special cases for dropping\nbytes in the front, merging bytes in to various integer types and\nabandoning buffer without penalty for previous chunk merges.\n\nUsed in spyd-transport, part of spdy support for http2.\n\nThis software is licensed under the MIT License.\n\nBy Fedor Indutny, 2015.\n\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-03-10T21:33:19.721Z",
+    "created": "2014-08-30T12:51:50.511Z",
+    "0.1.0": "2014-08-30T12:51:50.511Z",
+    "0.1.1": "2014-09-03T10:52:35.520Z",
+    "1.0.0": "2015-06-11T20:16:10.711Z",
+    "1.0.1": "2015-06-16T22:39:56.216Z",
+    "1.0.2": "2015-06-16T22:56:34.623Z",
+    "1.0.3": "2015-06-16T23:00:46.560Z",
+    "1.0.4": "2015-06-19T00:35:24.795Z",
+    "1.1.0": "2015-06-20T23:19:27.859Z",
+    "1.1.1": "2015-07-14T00:30:43.787Z",
+    "1.1.2": "2018-03-10T21:33:18.385Z"
+  },
+  "homepage": "https://github.com/indutny/offset-buffer",
+  "keywords": [
+    "Offset",
+    "Buffer",
+    "reader"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/offset-buffer.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/offset-buffer/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "description": "Byte buffer specialized for data in chunks with special cases for dropping bytes in the front, merging bytes in to various integer types and abandoning buffer without penalty for previous chunk merges.",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/obuf.min.json
+++ b/test/fixtures/registry-mocks/content/obuf.min.json
@@ -1,0 +1,122 @@
+{
+  "name": "obuf",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "obuf",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "4761976805f7b1306c127525c8200d46a054df2c",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "obuf",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "be0444a2ccc1d55ae85a23d9628aeec7b6331166",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-0.1.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "obuf",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "ca8b9275ea3cf4fe210d87a070b4a3572f8a96ea",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "obuf",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "ff94cb1621eab2952755e8e5ef44ea6e389f3669",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "obuf",
+      "version": "1.0.2",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "66e11f272f1cb8d912f8efdb294f3552a31f7b2a",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "obuf",
+      "version": "1.0.3",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "d8d59659f4689b49589db57f6eeead4464251d0c",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "obuf",
+      "version": "1.0.4",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "530a9c3aa6b40c94515ce174701b333ae7ed8757",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.0.4.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "obuf",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "2592ef8d00e52bf50a4b13a994e1aa3024e4d630",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "obuf",
+      "version": "1.1.1",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "104124b6c602c6796881a042541d36db43a5264e",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "obuf",
+      "version": "1.1.2",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+        "shasum": "09bea3343d41859ebd446292d11c9d4db619084e",
+        "tarball": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19129
+      }
+    }
+  },
+  "modified": "2018-03-10T21:33:19.721Z"
+}

--- a/test/fixtures/registry-mocks/content/on-finished.json
+++ b/test/fixtures/registry-mocks/content/on-finished.json
@@ -1,0 +1,485 @@
+{
+  "_id": "on-finished",
+  "_rev": "38-9e01c4baec86f4d1ea327b4327a9c9c1",
+  "name": "on-finished",
+  "description": "Execute a callback when a request closes, finishes, or errors",
+  "dist-tags": {
+    "latest": "2.3.0"
+  },
+  "versions": {
+    "2.0.0": {
+      "name": "on-finished",
+      "description": "Execute a callback when a request closes, finishes, or errors",
+      "version": "2.0.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/on-finished"
+      },
+      "dependencies": {
+        "ee-first": "1.0.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "engine": {
+        "node": ">= 0.8.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "86e64f85de7a80e18c3db0ae9a0d30ffbf37bdbd",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-finished/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-finished",
+      "_id": "on-finished@2.0.0",
+      "_shasum": "7286551c58c874d8342624cda56e2b42ea227f81",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7286551c58c874d8342624cda56e2b42ea227f81",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "on-finished",
+      "description": "Execute a callback when a request closes, finishes, or errors",
+      "version": "2.1.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/on-finished"
+      },
+      "dependencies": {
+        "ee-first": "1.0.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "engine": {
+        "node": ">= 0.8.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "1ad808e704e2aeda3a7464b78cacead2fb453727",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-finished/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-finished",
+      "_id": "on-finished@2.1.0",
+      "_shasum": "0c539f09291e8ffadde0c8a25850fb2cedc7022d",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0c539f09291e8ffadde0c8a25850fb2cedc7022d",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "on-finished",
+      "description": "Execute a callback when a request closes, finishes, or errors",
+      "version": "2.1.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/on-finished"
+      },
+      "dependencies": {
+        "ee-first": "1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "8ec5fa639ace400b543b5bc1821ce909b9acdc03",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-finished/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-finished",
+      "_id": "on-finished@2.1.1",
+      "_shasum": "f82ca1c9e3a4f3286b1b9938610e5b8636bd3cb2",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f82ca1c9e3a4f3286b1b9938610e5b8636bd3cb2",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "on-finished",
+      "description": "Execute a callback when a request closes, finishes, or errors",
+      "version": "2.2.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/on-finished"
+      },
+      "dependencies": {
+        "ee-first": "1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "fcd56f5674721cac92a16eff93547929716f5192",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-finished/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-finished",
+      "_id": "on-finished@2.2.0",
+      "_shasum": "e6ba6a09a3482d6b7969bc3da92c86f0a967605e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e6ba6a09a3482d6b7969bc3da92c86f0a967605e",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.1": {
+      "name": "on-finished",
+      "description": "Execute a callback when a request closes, finishes, or errors",
+      "version": "2.2.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/on-finished"
+      },
+      "dependencies": {
+        "ee-first": "1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f3ecb92fb09d590d314ffe772a6ffd6f76c84223",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-finished/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-finished",
+      "_id": "on-finished@2.2.1",
+      "_shasum": "5c85c1cc36299f78029653f667f27b6b99ebc029",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5c85c1cc36299f78029653f667f27b6b99ebc029",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "on-finished",
+      "description": "Execute a callback when a request closes, finishes, or errors",
+      "version": "2.3.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/on-finished"
+      },
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "34babcb58126a416fcf5205768204f2e12699dda",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-finished/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-finished",
+      "_id": "on-finished@2.3.0",
+      "_shasum": "20f1336481b083cd75337992a16971aa2d906947",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "20f1336481b083cd75337992a16971aa2d906947",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# on-finished\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nExecute a callback when a HTTP request closes, finishes, or errors.\n\n## Install\n\n```sh\n$ npm install on-finished\n```\n\n## API\n\n```js\nvar onFinished = require('on-finished')\n```\n\n### onFinished(res, listener)\n\nAttach a listener to listen for the response to finish. The listener will\nbe invoked only once when the response finished. If the response finished\nto an error, the first argument will contain the error. If the response\nhas already finished, the listener will be invoked.\n\nListening to the end of a response would be used to close things associated\nwith the response, like open files.\n\nListener is invoked as `listener(err, res)`.\n\n```js\nonFinished(res, function (err, res) {\n  // clean up open fds, etc.\n  // err contains the error is request error'd\n})\n```\n\n### onFinished(req, listener)\n\nAttach a listener to listen for the request to finish. The listener will\nbe invoked only once when the request finished. If the request finished\nto an error, the first argument will contain the error. If the request\nhas already finished, the listener will be invoked.\n\nListening to the end of a request would be used to know when to continue\nafter reading the data.\n\nListener is invoked as `listener(err, req)`.\n\n```js\nvar data = ''\n\nreq.setEncoding('utf8')\nres.on('data', function (str) {\n  data += str\n})\n\nonFinished(req, function (err, req) {\n  // data is read unless there is err\n})\n```\n\n### onFinished.isFinished(res)\n\nDetermine if `res` is already finished. This would be useful to check and\nnot even start certain operations if the response has already finished.\n\n### onFinished.isFinished(req)\n\nDetermine if `req` is already finished. This would be useful to check and\nnot even start certain operations if the request has already finished.\n\n## Special Node.js requests\n\n### HTTP CONNECT method\n\nThe meaning of the `CONNECT` method from RFC 7231, section 4.3.6:\n\n> The CONNECT method requests that the recipient establish a tunnel to\n> the destination origin server identified by the request-target and,\n> if successful, thereafter restrict its behavior to blind forwarding\n> of packets, in both directions, until the tunnel is closed.  Tunnels\n> are commonly used to create an end-to-end virtual connection, through\n> one or more proxies, which can then be secured using TLS (Transport\n> Layer Security, [RFC5246]).\n\nIn Node.js, these request objects come from the `'connect'` event on\nthe HTTP server.\n\nWhen this module is used on a HTTP `CONNECT` request, the request is\nconsidered \"finished\" immediately, **due to limitations in the Node.js\ninterface**. This means if the `CONNECT` request contains a request entity,\nthe request will be considered \"finished\" even before it has been read.\n\nThere is no such thing as a response object to a `CONNECT` request in\nNode.js, so there is no support for for one.\n\n### HTTP Upgrade request\n\nThe meaning of the `Upgrade` header from RFC 7230, section 6.1:\n\n> The \"Upgrade\" header field is intended to provide a simple mechanism\n> for transitioning from HTTP/1.1 to some other protocol on the same\n> connection.\n\nIn Node.js, these request objects come from the `'upgrade'` event on\nthe HTTP server.\n\nWhen this module is used on a HTTP request with an `Upgrade` header, the\nrequest is considered \"finished\" immediately, **due to limitations in the\nNode.js interface**. This means if the `Upgrade` request contains a request\nentity, the request will be considered \"finished\" even before it has been\nread.\n\nThere is no such thing as a response object to a `Upgrade` request in\nNode.js, so there is no support for for one.\n\n## Example\n\nThe following code ensures that file descriptors are always closed\nonce the response finishes.\n\n```js\nvar destroy = require('destroy')\nvar http = require('http')\nvar onFinished = require('on-finished')\n\nhttp.createServer(function onRequest(req, res) {\n  var stream = fs.createReadStream('package.json')\n  stream.pipe(res)\n  onFinished(res, function (err) {\n    destroy(stream)\n  })\n})\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/on-finished.svg\n[npm-url]: https://npmjs.org/package/on-finished\n[node-version-image]: https://img.shields.io/node/v/on-finished.svg\n[node-version-url]: http://nodejs.org/download/\n[travis-image]: https://img.shields.io/travis/jshttp/on-finished/master.svg\n[travis-url]: https://travis-ci.org/jshttp/on-finished\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/on-finished/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/on-finished?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/on-finished.svg\n[downloads-url]: https://npmjs.org/package/on-finished\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-01-19T08:15:32.233Z",
+    "created": "2014-08-16T05:19:04.281Z",
+    "2.0.0": "2014-08-16T05:19:04.281Z",
+    "2.1.0": "2014-08-17T02:49:35.720Z",
+    "2.1.1": "2014-10-23T01:19:12.662Z",
+    "2.2.0": "2014-12-23T06:51:30.412Z",
+    "2.2.1": "2015-04-23T01:33:13.247Z",
+    "2.3.0": "2015-05-27T01:58:14.758Z"
+  },
+  "homepage": "https://github.com/jshttp/on-finished",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jshttp/on-finished"
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/jshttp/on-finished/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "285858315": true,
+    "tunnckocore": true,
+    "goodseller": true,
+    "simplyianm": true,
+    "aslezak": true,
+    "fullrec": true,
+    "softwind": true,
+    "bapinney": true,
+    "kankungyip": true,
+    "scottfreecode": true,
+    "gejiawen": true,
+    "monjer": true,
+    "mojaray2k": true,
+    "dburdese": true,
+    "trevorgowing": true,
+    "ziflex": true,
+    "craigpatten": true,
+    "wangnan0610": true,
+    "ivan.marquez": true,
+    "shanewholloway": true,
+    "eyson": true,
+    "tedyhy": true,
+    "semir2": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/on-finished.min.json
+++ b/test/fixtures/registry-mocks/content/on-finished.min.json
@@ -1,0 +1,111 @@
+{
+  "name": "on-finished",
+  "dist-tags": {
+    "latest": "2.3.0"
+  },
+  "versions": {
+    "2.0.0": {
+      "name": "on-finished",
+      "version": "2.0.0",
+      "dependencies": {
+        "ee-first": "1.0.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "7286551c58c874d8342624cda56e2b42ea227f81",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.0.0.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "on-finished",
+      "version": "2.1.0",
+      "dependencies": {
+        "ee-first": "1.0.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "0c539f09291e8ffadde0c8a25850fb2cedc7022d",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz"
+      }
+    },
+    "2.1.1": {
+      "name": "on-finished",
+      "version": "2.1.1",
+      "dependencies": {
+        "ee-first": "1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0"
+      },
+      "dist": {
+        "shasum": "f82ca1c9e3a4f3286b1b9938610e5b8636bd3cb2",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.2.0": {
+      "name": "on-finished",
+      "version": "2.2.0",
+      "dependencies": {
+        "ee-first": "1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.1"
+      },
+      "dist": {
+        "shasum": "e6ba6a09a3482d6b7969bc3da92c86f0a967605e",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.2.1": {
+      "name": "on-finished",
+      "version": "2.2.1",
+      "dependencies": {
+        "ee-first": "1.1.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4"
+      },
+      "dist": {
+        "shasum": "5c85c1cc36299f78029653f667f27b6b99ebc029",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.3.0": {
+      "name": "on-finished",
+      "version": "2.3.0",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5"
+      },
+      "dist": {
+        "shasum": "20f1336481b083cd75337992a16971aa2d906947",
+        "tarball": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2018-01-19T08:15:32.233Z"
+}

--- a/test/fixtures/registry-mocks/content/on-headers.json
+++ b/test/fixtures/registry-mocks/content/on-headers.json
@@ -1,0 +1,308 @@
+{
+  "_id": "on-headers",
+  "_rev": "17-5e7360cec11987e1dd2598e3a2f11e09",
+  "name": "on-headers",
+  "description": "Execute a listener when a response is about to write headers",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "on-headers",
+      "description": "Execute a listener when a response is about to write headers",
+      "version": "0.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "event",
+        "headers",
+        "http",
+        "onheaders"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/on-headers.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/on-headers/issues"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "supertest": "~0.12.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/"
+      },
+      "homepage": "https://github.com/expressjs/on-headers",
+      "_id": "on-headers@0.0.0",
+      "dist": {
+        "shasum": "ee2817f8344325785cd9c2df2b242bbc17caf4c4",
+        "tarball": "https://registry.npmjs.org/on-headers/-/on-headers-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "on-headers",
+      "description": "Execute a listener when a response is about to write headers",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "event",
+        "headers",
+        "http",
+        "onheaders"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/on-headers"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "434950a0748cd38bf9a04f3fd4f3ff89cf565fda",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-headers/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-headers",
+      "_id": "on-headers@1.0.0",
+      "_shasum": "2c75b5da4375513d0161c6052e7fcbe4953fca5d",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2c75b5da4375513d0161c6052e7fcbe4953fca5d",
+        "tarball": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "on-headers",
+      "description": "Execute a listener when a response is about to write headers",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "event",
+        "headers",
+        "http",
+        "onheaders"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/on-headers"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "2.3.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ab0156a979d72353cfe666cccb3639e016b00280",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-headers/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-headers",
+      "_id": "on-headers@1.0.1",
+      "_shasum": "928f5d0f470d49342651ea6794b0857c100693f7",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "928f5d0f470d49342651ea6794b0857c100693f7",
+        "tarball": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "on-headers",
+      "description": "Execute a listener when a response is about to write headers",
+      "version": "1.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "event",
+        "headers",
+        "http",
+        "onheaders"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/on-headers.git"
+      },
+      "devDependencies": {
+        "eslint": "5.14.1",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.0.1",
+        "supertest": "3.4.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "c05140cde9bbce2127926752433271c6f3fe8787",
+      "bugs": {
+        "url": "https://github.com/jshttp/on-headers/issues"
+      },
+      "homepage": "https://github.com/jshttp/on-headers#readme",
+      "_id": "on-headers@1.0.2",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+        "shasum": "772b0ae6aaa525c399e489adfad90c403eb3c28f",
+        "tarball": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7538,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcb3EnCRA9TVsSAnZWagAAJ74P/1Wi5XP0E+17U7xu01zR\nnaF1VUbte8DFEouoT4ZgQH9ope94hmbAOW6QrMq2S0FxuTTzZFuDSyKBeQ2g\n2JrwURxitZGU36AX+WuPlQ5+Zw5pmDXk6UjdsA8DpNTOCE6T0N7mKS1KQFFH\nantgfK6JJSRYN1Pv0PIsLFrANaWo2j+tgu+c0Eir0fBk7dEe3Q82B9oaDpP8\nKuJ6jDLC7pz/qcJIdUErE6OaNknALNF0GaqW9ikJgthgZvNsMcA5jP7V3CVg\nmnO20iDAGuDRmTjPdDOThrLPX4oYF5p+xWO6LqxHr2oO/f+NrIRrlJu9JQeP\nFHhqCbh9LEBy6gcg7U+XgIuaFHO0Ujy0hu/rs39TowjuQOuQW9QR58UphGtY\ncDe4lRvwDf86XW+vT65ps/gSABNm8hO/ShPi2A5rVlxIPv+RSWrC3Ril+8CA\n6znvDPyrbB5MuAQB5CZ1Jq9Z0AJ+Js/iNrKjxEwaht1JWmH9LN2PzCe2Upk9\n/4s1u4FsPvExwRWyCDgUnvM3bcNg/ksz9E+OMs6B63I+ywW2iFnpXDzFVKLA\np2TB/bhfRYlgf0lK6KNy8B3Z+iTaPX9ie5aRimU7wZaml0jlh0kwzPxwJyPz\nSEI4ssy0yxHXw+d9DDBl4OOTycrM+fSIrL/qKkWaS/6foiGc/cMsgt/YYMww\nBpKq\r\n=27fC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/on-headers_1.0.2_1550807334461_0.2296705941712791"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# on-headers\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nExecute a listener when a response is about to write headers.\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install on-headers\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar onHeaders = require('on-headers')\n```\n\n### onHeaders(res, listener)\n\nThis will add the listener `listener` to fire when headers are emitted for `res`.\nThe listener is passed the `response` object as it's context (`this`). Headers are\nconsidered to be emitted only once, right before they are sent to the client.\n\nWhen this is called multiple times on the same `res`, the `listener`s are fired\nin the reverse order they were added.\n\n## Examples\n\n```js\nvar http = require('http')\nvar onHeaders = require('on-headers')\n\nhttp\n  .createServer(onRequest)\n  .listen(3000)\n\nfunction addPoweredBy () {\n  // set if not set by end of request\n  if (!this.getHeader('X-Powered-By')) {\n    this.setHeader('X-Powered-By', 'Node.js')\n  }\n}\n\nfunction onRequest (req, res) {\n  onHeaders(res, addPoweredBy)\n\n  res.setHeader('Content-Type', 'text/plain')\n  res.end('hello!')\n}\n```\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/on-headers/master\n[coveralls-url]: https://coveralls.io/r/jshttp/on-headers?branch=master\n[node-version-image]: https://badgen.net/npm/node/on-headers\n[node-version-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/on-headers\n[npm-url]: https://npmjs.org/package/on-headers\n[npm-version-image]: https://badgen.net/npm/v/on-headers\n[travis-image]: https://badgen.net/travis/jshttp/on-headers/master\n[travis-url]: https://travis-ci.org/jshttp/on-headers\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-02-22T03:48:57.059Z",
+    "created": "2014-05-14T01:43:08.147Z",
+    "0.0.0": "2014-05-14T01:43:08.147Z",
+    "1.0.0": "2014-08-10T23:14:54.117Z",
+    "1.0.1": "2015-09-30T03:47:06.558Z",
+    "1.0.2": "2019-02-22T03:48:54.600Z"
+  },
+  "homepage": "https://github.com/jshttp/on-headers#readme",
+  "keywords": [
+    "event",
+    "headers",
+    "http",
+    "onheaders"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/on-headers.git"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/on-headers/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "tarunbk": true,
+    "henrytseng": true,
+    "carlosvillademor": true,
+    "mojaray2k": true,
+    "jimjin": true,
+    "rocket0191": true,
+    "shanewholloway": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/on-headers.min.json
+++ b/test/fixtures/registry-mocks/content/on-headers.min.json
@@ -1,0 +1,83 @@
+{
+  "name": "on-headers",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "on-headers",
+      "version": "0.0.0",
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "supertest": "~0.12.1"
+      },
+      "dist": {
+        "shasum": "ee2817f8344325785cd9c2df2b242bbc17caf4c4",
+        "tarball": "https://registry.npmjs.org/on-headers/-/on-headers-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.0": {
+      "name": "on-headers",
+      "version": "1.0.0",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "2c75b5da4375513d0161c6052e7fcbe4953fca5d",
+        "tarball": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.1": {
+      "name": "on-headers",
+      "version": "1.0.1",
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "2.3.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "928f5d0f470d49342651ea6794b0857c100693f7",
+        "tarball": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.0.2": {
+      "name": "on-headers",
+      "version": "1.0.2",
+      "devDependencies": {
+        "eslint": "5.14.1",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.0.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.0.1",
+        "supertest": "3.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+        "shasum": "772b0ae6aaa525c399e489adfad90c403eb3c28f",
+        "tarball": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 7538,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcb3EnCRA9TVsSAnZWagAAJ74P/1Wi5XP0E+17U7xu01zR\nnaF1VUbte8DFEouoT4ZgQH9ope94hmbAOW6QrMq2S0FxuTTzZFuDSyKBeQ2g\n2JrwURxitZGU36AX+WuPlQ5+Zw5pmDXk6UjdsA8DpNTOCE6T0N7mKS1KQFFH\nantgfK6JJSRYN1Pv0PIsLFrANaWo2j+tgu+c0Eir0fBk7dEe3Q82B9oaDpP8\nKuJ6jDLC7pz/qcJIdUErE6OaNknALNF0GaqW9ikJgthgZvNsMcA5jP7V3CVg\nmnO20iDAGuDRmTjPdDOThrLPX4oYF5p+xWO6LqxHr2oO/f+NrIRrlJu9JQeP\nFHhqCbh9LEBy6gcg7U+XgIuaFHO0Ujy0hu/rs39TowjuQOuQW9QR58UphGtY\ncDe4lRvwDf86XW+vT65ps/gSABNm8hO/ShPi2A5rVlxIPv+RSWrC3Ril+8CA\n6znvDPyrbB5MuAQB5CZ1Jq9Z0AJ+Js/iNrKjxEwaht1JWmH9LN2PzCe2Upk9\n/4s1u4FsPvExwRWyCDgUnvM3bcNg/ksz9E+OMs6B63I+ywW2iFnpXDzFVKLA\np2TB/bhfRYlgf0lK6KNy8B3Z+iTaPX9ie5aRimU7wZaml0jlh0kwzPxwJyPz\nSEI4ssy0yxHXw+d9DDBl4OOTycrM+fSIrL/qKkWaS/6foiGc/cMsgt/YYMww\nBpKq\r\n=27fC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-02-22T03:48:57.059Z"
+}

--- a/test/fixtures/registry-mocks/content/opn.json
+++ b/test/fixtures/registry-mocks/content/opn.json
@@ -1,0 +1,2017 @@
+{
+  "_id": "opn",
+  "_rev": "169-22a1b1d901e09e4e42971c73beab1a5b",
+  "name": "opn",
+  "description": "Open stuff like URLs, files, executables. Cross-platform.",
+  "dist-tags": {
+    "latest": "6.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "opn",
+      "version": "0.1.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sindresorhus/opn"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "cli.js",
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "cli",
+        "bin",
+        "app",
+        "open",
+        "opn",
+        "launch",
+        "start",
+        "xdg-open",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@0.1.0",
+      "dist": {
+        "shasum": "5a71077eedb87458794cb214a88b80952ea08906",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "opn",
+      "version": "0.1.1",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sindresorhus/opn"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "cli.js",
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "cli",
+        "bin",
+        "app",
+        "open",
+        "opn",
+        "launch",
+        "start",
+        "xdg-open",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@0.1.1",
+      "dist": {
+        "shasum": "d785acb79f0dbe8c6a6849d6f46112b7f1d78c9d",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "opn",
+      "version": "0.1.2",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sindresorhus/opn"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "cli.js",
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "cli",
+        "bin",
+        "app",
+        "open",
+        "opn",
+        "launch",
+        "start",
+        "xdg-open",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@0.1.2",
+      "_shasum": "c527832cfd964d52096b524d0035ecaece51db4f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c527832cfd964d52096b524d0035ecaece51db4f",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "opn",
+      "version": "1.0.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sindresorhus/opn"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "cli.js",
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "cli",
+        "bin",
+        "app",
+        "open",
+        "opn",
+        "launch",
+        "start",
+        "xdg-open",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "e29d05bebe51c41be5193de85c7e1d78236d386c",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@1.0.0",
+      "_shasum": "1baa822af649a45fca744179a29a8b4c19346574",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1baa822af649a45fca744179a29a8b4c19346574",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "opn",
+      "version": "1.0.1",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "cli.js",
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "cli",
+        "bin",
+        "app",
+        "open",
+        "opn",
+        "launch",
+        "start",
+        "xdg-open",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "728990221e9cf807725173aa4ce4ee6cb3849bd2",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@1.0.1",
+      "_shasum": "c2dce2a5c41ab9589a7486aaff4d8de002d041ca",
+      "_from": ".",
+      "_npmVersion": "2.1.16",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c2dce2a5c41ab9589a7486aaff4d8de002d041ca",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "opn",
+      "version": "1.0.2",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "http://sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "cli.js",
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "cli",
+        "bin",
+        "app",
+        "open",
+        "opn",
+        "launch",
+        "start",
+        "xdg-open",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable"
+      ],
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "9e4d37d526da034defa1d6856b2efad382945bc1",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@1.0.2",
+      "_shasum": "b909643346d00a1abc977a8b96f3ce3c53d5cf5f",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b909643346d00a1abc977a8b96f3ce3c53d5cf5f",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "opn",
+      "version": "2.0.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "cli.js",
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "cli-app",
+        "cli",
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "meow": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "be159c8622eee3d91274d7fee5c8e75caefae45e",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@2.0.0",
+      "_shasum": "63bf4560d0de234d113f70f8b4ea58125c536da8",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "63bf4560d0de234d113f70f8b4ea58125c536da8",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "opn",
+      "version": "2.0.1",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "cli.js",
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "cli-app",
+        "cli",
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "meow": "^3.3.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "d5bff06315cf9e5d0619d763966ba7d647fc9e9d",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@2.0.1",
+      "_shasum": "1b739608f4b92220e7021ab35fa85be73036c2e6",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "1b739608f4b92220e7021ab35fa85be73036c2e6",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "opn",
+      "version": "3.0.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "object-assign": "^3.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "30b8e450e7b6daae239d55b51aaa032795c13131",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@3.0.0",
+      "_shasum": "0b3b75c7b12d3326ee452960c4e4c6c07ece423f",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "0b3b75c7b12d3326ee452960c4e4c6c07ece423f",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "opn",
+      "version": "3.0.1",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "object-assign": "^3.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "ef575151ab7cbd8508963755831ffc8e38b6dee1",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@3.0.1",
+      "_shasum": "39b10af99e5df95c16f652085d59c51d41561dde",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "39b10af99e5df95c16f652085d59c51d41561dde",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-3.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "opn",
+      "version": "3.0.2",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "object-assign": "^3.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "57ac2666dace81593b78a2e59f2ab397f88a90d9",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@3.0.2",
+      "_shasum": "d3380607008b2e5cc41e7bd524f54c6adbdeea78",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "d3380607008b2e5cc41e7bd524f54c6adbdeea78",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-3.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.3": {
+      "name": "opn",
+      "version": "3.0.3",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "object-assign": "^4.0.1"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "gitHead": "80d06d7f4a7daa7a215bf9b0a2e530dc277497d8",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@3.0.3",
+      "_shasum": "b6d99e7399f78d65c3baaffef1fb288e9b85243a",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "b6d99e7399f78d65c3baaffef1fb288e9b85243a",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "opn",
+      "version": "4.0.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/opn.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "c9b6ee66c86757162d787a710282fa998aa384e6",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn#readme",
+      "_id": "opn@4.0.0",
+      "_shasum": "cf8ce4e104c14f87d20156c17922876cda09bf79",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "cf8ce4e104c14f87d20156c17922876cda09bf79",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.1": {
+      "name": "opn",
+      "version": "4.0.1",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/opn"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "34626da5fbb93e324b51ad281c60091d3bda9205",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn",
+      "_id": "opn@4.0.1",
+      "_shasum": "9bd30ee3eba4fd533be2c83d56329a4e58913bf8",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "9bd30ee3eba4fd533be2c83d56329a4e58913bf8",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-4.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/opn-4.0.1.tgz_1456989823472_0.5448145705740899"
+      },
+      "directories": {}
+    },
+    "4.0.2": {
+      "name": "opn",
+      "version": "4.0.2",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/opn.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "b56b0e981ee377d3b04c57a4e6748ad2793ada17",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn#readme",
+      "_id": "opn@4.0.2",
+      "_shasum": "7abc22e644dff63b0a96d5ab7f2790c0f01abc95",
+      "_from": ".",
+      "_npmVersion": "3.9.0",
+      "_nodeVersion": "4.4.2",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "7abc22e644dff63b0a96d5ab7f2790c0f01abc95",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/opn-4.0.2.tgz_1463477356148_0.1645404922310263"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "opn",
+      "version": "5.0.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/opn.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "a1a4fa93ba01b04a144ad58fd4fe0e75b19f29a4",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn#readme",
+      "_id": "opn@5.0.0",
+      "_shasum": "f8870d7cd969b218030cb6ce5a1285e795931df3",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "f8870d7cd969b218030cb6ce5a1285e795931df3",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/opn-5.0.0.tgz_1493542232271_0.7398870571050793"
+      },
+      "directories": {}
+    },
+    "5.1.0": {
+      "name": "opn",
+      "version": "5.1.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/opn.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "ebae31e9117ae3ca5c9ee642bafa9449f1e237c2",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn#readme",
+      "_id": "opn@5.1.0",
+      "_npmVersion": "5.0.0",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+        "shasum": "72ce2306a17dbea58ff1041853352b4a8fc77519",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/opn-5.1.0.tgz_1497093567063_0.9740056861191988"
+      },
+      "directories": {}
+    },
+    "5.2.0": {
+      "name": "opn",
+      "version": "5.2.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/opn.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "5bb575fdefb6e26bceea1727e162a90c79440dfb",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn#readme",
+      "_id": "opn@5.2.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+        "shasum": "71fdf934d6827d676cecbea1531f95d354641225",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/opn-5.2.0.tgz_1515897630486_0.6569689619354904"
+      },
+      "directories": {}
+    },
+    "5.3.0": {
+      "name": "opn",
+      "version": "5.3.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/opn.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js",
+        "xdg-open"
+      ],
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "cfab3f9ba2096b00fef655f454be65b070f49d8a",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn#readme",
+      "_id": "opn@5.3.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+        "shasum": "64871565c863875f052cfdf53d3e3cb5adb53b1c",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 31066
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/opn_5.3.0_1521043017699_0.273982435971718"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.4.0": {
+      "name": "opn",
+      "version": "5.4.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/opn.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo"
+      },
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "^0.25.0",
+        "xo": "^0.20.0"
+      },
+      "gitHead": "56798ff3a2ddc4019e6dd6fe5219230ddd32bb78",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn#readme",
+      "_id": "opn@5.4.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.12.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+        "shasum": "cb545e7aab78562beb11aa3bfabc7042e1761035",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 31787,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbo5r1CRA9TVsSAnZWagAAdecP/jmUL6X3/d8C6vQOuUm+\nGFsvvGtPqnrNhkSvLmb9eZnNk/AobObvAheW4mSCIhiuw14zbUsjVqgL4ZSu\np3fQ58R3TJ/W0vp6E2NHcG35IcUjju0GOgUaLgpXamQz3aHq7pd9+urtn688\nR/0HabqGLLYwx5F4xsc2pOc28w1Zz+xk1+clPyr/eqjBttTZKlrBUMnucAGZ\nvVrHBtWl40YEaeecR1q+9w/Z4sN/akLRJ5iXGw1y+sGkT9c/Rz0JS99FcuYG\ntoypUvtJyXs/X7wTeDNebtrwW9WjTA4Ox23f2soFyLZ7j8fBcYK9pdCFDle8\n56lpGdUn+RAyrykJz95+Jj7hCrBi82cyF42xpwrluYrNZV4pJJkJ05ePQ/Qr\n5q84EjcqmPity18513MqIC2i3WvJy/+ZT20Eh77TvKspnIY3q7B516C3l3Lu\nVQgS9jrOvxugZPLgnaS3/Lp00zNyQI8h16II3pf5T1ctGScrC/NsjXecKWdo\nz2wJKv+Y7vyS/J8mtYcjvns7LKzp5Mi7unc8LCmcsyVLSRvv0aNRzJHHgLsJ\nl6oIam4aia0o3EzqDnKEl9CEEVaANg/OFZC4DfoIv8lg0cJJmITlQbUgw3C2\nU7WZPuJELwYpoyZhe1rzR1ddoS7P14gR8VwecOxm+mNAlF3z1lRwD4/5Ta+1\nN4Ma\r\n=G8Jd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/opn_5.4.0_1537448692606_0.03009166513985173"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.5.0": {
+      "name": "opn",
+      "version": "5.5.0",
+      "description": "A better node-open. Opens stuff like websites, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/opn.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo"
+      },
+      "keywords": [
+        "app",
+        "open",
+        "opn",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "^0.25.0",
+        "xo": "^0.20.0"
+      },
+      "gitHead": "15caf1c276f1251c9cf8c9cebd40c5ec0681a8c9",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/opn/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/opn#readme",
+      "_id": "opn@5.5.0",
+      "_nodeVersion": "8.15.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+        "shasum": "fc7164fab56d235904c51c3b27da6758ca3b9bfc",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 31985,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcjJNHCRA9TVsSAnZWagAADrAP/3Mk+1iAc3bpbPdWuoYv\nNqT4KJTP8IIZzHGCIFMYITEXFDMOGt8+wEI+oNudYw/styaJ+1AFuReV67ck\ntwTwFLXomrrz8Cwp8B3SEdP5L3O7JETOet+qfu+b5wH7Mwt6l7DQR/pxxQqh\n3hoxI/yOISIpMAsY/3/PJNHUCbYt7s2NscF8MXWMnXkGXJ1JCktSQ43OgIWM\nEZnoRAfFolG3n13ODgmJF6U/88/TFXC1F4C1baND9KNa6bxUrZIN0FiJY9/v\nTYrcTAt4fuxE/qEyAot3C8PRSUrQKYXcE50hjtMNjqicWVQF3GJc+ANURdaO\nouDkL3ufLfexxbuY5hdlhC5iaP91Rj5hBzXSaMeaQx42e1uttCD+gs68MZPk\nJnQ2FRcBuVJPtOke79E8H/V5krS+zaL60im2kLl4z/BunI0EAuwTvWYqpUOd\n6zGJCACIqCyOULc7q/GAYvzMBTKiMT6zlLAGf+EURztoGJ3pZtg96lpyfTkN\nX4ifCAX5X0UGLYkNO75AoIP4ioQxAMXZ/EgJhybxJ2r/0VKbjoe0iznv2o4g\nhWZh7EjyxPlTkip1TdZ5o68SjxTIwsQPrq/Qi7TS7tBZPu1si+A/kNIejEdD\n0raufN0LKpABuFjfgATGjGHzi8yRx7zp6xG/ZsWBloVU5e6Qz9cvIHutGa7n\nfzk7\r\n=sSOf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/opn_5.5.0_1552716614835_0.41186892941716247"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.0": {
+      "name": "opn",
+      "version": "6.0.0",
+      "description": "Open stuff like URLs, files, executables. Cross-platform.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/open.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo"
+      },
+      "keywords": [
+        "app",
+        "open",
+        "opener",
+        "opens",
+        "launch",
+        "start",
+        "xdg-open",
+        "xdg",
+        "default",
+        "cmd",
+        "browser",
+        "editor",
+        "executable",
+        "exe",
+        "url",
+        "urls",
+        "arguments",
+        "args",
+        "spawn",
+        "exec",
+        "child",
+        "process",
+        "website",
+        "file"
+      ],
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.0",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "eca88d863dde48695a5f931390d57d3b805a072a",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/open/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/open#readme",
+      "_id": "opn@6.0.0",
+      "_nodeVersion": "8.15.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+        "shasum": "3c5b0db676d5f97da1233d1ed42d182bc5a27d2d",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33495,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcmmanCRA9TVsSAnZWagAAKnwP/1o7oqsazBfYzzfdAvHU\njJAZmnI/JZRMp6te/cMxgl7p9lOPUmpiFo7grZl7cqzC2EFPwfkSneqmxwpH\n9x+pDQVn9qayajjAbZKHXz0N0/mwhC5NxfG6tOSG6uc+P5nE2bAP7/I17YgY\n2hgJtquHdu7IiQ1aHOjeaoLYnMeJZLPT6kjVNN41pAcBkvdqlrI0szR3kepy\n4N/xOei9lkIbZJj4E7O2IaVAm/i8/b8TDVShbQabjj4rf2IBpDLvEgcI3reX\ntrYMZCTgGQj/DhtB7vBxuBWvGmPCuSMtv5B/HV88jh3S1AWUGMtDybnmi7zO\nd2FidFta+oohbBbvZxPj521tc2kcaJIcDMh6zCl5VtyaRox1IGe2J9+Y2pgI\nW9a9rG5pRydMtDMdvsWQgrm/0yDB8fiS2u+0NE2pgeuEJgXXryT6f4eUG63d\nmBYSurg9D4TO62IQvYao999/a/dxI3t9O9U7JHr8RMkycNvtZHHi01fPBsk4\nqbLvD+fcZ2+HORxuIufVVDsOgo/3iuxNRD/fGM7gbN22YRJuQZ4pXKGrCVkG\n7KQp59EePgKSy99xPylfNix7XK7wy8TS9Uzj4Vs79aTf4DL8saexxMdi0jT9\nhE7GgSN6dNyRZxf/0zMytPOgeyAD70k5AgPqiteH++ix9z+d4Yr/uDU+iWgy\nZWyJ\r\n=PYIj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/opn_6.0.0_1553622694250_0.035009452703874455"
+      },
+      "_hasShrinkwrap": false,
+      "deprecated": "The package has been renamed to `open`"
+    }
+  },
+  "readme": "# open\n\n> Open stuff like URLs, files, executables. Cross-platform.\n\nIf need this for Electron, use [`shell.openItem()`](https://electronjs.org/docs/api/shell#shellopenitemfullpath) instead.\n\nNote: The original [`open` package](https://github.com/pwnall/node-open) was recently deprecated in favor of this package, and we got the name, so this package is now named `open` instead of `opn`. If you're upgrading from the original `open` package (`open@0.0.5` or lower), keep in mind that the API is different.\n\n#### Why?\n\n- Actively maintained.\n- Supports app arguments.\n- Safer as it uses `spawn` instead of `exec`.\n- Fixes most of the open original `node-open` issues.\n- Includes the latest [`xdg-open` script](http://cgit.freedesktop.org/xdg/xdg-utils/commit/?id=c55122295c2a480fa721a9614f0e2d42b2949c18) for Linux.\n- Supports WSL paths to Windows apps under `/mnt/*`.\n\n\n## Install\n\n```\n$ npm install open\n```\n\n\n## Usage\n\n```js\nconst open = require('open');\n\n// Opens the image in the default image viewer\n(async () => {\n\tawait open('unicorn.png', {wait: true});\n\tconsole.log('The image viewer app closed');\n\n\t// Opens the url in the default browser\n\tawait open('https://sindresorhus.com');\n\n\t// Specify the app to open in\n\tawait open('https://sindresorhus.com', {app: 'firefox'});\n\n\t// Specify app arguments\n\tawait open('https://sindresorhus.com', {app: ['google chrome', '--incognito']});\n})();\n```\n\n\n## API\n\nIt uses the command `open` on macOS, `start` on Windows and `xdg-open` on other platforms.\n\n### open(target, [options])\n\nReturns a promise for the [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You would normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.\n\n#### target\n\nType: `string`\n\nThe thing you want to open. Can be a URL, file, or executable.\n\nOpens in the default app for the file type. For example, URLs opens in your default browser.\n\n#### options\n\nType: `Object`\n\n##### wait\n\nType: `boolean`<br>\nDefault: `false`\n\nWait for the opened app to exit before fulfilling the promise. If `false` it's fulfilled immediately when opening the app.\n\nNote that it waits for the app to exit, not just for the window to close.\n\nOn Windows, you have to explicitly specify an app for it to be able to wait.\n\n##### app\n\nType: `string | string[]`\n\nSpecify the app to open the `target` with, or an array with the app and app arguments.\n\nThe app name is platform dependent. Don't hard code it in reusable modules. For example, Chrome is `google chrome` on macOS, `google-chrome` on Linux and `chrome` on Windows.\n\nYou may also pass in the app's full path. For example on WSL, this can be `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe` for the Windows installation of Chrome.\n\n\n## Related\n\n- [opn-cli](https://github.com/sindresorhus/opn-cli) - CLI for this module\n- [open-editor](https://github.com/sindresorhus/open-editor) - Open files in your editor at a specific line and column\n\n\n## License\n\nMIT © [Sindre Sorhus](https://sindresorhus.com)\n",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-03-26T17:52:47.018Z",
+    "created": "2014-04-05T15:16:05.166Z",
+    "0.1.0": "2014-04-05T15:16:05.166Z",
+    "0.1.1": "2014-04-05T16:28:00.560Z",
+    "0.1.2": "2014-05-21T09:43:21.106Z",
+    "1.0.0": "2014-08-02T21:17:09.421Z",
+    "1.0.1": "2014-12-25T14:00:17.922Z",
+    "1.0.2": "2015-04-22T08:47:10.539Z",
+    "2.0.0": "2015-06-13T00:22:56.191Z",
+    "2.0.1": "2015-06-20T17:29:01.118Z",
+    "3.0.0": "2015-06-29T18:10:25.478Z",
+    "3.0.1": "2015-06-29T18:24:19.804Z",
+    "3.0.2": "2015-06-29T19:08:18.488Z",
+    "3.0.3": "2015-11-04T13:37:23.714Z",
+    "4.0.0": "2016-01-16T20:45:19.892Z",
+    "4.0.1": "2016-03-03T07:23:44.337Z",
+    "4.0.2": "2016-05-17T09:29:16.736Z",
+    "5.0.0": "2017-04-30T08:50:32.560Z",
+    "5.1.0": "2017-06-10T11:19:28.026Z",
+    "5.2.0": "2018-01-14T02:40:30.659Z",
+    "5.3.0": "2018-03-14T15:56:57.782Z",
+    "5.4.0": "2018-09-20T13:04:52.756Z",
+    "5.5.0": "2019-03-16T06:10:14.988Z",
+    "6.0.0": "2019-03-26T17:51:34.422Z"
+  },
+  "homepage": "https://github.com/sindresorhus/open#readme",
+  "keywords": [
+    "app",
+    "open",
+    "opener",
+    "opens",
+    "launch",
+    "start",
+    "xdg-open",
+    "xdg",
+    "default",
+    "cmd",
+    "browser",
+    "editor",
+    "executable",
+    "exe",
+    "url",
+    "urls",
+    "arguments",
+    "args",
+    "spawn",
+    "exec",
+    "child",
+    "process",
+    "website",
+    "file"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/open.git"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/open/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "jonkemp": true,
+    "tunnckocore": true,
+    "sbruchmann": true,
+    "ijy": true,
+    "scotttesler": true,
+    "gdbtek": true,
+    "zoxon": true,
+    "ignatovmsu": true,
+    "robermac": true,
+    "dantman": true,
+    "ericwbailey": true,
+    "mrmartineau": true,
+    "hedleysmith": true,
+    "fotooo": true,
+    "dogancelik": true,
+    "koulmomo": true,
+    "szmtcjm": true,
+    "buzz-dee": true,
+    "anhulife": true,
+    "a3.ivanenko": true,
+    "aus": true,
+    "mimmo1": true,
+    "maxime1992": true,
+    "guananddu": true,
+    "gregmatys": true,
+    "jasonwang1888": true,
+    "vzg03566": true,
+    "lestad": true,
+    "j.su": true,
+    "rexpan": true,
+    "tedyhy": true,
+    "parkerproject": true,
+    "qqcome110": true,
+    "lorenazohar": true,
+    "leonardorb": true,
+    "manikantag": true,
+    "scottfreecode": true,
+    "brainmurder": true,
+    "mhaidarh": true,
+    "sternelee": true,
+    "abhisekp": true,
+    "dzhou777": true,
+    "shakakira": true,
+    "fibo": true,
+    "bobxuyang": true,
+    "mecode": true,
+    "phantomk": true,
+    "abuelwafa": true,
+    "nanxing": true,
+    "maxwang": true,
+    "shangsinian": true,
+    "seangenabe": true,
+    "flftfqwxf": true,
+    "fattypanda": true,
+    "sqrtthree": true,
+    "yong_a": true,
+    "iori20091101": true,
+    "panlw": true,
+    "daizch": true,
+    "wangnan0610": true,
+    "tongjieme": true,
+    "pmbenjamin": true,
+    "shuoshubao": true,
+    "ninozhang": true,
+    "chinawolf_wyp": true,
+    "tsxuehu": true,
+    "kimhoe": true,
+    "npmlincq": true,
+    "alexchao": true,
+    "pddivine": true,
+    "heartnett": true,
+    "alexxnica": true,
+    "fengmiaosen": true,
+    "goliatone": true,
+    "rocket0191": true,
+    "bryan.ygf": true,
+    "detj": true,
+    "ahmed-dinar": true,
+    "jon_shen": true,
+    "yl2014": true,
+    "duzun": true,
+    "gxglwy": true,
+    "d-band": true,
+    "ldq-first": true,
+    "lvivier": true,
+    "hq229075284": true,
+    "constantinc": true,
+    "uojo": true,
+    "dwqs": true,
+    "liuyidi": true,
+    "stone-jin": true,
+    "shanewholloway": true,
+    "yeming": true,
+    "fabioper": true,
+    "netweb": true,
+    "icodeforcookies": true,
+    "fakefarm": true,
+    "xfloops": true,
+    "jarvis-npm": true,
+    "xuu": true,
+    "shiva127": true,
+    "zuojiang": true,
+    "yinfxs": true,
+    "stona": true,
+    "xtx1130": true,
+    "allen_lyu": true,
+    "windyh": true,
+    "jalcine": true,
+    "monjer": true,
+    "yisen": true,
+    "jiesiren": true,
+    "eralpkaraduman": true,
+    "sammy_winchester": true,
+    "willwolffmyren": true,
+    "nefzaoui": true,
+    "uxabdullah": true,
+    "aidenzou": true,
+    "akinjide": true,
+    "fm-96": true,
+    "benhuang": true,
+    "johniexu": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/opn.min.json
+++ b/test/fixtures/registry-mocks/content/opn.min.json
@@ -1,0 +1,420 @@
+{
+  "name": "opn",
+  "dist-tags": {
+    "latest": "6.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "opn",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "dist": {
+        "shasum": "5a71077eedb87458794cb214a88b80952ea08906",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "opn",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "dist": {
+        "shasum": "d785acb79f0dbe8c6a6849d6f46112b7f1d78c9d",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "opn",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "dist": {
+        "shasum": "c527832cfd964d52096b524d0035ecaece51db4f",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "opn",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "dist": {
+        "shasum": "1baa822af649a45fca744179a29a8b4c19346574",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "opn",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "dist": {
+        "shasum": "c2dce2a5c41ab9589a7486aaff4d8de002d041ca",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.2": {
+      "name": "opn",
+      "version": "1.0.2",
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "dist": {
+        "shasum": "b909643346d00a1abc977a8b96f3ce3c53d5cf5f",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "opn",
+      "version": "2.0.0",
+      "dependencies": {
+        "meow": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "dist": {
+        "shasum": "63bf4560d0de234d113f70f8b4ea58125c536da8",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.1": {
+      "name": "opn",
+      "version": "2.0.1",
+      "dependencies": {
+        "meow": "^3.3.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "bin": {
+        "opn": "cli.js"
+      },
+      "dist": {
+        "shasum": "1b739608f4b92220e7021ab35fa85be73036c2e6",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "opn",
+      "version": "3.0.0",
+      "dependencies": {
+        "object-assign": "^3.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "0b3b75c7b12d3326ee452960c4e4c6c07ece423f",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.1": {
+      "name": "opn",
+      "version": "3.0.1",
+      "dependencies": {
+        "object-assign": "^3.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "39b10af99e5df95c16f652085d59c51d41561dde",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-3.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.2": {
+      "name": "opn",
+      "version": "3.0.2",
+      "dependencies": {
+        "object-assign": "^3.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "d3380607008b2e5cc41e7bd524f54c6adbdeea78",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-3.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.3": {
+      "name": "opn",
+      "version": "3.0.3",
+      "dependencies": {
+        "object-assign": "^4.0.1"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "b6d99e7399f78d65c3baaffef1fb288e9b85243a",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "4.0.0": {
+      "name": "opn",
+      "version": "4.0.0",
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "cf8ce4e104c14f87d20156c17922876cda09bf79",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-4.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "4.0.1": {
+      "name": "opn",
+      "version": "4.0.1",
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "9bd30ee3eba4fd533be2c83d56329a4e58913bf8",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-4.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "4.0.2": {
+      "name": "opn",
+      "version": "4.0.2",
+      "dependencies": {
+        "object-assign": "^4.0.1",
+        "pinkie-promise": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "7abc22e644dff63b0a96d5ab7f2790c0f01abc95",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "5.0.0": {
+      "name": "opn",
+      "version": "5.0.0",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "f8870d7cd969b218030cb6ce5a1285e795931df3",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "5.1.0": {
+      "name": "opn",
+      "version": "5.1.0",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+        "shasum": "72ce2306a17dbea58ff1041853352b4a8fc77519",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "5.2.0": {
+      "name": "opn",
+      "version": "5.2.0",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-Jd/GpzPyHF4P2/aNOVmS3lfMSWV9J7cOhCG1s08XCEAsPkB7lp6ddiU0J7XzyQRDUh8BqJ7PchfINjR8jyofRQ==",
+        "shasum": "71fdf934d6827d676cecbea1531f95d354641225",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "5.3.0": {
+      "name": "opn",
+      "version": "5.3.0",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+        "shasum": "64871565c863875f052cfdf53d3e3cb5adb53b1c",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 31066
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "5.4.0": {
+      "name": "opn",
+      "version": "5.4.0",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "^0.25.0",
+        "xo": "^0.20.0"
+      },
+      "dist": {
+        "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
+        "shasum": "cb545e7aab78562beb11aa3bfabc7042e1761035",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 31787,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbo5r1CRA9TVsSAnZWagAAdecP/jmUL6X3/d8C6vQOuUm+\nGFsvvGtPqnrNhkSvLmb9eZnNk/AobObvAheW4mSCIhiuw14zbUsjVqgL4ZSu\np3fQ58R3TJ/W0vp6E2NHcG35IcUjju0GOgUaLgpXamQz3aHq7pd9+urtn688\nR/0HabqGLLYwx5F4xsc2pOc28w1Zz+xk1+clPyr/eqjBttTZKlrBUMnucAGZ\nvVrHBtWl40YEaeecR1q+9w/Z4sN/akLRJ5iXGw1y+sGkT9c/Rz0JS99FcuYG\ntoypUvtJyXs/X7wTeDNebtrwW9WjTA4Ox23f2soFyLZ7j8fBcYK9pdCFDle8\n56lpGdUn+RAyrykJz95+Jj7hCrBi82cyF42xpwrluYrNZV4pJJkJ05ePQ/Qr\n5q84EjcqmPity18513MqIC2i3WvJy/+ZT20Eh77TvKspnIY3q7B516C3l3Lu\nVQgS9jrOvxugZPLgnaS3/Lp00zNyQI8h16II3pf5T1ctGScrC/NsjXecKWdo\nz2wJKv+Y7vyS/J8mtYcjvns7LKzp5Mi7unc8LCmcsyVLSRvv0aNRzJHHgLsJ\nl6oIam4aia0o3EzqDnKEl9CEEVaANg/OFZC4DfoIv8lg0cJJmITlQbUgw3C2\nU7WZPuJELwYpoyZhe1rzR1ddoS7P14gR8VwecOxm+mNAlF3z1lRwD4/5Ta+1\nN4Ma\r\n=G8Jd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "5.5.0": {
+      "name": "opn",
+      "version": "5.5.0",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "^0.25.0",
+        "xo": "^0.20.0"
+      },
+      "dist": {
+        "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+        "shasum": "fc7164fab56d235904c51c3b27da6758ca3b9bfc",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 31985,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcjJNHCRA9TVsSAnZWagAADrAP/3Mk+1iAc3bpbPdWuoYv\nNqT4KJTP8IIZzHGCIFMYITEXFDMOGt8+wEI+oNudYw/styaJ+1AFuReV67ck\ntwTwFLXomrrz8Cwp8B3SEdP5L3O7JETOet+qfu+b5wH7Mwt6l7DQR/pxxQqh\n3hoxI/yOISIpMAsY/3/PJNHUCbYt7s2NscF8MXWMnXkGXJ1JCktSQ43OgIWM\nEZnoRAfFolG3n13ODgmJF6U/88/TFXC1F4C1baND9KNa6bxUrZIN0FiJY9/v\nTYrcTAt4fuxE/qEyAot3C8PRSUrQKYXcE50hjtMNjqicWVQF3GJc+ANURdaO\nouDkL3ufLfexxbuY5hdlhC5iaP91Rj5hBzXSaMeaQx42e1uttCD+gs68MZPk\nJnQ2FRcBuVJPtOke79E8H/V5krS+zaL60im2kLl4z/BunI0EAuwTvWYqpUOd\n6zGJCACIqCyOULc7q/GAYvzMBTKiMT6zlLAGf+EURztoGJ3pZtg96lpyfTkN\nX4ifCAX5X0UGLYkNO75AoIP4ioQxAMXZ/EgJhybxJ2r/0VKbjoe0iznv2o4g\nhWZh7EjyxPlTkip1TdZ5o68SjxTIwsQPrq/Qi7TS7tBZPu1si+A/kNIejEdD\n0raufN0LKpABuFjfgATGjGHzi8yRx7zp6xG/ZsWBloVU5e6Qz9cvIHutGa7n\nfzk7\r\n=sSOf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "6.0.0": {
+      "name": "opn",
+      "version": "6.0.0",
+      "dependencies": {
+        "is-wsl": "^1.1.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.0",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+        "shasum": "3c5b0db676d5f97da1233d1ed42d182bc5a27d2d",
+        "tarball": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33495,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcmmanCRA9TVsSAnZWagAAKnwP/1o7oqsazBfYzzfdAvHU\njJAZmnI/JZRMp6te/cMxgl7p9lOPUmpiFo7grZl7cqzC2EFPwfkSneqmxwpH\n9x+pDQVn9qayajjAbZKHXz0N0/mwhC5NxfG6tOSG6uc+P5nE2bAP7/I17YgY\n2hgJtquHdu7IiQ1aHOjeaoLYnMeJZLPT6kjVNN41pAcBkvdqlrI0szR3kepy\n4N/xOei9lkIbZJj4E7O2IaVAm/i8/b8TDVShbQabjj4rf2IBpDLvEgcI3reX\ntrYMZCTgGQj/DhtB7vBxuBWvGmPCuSMtv5B/HV88jh3S1AWUGMtDybnmi7zO\nd2FidFta+oohbBbvZxPj521tc2kcaJIcDMh6zCl5VtyaRox1IGe2J9+Y2pgI\nW9a9rG5pRydMtDMdvsWQgrm/0yDB8fiS2u+0NE2pgeuEJgXXryT6f4eUG63d\nmBYSurg9D4TO62IQvYao999/a/dxI3t9O9U7JHr8RMkycNvtZHHi01fPBsk4\nqbLvD+fcZ2+HORxuIufVVDsOgo/3iuxNRD/fGM7gbN22YRJuQZ4pXKGrCVkG\n7KQp59EePgKSy99xPylfNix7XK7wy8TS9Uzj4Vs79aTf4DL8saexxMdi0jT9\nhE7GgSN6dNyRZxf/0zMytPOgeyAD70k5AgPqiteH++ix9z+d4Yr/uDU+iWgy\nZWyJ\r\n=PYIj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "deprecated": "The package has been renamed to `open`"
+    }
+  },
+  "modified": "2019-03-26T17:52:47.018Z"
+}

--- a/test/fixtures/registry-mocks/content/original.json
+++ b/test/fixtures/registry-mocks/content/original.json
@@ -1,0 +1,761 @@
+{
+  "_id": "original",
+  "_rev": "27-863ac1562cd685569d128e92dd57002a",
+  "name": "original",
+  "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "original",
+      "version": "0.0.0",
+      "description": "Check if two urls have same URL",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "_id": "original@0.0.0",
+      "_shasum": "a674957d733653d99b9332b9d936abc6174547fa",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a674957d733653d99b9332b9d936abc6174547fa",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "original",
+      "version": "0.0.1",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "gitHead": "fc6695959609055f847f1d7dc69989eef8b428a3",
+      "_id": "original@0.0.1",
+      "_shasum": "387bc64bf1e70ceb42e1b31caad9a5ad1e3f5387",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "387bc64bf1e70ceb42e1b31caad9a5ad1e3f5387",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "original",
+      "version": "0.0.2",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "41764efd841387831f1ef76d934f38f8928e7b4b",
+      "_id": "original@0.0.2",
+      "_shasum": "772ac5a4f8ea0227d8607fb243d655730421d270",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "772ac5a4f8ea0227d8607fb243d655730421d270",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "original",
+      "version": "0.0.3",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/original"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "71f9296bd8473a3264115c228d1355038b5e1149",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original",
+      "_id": "original@0.0.3",
+      "_shasum": "a0f54512e1b1c1233c79787bf66ed88bc082e7f1",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a0f54512e1b1c1233c79787bf66ed88bc082e7f1",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "original",
+      "version": "0.0.4",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/original"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "db3a521cef937d4ddb040aa4d8e8aaabe17a62e7",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original",
+      "_id": "original@0.0.4",
+      "_shasum": "6fa37fb754c1cf53551f01abc85c10e340b97ba7",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6fa37fb754c1cf53551f01abc85c10e340b97ba7",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "original",
+      "version": "0.0.5",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/original"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "381cd1532f1e235f4f4706874d74e927ee0f9f0e",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original",
+      "_id": "original@0.0.5",
+      "_shasum": "77a757f62fc7f7371d43ee246dcf8ec302afb784",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "77a757f62fc7f7371d43ee246dcf8ec302afb784",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.6": {
+      "name": "original",
+      "version": "0.0.6",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/original"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "requires-port": "0.0.x",
+        "url-parse": "0.1.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "c91daa8551a1176a875492c9c6f0e8fb9ff08454",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original",
+      "_id": "original@0.0.6",
+      "_shasum": "079677f0217c6c384650b7ab70094fd095b0a2e7",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "079677f0217c6c384650b7ab70094fd095b0a2e7",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.7": {
+      "name": "original",
+      "version": "0.0.7",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/original"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "0.1.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "f087fdbc4f4b4bc3c1b21636a7c77e11ad1ced9f",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original",
+      "_id": "original@0.0.7",
+      "_shasum": "a1a90a87c676111a04347c0192a38aa668f02f84",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "a1a90a87c676111a04347c0192a38aa668f02f84",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.8": {
+      "name": "original",
+      "version": "0.0.8",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/original"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "0.2.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "14c4c0d3c8a7ec654b8f76a12894485ff17df1a2",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original",
+      "_id": "original@0.0.8",
+      "_shasum": "5d0bcc4c673921705e2a8842cdca1684271bae0c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "5d0bcc4c673921705e2a8842cdca1684271bae0c",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "original",
+      "version": "1.0.0",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/original.git"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.3.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.3.x",
+        "pre-commit": "1.1.x"
+      },
+      "gitHead": "ee5fb8a2bad22c67a64337897e0505d94cb23b6b",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original#readme",
+      "_id": "original@1.0.0",
+      "_shasum": "9147f93fa1696d04be61e01bd50baeaca656bd3b",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9147f93fa1696d04be61e01bd50baeaca656bd3b",
+        "tarball": "https://registry.npmjs.org/original/-/original-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "original",
+      "version": "1.0.1",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/original.git"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "~1.4.0"
+      },
+      "devDependencies": {
+        "assume": "~2.0.1",
+        "istanbul": "0.4.x",
+        "mocha": "~3.5.0",
+        "pre-commit": "~1.2.0"
+      },
+      "gitHead": "f060834a29628284c0c7964c4c789406400a4e80",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original#readme",
+      "_id": "original@1.0.1",
+      "_npmVersion": "6.0.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
+        "shasum": "b0a53ff42ba997a8c9cd1fb5daaeb42b9d693190",
+        "tarball": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4796,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa+rCtCRA9TVsSAnZWagAAnZQQAJy3HVH2YR3e8iJ/RvVQ\n7edwqIZ2EISxqg3UoRS/bNI5PBkjh04DLNHvxDKOQMbfbX8sxGScyg8x2muC\ntmdCueeBAxs5v85sQNcPTWNdOCL8Dy/xURdbfTYZZ+ewXUYBSN8Bq3g4SOUL\nI/xVcKHzMFnHF5l/iOOk3VA2N1y07hhnVmIDR53y8ff/HhzKr/AF1Myn7bNU\nfF2FOIAPIyt2zd2CXdHus3Fo3wnU4FzaIIagDQ8XJD8HO0fu9MctJ9qjrKwt\niPRHEwc4uUw8/9eBljZNjRvUpvJvTWaf0MB5+WMLkEwEbARHCEQ1X+Zuv68t\n2B7RpuhCd6S+eKN6qfqHpvo+qryFrHtGFXKMmwlIunhFeT9mTtudEXgOp8NY\nYVYqeDoRHgq17GCsUTrx6fEdcOrMp9CEC0bZG179PXlc481DssFzJPBOsp2Z\nW8hxvwoTZzNiu27pIRak9yeFurUYkLLNTBQy+doq3OY+i4rTpcg7x7BZUnob\nf659IB1spGVlArPfmbkfZyBxy4Vh3NyPIUB3MZHrLJs0zUn+TEoDmnGVwlBG\nNa4+62eS/kthZMlZEYhP/Hgmnzt8pFk0M4v7DGIfZc2t8K/GTAYiHnaR/CG7\nJGo685005ZMiXdibDAyTljLU8DxRJk1+9XTacWkb8wxi3AiDlY3t9OY+8BY1\ntmEL\r\n=y8bg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/original_1.0.1_1526378667540_0.16775711344228372"
+      }
+    },
+    "1.0.2": {
+      "name": "original",
+      "version": "1.0.2",
+      "description": "Generate the origin from an URL or check if two URL/Origins are the same",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/original.git"
+      },
+      "keywords": [
+        "origin",
+        "url",
+        "parse"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "assume": "~2.1.0",
+        "istanbul": "0.4.x",
+        "mocha": "~3.5.0",
+        "pre-commit": "~1.2.0"
+      },
+      "gitHead": "3a6b7dfc741587920f0cdd3aebe4e589bff0f7d3",
+      "bugs": {
+        "url": "https://github.com/unshiftio/original/issues"
+      },
+      "homepage": "https://github.com/unshiftio/original#readme",
+      "_id": "original@1.0.2",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+        "shasum": "e442a61cffe1c5fd20a65f3261c26663b303f25f",
+        "tarball": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4796,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaGytCRA9TVsSAnZWagAA5noP/2w8i+zQfUXNnSTCcc/x\n9exUswGdlz0qdZIdwvs00rAx4o5S8igwozTmgHgRvDdIxOswb1q3sVE9mRxR\nyl4TmQMoJKbHtHe9RU7ADjrVYJmW8kT9egk/fauEQ8eZcbvxuidzOdc6u7P6\nMP3rA89aZw338m/qN6LNQSQK/5eEw1ENtbqsqFzFqjH73JvRB7AsA8Zbekh0\nBtpOf7Jz75IYRp8L37CVZ4FmeLV3v6eTdicZpPS4d6JXP/tZy//Tx0nTMROJ\njjCYszR1ZYT9HAIoSMT1TnJ7bFAtXXsL+ptp+d3CNjBoke0MM3wPoywiLVxR\n5pByrZ7ad0IAp73uGvIVZQfgK8zEvMxS/Vx2VMVk+rN5eiLvR0u4fkztZW0d\nVmASyrmJ6JZMhj/K8i6u0H+1hQbDR9DoDU+xMckvO7FWFKd/WmO2SrkealPt\n18KW2vhl3ft7SgThVBRcr8ACjWUSBDFvXJgV1B0zGgJsInOCOSiV4Q0/bgif\nhL6hzCB1tblMlxyu0eZpFdTtth/GTvSIqcbeOupLugjMlcSyk26Ci032PAaN\nuUeg5dAYK5e66E5gI0t2b+1gU0s+dqUKSTpNEtvNXAAknverWFHmxnQHQ77K\nvIZ1h5BQoufIBq8wJBsbSG0uGvPjUHvkh1OQg03m6bE0Dh3296b4Uj0fm3Qp\nKO5v\r\n=RYkI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/original_1.0.2_1533570221121_0.20029329496915493"
+      }
+    }
+  },
+  "readme": "# origin(al)\n\n[![Made by unshift](https://img.shields.io/badge/made%20by-unshift-00ffcc.svg?style=flat-square)](http://unshift.io)[![Version npm](http://img.shields.io/npm/v/original.svg?style=flat-square)](http://browsenpm.org/package/original)[![Build Status](http://img.shields.io/travis/unshiftio/original/master.svg?style=flat-square)](https://travis-ci.org/unshiftio/original)[![Dependencies](https://img.shields.io/david/unshiftio/original.svg?style=flat-square)](https://david-dm.org/unshiftio/original)[![Coverage Status](http://img.shields.io/coveralls/unshiftio/original/master.svg?style=flat-square)](https://coveralls.io/r/unshiftio/original?branch=master)[![IRC channel](http://img.shields.io/badge/IRC-irc.freenode.net%23unshift-00a8ff.svg?style=flat-square)](http://webchat.freenode.net/?channels=unshift)\n\nOriginal generates the origin URL for a given URL or URL object. In addition to\nthat it also comes with a simple `same` function to check if two URL's have the\nsame origin.\n\n## Install\n\nThis module is browserify and node compatible and is therefor release in the npm\nregistry and can be installed using:\n\n```\nnpm install --save original\n```\n\n## Usage\n\nIn all the examples we assume that the module is loaded using:\n\n```js\n'use strict';\n\nvar origin = require('original');\n```\n\nTo get the origin of a given URL simply call `origin` function with any given\nURL to get origin.\n\n```js\nvar o = origin('https://google.com/foo/bar?path');\n\n// o = https://google.com\n```\n\nTo compare if two URL's share the same origin you can call the `same` method.\n\n```js\nif (origin.same('https://google.com/foo', 'https://primus.io')) {\n  console.log('same');\n} else {\n  console.log('guess what, google.com and primus.io are not the same origin');\n}\n```\n\nAnd that's it.\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "3rdeden"
+    },
+    {
+      "email": "npm@unshift.io",
+      "name": "unshift"
+    },
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "v1"
+    }
+  ],
+  "time": {
+    "modified": "2018-08-06T15:43:52.297Z",
+    "created": "2014-10-04T18:06:31.427Z",
+    "0.0.0": "2014-10-04T18:06:31.427Z",
+    "0.0.1": "2014-10-08T15:08:08.387Z",
+    "0.0.2": "2014-10-09T12:46:42.420Z",
+    "0.0.3": "2014-10-13T19:43:59.427Z",
+    "0.0.4": "2014-10-15T22:21:47.650Z",
+    "0.0.5": "2014-10-30T14:12:10.117Z",
+    "0.0.6": "2014-11-09T23:04:01.366Z",
+    "0.0.7": "2014-12-06T22:45:42.229Z",
+    "0.0.8": "2014-12-09T10:49:03.256Z",
+    "1.0.0": "2015-10-30T14:44:19.667Z",
+    "1.0.1": "2018-05-15T10:04:27.637Z",
+    "1.0.2": "2018-08-06T15:43:41.371Z"
+  },
+  "keywords": [
+    "origin",
+    "url",
+    "parse"
+  ],
+  "author": {
+    "name": "Arnout Kazemier"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/unshiftio/original#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unshiftio/original.git"
+  },
+  "bugs": {
+    "url": "https://github.com/unshiftio/original/issues"
+  },
+  "users": {
+    "staydan": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/original.min.json
+++ b/test/fixtures/registry-mocks/content/original.min.json
@@ -1,0 +1,207 @@
+{
+  "name": "original",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "original",
+      "version": "0.0.0",
+      "dist": {
+        "shasum": "a674957d733653d99b9332b9d936abc6174547fa",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "original",
+      "version": "0.0.1",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "dist": {
+        "shasum": "387bc64bf1e70ceb42e1b31caad9a5ad1e3f5387",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "original",
+      "version": "0.0.2",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "772ac5a4f8ea0227d8607fb243d655730421d270",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "original",
+      "version": "0.0.3",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "a0f54512e1b1c1233c79787bf66ed88bc082e7f1",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "original",
+      "version": "0.0.4",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "6fa37fb754c1cf53551f01abc85c10e340b97ba7",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.4.tgz"
+      }
+    },
+    "0.0.5": {
+      "name": "original",
+      "version": "0.0.5",
+      "dependencies": {
+        "url-parse": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "77a757f62fc7f7371d43ee246dcf8ec302afb784",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.5.tgz"
+      }
+    },
+    "0.0.6": {
+      "name": "original",
+      "version": "0.0.6",
+      "dependencies": {
+        "requires-port": "0.0.x",
+        "url-parse": "0.1.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "079677f0217c6c384650b7ab70094fd095b0a2e7",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.6.tgz"
+      }
+    },
+    "0.0.7": {
+      "name": "original",
+      "version": "0.0.7",
+      "dependencies": {
+        "url-parse": "0.1.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "a1a90a87c676111a04347c0192a38aa668f02f84",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.7.tgz"
+      }
+    },
+    "0.0.8": {
+      "name": "original",
+      "version": "0.0.8",
+      "dependencies": {
+        "url-parse": "0.2.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "5d0bcc4c673921705e2a8842cdca1684271bae0c",
+        "tarball": "https://registry.npmjs.org/original/-/original-0.0.8.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "original",
+      "version": "1.0.0",
+      "dependencies": {
+        "url-parse": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.3.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.3.x",
+        "pre-commit": "1.1.x"
+      },
+      "dist": {
+        "shasum": "9147f93fa1696d04be61e01bd50baeaca656bd3b",
+        "tarball": "https://registry.npmjs.org/original/-/original-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "original",
+      "version": "1.0.1",
+      "dependencies": {
+        "url-parse": "~1.4.0"
+      },
+      "devDependencies": {
+        "assume": "~2.0.1",
+        "istanbul": "0.4.x",
+        "mocha": "~3.5.0",
+        "pre-commit": "~1.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
+        "shasum": "b0a53ff42ba997a8c9cd1fb5daaeb42b9d693190",
+        "tarball": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4796,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa+rCtCRA9TVsSAnZWagAAnZQQAJy3HVH2YR3e8iJ/RvVQ\n7edwqIZ2EISxqg3UoRS/bNI5PBkjh04DLNHvxDKOQMbfbX8sxGScyg8x2muC\ntmdCueeBAxs5v85sQNcPTWNdOCL8Dy/xURdbfTYZZ+ewXUYBSN8Bq3g4SOUL\nI/xVcKHzMFnHF5l/iOOk3VA2N1y07hhnVmIDR53y8ff/HhzKr/AF1Myn7bNU\nfF2FOIAPIyt2zd2CXdHus3Fo3wnU4FzaIIagDQ8XJD8HO0fu9MctJ9qjrKwt\niPRHEwc4uUw8/9eBljZNjRvUpvJvTWaf0MB5+WMLkEwEbARHCEQ1X+Zuv68t\n2B7RpuhCd6S+eKN6qfqHpvo+qryFrHtGFXKMmwlIunhFeT9mTtudEXgOp8NY\nYVYqeDoRHgq17GCsUTrx6fEdcOrMp9CEC0bZG179PXlc481DssFzJPBOsp2Z\nW8hxvwoTZzNiu27pIRak9yeFurUYkLLNTBQy+doq3OY+i4rTpcg7x7BZUnob\nf659IB1spGVlArPfmbkfZyBxy4Vh3NyPIUB3MZHrLJs0zUn+TEoDmnGVwlBG\nNa4+62eS/kthZMlZEYhP/Hgmnzt8pFk0M4v7DGIfZc2t8K/GTAYiHnaR/CG7\nJGo685005ZMiXdibDAyTljLU8DxRJk1+9XTacWkb8wxi3AiDlY3t9OY+8BY1\ntmEL\r\n=y8bg\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.2": {
+      "name": "original",
+      "version": "1.0.2",
+      "dependencies": {
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "assume": "~2.1.0",
+        "istanbul": "0.4.x",
+        "mocha": "~3.5.0",
+        "pre-commit": "~1.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+        "shasum": "e442a61cffe1c5fd20a65f3261c26663b303f25f",
+        "tarball": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4796,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaGytCRA9TVsSAnZWagAA5noP/2w8i+zQfUXNnSTCcc/x\n9exUswGdlz0qdZIdwvs00rAx4o5S8igwozTmgHgRvDdIxOswb1q3sVE9mRxR\nyl4TmQMoJKbHtHe9RU7ADjrVYJmW8kT9egk/fauEQ8eZcbvxuidzOdc6u7P6\nMP3rA89aZw338m/qN6LNQSQK/5eEw1ENtbqsqFzFqjH73JvRB7AsA8Zbekh0\nBtpOf7Jz75IYRp8L37CVZ4FmeLV3v6eTdicZpPS4d6JXP/tZy//Tx0nTMROJ\njjCYszR1ZYT9HAIoSMT1TnJ7bFAtXXsL+ptp+d3CNjBoke0MM3wPoywiLVxR\n5pByrZ7ad0IAp73uGvIVZQfgK8zEvMxS/Vx2VMVk+rN5eiLvR0u4fkztZW0d\nVmASyrmJ6JZMhj/K8i6u0H+1hQbDR9DoDU+xMckvO7FWFKd/WmO2SrkealPt\n18KW2vhl3ft7SgThVBRcr8ACjWUSBDFvXJgV1B0zGgJsInOCOSiV4Q0/bgif\nhL6hzCB1tblMlxyu0eZpFdTtth/GTvSIqcbeOupLugjMlcSyk26Ci032PAaN\nuUeg5dAYK5e66E5gI0t2b+1gU0s+dqUKSTpNEtvNXAAknverWFHmxnQHQ77K\nvIZ1h5BQoufIBq8wJBsbSG0uGvPjUHvkh1OQg03m6bE0Dh3296b4Uj0fm3Qp\nKO5v\r\n=RYkI\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2018-08-06T15:43:52.297Z"
+}

--- a/test/fixtures/registry-mocks/content/os-browserify.json
+++ b/test/fixtures/registry-mocks/content/os-browserify.json
@@ -1,0 +1,314 @@
+{
+  "_id": "os-browserify",
+  "_rev": "13-8885cb42ab367934f6c3aeed48615a4e",
+  "name": "os-browserify",
+  "description": "The [os](https://nodejs.org/api/os.html) module from node.js, but for browsers.",
+  "dist-tags": {
+    "latest": "0.3.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "os-browserify",
+      "version": "0.1.0",
+      "author": {
+        "name": "Drew Young"
+      },
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/drewyoung1/os-browserify.git"
+      },
+      "_id": "os-browserify@0.1.0",
+      "description": "os-browserify =============",
+      "dist": {
+        "shasum": "80833598f5a1a685f9c805c6c0517bdc7b6ee1be",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.0.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "drewyoung1",
+        "email": "drewyoung1@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "drewyoung1",
+          "email": "drewyoung1@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "os-browserify",
+      "version": "0.1.1",
+      "author": {
+        "name": "Drew Young"
+      },
+      "main": "main.js",
+      "browser": "browser.js",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/drewyoung1/os-browserify.git"
+      },
+      "_id": "os-browserify@0.1.1",
+      "description": "os-browserify =============",
+      "dist": {
+        "shasum": "c1c6b8b27be18cb09da7fa87476e0bcf3b465cbe",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "drewyoung1",
+        "email": "drewyoung1@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "drewyoung1",
+          "email": "drewyoung1@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "os-browserify",
+      "version": "0.1.2",
+      "author": {
+        "name": "Drew Young"
+      },
+      "license": "MIT",
+      "main": "main.js",
+      "browser": "browser.js",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/drewyoung1/os-browserify.git"
+      },
+      "description": "os-browserify =============",
+      "bugs": {
+        "url": "https://github.com/drewyoung1/os-browserify/issues"
+      },
+      "homepage": "https://github.com/drewyoung1/os-browserify",
+      "_id": "os-browserify@0.1.2",
+      "dist": {
+        "shasum": "49ca0293e0b19590a5f5de10c7f265a617d8fe54",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "drewyoung1",
+        "email": "drewyoung1@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "drewyoung1",
+          "email": "drewyoung1@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "os-browserify",
+      "version": "0.2.0",
+      "author": {
+        "name": "Drew Young"
+      },
+      "license": "MIT",
+      "main": "main.js",
+      "browser": "browser.js",
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/os",
+            "browser": "./browser.js"
+          }
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/drewyoung1/os-browserify.git"
+      },
+      "gitHead": "f718a68b7ce43b9c57424ae5dce0c0f017f00f4c",
+      "description": "os-browserify =============",
+      "bugs": {
+        "url": "https://github.com/drewyoung1/os-browserify/issues"
+      },
+      "homepage": "https://github.com/drewyoung1/os-browserify#readme",
+      "_id": "os-browserify@0.2.0",
+      "scripts": {},
+      "_shasum": "4917d1eacbbfd2aa1a2ee439b43d44b0f9d3c790",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "drewyoung1",
+        "email": "drewyoung1@gmail.com"
+      },
+      "dist": {
+        "shasum": "4917d1eacbbfd2aa1a2ee439b43d44b0f9d3c790",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "drewyoung1",
+          "email": "drewyoung1@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "os-browserify",
+      "version": "0.2.1",
+      "author": {
+        "name": "CoderPuppy",
+        "email": "coderpup@gmail.com"
+      },
+      "license": "MIT",
+      "main": "main.js",
+      "browser": "browser.js",
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/os",
+            "browser": "./browser.js"
+          }
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/CoderPuppy/os-browserify.git"
+      },
+      "gitHead": "af8f17481c8097e679ea24700c6bf18d497ba3a1",
+      "description": "The [os](https://nodejs.org/api/os.html) module from node.js, but for browsers.",
+      "bugs": {
+        "url": "https://github.com/CoderPuppy/os-browserify/issues"
+      },
+      "homepage": "https://github.com/CoderPuppy/os-browserify#readme",
+      "_id": "os-browserify@0.2.1",
+      "scripts": {},
+      "_shasum": "63fc4ccee5d2d7763d26bbf8601078e6c2e0044f",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.9.1",
+      "_npmUser": {
+        "name": "drewyoung1",
+        "email": "coderpup@gmail.com"
+      },
+      "dist": {
+        "shasum": "63fc4ccee5d2d7763d26bbf8601078e6c2e0044f",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coderpuppy",
+          "email": "coderpup@gmail.com"
+        },
+        {
+          "name": "drewyoung1",
+          "email": "coderpup@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/os-browserify-0.2.1.tgz_1459319484624_0.4566183206625283"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "os-browserify",
+      "version": "0.3.0",
+      "author": {
+        "name": "CoderPuppy",
+        "email": "coderpup@gmail.com"
+      },
+      "license": "MIT",
+      "main": "main.js",
+      "browser": "browser.js",
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/os",
+            "browser": "./browser.js"
+          }
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/CoderPuppy/os-browserify.git"
+      },
+      "gitHead": "9e931aec1131f02a582f715b23c8f6d157622554",
+      "description": "The [os](https://nodejs.org/api/os.html) module from node.js, but for browsers.",
+      "bugs": {
+        "url": "https://github.com/CoderPuppy/os-browserify/issues"
+      },
+      "homepage": "https://github.com/CoderPuppy/os-browserify#readme",
+      "_id": "os-browserify@0.3.0",
+      "scripts": {},
+      "_shasum": "854373c7f5c2315914fc9bfc6bd8238fdda1ec27",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "coderpuppy",
+        "email": "coderpup@gmail.com"
+      },
+      "dist": {
+        "shasum": "854373c7f5c2315914fc9bfc6bd8238fdda1ec27",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coderpuppy",
+          "email": "coderpup@gmail.com"
+        },
+        {
+          "name": "drewyoung1",
+          "email": "coderpup@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/os-browserify-0.3.0.tgz_1492659499835_0.43543427833355963"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# os-browserify\n\nThe [os](https://nodejs.org/api/os.html) module from node.js, but for browsers.\n\nWhen you `require('os')` in [browserify](http://github.com/substack/node-browserify), this module will be loaded.\n",
+  "maintainers": [
+    {
+      "name": "coderpuppy",
+      "email": "coderpup@gmail.com"
+    },
+    {
+      "name": "drewyoung1",
+      "email": "coderpup@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-04-20T03:38:21.786Z",
+    "created": "2012-12-22T02:07:46.303Z",
+    "0.1.0": "2012-12-22T02:07:48.570Z",
+    "0.1.1": "2013-09-21T21:18:37.917Z",
+    "0.1.2": "2014-03-12T17:04:56.773Z",
+    "0.2.0": "2015-12-01T22:43:05.029Z",
+    "0.2.1": "2016-03-30T06:31:25.669Z",
+    "0.3.0": "2017-04-20T03:38:21.786Z"
+  },
+  "author": {
+    "name": "CoderPuppy",
+    "email": "coderpup@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/CoderPuppy/os-browserify.git"
+  },
+  "homepage": "https://github.com/CoderPuppy/os-browserify#readme",
+  "bugs": {
+    "url": "https://github.com/CoderPuppy/os-browserify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "wenbing": true,
+    "simplyianm": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/os-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/os-browserify.min.json
@@ -1,0 +1,57 @@
+{
+  "name": "os-browserify",
+  "dist-tags": {
+    "latest": "0.3.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "os-browserify",
+      "version": "0.1.0",
+      "dist": {
+        "shasum": "80833598f5a1a685f9c805c6c0517bdc7b6ee1be",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "os-browserify",
+      "version": "0.1.1",
+      "dist": {
+        "shasum": "c1c6b8b27be18cb09da7fa87476e0bcf3b465cbe",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "os-browserify",
+      "version": "0.1.2",
+      "dist": {
+        "shasum": "49ca0293e0b19590a5f5de10c7f265a617d8fe54",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "os-browserify",
+      "version": "0.2.0",
+      "dist": {
+        "shasum": "4917d1eacbbfd2aa1a2ee439b43d44b0f9d3c790",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "os-browserify",
+      "version": "0.2.1",
+      "dist": {
+        "shasum": "63fc4ccee5d2d7763d26bbf8601078e6c2e0044f",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "os-browserify",
+      "version": "0.3.0",
+      "dist": {
+        "shasum": "854373c7f5c2315914fc9bfc6bd8238fdda1ec27",
+        "tarball": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz"
+      }
+    }
+  },
+  "modified": "2017-04-20T03:38:21.786Z"
+}

--- a/test/fixtures/registry-mocks/content/p-retry.json
+++ b/test/fixtures/registry-mocks/content/p-retry.json
@@ -1,0 +1,640 @@
+{
+  "_id": "p-retry",
+  "_rev": "10-640bc99bda33230566a0cc4e32798cfb",
+  "name": "p-retry",
+  "description": "Retry a promise-returning or async function",
+  "dist-tags": {
+    "latest": "4.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "p-retry",
+      "version": "1.0.0",
+      "description": "Retry a promise-returning or async function",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/p-retry.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "promise",
+        "retry",
+        "retries",
+        "operation",
+        "failed",
+        "rejected",
+        "try",
+        "exponential",
+        "backoff",
+        "attempt",
+        "async",
+        "await",
+        "promises",
+        "concurrently",
+        "concurrency",
+        "parallel",
+        "bluebird"
+      ],
+      "dependencies": {
+        "retry": "^0.10.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "delay": "^1.3.1",
+        "xo": "*"
+      },
+      "xo": {
+        "esnext": true
+      },
+      "gitHead": "7d9ea993a59e23ca8d19cd651efa39a1651e6357",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/p-retry/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/p-retry#readme",
+      "_id": "p-retry@1.0.0",
+      "_shasum": "3927332a4b7d70269b535515117fc547da1a6968",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "3927332a4b7d70269b535515117fc547da1a6968",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/p-retry-1.0.0.tgz_1477036222168_0.5073128861840814"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "p-retry",
+      "version": "2.0.0",
+      "description": "Retry a promise-returning or async function",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/p-retry.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "promise",
+        "retry",
+        "retries",
+        "operation",
+        "failed",
+        "rejected",
+        "try",
+        "exponential",
+        "backoff",
+        "attempt",
+        "async",
+        "await",
+        "promises",
+        "concurrently",
+        "concurrency",
+        "parallel",
+        "bluebird"
+      ],
+      "dependencies": {
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "delay": "^2.0.0",
+        "xo": "*"
+      },
+      "gitHead": "8fa0decbb30cf97a74f242c9ab70bd069cd3e446",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/p-retry/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/p-retry#readme",
+      "_id": "p-retry@2.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
+        "shasum": "b97f1f4d6d81a3c065b2b40107b811e995c1bfba",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5629,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa4i26CRA9TVsSAnZWagAATwIP/1n1EEaOrGwqi3kX7Ivg\n9o0okbSaOktXAhkXDn7WyirQPc9PKMHoKS6IRPFzw/0EtPJzwE4nw2eYE0xu\nTe9qSH1nTdfPlp2objfT487MubFy//wBHCduTRN0RcA5XmioXpNg7GL9EBUY\nvRR5vArD1jCm8VNIuryOWAUvhtrOFpcScQuEL1Q17gyWUJ/X/LfSUpDbSLeZ\nKf1D3FGMQ+EaaIyrZS2KZeMgWq3QIJRzp7GafXtgc9SIFVJAzr21qkcYGzZ9\n8Bt0PfZ3aubCbhCX1wWRRJ0nDgmzb0V6MZYJyZY4XSAaG5xzFqtnHKc8uazO\nBiIVs9Rh0WyZe/iOltik0WfP8P/0/AiwAM23KGNFYVDqqP765k9mIKv2IgJM\nbt12KyReEVEKSdIleZO+o5AJjg1P2IJN6MufW0QadHLW6Sw9VeXn39YKc12q\nCvU7tfFrwZUbf7DyEci0mys7RiQCN3aHkv/dOWFB45yldny1zN46qWJdwEi/\nwToT+6RNNIxmDr+YsRLpF8QGHc3Lu9tRYqGWo6Hj5qcYPz5033VTzjpXwmcn\nEo9u6F0oycmcgzHwu1nPeSXZNxGNpkZOho13Iv5F6CGkcCJFD+ayxVazpfqq\nlaDBsw3thqPKRb2EE9G3S2YQmo8vVulNBTlwllLegdJtTnRW8IGgqr1hirxd\nI6yk\r\n=HiK1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/p-retry_2.0.0_1524772281457_0.13741405149716912"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "p-retry",
+      "version": "3.0.0",
+      "description": "Retry a promise-returning or async function",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/p-retry.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "keywords": [
+        "promise",
+        "retry",
+        "retries",
+        "operation",
+        "failed",
+        "rejected",
+        "try",
+        "exponential",
+        "backoff",
+        "attempt",
+        "async",
+        "await",
+        "promises",
+        "concurrently",
+        "concurrency",
+        "parallel",
+        "bluebird"
+      ],
+      "dependencies": {
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^0.25.0",
+        "delay": "^4.1.0",
+        "xo": "^0.23.0"
+      },
+      "gitHead": "a9b5fc1e71ebc1fd5bd5926d2b1eff57512c124f",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/p-retry/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/p-retry#readme",
+      "_id": "p-retry@3.0.0",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-fAB7bebxaj8nylNAsxPNkwPZ/48bXFdFnWrz0v2sV+H5BsGfVL7Ap7KgONqy7rOK4ZI1I+SU+lmettO3hM+2HQ==",
+        "shasum": "f1a09233417dd40b42a7a4a3ed0f4780f23b90d8",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6024,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcESWVCRA9TVsSAnZWagAArOwP/0p+mRIhK3+IVAB63YSE\n9nDYrW6Kdg/H63TIagopJ4uoWABKKy84IFZFYFndcUkTs9Sa6DRNEn2Hmyhb\nRSOC2WlNy9ZKE9ZEACUuJRW69isnDj2ORYWH6Vp59PYgMNb1EDeKGSm38+ny\n0yOhkJjmyNxAe9mT1zGlff1pEESXPfTdIHiQ/uvqAyqrCAPf63KAWbHMlFdR\nOYeIDBoBjQyAV9Sj8m9Z9f1swdSVzFfeiVgfiLL7pmB0FkGkqNPqY8xn+qGo\n9draJJlIzyuYEeYLO9MvQ9KkhwKozZ92bfGB19PFNnvuj2sPfizcFFWvk2gL\nkRprWSRp6476nGCx2Hx9deA7Vgia9pyzGjiOPFTnMfoDaVqcozTtiWER+6dE\nELEtdQz9TCMYU42Iy/N48AeuR3YuXavzWr61TN2EHSfs7xqIzCwJNRzNTeP0\n3wGW/2yG/e4e8/y+rJk6FbPavcSRbeFLlPI6CqaSJ7u8IyeaiJmTdye8OIIE\nceTCLTyrwo/ggyKMWueWE1SWt+y3jnvp5klOvAgyhk/pdVdziiEnA308WxjG\nDvk3wyfw8yPKSy+10Y4Wdt1qA6bnbyGtoRYsiYChoEOH6TimF1K/7w6mVvuR\nbve8h07DgGHkmh9083dpCVDNB3rtQFmRWgj9uqarrhnwVDjF/4OATMRcIpu8\nCXLV\r\n=ouCA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/p-retry_3.0.0_1544627604837_0.13288153733032493"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1": {
+      "name": "p-retry",
+      "version": "3.0.1",
+      "description": "Retry a promise-returning or async function",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/p-retry.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "keywords": [
+        "promise",
+        "retry",
+        "retries",
+        "operation",
+        "failed",
+        "rejected",
+        "try",
+        "exponential",
+        "backoff",
+        "attempt",
+        "async",
+        "await",
+        "promises",
+        "concurrently",
+        "concurrency",
+        "parallel",
+        "bluebird"
+      ],
+      "dependencies": {
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^1.1.0",
+        "delay": "^4.1.0",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "2187e87bca3d06795b34d5422c940bd99d3dd3d1",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/p-retry/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/p-retry#readme",
+      "_id": "p-retry@3.0.1",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+        "shasum": "316b4c8893e2c8dc1cfa891f406c4b422bebf328",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6360,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcPJVRCRA9TVsSAnZWagAADW4P/3B97InLQLUYgxvfgH3B\nHyog9CWU/OzvY0f7wTuDXbG7eaCuki5652pHfW4AonUC/v9o5bSpfY67yb2w\ndXrsO+GMZZtieFsaZW+tB8U/QzvKCfvKbQkSd3pdgL3mWkYnM0wOKjVcmasO\nB4atXZoqXMzbYpnWyRzQ5hjMlC99nKJnRRMC2MUsTP1AX4swXVfbuQ3EhxPw\n9UuzNBMyNuRZdPVBCvcOySiLwpEfas8S+53OGS7JuhtlVTAUtGQAmY56wOWF\nBUy7RK7AeKAjHB6jmqRAA2J/KeJNoMj/FHOQ4gGiORUubRq6Hz79l06CqHJo\n1CQMppsJwtBw3M7Cjt6QvOCOPVxnki6ZpNn/lyVO1H85IbEyGtLGuz+ej8G2\ntgaLroEBHfCGjRf8gRjsxeZPn9TuhiSFqDNoBg6URPnEMKLRAte9Zd8iYojq\nQ7vaqPN++N1DRqWxw6IrMklSz70djK4wErKhiWdai1dieDcqcgdwFz5+AJ17\nerTmK1bHpAAXAp6xyA66P61WccgjXxopFBY25OVrgJsFQTTzCzXBk6GiVVPD\nexaAndvcxr3VO5xr/eSPab4vx/QhoIH/kkiuJ7YOWYQvAceR3/J6ZYpLzveO\nqgpN+WwKlOA+cvGLBTUBSUOUE5Mz6aPcYA7ANgVzo5bSye2xgNjKCB1byp/0\nu3IP\r\n=bb5S\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/p-retry_3.0.1_1547474257271_0.5381000574836654"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "p-retry",
+      "version": "4.0.0",
+      "description": "Retry a promise-returning or async function",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/p-retry.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd-check"
+      },
+      "keywords": [
+        "promise",
+        "retry",
+        "retries",
+        "operation",
+        "failed",
+        "rejected",
+        "try",
+        "exponential",
+        "backoff",
+        "attempt",
+        "async",
+        "await",
+        "promises",
+        "concurrently",
+        "concurrency",
+        "parallel",
+        "bluebird"
+      ],
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^1.3.1",
+        "delay": "^4.1.0",
+        "tsd-check": "^0.3.0",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "0e71c46bc994114b2fa56aa38c79e667f22f46de",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/p-retry/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/p-retry#readme",
+      "_id": "p-retry@4.0.0",
+      "_nodeVersion": "8.15.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-bMW1FwszSBsMi6DgPnDKLhAVMDhqeySD4viMI0UiKRv7cQzRS/KYhRPWjnoxSQdvunXwZYKgN10Ya6VxF9w+Og==",
+        "shasum": "56633299ac2fc9f6ecda749398330fdff632607a",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-4.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8018,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJchelwCRA9TVsSAnZWagAAUAUP/AqaZoeQYMbb0VRz5XMJ\nVdELSGP2vk1eHDYruV/UXV0kvcpi5ce11Ml1FtiBRfNLPtujN0O07KV5vNxJ\nAbCuoLyB9q4/AgLUVEtnsfoDBXQe3f/K6vn5fqcPd6QICe/mehQuHCdBma09\nkfDVxMkgqS805Jl3ZkWCIJHaKmYS+MYPk/g+//742gxEbwU3+J6sDCnsdFTi\nWBGoc9FiDi94MuiU3jVuRqBLUzVSkOgcamndYYsGPcdWI0bFgIXuGkTnXkx/\ndGMRu5HFpz4fVHgb3ObbhhlPLdcDyMMxrkFHtfhFo3hAeUi88oVXwKUGCx0e\nxsnvgYePczmzlEwL9MvW+M00suec0r4Gg+gRXMa9KleAkcWjzB/WRwErjaJh\n640MGlqpjT11NGz1NSvKqsM6uBQpS6M2o2Q6RLkZU47qrPd3RJvj+MKmq9HT\n4Ah+iutZbEQDGp4Fcq+S9q156wmc1knrWeftz0LsY3i0WpIOOTPWwMYAn6OO\nR6aNKzGV9lwcy+GaKBW4uhPRsszN67xcGBP7XR9sinGEOPxtZWkpMlYw1L5p\nyoVo/aIZArQB2YDJiOM5vZpNa5m6bpOQvle6AmDY3hdF1o+M9F/YTFZqTkhW\n2/9TsfGAPPfTozsbwYoVF0UuzpXK142V96dAtvjC2/sKJSH3Jf+9zuvE7DUm\nO8w8\r\n=sSXH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/p-retry_4.0.0_1552279919864_0.31116028535357"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.1.0": {
+      "name": "p-retry",
+      "version": "4.1.0",
+      "description": "Retry a promise-returning or async function",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/p-retry.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "promise",
+        "retry",
+        "retries",
+        "operation",
+        "failed",
+        "rejected",
+        "try",
+        "exponential",
+        "backoff",
+        "attempt",
+        "async",
+        "await",
+        "promises",
+        "concurrently",
+        "concurrency",
+        "parallel",
+        "bluebird"
+      ],
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "delay": "^4.1.0",
+        "tsd": "^0.7.1",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "9e2c0169f5e52ce2b9f08aa1ea024ed99e6c8f20",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/p-retry/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/p-retry#readme",
+      "_id": "p-retry@4.1.0",
+      "_nodeVersion": "8.15.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
+        "shasum": "9ce7cef2069e84bf590df3b8ec18d740109338d6",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9071,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcoKr6CRA9TVsSAnZWagAAqIAP/AoqYWHfa3UjmQSYEQKZ\nrIZBom40lSEgovWa2RMnh8EeszSKFtEaRCxQ7/iaep4KGanURFQLhTG+A3Wy\nyM5wlZgbgniUrZauFk4xtQwqGN/rQAXMA5kUPvkOG3NY4ySrzXKqc8lOcUzP\nScaSvL1qHvdq7ihX53lC/QLVFJzRqyNvjV2DHjXirXxgC0psDAXvVvWA8TaN\n2scPs5nqV/fkPyYb7FhOlQ4N8yUQz1M+1IUmcKRGTwhmbtCTmqjwDokeuJzZ\nUew6eGHGkIGUqTQhwvFw9KDoVCtFAC1C1/cC0dEEjmCfU/91xvPio/qaW0mW\nhmxxKz3cs+Mez1RheK6zkziAuz3Wd9OXAVMzuzN6SDpioBiJhVHSkF83OZEi\ngbzMtlV624iG6QKRMmKDOXTh3KJ5Qf4lA+bwI8bfTIitYAxake77AepNlI5c\nuPu8zxXQUND6K5ywY71YDFvA6oqGysoRQuFJZsKHHFUeVJZf0hdPuEJPRVsC\nMXYiqtJu+ySa8HCklaqgk0MlbXdt5rgdfjdEwhPkqilCgDYT5BL96ar5Ndk/\nGJifIZ0a9+jYo1gBpk4GA1NLxDcDor4lmoWKOzNjQnqkRgn0G01Wv4WrII+m\njxUA5PtH29tlwlP320Cfqi+GEsq5USGxWNh/qJSe/D5+UNtoe51qV/Fmi0k5\nqXhO\r\n=FfH+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/p-retry_4.1.0_1554033401809_0.38545075931703976"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.2.0": {
+      "name": "p-retry",
+      "version": "4.2.0",
+      "description": "Retry a promise-returning or async function",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/p-retry.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "promise",
+        "retry",
+        "retries",
+        "operation",
+        "failed",
+        "rejected",
+        "try",
+        "exponential",
+        "backoff",
+        "attempt",
+        "async",
+        "await",
+        "promises",
+        "concurrently",
+        "concurrency",
+        "parallel",
+        "bluebird"
+      ],
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^2.4.0",
+        "delay": "^4.1.0",
+        "tsd": "^0.10.0",
+        "xo": "^0.25.3"
+      },
+      "gitHead": "7cf46fe6037cd4f8303f06b7ce4bda29cc6f4010",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/p-retry/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/p-retry#readme",
+      "_id": "p-retry@4.2.0",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.12.1",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+        "shasum": "ea9066c6b44f23cab4cd42f6147cdbbc6604da5d",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10232,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdusTnCRA9TVsSAnZWagAAy5AP/R1Cm+osSni2bNUDI3TQ\n9YajvxxcWk6tsE/6JinW3DuzeDd9qJROSGbw49aFok/HCL9Civ9z0cirBcTb\nbjvFc8tv7duxl/lxctEFcWzKh6XP4yisFBPbD/ncCTt8X2PLcV6cOYECu/lW\nzT6/q2GzggpTffR7IAV0Te0A8MIR9+G6oAxFwRrlNxanDh4F4kGcy4uEboEy\nZz0suO0b+mPs5oqlFgBWYGKmI+bQJ+1dX4clF9gPVj1RxzWot8jiLoN7oo4Y\ncebU13ptmxrVibIDjwmQWZ6gtW4NVa+V3mQGL0vt/+w5FSdIYwCPRTCeaTiT\n8NU939x9wY2+tqalqrho9Ju77Zr9pR9vn8fh96Qi+tzxRB2KQhDi8zYm+eLR\ngT5mpd1V98cGw2G2J7KCw+G4Uslbv6phADG06G6gngubJeewGrtmyBDTUdio\nk/JCk5+CEGjOxOqHiK25aXMrwdp0Tp2hlUnQS0jBNiXIFlDRNidk6bUJe52x\nqB1IZB0kq/iC/Y0gNLPlAHUneLghTXjB/5PjiIjn2ixKawchjvrkL//8Iekl\nR3RjvJm6TVwfFWeA8wtVWWk5YT/YPXwKsjHdFouJfyapTAckqyduQaSsg1I6\nO9w7rJhtTFNfdlmS4mwOSpqMwrTtKQWW4EhseOBiYw7EWZZsXAERLp12crKO\ncl0H\r\n=YYLB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/p-retry_4.2.0_1572521190506_0.46832001284144087"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# p-retry [![Build Status](https://travis-ci.org/sindresorhus/p-retry.svg?branch=master)](https://travis-ci.org/sindresorhus/p-retry)\n\n> Retry a promise-returning or async function\n\nIt does exponential backoff and supports custom retry strategies for failed operations.\n\n\n## Install\n\n```\n$ npm install p-retry\n```\n\n\n## Usage\n\n```js\nconst pRetry = require('p-retry');\nconst fetch = require('node-fetch');\n\nconst run = async () => {\n\tconst response = await fetch('https://sindresorhus.com/unicorn');\n\n\t// Abort retrying if the resource doesn't exist\n\tif (response.status === 404) {\n\t\tthrow new pRetry.AbortError(response.statusText);\n\t}\n\n\treturn response.blob();\n};\n\n(async () => {\n\tconsole.log(await pRetry(run, {retries: 5}));\n})();\n```\n\n## API\n\n### pRetry(input, options?)\n\nReturns a `Promise` that is fulfilled when calling `input` returns a fulfilled promise. If calling `input` returns a rejected promise, `input` is called again until the maximum number of retries is reached. It then rejects with the last rejection reason.\n\nIt doesn't retry on `TypeError` as that's a user error.\n\n#### input\n\nType: `Function`\n\nReceives the current attempt number as the first argument and is expected to return a `Promise` or any value.\n\n#### options\n\nType: `object`\n\nOptions are passed to the [`retry`](https://github.com/tim-kos/node-retry#retryoperationoptions) module.\n\n##### onFailedAttempt(error)\n\nType: `Function`\n\nCallback invoked on each retry. Receives the error thrown by `input` as the first argument with properties `attemptNumber` and `retriesLeft` which indicate the current attempt number and the number of attempts left, respectively.\n\n```js\nconst run = async () => {\n\tconst response = await fetch('https://sindresorhus.com/unicorn');\n\n\tif (response.status !== 200) {\n\t\tthrow new Error(response.statusText);\n\t}\n\n\treturn response.json();\n};\n\n(async () => {\n\tconst result = await pRetry(run, {\n\t\tonFailedAttempt: error => {\n\t\t\tconsole.log(`Attempt ${error.attemptNumber} failed. There are ${error.retriesLeft} retries left.`);\n\t\t\t// 1st request => Attempt 1 failed. There are 4 retries left.\n\t\t\t// 2nd request => Attempt 2 failed. There are 3 retries left.\n\t\t\t// …\n\t\t},\n\t\tretries: 5\n\t});\n\n\tconsole.log(result);\n})();\n```\n\nThe `onFailedAttempt` function can return a promise. For example, to add a [delay](https://github.com/sindresorhus/delay):\n\n```js\nconst pRetry = require('p-retry');\nconst delay = require('delay');\n\nconst run = async () => { ... };\n\n(async () => {\n\tconst result = await pRetry(run, {\n\t\tonFailedAttempt: async error => {\n\t\t\tconsole.log('Waiting for 1 second before retrying');\n\t\t\tawait delay(1000);\n\t\t}\n\t});\n})();\n```\n\nIf the `onFailedAttempt` function throws, all retries will be aborted and the original promise will reject with the thrown error.\n\n### pRetry.AbortError(message)\n### pRetry.AbortError(error)\n\nAbort retrying and reject the promise.\n\n### message\n\nType: `string`\n\nError message.\n\n### error\n\nType: `Error`\n\nCustom error.\n\n\n## Tip\n\nYou can pass arguments to the function being retried by wrapping it in an inline arrow function:\n\n```js\nconst pRetry = require('p-retry');\n\nconst run = async emoji => {\n\t// …\n};\n\n(async () => {\n\t// Without arguments\n\tawait pRetry(run, {retries: 5});\n\n\t// With arguments\n\tawait pRetry(() => run('🦄'), {retries: 5});\n})();\n```\n\n\n## Related\n\n- [p-timeout](https://github.com/sindresorhus/p-timeout) - Timeout a promise after a specified amount of time\n- [More…](https://github.com/sindresorhus/promise-fun)\n",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-10-31T11:26:34.590Z",
+    "created": "2016-10-21T07:50:24.250Z",
+    "1.0.0": "2016-10-21T07:50:24.250Z",
+    "2.0.0": "2018-04-26T19:51:21.523Z",
+    "3.0.0": "2018-12-12T15:13:25.041Z",
+    "3.0.1": "2019-01-14T13:57:37.382Z",
+    "4.0.0": "2019-03-11T04:52:00.041Z",
+    "4.1.0": "2019-03-31T11:56:41.924Z",
+    "4.2.0": "2019-10-31T11:26:30.643Z"
+  },
+  "homepage": "https://github.com/sindresorhus/p-retry#readme",
+  "keywords": [
+    "promise",
+    "retry",
+    "retries",
+    "operation",
+    "failed",
+    "rejected",
+    "try",
+    "exponential",
+    "backoff",
+    "attempt",
+    "async",
+    "await",
+    "promises",
+    "concurrently",
+    "concurrency",
+    "parallel",
+    "bluebird"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/p-retry.git"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/p-retry/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "rocket0191": true,
+    "johnloy": true,
+    "ash": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/p-retry.min.json
+++ b/test/fixtures/registry-mocks/content/p-retry.min.json
@@ -1,0 +1,172 @@
+{
+  "name": "p-retry",
+  "dist-tags": {
+    "latest": "4.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "p-retry",
+      "version": "1.0.0",
+      "dependencies": {
+        "retry": "^0.10.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "delay": "^1.3.1",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "3927332a4b7d70269b535515117fc547da1a6968",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "2.0.0": {
+      "name": "p-retry",
+      "version": "2.0.0",
+      "dependencies": {
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "delay": "^2.0.0",
+        "xo": "*"
+      },
+      "dist": {
+        "integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
+        "shasum": "b97f1f4d6d81a3c065b2b40107b811e995c1bfba",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5629,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa4i26CRA9TVsSAnZWagAATwIP/1n1EEaOrGwqi3kX7Ivg\n9o0okbSaOktXAhkXDn7WyirQPc9PKMHoKS6IRPFzw/0EtPJzwE4nw2eYE0xu\nTe9qSH1nTdfPlp2objfT487MubFy//wBHCduTRN0RcA5XmioXpNg7GL9EBUY\nvRR5vArD1jCm8VNIuryOWAUvhtrOFpcScQuEL1Q17gyWUJ/X/LfSUpDbSLeZ\nKf1D3FGMQ+EaaIyrZS2KZeMgWq3QIJRzp7GafXtgc9SIFVJAzr21qkcYGzZ9\n8Bt0PfZ3aubCbhCX1wWRRJ0nDgmzb0V6MZYJyZY4XSAaG5xzFqtnHKc8uazO\nBiIVs9Rh0WyZe/iOltik0WfP8P/0/AiwAM23KGNFYVDqqP765k9mIKv2IgJM\nbt12KyReEVEKSdIleZO+o5AJjg1P2IJN6MufW0QadHLW6Sw9VeXn39YKc12q\nCvU7tfFrwZUbf7DyEci0mys7RiQCN3aHkv/dOWFB45yldny1zN46qWJdwEi/\nwToT+6RNNIxmDr+YsRLpF8QGHc3Lu9tRYqGWo6Hj5qcYPz5033VTzjpXwmcn\nEo9u6F0oycmcgzHwu1nPeSXZNxGNpkZOho13Iv5F6CGkcCJFD+ayxVazpfqq\nlaDBsw3thqPKRb2EE9G3S2YQmo8vVulNBTlwllLegdJtTnRW8IGgqr1hirxd\nI6yk\r\n=HiK1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.0": {
+      "name": "p-retry",
+      "version": "3.0.0",
+      "dependencies": {
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^0.25.0",
+        "delay": "^4.1.0",
+        "xo": "^0.23.0"
+      },
+      "dist": {
+        "integrity": "sha512-fAB7bebxaj8nylNAsxPNkwPZ/48bXFdFnWrz0v2sV+H5BsGfVL7Ap7KgONqy7rOK4ZI1I+SU+lmettO3hM+2HQ==",
+        "shasum": "f1a09233417dd40b42a7a4a3ed0f4780f23b90d8",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6024,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcESWVCRA9TVsSAnZWagAArOwP/0p+mRIhK3+IVAB63YSE\n9nDYrW6Kdg/H63TIagopJ4uoWABKKy84IFZFYFndcUkTs9Sa6DRNEn2Hmyhb\nRSOC2WlNy9ZKE9ZEACUuJRW69isnDj2ORYWH6Vp59PYgMNb1EDeKGSm38+ny\n0yOhkJjmyNxAe9mT1zGlff1pEESXPfTdIHiQ/uvqAyqrCAPf63KAWbHMlFdR\nOYeIDBoBjQyAV9Sj8m9Z9f1swdSVzFfeiVgfiLL7pmB0FkGkqNPqY8xn+qGo\n9draJJlIzyuYEeYLO9MvQ9KkhwKozZ92bfGB19PFNnvuj2sPfizcFFWvk2gL\nkRprWSRp6476nGCx2Hx9deA7Vgia9pyzGjiOPFTnMfoDaVqcozTtiWER+6dE\nELEtdQz9TCMYU42Iy/N48AeuR3YuXavzWr61TN2EHSfs7xqIzCwJNRzNTeP0\n3wGW/2yG/e4e8/y+rJk6FbPavcSRbeFLlPI6CqaSJ7u8IyeaiJmTdye8OIIE\nceTCLTyrwo/ggyKMWueWE1SWt+y3jnvp5klOvAgyhk/pdVdziiEnA308WxjG\nDvk3wyfw8yPKSy+10Y4Wdt1qA6bnbyGtoRYsiYChoEOH6TimF1K/7w6mVvuR\nbve8h07DgGHkmh9083dpCVDNB3rtQFmRWgj9uqarrhnwVDjF/4OATMRcIpu8\nCXLV\r\n=ouCA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.1": {
+      "name": "p-retry",
+      "version": "3.0.1",
+      "dependencies": {
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^1.1.0",
+        "delay": "^4.1.0",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+        "shasum": "316b4c8893e2c8dc1cfa891f406c4b422bebf328",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6360,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcPJVRCRA9TVsSAnZWagAADW4P/3B97InLQLUYgxvfgH3B\nHyog9CWU/OzvY0f7wTuDXbG7eaCuki5652pHfW4AonUC/v9o5bSpfY67yb2w\ndXrsO+GMZZtieFsaZW+tB8U/QzvKCfvKbQkSd3pdgL3mWkYnM0wOKjVcmasO\nB4atXZoqXMzbYpnWyRzQ5hjMlC99nKJnRRMC2MUsTP1AX4swXVfbuQ3EhxPw\n9UuzNBMyNuRZdPVBCvcOySiLwpEfas8S+53OGS7JuhtlVTAUtGQAmY56wOWF\nBUy7RK7AeKAjHB6jmqRAA2J/KeJNoMj/FHOQ4gGiORUubRq6Hz79l06CqHJo\n1CQMppsJwtBw3M7Cjt6QvOCOPVxnki6ZpNn/lyVO1H85IbEyGtLGuz+ej8G2\ntgaLroEBHfCGjRf8gRjsxeZPn9TuhiSFqDNoBg6URPnEMKLRAte9Zd8iYojq\nQ7vaqPN++N1DRqWxw6IrMklSz70djK4wErKhiWdai1dieDcqcgdwFz5+AJ17\nerTmK1bHpAAXAp6xyA66P61WccgjXxopFBY25OVrgJsFQTTzCzXBk6GiVVPD\nexaAndvcxr3VO5xr/eSPab4vx/QhoIH/kkiuJ7YOWYQvAceR3/J6ZYpLzveO\nqgpN+WwKlOA+cvGLBTUBSUOUE5Mz6aPcYA7ANgVzo5bSye2xgNjKCB1byp/0\nu3IP\r\n=bb5S\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "4.0.0": {
+      "name": "p-retry",
+      "version": "4.0.0",
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^1.3.1",
+        "delay": "^4.1.0",
+        "tsd-check": "^0.3.0",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-bMW1FwszSBsMi6DgPnDKLhAVMDhqeySD4viMI0UiKRv7cQzRS/KYhRPWjnoxSQdvunXwZYKgN10Ya6VxF9w+Og==",
+        "shasum": "56633299ac2fc9f6ecda749398330fdff632607a",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-4.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8018,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJchelwCRA9TVsSAnZWagAAUAUP/AqaZoeQYMbb0VRz5XMJ\nVdELSGP2vk1eHDYruV/UXV0kvcpi5ce11Ml1FtiBRfNLPtujN0O07KV5vNxJ\nAbCuoLyB9q4/AgLUVEtnsfoDBXQe3f/K6vn5fqcPd6QICe/mehQuHCdBma09\nkfDVxMkgqS805Jl3ZkWCIJHaKmYS+MYPk/g+//742gxEbwU3+J6sDCnsdFTi\nWBGoc9FiDi94MuiU3jVuRqBLUzVSkOgcamndYYsGPcdWI0bFgIXuGkTnXkx/\ndGMRu5HFpz4fVHgb3ObbhhlPLdcDyMMxrkFHtfhFo3hAeUi88oVXwKUGCx0e\nxsnvgYePczmzlEwL9MvW+M00suec0r4Gg+gRXMa9KleAkcWjzB/WRwErjaJh\n640MGlqpjT11NGz1NSvKqsM6uBQpS6M2o2Q6RLkZU47qrPd3RJvj+MKmq9HT\n4Ah+iutZbEQDGp4Fcq+S9q156wmc1knrWeftz0LsY3i0WpIOOTPWwMYAn6OO\nR6aNKzGV9lwcy+GaKBW4uhPRsszN67xcGBP7XR9sinGEOPxtZWkpMlYw1L5p\nyoVo/aIZArQB2YDJiOM5vZpNa5m6bpOQvle6AmDY3hdF1o+M9F/YTFZqTkhW\n2/9TsfGAPPfTozsbwYoVF0UuzpXK142V96dAtvjC2/sKJSH3Jf+9zuvE7DUm\nO8w8\r\n=sSXH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "4.1.0": {
+      "name": "p-retry",
+      "version": "4.1.0",
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "delay": "^4.1.0",
+        "tsd": "^0.7.1",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-oepllyG9gX1qH4Sm20YAKxg1GA7L7puhvGnTfimi31P07zSIj7SDV6YtuAx9nbJF51DES+2CIIRkXs8GKqWJxA==",
+        "shasum": "9ce7cef2069e84bf590df3b8ec18d740109338d6",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-4.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9071,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcoKr6CRA9TVsSAnZWagAAqIAP/AoqYWHfa3UjmQSYEQKZ\nrIZBom40lSEgovWa2RMnh8EeszSKFtEaRCxQ7/iaep4KGanURFQLhTG+A3Wy\nyM5wlZgbgniUrZauFk4xtQwqGN/rQAXMA5kUPvkOG3NY4ySrzXKqc8lOcUzP\nScaSvL1qHvdq7ihX53lC/QLVFJzRqyNvjV2DHjXirXxgC0psDAXvVvWA8TaN\n2scPs5nqV/fkPyYb7FhOlQ4N8yUQz1M+1IUmcKRGTwhmbtCTmqjwDokeuJzZ\nUew6eGHGkIGUqTQhwvFw9KDoVCtFAC1C1/cC0dEEjmCfU/91xvPio/qaW0mW\nhmxxKz3cs+Mez1RheK6zkziAuz3Wd9OXAVMzuzN6SDpioBiJhVHSkF83OZEi\ngbzMtlV624iG6QKRMmKDOXTh3KJ5Qf4lA+bwI8bfTIitYAxake77AepNlI5c\nuPu8zxXQUND6K5ywY71YDFvA6oqGysoRQuFJZsKHHFUeVJZf0hdPuEJPRVsC\nMXYiqtJu+ySa8HCklaqgk0MlbXdt5rgdfjdEwhPkqilCgDYT5BL96ar5Ndk/\nGJifIZ0a9+jYo1gBpk4GA1NLxDcDor4lmoWKOzNjQnqkRgn0G01Wv4WrII+m\njxUA5PtH29tlwlP320Cfqi+GEsq5USGxWNh/qJSe/D5+UNtoe51qV/Fmi0k5\nqXhO\r\n=FfH+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "4.2.0": {
+      "name": "p-retry",
+      "version": "4.2.0",
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "devDependencies": {
+        "ava": "^2.4.0",
+        "delay": "^4.1.0",
+        "tsd": "^0.10.0",
+        "xo": "^0.25.3"
+      },
+      "dist": {
+        "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+        "shasum": "ea9066c6b44f23cab4cd42f6147cdbbc6604da5d",
+        "tarball": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10232,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdusTnCRA9TVsSAnZWagAAy5AP/R1Cm+osSni2bNUDI3TQ\n9YajvxxcWk6tsE/6JinW3DuzeDd9qJROSGbw49aFok/HCL9Civ9z0cirBcTb\nbjvFc8tv7duxl/lxctEFcWzKh6XP4yisFBPbD/ncCTt8X2PLcV6cOYECu/lW\nzT6/q2GzggpTffR7IAV0Te0A8MIR9+G6oAxFwRrlNxanDh4F4kGcy4uEboEy\nZz0suO0b+mPs5oqlFgBWYGKmI+bQJ+1dX4clF9gPVj1RxzWot8jiLoN7oo4Y\ncebU13ptmxrVibIDjwmQWZ6gtW4NVa+V3mQGL0vt/+w5FSdIYwCPRTCeaTiT\n8NU939x9wY2+tqalqrho9Ju77Zr9pR9vn8fh96Qi+tzxRB2KQhDi8zYm+eLR\ngT5mpd1V98cGw2G2J7KCw+G4Uslbv6phADG06G6gngubJeewGrtmyBDTUdio\nk/JCk5+CEGjOxOqHiK25aXMrwdp0Tp2hlUnQS0jBNiXIFlDRNidk6bUJe52x\nqB1IZB0kq/iC/Y0gNLPlAHUneLghTXjB/5PjiIjn2ixKawchjvrkL//8Iekl\nR3RjvJm6TVwfFWeA8wtVWWk5YT/YPXwKsjHdFouJfyapTAckqyduQaSsg1I6\nO9w7rJhtTFNfdlmS4mwOSpqMwrTtKQWW4EhseOBiYw7EWZZsXAERLp12crKO\ncl0H\r\n=YYLB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "modified": "2019-10-31T11:26:34.590Z"
+}

--- a/test/fixtures/registry-mocks/content/pako.json
+++ b/test/fixtures/registry-mocks/content/pako.json
@@ -1,0 +1,2062 @@
+{
+  "_id": "pako",
+  "_rev": "65-b9693e042268262bc4b9841fca625d40",
+  "name": "pako",
+  "description": "zlib port to javascript - fast, modularized, with browser support",
+  "dist-tags": {
+    "latest": "1.0.11"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support.",
+      "version": "0.0.0",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10"
+      },
+      "_id": "pako@0.0.0",
+      "dist": {
+        "shasum": "9d63e90867d1d1c8d565527a15a671a2666d21d5",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.1.0",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.0",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.0.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "_id": "pako@0.1.0",
+      "dist": {
+        "shasum": "c6bc3e165098740ce5409a39269267cb48bb945b",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.1.0.tgz"
+      },
+      "_from": "https://github.com/nodeca/pako/tarball/0.1.0",
+      "_resolved": "https://github.com/nodeca/pako/tarball/0.1.0",
+      "scripts": {},
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.1.1",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.0",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.0.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "_id": "pako@0.1.1",
+      "dist": {
+        "shasum": "5053d4d5d90b1681e037b3c60e857d4756d5f25f",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.1.1.tgz"
+      },
+      "_from": "https://github.com/nodeca/pako/tarball/0.1.1",
+      "_resolved": "https://github.com/nodeca/pako/tarball/0.1.1",
+      "scripts": {},
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.0",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.1.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "_id": "pako@0.2.0",
+      "dist": {
+        "shasum": "bb93787e8c60587c8b13cd3cd8802e9d6f5dd8d5",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.0.tgz"
+      },
+      "_from": "https://github.com/nodeca/pako/tarball/0.2.0",
+      "_resolved": "https://github.com/nodeca/pako/tarball/0.2.0",
+      "scripts": {},
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.1",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.1.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "_id": "pako@0.2.1",
+      "dist": {
+        "shasum": "65150277c8447a9e83877f00476d533e1d380ad3",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.1.tgz"
+      },
+      "_from": "https://github.com/nodeca/pako/tarball/0.2.1",
+      "_resolved": "https://github.com/nodeca/pako/tarball/0.2.1",
+      "scripts": {},
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.2",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.1.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "_id": "pako@0.2.2",
+      "dist": {
+        "shasum": "0154fcebb02d53d188827edbdc37d358e3a12cbe",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.2.tgz"
+      },
+      "_from": "https://github.com/nodeca/pako/tarball/0.2.2",
+      "_resolved": "https://github.com/nodeca/pako/tarball/0.2.2",
+      "scripts": {},
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.3",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.0.2",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "_id": "pako@0.2.3",
+      "_shasum": "da97260282d270c43f210d9e9bf9abdf54072641",
+      "_from": "https://github.com/nodeca/pako/tarball/0.2.3",
+      "_resolved": "https://github.com/nodeca/pako/tarball/0.2.3",
+      "scripts": {},
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "da97260282d270c43f210d9e9bf9abdf54072641",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.4": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.4",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.0.2",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "_id": "pako@0.2.4",
+      "_shasum": "015399af84fc28c6d9ce5abe5874b7dcb968a751",
+      "_from": "https://github.com/nodeca/pako/tarball/0.2.4",
+      "_resolved": "https://github.com/nodeca/pako/tarball/0.2.4",
+      "scripts": {},
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "015399af84fc28c6d9ce5abe5874b7dcb968a751",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.5": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.5",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.0.2",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "_id": "pako@0.2.5",
+      "_shasum": "36df19467a3879152e9adcc44784f07d0a80c525",
+      "_from": "https://github.com/nodeca/pako/tarball/0.2.5",
+      "_resolved": "https://github.com/nodeca/pako/tarball/0.2.5",
+      "scripts": {},
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "36df19467a3879152e9adcc44784f07d0a80c525",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.6": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.6",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "gitHead": "4ace00c10b5f4be0b008c3799fd5b076173f19c2",
+      "_id": "pako@0.2.6",
+      "scripts": {},
+      "_shasum": "3e0c548353b859ab9c8005fac706bdd6c7af505f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "3e0c548353b859ab9c8005fac706bdd6c7af505f",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.7": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.7",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "0.17.1",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "gitHead": "8070869d8cef31f291e02498c28d7f423de34ade",
+      "_id": "pako@0.2.7",
+      "scripts": {},
+      "_shasum": "90e8917affd5ee2b69dfe943ec16b783c4e0c441",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "90e8917affd5ee2b69dfe943ec16b783c4e0c441",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.8": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.8",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/nodeca/pako/blob/master/LICENSE"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/nodeca/pako.git"
+      },
+      "main": "./index.js",
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "0.17.1",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "gitHead": "08c5cfb4fe2f744bedbd249be908bba0d8fc0946",
+      "_id": "pako@0.2.8",
+      "scripts": {},
+      "_shasum": "15ad772915362913f20de4a8a164b4aacc6165d6",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "15ad772915362913f20de4a8a164b4aacc6165d6",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.0",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "files": [
+        "index.js",
+        "dist/",
+        "lib/"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "gitHead": "c3cf4566da9c443575ac7f447e5404af7f34aa3d",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.0",
+      "scripts": {},
+      "_shasum": "ec8b6f0a7e1512d20a21bd58568db7777bb7ccb1",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.0",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "ec8b6f0a7e1512d20a21bd58568db7777bb7ccb1",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/pako-1.0.0.tgz_1455700678142_0.584279963048175"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.1",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "files": [
+        "index.js",
+        "dist/",
+        "lib/"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "gitHead": "78603f42fc4b33393451a9377479d0869886429b",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.1",
+      "scripts": {},
+      "_shasum": "030267fd61934761c70331728ffa59a9a845152e",
+      "_from": ".",
+      "_npmVersion": "2.14.20",
+      "_nodeVersion": "4.4.1",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "030267fd61934761c70331728ffa59a9a845152e",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pako-1.0.1.tgz_1459521071752_0.24107903544791043"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.2",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "files": [
+        "index.js",
+        "dist/",
+        "lib/"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "gitHead": "d53e2219e3ea14ac5759e5925cfd8d14a29c1da6",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.2",
+      "scripts": {},
+      "_shasum": "ce4ff912366c028a4dbe3f64bf9de8441ba02b75",
+      "_from": ".",
+      "_npmVersion": "2.15.5",
+      "_nodeVersion": "4.4.5",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "ce4ff912366c028a4dbe3f64bf9de8441ba02b75",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pako-1.0.2.tgz_1469133085971_0.8812384714838117"
+      },
+      "directories": {}
+    },
+    "0.2.9": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "0.2.9",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "files": [
+        "index.js",
+        "dist/",
+        "lib/"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "gitHead": "85d145e616967f3720382f416da530c23c02ad13",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@0.2.9",
+      "scripts": {},
+      "_shasum": "f3f7522f4ef782348da8161bad9ecfd51bf83a75",
+      "_from": ".",
+      "_npmVersion": "2.15.5",
+      "_nodeVersion": "4.4.5",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "f3f7522f4ef782348da8161bad9ecfd51bf83a75",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pako-0.2.9.tgz_1469133699053_0.013920168625190854"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.3",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "files": [
+        "index.js",
+        "dist/",
+        "lib/"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "gitHead": "653c0b00d8941c89d09ed4546d2179001ec44efc",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.3",
+      "scripts": {},
+      "_shasum": "5f515b0c6722e1982920ae8005eacb0b7ca73ccf",
+      "_from": ".",
+      "_npmVersion": "2.15.5",
+      "_nodeVersion": "4.4.5",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "5f515b0c6722e1982920ae8005eacb0b7ca73ccf",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pako-1.0.3.tgz_1469476123771_0.3454044258687645"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.4",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        }
+      ],
+      "files": [
+        "index.js",
+        "dist/",
+        "lib/"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^3.12.2",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "^1.0.1",
+        "grunt-cli": "^1.2.0",
+        "grunt-saucelabs": "^9.0.0",
+        "grunt-contrib-connect": "^1.0.2"
+      },
+      "gitHead": "8737672b4146ff5bc510f6552bf30bad500aa4b4",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.4",
+      "scripts": {},
+      "_shasum": "412cc97c3b7ff06dc6c2557fd4f03d06f5e708d4",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "412cc97c3b7ff06dc6c2557fd4f03d06f5e708d4",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pako-1.0.4.tgz_1481762024868_0.25667452113702893"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.5",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        },
+        {
+          "name": "Friedel Ziegelmayer",
+          "url": "https://github.com/dignifiedquire"
+        },
+        {
+          "name": "Kirill Efimov",
+          "url": "https://github.com/Kirill89"
+        },
+        {
+          "name": "Jean-loup Gailly"
+        },
+        {
+          "name": "Mark Adler"
+        }
+      ],
+      "files": [
+        "index.js",
+        "dist/",
+        "lib/"
+      ],
+      "license": "(MIT AND Zlib)",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "devDependencies": {
+        "ansi": "*",
+        "async": "*",
+        "benchmark": "*",
+        "bluebird": "^3.5.0",
+        "browserify": "*",
+        "eslint": "^3.12.2",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "grunt": "^1.0.1",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.2",
+        "grunt-saucelabs": "^9.0.0",
+        "istanbul": "*",
+        "lodash": "*",
+        "mocha": "^3.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "*",
+        "uglify-js": "*",
+        "zlibjs": "^0.2.0"
+      },
+      "gitHead": "588a4376d24f24b3bae4167b4a5c8cd43761a5cd",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.5",
+      "scripts": {},
+      "_shasum": "d2205dfe5b9da8af797e7c163db4d1f84e4600bc",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.4",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "shasum": "d2205dfe5b9da8af797e7c163db4d1f84e4600bc",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/pako-1.0.5.tgz_1490543279075_0.5095277389045805"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.6",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        },
+        {
+          "name": "Friedel Ziegelmayer",
+          "url": "https://github.com/dignifiedquire"
+        },
+        {
+          "name": "Kirill Efimov",
+          "url": "https://github.com/Kirill89"
+        },
+        {
+          "name": "Jean-loup Gailly"
+        },
+        {
+          "name": "Mark Adler"
+        }
+      ],
+      "files": [
+        "index.js",
+        "dist/",
+        "lib/"
+      ],
+      "license": "(MIT AND Zlib)",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "bluebird": "^3.5.0",
+        "browserify": "^14.4.0",
+        "eslint": "^3.12.2",
+        "grunt": "^1.0.1",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.2",
+        "grunt-saucelabs": "^9.0.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "^3.0.25",
+        "zlibjs": "^0.3.1"
+      },
+      "dependencies": {},
+      "gitHead": "893381abcafa10fa2081ce60dae7d4d8e873a658",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.6",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+        "shasum": "0101211baa70c4bca4a0f63f2206e97b7dfaf258",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pako-1.0.6.tgz_1505389320912_0.5741512756794691"
+      },
+      "directories": {}
+    },
+    "1.0.7": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.7",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        },
+        {
+          "name": "Friedel Ziegelmayer",
+          "url": "https://github.com/dignifiedquire"
+        },
+        {
+          "name": "Kirill Efimov",
+          "url": "https://github.com/Kirill89"
+        },
+        {
+          "name": "Jean-loup Gailly"
+        },
+        {
+          "name": "Mark Adler"
+        }
+      ],
+      "license": "(MIT AND Zlib)",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "bluebird": "^3.5.0",
+        "browserify": "^14.4.0",
+        "eslint": "^3.12.2",
+        "grunt": "^1.0.1",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.2",
+        "grunt-saucelabs": "^9.0.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "^3.0.25",
+        "zlibjs": "^0.3.1"
+      },
+      "dependencies": {},
+      "gitHead": "73edc8b9a3b9c189a8beb641c546106a74747925",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.7",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.11.0",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "dist": {
+        "integrity": "sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==",
+        "shasum": "2473439021b57f1516c82f58be7275ad8ef1bb27",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.7.tgz",
+        "fileCount": 27,
+        "unpackedSize": 784594,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcABbwCRA9TVsSAnZWagAAIMMP/12OxNEjEeK9FTDX6zGw\njgas/F6vNOEYGAXSjJcSUcol29zqM9KOgy31AHGLPmI02JhexZEqGll+/H+s\nnjDVPyc1HwTK0WUJoz15J+HbqLlXIwh1oyFk3p421qF5eItjKwKeJzm1utX0\nw1QMpR3103jCLV6ht2dA3A4LZuPAWj2e4wazmoLqVWWle6vcWhduyuLbOIUu\nylBpq3xIzOnJhVX7h9qWpPKTIC3n+Qz4WII46SsZ6JKJxkPc6gXcJadLfg9N\nX20+b3fODCGsFSL/5nBqBe8uWZp2aeI452F2/OzJJvZ+PL8Z//qj2XhZ9QHi\n9KZl4MqS36o5rCOmkPqtzLMOG9f0+RcqNKSgJXB42uxdFLBSswRnJDeMYmRe\n+jmJl51KhIUJP7tP/vnFO7zSx5Vg61vlBOEu7vwMcUEfK1jHWBQ7dSxV2xfL\n80xquvqSomSTUQQRcaQj6BZn1fHtlGvWdrNi2gxXUyNarix0RMHbF5gSXhq8\ncfJlIAyPnK9yB/oWRxs7vLrTv2WvsRTYDjRDw8NMQwRLHQFaPsl/OTl3IPYG\n9tN/7ZBGUyptp5OXdvbyJUI7hm0OSzdS6blfn9AFgsGKQE6NlJovlmHxwudP\nG4TT91G4mybSMMDHOxLk3RT70dFVC8E+/Y+KRi7oCA5Q5J78GY/HKUIjd9g2\nNQDA\r\n=+aMR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pako_1.0.7_1543509743882_0.19308814258998264"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.8": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.8",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        },
+        {
+          "name": "Friedel Ziegelmayer",
+          "url": "https://github.com/dignifiedquire"
+        },
+        {
+          "name": "Kirill Efimov",
+          "url": "https://github.com/Kirill89"
+        },
+        {
+          "name": "Jean-loup Gailly"
+        },
+        {
+          "name": "Mark Adler"
+        }
+      ],
+      "license": "(MIT AND Zlib)",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.2.3",
+        "eslint": "^5.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "^3.0.25",
+        "zlibjs": "^0.3.1"
+      },
+      "dependencies": {},
+      "gitHead": "021f307fa3a64d9b04a9a44ec721acfd71640fcc",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.8",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.11.0",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "dist": {
+        "integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==",
+        "shasum": "6844890aab9c635af868ad5fecc62e8acbba3ea4",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
+        "fileCount": 27,
+        "unpackedSize": 785729,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcPNOKCRA9TVsSAnZWagAAa+IP/1H8fDDhZ43+xYAVSjs7\n4HxUzXLPIhGSZMHnOwoGI08sAzlD/Ydfymu8mS1GXwUb5BkNOTiPHwmNFx5T\n79Y50XnW2Ji/4zDM/Tl/+E1NBrEF3NLitGgZaN1I+XmxW27Cdzo5a7pnW2L/\n+Fm/gXPCssJq5BZF8iTG3MWB3BfhJ5b76MIS+Q0HAdCP681qsVq/WW+pGknc\n09aNJELmoDhNqYRiqOPqhGWhwCEC5VrF5j6s/TnBeicLq1tCM7MIL++rl1N7\n/Y2aU9kxiXGAsOy3CUk501dgW4Qn9YHwo1peG5oEUt7NXBs3WtIijywCIz5W\nDfHV115lDUrdHer3ZC9vx8M3K8QXMrWtqqUZvdWAkxYNeCZpqMn2lhteMHel\nAW6Inhs3ansqb5HMQTDh5opZMYlaRfceRm3iSWV0+aC6j+rf9kgAZYRxbcnn\n1nfbfIb4ChreeciOgLRZZ4dGHR8KHxBVGkpGF07IaAJLrZmJ5M0zkDFUd6Is\nRUVX6AyPA0boOBv11Qj+SF525IbN/9fPFV0T4AJyw2d9r9YY5ts1mbCyEcMy\nl1F8tL2Qvf2VEKB5mBWDZvR1Qnm++cUklbTEAYd67NWFWKOKo6nAk63JeWCQ\nxt+5XZNRhQ64yC6OY4ZJtNiTeBVMDVNLlUPFUcjg5GTQjsbyvXD3wlatCN0V\ntfXM\r\n=d0w4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pako_1.0.8_1547490185935_0.3104884168277744"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.9": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.9",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        },
+        {
+          "name": "Friedel Ziegelmayer",
+          "url": "https://github.com/dignifiedquire"
+        },
+        {
+          "name": "Kirill Efimov",
+          "url": "https://github.com/Kirill89"
+        },
+        {
+          "name": "Jean-loup Gailly"
+        },
+        {
+          "name": "Mark Adler"
+        }
+      ],
+      "license": "(MIT AND Zlib)",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.2.3",
+        "buffer-from": "^1.1.1",
+        "eslint": "^5.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "^3.0.25",
+        "zlibjs": "^0.3.1"
+      },
+      "dependencies": {},
+      "gitHead": "731065b150f0d62a23ea6c3574c8c6223a16004d",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.9",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "dist": {
+        "integrity": "sha512-tPjtE6dq+dOSg8NMkqRmFjUYH9fect1zmYgB0g6ztQMaVNI7N1CEvLZud2bPHhg7PRgfKEeTshSPiqXb1F7A+A==",
+        "shasum": "410f6784fbba83e5e743be90899fa050e9c6f787",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.9.tgz",
+        "fileCount": 27,
+        "unpackedSize": 785835,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJceDWfCRA9TVsSAnZWagAAqRcP/1RPYmdRdVmrZbBiWbQQ\n/KsIHCxt4qzk0fM4g3YroG+8ZTXwks4jkWnNAgdFxD5Xd0gzWDTr54y5l9++\nfd6ZQy4Qb5q3yzezrxmPZ6yhPfaLvhEtRNocCLBNTCIUSGjo7z8MVIgGK9LC\n9D2SRMI3FOEt/uTDxSrOQs7C4I+nOFAEORJ20WRZ0aHTmxJdn4hq0sfsX7P7\ncvLy6empMvgtAlA9DS5QAMH6ULBVF4l0Bnmc/vLbtQ51PLHmtsNBf3ZeYpmd\n6ASUEcjJlg7FLhcb9tQI4NY/OSB97esQyBnJbuG50xV94NEUwcTko7+f86Ll\nQkiTD3y2mmiaIYIYSxmvtzqO32ozmWox2zZOHN1hjpTgKz7Q6rZEYTcg4L52\ndCwvVmXBWKdtYpy/3MnuCpzeqwaX/d7Wk7Tha0dMAn9xTLpx6MdXqlKZ5/VU\nGOnNdubuTnw6nOaYjppwGTGrgR8/hJE+kptLiQUcaZarPVF2wGdUoEBbvMVo\nPyq+YxfaZaX0KzgFAK4nIGjw6Sdi7vQKEA8kw3nMkdrrNIpClhbcZM+eJdw7\nJTlwIfvDuDd6rcqZ4ZhM9nbfcopd/KCKKDbY0EQdVZIbcGxzxGjfpjGxGXaj\n+DNrwKXdI6LnfHGL1+vvdDm+SPOuz+09rvjdP2s2+ymUi5xiY9ADL3MzPGUF\nzi20\r\n=AMXM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pako_1.0.9_1551381918409_0.37797388891588146"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.10": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.10",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        },
+        {
+          "name": "Friedel Ziegelmayer",
+          "url": "https://github.com/dignifiedquire"
+        },
+        {
+          "name": "Kirill Efimov",
+          "url": "https://github.com/Kirill89"
+        },
+        {
+          "name": "Jean-loup Gailly"
+        },
+        {
+          "name": "Mark Adler"
+        }
+      ],
+      "license": "(MIT AND Zlib)",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.2.3",
+        "buffer-from": "^1.1.1",
+        "eslint": "^5.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "=3.4.8",
+        "zlibjs": "^0.3.1"
+      },
+      "dependencies": {},
+      "gitHead": "69798959ca01d40bc692d4fe9c54b9d23a4994bf",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.10",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "dist": {
+        "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+        "shasum": "4328badb5086a426aa90f541977d4955da5c9732",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+        "fileCount": 27,
+        "unpackedSize": 786051,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJceFXmCRA9TVsSAnZWagAAFHQP/i+R5tx15QJjRXBY283W\nYGE2j0m0aBKGE0vXcIu6jHXmS8tBZWxbDkdV9KtjNHh+aEzk2T4T4WQyAdRx\nXlApzs7yrj2QjGhuOhtF7eQ2jZ5bUWqjxjBDGN5vqYUnXn1VL8lI/moIALOS\nMB6ai5dZgNH5hvzk1kl+NkNPgKn/OhjsEGRD4wLJjEnf0ZbaaqShATtArOsA\n1U1ENIs3ooGSp2Al3MQwXuJ+kAl0+C0391uvkkpCeFE0J7Sly20a8SvESPsb\nP0Jupw2sbhgiaXv6p/Csoroxjw6GTmL+xPJH7rQqNwAepvhjjnU7ODiltstV\nG4+xwXTy9qg9tf+4Flw5UMfMVVmaMMpPSC31t+PjHjvjsJlu21gzNm5vb7uf\nYLvlpMPboeNSpTw/o18BI/B+NwVN4mIS2/Ksi9THpCL4gHQ8y5CiIlnqqKk0\n4mj5CZufp5EvGW144vcRRU+ExRbVqhH0JfLfxO0WBwAaY8JbLy6+688lZ5+8\n1s3EwWd1KALjGCdyh5UV7VcAdM/OrgnNGihip8OoVVRpNlZARpsQ7KKXrr7D\nOlMGjMCFc7L7ATQ3iRu2fGsRwVcq6a2a1Fc/0c3lqcSUn9xTMnKbbhbgkxyu\nr05AlogNX1voD/24LLTHtX7axCAkjfJLi8qtVhoigMm1BUHhhjmDZGa65VDT\nyQJ9\r\n=XskI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pako_1.0.10_1551390181873_0.5202119682665474"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.11": {
+      "name": "pako",
+      "description": "zlib port to javascript - fast, modularized, with browser support",
+      "version": "1.0.11",
+      "keywords": [
+        "zlib",
+        "deflate",
+        "inflate",
+        "gzip"
+      ],
+      "homepage": "https://github.com/nodeca/pako",
+      "contributors": [
+        {
+          "name": "Andrei Tuputcyn",
+          "url": "https://github.com/andr83"
+        },
+        {
+          "name": "Vitaly Puzrin",
+          "url": "https://github.com/puzrin"
+        },
+        {
+          "name": "Friedel Ziegelmayer",
+          "url": "https://github.com/dignifiedquire"
+        },
+        {
+          "name": "Kirill Efimov",
+          "url": "https://github.com/Kirill89"
+        },
+        {
+          "name": "Jean-loup Gailly"
+        },
+        {
+          "name": "Mark Adler"
+        }
+      ],
+      "license": "(MIT AND Zlib)",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/nodeca/pako.git"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.2.3",
+        "buffer-from": "^1.1.1",
+        "eslint": "^5.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "=3.4.8",
+        "zlibjs": "^0.3.1"
+      },
+      "dependencies": {},
+      "gitHead": "a718e4f6e5ce87b0964d8f84541d92a23263365b",
+      "bugs": {
+        "url": "https://github.com/nodeca/pako/issues"
+      },
+      "_id": "pako@1.0.11",
+      "_nodeVersion": "12.14.1",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+        "shasum": "6c9599d340d54dfd3946380252a35705a6b992bf",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+        "fileCount": 27,
+        "unpackedSize": 788283,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeMThCCRA9TVsSAnZWagAAUokQAIXP/sogHkcjaJDsXEm4\nxwCJ6+XRKT706p/6wpHxglDgR9ea47MeHXc4+M6orKXFVUFaN/DIDTDnfNC0\nrzuwOxcLs3OkA32xpiEq15U6MDIqv8vUuVUL8tR5Gr24H3z4ie4P0VBuJ5F5\nzCEEi7/hfMxyaqxSh/SkH5bJemQhJRUekFOW3vYxqAM3665ZNCXkuYWcE1jy\nNMPTDvX4EkeLDCxPLIRWjwmEUrhXj14NKy6bQSBoGGivVP+SXP9TVUFk46p7\n6mTHxJeLJqHitjTRUsSQjl060u8C9gP3Fcmbt4eEMJyAGFajz0Sc8HKUQkM0\noC9JY8anTgWXTxAX8UkVsm42sWI6oyQe1poAa85+L72PZLJJeamvVFNeJoqd\ndWJpTj1Ak1cNxxul4DPi3F1I2LQXU3RyKUEHE8Vl8ZFTRwZdeVGQD/gms3D9\n28hyagU/02x+Wy3Z4NzLIBhB7p9MEsZd3HVDF2tEs1SnLTSp1AdNwtnyHJaD\neEln3zjVs5SIxfgNiJR9ycD/CmZpV1YGtLDPBFWM8XN2u6YaoxZ+VZI6390A\nJTrKW9u/nu7DlT839v/GTOKpmt6yGPCfm0jKywVQGhyWq8WlZF5EZENm5ilA\nZ0QvGDTUSkv93idyYXDXunBQT3qx9SqVGeaBXdeQCCLOJt/knizQJTYfjgOa\nRo6X\r\n=Ndry\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "vitaly",
+          "email": "vitaly@rcdesign.ru"
+        }
+      ],
+      "_npmUser": {
+        "name": "vitaly",
+        "email": "vitaly@rcdesign.ru"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pako_1.0.11_1580283969487_0.1408742612529914"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "pako\n==========================================\n\n[![Build Status](https://travis-ci.org/nodeca/pako.svg?branch=master)](https://travis-ci.org/nodeca/pako)\n[![NPM version](https://img.shields.io/npm/v/pako.svg)](https://www.npmjs.org/package/pako)\n\n> zlib port to javascript, very fast!\n\n__Why pako is cool:__\n\n- Almost as fast in modern JS engines as C implementation (see benchmarks).\n- Works in browsers, you can browserify any separate component.\n- Chunking support for big blobs.\n- Results are binary equal to well known [zlib](http://www.zlib.net/) (now contains ported zlib v1.2.8).\n\nThis project was done to understand how fast JS can be and is it necessary to\ndevelop native C modules for CPU-intensive tasks. Enjoy the result!\n\n\n__Famous projects, using pako:__\n\n- [browserify](http://browserify.org/) (via [browserify-zlib](https://github.com/devongovett/browserify-zlib))\n- [JSZip](http://stuk.github.io/jszip/)\n- [mincer](https://github.com/nodeca/mincer)\n- [JS-Git](https://github.com/creationix/js-git) and\n  [Tedit](https://chrome.google.com/webstore/detail/tedit-development-environ/ooekdijbnbbjdfjocaiflnjgoohnblgf)\n  by [@creationix](https://github.com/creationix)\n\n\n__Benchmarks:__\n\n```\nnode v0.10.26, 1mb sample:\n\n   deflate-dankogai x 4.73 ops/sec ±0.82% (15 runs sampled)\n   deflate-gildas x 4.58 ops/sec ±2.33% (15 runs sampled)\n   deflate-imaya x 3.22 ops/sec ±3.95% (12 runs sampled)\n ! deflate-pako x 6.99 ops/sec ±0.51% (21 runs sampled)\n   deflate-pako-string x 5.89 ops/sec ±0.77% (18 runs sampled)\n   deflate-pako-untyped x 4.39 ops/sec ±1.58% (14 runs sampled)\n * deflate-zlib x 14.71 ops/sec ±4.23% (59 runs sampled)\n   inflate-dankogai x 32.16 ops/sec ±0.13% (56 runs sampled)\n   inflate-imaya x 30.35 ops/sec ±0.92% (53 runs sampled)\n ! inflate-pako x 69.89 ops/sec ±1.46% (71 runs sampled)\n   inflate-pako-string x 19.22 ops/sec ±1.86% (49 runs sampled)\n   inflate-pako-untyped x 17.19 ops/sec ±0.85% (32 runs sampled)\n * inflate-zlib x 70.03 ops/sec ±1.64% (81 runs sampled)\n\nnode v0.11.12, 1mb sample:\n\n   deflate-dankogai x 5.60 ops/sec ±0.49% (17 runs sampled)\n   deflate-gildas x 5.06 ops/sec ±6.00% (16 runs sampled)\n   deflate-imaya x 3.52 ops/sec ±3.71% (13 runs sampled)\n ! deflate-pako x 11.52 ops/sec ±0.22% (32 runs sampled)\n   deflate-pako-string x 9.53 ops/sec ±1.12% (27 runs sampled)\n   deflate-pako-untyped x 5.44 ops/sec ±0.72% (17 runs sampled)\n * deflate-zlib x 14.05 ops/sec ±3.34% (63 runs sampled)\n   inflate-dankogai x 42.19 ops/sec ±0.09% (56 runs sampled)\n   inflate-imaya x 79.68 ops/sec ±1.07% (68 runs sampled)\n ! inflate-pako x 97.52 ops/sec ±0.83% (80 runs sampled)\n   inflate-pako-string x 45.19 ops/sec ±1.69% (57 runs sampled)\n   inflate-pako-untyped x 24.35 ops/sec ±2.59% (40 runs sampled)\n * inflate-zlib x 60.32 ops/sec ±1.36% (69 runs sampled)\n```\n\nzlib's test is partially affected by marshalling (that make sense for inflate only).\nYou can change deflate level to 0 in benchmark source, to investigate details.\nFor deflate level 6 results can be considered as correct.\n\n__Install:__\n\nnode.js:\n\n```\nnpm install pako\n```\n\nbrowser:\n\n```\nbower install pako\n```\n\n\nExample & API\n-------------\n\nFull docs - http://nodeca.github.io/pako/\n\n```javascript\nvar pako = require('pako');\n\n// Deflate\n//\nvar input = new Uint8Array();\n//... fill input data here\nvar output = pako.deflate(input);\n\n// Inflate (simple wrapper can throw exception on broken stream)\n//\nvar compressed = new Uint8Array();\n//... fill data to uncompress here\ntry {\n  var result = pako.inflate(compressed);\n} catch (err) {\n  console.log(err);\n}\n\n//\n// Alternate interface for chunking & without exceptions\n//\n\nvar inflator = new pako.Inflate();\n\ninflator.push(chunk1, false);\ninflator.push(chunk2, false);\n...\ninflator.push(chunkN, true); // true -> last chunk\n\nif (inflator.err) {\n  console.log(inflator.msg);\n}\n\nvar output = inflator.result;\n\n```\n\nSometime you can wish to work with strings. For example, to send\nbig objects as json to server. Pako detects input data type. You can\nforce output to be string with option `{ to: 'string' }`.\n\n```javascript\nvar pako = require('pako');\n\nvar test = { my: 'super', puper: [456, 567], awesome: 'pako' };\n\nvar binaryString = pako.deflate(JSON.stringify(test), { to: 'string' });\n\n//\n// Here you can do base64 encode, make xhr requests and so on.\n//\n\nvar restored = JSON.parse(pako.inflate(binaryString, { to: 'string' }));\n```\n\n\nNotes\n-----\n\nPako does not contain some specific zlib functions:\n\n- __deflate__ -  methods `deflateCopy`, `deflateBound`, `deflateParams`,\n  `deflatePending`, `deflatePrime`, `deflateTune`.\n- __inflate__ - methods `inflateCopy`, `inflateMark`,\n  `inflatePrime`, `inflateGetDictionary`, `inflateSync`, `inflateSyncPoint`, `inflateUndermine`.\n- High level inflate/deflate wrappers (classes) may not support some flush\n  modes. Those should work: Z_NO_FLUSH, Z_FINISH, Z_SYNC_FLUSH.\n\n\npako for enterprise\n-------------------\n\nAvailable as part of the Tidelift Subscription\n\nThe maintainers of pako and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/npm-pako?utm_source=npm-pako&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)\n\n\nAuthors\n-------\n\n- Andrey Tupitsin [@anrd83](https://github.com/andr83)\n- Vitaly Puzrin [@puzrin](https://github.com/puzrin)\n\nPersonal thanks to:\n\n- Vyacheslav Egorov ([@mraleph](https://github.com/mraleph)) for his awesome\n  tutorials about optimising JS code for v8, [IRHydra](http://mrale.ph/irhydra/)\n  tool and his advices.\n- David Duponchel ([@dduponchel](https://github.com/dduponchel)) for help with\n  testing.\n\nOriginal implementation (in C):\n\n- [zlib](http://zlib.net/) by Jean-loup Gailly and Mark Adler.\n\n\nLicense\n-------\n\n- MIT - all files, except `/lib/zlib` folder\n- ZLIB - `/lib/zlib` content\n",
+  "maintainers": [
+    {
+      "name": "vitaly",
+      "email": "vitaly@rcdesign.ru"
+    }
+  ],
+  "time": {
+    "modified": "2020-01-29T07:46:12.029Z",
+    "created": "2014-02-19T16:02:05.385Z",
+    "0.0.0": "2014-02-19T16:02:05.385Z",
+    "0.1.0": "2014-03-15T17:36:20.687Z",
+    "0.1.1": "2014-03-20T02:31:52.798Z",
+    "0.2.0": "2014-04-18T05:44:58.777Z",
+    "0.2.1": "2014-05-01T18:14:04.622Z",
+    "0.2.2": "2014-06-04T07:31:28.956Z",
+    "0.2.3": "2014-06-08T20:46:47.067Z",
+    "0.2.4": "2014-07-07T05:50:16.563Z",
+    "0.2.5": "2014-07-19T10:08:28.458Z",
+    "0.2.6": "2015-03-24T01:51:57.856Z",
+    "0.2.7": "2015-06-09T19:58:14.372Z",
+    "0.2.8": "2015-09-14T12:21:28.534Z",
+    "1.0.0": "2016-02-17T09:18:02.220Z",
+    "1.0.1": "2016-04-01T14:31:14.198Z",
+    "1.0.2": "2016-07-21T20:31:28.170Z",
+    "0.2.9": "2016-07-21T20:41:41.367Z",
+    "1.0.3": "2016-07-25T19:48:45.827Z",
+    "1.0.4": "2016-12-15T00:33:47.154Z",
+    "1.0.5": "2017-03-26T15:47:59.658Z",
+    "1.0.6": "2017-09-14T11:42:02.356Z",
+    "1.0.7": "2018-11-29T16:42:24.021Z",
+    "1.0.8": "2019-01-14T18:23:06.100Z",
+    "1.0.9": "2019-02-28T19:25:18.605Z",
+    "1.0.10": "2019-02-28T21:43:02.072Z",
+    "1.0.11": "2020-01-29T07:46:09.668Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/nodeca/pako",
+  "keywords": [
+    "zlib",
+    "deflate",
+    "inflate",
+    "gzip"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nodeca/pako.git"
+  },
+  "contributors": [
+    {
+      "name": "Andrei Tuputcyn",
+      "url": "https://github.com/andr83"
+    },
+    {
+      "name": "Vitaly Puzrin",
+      "url": "https://github.com/puzrin"
+    },
+    {
+      "name": "Friedel Ziegelmayer",
+      "url": "https://github.com/dignifiedquire"
+    },
+    {
+      "name": "Kirill Efimov",
+      "url": "https://github.com/Kirill89"
+    },
+    {
+      "name": "Jean-loup Gailly"
+    },
+    {
+      "name": "Mark Adler"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/nodeca/pako/issues"
+  },
+  "license": "(MIT AND Zlib)",
+  "users": {
+    "306766053": true,
+    "maxogden": true,
+    "guybrush": true,
+    "devongovett": true,
+    "sidwood": true,
+    "pid": true,
+    "ivansky": true,
+    "vlazar": true,
+    "gudvinr": true,
+    "flozz": true,
+    "moimikey": true,
+    "illuminator": true,
+    "jhuckaby": true,
+    "forresto": true,
+    "monolithed": true,
+    "mhaidarh": true,
+    "zewish": true,
+    "create3000": true,
+    "justjavac": true,
+    "jolg42": true,
+    "mysticatea": true,
+    "tomekf": true,
+    "ruchirgodura": true,
+    "iwasawafag": true,
+    "daizch": true,
+    "yanghcc": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/pako.min.json
+++ b/test/fixtures/registry-mocks/content/pako.min.json
@@ -1,0 +1,627 @@
+{
+  "name": "pako",
+  "dist-tags": {
+    "latest": "1.0.11"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "pako",
+      "version": "0.0.0",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10"
+      },
+      "dist": {
+        "shasum": "9d63e90867d1d1c8d565527a15a671a2666d21d5",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.0.0.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "pako",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.0",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.0.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "dist": {
+        "shasum": "c6bc3e165098740ce5409a39269267cb48bb945b",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "pako",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.0",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.0.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "dist": {
+        "shasum": "5053d4d5d90b1681e037b3c60e857d4756d5f25f",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.1.1.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "pako",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.1.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "dist": {
+        "shasum": "bb93787e8c60587c8b13cd3cd8802e9d6f5dd8d5",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "pako",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.1.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "dist": {
+        "shasum": "65150277c8447a9e83877f00476d533e1d380ad3",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "pako",
+      "version": "0.2.2",
+      "devDependencies": {
+        "mocha": "*",
+        "chai": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "2.4.1",
+        "async": "0.2.10",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~5.1.1",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "dist": {
+        "shasum": "0154fcebb02d53d188827edbdc37d358e3a12cbe",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.2.tgz"
+      }
+    },
+    "0.2.3": {
+      "name": "pako",
+      "version": "0.2.3",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.0.2",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "dist": {
+        "shasum": "da97260282d270c43f210d9e9bf9abdf54072641",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.3.tgz"
+      }
+    },
+    "0.2.4": {
+      "name": "pako",
+      "version": "0.2.4",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.0.2",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "dist": {
+        "shasum": "015399af84fc28c6d9ce5abe5874b7dcb968a751",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.4.tgz"
+      }
+    },
+    "0.2.5": {
+      "name": "pako",
+      "version": "0.2.5",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.0.2",
+        "grunt-contrib-connect": "~0.7.1"
+      },
+      "dist": {
+        "shasum": "36df19467a3879152e9adcc44784f07d0a80c525",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.5.tgz"
+      }
+    },
+    "0.2.6": {
+      "name": "pako",
+      "version": "0.2.6",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "uglify-js": "*",
+        "jshint": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "3e0c548353b859ab9c8005fac706bdd6c7af505f",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+      }
+    },
+    "0.2.7": {
+      "name": "pako",
+      "version": "0.2.7",
+      "devDependencies": {
+        "mocha": "*",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "0.17.1",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "90e8917affd5ee2b69dfe943ec16b783c4e0c441",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.7.tgz"
+      }
+    },
+    "0.2.8": {
+      "name": "pako",
+      "version": "0.2.8",
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "0.17.1",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "15ad772915362913f20de4a8a164b4aacc6165d6",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "pako",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "ec8b6f0a7e1512d20a21bd58568db7777bb7ccb1",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "pako",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "030267fd61934761c70331728ffa59a9a845152e",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "pako",
+      "version": "1.0.2",
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "ce4ff912366c028a4dbe3f64bf9de8441ba02b75",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.2.tgz"
+      }
+    },
+    "0.2.9": {
+      "name": "pako",
+      "version": "0.2.9",
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "f3f7522f4ef782348da8161bad9ecfd51bf83a75",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "pako",
+      "version": "1.0.3",
+      "devDependencies": {
+        "mocha": "1.21.5",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^2.1.0",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "~0.4.4",
+        "grunt-cli": "~0.1.13",
+        "grunt-saucelabs": "~8.6.0",
+        "grunt-contrib-connect": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "5f515b0c6722e1982920ae8005eacb0b7ca73ccf",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "pako",
+      "version": "1.0.4",
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "benchmark": "*",
+        "ansi": "*",
+        "browserify": "*",
+        "eslint": "^3.12.2",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "uglify-js": "*",
+        "istanbul": "*",
+        "ndoc": "*",
+        "lodash": "*",
+        "async": "*",
+        "grunt": "^1.0.1",
+        "grunt-cli": "^1.2.0",
+        "grunt-saucelabs": "^9.0.0",
+        "grunt-contrib-connect": "^1.0.2"
+      },
+      "dist": {
+        "shasum": "412cc97c3b7ff06dc6c2557fd4f03d06f5e708d4",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "pako",
+      "version": "1.0.5",
+      "devDependencies": {
+        "ansi": "*",
+        "async": "*",
+        "benchmark": "*",
+        "bluebird": "^3.5.0",
+        "browserify": "*",
+        "eslint": "^3.12.2",
+        "eslint-plugin-nodeca": "~1.0.3",
+        "grunt": "^1.0.1",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.2",
+        "grunt-saucelabs": "^9.0.0",
+        "istanbul": "*",
+        "lodash": "*",
+        "mocha": "^3.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "*",
+        "uglify-js": "*",
+        "zlibjs": "^0.2.0"
+      },
+      "dist": {
+        "shasum": "d2205dfe5b9da8af797e7c163db4d1f84e4600bc",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.5.tgz"
+      }
+    },
+    "1.0.6": {
+      "name": "pako",
+      "version": "1.0.6",
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "bluebird": "^3.5.0",
+        "browserify": "^14.4.0",
+        "eslint": "^3.12.2",
+        "grunt": "^1.0.1",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.2",
+        "grunt-saucelabs": "^9.0.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "^3.0.25",
+        "zlibjs": "^0.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+        "shasum": "0101211baa70c4bca4a0f63f2206e97b7dfaf258",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz"
+      }
+    },
+    "1.0.7": {
+      "name": "pako",
+      "version": "1.0.7",
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "bluebird": "^3.5.0",
+        "browserify": "^14.4.0",
+        "eslint": "^3.12.2",
+        "grunt": "^1.0.1",
+        "grunt-cli": "^1.2.0",
+        "grunt-contrib-connect": "^1.0.2",
+        "grunt-saucelabs": "^9.0.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "^3.0.25",
+        "zlibjs": "^0.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==",
+        "shasum": "2473439021b57f1516c82f58be7275ad8ef1bb27",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.7.tgz",
+        "fileCount": 27,
+        "unpackedSize": 784594,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcABbwCRA9TVsSAnZWagAAIMMP/12OxNEjEeK9FTDX6zGw\njgas/F6vNOEYGAXSjJcSUcol29zqM9KOgy31AHGLPmI02JhexZEqGll+/H+s\nnjDVPyc1HwTK0WUJoz15J+HbqLlXIwh1oyFk3p421qF5eItjKwKeJzm1utX0\nw1QMpR3103jCLV6ht2dA3A4LZuPAWj2e4wazmoLqVWWle6vcWhduyuLbOIUu\nylBpq3xIzOnJhVX7h9qWpPKTIC3n+Qz4WII46SsZ6JKJxkPc6gXcJadLfg9N\nX20+b3fODCGsFSL/5nBqBe8uWZp2aeI452F2/OzJJvZ+PL8Z//qj2XhZ9QHi\n9KZl4MqS36o5rCOmkPqtzLMOG9f0+RcqNKSgJXB42uxdFLBSswRnJDeMYmRe\n+jmJl51KhIUJP7tP/vnFO7zSx5Vg61vlBOEu7vwMcUEfK1jHWBQ7dSxV2xfL\n80xquvqSomSTUQQRcaQj6BZn1fHtlGvWdrNi2gxXUyNarix0RMHbF5gSXhq8\ncfJlIAyPnK9yB/oWRxs7vLrTv2WvsRTYDjRDw8NMQwRLHQFaPsl/OTl3IPYG\n9tN/7ZBGUyptp5OXdvbyJUI7hm0OSzdS6blfn9AFgsGKQE6NlJovlmHxwudP\nG4TT91G4mybSMMDHOxLk3RT70dFVC8E+/Y+KRi7oCA5Q5J78GY/HKUIjd9g2\nNQDA\r\n=+aMR\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.8": {
+      "name": "pako",
+      "version": "1.0.8",
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.2.3",
+        "eslint": "^5.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "^3.0.25",
+        "zlibjs": "^0.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==",
+        "shasum": "6844890aab9c635af868ad5fecc62e8acbba3ea4",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
+        "fileCount": 27,
+        "unpackedSize": 785729,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcPNOKCRA9TVsSAnZWagAAa+IP/1H8fDDhZ43+xYAVSjs7\n4HxUzXLPIhGSZMHnOwoGI08sAzlD/Ydfymu8mS1GXwUb5BkNOTiPHwmNFx5T\n79Y50XnW2Ji/4zDM/Tl/+E1NBrEF3NLitGgZaN1I+XmxW27Cdzo5a7pnW2L/\n+Fm/gXPCssJq5BZF8iTG3MWB3BfhJ5b76MIS+Q0HAdCP681qsVq/WW+pGknc\n09aNJELmoDhNqYRiqOPqhGWhwCEC5VrF5j6s/TnBeicLq1tCM7MIL++rl1N7\n/Y2aU9kxiXGAsOy3CUk501dgW4Qn9YHwo1peG5oEUt7NXBs3WtIijywCIz5W\nDfHV115lDUrdHer3ZC9vx8M3K8QXMrWtqqUZvdWAkxYNeCZpqMn2lhteMHel\nAW6Inhs3ansqb5HMQTDh5opZMYlaRfceRm3iSWV0+aC6j+rf9kgAZYRxbcnn\n1nfbfIb4ChreeciOgLRZZ4dGHR8KHxBVGkpGF07IaAJLrZmJ5M0zkDFUd6Is\nRUVX6AyPA0boOBv11Qj+SF525IbN/9fPFV0T4AJyw2d9r9YY5ts1mbCyEcMy\nl1F8tL2Qvf2VEKB5mBWDZvR1Qnm++cUklbTEAYd67NWFWKOKo6nAk63JeWCQ\nxt+5XZNRhQ64yC6OY4ZJtNiTeBVMDVNLlUPFUcjg5GTQjsbyvXD3wlatCN0V\ntfXM\r\n=d0w4\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.9": {
+      "name": "pako",
+      "version": "1.0.9",
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.2.3",
+        "buffer-from": "^1.1.1",
+        "eslint": "^5.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "^3.0.25",
+        "zlibjs": "^0.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-tPjtE6dq+dOSg8NMkqRmFjUYH9fect1zmYgB0g6ztQMaVNI7N1CEvLZud2bPHhg7PRgfKEeTshSPiqXb1F7A+A==",
+        "shasum": "410f6784fbba83e5e743be90899fa050e9c6f787",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.9.tgz",
+        "fileCount": 27,
+        "unpackedSize": 785835,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJceDWfCRA9TVsSAnZWagAAqRcP/1RPYmdRdVmrZbBiWbQQ\n/KsIHCxt4qzk0fM4g3YroG+8ZTXwks4jkWnNAgdFxD5Xd0gzWDTr54y5l9++\nfd6ZQy4Qb5q3yzezrxmPZ6yhPfaLvhEtRNocCLBNTCIUSGjo7z8MVIgGK9LC\n9D2SRMI3FOEt/uTDxSrOQs7C4I+nOFAEORJ20WRZ0aHTmxJdn4hq0sfsX7P7\ncvLy6empMvgtAlA9DS5QAMH6ULBVF4l0Bnmc/vLbtQ51PLHmtsNBf3ZeYpmd\n6ASUEcjJlg7FLhcb9tQI4NY/OSB97esQyBnJbuG50xV94NEUwcTko7+f86Ll\nQkiTD3y2mmiaIYIYSxmvtzqO32ozmWox2zZOHN1hjpTgKz7Q6rZEYTcg4L52\ndCwvVmXBWKdtYpy/3MnuCpzeqwaX/d7Wk7Tha0dMAn9xTLpx6MdXqlKZ5/VU\nGOnNdubuTnw6nOaYjppwGTGrgR8/hJE+kptLiQUcaZarPVF2wGdUoEBbvMVo\nPyq+YxfaZaX0KzgFAK4nIGjw6Sdi7vQKEA8kw3nMkdrrNIpClhbcZM+eJdw7\nJTlwIfvDuDd6rcqZ4ZhM9nbfcopd/KCKKDbY0EQdVZIbcGxzxGjfpjGxGXaj\n+DNrwKXdI6LnfHGL1+vvdDm+SPOuz+09rvjdP2s2+ymUi5xiY9ADL3MzPGUF\nzi20\r\n=AMXM\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.10": {
+      "name": "pako",
+      "version": "1.0.10",
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.2.3",
+        "buffer-from": "^1.1.1",
+        "eslint": "^5.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "=3.4.8",
+        "zlibjs": "^0.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+        "shasum": "4328badb5086a426aa90f541977d4955da5c9732",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+        "fileCount": 27,
+        "unpackedSize": 786051,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJceFXmCRA9TVsSAnZWagAAFHQP/i+R5tx15QJjRXBY283W\nYGE2j0m0aBKGE0vXcIu6jHXmS8tBZWxbDkdV9KtjNHh+aEzk2T4T4WQyAdRx\nXlApzs7yrj2QjGhuOhtF7eQ2jZ5bUWqjxjBDGN5vqYUnXn1VL8lI/moIALOS\nMB6ai5dZgNH5hvzk1kl+NkNPgKn/OhjsEGRD4wLJjEnf0ZbaaqShATtArOsA\n1U1ENIs3ooGSp2Al3MQwXuJ+kAl0+C0391uvkkpCeFE0J7Sly20a8SvESPsb\nP0Jupw2sbhgiaXv6p/Csoroxjw6GTmL+xPJH7rQqNwAepvhjjnU7ODiltstV\nG4+xwXTy9qg9tf+4Flw5UMfMVVmaMMpPSC31t+PjHjvjsJlu21gzNm5vb7uf\nYLvlpMPboeNSpTw/o18BI/B+NwVN4mIS2/Ksi9THpCL4gHQ8y5CiIlnqqKk0\n4mj5CZufp5EvGW144vcRRU+ExRbVqhH0JfLfxO0WBwAaY8JbLy6+688lZ5+8\n1s3EwWd1KALjGCdyh5UV7VcAdM/OrgnNGihip8OoVVRpNlZARpsQ7KKXrr7D\nOlMGjMCFc7L7ATQ3iRu2fGsRwVcq6a2a1Fc/0c3lqcSUn9xTMnKbbhbgkxyu\nr05AlogNX1voD/24LLTHtX7axCAkjfJLi8qtVhoigMm1BUHhhjmDZGa65VDT\nyQJ9\r\n=XskI\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.11": {
+      "name": "pako",
+      "version": "1.0.11",
+      "devDependencies": {
+        "ansi": "^0.3.1",
+        "benchmark": "^2.1.4",
+        "browserify": "^16.2.3",
+        "buffer-from": "^1.1.1",
+        "eslint": "^5.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "multiparty": "^4.1.3",
+        "ndoc": "^5.0.1",
+        "uglify-js": "=3.4.8",
+        "zlibjs": "^0.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+        "shasum": "6c9599d340d54dfd3946380252a35705a6b992bf",
+        "tarball": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+        "fileCount": 27,
+        "unpackedSize": 788283,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeMThCCRA9TVsSAnZWagAAUokQAIXP/sogHkcjaJDsXEm4\nxwCJ6+XRKT706p/6wpHxglDgR9ea47MeHXc4+M6orKXFVUFaN/DIDTDnfNC0\nrzuwOxcLs3OkA32xpiEq15U6MDIqv8vUuVUL8tR5Gr24H3z4ie4P0VBuJ5F5\nzCEEi7/hfMxyaqxSh/SkH5bJemQhJRUekFOW3vYxqAM3665ZNCXkuYWcE1jy\nNMPTDvX4EkeLDCxPLIRWjwmEUrhXj14NKy6bQSBoGGivVP+SXP9TVUFk46p7\n6mTHxJeLJqHitjTRUsSQjl060u8C9gP3Fcmbt4eEMJyAGFajz0Sc8HKUQkM0\noC9JY8anTgWXTxAX8UkVsm42sWI6oyQe1poAa85+L72PZLJJeamvVFNeJoqd\ndWJpTj1Ak1cNxxul4DPi3F1I2LQXU3RyKUEHE8Vl8ZFTRwZdeVGQD/gms3D9\n28hyagU/02x+Wy3Z4NzLIBhB7p9MEsZd3HVDF2tEs1SnLTSp1AdNwtnyHJaD\neEln3zjVs5SIxfgNiJR9ycD/CmZpV1YGtLDPBFWM8XN2u6YaoxZ+VZI6390A\nJTrKW9u/nu7DlT839v/GTOKpmt6yGPCfm0jKywVQGhyWq8WlZF5EZENm5ilA\nZ0QvGDTUSkv93idyYXDXunBQT3qx9SqVGeaBXdeQCCLOJt/knizQJTYfjgOa\nRo6X\r\n=Ndry\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-01-29T07:46:12.029Z"
+}

--- a/test/fixtures/registry-mocks/content/parallel-transform.json
+++ b/test/fixtures/registry-mocks/content/parallel-transform.json
@@ -1,0 +1,588 @@
+{
+  "_id": "parallel-transform",
+  "_rev": "23-3aedca550f6d9fe32941ad43f50b6218",
+  "name": "parallel-transform",
+  "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "parallel-transform",
+      "version": "0.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "_id": "parallel-transform@0.1.0",
+      "dist": {
+        "shasum": "7193939cafb80eb367f4f9665739e7375ff581de",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "parallel-transform",
+      "version": "0.1.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "_id": "parallel-transform@0.1.1",
+      "dist": {
+        "shasum": "a1c891797dcc43cda07aa8c0ecb9d63ae947b5c8",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "parallel-transform",
+      "version": "0.1.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "_id": "parallel-transform@0.1.2",
+      "dist": {
+        "shasum": "01afe1b54366d8f1835337539009f74173c416cc",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "parallel-transform",
+      "version": "0.1.3",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "_id": "parallel-transform@0.1.3",
+      "dist": {
+        "shasum": "01556c3de7d67d3dfcbc477efca0a2e22b29b235",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "parallel-transform",
+      "version": "0.1.4",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "_id": "parallel-transform@0.1.4",
+      "dist": {
+        "shasum": "47629c708a60b472a72cce6dd9069802161592e4",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "parallel-transform",
+      "version": "0.2.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "_id": "parallel-transform@0.2.0",
+      "dist": {
+        "shasum": "46218994bd230e89735ce97b9b395375d3f169a2",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "parallel-transform",
+      "version": "0.2.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "_id": "parallel-transform@0.2.1",
+      "dist": {
+        "shasum": "7f92a1e9fd67daa3c0b62e65b9fbfcc4e6b75611",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "parallel-transform",
+      "version": "0.2.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "homepage": "https://github.com/mafintosh/parallel-transform",
+      "_id": "parallel-transform@0.2.2",
+      "dist": {
+        "shasum": "77a9c0b4bc99f52349b3bf2c71519506f4758f6e",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "parallel-transform",
+      "version": "1.0.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "gitHead": "f351311406eebfb5eacc1d467d3451154ea6a636",
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "homepage": "https://github.com/mafintosh/parallel-transform",
+      "_id": "parallel-transform@1.0.0",
+      "scripts": {},
+      "_shasum": "6130d87e17adab11999354493d0dbee9a441753c",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "6130d87e17adab11999354493d0dbee9a441753c",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/parallel-transform-1.0.0.tgz_1462544755191_0.5816936211194843"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "parallel-transform",
+      "version": "1.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      },
+      "gitHead": "1b4919bc318eb0cbd6e8ee08c4d56f405d74e643",
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "homepage": "https://github.com/mafintosh/parallel-transform",
+      "_id": "parallel-transform@1.1.0",
+      "scripts": {},
+      "_shasum": "d410f065b05da23081fcd10f28854c29bda33b06",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "d410f065b05da23081fcd10f28854c29bda33b06",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/parallel-transform-1.1.0.tgz_1478596056784_0.9169374129269272"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "parallel-transform",
+      "version": "1.2.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/parallel-transform.git"
+      },
+      "license": "MIT",
+      "description": "Transform stream that allows you to run your transforms in parallel without changing the order",
+      "keywords": [
+        "transform",
+        "stream",
+        "parallel",
+        "preserve",
+        "order"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dependencies": {
+        "cyclist": "^1.0.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      },
+      "gitHead": "4548c6075d990d587fd40e7918fc467890b21dab",
+      "bugs": {
+        "url": "https://github.com/mafintosh/parallel-transform/issues"
+      },
+      "homepage": "https://github.com/mafintosh/parallel-transform#readme",
+      "_id": "parallel-transform@1.2.0",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
+        "shasum": "9049ca37d6cb2182c3b1d2c720be94d14a5814fc",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5538,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdcNEWCRA9TVsSAnZWagAAKk4P+QCfs14Ci+r/mwjGFwd0\nzo6q6KXrae5487ZDG/vngyFQnXI0YaTEu8HgsKQ89P/lPZGYspslbJEg15+H\nKImp6sCRJHRBeyiAiiMqIanDTGYEgBeZjRc+d2qpmPUda/egO2vFHaZeS11J\n0EdyuDbz8sUszlruHAVk9uYXMXlR/tUZYoWw8mWo0vpoiMXLolnikOFshqqH\nMi/Gux2m9zKJ78doj9xPEUY5g/gRFuPlhl/BZZFNCHxO18MyN75Gs3IGINXp\n+kxcbCm4KHTHjvADfYG+zQxsqMgsou17bKPO1F1i6D3/JEqhwvGWmJnOckGC\nWXL8PQHVXcoNNssFMjfAIHe7IYE1fG9nM+3b5jG6LBLkYX00VwRl36M5PPAm\nKSnGuoGMytTY+0JMgvXhs9H+LD20EN4UNKtda5M4HzbYLCGv/WuWcP5H9eMI\nNVKNP/7Cf31vB3vceqzvKkwuVsafbc+OdjvCMXdzOBABpdCt9rY+QVvR7Ue3\nzhBxAB4WRdCuodEI06M+beSz7AUxaE79EpUyDi6JdCr3dAY9LpPWNe36BkMf\ncMTf0DfQfgVIez0G8MFdgzcUurisMhtiUoMQs+IIpIVq0CjWS3ESr+yHhtx1\ng97Wnb0bSbEs0qEtbGv4mJXNkxFRLkCtirYkyh0r7hr+gKTzyTAvou7D+8SA\nS1xV\r\n=qMBR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parallel-transform_1.2.0_1567674645884_0.45734840049735426"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# parallel-transform\n\n[Transform stream](http://nodejs.org/api/stream.html#stream_class_stream_transform_1) for Node.js that allows you to run your transforms\nin parallel without changing the order of the output.\n\n\tnpm install parallel-transform\n\nIt is easy to use\n\n``` js\nvar transform = require('parallel-transform');\n\nvar stream = transform(10, function(data, callback) { // 10 is the parallism level\n\tsetTimeout(function() {\n\t\tcallback(null, data);\n\t}, Math.random() * 1000);\n});\n\nfor (var i = 0; i < 10; i++) {\n\tstream.write(''+i);\n}\nstream.end();\n\nstream.on('data', function(data) {\n\tconsole.log(data); // prints 0,1,2,...\n});\nstream.on('end', function() {\n\tconsole.log('stream has ended');\n});\n```\n\nIf you run the above example you'll notice that it runs in parallel\n(does not take ~1 second between each print) and that the order is preserved\n\n## Stream options\n\nAll transforms are Node 0.10 streams. Per default they are created with the options `{objectMode:true}`.\nIf you want to use your own stream options pass them as the second parameter\n\n``` js\nvar stream = transform(10, {objectMode:false}, function(data, callback) {\n\t// data is now a buffer\n\tcallback(null, data);\n});\n\nfs.createReadStream('filename').pipe(stream).pipe(process.stdout);\n```\n\n### Unordered\nPassing the option `{ordered:false}` will output the data as soon as it's processed by a transform, without waiting to respect the order.\n\n## License\n\nMIT",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-09-05T09:10:48.581Z",
+    "created": "2013-07-30T21:25:16.628Z",
+    "0.1.0": "2013-07-30T21:25:22.056Z",
+    "0.1.1": "2013-07-30T22:04:52.519Z",
+    "0.1.2": "2013-07-30T22:07:41.892Z",
+    "0.1.3": "2013-07-30T22:59:17.016Z",
+    "0.1.4": "2013-07-30T23:34:23.642Z",
+    "0.2.0": "2013-08-10T16:48:55.586Z",
+    "0.2.1": "2013-08-22T19:39:56.489Z",
+    "0.2.2": "2013-12-13T10:42:00.712Z",
+    "1.0.0": "2016-05-06T14:25:57.650Z",
+    "1.1.0": "2016-11-08T09:07:37.008Z",
+    "1.2.0": "2019-09-05T09:10:46.038Z"
+  },
+  "author": {
+    "name": "Mathias Buus Madsen",
+    "email": "mathiasbuus@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mafintosh/parallel-transform.git"
+  },
+  "users": {
+    "bmpvieira": true,
+    "zewish": true,
+    "morewry": true
+  },
+  "homepage": "https://github.com/mafintosh/parallel-transform#readme",
+  "keywords": [
+    "transform",
+    "stream",
+    "parallel",
+    "preserve",
+    "order"
+  ],
+  "bugs": {
+    "url": "https://github.com/mafintosh/parallel-transform/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/parallel-transform.min.json
+++ b/test/fixtures/registry-mocks/content/parallel-transform.min.json
@@ -1,0 +1,138 @@
+{
+  "name": "parallel-transform",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "parallel-transform",
+      "version": "0.1.0",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "7193939cafb80eb367f4f9665739e7375ff581de",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "parallel-transform",
+      "version": "0.1.1",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "a1c891797dcc43cda07aa8c0ecb9d63ae947b5c8",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "parallel-transform",
+      "version": "0.1.2",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "01afe1b54366d8f1835337539009f74173c416cc",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "parallel-transform",
+      "version": "0.1.3",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "01556c3de7d67d3dfcbc477efca0a2e22b29b235",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "parallel-transform",
+      "version": "0.1.4",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "47629c708a60b472a72cce6dd9069802161592e4",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.1.4.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "parallel-transform",
+      "version": "0.2.0",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "46218994bd230e89735ce97b9b395375d3f169a2",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "parallel-transform",
+      "version": "0.2.1",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "7f92a1e9fd67daa3c0b62e65b9fbfcc4e6b75611",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "parallel-transform",
+      "version": "0.2.2",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "77a9c0b4bc99f52349b3bf2c71519506f4758f6e",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-0.2.2.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "parallel-transform",
+      "version": "1.0.0",
+      "dependencies": {
+        "cyclist": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "6130d87e17adab11999354493d0dbee9a441753c",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "parallel-transform",
+      "version": "1.1.0",
+      "dependencies": {
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      },
+      "dist": {
+        "shasum": "d410f065b05da23081fcd10f28854c29bda33b06",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "parallel-transform",
+      "version": "1.2.0",
+      "dependencies": {
+        "cyclist": "^1.0.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      },
+      "dist": {
+        "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
+        "shasum": "9049ca37d6cb2182c3b1d2c720be94d14a5814fc",
+        "tarball": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5538,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdcNEWCRA9TVsSAnZWagAAKk4P+QCfs14Ci+r/mwjGFwd0\nzo6q6KXrae5487ZDG/vngyFQnXI0YaTEu8HgsKQ89P/lPZGYspslbJEg15+H\nKImp6sCRJHRBeyiAiiMqIanDTGYEgBeZjRc+d2qpmPUda/egO2vFHaZeS11J\n0EdyuDbz8sUszlruHAVk9uYXMXlR/tUZYoWw8mWo0vpoiMXLolnikOFshqqH\nMi/Gux2m9zKJ78doj9xPEUY5g/gRFuPlhl/BZZFNCHxO18MyN75Gs3IGINXp\n+kxcbCm4KHTHjvADfYG+zQxsqMgsou17bKPO1F1i6D3/JEqhwvGWmJnOckGC\nWXL8PQHVXcoNNssFMjfAIHe7IYE1fG9nM+3b5jG6LBLkYX00VwRl36M5PPAm\nKSnGuoGMytTY+0JMgvXhs9H+LD20EN4UNKtda5M4HzbYLCGv/WuWcP5H9eMI\nNVKNP/7Cf31vB3vceqzvKkwuVsafbc+OdjvCMXdzOBABpdCt9rY+QVvR7Ue3\nzhBxAB4WRdCuodEI06M+beSz7AUxaE79EpUyDi6JdCr3dAY9LpPWNe36BkMf\ncMTf0DfQfgVIez0G8MFdgzcUurisMhtiUoMQs+IIpIVq0CjWS3ESr+yHhtx1\ng97Wnb0bSbEs0qEtbGv4mJXNkxFRLkCtirYkyh0r7hr+gKTzyTAvou7D+8SA\nS1xV\r\n=qMBR\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-09-05T09:10:48.581Z"
+}

--- a/test/fixtures/registry-mocks/content/parse-asn1.json
+++ b/test/fixtures/registry-mocks/content/parse-asn1.json
@@ -1,0 +1,1139 @@
+{
+  "_id": "parse-asn1",
+  "_rev": "39-7ab862fb8052c5078ab8a9294aa211f6",
+  "name": "parse-asn1",
+  "description": "utility library for parsing asn1 files for use with browserify-sign.",
+  "dist-tags": {
+    "latest": "5.1.6"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "parse-asn1",
+      "version": "1.0.0",
+      "description": "parse-asn1 ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^0.6.5",
+        "asn1.js-rfc3280": "^0.5.1",
+        "pemstrip": "0.0.1"
+      },
+      "gitHead": "6cfeecb4cd46c8032833e76360386f9c64d88c19",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/parse-asn1",
+      "_id": "parse-asn1@1.0.0",
+      "_shasum": "f38aed01e681fbb03a028522e9f0d68258b47e3c",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f38aed01e681fbb03a028522e9f0d68258b47e3c",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "parse-asn1",
+      "version": "1.0.1",
+      "description": "parse-asn1 ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^0.6.5",
+        "asn1.js-rfc3280": "^0.5.1",
+        "pemstrip": "0.0.1"
+      },
+      "gitHead": "4ba433ad8ca2c5e5d5b6f6f136334c1de57850cd",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/parse-asn1",
+      "_id": "parse-asn1@1.0.1",
+      "_shasum": "0f585a6a2a2d216ba95cf52ed90f3c016ce8c1bc",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0f585a6a2a2d216ba95cf52ed90f3c016ce8c1bc",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "parse-asn1",
+      "version": "1.1.0",
+      "description": "parse-asn1 ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^0.6.5",
+        "asn1.js-rfc3280": "^0.5.1",
+        "pemstrip": "0.0.1"
+      },
+      "gitHead": "38920a36fe21fae3c7af3373b4d865cb3471d0e2",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/parse-asn1",
+      "_id": "parse-asn1@1.1.0",
+      "_shasum": "aa57c6b247ae742888ddf2696c66a8ce5f43ae19",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "aa57c6b247ae742888ddf2696c66a8ce5f43ae19",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "parse-asn1",
+      "version": "1.2.0",
+      "description": "parse-asn1 ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^0.6.5",
+        "asn1.js-rfc3280": "^0.5.1",
+        "pemstrip": "0.0.1"
+      },
+      "gitHead": "5f14a56ae367d72cb8c0b72b82040f9d120a4788",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/parse-asn1",
+      "_id": "parse-asn1@1.2.0",
+      "_shasum": "d6a8926be45c4ff032842bd86b36b7b574a810ae",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d6a8926be45c4ff032842bd86b36b7b574a810ae",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "parse-asn1",
+      "version": "2.0.0",
+      "description": "parse-asn1 ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^1.0.0",
+        "asn1.js-rfc3280": "^1.0.0",
+        "pemstrip": "0.0.1"
+      },
+      "gitHead": "6f8f1871dd3d076f01c5d92f72fda99c0a7e0793",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/parse-asn1",
+      "_id": "parse-asn1@2.0.0",
+      "_shasum": "c8cbc588abc91ade087c02ecbdfd7b66d9a8405f",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c8cbc588abc91ade087c02ecbdfd7b66d9a8405f",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "parse-asn1",
+      "version": "3.0.0",
+      "description": "parse-asn1 ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node ./test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/calvinmetcalf/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^1.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "pbkdf2-compat": "^3.0.0"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0"
+      },
+      "gitHead": "a6be135aec21fdc648d15f267381315821734a87",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/parse-asn1",
+      "_id": "parse-asn1@3.0.0",
+      "_shasum": "36ea30eb2ad99084e738e92801647910cdbf1ee4",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "36ea30eb2ad99084e738e92801647910cdbf1ee4",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "parse-asn1",
+      "version": "3.0.1",
+      "description": "parse-asn1 ===",
+      "main": "index.js",
+      "scripts": {
+        "test": "node ./test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^2.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0"
+      },
+      "gitHead": "c5d99d0c4b94e22a0eaf3f31e2bfa9abe52a9b76",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1",
+      "_id": "parse-asn1@3.0.1",
+      "_shasum": "a0ef5aa6fc6747f4166cd18432bd67bd8dc438b5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a0ef5aa6fc6747f4166cd18432bd67bd8dc438b5",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "parse-asn1",
+      "version": "3.0.2",
+      "description": "[![TRAVIS](https://secure.travis-ci.org/crypto-browserify/parse-asn1.png)](http://travis-ci.org/crypto-browserify/parse-asn1) [![NPM](http://img.shields.io/npm/v/parse-asn1.svg)](https://www.npmjs.org/package/parse-asn1)",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^2.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "bc8af2462a28fcebc36a9cd0e4566b81fb2b3f8e",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@3.0.2",
+      "_shasum": "b42431beba32e08eac6d9153a54430bfd95d2d5e",
+      "_from": ".",
+      "_npmVersion": "3.3.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "b42431beba32e08eac6d9153a54430bfd95d2d5e",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "parse-asn1",
+      "version": "4.0.0",
+      "description": "[![TRAVIS](https://secure.travis-ci.org/crypto-browserify/parse-asn1.png)](http://travis-ci.org/crypto-browserify/parse-asn1) [![NPM](http://img.shields.io/npm/v/parse-asn1.svg)](https://www.npmjs.org/package/parse-asn1)",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^3.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "c895b21e8804f6b9b410b16ca761eccea8eb68a2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@4.0.0",
+      "_shasum": "e28a3b660c1e7d2c3c0559ee8a7c8615cf76ff2e",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "3.3.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "e28a3b660c1e7d2c3c0559ee8a7c8615cf76ff2e",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "parse-asn1",
+      "version": "5.0.0",
+      "description": "[![TRAVIS](https://secure.travis-ci.org/crypto-browserify/parse-asn1.png)](http://travis-ci.org/crypto-browserify/parse-asn1) [![NPM](http://img.shields.io/npm/v/parse-asn1.svg)](https://www.npmjs.org/package/parse-asn1)",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "eb88523b7c6dc896a407b896bba470218fde70b4",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@5.0.0",
+      "_shasum": "35060f6d5015d37628c770f4e091a0b5a278bc23",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "35060f6d5015d37628c770f4e091a0b5a278bc23",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "5.1.0": {
+      "name": "parse-asn1",
+      "version": "5.1.0",
+      "description": "utility library for parsing asn1 files for use with browserify-sign.",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "da019013e56630e7f49c7bc1d90eeefab3d97c7e",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@5.1.0",
+      "_shasum": "37c4f9b7ed3ab65c74817b5f2480937fbf97c712",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "37c4f9b7ed3ab65c74817b5f2480937fbf97c712",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/parse-asn1-5.1.0.tgz_1489415296693_0.6854203154798597"
+      },
+      "directories": {}
+    },
+    "5.1.1": {
+      "name": "parse-asn1",
+      "version": "5.1.1",
+      "description": "utility library for parsing asn1 files for use with browserify-sign.",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "4203d44e1c5f20b84390fb862c578b36b3334164",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@5.1.1",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+        "shasum": "f6bf293818332bd0dab54efb16087724745e6ca8",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+        "fileCount": 38,
+        "unpackedSize": 37094
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parse-asn1_5.1.1_1523449360549_0.37417268391545266"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.2": {
+      "name": "parse-asn1",
+      "version": "5.1.2",
+      "description": "utility library for parsing asn1 files for use with browserify-sign.",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "6460966c65f9da0e57bed17de12d16263b1d0529",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@5.1.2",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.15.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-zVAb35DsNvwINEA7EEK+78YoNDGRpYEAGoIl3bSHyI9OU4IIrrrU5DC4xaCLZ42gvOfQg1+wS778WbJW+mCMCQ==",
+        "shasum": "13efbaaac8da669a9751a6b50a7cfccfdef756ae",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.2.tgz",
+        "fileCount": 39,
+        "unpackedSize": 39288,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQIE3CRA9TVsSAnZWagAACeEQAKE9Y6S0EH9oul/H0nzF\niqExpxywrnSmQ+ierO0ew+RCvwrb+BKnpZYyApm77GFnLOl97Xp0N9pJuhJ/\n+bT7f5f3kcgmyyodpxsjo8Cbv7v0/MGjoQfvNmyJDJiH1adlo8Zb1W8M0OV0\n0DAxlf7x4OirSXzh0ANSEnP4V31f/ZkmTS8PzGgXxk8MSW2yD1s4WkWA1SA/\ngnqTjYuLtE0F4huH+NWsnsw0e0e9yrsL7jsF5dU9ts8HJYLMDPzV1W01UCWA\n3VmkyTD5/Upu+HgM4+HxNpYJmferZumu5Iy1tQpInqiUZUOj8idrj3z7cqAD\ndowJ9FfbPYGoapHSLviiyBd6lbeAlDBRfvXWXZLc5K0AV/N088zlau1CZvA/\nGJNHcY1IE2o7tDlN+ulWA4K9MejDsA5my/D9Krv1J4bYhDaISrq4vW2IvG03\n+n0bIWdG1Atvkp1H5ngx06hInqFbHNQZto5KKTeZDlCHzQKty8OCYI/l8/Vr\n/ifI3dPkK/OaRGSt4k2lgHYu13Bxy3tC2RKFiLZd1AOSfU9i3cXTYSlBOxD+\nSrbezxM8nyWPHpHeNEi/OZGglSMNqZNWXhS7tnWY+IyX06F6Vrt72AFgWmZ8\n8WbaFU6ssd9XWdTfenTfYXOlrDGAd4dEU3FD3lTz2m3k77ZIVDEFKI3JEwOQ\nDPMj\r\n=XSVX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parse-asn1_5.1.2_1547731255243_0.42146469361899164"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.3": {
+      "name": "parse-asn1",
+      "version": "5.1.3",
+      "description": "utility library for parsing asn1 files for use with browserify-sign.",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "2fcef4d6847322ecd35a409cc38593056eb079eb",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@5.1.3",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.15.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+        "shasum": "1600c6cc0727365d68b97f3aa78939e735a75204",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
+        "fileCount": 39,
+        "unpackedSize": 39286,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQL3BCRA9TVsSAnZWagAAwnQP/0eyU171Hvt1/XjgciMm\ngKfO1YUC+K7WDvMFrC+3Q1MNrmuQBXPdx1kPasoSWClSELFhgiHNCpYf2uJ3\ndA8O+P3eHiNNH3k/2fKPqjBmWlNE2/OC1iDtnpHjnMqi8re/ouGy7ow+E2bC\nTE3w0a9jv8Lxu7S2PYsYuya0P4/pDlz9AvsPD2h1PZ7v++AsYJkBXdmv3zdd\nBRuJJ5nFUuwbHSOBr9kyuCNB6rw00yFd3RRNyfkwT9z9GVM6RtXH44AcqxBT\njUe3dmxR1ByeeobFUfetsWI8a9WbziMgDbKmcFiIpjfiFhMLCopYf8nO0Lx+\n0idsJPkYKSCEua/GroOmSRTyTNKeDMeVZaoV3/58jsRzOmoQ81G8M7XkaFDM\nIx+GaEzutaXYIPQXiIXc4MAOPdhNAxDpKgeANoSS8ynDwEp5rkPtbwuiS46s\nOsP+h8RwWGF69IvitJTuSiffzVe3qRywuHILfOs01b9tNVbs1opeHjhbirQg\n9vBrWMd84tzDBJAgtpShQm9Taq9a19QSyNgXXqL6hfE+kbJRN0urYUhGuvmq\nU9PuTNUXaz/rsT4NFi7mF8uUFuj9lH3AyXZIb5IilWgo52MKkWhb7Joorz+s\nq+QcqxuxvV+qUvJHm3CZN3p5B2g+bADf+jS1Z9N0Mc2Nk9gs8uK5Gn4X2pOb\n42yF\r\n=qm7I\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parse-asn1_5.1.3_1547746752515_0.06173921194190379"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.4": {
+      "name": "parse-asn1",
+      "version": "5.1.4",
+      "description": "utility library for parsing asn1 files for use with browserify-sign.",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "01c9a7a9ca91c9b1b2e0d5ae2abe5214705c3afe",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@5.1.4",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+        "shasum": "37f6628f823fbdeb2273b4d540434a22f3ef1fcc",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+        "fileCount": 39,
+        "unpackedSize": 39333,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcZZd0CRA9TVsSAnZWagAA9ooP/jme7QTlAfYmH1BCaHUQ\nAiaqPjCfLFyHvXGg8wVTSHiCLCxxbNLbwJKmQa911JLawGwuncprIJNjV2Ot\nqIP7tfNv3RkVTSopEU6Ns415Qxcxt9YSPVIDNylU1r15mPrv8BmKJz4xJG8g\nzn1Pj25pTQu4IVrQAMpV/o4pCBUC+B0ln4vzjymnj4PsADE+A6IQTLr3iUwc\n3+JQMRTdMMVhs0m67LFsdhMGTaZJN0Ok8wJ1+f5P4lC4IhqR6DR+0ccGe/jj\nn9263JhtB67pz8TfTUSHhzrwg1IxqMinqpUFB1i2BMYVB5gq3Kx4iQVyIi1s\nxXP86prtbtWZj0TJDhPFKG781mOYV4gZnr59jyO5d7Eg5tIQjqhSH/fAcen2\n4zSgLit9LjYqn1F0bVr7BNgae3nn+rHhTNW+h08Bj4DwX3uzmf39CzA79fQg\n9ZolcBdhEnYt7Czt492FLiJlfmrexC4jIIAEfG1qDRA4PGgQhetVQO1TwLWd\n0owbDu5eDrgXovKcZfKu4deiFd1kR3V7fv32/x+VSSEva3K0w2P9qAybpKKz\njIwQG6a4K0rkOH5CoxUXfrGu/T+xBuA3oLtYCoCiX2Ixmbd3f89bEfITXwMl\nya8Qyf/niAuwMAf/ml5c318iUvIVnJNYYFjr06lOOVFXqpprBfJuDRhXYJ0h\n9ody\r\n=AKWi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parse-asn1_5.1.4_1550161779949_0.35032546706725576"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.5": {
+      "name": "parse-asn1",
+      "version": "5.1.5",
+      "description": "utility library for parsing asn1 files for use with browserify-sign.",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "gitHead": "84cc73573602d63e6c6206e891ebd97f28d0c0e8",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@5.1.5",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+        "shasum": "003271343da58dc94cace494faef3d2147ecea0e",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+        "fileCount": 8,
+        "unpackedSize": 13056,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdghSlCRA9TVsSAnZWagAAGcUP/3Xc8F0gROouwFFwHVXM\nRRRg4yexXSp38s2ndj8QU2C3E1h4q4LZR4srnXHb0EW2g/OO50bEK9MbY/nw\nIJiEXFr20tCvM8W0wjTI+05JK5wgWlPHGltAhmYPXLaLhUFDqqsv3gm0cRwA\nfxX54837qbSxM1JcAYEwFvc+3WFb9F/IMSrbaS7QZ78t3+/lb+W4TMrSqDEp\njlO7MZXlAb7q1f9LPZBjDUjpOSPujGX5jr3E6eXWXwpbvqEvAfGyJU5z1tEl\n9YG/Pw0j4+ieT8UDwhlfjWgHy79YaJ9J2uhWUxO6kHQdS1J49Gi9A7Nr0CI1\nLNyfFSZLmgic8D3gTjOTnXJcyqvrIdNuCAqWLFHnWpRNeYaVTyXE0RJTY8sS\nwNdlSw0oJtN/ObVjEWuHyCSGejVcHbunLEA4Jgx3GSjRwxDX5c7lqf0Ehdxx\n1vqIth2d0vwxxgDV3yYB+kxz5xNnuu+1KavcUn9pQNeDXdW/RjKt/zpvPS8L\nVyK77hadSCVt6QQOwUhgpd/EEk4qhS17LURIWJtj23EFgnnyhmyPJJf1gXHa\nlLVv5ER7jNUYNjPji1Ylhleg0IMA6Elfpa6OY8OWPtHWwjkrGmu2tik4XSYn\nxFBPeo7/bLOiPLrcuKtg/hWpl0ajeXBL1kPoaYnrwn92Tl9d/lqVHZVE/9X0\nSgkY\r\n=cqTh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parse-asn1_5.1.5_1568806053236_0.6788907189998616"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.1.6": {
+      "name": "parse-asn1",
+      "version": "5.1.6",
+      "description": "utility library for parsing asn1 files for use with browserify-sign.",
+      "main": "index.js",
+      "scripts": {
+        "unit": "node ./test",
+        "standard": "standard",
+        "test": "npm run standard && npm run unit"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/parse-asn1.git"
+      },
+      "author": "",
+      "license": "ISC",
+      "dependencies": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "standard": "^14.3.4",
+        "tape": "^5.0.1"
+      },
+      "gitHead": "fbd70dca8670d17955893e083ca69118908570be",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+      "_id": "parse-asn1@5.1.6",
+      "_nodeVersion": "12.16.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+        "shasum": "385080a3ec13cb62a62d39409cb3e88844cdaed4",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+        "fileCount": 8,
+        "unpackedSize": 13029,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfMtZXCRA9TVsSAnZWagAAAU0P/idaJ1RnfYgcAVmhmbJD\nffROlPYMpsSD+2GmuJiCJlk8LS3noQjlGn9aY8evlVudFU7XwmQO35hr6VTM\n69THOR2wlj8wWnfwUOKm0I9TpAOs+VeTj0WkGAmowyhCcB33YdVl8LylzrPz\nXutW3rwTDrksgyGnFumZlEcIEJmj4nG6s6xRCOqdIAewudUlKlca4lDlExXg\n49Jrdt32eeny/zsGYtRECymtEHpTRMDPwGpN66uAEQFXEzPXOM0o+9EehAuN\nyLSpd/b+SxdqgimMZ4Xhdf1ry0GOvonAWPNDzN8tOWxQOIjK7wuZdpD6zkLi\nVZEjtkK6Yxo5kGqvvXlgAZptXdp89n7c6MDtI357w5m12/1c9aTXWzSy2uHv\nU9W6h0gDN+xeYFiCOf56+whwBYWIxkMPfPE/kuNlKcyDOKjSxsAb/3rYrEZk\nX31W9x/fG929TEHo6+K5V6pCAit/yYOEBosVqUvvwZs5BqdHzfVfBtY3B+UC\nzRg5tHFci9Z/aHywu2JN8NIzC/bN8pMSmzVJiJyUCaDuC+MSI1h7TkthG5rz\nGrjuBJhbIui7wQ525Y6EZUQ5hmv6VemODpdkeBUzB3VJh3OLikH1YIiTlinD\nRzw86v9Xx6Xe70dWSAf6t7U+03h6vTBXzl9R775fRZS1Rgr+/t2933ETQtxe\nfmyM\r\n=gfjf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parse-asn1_5.1.6_1597167190910_0.7321398842975677"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# parse-asn1\n\n[![TRAVIS](https://secure.travis-ci.org/crypto-browserify/parse-asn1.png)](http://travis-ci.org/crypto-browserify/parse-asn1)\n[![NPM](http://img.shields.io/npm/v/parse-asn1.svg)](https://www.npmjs.org/package/parse-asn1)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nutility library for parsing asn1 files for use with browserify-sign.\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-11T17:33:13.478Z",
+    "created": "2014-12-16T15:19:17.427Z",
+    "1.0.0": "2014-12-16T15:19:17.427Z",
+    "1.0.1": "2014-12-16T18:17:57.777Z",
+    "1.1.0": "2014-12-18T15:19:53.485Z",
+    "1.2.0": "2014-12-18T21:32:43.373Z",
+    "1.2.1": "2015-01-04T15:08:16.341Z",
+    "2.0.0": "2015-01-06T12:48:49.764Z",
+    "3.0.0": "2015-01-28T15:04:38.418Z",
+    "3.0.1": "2015-05-21T02:59:47.870Z",
+    "3.0.2": "2015-09-27T23:24:42.405Z",
+    "4.0.0": "2015-10-26T22:34:38.086Z",
+    "4.0.1": "2015-10-29T12:56:56.234Z",
+    "5.0.0": "2015-10-29T13:09:16.782Z",
+    "5.1.0": "2017-03-13T14:28:18.602Z",
+    "5.1.1": "2018-04-11T12:22:40.727Z",
+    "5.1.2": "2019-01-17T13:20:55.487Z",
+    "5.1.3": "2019-01-17T17:39:12.620Z",
+    "5.1.4": "2019-02-14T16:29:40.122Z",
+    "5.1.5": "2019-09-18T11:27:33.382Z",
+    "5.1.6": "2020-08-11T17:33:10.992Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/parse-asn1#readme",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/crypto-browserify/parse-asn1.git"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/parse-asn1/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "ffi": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/parse-asn1.min.json
+++ b/test/fixtures/registry-mocks/content/parse-asn1.min.json
@@ -1,0 +1,325 @@
+{
+  "name": "parse-asn1",
+  "dist-tags": {
+    "latest": "5.1.6"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "parse-asn1",
+      "version": "1.0.0",
+      "dependencies": {
+        "asn1.js": "^0.6.5",
+        "asn1.js-rfc3280": "^0.5.1",
+        "pemstrip": "0.0.1"
+      },
+      "dist": {
+        "shasum": "f38aed01e681fbb03a028522e9f0d68258b47e3c",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "parse-asn1",
+      "version": "1.0.1",
+      "dependencies": {
+        "asn1.js": "^0.6.5",
+        "asn1.js-rfc3280": "^0.5.1",
+        "pemstrip": "0.0.1"
+      },
+      "dist": {
+        "shasum": "0f585a6a2a2d216ba95cf52ed90f3c016ce8c1bc",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "parse-asn1",
+      "version": "1.1.0",
+      "dependencies": {
+        "asn1.js": "^0.6.5",
+        "asn1.js-rfc3280": "^0.5.1",
+        "pemstrip": "0.0.1"
+      },
+      "dist": {
+        "shasum": "aa57c6b247ae742888ddf2696c66a8ce5f43ae19",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "parse-asn1",
+      "version": "1.2.0",
+      "dependencies": {
+        "asn1.js": "^0.6.5",
+        "asn1.js-rfc3280": "^0.5.1",
+        "pemstrip": "0.0.1"
+      },
+      "dist": {
+        "shasum": "d6a8926be45c4ff032842bd86b36b7b574a810ae",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-1.2.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "parse-asn1",
+      "version": "2.0.0",
+      "dependencies": {
+        "asn1.js": "^1.0.0",
+        "asn1.js-rfc3280": "^1.0.0",
+        "pemstrip": "0.0.1"
+      },
+      "dist": {
+        "shasum": "c8cbc588abc91ade087c02ecbdfd7b66d9a8405f",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-2.0.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "parse-asn1",
+      "version": "3.0.0",
+      "dependencies": {
+        "asn1.js": "^1.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "pbkdf2-compat": "^3.0.0"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0"
+      },
+      "dist": {
+        "shasum": "36ea30eb2ad99084e738e92801647910cdbf1ee4",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "parse-asn1",
+      "version": "3.0.1",
+      "dependencies": {
+        "asn1.js": "^2.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0"
+      },
+      "dist": {
+        "shasum": "a0ef5aa6fc6747f4166cd18432bd67bd8dc438b5",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.1.tgz"
+      }
+    },
+    "3.0.2": {
+      "name": "parse-asn1",
+      "version": "3.0.2",
+      "dependencies": {
+        "asn1.js": "^2.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "shasum": "b42431beba32e08eac6d9153a54430bfd95d2d5e",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-3.0.2.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "parse-asn1",
+      "version": "4.0.0",
+      "dependencies": {
+        "asn1.js": "^3.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "shasum": "e28a3b660c1e7d2c3c0559ee8a7c8615cf76ff2e",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-4.0.0.tgz"
+      }
+    },
+    "5.0.0": {
+      "name": "parse-asn1",
+      "version": "5.0.0",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "shasum": "35060f6d5015d37628c770f4e091a0b5a278bc23",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.0.0.tgz"
+      }
+    },
+    "5.1.0": {
+      "name": "parse-asn1",
+      "version": "5.1.0",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "shasum": "37c4f9b7ed3ab65c74817b5f2480937fbf97c712",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
+      }
+    },
+    "5.1.1": {
+      "name": "parse-asn1",
+      "version": "5.1.1",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
+        "shasum": "f6bf293818332bd0dab54efb16087724745e6ca8",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+        "fileCount": 38,
+        "unpackedSize": 37094
+      }
+    },
+    "5.1.2": {
+      "name": "parse-asn1",
+      "version": "5.1.2",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-zVAb35DsNvwINEA7EEK+78YoNDGRpYEAGoIl3bSHyI9OU4IIrrrU5DC4xaCLZ42gvOfQg1+wS778WbJW+mCMCQ==",
+        "shasum": "13efbaaac8da669a9751a6b50a7cfccfdef756ae",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.2.tgz",
+        "fileCount": 39,
+        "unpackedSize": 39288,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQIE3CRA9TVsSAnZWagAACeEQAKE9Y6S0EH9oul/H0nzF\niqExpxywrnSmQ+ierO0ew+RCvwrb+BKnpZYyApm77GFnLOl97Xp0N9pJuhJ/\n+bT7f5f3kcgmyyodpxsjo8Cbv7v0/MGjoQfvNmyJDJiH1adlo8Zb1W8M0OV0\n0DAxlf7x4OirSXzh0ANSEnP4V31f/ZkmTS8PzGgXxk8MSW2yD1s4WkWA1SA/\ngnqTjYuLtE0F4huH+NWsnsw0e0e9yrsL7jsF5dU9ts8HJYLMDPzV1W01UCWA\n3VmkyTD5/Upu+HgM4+HxNpYJmferZumu5Iy1tQpInqiUZUOj8idrj3z7cqAD\ndowJ9FfbPYGoapHSLviiyBd6lbeAlDBRfvXWXZLc5K0AV/N088zlau1CZvA/\nGJNHcY1IE2o7tDlN+ulWA4K9MejDsA5my/D9Krv1J4bYhDaISrq4vW2IvG03\n+n0bIWdG1Atvkp1H5ngx06hInqFbHNQZto5KKTeZDlCHzQKty8OCYI/l8/Vr\n/ifI3dPkK/OaRGSt4k2lgHYu13Bxy3tC2RKFiLZd1AOSfU9i3cXTYSlBOxD+\nSrbezxM8nyWPHpHeNEi/OZGglSMNqZNWXhS7tnWY+IyX06F6Vrt72AFgWmZ8\n8WbaFU6ssd9XWdTfenTfYXOlrDGAd4dEU3FD3lTz2m3k77ZIVDEFKI3JEwOQ\nDPMj\r\n=XSVX\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.3": {
+      "name": "parse-asn1",
+      "version": "5.1.3",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+        "shasum": "1600c6cc0727365d68b97f3aa78939e735a75204",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
+        "fileCount": 39,
+        "unpackedSize": 39286,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQL3BCRA9TVsSAnZWagAAwnQP/0eyU171Hvt1/XjgciMm\ngKfO1YUC+K7WDvMFrC+3Q1MNrmuQBXPdx1kPasoSWClSELFhgiHNCpYf2uJ3\ndA8O+P3eHiNNH3k/2fKPqjBmWlNE2/OC1iDtnpHjnMqi8re/ouGy7ow+E2bC\nTE3w0a9jv8Lxu7S2PYsYuya0P4/pDlz9AvsPD2h1PZ7v++AsYJkBXdmv3zdd\nBRuJJ5nFUuwbHSOBr9kyuCNB6rw00yFd3RRNyfkwT9z9GVM6RtXH44AcqxBT\njUe3dmxR1ByeeobFUfetsWI8a9WbziMgDbKmcFiIpjfiFhMLCopYf8nO0Lx+\n0idsJPkYKSCEua/GroOmSRTyTNKeDMeVZaoV3/58jsRzOmoQ81G8M7XkaFDM\nIx+GaEzutaXYIPQXiIXc4MAOPdhNAxDpKgeANoSS8ynDwEp5rkPtbwuiS46s\nOsP+h8RwWGF69IvitJTuSiffzVe3qRywuHILfOs01b9tNVbs1opeHjhbirQg\n9vBrWMd84tzDBJAgtpShQm9Taq9a19QSyNgXXqL6hfE+kbJRN0urYUhGuvmq\nU9PuTNUXaz/rsT4NFi7mF8uUFuj9lH3AyXZIb5IilWgo52MKkWhb7Joorz+s\nq+QcqxuxvV+qUvJHm3CZN3p5B2g+bADf+jS1Z9N0Mc2Nk9gs8uK5Gn4X2pOb\n42yF\r\n=qm7I\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.4": {
+      "name": "parse-asn1",
+      "version": "5.1.4",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+        "shasum": "37f6628f823fbdeb2273b4d540434a22f3ef1fcc",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+        "fileCount": 39,
+        "unpackedSize": 39333,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcZZd0CRA9TVsSAnZWagAA9ooP/jme7QTlAfYmH1BCaHUQ\nAiaqPjCfLFyHvXGg8wVTSHiCLCxxbNLbwJKmQa911JLawGwuncprIJNjV2Ot\nqIP7tfNv3RkVTSopEU6Ns415Qxcxt9YSPVIDNylU1r15mPrv8BmKJz4xJG8g\nzn1Pj25pTQu4IVrQAMpV/o4pCBUC+B0ln4vzjymnj4PsADE+A6IQTLr3iUwc\n3+JQMRTdMMVhs0m67LFsdhMGTaZJN0Ok8wJ1+f5P4lC4IhqR6DR+0ccGe/jj\nn9263JhtB67pz8TfTUSHhzrwg1IxqMinqpUFB1i2BMYVB5gq3Kx4iQVyIi1s\nxXP86prtbtWZj0TJDhPFKG781mOYV4gZnr59jyO5d7Eg5tIQjqhSH/fAcen2\n4zSgLit9LjYqn1F0bVr7BNgae3nn+rHhTNW+h08Bj4DwX3uzmf39CzA79fQg\n9ZolcBdhEnYt7Czt492FLiJlfmrexC4jIIAEfG1qDRA4PGgQhetVQO1TwLWd\n0owbDu5eDrgXovKcZfKu4deiFd1kR3V7fv32/x+VSSEva3K0w2P9qAybpKKz\njIwQG6a4K0rkOH5CoxUXfrGu/T+xBuA3oLtYCoCiX2Ixmbd3f89bEfITXwMl\nya8Qyf/niAuwMAf/ml5c318iUvIVnJNYYFjr06lOOVFXqpprBfJuDRhXYJ0h\n9ody\r\n=AKWi\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.5": {
+      "name": "parse-asn1",
+      "version": "5.1.5",
+      "dependencies": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "tape": "^3.4.0",
+        "standard": "^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+        "shasum": "003271343da58dc94cace494faef3d2147ecea0e",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+        "fileCount": 8,
+        "unpackedSize": 13056,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdghSlCRA9TVsSAnZWagAAGcUP/3Xc8F0gROouwFFwHVXM\nRRRg4yexXSp38s2ndj8QU2C3E1h4q4LZR4srnXHb0EW2g/OO50bEK9MbY/nw\nIJiEXFr20tCvM8W0wjTI+05JK5wgWlPHGltAhmYPXLaLhUFDqqsv3gm0cRwA\nfxX54837qbSxM1JcAYEwFvc+3WFb9F/IMSrbaS7QZ78t3+/lb+W4TMrSqDEp\njlO7MZXlAb7q1f9LPZBjDUjpOSPujGX5jr3E6eXWXwpbvqEvAfGyJU5z1tEl\n9YG/Pw0j4+ieT8UDwhlfjWgHy79YaJ9J2uhWUxO6kHQdS1J49Gi9A7Nr0CI1\nLNyfFSZLmgic8D3gTjOTnXJcyqvrIdNuCAqWLFHnWpRNeYaVTyXE0RJTY8sS\nwNdlSw0oJtN/ObVjEWuHyCSGejVcHbunLEA4Jgx3GSjRwxDX5c7lqf0Ehdxx\n1vqIth2d0vwxxgDV3yYB+kxz5xNnuu+1KavcUn9pQNeDXdW/RjKt/zpvPS8L\nVyK77hadSCVt6QQOwUhgpd/EEk4qhS17LURIWJtj23EFgnnyhmyPJJf1gXHa\nlLVv5ER7jNUYNjPji1Ylhleg0IMA6Elfpa6OY8OWPtHWwjkrGmu2tik4XSYn\nxFBPeo7/bLOiPLrcuKtg/hWpl0ajeXBL1kPoaYnrwn92Tl9d/lqVHZVE/9X0\nSgkY\r\n=cqTh\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.1.6": {
+      "name": "parse-asn1",
+      "version": "5.1.6",
+      "dependencies": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "standard": "^14.3.4",
+        "tape": "^5.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+        "shasum": "385080a3ec13cb62a62d39409cb3e88844cdaed4",
+        "tarball": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+        "fileCount": 8,
+        "unpackedSize": 13029,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfMtZXCRA9TVsSAnZWagAAAU0P/idaJ1RnfYgcAVmhmbJD\nffROlPYMpsSD+2GmuJiCJlk8LS3noQjlGn9aY8evlVudFU7XwmQO35hr6VTM\n69THOR2wlj8wWnfwUOKm0I9TpAOs+VeTj0WkGAmowyhCcB33YdVl8LylzrPz\nXutW3rwTDrksgyGnFumZlEcIEJmj4nG6s6xRCOqdIAewudUlKlca4lDlExXg\n49Jrdt32eeny/zsGYtRECymtEHpTRMDPwGpN66uAEQFXEzPXOM0o+9EehAuN\nyLSpd/b+SxdqgimMZ4Xhdf1ry0GOvonAWPNDzN8tOWxQOIjK7wuZdpD6zkLi\nVZEjtkK6Yxo5kGqvvXlgAZptXdp89n7c6MDtI357w5m12/1c9aTXWzSy2uHv\nU9W6h0gDN+xeYFiCOf56+whwBYWIxkMPfPE/kuNlKcyDOKjSxsAb/3rYrEZk\nX31W9x/fG929TEHo6+K5V6pCAit/yYOEBosVqUvvwZs5BqdHzfVfBtY3B+UC\nzRg5tHFci9Z/aHywu2JN8NIzC/bN8pMSmzVJiJyUCaDuC+MSI1h7TkthG5rz\nGrjuBJhbIui7wQ525Y6EZUQ5hmv6VemODpdkeBUzB3VJh3OLikH1YIiTlinD\nRzw86v9Xx6Xe70dWSAf6t7U+03h6vTBXzl9R775fRZS1Rgr+/t2933ETQtxe\nfmyM\r\n=gfjf\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-08-11T17:33:13.478Z"
+}

--- a/test/fixtures/registry-mocks/content/parseurl.json
+++ b/test/fixtures/registry-mocks/content/parseurl.json
@@ -1,0 +1,782 @@
+{
+  "_id": "parseurl",
+  "_rev": "56-c89f6040711784eea001cbf53de41d7f",
+  "name": "parseurl",
+  "description": "parse a url with memoization",
+  "dist-tags": {
+    "latest": "1.3.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/parseurl.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/parseurl/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/parseurl",
+      "_id": "parseurl@1.0.0",
+      "dist": {
+        "shasum": "060280cfeecd8788fec6459ca0cc5df218477fe4",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/parseurl.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/parseurl/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/parseurl",
+      "_id": "parseurl@1.0.1",
+      "dist": {
+        "shasum": "2e57dce6efdd37c3518701030944c22bf388b7b4",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/parseurl.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/parseurl/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/parseurl",
+      "_id": "parseurl@1.1.0",
+      "dist": {
+        "shasum": "b389c827d9426b4d8698ef45eaf14f1b63596371",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/parseurl.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/parseurl/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/parseurl",
+      "_id": "parseurl@1.1.1",
+      "dist": {
+        "shasum": "3b8fdb423aeb18c997dcdf9ac9ecd7f037b3500a",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.1.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/parseurl.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/parseurl/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/parseurl",
+      "_id": "parseurl@1.1.2",
+      "dist": {
+        "shasum": "d3294c91119d19885e586fcc871b90d2006eb006",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.1.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/parseurl.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/parseurl/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/parseurl",
+      "_id": "parseurl@1.1.3",
+      "dist": {
+        "shasum": "1f005738ac71b417bc2d0845cbdfa2a8b63ea639",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/parseurl"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "fast-url-parser": "~1.0.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --check-leaks --bail --reporter spec test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/parseurl/issues"
+      },
+      "homepage": "https://github.com/expressjs/parseurl",
+      "_id": "parseurl@1.2.0",
+      "dist": {
+        "shasum": "be7df2d698eb49ffb10ea62939693e152991c008",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.3.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/parseurl"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "fast-url-parser": "~1.0.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --check-leaks --bail --reporter spec test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec test/"
+      },
+      "gitHead": "03b7ccca240e2bef5df6c25797e99175d28fb2cb",
+      "bugs": {
+        "url": "https://github.com/expressjs/parseurl/issues"
+      },
+      "homepage": "https://github.com/expressjs/parseurl",
+      "_id": "parseurl@1.3.0",
+      "_shasum": "b58046db4223e145afa76009e61bac87cc2281b3",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b58046db4223e145afa76009e61bac87cc2281b3",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.3.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/parseurl"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "benchmark": "2.0.0",
+        "beautify-benchmark": "0.2.4",
+        "fast-url-parser": "1.1.3",
+        "istanbul": "0.4.2",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --check-leaks --bail --reporter spec test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec test/"
+      },
+      "gitHead": "6d22d376d75b927ab2b5347ce3a1d6735133dd43",
+      "bugs": {
+        "url": "https://github.com/pillarjs/parseurl/issues"
+      },
+      "homepage": "https://github.com/pillarjs/parseurl",
+      "_id": "parseurl@1.3.1",
+      "_shasum": "c8ab8c9223ba34888aa64a297b28853bec18da56",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c8ab8c9223ba34888aa64a297b28853bec18da56",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.3.2",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/parseurl.git"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "fast-url-parser": "1.1.3",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint .",
+        "test": "mocha --check-leaks --bail --reporter spec test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec test/"
+      },
+      "gitHead": "0022a009d0973a44ae3849e83112ea4d12ad5b49",
+      "bugs": {
+        "url": "https://github.com/pillarjs/parseurl/issues"
+      },
+      "homepage": "https://github.com/pillarjs/parseurl#readme",
+      "_id": "parseurl@1.3.2",
+      "_shasum": "fc289d4ed8993119460c156253262cdc8de65bf3",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "fc289d4ed8993119460c156253262cdc8de65bf3",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parseurl-1.3.2.tgz_1504992079883_0.05658079497516155"
+      },
+      "directories": {}
+    },
+    "1.3.3": {
+      "name": "parseurl",
+      "description": "parse a url with memoization",
+      "version": "1.3.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/parseurl.git"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.1",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "fast-url-parser": "1.1.3",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.3"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint .",
+        "test": "mocha --check-leaks --bail --reporter spec test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec test/"
+      },
+      "gitHead": "0a5323370b02f4eff4069472d1e96a0094aef621",
+      "bugs": {
+        "url": "https://github.com/pillarjs/parseurl/issues"
+      },
+      "homepage": "https://github.com/pillarjs/parseurl#readme",
+      "_id": "parseurl@1.3.3",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+        "shasum": "9da19e7bee8d12dff0513ed5b76957793bc2e8d4",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10299,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJctVcbCRA9TVsSAnZWagAAUsoQAItlF92ss4WrI6lZGFUQ\n94+a7wb5I/oCJxcya6zpvv9F0TjfE2Gv/wdM5wTah83LqQ/FQbKiOKlarWAy\nUFC9i3oFqNCNf9Q4JoiUvFgFpA8K3VdjFL2FG5kXtxSPBEJ7DQ2LiFtp0316\nRJ7BFr6ICgWHl/IA8K0OvLmx4X8/nlbF0Gjuvzdv4dWFkkxWGDNaath51wRt\nKnp32YsQxzQPZJaDFpfOOfweIL4M1Xw3Mzm9T3C7IEdDIH1VeLis41IwVMx6\naCMDeTe9p29yl+uvf6JIBq7gYS1jSmfUgstTU34fu1bgaqavgs5wbv73ECEQ\nYWpS/27rVa/wjAfzIEyahL8Tgw7i3ZuwGaHVApOdackwGY3GZXLufRw5aZt+\n1e20FvF6iap14ONf6fDavmBgla6L5zQfsKPP1uynoPYiPAwLnDGyfK63WNQ4\nuE3CTFJwq8vKZ5byW2g8LrAE1+rDzy2FUWDkLc6sGTz0Nyk+ixM0i8qlA5/Q\nj8qzolmkHixA8UQkgMuCD1pbfDvrj8mrHicZkJLtc8z4mHvZKgAFClTfhcx9\n6LuUqhpkK1LD5kc4HImtYlwZ2NbLSc0QSthgCzxL429GWoxsPl6HnDfStZqR\n6UeYTkoLWR2K9tvhykwPHhCt/cTSpuWnlnDqovHap4ogM/HvLqcKkaomOdVa\nuzpW\r\n=CkLQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/parseurl_1.3.3_1555388186313_0.9689221694795169"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# parseurl\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-image]][node-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nParse a URL with memoization.\n\n## Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install parseurl\n```\n\n## API\n\n```js\nvar parseurl = require('parseurl')\n```\n\n### parseurl(req)\n\nParse the URL of the given request object (looks at the `req.url` property)\nand return the result. The result is the same as `url.parse` in Node.js core.\nCalling this function multiple times on the same `req` where `req.url` does\nnot change will return a cached parsed object, rather than parsing again.\n\n### parseurl.original(req)\n\nParse the original URL of the given request object and return the result.\nThis works by trying to parse `req.originalUrl` if it is a string, otherwise\nparses `req.url`. The result is the same as `url.parse` in Node.js core.\nCalling this function multiple times on the same `req` where `req.originalUrl`\ndoes not change will return a cached parsed object, rather than parsing again.\n\n## Benchmark\n\n```bash\n$ npm run-script bench\n\n> parseurl@1.3.3 bench nodejs-parseurl\n> node benchmark/index.js\n\n  http_parser@2.8.0\n  node@10.6.0\n  v8@6.7.288.46-node.13\n  uv@1.21.0\n  zlib@1.2.11\n  ares@1.14.0\n  modules@64\n  nghttp2@1.32.0\n  napi@3\n  openssl@1.1.0h\n  icu@61.1\n  unicode@10.0\n  cldr@33.0\n  tz@2018c\n\n> node benchmark/fullurl.js\n\n  Parsing URL \"http://localhost:8888/foo/bar?user=tj&pet=fluffy\"\n\n  4 tests completed.\n\n  fasturl            x 2,207,842 ops/sec ±3.76% (184 runs sampled)\n  nativeurl - legacy x   507,180 ops/sec ±0.82% (191 runs sampled)\n  nativeurl - whatwg x   290,044 ops/sec ±1.96% (189 runs sampled)\n  parseurl           x   488,907 ops/sec ±2.13% (192 runs sampled)\n\n> node benchmark/pathquery.js\n\n  Parsing URL \"/foo/bar?user=tj&pet=fluffy\"\n\n  4 tests completed.\n\n  fasturl            x 3,812,564 ops/sec ±3.15% (188 runs sampled)\n  nativeurl - legacy x 2,651,631 ops/sec ±1.68% (189 runs sampled)\n  nativeurl - whatwg x   161,837 ops/sec ±2.26% (189 runs sampled)\n  parseurl           x 4,166,338 ops/sec ±2.23% (184 runs sampled)\n\n> node benchmark/samerequest.js\n\n  Parsing URL \"/foo/bar?user=tj&pet=fluffy\" on same request object\n\n  4 tests completed.\n\n  fasturl            x  3,821,651 ops/sec ±2.42% (185 runs sampled)\n  nativeurl - legacy x  2,651,162 ops/sec ±1.90% (187 runs sampled)\n  nativeurl - whatwg x    175,166 ops/sec ±1.44% (188 runs sampled)\n  parseurl           x 14,912,606 ops/sec ±3.59% (183 runs sampled)\n\n> node benchmark/simplepath.js\n\n  Parsing URL \"/foo/bar\"\n\n  4 tests completed.\n\n  fasturl            x 12,421,765 ops/sec ±2.04% (191 runs sampled)\n  nativeurl - legacy x  7,546,036 ops/sec ±1.41% (188 runs sampled)\n  nativeurl - whatwg x    198,843 ops/sec ±1.83% (189 runs sampled)\n  parseurl           x 24,244,006 ops/sec ±0.51% (194 runs sampled)\n\n> node benchmark/slash.js\n\n  Parsing URL \"/\"\n\n  4 tests completed.\n\n  fasturl            x 17,159,456 ops/sec ±3.25% (188 runs sampled)\n  nativeurl - legacy x 11,635,097 ops/sec ±3.79% (184 runs sampled)\n  nativeurl - whatwg x    240,693 ops/sec ±0.83% (189 runs sampled)\n  parseurl           x 42,279,067 ops/sec ±0.55% (190 runs sampled)\n```\n\n## License\n\n  [MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/pillarjs/parseurl/master\n[coveralls-url]: https://coveralls.io/r/pillarjs/parseurl?branch=master\n[node-image]: https://badgen.net/npm/node/parseurl\n[node-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/parseurl\n[npm-url]: https://npmjs.org/package/parseurl\n[npm-version-image]: https://badgen.net/npm/v/parseurl\n[travis-image]: https://badgen.net/travis/pillarjs/parseurl/master\n[travis-url]: https://travis-ci.org/pillarjs/parseurl\n",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-16T04:16:30.465Z",
+    "created": "2014-03-08T02:08:58.819Z",
+    "1.0.0": "2014-03-08T02:08:58.819Z",
+    "1.0.1": "2014-03-08T02:11:05.583Z",
+    "1.1.0": "2014-07-09T02:22:48.887Z",
+    "1.1.1": "2014-07-09T05:05:40.824Z",
+    "1.1.2": "2014-07-09T05:18:03.016Z",
+    "1.1.3": "2014-07-09T05:25:36.837Z",
+    "1.2.0": "2014-07-21T19:12:21.102Z",
+    "1.3.0": "2014-08-10T02:54:41.099Z",
+    "1.3.1": "2016-01-17T19:49:35.110Z",
+    "1.3.2": "2017-09-09T21:21:20.714Z",
+    "1.3.3": "2019-04-16T04:16:26.547Z"
+  },
+  "homepage": "https://github.com/pillarjs/parseurl#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pillarjs/parseurl.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pillarjs/parseurl/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ],
+  "users": {
+    "goodseller": true,
+    "simplyianm": true,
+    "qqqppp9998": true,
+    "princetoad": true,
+    "pandao": true,
+    "aredridel": true,
+    "kankungyip": true,
+    "ramoslin02": true,
+    "wangnan0610": true,
+    "wkaifang": true,
+    "wangshijun": true,
+    "xu_q90": true,
+    "monjer": true,
+    "mojaray2k": true,
+    "hyokosdeveloper": true,
+    "giussa_dan": true,
+    "shuoshubao": true,
+    "justjavac": true,
+    "wxttxw125": true,
+    "eyson": true,
+    "raycharles": true,
+    "avivharuzi": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/parseurl.min.json
+++ b/test/fixtures/registry-mocks/content/parseurl.min.json
@@ -1,0 +1,157 @@
+{
+  "name": "parseurl",
+  "dist-tags": {
+    "latest": "1.3.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "parseurl",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "060280cfeecd8788fec6459ca0cc5df218477fe4",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "parseurl",
+      "version": "1.0.1",
+      "dist": {
+        "shasum": "2e57dce6efdd37c3518701030944c22bf388b7b4",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "parseurl",
+      "version": "1.1.0",
+      "dist": {
+        "shasum": "b389c827d9426b4d8698ef45eaf14f1b63596371",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "parseurl",
+      "version": "1.1.1",
+      "dist": {
+        "shasum": "3b8fdb423aeb18c997dcdf9ac9ecd7f037b3500a",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "parseurl",
+      "version": "1.1.2",
+      "dist": {
+        "shasum": "d3294c91119d19885e586fcc871b90d2006eb006",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "parseurl",
+      "version": "1.1.3",
+      "dist": {
+        "shasum": "1f005738ac71b417bc2d0845cbdfa2a8b63ea639",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.1.3.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "parseurl",
+      "version": "1.2.0",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "fast-url-parser": "~1.0.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0"
+      },
+      "dist": {
+        "shasum": "be7df2d698eb49ffb10ea62939693e152991c008",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "parseurl",
+      "version": "1.3.0",
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "fast-url-parser": "~1.0.0",
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "b58046db4223e145afa76009e61bac87cc2281b3",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+      }
+    },
+    "1.3.1": {
+      "name": "parseurl",
+      "version": "1.3.1",
+      "devDependencies": {
+        "benchmark": "2.0.0",
+        "beautify-benchmark": "0.2.4",
+        "fast-url-parser": "1.1.3",
+        "istanbul": "0.4.2",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "c8ab8c9223ba34888aa64a297b28853bec18da56",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.3.2": {
+      "name": "parseurl",
+      "version": "1.3.2",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "fast-url-parser": "1.1.3",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3"
+      },
+      "dist": {
+        "shasum": "fc289d4ed8993119460c156253262cdc8de65bf3",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.3.3": {
+      "name": "parseurl",
+      "version": "1.3.3",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.1",
+        "eslint-plugin-node": "7.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "fast-url-parser": "1.1.3",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.3"
+      },
+      "dist": {
+        "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+        "shasum": "9da19e7bee8d12dff0513ed5b76957793bc2e8d4",
+        "tarball": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10299,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJctVcbCRA9TVsSAnZWagAAUsoQAItlF92ss4WrI6lZGFUQ\n94+a7wb5I/oCJxcya6zpvv9F0TjfE2Gv/wdM5wTah83LqQ/FQbKiOKlarWAy\nUFC9i3oFqNCNf9Q4JoiUvFgFpA8K3VdjFL2FG5kXtxSPBEJ7DQ2LiFtp0316\nRJ7BFr6ICgWHl/IA8K0OvLmx4X8/nlbF0Gjuvzdv4dWFkkxWGDNaath51wRt\nKnp32YsQxzQPZJaDFpfOOfweIL4M1Xw3Mzm9T3C7IEdDIH1VeLis41IwVMx6\naCMDeTe9p29yl+uvf6JIBq7gYS1jSmfUgstTU34fu1bgaqavgs5wbv73ECEQ\nYWpS/27rVa/wjAfzIEyahL8Tgw7i3ZuwGaHVApOdackwGY3GZXLufRw5aZt+\n1e20FvF6iap14ONf6fDavmBgla6L5zQfsKPP1uynoPYiPAwLnDGyfK63WNQ4\nuE3CTFJwq8vKZ5byW2g8LrAE1+rDzy2FUWDkLc6sGTz0Nyk+ixM0i8qlA5/Q\nj8qzolmkHixA8UQkgMuCD1pbfDvrj8mrHicZkJLtc8z4mHvZKgAFClTfhcx9\n6LuUqhpkK1LD5kc4HImtYlwZ2NbLSc0QSthgCzxL429GWoxsPl6HnDfStZqR\n6UeYTkoLWR2K9tvhykwPHhCt/cTSpuWnlnDqovHap4ogM/HvLqcKkaomOdVa\nuzpW\r\n=CkLQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-04-16T04:16:30.465Z"
+}

--- a/test/fixtures/registry-mocks/content/pascalcase.json
+++ b/test/fixtures/registry-mocks/content/pascalcase.json
@@ -1,0 +1,286 @@
+{
+  "_id": "pascalcase",
+  "_rev": "4-9c81969d62492c9769a8e7a2076ba8fa",
+  "name": "pascalcase",
+  "description": "Convert a string to pascal-case.",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "pascalcase",
+      "description": "Convert a string to pascal-case.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/pascalcase",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/pascalcase.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/pascalcase/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "case",
+        "pascal",
+        "pascal-case",
+        "pascalcase",
+        "string"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "pad-left",
+            "pad-right",
+            "word-wrap",
+            "repeat-string",
+            "justified"
+          ]
+        }
+      },
+      "_id": "pascalcase@0.1.0",
+      "_shasum": "5d26610e847dca1304100f494deb09e4fc49ff82",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5d26610e847dca1304100f494deb09e4fc49ff82",
+        "tarball": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "pascalcase",
+      "description": "Convert a string to pascal-case.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/pascalcase",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/pascalcase.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/pascalcase/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "camelcase",
+        "case",
+        "casing",
+        "pascal",
+        "pascal-case",
+        "pascalcase",
+        "string"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "pad-left",
+            "pad-right",
+            "word-wrap",
+            "repeat-string",
+            "justified"
+          ]
+        }
+      },
+      "gitHead": "c2600f8aa648fe093381a064ba364d99b374911c",
+      "_id": "pascalcase@0.1.1",
+      "_shasum": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
+        "tarball": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "pascalcase",
+      "description": "Convert a string to pascal-case.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/pascalcase",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/pascalcase.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/pascalcase/issues"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^2.0.0",
+        "mocha": "^6.2.0"
+      },
+      "keywords": [
+        "camelcase",
+        "case",
+        "casing",
+        "pascal",
+        "pascal-case",
+        "pascal case",
+        "pascalcase",
+        "string",
+        "UpperCamelCase"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "ansi-colors",
+            "word-wrap",
+            "randomatic",
+            "justified"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "64ee9eefbf4ba9e05152a72eb6d59a284af95dd6",
+      "_id": "pascalcase@1.0.0",
+      "_nodeVersion": "12.7.0",
+      "_npmVersion": "6.10.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-BSExi0rRnCHReJys6NocaK+cfTXNinAegfWBvr0JD3hiaEG7Nuc7r0CIdOJunXrs8gU/sbHQ9dxVAtiVQisjmg==",
+        "shasum": "d2fd7d73f2969606d2b56e17f5261be41c43c381",
+        "tarball": "https://registry.npmjs.org/pascalcase/-/pascalcase-1.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7235,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdS9vqCRA9TVsSAnZWagAAmbIP/jAt9hdFsQUOs24CYZFl\nq5j8EJCUMI32UZnkYi7KkTMNs55uKXOK+dVYGikYpHNdeL7a7blKaMHk+Ong\nvMG5H6fo+Xc65S03xWJboGs1p2NB6sA0T88nLI15onXPV8YSeFLxLdWEgawm\nOywj3u/pxzEZeIgtcDqeHFBomkRyaLi0+FqK1zBFiKnzVise2U6QVknbNMQ0\ntVghy0qZbhv+IMmdpcbQdrlqPQf/etnk171RrUySHDrJrxnFR/T0YigGIbtg\nqBLoYJoV3xudoL1iBF7OlmsEzmnmF+a9MOoFnemWA+Qs5h2IeosKJ1lP89hZ\nemjGKj+SjYGOKpEN5j2H2Z0qSDqKi1ZlwO/FewgTr6ZqsdrhoNGQgfPbQr8H\naRr27OuEVfByyp9vqb50rLDVzc6q1RJHSsep1omxkp8ih1P62PdSsSqp7q1F\nkERAwONblppybSUENUfnoDZuZh3rqbgWhugqa+vLhMSzPB9C4lEcHBOQRytE\nu1q/rUE07wCvoR4lIcpx2SB7L8HuWd3Eb4dClut68NxTgLnvzIvv4KRWbR/P\n+7POzupaY+wuhuCcryaepLjtf8wRR8skuL5ZSmvo8MwZvKfUbBg42AzCUmIH\n3zRltKUrGqMrl/oCM8FKYunOwnnS6EeLOvMa47gb394QgHrteSGKB6qfZ7pJ\nPBSE\r\n=cwQs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pascalcase_1.0.0_1565252586202_0.3015869803399853"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# pascalcase [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=W8YFZ425KND68) [![NPM version](https://img.shields.io/npm/v/pascalcase.svg?style=flat)](https://www.npmjs.com/package/pascalcase) [![NPM monthly downloads](https://img.shields.io/npm/dm/pascalcase.svg?style=flat)](https://npmjs.org/package/pascalcase) [![NPM total downloads](https://img.shields.io/npm/dt/pascalcase.svg?style=flat)](https://npmjs.org/package/pascalcase) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/pascalcase.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/pascalcase)\n\n> Convert a string to pascal-case.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/) (requires [Node.js](https://nodejs.org/en/) >=8):\n\n```sh\n$ npm install --save pascalcase\n```\n\n## Usage\n\n```js\nconst pascalcase = require('pascalcase');\n\nconsole.log(pascalcase('a')); //=> 'A'\nconsole.log(pascalcase('foo bar baz')); //=> 'FooBarBaz'\nconsole.log(pascalcase('  foo bar baz  ')); //=> 'FooBarBaz'\nconsole.log(pascalcase('foo_bar-baz')); //=> 'FooBarBaz'\nconsole.log(pascalcase('foo.bar.baz')); //=> 'FooBarBaz'\nconsole.log(pascalcase('foo/bar/baz')); //=> 'FooBarBaz'\nconsole.log(pascalcase('foo[bar)baz')); //=> 'FooBarBaz'\nconsole.log(pascalcase('#foo+bar*baz')); //=> 'FooBarBaz'\nconsole.log(pascalcase('$foo~bar`baz')); //=> 'FooBarBaz'\nconsole.log(pascalcase('_foo_bar-baz-')); //=> 'FooBarBaz'\nconsole.log(pascalcase('foo 2 bar 5 baz')); //=> 'Foo2Bar5Baz'\nconsole.log(pascalcase('foo2bar5baz')); //=> 'Foo2bar5baz'\n```\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [ansi-colors](https://www.npmjs.com/package/ansi-colors): Easily add ANSI colors to your text and symbols in the terminal. A faster drop-in… [more](https://github.com/doowb/ansi-colors) | [homepage](https://github.com/doowb/ansi-colors \"Easily add ANSI colors to your text and symbols in the terminal. A faster drop-in replacement for chalk, kleur and turbocolor (without the dependencies and rendering bugs).\")\n* [justified](https://www.npmjs.com/package/justified): Wraps words to a specified length and justifies the text in each line. | [homepage](https://github.com/jonschlinkert/justified \"Wraps words to a specified length and justifies the text in each line.\")\n* [randomatic](https://www.npmjs.com/package/randomatic): Generate randomized strings of a specified length using simple character sequences. The original generate-password. | [homepage](https://github.com/jonschlinkert/randomatic \"Generate randomized strings of a specified length using simple character sequences. The original generate-password.\")\n* [word-wrap](https://www.npmjs.com/package/word-wrap): Wrap words to a specified length. | [homepage](https://github.com/jonschlinkert/word-wrap \"Wrap words to a specified length.\")\n\n### Author\n\n**Jon Schlinkert**\n\n* [GitHub Profile](https://github.com/jonschlinkert)\n* [Twitter Profile](https://twitter.com/jonschlinkert)\n* [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)\n\n### License\n\nCopyright © 2019, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.8.0, on August 08, 2019._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-08-08T08:23:09.034Z",
+    "created": "2015-08-19T05:13:36.572Z",
+    "0.1.0": "2015-08-19T05:13:36.572Z",
+    "0.1.1": "2015-12-04T22:12:32.187Z",
+    "1.0.0": "2019-08-08T08:23:06.351Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/pascalcase",
+  "keywords": [
+    "camelcase",
+    "case",
+    "casing",
+    "pascal",
+    "pascal-case",
+    "pascal case",
+    "pascalcase",
+    "string",
+    "UpperCamelCase"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/pascalcase.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/pascalcase/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "quafoo": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/pascalcase.min.json
+++ b/test/fixtures/registry-mocks/content/pascalcase.min.json
@@ -1,0 +1,58 @@
+{
+  "name": "pascalcase",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "pascalcase",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "5d26610e847dca1304100f494deb09e4fc49ff82",
+        "tarball": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "pascalcase",
+      "version": "0.1.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "b363e55e8006ca6fe21784d2db22bd15d7917f14",
+        "tarball": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "pascalcase",
+      "version": "1.0.0",
+      "devDependencies": {
+        "gulp-format-md": "^2.0.0",
+        "mocha": "^6.2.0"
+      },
+      "dist": {
+        "integrity": "sha512-BSExi0rRnCHReJys6NocaK+cfTXNinAegfWBvr0JD3hiaEG7Nuc7r0CIdOJunXrs8gU/sbHQ9dxVAtiVQisjmg==",
+        "shasum": "d2fd7d73f2969606d2b56e17f5261be41c43c381",
+        "tarball": "https://registry.npmjs.org/pascalcase/-/pascalcase-1.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7235,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdS9vqCRA9TVsSAnZWagAAmbIP/jAt9hdFsQUOs24CYZFl\nq5j8EJCUMI32UZnkYi7KkTMNs55uKXOK+dVYGikYpHNdeL7a7blKaMHk+Ong\nvMG5H6fo+Xc65S03xWJboGs1p2NB6sA0T88nLI15onXPV8YSeFLxLdWEgawm\nOywj3u/pxzEZeIgtcDqeHFBomkRyaLi0+FqK1zBFiKnzVise2U6QVknbNMQ0\ntVghy0qZbhv+IMmdpcbQdrlqPQf/etnk171RrUySHDrJrxnFR/T0YigGIbtg\nqBLoYJoV3xudoL1iBF7OlmsEzmnmF+a9MOoFnemWA+Qs5h2IeosKJ1lP89hZ\nemjGKj+SjYGOKpEN5j2H2Z0qSDqKi1ZlwO/FewgTr6ZqsdrhoNGQgfPbQr8H\naRr27OuEVfByyp9vqb50rLDVzc6q1RJHSsep1omxkp8ih1P62PdSsSqp7q1F\nkERAwONblppybSUENUfnoDZuZh3rqbgWhugqa+vLhMSzPB9C4lEcHBOQRytE\nu1q/rUE07wCvoR4lIcpx2SB7L8HuWd3Eb4dClut68NxTgLnvzIvv4KRWbR/P\n+7POzupaY+wuhuCcryaepLjtf8wRR8skuL5ZSmvo8MwZvKfUbBg42AzCUmIH\n3zRltKUrGqMrl/oCM8FKYunOwnnS6EeLOvMa47gb394QgHrteSGKB6qfZ7pJ\nPBSE\r\n=cwQs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "modified": "2019-08-08T08:23:09.034Z"
+}

--- a/test/fixtures/registry-mocks/content/path-browserify.json
+++ b/test/fixtures/registry-mocks/content/path-browserify.json
@@ -1,0 +1,903 @@
+{
+  "_id": "path-browserify",
+  "_rev": "21-ec21494cd23362fef9f81cce79865358",
+  "name": "path-browserify",
+  "description": "the path module from node core for browsers",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "path-browserify",
+      "version": "0.0.0",
+      "description": "the path module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/path-browserify.git"
+      },
+      "homepage": "https://github.com/substack/path-browserify",
+      "keywords": [
+        "path",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/path-browserify/issues"
+      },
+      "_id": "path-browserify@0.0.0",
+      "dist": {
+        "shasum": "a0b870729aae214005b7d5032ec2cbbb0fb4451a",
+        "tarball": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "path-browserify",
+      "description": "the path module from node core for browsers",
+      "version": "1.0.0",
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "bugs": {
+        "url": "https://github.com/browserify/path-browserify/issues"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "^4.9.0"
+      },
+      "homepage": "https://github.com/browserify/path-browserify",
+      "keywords": [
+        "browser",
+        "browserify",
+        "path"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/path-browserify.git"
+      },
+      "scripts": {
+        "test": "node test"
+      },
+      "gitHead": "c99fae5ce1f632581952ee5ffd89234d04b67520",
+      "_id": "path-browserify@1.0.0",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.3.0",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g==",
+        "shasum": "40702a97af46ae00b0ea6fa8998c0b03c0af160d",
+        "tarball": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 53210,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbF+qkCRA9TVsSAnZWagAAz+QQAIwA0t8wx1mP3+vbtoV9\nh6n/aXBjYMt3FfBqQCcA/TOzJgfepUJXyZYkigcgei0Xi1c6mb7CgNpgayO4\nvbbYsKjqnm9XpwF+yAEERBc33rnBMxlHro4sj41hWYdshlxVMT/62kt2J4sE\nUjA1+JXngKg4BrENLypHOz9ovRP9UkzNQMYhUFWY/LSIDiNmUz8qz54i8WgJ\n2ao8eeugSdcF/VziYhAXPdhEAh+inkrOzQPi+P/IVlVvcXVa2bmZXG5/YOVq\n83qRbHJzTVsm1+w9qcSUBfgRw3eUracjcAkner7drhtpz14nhyPs39isP/1A\noHS8sXgfVN99HuoNjPLXkJchqc+AlQV095aURZ3CJrpAFbltcGkrNwcCggnZ\nmu93RwPs1svgNGdpszvehz+9adaXXGJR8T4gIcbjNyFdKnkkunv3BuGtia6w\nNKRxIl1GqarkbjWC4FR+7qQJCRFUerP1wIU8GQaVs2DH/8yyyzAvVqOwxo5Q\nsuVmw/XyQJHtF8P01aEZpeEHVNFWixiNOSYd0iIpG93T2nudpxCE5J0E/p5L\n+yO12hyRJR3+VxPkxcmsCrXiJvNxt8q8JiIYVkD369u7CdMj9sk35DWQ18J9\nUjrPzjUtPEi73d+/XL8Ifu+lqEBlWg5UhKW6VLXEO6yIsP4sp8KMGB5kjDXI\n729S\r\n=QyT0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-browserify_1.0.0_1528294051083_0.08595232904848471"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.0.1": {
+      "name": "path-browserify",
+      "version": "0.0.1",
+      "description": "the path module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "scripts": {
+        "test": "node test/test-path.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/path-browserify.git"
+      },
+      "homepage": "https://github.com/substack/path-browserify",
+      "keywords": [
+        "path",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "gitHead": "8245acefb8d5bd39c0326d14984c83e5df97d1b6",
+      "bugs": {
+        "url": "https://github.com/substack/path-browserify/issues"
+      },
+      "_id": "path-browserify@0.0.1",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.4.1",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+        "shasum": "e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a",
+        "tarball": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 27016,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbKiPVCRA9TVsSAnZWagAA49QP/iOLbBrfYvj1GgPG/Iml\nAUpfhQOEZ3juPvhTed68NvHvtwXzng4X1ijYkuM7yxi4KSgv83iYut5/Ukx2\nsvOuK/VGiLV5+/KOUx6O74Ah47UGWYMS74vCcjPks28IOekp0DYXxnF4fziQ\nIdxakyS1Nn+Pnz+aas5WqOVOZn2XkN6SPnXfBx1uA+UY9sCRR5gd+EWVPmyV\n5G9ozmS0Tg1oMroa9forJC7JLfpJFGL8Bb8I3oQF9Zo8Vc9+TzgWmP79e/4D\nYukk8pyMDUVYhIFDbH2dAGTqrUiMagsrHlP29ojvcceV6fWyf/DeG6rE2Bun\nvCQHvzePRwzr+soNHJyg+Wzhy8FmsTYLPlhyktRXbYhkj9UPsfdkhpS5V1nl\nXL27WHstgmtZQoLVOPFfTGgnMg5oYt4TwC84OHq5ZUKGWYcl8MtWWklHLO0z\n7FA49pgYkF494sHbVhVLnwNfFDySUf4zQAJ4mYCgPeXyf6FaEP6EKUaq9TD+\ngfLu81jZKK93YOAXfSTxyjWO6YEmB6GhUjH7ohsivS4M+IF6tmVGa1gPl0Cn\n/T7OzlQnfJ4o4bz9WTLKThv82DnRlPuHA94ptroOrWcb+oMGXBEpG5EFpoTM\nNWC7KFFLRppndI0Xs9+ndDYWqzy5WE5wjHNT9W23R7oVDqRga/N59jsE8tie\ncQV/\r\n=E5oF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-browserify_0.0.1_1529488340829_0.9848713260382573"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.1": {
+      "name": "path-browserify",
+      "description": "the path module from node core for browsers",
+      "version": "1.0.1",
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "bugs": {
+        "url": "https://github.com/browserify/path-browserify/issues"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "^4.9.0"
+      },
+      "homepage": "https://github.com/browserify/path-browserify",
+      "keywords": [
+        "browser",
+        "browserify",
+        "path"
+      ],
+      "license": "MIT",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/path-browserify.git"
+      },
+      "scripts": {
+        "test": "node test"
+      },
+      "gitHead": "872fec31a8bac7b9b43be0e54ef3037e0202c5fb",
+      "_id": "path-browserify@1.0.1",
+      "_nodeVersion": "13.9.0",
+      "_npmVersion": "6.14.1",
+      "dist": {
+        "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+        "shasum": "d98454a9c3753d5790860f16f68867b9e46be1fd",
+        "tarball": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+        "fileCount": 19,
+        "unpackedSize": 54293,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeXotWCRA9TVsSAnZWagAAQs4P/RgxM3LeL/6hBXl32TVj\nU60/D8yCL/sgtNucST9YxjQY1/Soj6eFbVhApQFKNCDkzGZUYm5SIR2pphla\nnzR08/vse1W5lt/hHHlih6Z1eq1WkipEXYpOG8K389KBcvnEANegzAEjYFtN\nAz9RP+hdxQ1gnF8b+fZKUYm5h/sIsNYHnX1KZP3ecVXoMw2OgE+eKj3LEZ1c\nRAEE3YYEnt+PaEINSfP00aDOhWuiD8ojkJVL+p/4U+MBbyopXmysjRBBOo6k\np1umLhUy/bDjng0bmCZxbSIC5ldALpKC0YafNkaZJSkmNJkp+YTXTMEgc4/W\nFpxYujRp2SxVcXStRwuVuM9Q3SR0dsgJVMS/wUB1zBEPOJhfxolUh2s5wOrl\ny8jjrTVlpzfMQZ48ie6E1KSLj2hqm0otB0zo4I4kvgut2Pg4HPugEjXpqePK\n0mUHzC3nBaswilokbbzhxQlRj9ZwdHEHMkkLc2qhT+c1FIVFWUgpOIgEbJAK\nUyO8A0jojkqCd7Mdge1easIa4E7WUN4Va3SV9z/NcaFM1DSCD0PqDv8g3TE7\n0TkrPOxe1u728SNgmdcy1huTwinhjw9BF85Ik39W67KbEe4Q7fVkp4FRD5qL\nP4EV21Ac8Wh6PALGD8hV56d618rmZ9HaJoO/XWYVfSz/9WtRCIwZznshx2md\nkwG7\r\n=fblg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-browserify_1.0.1_1583254358346_0.9623061789450384"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# path-browserify [![Build Status](https://travis-ci.org/browserify/path-browserify.png?branch=master)](https://travis-ci.org/browserify/path-browserify)\n\n> The `path` module from Node.js for browsers\n\nThis implements the Node.js [`path`][path] module for environments that do not have it, like browsers.\n\n> `path-browserify` currently matches the **Node.js 10.3** API.\n\n## Install\n\nYou usually do not have to install `path-browserify` yourself! If your code runs in Node.js, `path` is built in. If your code runs in the browser, bundlers like [browserify](https://github.com/browserify/browserify) or [webpack](https://github.com/webpack/webpack) include the `path-browserify` module by default.\n\nBut if none of those apply, with npm do:\n\n```\nnpm install path-browserify\n```\n\n## Usage\n\n```javascript\nvar path = require('path')\n\nvar filename = 'logo.png';\nvar logo = path.join('./assets/img', filename);\ndocument.querySelector('#logo').src = logo;\n```\n\n## API\n\nSee the [Node.js path docs][path]. `path-browserify` currently matches the Node.js 10.3 API.\n`path-browserify` only implements the POSIX functions, not the win32 ones.\n\n## Contributing\n\nPRs are very welcome! The main way to contribute to `path-browserify` is by porting features, bugfixes and tests from Node.js. Ideally, code contributions to this module are copy-pasted from Node.js and transpiled to ES5, rather than reimplemented from scratch. Matching the Node.js code as closely as possible makes maintenance simpler when new changes land in Node.js.\nThis module intends to provide exactly the same API as Node.js, so features that are not available in the core `path` module will not be accepted. Feature requests should instead be directed at [nodejs/node](https://github.com/nodejs/node) and will be added to this module once they are implemented in Node.js.\n\nIf there is a difference in behaviour between Node.js's `path` module and this module, please open an issue!\n\n## License\n\n[MIT](./LICENSE)\n\n[path]: https://nodejs.org/docs/v10.3.0/api/path.html\n",
+  "maintainers": [
+    {
+      "email": "raynos2@gmail.com",
+      "name": "raynos"
+    },
+    {
+      "email": "lukechilds123@gmail.com",
+      "name": "lukechilds"
+    },
+    {
+      "email": "shtylman@gmail.com",
+      "name": "defunctzombie"
+    },
+    {
+      "email": "substack@gmail.com",
+      "name": "substack"
+    },
+    {
+      "email": "feross@feross.org",
+      "name": "feross"
+    },
+    {
+      "email": "me@gkatsev.com",
+      "name": "gkatsev"
+    },
+    {
+      "email": "zertosh@gmail.com",
+      "name": "zertosh"
+    },
+    {
+      "email": "mathiasbuus@gmail.com",
+      "name": "mafintosh"
+    },
+    {
+      "email": "max@maxogden.com",
+      "name": "maxogden"
+    },
+    {
+      "email": "dominic.tarr@gmail.com",
+      "name": "dominictarr"
+    },
+    {
+      "email": "thlorenz10@gmail.com",
+      "name": "thlorenz"
+    },
+    {
+      "email": "terinjokes@gmail.com",
+      "name": "terinjokes"
+    },
+    {
+      "email": "npm-public@jessemccarthy.net",
+      "name": "jmm"
+    },
+    {
+      "email": "palmermebane@gmail.com",
+      "name": "mellowmelon"
+    },
+    {
+      "email": "darawk@gmail.com",
+      "name": "ashaffer88"
+    },
+    {
+      "email": "b@lupton.cc",
+      "name": "balupton"
+    },
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jryans@gmail.com",
+      "name": "jryans"
+    },
+    {
+      "email": "sethvincent@gmail.com",
+      "name": "sethvincent"
+    },
+    {
+      "email": "yoshuawuyts@gmail.com",
+      "name": "yoshuawuyts"
+    },
+    {
+      "email": "ungoldman@gmail.com",
+      "name": "ungoldman"
+    },
+    {
+      "email": "michael.williams@enspiral.com",
+      "name": "ahdinosaur"
+    },
+    {
+      "email": "contact@elnounch.net",
+      "name": "elnounch"
+    },
+    {
+      "email": "parshap+npm@gmail.com",
+      "name": "parshap"
+    },
+    {
+      "email": "yerko.palma@usach.cl",
+      "name": "yerkopalma"
+    },
+    {
+      "email": "forbes@lindesay.co.uk",
+      "name": "forbeslindesay"
+    },
+    {
+      "email": "martin.heidegger@gmail.com",
+      "name": "leichtgewicht"
+    },
+    {
+      "email": "garann@gmail.com",
+      "name": "garann"
+    },
+    {
+      "email": "bcomnes@gmail.com",
+      "name": "bret"
+    },
+    {
+      "email": "vestibule@anandthakker.net",
+      "name": "anandthakker"
+    },
+    {
+      "email": "dave.des@gmail.com",
+      "name": "mattdesl"
+    },
+    {
+      "email": "hughskennedy@gmail.com",
+      "name": "hughsk"
+    },
+    {
+      "email": "pereira.filype@gmail.com",
+      "name": "fpereira1"
+    },
+    {
+      "email": "renee@kooi.me",
+      "name": "goto-bus-stop"
+    },
+    {
+      "email": "post.ben.here@gmail.com",
+      "name": "bpostlethwaite"
+    },
+    {
+      "email": "github@tixz.dk",
+      "name": "emilbayes"
+    },
+    {
+      "email": "maochenyan@gmail.com",
+      "name": "stevemao"
+    },
+    {
+      "email": "peteris.krumins@gmail.com",
+      "name": "pkrumins"
+    },
+    {
+      "email": "me@JoshDuff.com",
+      "name": "tehshrike"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-09T12:54:32.635Z",
+    "created": "2013-12-03T19:48:36.301Z",
+    "0.0.0": "2013-12-03T19:48:37.866Z",
+    "1.0.0": "2018-06-06T14:07:31.193Z",
+    "0.0.1": "2018-06-20T09:52:20.906Z",
+    "1.0.1": "2020-03-03T16:52:38.480Z"
+  },
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/browserify/path-browserify.git"
+  },
+  "users": {
+    "wenbing": true,
+    "simplyianm": true,
+    "inflowmotion": true,
+    "koulmomo": true,
+    "rbecheras": true
+  },
+  "homepage": "https://github.com/browserify/path-browserify",
+  "keywords": [
+    "browser",
+    "browserify",
+    "path"
+  ],
+  "bugs": {
+    "url": "https://github.com/browserify/path-browserify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/path-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/path-browserify.min.json
@@ -1,0 +1,65 @@
+{
+  "name": "path-browserify",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "path-browserify",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "a0b870729aae214005b7d5032ec2cbbb0fb4451a",
+        "tarball": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "path-browserify",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "^4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g==",
+        "shasum": "40702a97af46ae00b0ea6fa8998c0b03c0af160d",
+        "tarball": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 53210,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbF+qkCRA9TVsSAnZWagAAz+QQAIwA0t8wx1mP3+vbtoV9\nh6n/aXBjYMt3FfBqQCcA/TOzJgfepUJXyZYkigcgei0Xi1c6mb7CgNpgayO4\nvbbYsKjqnm9XpwF+yAEERBc33rnBMxlHro4sj41hWYdshlxVMT/62kt2J4sE\nUjA1+JXngKg4BrENLypHOz9ovRP9UkzNQMYhUFWY/LSIDiNmUz8qz54i8WgJ\n2ao8eeugSdcF/VziYhAXPdhEAh+inkrOzQPi+P/IVlVvcXVa2bmZXG5/YOVq\n83qRbHJzTVsm1+w9qcSUBfgRw3eUracjcAkner7drhtpz14nhyPs39isP/1A\noHS8sXgfVN99HuoNjPLXkJchqc+AlQV095aURZ3CJrpAFbltcGkrNwcCggnZ\nmu93RwPs1svgNGdpszvehz+9adaXXGJR8T4gIcbjNyFdKnkkunv3BuGtia6w\nNKRxIl1GqarkbjWC4FR+7qQJCRFUerP1wIU8GQaVs2DH/8yyyzAvVqOwxo5Q\nsuVmw/XyQJHtF8P01aEZpeEHVNFWixiNOSYd0iIpG93T2nudpxCE5J0E/p5L\n+yO12hyRJR3+VxPkxcmsCrXiJvNxt8q8JiIYVkD369u7CdMj9sk35DWQ18J9\nUjrPzjUtPEi73d+/XL8Ifu+lqEBlWg5UhKW6VLXEO6yIsP4sp8KMGB5kjDXI\n729S\r\n=QyT0\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.0.1": {
+      "name": "path-browserify",
+      "version": "0.0.1",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+        "shasum": "e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a",
+        "tarball": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 27016,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbKiPVCRA9TVsSAnZWagAA49QP/iOLbBrfYvj1GgPG/Iml\nAUpfhQOEZ3juPvhTed68NvHvtwXzng4X1ijYkuM7yxi4KSgv83iYut5/Ukx2\nsvOuK/VGiLV5+/KOUx6O74Ah47UGWYMS74vCcjPks28IOekp0DYXxnF4fziQ\nIdxakyS1Nn+Pnz+aas5WqOVOZn2XkN6SPnXfBx1uA+UY9sCRR5gd+EWVPmyV\n5G9ozmS0Tg1oMroa9forJC7JLfpJFGL8Bb8I3oQF9Zo8Vc9+TzgWmP79e/4D\nYukk8pyMDUVYhIFDbH2dAGTqrUiMagsrHlP29ojvcceV6fWyf/DeG6rE2Bun\nvCQHvzePRwzr+soNHJyg+Wzhy8FmsTYLPlhyktRXbYhkj9UPsfdkhpS5V1nl\nXL27WHstgmtZQoLVOPFfTGgnMg5oYt4TwC84OHq5ZUKGWYcl8MtWWklHLO0z\n7FA49pgYkF494sHbVhVLnwNfFDySUf4zQAJ4mYCgPeXyf6FaEP6EKUaq9TD+\ngfLu81jZKK93YOAXfSTxyjWO6YEmB6GhUjH7ohsivS4M+IF6tmVGa1gPl0Cn\n/T7OzlQnfJ4o4bz9WTLKThv82DnRlPuHA94ptroOrWcb+oMGXBEpG5EFpoTM\nNWC7KFFLRppndI0Xs9+ndDYWqzy5WE5wjHNT9W23R7oVDqRga/N59jsE8tie\ncQV/\r\n=E5oF\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.1": {
+      "name": "path-browserify",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tape": "^4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+        "shasum": "d98454a9c3753d5790860f16f68867b9e46be1fd",
+        "tarball": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+        "fileCount": 19,
+        "unpackedSize": 54293,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeXotWCRA9TVsSAnZWagAAQs4P/RgxM3LeL/6hBXl32TVj\nU60/D8yCL/sgtNucST9YxjQY1/Soj6eFbVhApQFKNCDkzGZUYm5SIR2pphla\nnzR08/vse1W5lt/hHHlih6Z1eq1WkipEXYpOG8K389KBcvnEANegzAEjYFtN\nAz9RP+hdxQ1gnF8b+fZKUYm5h/sIsNYHnX1KZP3ecVXoMw2OgE+eKj3LEZ1c\nRAEE3YYEnt+PaEINSfP00aDOhWuiD8ojkJVL+p/4U+MBbyopXmysjRBBOo6k\np1umLhUy/bDjng0bmCZxbSIC5ldALpKC0YafNkaZJSkmNJkp+YTXTMEgc4/W\nFpxYujRp2SxVcXStRwuVuM9Q3SR0dsgJVMS/wUB1zBEPOJhfxolUh2s5wOrl\ny8jjrTVlpzfMQZ48ie6E1KSLj2hqm0otB0zo4I4kvgut2Pg4HPugEjXpqePK\n0mUHzC3nBaswilokbbzhxQlRj9ZwdHEHMkkLc2qhT+c1FIVFWUgpOIgEbJAK\nUyO8A0jojkqCd7Mdge1easIa4E7WUN4Va3SV9z/NcaFM1DSCD0PqDv8g3TE7\n0TkrPOxe1u728SNgmdcy1huTwinhjw9BF85Ik39W67KbEe4Q7fVkp4FRD5qL\nP4EV21Ac8Wh6PALGD8hV56d618rmZ9HaJoO/XWYVfSz/9WtRCIwZznshx2md\nkwG7\r\n=fblg\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-09T12:54:32.635Z"
+}

--- a/test/fixtures/registry-mocks/content/path-dirname.json
+++ b/test/fixtures/registry-mocks/content/path-dirname.json
@@ -1,0 +1,120 @@
+{
+  "_id": "path-dirname",
+  "_rev": "6-0e82c866df669cda46b0da45d3bf7a42",
+  "name": "path-dirname",
+  "time": {
+    "modified": "2019-03-12T18:20:25.201Z",
+    "created": "2016-10-18T15:48:44.940Z",
+    "1.0.0": "2016-10-18T15:48:44.940Z",
+    "1.0.1": "2016-10-18T17:14:25.090Z",
+    "1.0.2": "2016-10-18T17:27:03.641Z"
+  },
+  "maintainers": [
+    {
+      "email": "elan.shanker+npm@gmail.com",
+      "name": "es128"
+    },
+    {
+      "email": "blaine.bublitz@gmail.com",
+      "name": "phated"
+    }
+  ],
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "description": "Node.js path.dirname() ponyfill",
+  "readme": "# path-dirname [![Build Status](https://travis-ci.org/es128/path-dirname.svg?branch=master)](https://travis-ci.org/es128/path-dirname)\n\n> Node.js [`path.dirname()`](https://nodejs.org/api/path.html#path_path_dirname_path) [ponyfill](https://ponyfill.com)\n\nThis was needed in order to expose `path.posix.dirname()` on Node.js v0.10\n\n## Install\n\n```\n$ npm install --save path-dirname\n```\n\n\n## Usage\n\n```js\nconst pathDirname = require('path-dirname');\n\npathDirname('/home/foo');\n//=> '/home'\npathDirname('C:\\\\Users\\\\foo');\n//=> 'C:\\\\Users'\npathDirname('foo');\n//=> '.'\npathDirname('foo/bar');\n//=> 'foo'\n\n//Using posix version for consistent output when dealing with glob escape chars\npathDirname.win32('C:\\\\Users\\\\foo/\\\\*bar');\n//=> 'C:\\\\Users\\\\foo/'\npathDirname.posix('C:\\\\Users\\\\foo/\\\\*bar');\n//=> 'C:\\\\Users\\\\foo'\n```\n\n\n## API\n\nSee the [`path.dirname()` docs](https://nodejs.org/api/path.html#path_path_dirname_path).\n\n### pathDirname(path)\n\n### pathDirname.posix(path)\n\nPOSIX specific version.\n\n### pathDirname.win32(path)\n\nWindows specific version.\n\n\n## License\n\nMIT\n",
+  "versions": {
+    "1.0.2": {
+      "name": "path-dirname",
+      "version": "1.0.2",
+      "description": "Node.js path.dirname() ponyfill",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/es128/path-dirname.git"
+      },
+      "author": {
+        "name": "Elan Shanker"
+      },
+      "scripts": {
+        "test": "node test.js"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "dirname",
+        "dir",
+        "path",
+        "paths",
+        "file",
+        "built-in",
+        "util",
+        "utils",
+        "core",
+        "stdlib",
+        "ponyfill",
+        "polyfill",
+        "shim"
+      ],
+      "gitHead": "ba28247b19f27ec3fa187088d6169241b223f9f8",
+      "bugs": {
+        "url": "https://github.com/es128/path-dirname/issues"
+      },
+      "homepage": "https://github.com/es128/path-dirname#readme",
+      "_id": "path-dirname@1.0.2",
+      "_shasum": "cc33d24d525e099a5388c0336c6e32b9160609e0",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.12.0",
+      "_npmUser": {
+        "name": "es128",
+        "email": "elan.shanker+npm@gmail.com"
+      },
+      "dist": {
+        "shasum": "cc33d24d525e099a5388c0336c6e32b9160609e0",
+        "tarball": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "es128",
+          "email": "elan.shanker+npm@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/path-dirname-1.0.2.tgz_1476811621782_0.25002457783557475"
+      },
+      "directories": {}
+    }
+  },
+  "homepage": "https://github.com/es128/path-dirname#readme",
+  "keywords": [
+    "dirname",
+    "dir",
+    "path",
+    "paths",
+    "file",
+    "built-in",
+    "util",
+    "utils",
+    "core",
+    "stdlib",
+    "ponyfill",
+    "polyfill",
+    "shim"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/es128/path-dirname.git"
+  },
+  "author": {
+    "name": "Elan Shanker"
+  },
+  "bugs": {
+    "url": "https://github.com/es128/path-dirname/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md"
+}

--- a/test/fixtures/registry-mocks/content/path-dirname.min.json
+++ b/test/fixtures/registry-mocks/content/path-dirname.min.json
@@ -1,0 +1,17 @@
+{
+  "name": "path-dirname",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "1.0.2": {
+      "name": "path-dirname",
+      "version": "1.0.2",
+      "dist": {
+        "shasum": "cc33d24d525e099a5388c0336c6e32b9160609e0",
+        "tarball": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz"
+      }
+    }
+  },
+  "modified": "2019-03-12T18:20:25.201Z"
+}

--- a/test/fixtures/registry-mocks/content/path-to-regexp.json
+++ b/test/fixtures/registry-mocks/content/path-to-regexp.json
@@ -1,0 +1,7762 @@
+{
+  "_id": "path-to-regexp",
+  "_rev": "261-5fbd44186fac1774890ba0813804a8af",
+  "name": "path-to-regexp",
+  "description": "Express style path to RegExp utility",
+  "dist-tags": {
+    "latest": "6.2.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.0.1",
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "_id": "path-to-regexp@0.0.1",
+      "dist": {
+        "shasum": "2383ddd9c24c6ecf8bc9e39711e3ecb37c61c4cc",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.0.2",
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "_id": "path-to-regexp@0.0.2",
+      "dist": {
+        "shasum": "489feb060b314443a5494ab1da2efed2040ab24c",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.2",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.1.0",
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.1.0",
+      "dist": {
+        "shasum": "23dd6da3e04f2a3e97ba275e7c025c918b50a46a",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.1.1",
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "dependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.1.1",
+      "dist": {
+        "shasum": "27d101134fd0fda80923cf2102bc12529841002e",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.1.2",
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.1.2",
+      "dist": {
+        "shasum": "9b2b151f9cc3018c9eea50ca95729e05781712b4",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.2.0",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.2.0",
+      "_shasum": "8ac7593477f8c321dc5a2aefffcc28e74cdf9c82",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        }
+      ],
+      "dist": {
+        "shasum": "8ac7593477f8c321dc5a2aefffcc28e74cdf9c82",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.2.1",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.2.1",
+      "_shasum": "d7e13bfc1ff9082d6723a27b54b7ae6bccbe80e3",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        }
+      ],
+      "dist": {
+        "shasum": "d7e13bfc1ff9082d6723a27b54b7ae6bccbe80e3",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.1.3",
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.1.3",
+      "_shasum": "21b9ab82274279de25b156ea08fd12ca51b8aecb",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "21b9ab82274279de25b156ea08fd12ca51b8aecb",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.2.2",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.2.2",
+      "_shasum": "605fcb541f6ae51fdd0643e00e0f1453fb56c1ef",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "605fcb541f6ae51fdd0643e00e0f1453fb56c1ef",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.2.3",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.2.3",
+      "_shasum": "b695cd2d139d3b502ede11fdaf5326c05b48fd04",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b695cd2d139d3b502ede11fdaf5326c05b48fd04",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.4": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.2.4",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "gitHead": "877ca4b845d2112150900ed4926e6dca5951613a",
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.2.4",
+      "_shasum": "5a56488dae6f4ddabc401729a79e3bb829db9dc0",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5a56488dae6f4ddabc401729a79e3bb829db9dc0",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.5": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.2.5",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "gitHead": "fad140982d9baddfcf398bf7ded44b7cdbb7cf8b",
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.2.5",
+      "_shasum": "0b426991e387fc4c675de23557f358715eb66fb0",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0b426991e387fc4c675de23557f358715eb66fb0",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.0.0",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "^0.3.0",
+        "mocha": "^1.21.4"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@1.0.0",
+      "_shasum": "6fc04df3f802bcb3e76ef65ec75de2aae38f4a26",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6fc04df3f802bcb3e76ef65ec75de2aae38f4a26",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.0.1",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "_id": "path-to-regexp@1.0.1",
+      "dist": {
+        "shasum": "0b87a97d09ed6c301508e710272852b24360c8b2",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.0.2",
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "59cb06498efcba7f7b73608fe675ccc663b660f2",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp",
+      "_id": "path-to-regexp@1.0.2",
+      "_shasum": "293be955eabc0504906e0f9e129dde8ac111a21f",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "293be955eabc0504906e0f9e129dde8ac111a21f",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.0.3",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "a76d908bf45b1534f10701bc5ba0f40567097274",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp",
+      "_id": "path-to-regexp@1.0.3",
+      "_shasum": "eea5a32cf82b7141d4987bfe7e0557990e2d260e",
+      "_from": ".",
+      "_npmVersion": "2.1.17",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "eea5a32cf82b7141d4987bfe7e0557990e2d260e",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.1.4",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "gitHead": "66f8d3f63541b176a7aadbe69e0cd9f78fe206ce",
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.1.4",
+      "_shasum": "65868166d96fd548de3bbe7dc8e8ab694a8bda57",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "65868166d96fd548de3bbe7dc8e8ab694a8bda57",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.1.5",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "gitHead": "fa40b5f34d507a7afdef9dc8ae78f847801e05a2",
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.1.5",
+      "_shasum": "a81f223d192e0cc6a92ef619633cae1fede52c5d",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "1.8.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a81f223d192e0cc6a92ef619633cae1fede52c5d",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.1.0",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha -R spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "c368dc9a90ee0e5b8cafb9f8f25d7c86dc8bca16",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp",
+      "_id": "path-to-regexp@1.1.0",
+      "_shasum": "40c5a8aed1298e44e097b8dcbd2d2697b83d89e8",
+      "_from": ".",
+      "_npmVersion": "2.8.3",
+      "_nodeVersion": "1.8.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "40c5a8aed1298e44e097b8dcbd2d2697b83d89e8",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.1.1",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha -R spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "5ff1028cca4fc7440bf56f44451052ba67c215ca",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp",
+      "_id": "path-to-regexp@1.1.1",
+      "_shasum": "8dd70fdecb4da27858aee1e5e3b6f0eda8f45a35",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8dd70fdecb4da27858aee1e5e3b6f0eda8f45a35",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.2.0",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha -R spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "7aff887e73ee8bca5cc98ee6239616da07eb8523",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp",
+      "_id": "path-to-regexp@1.2.0",
+      "_shasum": "81da890cb13bacc657670e0cfeecc90fd703b387",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "81da890cb13bacc657670e0cfeecc90fd703b387",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.6": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.1.6",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "gitHead": "41abe347ea83b203a711856df51c50a51deb03a2",
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp",
+      "_id": "path-to-regexp@0.1.6",
+      "_shasum": "f01fd5734047b6bfbc5f208c6135a33d7af09c36",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f01fd5734047b6bfbc5f208c6135a33d7af09c36",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.7": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "0.1.7",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "test": "istanbul cover _mocha -- -R spec"
+      },
+      "keywords": [
+        "express",
+        "regexp"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/component/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "gitHead": "039118d6c3c186d3f176c73935ca887a32a33d93",
+      "bugs": {
+        "url": "https://github.com/component/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/component/path-to-regexp#readme",
+      "_id": "path-to-regexp@0.1.7",
+      "_shasum": "df604178005f522f15eb4490e7247a1bfaa67f8c",
+      "_from": ".",
+      "_npmVersion": "2.13.2",
+      "_nodeVersion": "2.3.3",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "df604178005f522f15eb4490e7247a1bfaa67f8c",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.2.1",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha -R spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -R spec",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "484d7a85329fa5f741fa7bd1d6272fbdff00448c",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp",
+      "_id": "path-to-regexp@1.2.1",
+      "_shasum": "b33705c140234d873c8721c7b9fd8b541ed3aff9",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "b33705c140234d873c8721c7b9fd8b541ed3aff9",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristian@gravityonmars.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.3.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^0.6.9"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "b6a4dd1216e5ad6ca93944fef4987d4b96499bc1",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp",
+      "_id": "path-to-regexp@1.3.0",
+      "_shasum": "b32ddce482da48876c3e5677447b0213e694c7b8",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "b32ddce482da48876c3e5677447b0213e694c7b8",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristiandouce@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/path-to-regexp-1.3.0.tgz_1462745824858_0.04041688865981996"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.4.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "27d8e89b77fe9c8dc51ca66d6196cee5b7842a50",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@1.4.0",
+      "_shasum": "0820f32b4d2338cbbb8a12b614d20ad59457a4ef",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "0820f32b4d2338cbbb8a12b614d20ad59457a4ef",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristiandouce@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/path-to-regexp-1.4.0.tgz_1463636268107_0.9229077105410397"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.5.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "f6e1b2a5185f932b70e1f75f24acba5caff008bb",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@1.5.0",
+      "_shasum": "c38e7efa3c00dda2e61f41addf74babbbdb69ca2",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "c38e7efa3c00dda2e61f41addf74babbbdb69ca2",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristiandouce@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/path-to-regexp-1.5.0.tgz_1463767793397_0.14544912171550095"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.5.1",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "d933b45c24d79d58fc808d0580fa092b7b9300b4",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@1.5.1",
+      "_shasum": "625f98affdf68b3df2191b6a0fd9dc922335db53",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "625f98affdf68b3df2191b6a0fd9dc922335db53",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristiandouce@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/path-to-regexp-1.5.1.tgz_1465400064074_0.8880169179756194"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.5.2",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "e2470a5ab8fd18b3c21b8d61bc1a2c4fa63b5110",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@1.5.2",
+      "_shasum": "97743e23874d7a85f22807535389f1e1aa12280e",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "97743e23874d7a85f22807535389f1e1aa12280e",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristiandouce@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/path-to-regexp-1.5.2.tgz_1466042132651_0.36399424890987575"
+      },
+      "directories": {}
+    },
+    "1.5.3": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.5.3",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "7bbe1ba23ded0848b1d10bcab7504a127359a014",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@1.5.3",
+      "_shasum": "7221ddd42483538bddf9fead942a79ff3164f57a",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "7221ddd42483538bddf9fead942a79ff3164f57a",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristiandouce@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/path-to-regexp-1.5.3.tgz_1466048195033_0.6013146284967661"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.6.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "bdf17de3dfcf62b410e7cab15998c6e32361c7f9",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@1.6.0",
+      "_shasum": "4c59cfeab5e360a2657b180730a4bb4582ecec5b",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.5.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "4c59cfeab5e360a2657b180730a4bb4582ecec5b",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristiandouce@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/path-to-regexp-1.6.0.tgz_1475519937646_0.46747635514475405"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.7.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "a99ec3c149e8c1d91fa533aa54d3ee7e34449bb3",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@1.7.0",
+      "_shasum": "59fde0f435badacba103a84e9d3bc64e96b9937d",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "shasum": "59fde0f435badacba103a84e9d3bc64e96b9937d",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "anthonyshort",
+          "email": "antshort@gmail.com"
+        },
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "calvinfo",
+          "email": "calvin@calv.info"
+        },
+        {
+          "name": "clintwood",
+          "email": "clint@anotherway.co.za"
+        },
+        {
+          "name": "coreh",
+          "email": "thecoreh@gmail.com"
+        },
+        {
+          "name": "cristiandouce",
+          "email": "cristiandouce@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dfcreative",
+          "email": "df.creative@gmail.com"
+        },
+        {
+          "name": "dominicbarnes",
+          "email": "dominic@dbarnes.info"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "ianstormtaylor",
+          "email": "ian@ianstormtaylor.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "juliangruber",
+          "email": "julian@juliangruber.com"
+        },
+        {
+          "name": "kelonye",
+          "email": "kelonyemitchel@gmail.com"
+        },
+        {
+          "name": "mattmueller",
+          "email": "mattmuelle@gmail.com"
+        },
+        {
+          "name": "nami-doc",
+          "email": "vendethiel@hotmail.fr"
+        },
+        {
+          "name": "queckezz",
+          "email": "fabian.eichenberger@gmail.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        },
+        {
+          "name": "retrofox",
+          "email": "rdsuarez@gmail.com"
+        },
+        {
+          "name": "stagas",
+          "email": "gstagas@gmail.com"
+        },
+        {
+          "name": "stephenmathieson",
+          "email": "me@stephenmathieson.com"
+        },
+        {
+          "name": "swatinem",
+          "email": "arpad.borsos@googlemail.com"
+        },
+        {
+          "name": "thehydroimpulse",
+          "email": "dnfagnan@gmail.com"
+        },
+        {
+          "name": "timaschew",
+          "email": "timaschew@gmail.com"
+        },
+        {
+          "name": "timoxley",
+          "email": "secoif@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "tootallnate",
+          "email": "nathan@tootallnate.net"
+        },
+        {
+          "name": "trevorgerhardt",
+          "email": "trevorgerhardt@gmail.com"
+        },
+        {
+          "name": "yields",
+          "email": "yields@icloud.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/path-to-regexp-1.7.0.tgz_1478630327407_0.5980636477470398"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "2.0.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.0.24",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.5.0",
+        "standard": "^10.0.3",
+        "ts-node": "^3.3.0",
+        "typescript": "^2.4.2"
+      },
+      "gitHead": "c98ca8d46a807145933d0bfbfe63a79bf0aa20e5",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@2.0.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "integrity": "sha512-DPZblKdQsbV6B3fHknj89h6Nw/Z5zFK0nFX+DVN7y8a+IUHf9taJWvMK+ue0+AEjXrke0KVRCcfm2pOYGSRk8g==",
+        "shasum": "b77a8168c2e78bc31f3d312d71b1ace97df23870",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp-2.0.0.tgz_1503527454886_0.7450068956241012"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "2.1.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.0.24",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.5.0",
+        "standard": "^10.0.3",
+        "ts-node": "^3.3.0",
+        "typescript": "^2.4.2"
+      },
+      "gitHead": "42a3869820a8a02f4545c6b9c460175a983eb6f0",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@2.1.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==",
+        "shasum": "7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp-2.1.0.tgz_1508521635899_0.9024346047081053"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "2.2.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.0.24",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.5.0",
+        "standard": "^10.0.3",
+        "ts-node": "^3.3.0",
+        "typescript": "^2.4.2"
+      },
+      "gitHead": "3cf45556002978802ed365d81f7fe1b6487703ff",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@2.2.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.6.1",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "integrity": "sha512-zJcOPeBsraLjWXwUzFMPzH3QO2CmO1yRggtADPJjOTyCF5csQxfUGJL+CbyyRvIS09wOipi4F/fgRhdmVGSwxQ==",
+        "shasum": "80f0ff45c1e0e641da74df313644eaf115050972",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 26717
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_2.2.0_1520402693889_0.9584686736657209"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.2.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "2.2.1",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.0.24",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.5.0",
+        "standard": "^10.0.3",
+        "ts-node": "^3.3.0",
+        "typescript": "^2.4.2"
+      },
+      "gitHead": "ef07df50699d14659e672740643f905e2af252aa",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@2.2.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+        "shasum": "90b617025a16381a879bc82a38d4e8bdeb2bcf45",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 26739,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa3z6qCRA9TVsSAnZWagAAasAQAIahXJ9o/eNTV50kUK9Y\nFKt35Fu/QDl8MGg3nEXTk/5+RbPO+zexPHAbpIR4wgwSgq8MnCe4ZjpsmWiI\nzUNLQTK3ampkqRwN7YEyPzdXsqr9lmeH2DZJc+Q5m3dyjYt79QvtGxB8H0ND\ny7vkyL7vjEdVY6s+cPNeiZcEJsYLheMBE+X9W9oCogkpMThmxjcA4g0f3obi\n5YmUo0k2PGtRrGveUM9TmCQ1vk8xl+RMt0Aull+BSFgyfTDjoOcGeXlClXBH\nJqDRkXssQcGKne34MiyYNMHAe+A0RQYpisEZF8q4kjAXSi3IRq4P2MhQ1qIW\nbA1oqXWtolEFtvSz8sLIok1iO0HnNmBwzmpSEkjClhbfD6HkicZ4eboyJXOI\n1VqiezHpDWzO7u6KuFHrszHwwcqUHZTDrHt51b4XWlMqBr6IZFOVgK7eb2QZ\nAgwQjHobF2FpwNpSD+hWHwSDxT+F5JW63F5guM5UwjEKIfd4gCh9WbB1Xxpe\nkhBIYOGjaIBruLwKVqrsXIIEaXcwryQzBNdyn2baf4I/N8iYU5fa1YyGhi2v\n1EjRiRMjow1zdHanwXI87roqLxTfHP0UiAdWCiIGJuguuTYkTW42s8iWx1FZ\nJyuAp7ISKecAMHhDCM503GVTt40UeA2ot88fyWBgS7FZpd9izFC0e2fiET7r\nRK5R\r\n=wfap\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_2.2.1_1524580008999_0.38909645986389574"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.3.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "2.3.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^10.7.1",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "standard": "^11.0.1",
+        "ts-node": "^7.0.1",
+        "typescript": "^3.0.1"
+      },
+      "gitHead": "205665e451521270825ac5d74273e70ed5e8c7c3",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@2.3.0",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "integrity": "sha512-wWRwboLa//uIppXIodKsl+qe4zAUNHwGBZUIkc32xR64fcSqGXCnxEZ3Fyl8M2muy9fq+mv2BQbFmZB3hZ4Bfg==",
+        "shasum": "690d682cb9e2dde26d25f41bcc2b4774b67d1fa2",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.3.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 26981,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbevT7CRA9TVsSAnZWagAAIRUP/0cX+zVisA0RDZ/oJbh5\n3uNjXGY5PNftGlb0AJzTXW2YKVCwJhaJ68ERv7Nh40KNlxhcQhyD1DivQb6C\nkEtnBJ0x8cNP86wAahpFQk5h8hZdgeVnsjnTDRWyjDEmp2mKB9hDrb2pTmkU\nq0TtMmrqKNTE32B9Cng72fJ05EO6GImKURk9KXJqp+fYustQK22HHN3LyNQV\nST9XMfEfIpYjzr65oiq11ceenU/+jrHinN79QN5JPsSRaGcbEYLl5+NeyqmM\nivenbIbmNIYaN7g23aR5QJ/XTmhcikFXoifGVD+gdT0msLNNreJDRzEJt6VF\nlQnj3XfqHWhSPVtZ7KHCiOYhwtD7YLpX2bdAYftW1Q53wnEnjoY7Lfxoqd1e\n7AtnjF6MGvEEFK/FHRHO+ao3y3f1FOj6yL1zJe+EK1hrEOuplPMqMG8HsiCg\nFEcTm31nw7ciwi5Gi6segCle0frLswKYRwYFlY6cc4Te0h6cFRv6sBN2CvRj\nsyeQ6rR/wl4zHFeA7jiDUyOYyTEfyqSQfsB8WjHhxLkCNtBjTfRygu294qtI\n166rKoreU72oNTIvozalQwmcc272RCeDLSruy7MY41LO1DKZhohYWoeyLCG2\nEwFYrQryVaVSQJyUtXI59XQBZAGDBML4yM93y2RQpq2mddIfQNpBEiO2YuTo\n1Dd6\r\n=18IO\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_2.3.0_1534784763241_0.8078344441228074"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "2.4.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "files": [
+        "index.js",
+        "index.d.ts",
+        "LICENSE"
+      ],
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^10.7.1",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "standard": "^11.0.1",
+        "ts-node": "^7.0.1",
+        "typescript": "^3.0.1"
+      },
+      "gitHead": "bcba87cbd47d8aa3f826a88a7f6ef5a77072c71a",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@2.4.0",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+        "shasum": "35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 27372,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgz5cCRA9TVsSAnZWagAABV8P/j3O5fXfCEuI/D0M4ATo\ny7iDPQB+jEO81v7UbtKjca0IPpr/n1fkcX55Mr/wfzWlksctYk+EbwDVsole\nJAuXy05mirFkPyf78lid9YHnaFnSMUaNlhIz5kkABhPmH67DCYVMdZp6Gtys\ndUIxu//oroXDVd0Z4mmjkUfiToVCDD67uMkOxsJ7d2smR5XMhXfPtl4zHSIL\nJshs1jAuYXgz+zeYfkhMgg1owUqE74ueXORKEqmk8UUT6CNjaxv6tIfqv4DI\nkGnX+oIDOJgw8LaojqAV1sSEDWtD8AnnA5/DeQj/ADhIiLG8Yy4JVPdL3Mo9\nRpsRA8SYetpc3y49uLmlYgXG1A3ayR6RIBmqCWnU5hOrQT5p8kZmvlmRvSL2\nGDrfBW2WdvIBOzZTsOX6nSAg3w7C7abLp/MO1PeanXxmIXQKQ/oAf3asH35U\nJmEYT4Rf6kKnr/JlaweClhyvs91gJgMwSlO/MDeB7tgyFDjRwDJicVj9ue0H\ndYavvdZmr/CO7j4Zfn4ryaY+N4Ao34Ooa563NVj/At40n2HeRYCtik3CONNM\nYvuHwahO7h2limYCcrhTJSXuJ59HQiLedKL3FpYbCwMgGFPmw213GOIAeC+a\nbbZjYpP+fYLZGyxFdiaUwYpfkVkEE08q5zfX9pe7AZffuoqhUsJAH5kl6Nne\n56TB\r\n=8dfi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_2.4.0_1535327835872_0.40146254949467464"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "3.0.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^10.7.1",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "standard": "^12.0.1",
+        "ts-node": "^7.0.1",
+        "typescript": "^3.0.1"
+      },
+      "gitHead": "796f3fdae1186f3ef7afe029555e2b141ab9ece7",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@3.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.0",
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "dist": {
+        "integrity": "sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A==",
+        "shasum": "c981a218f3df543fa28696be2f88e0c58d2e012a",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 27504,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcO9hnCRA9TVsSAnZWagAAGzYP/RwVfwRM8T3aUyH29j8w\nKM4wjV6nOOS0TQXCl2U0ie1Z+hwv7yt65YYmvsuagF1ZbGtpXam7sVUUUfwN\nEudiEBap9ghQSRu1lU2CxDU/pkJm1lcuHgHs/nDyxkTGOeNxs2gqVnQlRNZU\nFaTui+RZI0710WUW/44hrAQj3Cvf3CKqxJUXjaO923kcSqaZAvxPPs+8FYsC\nKBMmddzrLbDBHCIBhQ+5BcDeLe+Bd/eQGZdEDWNATOX5Kngk3fG8FoW6Ejpi\noosNai0Ksr132rL8ZB50niD7Phx/FYchqyePghtG8nIrLxBcmn7tj2M+4Dw8\nydLnfPj5hova+YU2jTCa49HSmx9bgf4UW8Hcj8OcenMRJytq2rvAVp/W0lCA\nbyPuCA6zd/vtsGI6dtjZQ/juXt1udDusXAy8aytZaFHHIYd2Ru9e2SBhNDpg\nvsleLA6/pZHQFz+HvXgsdJrOD/oVY5Ka3UzuVzCUYyvdf2hJpjppY8kpvbWN\n9wHS8dfaDlfOh10NzVpsAF55+whxAExbjmC6i4+vr5gaahtQRPve/OZdVZnu\njPASkQ6D5b81DkVXjLJWpxs/VKlmcHVU1yTsK1rAUfQal3keBJ2dJ7XAPfAu\nPhlecsczU0JVfT4xeZDHLljtB0f7B5McI9xseJRIB42iClOgn4GQ5DwDxrYM\n8OiY\r\n=bFfL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_3.0.0_1547425895290_0.8013668208927054"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "3.1.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^12.7.3",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^6.2.0",
+        "standard": "^14.1.0",
+        "ts-node": "^8.3.0",
+        "typescript": "^3.0.1"
+      },
+      "gitHead": "f232e6d3fc256fc4def7062c7542c4230c6bf6cd",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@3.1.0",
+      "_nodeVersion": "10.16.1",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-PtHLisEvUOepjc+sStXxJ/pDV/s5UBTOKWJY2SOz3e6E/iN/jLknY9WL72kTwRrwXDUbZTEAtSnJbz2fF127DA==",
+        "shasum": "f45a9cc4dc6331ae8f131e0ce4fde8607f802367",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.1.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 28721,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdafCeCRA9TVsSAnZWagAAQ+gP/3pV6hwCl7uSt6t6LqkL\nlMUXgsuFfS4qWWC2hfOuKKCxs4wvBHRG0f8oAYNYDMptx6PjYycFt5GfgBM5\nnlnJH1J76IAz0NeqyabMpyqidMO9KO38EXCDAB6s4IO2ihUUZlP8xk+lHCWg\nGDGOrrtnfyi48Liwi4R7Iiy+yJ1hvD9DlzwSXhOyEmGXOVxEA0e5e9R9xRF/\norwgE//Th0F3WmA/Vfrox75JFg/KQzcFO30Rgj+Bjz6csv1aZXgChFKAxBMr\nVPwe2oS6D57a7clWslc5kZWHGa9s2jup1KjXD54JGwcGHp728m+j14UpWqr6\n20KXh78APgZxdeGVQM+cA4TjI+HV71bzJBrGUOYS9pHb5ncFi/BaBA1Z3u8i\nzAsZLvzXpcgdxFHNtDwUyPNWLTsOw//xft03zIxsaNxwtp6MHEBufoIumYBZ\npFgxj5Ze540moQ0bFz6w5KRFyQWmbJ0DqiCWKSGXimWZPrzlgFMMSGgAhaGS\nFWXeCLiu3kgTFnk6hLq1+1ikCIIVWaxYz+ZBopbbhHfx+qAIIMpGopfXkH2v\nOUO7l08WysJ1TxjZqqfdz3OwWiYBgQtIqlkcwDKHz+wxQ9TB4HlZtJkQjTmd\nVDwx+3Wcz1eJ6EPBw3dto/SsaOOJL2BlI5Hp7nu7tUQXItqyAVn4K3V8dRin\nfyqj\r\n=O2zj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_3.1.0_1567223965722_0.9583692105528006"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.8.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "1.8.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --require ts-node/register -R spec test.ts",
+        "prepublish": "typings install",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "gitHead": "79a5dcf5f2a79a99fbaaccae20cd922a745e0f83",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@1.8.0",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+        "shasum": "887b3ba9d84393e87a0a0b9f4cb756198b53548a",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 27719,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyNdyCRA9TVsSAnZWagAA3dsQAIdx4UYMUcXZ1jWemWIa\nWmAfv/EDjN9NRragvEchvin/p8JzhVM0eKAyDoHhNRD1gbvDr1JYNmVLap22\nyFuX2+k/KrQVPjeKDMrwpUMTuhXpeDFes/3F/Usu77tVy/0hu7noqKSYQSkK\ngIsJwnm4DZYGbMR3HicrY8scMsCgs3cD+6W1w0qljkbITnQnZCq4jtYHWVV7\n/YoenidG8WJ++wZc0uoELm9QTvRheprKcS6Rb4T7q+q7ElgGBpCLX9RO2xc8\nmPyOqa8RU2SoU4rMe1naIAcwwKrdg8xUCQ06qsZ63Nm1R9ciV9vcppDFBCMv\nGSOOIUAz517UPaKMi/97Blh0wxIIouBxWyKQqEDTd2P9jn0lPJ6rg5WR2+RC\nSpKjxLVhIj6vFUHYqEUN3CwYGdDNkzkgMutdu/lmMePMKXWdswfZux+9/A/h\nfGEomo/H06/8i5CxQl21Ks1Z9fm18beWgmp2m8UCzFxbPSsiztwlefL47LVr\nrkp+jB2sh6m3a/zum+LL/cmBsFskEPu3vghPM4ZWrhqGPY/anywauwHaoJH8\nyDDHJ+zVykS7Tq+rCLUsUcBMealHWneDzEqmfrK4MWbTN5njglM1niaTTheT\nXlDzR304qD8CO0rS+zZpWyA9EZzQvEIYczS6d0VOQ53CxrcVxYcWpfFmf4HG\nlj0T\r\n=EPuP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_1.8.0_1573443441622_0.7685358585219755"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.2.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "3.2.0",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "lint": "standard",
+        "test-spec": "mocha --require ts-node/register -R spec --bail test.ts",
+        "test-cov": "nyc --reporter=lcov mocha -- --require ts-node/register -R spec test.ts",
+        "coverage": "nyc report --reporter=text-lcov",
+        "test": "npm run lint && npm run test-cov"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "component": {
+        "scripts": {
+          "path-to-regexp": "index.js"
+        }
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^12.7.3",
+        "chai": "^4.1.1",
+        "mocha": "^6.2.0",
+        "nyc": "^14.1.1",
+        "standard": "^14.1.0",
+        "ts-node": "^8.3.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "6d2e8db0f1260921c63330c006f3b9f492b69aed",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@3.2.0",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
+        "shasum": "fa7877ecbc495c601907562222453c43cc204a5f",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 30871,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyPacCRA9TVsSAnZWagAABaAP/2X5SbiKS5o0b64IySTf\nK204AxDYUqid+vRNnT4j45OhKsoAS+VntbEyuRbTtHVDpapk/suuSL1z3hTl\njJwh6uM3/Aocd3G0/g6wlk+mzv87OEn4zJi+8BzGY3G31Z1W/2mKmSfx6QiY\niWYFQiM9iHWRWa3p0NqVV7cJBdh/hPYO9QgbmSauGryttAgWazq7Y2A6pOK4\nMlI5LVxXg42ajWAeApZRn2hFgCPQJOo8JZqQjuMt0Ffkpg1olEinqPRNzZfW\nETIicDxby9aKcDt4+WrQumGP8vLhEa/VbmiAdNW09WI/dMbinEpUeJQVfUxq\nTgc5MEf1J4sJAuitB1KzeUh60A2FphhLZvQoxjrgIF/qALQsjqyC6zv1MRhc\nqtjrNEw4dssSHlbhQ0VNddxoUWJ/4nNGSdhy85dvJsd1e5RX73JvoSrobuL6\nwAjz8isvsfo5VbuvOvjazIskU6T2ryMEUapxhwXGOiPHm7N9japL35o82d9p\nznbawukAgffBDHHPMJfyMLRZHYxnB9vFjoa/TdgJmZdwTD51CAMnMQy/hYVG\nnLdWbXCfkSCqHyboy+uDe53SBzBfuX8MoWB/nBf+KGmpvDRvMVrWNcYq/FW1\n7IGM3QJG6cSTuAZUyPFEw1VgcWsD3bP2OX5xTsqLJIWmWwHz3emA3ErU6YCN\nqbqx\r\n=CVMO\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_3.2.0_1573451419958_0.8282791889622563"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "4.0.0",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "1.7 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "38b42224a57199969197a2662ae34b8b3ebba1cb",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@4.0.0",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-WePdN1ndXgSWXXWrmKJxLSlazaMPeW8UYVQ63NDBHikr61eNUGCJrCEemfaQLSxGHzqzcu1YSlZu7CqqWh2Lfw==",
+        "shasum": "58768f48b2697004b12b3e5cd6bfb339ae8e7eab",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 470372,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyic8CRA9TVsSAnZWagAA5w8P/jqHH0zIaNeQgKuiUxTb\n0l/9+559VQxZLgBxrvWRVXpt3L1Yy5TjkrY3Z/O5T0te/hcaSrgJQIxaDrOk\nIQS7RjtP8qMCaN4+Ys4V1+qS0WmWSnDGv32ndt5NXOttMCLsfl7McYXniHh2\nZvXXrwCSYQQ1W7iRxjscKDgfw3Jn+fdk6a/79B1akfBRU/hAleMaYlt4Wrc9\nR+xUgObQQnm0IJDN0GapZpOPcJPjtejfHIjBN/8TwFbcFKYXb4iBYEert3Sc\nONd/uiY61rTiHtFiGcIDTUO+3vjuBQgcBqjAAl450De2g0po3OF43LZ6Sa7U\nkfjSswQrXrwJ8n3EFXARFuQEP1jkHG9bEWc500Rk10obHgabqq5zuFJTjeRi\nLOCYsg7KE8/uq8VlF94jjyBnXUYW2OzvZCvWKC8do5sHkv5KQsUwgY3HO8CJ\nDmpUzKsoGJzWONFLUHwlmn70/30DZ0xf9G0rTEev9C4CJdlIP+B3L5wqJf83\nWOrrOjt3NdvuqYaHLSQN5yvD4zX10i0OHJ0oFvDG+1LKDKe0AH5RqPVVhz2e\nlxic3riThY/rQRg5LJKUIL1faLMxRFKkJZt9Q72mlm9o2P4gbCCI1fEZF/3Q\nmZ5YAqCuSSjBe9RvfLqH3HsmQtW53oEcFIhAqenPPhSzQF5FR6EaPAvMvfzG\n0hwx\r\n=lrUd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_4.0.0_1573529403845_0.050478772222488644"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.1": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "4.0.1",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "1.7 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "6e55e15e49b3a6a55680fa7e31ad3a01435d3c94",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@4.0.1",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-gdAzunCn/o8fI5Fc1M9Ri+qgJSLKKEbfkoDij79QSOsRQVK/cOlWxzSlYJqLkGo3YCLm9ECDxJo53lWEVSp+Ug==",
+        "shasum": "119a9a7f0aa0b8f7048593ee0b7fca1512460caa",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.1.tgz",
+        "fileCount": 14,
+        "unpackedSize": 470372,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyjBWCRA9TVsSAnZWagAAtp0P/1EOxUnffzxiiDW7V3b1\nDZ+KsqnoaElDOqcfNK61MghxqXc70cTWm+UE/vvFHTF4G87s9NjS763ayutO\nS+9xB7puOFKAmp6b9tTbZlZF1I1vp/Bp8b6aFTMajYYH/3AUWf0KcqQOXjzC\nPuz4MOKblBJqWxGJL2AaVBG4fmiKLFf9mnaGPbQfwH26fZ0JMSF5rR0BItKP\n1pMmXY+574ADjwA0pBuu1xfFsmoYtNHjvPBK+zqIRdQybVdVDW0XWs+eLI8c\nTG5aTWJ7HJOXt2UA9uH8UyzRqwKbBsfIyCxfo0NukzOkbpt5AmNILhtlDXuC\nLOa7iqWeNMo/t4hvaxuM6yCpfQYHnq7BBL7eVYIYGV0xEz4lnb3WBoKwZsMx\ncTSvRBDkNJ9hmC9pvNFMl0iVJQ9dOQ3nsqoOPioIEsWGplSJJD+SPNs/M4SX\nxdEECMz7sMllpfFB5Rhyq24NefA1vX5q9tfp8UIdrjIzFYJahXYT+H1uPtXr\nD4Lt0iQ/rIe08osFtwC9mbSd/V3MqsN5aCyFJ6/qpmt3aqJvyAyxf49gREM0\nApGwxyOv9ZcIFlnMMvsxIIEvPXJatQOKoR2K3ScC0z2acFzZJYn53nGmbi2n\nDiM+jKvWTes7HxnVMuUsVkC+9JsE5NGDyZ/PM76w0un0J2yw6Wj/Wl2UmIph\nUqxB\r\n=5NM0\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_4.0.1_1573531734121_0.2668368456285348"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.2": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "4.0.2",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "1.7 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "a1ae34664db835385f777cb819fd6f673660d919",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@4.0.2",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-HsWwoyYDDkKyd/4Plv5Obcqxi1xXhIrG2LRdyX07yAIarSD/55itj/Y/SajVHDtRiaNIwsuujnOlRj5MFXd0Tw==",
+        "shasum": "c1f1508056be0c77971343e82f598d74830b3597",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.2.tgz",
+        "fileCount": 14,
+        "unpackedSize": 470420,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyjZ5CRA9TVsSAnZWagAAHRsP/1QjXEAj2jAHVvChWqSh\n0ZZavLdrcf4vud1oTINb/miuzVGm6bHXH5sTXykIKet9bWvNxNmbsKJnlDzP\n5qPsOe0jclcWEzX61+J5VdoIf4FTRGiPBf25ebsNWTlA3XgN1pkmTB31JDs8\nOI9txh4rzNun2AS0yKlH4+xDaiyhNkeRc1jpaR7oxhGGUE1CykDhg0+v5uAD\nnQqo6If/sYWZR22qxJf72nSicQuO40XRQ2kmc4GB6loU2YdHz8amtfXHqyJr\nSb8l0fjK0g+f6NR+7OL7krmLPqQBC4lH8lhBwMHUYx6twMTq0w7mOl2vnsHB\n2j0DHK5uY2WASpfo+9J/H9bGKds0Gh1gM7FlWZCe/56nnH/gVkxWF6ZcCiNk\ndyprMBa/BMrFjS2jda6hYHFInsxY4wDLGbYK64Va1l5uVS0/5xYJk1AvYigI\nNhWwl+EBxRlJbaIvJIQ2lyRyqwZRfW627lDxLdBJz72I1fKRu4kZqFJTODkB\nSF7CobpEG09v4pF0qD6QX9Di6cSO4/f+CQrEkIDpgM0QOoVOqQb3X9qSc5cz\nHWkP9QP8Wi0kMwGmRIJ8rnAgkGH7WLCzpawz7AAt0l7ls/U5rXlyY+xVL/nF\nBhvW1z5ZxglJe8ycX488jwQoquTYmsqksylPHT3r0Krr8es871D2tIe7Jdr/\nNSgZ\r\n=URSE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_4.0.2_1573533305237_0.37981372358406484"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.3": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "4.0.3",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "1.75 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "2ae4d25b54842ba471f054a173342a404e083e7b",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@4.0.3",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-JkDr0ji2zsBqaz/+X7WDpRM73y6m86Eh7Cba5zgY/bjFpeC9vprRFGptsXjJD7EJqwa7W2ESQpdObm0iwVpKWg==",
+        "shasum": "5b5428d180b0f115ad438e1ef010e63a0a25d7e1",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.3.tgz",
+        "fileCount": 14,
+        "unpackedSize": 473276,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdylbqCRA9TVsSAnZWagAA1GwP/102y3vEUHUt9Qa5Ieas\n5sZVHkt+lnWkPpPTM6Dx2g9NGyjw1HMDPOVsV1KrXc7nF5vxfi3iS5CF4CyH\nHFMuZbVZf6yaxy67+nhXwyzGP5rppCE2zbss9LA1y7gm7AJE2XVQTsyJO4P/\nUS9F+K+wyNF6zBIgmGSdsZeKZatFAq7adGLnSo8B6gUnun5L23mLfv686aNy\n7FaDBBuOwbotQibSrouPr9d1Uyh6W2TKHyUVbUi8tBqn5z8wWES3bUhlUbKS\nKZL04DK6d8jPYkA2CD1A3zO9Mo4VgnRben08kd+jmOkUu+k9cYIw3BM3wlG8\nMevHIkSkANG6HEtkz+zXuYgKoYGNx3f3QuUK/HXK+UO62vAjZuTHwDkPd3Dm\n6uZ6WVIUHUtiJwTLQNyaewrP1I2YCsks0eB/Nb/nAMCu4YV7Ptu8SfxpYudp\n5cPQAy87MztWk4HHkcqDQOBQI5mBSwsVIYFi6IEgr0DQrRTa/c1nuop/FT+u\nn9BXR0wWNssN9rv48axhmr1KgpUuDhrhQbs9rpsaOOy7CuTj9XoUjRwdqykI\n2kv/bVygNFSxYVwx8r9tWILcG1cXXaWvEe7wqh26FkQHKokVnBcOSj3xkGy8\nWZJckTeZAtkJLTYglGSVBRvByiKtXIxdwcxOMI2mpzA9JpIn2tUSa8TMXX5S\nM/eC\r\n=IBbz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_4.0.3_1573541610180_0.7153787923908863"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.4": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "4.0.4",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "1.75 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "f9bf1e06636a3d745b917c9521a94b5b1e2eaaed",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@4.0.4",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-Nu0+EVkG5T0wEqDT2roshNDnfoB1DS8q737dczIg+gpxt3QzxfLXi0oiuZso98IQrug9lW/anwi2+dTtrYngEw==",
+        "shasum": "9c0edc5500cc976d8e5f2520bf8722fc0b65019f",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.4.tgz",
+        "fileCount": 14,
+        "unpackedSize": 472934,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyl0gCRA9TVsSAnZWagAAzpUP/iZcZznRrg6jWnV9BSfZ\ngFQR3ONw608moWEXDwmcnAzO0l22PkytnYfvQP0CYIHq30agPwBTQt5e3OCi\nJDAdTQ08yj3lOD/C/wfTFLCAUIkCBVgOZsf39T9md7M1Kz3NB9zI0ajtbsQM\ndTYBB05t7SKcPFexT0yeTenV8q8VZ+pg5iGtpULSV5mlDzUFOHm9wHMJ39xW\nk3o/xWEZilQT2V8YsetoV/KJNvtcS/kFVpwNwZWJsutdbYxQmjy1AGUmngos\na/58QEdQRb89/K5sG0VtZqghL/bE3tAwI6VCcaj/FemGtGfRxczbkI29XN4c\n9PTGDabZLfotU63GSR+DMd2RWEJuWBpvV8L5/tnBMbxF4BKU0Dc1Jj57AA5E\nDsEk370PUV3EUa4MF6SUFaEd3rz3JtL6hUdEf7cbsOD3q3uq8RXznNS0yq+b\nzvsaC8N1czZ9WT4Zqyqdr1sOlfzmPgaj5FCZ9RwQQG/DMeMbPXstbHRCeEe7\nz5SDdItauI99B5Vo3xj9k6zv3fIDRBIRghqCJxssuA2pZhoQWNC1hA5u7apZ\nU9Wzu8dsIVxweshq9XCcGyu6ybbG1aAH5g2XZcFltJiNSsCxwp5jI3wOvl2N\nGvgem9AXmW24FE5zbfcNHt5nSnC5+bU74IvTHwOUgKQhuYFui/iVAXz+Ely0\nllgb\r\n=qXZz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_4.0.4_1573543200141_0.8404935333333745"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.5": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "4.0.5",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "1.75 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "e1ccbe1c83a1a63420df1d51478175d8f8f847e8",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@4.0.5",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-l+fTaGG2N9ZRpCEUj5fG1VKdDLaiqwCIvPngpnxzREhcdobhZC4ou4w984HBu72DqAJ5CfcdV6tjqNOunfpdsQ==",
+        "shasum": "2d4fd140af9a369bf7b68f77a7fdc340490f4239",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.5.tgz",
+        "fileCount": 14,
+        "unpackedSize": 471565,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyor9CRA9TVsSAnZWagAAYYgP/3gtNtAcB7+qnUkrYvnZ\nB7jJCtoSGD9gximFIyIrU6D3u+TMIP5O9ODrfi74snyi98pS2PcNGc8wflnz\nRGE3egYZC12Ojo1DoC7keO1JsXYI5/D1sL32JbdpRqR311j64Ux08UGHgvrV\nyGe1SCBuJ2mgCICT5dz/CRhiqr//zmz36IgkKZsYoWGFE9oNU/c64F2ND4w0\n921dlsj3bFhXeeasOcIIJBHpO34qVK3fLTKXvwhIvmrSGjNdws2q650pfz0P\nHtyT23vu25IZigXquPiflBpTw7QsQ1mAGEyupuIOj8l5Qw7c3iLrUwyGTZot\nK79sQzr4kaqHFwQt807P9QhKumZB7JDjR07j2PU/1FEuNy/LixJomvkTesry\nuWI4EEpwx/ARS4YxaPMqmhhIuqufWjPy5TpWqWOZQa1NE0VLXA+IvuJoWTVF\nC53ggoYa7rTawHkli2gAXUtBu5cQfMSVwrfxRG5h6dZmcOlxgaEUHyotQGoG\neLZjxnLTlpSC+rXh4dZyRPzHyPADQ9ZoMymKJBgQjmxn4rWRX8jrpgp3Lc/0\nUaCcCwXealS26nG+3/Dx/R7/6tQwB1+JOR0thjYdE63GGwy1HJAvqPuPGjl3\nw7Pw0NdkhZHPYbQBpACy4n+slRgUcG4dP3yUm5uswUBVusvF6EZc33Xbxs26\nBpZN\r\n=PUJ6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_4.0.5_1573554940397_0.24107604280429018"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.0.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "5.0.0",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "1.75 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "8a3710d6690502978c3aaa81e9711d4593d18b69",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@5.0.0",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-VOQVA+0mivusQfaveeWlrW7ddXKuStHMTdovn/1epf7cEpUL4dpzGl7eq8ho96H9w90/q66yJLsqn84jSCfkmQ==",
+        "shasum": "e56dd58778b9dc06e76f0f3e39e741bbddc0bd26",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-5.0.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 468899,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyp9RCRA9TVsSAnZWagAATbQP/0gaUnwfpr7qeQLhOsWT\nlf2zkosGpkbQSGjtirEMuo7bMxjj8i8t8hOszvTjBUPqLrDFdxDHzZlWIu5R\nwLzXO4EYb4BBxALyg+eJfgC1RMRD6YmYr/z3HmFy3/2rS07DH6b5dSuOm2GC\n1/igKX8tmyB7WNIHVodiTlSgpDCENOIoV/gRhXbGISByvDbegBKjIdSTyn3b\nAMfJxvNPpp3hDuNj7DfMuovboNGNNNeGv6O7MBSR543OSy5GTaBOXKKS5PAH\n4sI6UU7eK3SHWdbimt0scSVjTblWi+4oNkNj1JrYLL3WDCO/0me7AlQVATOl\ngBgDHKaHZwW/FgHJ/NGoks4TJ6LxJaO5PKkkMQvMUONtxvctatqjvQf8n7u8\nO4p59gB0aKu+YxShMW/Dh8EfSIkOU2kGsJYGw0SFjWTGXRxZuHmbX5ACTOH3\nygqPkmD5D+NpemL/Ln/yZRT/LdCSL+pVRNw780ngIW8VO7YIcDJnr7VHH3MV\nVn5IbCy41689eZwaZdz54CX9Ho7ye24KFASNsq2jOukQhaT05r6/8G+iwzLV\n0sfX9ksXgBwtxBhT9o2BQzuVHcgmwlA3/cQJWcm1FxOn3PubgO4WO5CYwg9u\n9L+nEaLkXCEYfzhv+2z+IOC2s5CuoaygfTPwOddYxujf3m2aTAwakPSdKfly\nMSpJ\r\n=xmXy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_5.0.0_1573560145223_0.9343356354627614"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "6.0.0",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "2 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "0d83cebcb6c1e16cf84a67b5d3beaecc993b134c",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@6.0.0",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-/BtzpwyPV+/I4gL16q3r3xb73zcLyALoP+FPXfp1W60N+qCkKATnt9bihaYMBCSxHhttopoFPw7diGBqcOXkqA==",
+        "shasum": "8797c236ca80f62b9e36e39eb3ef5208ad6ab68e",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.0.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 468051,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd1L0HCRA9TVsSAnZWagAAuRIP/3kSAeoYPYdgGW8hBOcA\nLmJjcB+x5mB977eSPQCq+lPLFVnMNXC+4RFlxVuQKovafDRLy9OLy59sVau1\nxoW8QTY9bOCTP7a1JMJwmPQJdFQ24R+7F0B5EdWTBnEt8i3hxMwNzw69GiMY\nUexNTesIvTY0tjsibJGlkw27EMzY/ePCqJU4WSPXDb+yyXvLqpPj0dYCBIe5\n8gUp0adv56isPZwWcwh1x7n52pKcDvhy/Gi/Gq0+3iwM4DK1hudmt0wSjs0G\nNLHwuvpkhwWF+dzCwb5+olswSJfZlGhIWjVTcT3O2hOP6Xq0nljBtNLPR2VP\ntEZ6KP7Fz/eqZBPg8Wdh2f9BbKwoFRSSsEzRHtJBR3Ow2MPVUdOIIgTo5IYk\ne66qOkRUk4bVM1dzGcGV3jalUf8RWKS0lTW3D5/BHBSGXbY4gzJ48ndqma+/\nGJI7LZNTz8pgipeAkz3sEi+Fd/1MRQP2Kh9JlV+KaVZxGWDHCgP8GuRMv8lL\nY4KhD8GABTtlaMsk6CVo3vaAqUhP0SScSPzu76ROTVHXyyq2xZW5DEwElRJL\nMwT77FTZLDRmtxpWSa0SuyCWt8eDwFnH3z152eleb6zxXubVUEWJgOkSWyNH\n49J7s4o82yoTF5DuY5NkerHepN9VugsE9kTfJ4a5L281hbpsZ1GX+gVZwBeU\nb6J0\r\n=U/zE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_6.0.0_1574223110991_0.6851713160787531"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.1.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "6.1.0",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "2 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": [
+          "npm run prettier",
+          "git add"
+        ]
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "gitHead": "4b8efcc506ce11401919d04c40e4b316f71742da",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@6.1.0",
+      "_nodeVersion": "13.1.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+        "shasum": "0b18f88b7a0ce0bfae6a25990c909ab86f512427",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 476190,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd1ZNPCRA9TVsSAnZWagAA5u0QAIPB+iLLHOaiLSK9m3gM\nS7HbJhsmxpWOEPzY+YkWMSZWEI1qpDz53JfjaMSguEZsysD9rJD28KmUoYlP\nmN95HEmjqv3z2YVbCBSeqPvCaxPx3zN6qF/NFMNTKS4ZWC/vk7zeItS60bKd\ngDnhbxVSyJP0CZTJwbMX72ELZPBNQBXJhI1vJrLDUkXBFwweTSaYhS0QClrH\nnjaTRVfKz+6KpXIjkh5r6guQNHX6cWVCahTx162wzg2gyqDt3pSI7P5WbxAr\nPabDtVZX2S+YdI5tcwLD642s1nm1GPixQ438/qwHCV/HKKWhV2av0ZHWlK2i\n+tDdw8yqKVIsp3fIv5KGbs2D+CUok+oqbFNPMzOqe1MHUJKUfY2R49EkKfjn\n+RXCEb3+9KHOsEVhZpGq+wkScepmcJ88tC9iYHvm+hyRODQbl3lWnP2hJBjw\nyGGhkSlNzfq3gH3Xn2GjA+tCvTaDo8nJbrx7L8QFR+J2yg8ERkjOzIJkVsID\nsdwWQT0oZ1j5y6mDMA0e8zP0ySgZq6rTbpGCFCLYqBiWwsR46BZaFz+r2uE1\n7ZozRC6FCplY+Ggi1rS7sIdYTqa8g6mItmhhj05kBw0sAY8rvLXKwwIczdm2\noGcvnMz79EqDSIw7FlJfZGk+PsHoRUtTKJwkezjEBwyRqxbMHj1lFO69BNDu\n0lJr\r\n=voQX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@blakeembrey.com",
+          "name": "blakeembrey"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_6.1.0_1574277967326_0.3005402446223706"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.2.0": {
+      "name": "path-to-regexp",
+      "description": "Express style path to RegExp utility",
+      "version": "6.2.0",
+      "main": "dist/index.js",
+      "typings": "dist/index.d.ts",
+      "module": "dist.es2015/index.js",
+      "sideEffects": false,
+      "scripts": {
+        "prettier": "prettier --write",
+        "lint": "tslint \"src/**/*\" --project tsconfig.json",
+        "format": "npm run prettier -- \"{.,src/**}/*.{js,jsx,ts,tsx,json,md,yml,yaml}\"",
+        "build": "rimraf dist/ dist.es2015/ && tsc && tsc -P tsconfig.es2015.json",
+        "specs": "jest --coverage",
+        "test": "npm run build && npm run lint && npm run specs && npm run size",
+        "size": "size-limit",
+        "prepare": "npm run build"
+      },
+      "keywords": [
+        "express",
+        "regexp",
+        "route",
+        "routing"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+      },
+      "size-limit": [
+        {
+          "path": "dist/index.js",
+          "limit": "2 kB"
+        }
+      ],
+      "jest": {
+        "roots": [
+          "<rootDir>/src/"
+        ],
+        "transform": {
+          "\\.tsx?$": "ts-jest"
+        },
+        "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
+        "moduleFileExtensions": [
+          "ts",
+          "tsx",
+          "js",
+          "jsx",
+          "json",
+          "node"
+        ]
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.{js,jsx,ts,tsx,json,md,yml,yaml}": "npm run prettier"
+      },
+      "publishConfig": {
+        "access": "public"
+      },
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^4.5.6",
+        "@types/jest": "^26.0.9",
+        "@types/node": "^14.0.27",
+        "@types/semver": "^7.3.1",
+        "husky": "^4.2.5",
+        "jest": "^26.2.2",
+        "lint-staged": "^10.2.11",
+        "prettier": "^2.0.5",
+        "rimraf": "^3.0.0",
+        "semver": "^7.3.2",
+        "size-limit": "^4.5.6",
+        "ts-jest": "^26.1.4",
+        "tslint": "^6.1.3",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^4.0.3"
+      },
+      "gitHead": "125c43e6481f68cc771a5af22b914acdb8c5ba1f",
+      "bugs": {
+        "url": "https://github.com/pillarjs/path-to-regexp/issues"
+      },
+      "homepage": "https://github.com/pillarjs/path-to-regexp#readme",
+      "_id": "path-to-regexp@6.2.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
+        "shasum": "f7b3803336104c346889adece614669230645f38",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 111238,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfc22XCRA9TVsSAnZWagAAeGoP/3UROxSdG31+M9LNl0x4\nWvZDtKYQpVRm31l+szSzlSwtQ06e0oY29I1r9DiSBPkY4OOvaEdJN3G9IWmo\n5Li1Htb3GYeuEkbkqk4Q1Ib6fyl5miYuRPNa7ndf+0ayMy2Z+C228GslJju0\nILzvuzXDGLCZe1LHShkhTbglrrrE0QuMSfjlRfLdwx0CgImYyRyEoeNkhXx9\nIhlzAlrZWrYF5wHhBI3VLVS9B/nx7mqV1XkHbwspckex1oxbghMGT1mqKoNO\njDsb+8ArURIIut0LyAMkjlgepMVPnbmwqsaXgyl/Eusrr1qUyF3sT5SkI9oA\nZvOAcGOvcrs5L7G1QwiwTpIeMJWbAtooxdJe3Al+Em8UtvPk8+74jObo8dAr\nHfQlg0BivYW0eTXP914cz9f6zSDaIrpDiXunplx/otTlqHf3FZYM3702GTQH\noZzfF0hwNYrjAJGFrW+BKzn+aQeAfGN+2+UhVTJxoIJ/6j8Tjc2TuT3rIpM1\n3sNB7Ar2tKM4nAq1BRd2Mp/k3DdEYptvW3PisOLF98kprq4VRRSN0AhRgDkd\nYHktaGkhymVG0cEfaeMbWTzxCEauJKjxbNUI6nD5720jejio1VGjXXLRYVzY\noh1n4Sy4TjqDySZcAbwGJmmtAU2HYB+sxoSPBTRUhNC1FU75JgGm4eP7DrBF\n0pW3\r\n=9dQo\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "blakeembrey",
+          "email": "hello@blakeembrey.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "blakeembrey",
+        "email": "hello@blakeembrey.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/path-to-regexp_6.2.0_1601400215264_0.3152332195116907"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Path-to-RegExp\n\n> Turn a path string such as `/user/:name` into a regular expression.\n\n[![NPM version][npm-image]][npm-url]\n[![Build status][travis-image]][travis-url]\n[![Test coverage][coveralls-image]][coveralls-url]\n[![Dependency Status][david-image]][david-url]\n[![License][license-image]][license-url]\n[![Downloads][downloads-image]][downloads-url]\n\n## Installation\n\n```\nnpm install path-to-regexp --save\n```\n\n## Usage\n\n```javascript\nconst { pathToRegexp, match, parse, compile } = require(\"path-to-regexp\");\n\n// pathToRegexp(path, keys?, options?)\n// match(path)\n// parse(path)\n// compile(path)\n```\n\n- **path** A string, array of strings, or a regular expression.\n- **keys** An array to populate with keys found in the path.\n- **options**\n  - **sensitive** When `true` the regexp will be case sensitive. (default: `false`)\n  - **strict** When `true` the regexp won't allow an optional trailing delimiter to match. (default: `false`)\n  - **end** When `true` the regexp will match to the end of the string. (default: `true`)\n  - **start** When `true` the regexp will match from the beginning of the string. (default: `true`)\n  - **delimiter** The default delimiter for segments, e.g. `[^/#?]` for `:named` patterns. (default: `'/#?'`)\n  - **endsWith** Optional character, or list of characters, to treat as \"end\" characters.\n  - **encode** A function to encode strings before inserting into `RegExp`. (default: `x => x`)\n  - **prefixes** List of characters to automatically consider prefixes when parsing. (default: `./`)\n\n```javascript\nconst keys = [];\nconst regexp = pathToRegexp(\"/foo/:bar\", keys);\n// regexp = /^\\/foo(?:\\/([^\\/#\\?]+?))[\\/#\\?]?$/i\n// keys = [{ name: 'bar', prefix: '/', suffix: '', pattern: '[^\\\\/#\\\\?]+?', modifier: '' }]\n```\n\n**Please note:** The `RegExp` returned by `path-to-regexp` is intended for ordered data (e.g. pathnames, hostnames). It can not handle arbitrarily ordered data (e.g. query strings, URL fragments, JSON, etc). When using paths that contain query strings, you need to escape the question mark (`?`) to ensure it does not flag the parameter as [optional](#optional).\n\n### Parameters\n\nThe path argument is used to define parameters and populate keys.\n\n#### Named Parameters\n\nNamed parameters are defined by prefixing a colon to the parameter name (`:foo`).\n\n```js\nconst regexp = pathToRegexp(\"/:foo/:bar\");\n// keys = [{ name: 'foo', prefix: '/', ... }, { name: 'bar', prefix: '/', ... }]\n\nregexp.exec(\"/test/route\");\n//=> [ '/test/route', 'test', 'route', index: 0, input: '/test/route', groups: undefined ]\n```\n\n**Please note:** Parameter names must use \"word characters\" (`[A-Za-z0-9_]`).\n\n##### Custom Matching Parameters\n\nParameters can have a custom regexp, which overrides the default match (`[^/]+`). For example, you can match digits or names in a path:\n\n```js\nconst regexpNumbers = pathToRegexp(\"/icon-:foo(\\\\d+).png\");\n// keys = [{ name: 'foo', ... }]\n\nregexpNumbers.exec(\"/icon-123.png\");\n//=> ['/icon-123.png', '123']\n\nregexpNumbers.exec(\"/icon-abc.png\");\n//=> null\n\nconst regexpWord = pathToRegexp(\"/(user|u)\");\n// keys = [{ name: 0, ... }]\n\nregexpWord.exec(\"/u\");\n//=> ['/u', 'u']\n\nregexpWord.exec(\"/users\");\n//=> null\n```\n\n**Tip:** Backslashes need to be escaped with another backslash in JavaScript strings.\n\n##### Custom Prefix and Suffix\n\nParameters can be wrapped in `{}` to create custom prefixes or suffixes for your segment:\n\n```js\nconst regexp = pathToRegexp(\"/:attr1?{-:attr2}?{-:attr3}?\");\n\nregexp.exec(\"/test\");\n// => ['/test', 'test', undefined, undefined]\n\nregexp.exec(\"/test-test\");\n// => ['/test', 'test', 'test', undefined]\n```\n\n#### Unnamed Parameters\n\nIt is possible to write an unnamed parameter that only consists of a regexp. It works the same the named parameter, except it will be numerically indexed:\n\n```js\nconst regexp = pathToRegexp(\"/:foo/(.*)\");\n// keys = [{ name: 'foo', ... }, { name: 0, ... }]\n\nregexp.exec(\"/test/route\");\n//=> [ '/test/route', 'test', 'route', index: 0, input: '/test/route', groups: undefined ]\n```\n\n#### Modifiers\n\nModifiers must be placed after the parameter (e.g. `/:foo?`, `/(test)?`, `/:foo(test)?`, or `{-:foo(test)}?`).\n\n##### Optional\n\nParameters can be suffixed with a question mark (`?`) to make the parameter optional.\n\n```js\nconst regexp = pathToRegexp(\"/:foo/:bar?\");\n// keys = [{ name: 'foo', ... }, { name: 'bar', prefix: '/', modifier: '?' }]\n\nregexp.exec(\"/test\");\n//=> [ '/test', 'test', undefined, index: 0, input: '/test', groups: undefined ]\n\nregexp.exec(\"/test/route\");\n//=> [ '/test/route', 'test', 'route', index: 0, input: '/test/route', groups: undefined ]\n```\n\n**Tip:** The prefix is also optional, escape the prefix `\\/` to make it required.\n\nWhen dealing with query strings, escape the question mark (`?`) so it doesn't mark the parameter as optional. Handling unordered data is outside the scope of this library.\n\n```js\nconst regexp = pathToRegexp(\"/search/:tableName\\\\?useIndex=true&term=amazing\");\n\nregexp.exec(\"/search/people?useIndex=true&term=amazing\");\n//=> [ '/search/people?useIndex=true&term=amazing', 'people', index: 0, input: '/search/people?useIndex=true&term=amazing', groups: undefined ]\n\n// This library does not handle query strings in different orders\nregexp.exec(\"/search/people?term=amazing&useIndex=true\");\n//=> null\n```\n\n##### Zero or more\n\nParameters can be suffixed with an asterisk (`*`) to denote a zero or more parameter matches.\n\n```js\nconst regexp = pathToRegexp(\"/:foo*\");\n// keys = [{ name: 'foo', prefix: '/', modifier: '*' }]\n\nregexp.exec(\"/\");\n//=> [ '/', undefined, index: 0, input: '/', groups: undefined ]\n\nregexp.exec(\"/bar/baz\");\n//=> [ '/bar/baz', 'bar/baz', index: 0, input: '/bar/baz', groups: undefined ]\n```\n\n##### One or more\n\nParameters can be suffixed with a plus sign (`+`) to denote a one or more parameter matches.\n\n```js\nconst regexp = pathToRegexp(\"/:foo+\");\n// keys = [{ name: 'foo', prefix: '/', modifier: '+' }]\n\nregexp.exec(\"/\");\n//=> null\n\nregexp.exec(\"/bar/baz\");\n//=> [ '/bar/baz','bar/baz', index: 0, input: '/bar/baz', groups: undefined ]\n```\n\n### Match\n\nThe `match` function will return a function for transforming paths into parameters:\n\n```js\n// Make sure you consistently `decode` segments.\nconst match = match(\"/user/:id\", { decode: decodeURIComponent });\n\nmatch(\"/user/123\"); //=> { path: '/user/123', index: 0, params: { id: '123' } }\nmatch(\"/invalid\"); //=> false\nmatch(\"/user/caf%C3%A9\"); //=> { path: '/user/caf%C3%A9', index: 0, params: { id: 'café' } }\n```\n\n#### Process Pathname\n\nYou should make sure variations of the same path match the expected `path`. Here's one possible solution using `encode`:\n\n```js\nconst match = match(\"/café\", { encode: encodeURI, decode: decodeURIComponent });\n\nmatch(\"/user/caf%C3%A9\"); //=> { path: '/user/caf%C3%A9', index: 0, params: { id: 'café' } }\n```\n\n**Note:** [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) automatically encodes pathnames for you.\n\n##### Alternative Using Normalize\n\nSometimes you won't have an already normalized pathname. You can normalize it yourself before processing:\n\n```js\n/**\n * Normalize a pathname for matching, replaces multiple slashes with a single\n * slash and normalizes unicode characters to \"NFC\". When using this method,\n * `decode` should be an identity function so you don't decode strings twice.\n */\nfunction normalizePathname(pathname: string) {\n  return (\n    decodeURI(pathname)\n      // Replaces repeated slashes in the URL.\n      .replace(/\\/+/g, \"/\")\n      // Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize\n      // Note: Missing native IE support, may want to skip this step.\n      .normalize()\n  );\n}\n\n// Two possible ways of writing `/café`:\nconst re = pathToRegexp(\"/caf\\u00E9\");\nconst input = encodeURI(\"/cafe\\u0301\");\n\nre.test(input); //=> false\nre.test(normalizePathname(input)); //=> true\n```\n\n### Parse\n\nThe `parse` function will return a list of strings and keys from a path string:\n\n```js\nconst tokens = parse(\"/route/:foo/(.*)\");\n\nconsole.log(tokens[0]);\n//=> \"/route\"\n\nconsole.log(tokens[1]);\n//=> { name: 'foo', prefix: '/', suffix: '', pattern: '[^\\\\/#\\\\?]+?', modifier: '' }\n\nconsole.log(tokens[2]);\n//=> { name: 0, prefix: '/', suffix: '', pattern: '.*', modifier: '' }\n```\n\n**Note:** This method only works with strings.\n\n### Compile (\"Reverse\" Path-To-RegExp)\n\nThe `compile` function will return a function for transforming parameters into a valid path:\n\n```js\n// Make sure you encode your path segments consistently.\nconst toPath = compile(\"/user/:id\", { encode: encodeURIComponent });\n\ntoPath({ id: 123 }); //=> \"/user/123\"\ntoPath({ id: \"café\" }); //=> \"/user/caf%C3%A9\"\ntoPath({ id: \"/\" }); //=> \"/user/%2F\"\n\ntoPath({ id: \":/\" }); //=> \"/user/%3A%2F\"\n\n// Without `encode`, you need to make sure inputs are encoded correctly.\nconst toPathRaw = compile(\"/user/:id\");\n\ntoPathRaw({ id: \"%3A%2F\" }); //=> \"/user/%3A%2F\"\ntoPathRaw({ id: \":/\" }, { validate: false }); //=> \"/user/:/\"\n\nconst toPathRepeated = compile(\"/:segment+\");\n\ntoPathRepeated({ segment: \"foo\" }); //=> \"/foo\"\ntoPathRepeated({ segment: [\"a\", \"b\", \"c\"] }); //=> \"/a/b/c\"\n\nconst toPathRegexp = compile(\"/user/:id(\\\\d+)\");\n\ntoPathRegexp({ id: 123 }); //=> \"/user/123\"\ntoPathRegexp({ id: \"123\" }); //=> \"/user/123\"\ntoPathRegexp({ id: \"abc\" }); //=> Throws `TypeError`.\ntoPathRegexp({ id: \"abc\" }, { validate: false }); //=> \"/user/abc\"\n```\n\n**Note:** The generated function will throw on invalid input.\n\n### Working with Tokens\n\nPath-To-RegExp exposes the two functions used internally that accept an array of tokens:\n\n- `tokensToRegexp(tokens, keys?, options?)` Transform an array of tokens into a matching regular expression.\n- `tokensToFunction(tokens)` Transform an array of tokens into a path generator function.\n\n#### Token Information\n\n- `name` The name of the token (`string` for named or `number` for unnamed index)\n- `prefix` The prefix string for the segment (e.g. `\"/\"`)\n- `suffix` The suffix string for the segment (e.g. `\"\"`)\n- `pattern` The RegExp used to match this token (`string`)\n- `modifier` The modifier character used for the segment (e.g. `?`)\n\n## Compatibility with Express <= 4.x\n\nPath-To-RegExp breaks compatibility with Express <= `4.x`:\n\n- RegExp special characters can only be used in a parameter\n  - Express.js 4.x supported `RegExp` special characters regardless of position - this is considered a bug\n- Parameters have suffixes that augment meaning - `*`, `+` and `?`. E.g. `/:user*`\n- No wildcard asterisk (`*`) - use parameters instead (`(.*)` or `:splat*`)\n\n## Live Demo\n\nYou can see a live demo of this library in use at [express-route-tester](http://forbeslindesay.github.com/express-route-tester/).\n\n## License\n\nMIT\n\n[npm-image]: https://img.shields.io/npm/v/path-to-regexp.svg?style=flat\n[npm-url]: https://npmjs.org/package/path-to-regexp\n[travis-image]: https://img.shields.io/travis/pillarjs/path-to-regexp.svg?style=flat\n[travis-url]: https://travis-ci.org/pillarjs/path-to-regexp\n[coveralls-image]: https://img.shields.io/coveralls/pillarjs/path-to-regexp.svg?style=flat\n[coveralls-url]: https://coveralls.io/r/pillarjs/path-to-regexp?branch=master\n[david-image]: http://img.shields.io/david/pillarjs/path-to-regexp.svg?style=flat\n[david-url]: https://david-dm.org/pillarjs/path-to-regexp\n[license-image]: http://img.shields.io/npm/l/path-to-regexp.svg?style=flat\n[license-url]: LICENSE.md\n[downloads-image]: http://img.shields.io/npm/dm/path-to-regexp.svg?style=flat\n[downloads-url]: https://npmjs.org/package/path-to-regexp\n",
+  "maintainers": [
+    {
+      "name": "blakeembrey",
+      "email": "hello@blakeembrey.com"
+    },
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "jonathanong",
+      "email": "jonathanrichardong@gmail.com"
+    },
+    {
+      "name": "jongleberry",
+      "email": "jonathanrichardong@gmail.com"
+    },
+    {
+      "name": "defunctzombie",
+      "email": "shtylman@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-09-29T17:23:37.768Z",
+    "created": "2012-08-01T22:49:08.434Z",
+    "0.0.1": "2012-08-01T22:49:10.343Z",
+    "0.0.2": "2013-02-10T17:41:48.985Z",
+    "0.1.0": "2014-03-06T06:35:14.721Z",
+    "0.1.1": "2014-03-10T14:41:25.104Z",
+    "0.1.2": "2014-03-10T14:43:49.209Z",
+    "0.2.0": "2014-06-10T03:52:35.899Z",
+    "0.2.1": "2014-06-11T17:31:21.785Z",
+    "0.1.3": "2014-07-06T07:26:10.022Z",
+    "0.2.2": "2014-07-06T09:25:41.750Z",
+    "0.2.3": "2014-07-08T23:57:48.403Z",
+    "0.2.4": "2014-08-02T08:27:55.044Z",
+    "0.2.5": "2014-08-07T17:35:25.995Z",
+    "1.0.0": "2014-08-17T22:37:49.113Z",
+    "1.0.1": "2014-08-28T01:37:57.382Z",
+    "1.0.2": "2014-12-17T07:03:45.043Z",
+    "1.0.3": "2015-01-17T12:07:04.806Z",
+    "0.1.4": "2015-03-05T03:08:44.032Z",
+    "0.1.5": "2015-05-09T02:42:27.038Z",
+    "1.1.0": "2015-05-09T18:58:21.134Z",
+    "1.1.1": "2015-05-12T14:47:20.532Z",
+    "1.2.0": "2015-05-21T03:13:26.332Z",
+    "0.1.6": "2015-06-19T12:04:42.779Z",
+    "0.1.7": "2015-07-28T03:07:52.808Z",
+    "1.2.1": "2015-08-17T19:25:00.465Z",
+    "1.3.0": "2016-05-08T22:17:07.390Z",
+    "1.4.0": "2016-05-19T05:37:48.670Z",
+    "1.5.0": "2016-05-20T18:09:55.851Z",
+    "1.5.1": "2016-06-08T15:34:26.314Z",
+    "1.5.2": "2016-06-16T01:55:33.030Z",
+    "1.5.3": "2016-06-16T03:36:35.520Z",
+    "1.6.0": "2016-10-03T18:39:00.127Z",
+    "1.7.0": "2016-11-08T18:38:49.258Z",
+    "2.0.0": "2017-08-23T22:30:56.210Z",
+    "2.1.0": "2017-10-20T17:47:16.057Z",
+    "2.2.0": "2018-03-07T06:04:53.987Z",
+    "2.2.1": "2018-04-24T14:26:49.071Z",
+    "2.3.0": "2018-08-20T17:06:03.320Z",
+    "2.4.0": "2018-08-26T23:57:15.931Z",
+    "3.0.0": "2019-01-14T00:31:35.407Z",
+    "3.1.0": "2019-08-31T03:59:25.875Z",
+    "1.8.0": "2019-11-11T03:37:21.803Z",
+    "3.2.0": "2019-11-11T05:50:20.071Z",
+    "4.0.0": "2019-11-12T03:30:04.004Z",
+    "4.0.1": "2019-11-12T04:08:54.217Z",
+    "4.0.2": "2019-11-12T04:35:05.519Z",
+    "4.0.3": "2019-11-12T06:53:30.304Z",
+    "4.0.4": "2019-11-12T07:20:00.337Z",
+    "4.0.5": "2019-11-12T10:35:40.566Z",
+    "5.0.0": "2019-11-12T12:02:25.405Z",
+    "6.0.0": "2019-11-20T04:11:51.111Z",
+    "6.1.0": "2019-11-20T19:26:07.428Z",
+    "6.2.0": "2020-09-29T17:23:35.481Z"
+  },
+  "users": {
+    "285858315": true,
+    "fgribreau": true,
+    "abdelhady": true,
+    "simplyianm": true,
+    "bruce313": true,
+    "d4nyll": true,
+    "cobject": true,
+    "nex": true,
+    "justinshea": true,
+    "tzsiga": true,
+    "n370": true,
+    "keelvin": true,
+    "boyw165": true,
+    "qqqppp9998": true,
+    "pandao": true,
+    "bapinney": true,
+    "456wyc": true,
+    "bojand": true,
+    "monjer": true,
+    "curioussavage": true,
+    "hugojosefson": true,
+    "season19840122": true,
+    "andyytung": true,
+    "necinc": true,
+    "emarcs": true,
+    "soulchainer": true,
+    "henrytseng": true,
+    "lianhr12": true,
+    "jovinbm": true,
+    "sunkeyhub": true,
+    "blakeembrey": true,
+    "wangnan0610": true,
+    "fchienvuhoang": true,
+    "shakakira": true,
+    "goliatone": true,
+    "markthethomas": true,
+    "mojaray2k": true,
+    "zhengyaing": true,
+    "semo100": true,
+    "princetoad": true,
+    "mingzhangyang": true,
+    "danielrhayes": true,
+    "sobear": true,
+    "arteffeckt": true,
+    "giussa_dan": true,
+    "papasavva": true,
+    "leonzhao": true,
+    "uldis.sturms~at~audatex.co.uk": true,
+    "thomas.li": true,
+    "staydan": true,
+    "quafoo": true,
+    "heineiuo": true,
+    "stone_breaker": true,
+    "fxkraus": true,
+    "jian263994241": true,
+    "bplok20010": true,
+    "ivan403704409": true,
+    "tomchao": true,
+    "zvit": true,
+    "simonfan": true,
+    "rocket0191": true,
+    "usex": true,
+    "shyling": true,
+    "bonashen": true,
+    "pasturn": true,
+    "gavinning": true,
+    "zhyq0826": true,
+    "xinwangwang": true,
+    "dillonace": true,
+    "deryck": true,
+    "leizongmin": true,
+    "ziflex": true,
+    "kontrax": true,
+    "hehaiyang": true,
+    "mfjv88": true,
+    "liximomo": true,
+    "iusfof": true,
+    "yayayahei": true,
+    "joakin": true,
+    "dwqs": true,
+    "darrentorpey": true,
+    "ierceg": true,
+    "detj": true,
+    "lulubozichang": true,
+    "itonyyo": true,
+    "planir": true,
+    "genovo": true,
+    "keenwon": true,
+    "hongyi0220": true,
+    "i-erokhin": true,
+    "ayoola_moore": true,
+    "eightyfour84": true,
+    "hanhq": true,
+    "elama": true,
+    "miloc": true,
+    "shanewholloway": true,
+    "mdedirudianto": true,
+    "qinbx": true,
+    "xrush": true,
+    "kkho595": true,
+    "zhenguo.zhao": true,
+    "attomos": true,
+    "yangteng": true,
+    "isenricho": true,
+    "tomgao365": true,
+    "knoja4": true,
+    "winjeysong": true,
+    "ahmedelgabri": true,
+    "ericyang89": true,
+    "losymear": true,
+    "wuxiaword": true,
+    "zuojiang": true
+  },
+  "readmeFilename": "Readme.md",
+  "keywords": [
+    "express",
+    "regexp",
+    "route",
+    "routing"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pillarjs/path-to-regexp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pillarjs/path-to-regexp/issues"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/pillarjs/path-to-regexp#readme"
+}

--- a/test/fixtures/registry-mocks/content/path-to-regexp.min.json
+++ b/test/fixtures/registry-mocks/content/path-to-regexp.min.json
@@ -1,0 +1,973 @@
+{
+  "name": "path-to-regexp",
+  "dist-tags": {
+    "latest": "6.2.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "path-to-regexp",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "2383ddd9c24c6ecf8bc9e39711e3ecb37c61c4cc",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "path-to-regexp",
+      "version": "0.0.2",
+      "dist": {
+        "shasum": "489feb060b314443a5494ab1da2efed2040ab24c",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.0.2.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "path-to-regexp",
+      "version": "0.1.0",
+      "dist": {
+        "shasum": "23dd6da3e04f2a3e97ba275e7c025c918b50a46a",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "path-to-regexp",
+      "version": "0.1.1",
+      "dependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "27d101134fd0fda80923cf2102bc12529841002e",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "path-to-regexp",
+      "version": "0.1.2",
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "9b2b151f9cc3018c9eea50ca95729e05781712b4",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.2.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "path-to-regexp",
+      "version": "0.2.0",
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "dist": {
+        "shasum": "8ac7593477f8c321dc5a2aefffcc28e74cdf9c82",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "path-to-regexp",
+      "version": "0.2.1",
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "dist": {
+        "shasum": "d7e13bfc1ff9082d6723a27b54b7ae6bccbe80e3",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.1.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "path-to-regexp",
+      "version": "0.1.3",
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "21b9ab82274279de25b156ea08fd12ca51b8aecb",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "path-to-regexp",
+      "version": "0.2.2",
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "dist": {
+        "shasum": "605fcb541f6ae51fdd0643e00e0f1453fb56c1ef",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.2.tgz"
+      }
+    },
+    "0.2.3": {
+      "name": "path-to-regexp",
+      "version": "0.2.3",
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "dist": {
+        "shasum": "b695cd2d139d3b502ede11fdaf5326c05b48fd04",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.3.tgz"
+      }
+    },
+    "0.2.4": {
+      "name": "path-to-regexp",
+      "version": "0.2.4",
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "dist": {
+        "shasum": "5a56488dae6f4ddabc401729a79e3bb829db9dc0",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.4.tgz"
+      }
+    },
+    "0.2.5": {
+      "name": "path-to-regexp",
+      "version": "0.2.5",
+      "devDependencies": {
+        "istanbul": "~0.2.6",
+        "mocha": "~1.18.2"
+      },
+      "dist": {
+        "shasum": "0b426991e387fc4c675de23557f358715eb66fb0",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.2.5.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "path-to-regexp",
+      "version": "1.0.0",
+      "devDependencies": {
+        "istanbul": "^0.3.0",
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "6fc04df3f802bcb3e76ef65ec75de2aae38f4a26",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "path-to-regexp",
+      "version": "1.0.1",
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "0b87a97d09ed6c301508e710272852b24360c8b2",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "path-to-regexp",
+      "version": "1.0.2",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "293be955eabc0504906e0f9e129dde8ac111a21f",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "path-to-regexp",
+      "version": "1.0.3",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~1.21.4"
+      },
+      "dist": {
+        "shasum": "eea5a32cf82b7141d4987bfe7e0557990e2d260e",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.0.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "path-to-regexp",
+      "version": "0.1.4",
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "65868166d96fd548de3bbe7dc8e8ab694a8bda57",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "path-to-regexp",
+      "version": "0.1.5",
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "a81f223d192e0cc6a92ef619633cae1fede52c5d",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.5.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "path-to-regexp",
+      "version": "1.1.0",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3"
+      },
+      "dist": {
+        "shasum": "40c5a8aed1298e44e097b8dcbd2d2697b83d89e8",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "path-to-regexp",
+      "version": "1.1.1",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3"
+      },
+      "dist": {
+        "shasum": "8dd70fdecb4da27858aee1e5e3b6f0eda8f45a35",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "path-to-regexp",
+      "version": "1.2.0",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3"
+      },
+      "dist": {
+        "shasum": "81da890cb13bacc657670e0cfeecc90fd703b387",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.0.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "path-to-regexp",
+      "version": "0.1.6",
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "f01fd5734047b6bfbc5f208c6135a33d7af09c36",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.6.tgz"
+      }
+    },
+    "0.1.7": {
+      "name": "path-to-regexp",
+      "version": "0.1.7",
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "istanbul": "^0.2.6"
+      },
+      "dist": {
+        "shasum": "df604178005f522f15eb4490e7247a1bfaa67f8c",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "path-to-regexp",
+      "version": "1.2.1",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3"
+      },
+      "dist": {
+        "shasum": "b33705c140234d873c8721c7b9fd8b541ed3aff9",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.2.1.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "path-to-regexp",
+      "version": "1.3.0",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "pre-commit": "~1.0.5",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^0.6.9"
+      },
+      "dist": {
+        "shasum": "b32ddce482da48876c3e5677447b0213e694c7b8",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.3.0.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "path-to-regexp",
+      "version": "1.4.0",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dist": {
+        "shasum": "0820f32b4d2338cbbb8a12b614d20ad59457a4ef",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.4.0.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "path-to-regexp",
+      "version": "1.5.0",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dist": {
+        "shasum": "c38e7efa3c00dda2e61f41addf74babbbdb69ca2",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.0.tgz"
+      }
+    },
+    "1.5.1": {
+      "name": "path-to-regexp",
+      "version": "1.5.1",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dist": {
+        "shasum": "625f98affdf68b3df2191b6a0fd9dc922335db53",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.1.tgz"
+      }
+    },
+    "1.5.2": {
+      "name": "path-to-regexp",
+      "version": "1.5.2",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dist": {
+        "shasum": "97743e23874d7a85f22807535389f1e1aa12280e",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.2.tgz"
+      }
+    },
+    "1.5.3": {
+      "name": "path-to-regexp",
+      "version": "1.5.3",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dist": {
+        "shasum": "7221ddd42483538bddf9fead942a79ff3164f57a",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.5.3.tgz"
+      }
+    },
+    "1.6.0": {
+      "name": "path-to-regexp",
+      "version": "1.6.0",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dist": {
+        "shasum": "4c59cfeab5e360a2657b180730a4bb4582ecec5b",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.6.0.tgz"
+      }
+    },
+    "1.7.0": {
+      "name": "path-to-regexp",
+      "version": "1.7.0",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dist": {
+        "shasum": "59fde0f435badacba103a84e9d3bc64e96b9937d",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "path-to-regexp",
+      "version": "2.0.0",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.0.24",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.5.0",
+        "standard": "^10.0.3",
+        "ts-node": "^3.3.0",
+        "typescript": "^2.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-DPZblKdQsbV6B3fHknj89h6Nw/Z5zFK0nFX+DVN7y8a+IUHf9taJWvMK+ue0+AEjXrke0KVRCcfm2pOYGSRk8g==",
+        "shasum": "b77a8168c2e78bc31f3d312d71b1ace97df23870",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.0.0.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "path-to-regexp",
+      "version": "2.1.0",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.0.24",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.5.0",
+        "standard": "^10.0.3",
+        "ts-node": "^3.3.0",
+        "typescript": "^2.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-dZY7QPCPp5r9cnNuQ955mOv4ZFVDXY/yvqeV7Y1W2PJA3PEFcuow9xKFfJxbBj1pIjOAP+M2B4/7xubmykLrXw==",
+        "shasum": "7e30f9f5b134bd6a28ffc2e3ef1e47075ac5259b",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.1.0.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "path-to-regexp",
+      "version": "2.2.0",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.0.24",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.5.0",
+        "standard": "^10.0.3",
+        "ts-node": "^3.3.0",
+        "typescript": "^2.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-zJcOPeBsraLjWXwUzFMPzH3QO2CmO1yRggtADPJjOTyCF5csQxfUGJL+CbyyRvIS09wOipi4F/fgRhdmVGSwxQ==",
+        "shasum": "80f0ff45c1e0e641da74df313644eaf115050972",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 26717
+      }
+    },
+    "2.2.1": {
+      "name": "path-to-regexp",
+      "version": "2.2.1",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^8.0.24",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.5.0",
+        "standard": "^10.0.3",
+        "ts-node": "^3.3.0",
+        "typescript": "^2.4.2"
+      },
+      "dist": {
+        "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+        "shasum": "90b617025a16381a879bc82a38d4e8bdeb2bcf45",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 26739,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa3z6qCRA9TVsSAnZWagAAasAQAIahXJ9o/eNTV50kUK9Y\nFKt35Fu/QDl8MGg3nEXTk/5+RbPO+zexPHAbpIR4wgwSgq8MnCe4ZjpsmWiI\nzUNLQTK3ampkqRwN7YEyPzdXsqr9lmeH2DZJc+Q5m3dyjYt79QvtGxB8H0ND\ny7vkyL7vjEdVY6s+cPNeiZcEJsYLheMBE+X9W9oCogkpMThmxjcA4g0f3obi\n5YmUo0k2PGtRrGveUM9TmCQ1vk8xl+RMt0Aull+BSFgyfTDjoOcGeXlClXBH\nJqDRkXssQcGKne34MiyYNMHAe+A0RQYpisEZF8q4kjAXSi3IRq4P2MhQ1qIW\nbA1oqXWtolEFtvSz8sLIok1iO0HnNmBwzmpSEkjClhbfD6HkicZ4eboyJXOI\n1VqiezHpDWzO7u6KuFHrszHwwcqUHZTDrHt51b4XWlMqBr6IZFOVgK7eb2QZ\nAgwQjHobF2FpwNpSD+hWHwSDxT+F5JW63F5guM5UwjEKIfd4gCh9WbB1Xxpe\nkhBIYOGjaIBruLwKVqrsXIIEaXcwryQzBNdyn2baf4I/N8iYU5fa1YyGhi2v\n1EjRiRMjow1zdHanwXI87roqLxTfHP0UiAdWCiIGJuguuTYkTW42s8iWx1FZ\nJyuAp7ISKecAMHhDCM503GVTt40UeA2ot88fyWBgS7FZpd9izFC0e2fiET7r\nRK5R\r\n=wfap\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.3.0": {
+      "name": "path-to-regexp",
+      "version": "2.3.0",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^10.7.1",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "standard": "^11.0.1",
+        "ts-node": "^7.0.1",
+        "typescript": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-wWRwboLa//uIppXIodKsl+qe4zAUNHwGBZUIkc32xR64fcSqGXCnxEZ3Fyl8M2muy9fq+mv2BQbFmZB3hZ4Bfg==",
+        "shasum": "690d682cb9e2dde26d25f41bcc2b4774b67d1fa2",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.3.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 26981,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbevT7CRA9TVsSAnZWagAAIRUP/0cX+zVisA0RDZ/oJbh5\n3uNjXGY5PNftGlb0AJzTXW2YKVCwJhaJ68ERv7Nh40KNlxhcQhyD1DivQb6C\nkEtnBJ0x8cNP86wAahpFQk5h8hZdgeVnsjnTDRWyjDEmp2mKB9hDrb2pTmkU\nq0TtMmrqKNTE32B9Cng72fJ05EO6GImKURk9KXJqp+fYustQK22HHN3LyNQV\nST9XMfEfIpYjzr65oiq11ceenU/+jrHinN79QN5JPsSRaGcbEYLl5+NeyqmM\nivenbIbmNIYaN7g23aR5QJ/XTmhcikFXoifGVD+gdT0msLNNreJDRzEJt6VF\nlQnj3XfqHWhSPVtZ7KHCiOYhwtD7YLpX2bdAYftW1Q53wnEnjoY7Lfxoqd1e\n7AtnjF6MGvEEFK/FHRHO+ao3y3f1FOj6yL1zJe+EK1hrEOuplPMqMG8HsiCg\nFEcTm31nw7ciwi5Gi6segCle0frLswKYRwYFlY6cc4Te0h6cFRv6sBN2CvRj\nsyeQ6rR/wl4zHFeA7jiDUyOYyTEfyqSQfsB8WjHhxLkCNtBjTfRygu294qtI\n166rKoreU72oNTIvozalQwmcc272RCeDLSruy7MY41LO1DKZhohYWoeyLCG2\nEwFYrQryVaVSQJyUtXI59XQBZAGDBML4yM93y2RQpq2mddIfQNpBEiO2YuTo\n1Dd6\r\n=18IO\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.4.0": {
+      "name": "path-to-regexp",
+      "version": "2.4.0",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^10.7.1",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "standard": "^11.0.1",
+        "ts-node": "^7.0.1",
+        "typescript": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+        "shasum": "35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 27372,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgz5cCRA9TVsSAnZWagAABV8P/j3O5fXfCEuI/D0M4ATo\ny7iDPQB+jEO81v7UbtKjca0IPpr/n1fkcX55Mr/wfzWlksctYk+EbwDVsole\nJAuXy05mirFkPyf78lid9YHnaFnSMUaNlhIz5kkABhPmH67DCYVMdZp6Gtys\ndUIxu//oroXDVd0Z4mmjkUfiToVCDD67uMkOxsJ7d2smR5XMhXfPtl4zHSIL\nJshs1jAuYXgz+zeYfkhMgg1owUqE74ueXORKEqmk8UUT6CNjaxv6tIfqv4DI\nkGnX+oIDOJgw8LaojqAV1sSEDWtD8AnnA5/DeQj/ADhIiLG8Yy4JVPdL3Mo9\nRpsRA8SYetpc3y49uLmlYgXG1A3ayR6RIBmqCWnU5hOrQT5p8kZmvlmRvSL2\nGDrfBW2WdvIBOzZTsOX6nSAg3w7C7abLp/MO1PeanXxmIXQKQ/oAf3asH35U\nJmEYT4Rf6kKnr/JlaweClhyvs91gJgMwSlO/MDeB7tgyFDjRwDJicVj9ue0H\ndYavvdZmr/CO7j4Zfn4ryaY+N4Ao34Ooa563NVj/At40n2HeRYCtik3CONNM\nYvuHwahO7h2limYCcrhTJSXuJ59HQiLedKL3FpYbCwMgGFPmw213GOIAeC+a\nbbZjYpP+fYLZGyxFdiaUwYpfkVkEE08q5zfX9pe7AZffuoqhUsJAH5kl6Nne\n56TB\r\n=8dfi\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.0.0": {
+      "name": "path-to-regexp",
+      "version": "3.0.0",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^10.7.1",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "standard": "^12.0.1",
+        "ts-node": "^7.0.1",
+        "typescript": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A==",
+        "shasum": "c981a218f3df543fa28696be2f88e0c58d2e012a",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 27504,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcO9hnCRA9TVsSAnZWagAAGzYP/RwVfwRM8T3aUyH29j8w\nKM4wjV6nOOS0TQXCl2U0ie1Z+hwv7yt65YYmvsuagF1ZbGtpXam7sVUUUfwN\nEudiEBap9ghQSRu1lU2CxDU/pkJm1lcuHgHs/nDyxkTGOeNxs2gqVnQlRNZU\nFaTui+RZI0710WUW/44hrAQj3Cvf3CKqxJUXjaO923kcSqaZAvxPPs+8FYsC\nKBMmddzrLbDBHCIBhQ+5BcDeLe+Bd/eQGZdEDWNATOX5Kngk3fG8FoW6Ejpi\noosNai0Ksr132rL8ZB50niD7Phx/FYchqyePghtG8nIrLxBcmn7tj2M+4Dw8\nydLnfPj5hova+YU2jTCa49HSmx9bgf4UW8Hcj8OcenMRJytq2rvAVp/W0lCA\nbyPuCA6zd/vtsGI6dtjZQ/juXt1udDusXAy8aytZaFHHIYd2Ru9e2SBhNDpg\nvsleLA6/pZHQFz+HvXgsdJrOD/oVY5Ka3UzuVzCUYyvdf2hJpjppY8kpvbWN\n9wHS8dfaDlfOh10NzVpsAF55+whxAExbjmC6i4+vr5gaahtQRPve/OZdVZnu\njPASkQ6D5b81DkVXjLJWpxs/VKlmcHVU1yTsK1rAUfQal3keBJ2dJ7XAPfAu\nPhlecsczU0JVfT4xeZDHLljtB0f7B5McI9xseJRIB42iClOgn4GQ5DwDxrYM\n8OiY\r\n=bFfL\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.1.0": {
+      "name": "path-to-regexp",
+      "version": "3.1.0",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^12.7.3",
+        "chai": "^4.1.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^6.2.0",
+        "standard": "^14.1.0",
+        "ts-node": "^8.3.0",
+        "typescript": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-PtHLisEvUOepjc+sStXxJ/pDV/s5UBTOKWJY2SOz3e6E/iN/jLknY9WL72kTwRrwXDUbZTEAtSnJbz2fF127DA==",
+        "shasum": "f45a9cc4dc6331ae8f131e0ce4fde8607f802367",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.1.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 28721,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdafCeCRA9TVsSAnZWagAAQ+gP/3pV6hwCl7uSt6t6LqkL\nlMUXgsuFfS4qWWC2hfOuKKCxs4wvBHRG0f8oAYNYDMptx6PjYycFt5GfgBM5\nnlnJH1J76IAz0NeqyabMpyqidMO9KO38EXCDAB6s4IO2ihUUZlP8xk+lHCWg\nGDGOrrtnfyi48Liwi4R7Iiy+yJ1hvD9DlzwSXhOyEmGXOVxEA0e5e9R9xRF/\norwgE//Th0F3WmA/Vfrox75JFg/KQzcFO30Rgj+Bjz6csv1aZXgChFKAxBMr\nVPwe2oS6D57a7clWslc5kZWHGa9s2jup1KjXD54JGwcGHp728m+j14UpWqr6\n20KXh78APgZxdeGVQM+cA4TjI+HV71bzJBrGUOYS9pHb5ncFi/BaBA1Z3u8i\nzAsZLvzXpcgdxFHNtDwUyPNWLTsOw//xft03zIxsaNxwtp6MHEBufoIumYBZ\npFgxj5Ze540moQ0bFz6w5KRFyQWmbJ0DqiCWKSGXimWZPrzlgFMMSGgAhaGS\nFWXeCLiu3kgTFnk6hLq1+1ikCIIVWaxYz+ZBopbbhHfx+qAIIMpGopfXkH2v\nOUO7l08WysJ1TxjZqqfdz3OwWiYBgQtIqlkcwDKHz+wxQ9TB4HlZtJkQjTmd\nVDwx+3Wcz1eJ6EPBw3dto/SsaOOJL2BlI5Hp7nu7tUQXItqyAVn4K3V8dRin\nfyqj\r\n=O2zj\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.8.0": {
+      "name": "path-to-regexp",
+      "version": "1.8.0",
+      "dependencies": {
+        "isarray": "0.0.1"
+      },
+      "devDependencies": {
+        "chai": "^2.3.0",
+        "istanbul": "~0.3.0",
+        "mocha": "~2.2.4",
+        "standard": "~3.7.3",
+        "ts-node": "^0.5.5",
+        "typescript": "^1.8.7",
+        "typings": "^1.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+        "shasum": "887b3ba9d84393e87a0a0b9f4cb756198b53548a",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 27719,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyNdyCRA9TVsSAnZWagAA3dsQAIdx4UYMUcXZ1jWemWIa\nWmAfv/EDjN9NRragvEchvin/p8JzhVM0eKAyDoHhNRD1gbvDr1JYNmVLap22\nyFuX2+k/KrQVPjeKDMrwpUMTuhXpeDFes/3F/Usu77tVy/0hu7noqKSYQSkK\ngIsJwnm4DZYGbMR3HicrY8scMsCgs3cD+6W1w0qljkbITnQnZCq4jtYHWVV7\n/YoenidG8WJ++wZc0uoELm9QTvRheprKcS6Rb4T7q+q7ElgGBpCLX9RO2xc8\nmPyOqa8RU2SoU4rMe1naIAcwwKrdg8xUCQ06qsZ63Nm1R9ciV9vcppDFBCMv\nGSOOIUAz517UPaKMi/97Blh0wxIIouBxWyKQqEDTd2P9jn0lPJ6rg5WR2+RC\nSpKjxLVhIj6vFUHYqEUN3CwYGdDNkzkgMutdu/lmMePMKXWdswfZux+9/A/h\nfGEomo/H06/8i5CxQl21Ks1Z9fm18beWgmp2m8UCzFxbPSsiztwlefL47LVr\nrkp+jB2sh6m3a/zum+LL/cmBsFskEPu3vghPM4ZWrhqGPY/anywauwHaoJH8\nyDDHJ+zVykS7Tq+rCLUsUcBMealHWneDzEqmfrK4MWbTN5njglM1niaTTheT\nXlDzR304qD8CO0rS+zZpWyA9EZzQvEIYczS6d0VOQ53CxrcVxYcWpfFmf4HG\nlj0T\r\n=EPuP\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.2.0": {
+      "name": "path-to-regexp",
+      "version": "3.2.0",
+      "devDependencies": {
+        "@types/chai": "^4.0.4",
+        "@types/mocha": "^5.2.5",
+        "@types/node": "^12.7.3",
+        "chai": "^4.1.1",
+        "mocha": "^6.2.0",
+        "nyc": "^14.1.1",
+        "standard": "^14.1.0",
+        "ts-node": "^8.3.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==",
+        "shasum": "fa7877ecbc495c601907562222453c43cc204a5f",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 30871,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyPacCRA9TVsSAnZWagAABaAP/2X5SbiKS5o0b64IySTf\nK204AxDYUqid+vRNnT4j45OhKsoAS+VntbEyuRbTtHVDpapk/suuSL1z3hTl\njJwh6uM3/Aocd3G0/g6wlk+mzv87OEn4zJi+8BzGY3G31Z1W/2mKmSfx6QiY\niWYFQiM9iHWRWa3p0NqVV7cJBdh/hPYO9QgbmSauGryttAgWazq7Y2A6pOK4\nMlI5LVxXg42ajWAeApZRn2hFgCPQJOo8JZqQjuMt0Ffkpg1olEinqPRNzZfW\nETIicDxby9aKcDt4+WrQumGP8vLhEa/VbmiAdNW09WI/dMbinEpUeJQVfUxq\nTgc5MEf1J4sJAuitB1KzeUh60A2FphhLZvQoxjrgIF/qALQsjqyC6zv1MRhc\nqtjrNEw4dssSHlbhQ0VNddxoUWJ/4nNGSdhy85dvJsd1e5RX73JvoSrobuL6\nwAjz8isvsfo5VbuvOvjazIskU6T2ryMEUapxhwXGOiPHm7N9japL35o82d9p\nznbawukAgffBDHHPMJfyMLRZHYxnB9vFjoa/TdgJmZdwTD51CAMnMQy/hYVG\nnLdWbXCfkSCqHyboy+uDe53SBzBfuX8MoWB/nBf+KGmpvDRvMVrWNcYq/FW1\n7IGM3QJG6cSTuAZUyPFEw1VgcWsD3bP2OX5xTsqLJIWmWwHz3emA3ErU6YCN\nqbqx\r\n=CVMO\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.0": {
+      "name": "path-to-regexp",
+      "version": "4.0.0",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-WePdN1ndXgSWXXWrmKJxLSlazaMPeW8UYVQ63NDBHikr61eNUGCJrCEemfaQLSxGHzqzcu1YSlZu7CqqWh2Lfw==",
+        "shasum": "58768f48b2697004b12b3e5cd6bfb339ae8e7eab",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 470372,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyic8CRA9TVsSAnZWagAA5w8P/jqHH0zIaNeQgKuiUxTb\n0l/9+559VQxZLgBxrvWRVXpt3L1Yy5TjkrY3Z/O5T0te/hcaSrgJQIxaDrOk\nIQS7RjtP8qMCaN4+Ys4V1+qS0WmWSnDGv32ndt5NXOttMCLsfl7McYXniHh2\nZvXXrwCSYQQ1W7iRxjscKDgfw3Jn+fdk6a/79B1akfBRU/hAleMaYlt4Wrc9\nR+xUgObQQnm0IJDN0GapZpOPcJPjtejfHIjBN/8TwFbcFKYXb4iBYEert3Sc\nONd/uiY61rTiHtFiGcIDTUO+3vjuBQgcBqjAAl450De2g0po3OF43LZ6Sa7U\nkfjSswQrXrwJ8n3EFXARFuQEP1jkHG9bEWc500Rk10obHgabqq5zuFJTjeRi\nLOCYsg7KE8/uq8VlF94jjyBnXUYW2OzvZCvWKC8do5sHkv5KQsUwgY3HO8CJ\nDmpUzKsoGJzWONFLUHwlmn70/30DZ0xf9G0rTEev9C4CJdlIP+B3L5wqJf83\nWOrrOjt3NdvuqYaHLSQN5yvD4zX10i0OHJ0oFvDG+1LKDKe0AH5RqPVVhz2e\nlxic3riThY/rQRg5LJKUIL1faLMxRFKkJZt9Q72mlm9o2P4gbCCI1fEZF/3Q\nmZ5YAqCuSSjBe9RvfLqH3HsmQtW53oEcFIhAqenPPhSzQF5FR6EaPAvMvfzG\n0hwx\r\n=lrUd\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.1": {
+      "name": "path-to-regexp",
+      "version": "4.0.1",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-gdAzunCn/o8fI5Fc1M9Ri+qgJSLKKEbfkoDij79QSOsRQVK/cOlWxzSlYJqLkGo3YCLm9ECDxJo53lWEVSp+Ug==",
+        "shasum": "119a9a7f0aa0b8f7048593ee0b7fca1512460caa",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.1.tgz",
+        "fileCount": 14,
+        "unpackedSize": 470372,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyjBWCRA9TVsSAnZWagAAtp0P/1EOxUnffzxiiDW7V3b1\nDZ+KsqnoaElDOqcfNK61MghxqXc70cTWm+UE/vvFHTF4G87s9NjS763ayutO\nS+9xB7puOFKAmp6b9tTbZlZF1I1vp/Bp8b6aFTMajYYH/3AUWf0KcqQOXjzC\nPuz4MOKblBJqWxGJL2AaVBG4fmiKLFf9mnaGPbQfwH26fZ0JMSF5rR0BItKP\n1pMmXY+574ADjwA0pBuu1xfFsmoYtNHjvPBK+zqIRdQybVdVDW0XWs+eLI8c\nTG5aTWJ7HJOXt2UA9uH8UyzRqwKbBsfIyCxfo0NukzOkbpt5AmNILhtlDXuC\nLOa7iqWeNMo/t4hvaxuM6yCpfQYHnq7BBL7eVYIYGV0xEz4lnb3WBoKwZsMx\ncTSvRBDkNJ9hmC9pvNFMl0iVJQ9dOQ3nsqoOPioIEsWGplSJJD+SPNs/M4SX\nxdEECMz7sMllpfFB5Rhyq24NefA1vX5q9tfp8UIdrjIzFYJahXYT+H1uPtXr\nD4Lt0iQ/rIe08osFtwC9mbSd/V3MqsN5aCyFJ6/qpmt3aqJvyAyxf49gREM0\nApGwxyOv9ZcIFlnMMvsxIIEvPXJatQOKoR2K3ScC0z2acFzZJYn53nGmbi2n\nDiM+jKvWTes7HxnVMuUsVkC+9JsE5NGDyZ/PM76w0un0J2yw6Wj/Wl2UmIph\nUqxB\r\n=5NM0\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.2": {
+      "name": "path-to-regexp",
+      "version": "4.0.2",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-HsWwoyYDDkKyd/4Plv5Obcqxi1xXhIrG2LRdyX07yAIarSD/55itj/Y/SajVHDtRiaNIwsuujnOlRj5MFXd0Tw==",
+        "shasum": "c1f1508056be0c77971343e82f598d74830b3597",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.2.tgz",
+        "fileCount": 14,
+        "unpackedSize": 470420,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyjZ5CRA9TVsSAnZWagAAHRsP/1QjXEAj2jAHVvChWqSh\n0ZZavLdrcf4vud1oTINb/miuzVGm6bHXH5sTXykIKet9bWvNxNmbsKJnlDzP\n5qPsOe0jclcWEzX61+J5VdoIf4FTRGiPBf25ebsNWTlA3XgN1pkmTB31JDs8\nOI9txh4rzNun2AS0yKlH4+xDaiyhNkeRc1jpaR7oxhGGUE1CykDhg0+v5uAD\nnQqo6If/sYWZR22qxJf72nSicQuO40XRQ2kmc4GB6loU2YdHz8amtfXHqyJr\nSb8l0fjK0g+f6NR+7OL7krmLPqQBC4lH8lhBwMHUYx6twMTq0w7mOl2vnsHB\n2j0DHK5uY2WASpfo+9J/H9bGKds0Gh1gM7FlWZCe/56nnH/gVkxWF6ZcCiNk\ndyprMBa/BMrFjS2jda6hYHFInsxY4wDLGbYK64Va1l5uVS0/5xYJk1AvYigI\nNhWwl+EBxRlJbaIvJIQ2lyRyqwZRfW627lDxLdBJz72I1fKRu4kZqFJTODkB\nSF7CobpEG09v4pF0qD6QX9Di6cSO4/f+CQrEkIDpgM0QOoVOqQb3X9qSc5cz\nHWkP9QP8Wi0kMwGmRIJ8rnAgkGH7WLCzpawz7AAt0l7ls/U5rXlyY+xVL/nF\nBhvW1z5ZxglJe8ycX488jwQoquTYmsqksylPHT3r0Krr8es871D2tIe7Jdr/\nNSgZ\r\n=URSE\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.3": {
+      "name": "path-to-regexp",
+      "version": "4.0.3",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-JkDr0ji2zsBqaz/+X7WDpRM73y6m86Eh7Cba5zgY/bjFpeC9vprRFGptsXjJD7EJqwa7W2ESQpdObm0iwVpKWg==",
+        "shasum": "5b5428d180b0f115ad438e1ef010e63a0a25d7e1",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.3.tgz",
+        "fileCount": 14,
+        "unpackedSize": 473276,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdylbqCRA9TVsSAnZWagAA1GwP/102y3vEUHUt9Qa5Ieas\n5sZVHkt+lnWkPpPTM6Dx2g9NGyjw1HMDPOVsV1KrXc7nF5vxfi3iS5CF4CyH\nHFMuZbVZf6yaxy67+nhXwyzGP5rppCE2zbss9LA1y7gm7AJE2XVQTsyJO4P/\nUS9F+K+wyNF6zBIgmGSdsZeKZatFAq7adGLnSo8B6gUnun5L23mLfv686aNy\n7FaDBBuOwbotQibSrouPr9d1Uyh6W2TKHyUVbUi8tBqn5z8wWES3bUhlUbKS\nKZL04DK6d8jPYkA2CD1A3zO9Mo4VgnRben08kd+jmOkUu+k9cYIw3BM3wlG8\nMevHIkSkANG6HEtkz+zXuYgKoYGNx3f3QuUK/HXK+UO62vAjZuTHwDkPd3Dm\n6uZ6WVIUHUtiJwTLQNyaewrP1I2YCsks0eB/Nb/nAMCu4YV7Ptu8SfxpYudp\n5cPQAy87MztWk4HHkcqDQOBQI5mBSwsVIYFi6IEgr0DQrRTa/c1nuop/FT+u\nn9BXR0wWNssN9rv48axhmr1KgpUuDhrhQbs9rpsaOOy7CuTj9XoUjRwdqykI\n2kv/bVygNFSxYVwx8r9tWILcG1cXXaWvEe7wqh26FkQHKokVnBcOSj3xkGy8\nWZJckTeZAtkJLTYglGSVBRvByiKtXIxdwcxOMI2mpzA9JpIn2tUSa8TMXX5S\nM/eC\r\n=IBbz\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.4": {
+      "name": "path-to-regexp",
+      "version": "4.0.4",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-Nu0+EVkG5T0wEqDT2roshNDnfoB1DS8q737dczIg+gpxt3QzxfLXi0oiuZso98IQrug9lW/anwi2+dTtrYngEw==",
+        "shasum": "9c0edc5500cc976d8e5f2520bf8722fc0b65019f",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.4.tgz",
+        "fileCount": 14,
+        "unpackedSize": 472934,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyl0gCRA9TVsSAnZWagAAzpUP/iZcZznRrg6jWnV9BSfZ\ngFQR3ONw608moWEXDwmcnAzO0l22PkytnYfvQP0CYIHq30agPwBTQt5e3OCi\nJDAdTQ08yj3lOD/C/wfTFLCAUIkCBVgOZsf39T9md7M1Kz3NB9zI0ajtbsQM\ndTYBB05t7SKcPFexT0yeTenV8q8VZ+pg5iGtpULSV5mlDzUFOHm9wHMJ39xW\nk3o/xWEZilQT2V8YsetoV/KJNvtcS/kFVpwNwZWJsutdbYxQmjy1AGUmngos\na/58QEdQRb89/K5sG0VtZqghL/bE3tAwI6VCcaj/FemGtGfRxczbkI29XN4c\n9PTGDabZLfotU63GSR+DMd2RWEJuWBpvV8L5/tnBMbxF4BKU0Dc1Jj57AA5E\nDsEk370PUV3EUa4MF6SUFaEd3rz3JtL6hUdEf7cbsOD3q3uq8RXznNS0yq+b\nzvsaC8N1czZ9WT4Zqyqdr1sOlfzmPgaj5FCZ9RwQQG/DMeMbPXstbHRCeEe7\nz5SDdItauI99B5Vo3xj9k6zv3fIDRBIRghqCJxssuA2pZhoQWNC1hA5u7apZ\nU9Wzu8dsIVxweshq9XCcGyu6ybbG1aAH5g2XZcFltJiNSsCxwp5jI3wOvl2N\nGvgem9AXmW24FE5zbfcNHt5nSnC5+bU74IvTHwOUgKQhuYFui/iVAXz+Ely0\nllgb\r\n=qXZz\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.5": {
+      "name": "path-to-regexp",
+      "version": "4.0.5",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-l+fTaGG2N9ZRpCEUj5fG1VKdDLaiqwCIvPngpnxzREhcdobhZC4ou4w984HBu72DqAJ5CfcdV6tjqNOunfpdsQ==",
+        "shasum": "2d4fd140af9a369bf7b68f77a7fdc340490f4239",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-4.0.5.tgz",
+        "fileCount": 14,
+        "unpackedSize": 471565,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyor9CRA9TVsSAnZWagAAYYgP/3gtNtAcB7+qnUkrYvnZ\nB7jJCtoSGD9gximFIyIrU6D3u+TMIP5O9ODrfi74snyi98pS2PcNGc8wflnz\nRGE3egYZC12Ojo1DoC7keO1JsXYI5/D1sL32JbdpRqR311j64Ux08UGHgvrV\nyGe1SCBuJ2mgCICT5dz/CRhiqr//zmz36IgkKZsYoWGFE9oNU/c64F2ND4w0\n921dlsj3bFhXeeasOcIIJBHpO34qVK3fLTKXvwhIvmrSGjNdws2q650pfz0P\nHtyT23vu25IZigXquPiflBpTw7QsQ1mAGEyupuIOj8l5Qw7c3iLrUwyGTZot\nK79sQzr4kaqHFwQt807P9QhKumZB7JDjR07j2PU/1FEuNy/LixJomvkTesry\nuWI4EEpwx/ARS4YxaPMqmhhIuqufWjPy5TpWqWOZQa1NE0VLXA+IvuJoWTVF\nC53ggoYa7rTawHkli2gAXUtBu5cQfMSVwrfxRG5h6dZmcOlxgaEUHyotQGoG\neLZjxnLTlpSC+rXh4dZyRPzHyPADQ9ZoMymKJBgQjmxn4rWRX8jrpgp3Lc/0\nUaCcCwXealS26nG+3/Dx/R7/6tQwB1+JOR0thjYdE63GGwy1HJAvqPuPGjl3\nw7Pw0NdkhZHPYbQBpACy4n+slRgUcG4dP3yUm5uswUBVusvF6EZc33Xbxs26\nBpZN\r\n=PUJ6\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "5.0.0": {
+      "name": "path-to-regexp",
+      "version": "5.0.0",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-VOQVA+0mivusQfaveeWlrW7ddXKuStHMTdovn/1epf7cEpUL4dpzGl7eq8ho96H9w90/q66yJLsqn84jSCfkmQ==",
+        "shasum": "e56dd58778b9dc06e76f0f3e39e741bbddc0bd26",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-5.0.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 468899,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdyp9RCRA9TVsSAnZWagAATbQP/0gaUnwfpr7qeQLhOsWT\nlf2zkosGpkbQSGjtirEMuo7bMxjj8i8t8hOszvTjBUPqLrDFdxDHzZlWIu5R\nwLzXO4EYb4BBxALyg+eJfgC1RMRD6YmYr/z3HmFy3/2rS07DH6b5dSuOm2GC\n1/igKX8tmyB7WNIHVodiTlSgpDCENOIoV/gRhXbGISByvDbegBKjIdSTyn3b\nAMfJxvNPpp3hDuNj7DfMuovboNGNNNeGv6O7MBSR543OSy5GTaBOXKKS5PAH\n4sI6UU7eK3SHWdbimt0scSVjTblWi+4oNkNj1JrYLL3WDCO/0me7AlQVATOl\ngBgDHKaHZwW/FgHJ/NGoks4TJ6LxJaO5PKkkMQvMUONtxvctatqjvQf8n7u8\nO4p59gB0aKu+YxShMW/Dh8EfSIkOU2kGsJYGw0SFjWTGXRxZuHmbX5ACTOH3\nygqPkmD5D+NpemL/Ln/yZRT/LdCSL+pVRNw780ngIW8VO7YIcDJnr7VHH3MV\nVn5IbCy41689eZwaZdz54CX9Ho7ye24KFASNsq2jOukQhaT05r6/8G+iwzLV\n0sfX9ksXgBwtxBhT9o2BQzuVHcgmwlA3/cQJWcm1FxOn3PubgO4WO5CYwg9u\n9L+nEaLkXCEYfzhv+2z+IOC2s5CuoaygfTPwOddYxujf3m2aTAwakPSdKfly\nMSpJ\r\n=xmXy\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "6.0.0": {
+      "name": "path-to-regexp",
+      "version": "6.0.0",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-/BtzpwyPV+/I4gL16q3r3xb73zcLyALoP+FPXfp1W60N+qCkKATnt9bihaYMBCSxHhttopoFPw7diGBqcOXkqA==",
+        "shasum": "8797c236ca80f62b9e36e39eb3ef5208ad6ab68e",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.0.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 468051,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd1L0HCRA9TVsSAnZWagAAuRIP/3kSAeoYPYdgGW8hBOcA\nLmJjcB+x5mB977eSPQCq+lPLFVnMNXC+4RFlxVuQKovafDRLy9OLy59sVau1\nxoW8QTY9bOCTP7a1JMJwmPQJdFQ24R+7F0B5EdWTBnEt8i3hxMwNzw69GiMY\nUexNTesIvTY0tjsibJGlkw27EMzY/ePCqJU4WSPXDb+yyXvLqpPj0dYCBIe5\n8gUp0adv56isPZwWcwh1x7n52pKcDvhy/Gi/Gq0+3iwM4DK1hudmt0wSjs0G\nNLHwuvpkhwWF+dzCwb5+olswSJfZlGhIWjVTcT3O2hOP6Xq0nljBtNLPR2VP\ntEZ6KP7Fz/eqZBPg8Wdh2f9BbKwoFRSSsEzRHtJBR3Ow2MPVUdOIIgTo5IYk\ne66qOkRUk4bVM1dzGcGV3jalUf8RWKS0lTW3D5/BHBSGXbY4gzJ48ndqma+/\nGJI7LZNTz8pgipeAkz3sEi+Fd/1MRQP2Kh9JlV+KaVZxGWDHCgP8GuRMv8lL\nY4KhD8GABTtlaMsk6CVo3vaAqUhP0SScSPzu76ROTVHXyyq2xZW5DEwElRJL\nMwT77FTZLDRmtxpWSa0SuyCWt8eDwFnH3z152eleb6zxXubVUEWJgOkSWyNH\n49J7s4o82yoTF5DuY5NkerHepN9VugsE9kTfJ4a5L281hbpsZ1GX+gVZwBeU\nb6J0\r\n=U/zE\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "6.1.0": {
+      "name": "path-to-regexp",
+      "version": "6.1.0",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^2.1.6",
+        "@types/jest": "^24.0.22",
+        "@types/node": "^12.12.7",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "lint-staged": "^9.4.2",
+        "prettier": "^1.19.1",
+        "rimraf": "^3.0.0",
+        "ts-jest": "^24.1.0",
+        "tslint": "^5.20.1",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+        "shasum": "0b18f88b7a0ce0bfae6a25990c909ab86f512427",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 476190,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd1ZNPCRA9TVsSAnZWagAA5u0QAIPB+iLLHOaiLSK9m3gM\nS7HbJhsmxpWOEPzY+YkWMSZWEI1qpDz53JfjaMSguEZsysD9rJD28KmUoYlP\nmN95HEmjqv3z2YVbCBSeqPvCaxPx3zN6qF/NFMNTKS4ZWC/vk7zeItS60bKd\ngDnhbxVSyJP0CZTJwbMX72ELZPBNQBXJhI1vJrLDUkXBFwweTSaYhS0QClrH\nnjaTRVfKz+6KpXIjkh5r6guQNHX6cWVCahTx162wzg2gyqDt3pSI7P5WbxAr\nPabDtVZX2S+YdI5tcwLD642s1nm1GPixQ438/qwHCV/HKKWhV2av0ZHWlK2i\n+tDdw8yqKVIsp3fIv5KGbs2D+CUok+oqbFNPMzOqe1MHUJKUfY2R49EkKfjn\n+RXCEb3+9KHOsEVhZpGq+wkScepmcJ88tC9iYHvm+hyRODQbl3lWnP2hJBjw\nyGGhkSlNzfq3gH3Xn2GjA+tCvTaDo8nJbrx7L8QFR+J2yg8ERkjOzIJkVsID\nsdwWQT0oZ1j5y6mDMA0e8zP0ySgZq6rTbpGCFCLYqBiWwsR46BZaFz+r2uE1\n7ZozRC6FCplY+Ggi1rS7sIdYTqa8g6mItmhhj05kBw0sAY8rvLXKwwIczdm2\noGcvnMz79EqDSIw7FlJfZGk+PsHoRUtTKJwkezjEBwyRqxbMHj1lFO69BNDu\n0lJr\r\n=voQX\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "6.2.0": {
+      "name": "path-to-regexp",
+      "version": "6.2.0",
+      "devDependencies": {
+        "@size-limit/preset-small-lib": "^4.5.6",
+        "@types/jest": "^26.0.9",
+        "@types/node": "^14.0.27",
+        "@types/semver": "^7.3.1",
+        "husky": "^4.2.5",
+        "jest": "^26.2.2",
+        "lint-staged": "^10.2.11",
+        "prettier": "^2.0.5",
+        "rimraf": "^3.0.0",
+        "semver": "^7.3.2",
+        "size-limit": "^4.5.6",
+        "ts-jest": "^26.1.4",
+        "tslint": "^6.1.3",
+        "tslint-config-prettier": "^1.18.0",
+        "tslint-config-standard": "^9.0.0",
+        "typescript": "^4.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
+        "shasum": "f7b3803336104c346889adece614669230645f38",
+        "tarball": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 111238,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfc22XCRA9TVsSAnZWagAAeGoP/3UROxSdG31+M9LNl0x4\nWvZDtKYQpVRm31l+szSzlSwtQ06e0oY29I1r9DiSBPkY4OOvaEdJN3G9IWmo\n5Li1Htb3GYeuEkbkqk4Q1Ib6fyl5miYuRPNa7ndf+0ayMy2Z+C228GslJju0\nILzvuzXDGLCZe1LHShkhTbglrrrE0QuMSfjlRfLdwx0CgImYyRyEoeNkhXx9\nIhlzAlrZWrYF5wHhBI3VLVS9B/nx7mqV1XkHbwspckex1oxbghMGT1mqKoNO\njDsb+8ArURIIut0LyAMkjlgepMVPnbmwqsaXgyl/Eusrr1qUyF3sT5SkI9oA\nZvOAcGOvcrs5L7G1QwiwTpIeMJWbAtooxdJe3Al+Em8UtvPk8+74jObo8dAr\nHfQlg0BivYW0eTXP914cz9f6zSDaIrpDiXunplx/otTlqHf3FZYM3702GTQH\noZzfF0hwNYrjAJGFrW+BKzn+aQeAfGN+2+UhVTJxoIJ/6j8Tjc2TuT3rIpM1\n3sNB7Ar2tKM4nAq1BRd2Mp/k3DdEYptvW3PisOLF98kprq4VRRSN0AhRgDkd\nYHktaGkhymVG0cEfaeMbWTzxCEauJKjxbNUI6nD5720jejio1VGjXXLRYVzY\noh1n4Sy4TjqDySZcAbwGJmmtAU2HYB+sxoSPBTRUhNC1FU75JgGm4eP7DrBF\n0pW3\r\n=9dQo\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-09-29T17:23:37.768Z"
+}

--- a/test/fixtures/registry-mocks/content/pbkdf2.json
+++ b/test/fixtures/registry-mocks/content/pbkdf2.json
@@ -1,0 +1,2059 @@
+{
+  "_id": "pbkdf2",
+  "_rev": "53-db1a7ec837a45c15e9b6fc6e76c7b76b",
+  "name": "pbkdf2",
+  "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+  "dist-tags": {
+    "latest": "3.1.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "pbkdf2",
+      "version": "0.0.1",
+      "description": "Hash password and compare using PBKDF2, pbkdf2-sha1, pbkdf2-sha256, pbkdf2-sha512.",
+      "keywords": [
+        "pbkdf2",
+        "pbkdf2-sha1",
+        "pbkdf2-sha256",
+        "pbkdf2-sha512",
+        "password",
+        "salt",
+        "pwd",
+        "authentication",
+        "auth"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fundon/pbkdf2.git"
+      },
+      "author": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.11.11"
+      },
+      "bugs": {
+        "url": "https://github.com/fundon/pbkdf2/issues"
+      },
+      "homepage": "https://github.com/fundon/pbkdf2",
+      "_id": "pbkdf2@0.0.1",
+      "dist": {
+        "shasum": "ff706d83cba1e0543de1862e5c788aba1828c002",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "pbkdf2",
+      "version": "0.0.2",
+      "description": "Hash password and compare using PBKDF2, pbkdf2-sha1, pbkdf2-sha256, pbkdf2-sha512.",
+      "keywords": [
+        "pbkdf2",
+        "pbkdf2-sha1",
+        "pbkdf2-sha256",
+        "pbkdf2-sha512",
+        "password",
+        "salt",
+        "pwd",
+        "authentication",
+        "auth"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fundon/pbkdf2.git"
+      },
+      "author": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.11.11"
+      },
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "should": "~3.1.2"
+      },
+      "bugs": {
+        "url": "https://github.com/fundon/pbkdf2/issues"
+      },
+      "homepage": "https://github.com/fundon/pbkdf2",
+      "_id": "pbkdf2@0.0.2",
+      "dist": {
+        "shasum": "8397b43c9dc057f71f6a01e01ea8a90f8d9cfb1c",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "pbkdf2",
+      "version": "0.0.3",
+      "description": "Hash password and compare using PBKDF2, pbkdf2-sha1, pbkdf2-sha256, pbkdf2-sha512.",
+      "keywords": [
+        "pbkdf2",
+        "pbkdf2-sha1",
+        "pbkdf2-sha256",
+        "pbkdf2-sha512",
+        "password",
+        "salt",
+        "pwd",
+        "authentication",
+        "auth"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fundon/pbkdf2.git"
+      },
+      "author": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.11.11"
+      },
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "should": "~3.1.2"
+      },
+      "bugs": {
+        "url": "https://github.com/fundon/pbkdf2/issues"
+      },
+      "homepage": "https://github.com/fundon/pbkdf2",
+      "_id": "pbkdf2@0.0.3",
+      "dist": {
+        "shasum": "08be85c48743961ca5e3f8a514e73a4e77f2f8d3",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "pbkdf2",
+      "version": "0.0.4",
+      "description": "Hash password and compare using PBKDF2, pbkdf2-sha1, pbkdf2-sha256, pbkdf2-sha512.",
+      "keywords": [
+        "pbkdf2",
+        "pbkdf2-sha1",
+        "pbkdf2-sha256",
+        "pbkdf2-sha512",
+        "password",
+        "salt",
+        "pwd",
+        "authentication",
+        "auth"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fundon/pbkdf2.git"
+      },
+      "author": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.11.11"
+      },
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "should": "~3.1.2"
+      },
+      "bugs": {
+        "url": "https://github.com/fundon/pbkdf2/issues"
+      },
+      "homepage": "https://github.com/fundon/pbkdf2",
+      "_id": "pbkdf2@0.0.4",
+      "dist": {
+        "shasum": "eeaa34181987c4e12c89077baeae41f9cec96b33",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "pbkdf2",
+      "version": "0.0.5",
+      "description": "Hash password and compare using PBKDF2, pbkdf2-sha1, pbkdf2-sha256, pbkdf2-sha512.",
+      "keywords": [
+        "pbkdf2",
+        "pbkdf2-sha1",
+        "pbkdf2-sha256",
+        "pbkdf2-sha512",
+        "password",
+        "salt",
+        "pwd",
+        "authentication",
+        "auth"
+      ],
+      "main": "index.js",
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fundon/pbkdf2.git"
+      },
+      "author": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.11.11"
+      },
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "should": "~3.1.2"
+      },
+      "bugs": {
+        "url": "https://github.com/fundon/pbkdf2/issues"
+      },
+      "homepage": "https://github.com/fundon/pbkdf2",
+      "_id": "pbkdf2@0.0.5",
+      "dist": {
+        "shasum": "8e6f6e559873196fba5be1202caed7bb439fdf49",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "fundon",
+        "email": "cfddream@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.3": {
+      "name": "pbkdf2",
+      "version": "3.0.3",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "main": "./index.js",
+      "browser": "./browser.js",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "scripts": {
+        "coverage": "istanbul cover _mocha -- -t 20000 test/index.js",
+        "coveralls": "npm run coverage && coveralls < coverage/lcov.info",
+        "standard": "standard",
+        "test": "mocha --reporter list -t 20000 test/index.js",
+        "bundle-test": "browserify test/index.js > test/bundle.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "devDependencies": {
+        "browserify": "^8.1.1",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "standard": "^1.3.0"
+      },
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "standard": {
+        "ignore": [
+          "test/**"
+        ]
+      },
+      "gitHead": "8bdd89160bcaae6ce87f827587b7036c6eabe13f",
+      "_id": "pbkdf2@3.0.3",
+      "_shasum": "a4ad0f23f81d6b71f82a03ffebf3ec82ab8ea8f7",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a4ad0f23f81d6b71f82a03ffebf3ec82ab8ea8f7",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.4": {
+      "name": "pbkdf2",
+      "version": "3.0.4",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "main": "./index.js",
+      "browser": "./browser.js",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "scripts": {
+        "coverage": "istanbul cover _mocha -- -t 20000 test/index.js",
+        "coveralls": "npm run coverage && coveralls < coverage/lcov.info",
+        "standard": "standard",
+        "test": "mocha --reporter list -t 20000 test/index.js",
+        "bundle-test": "browserify test/index.js > test/bundle.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "devDependencies": {
+        "browserify": "^8.1.1",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "standard": "^3.0.0"
+      },
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "standard": {
+        "ignore": [
+          "test/**"
+        ]
+      },
+      "gitHead": "c9b595c784154e433995faf6cd81813aef29c713",
+      "_id": "pbkdf2@3.0.4",
+      "_shasum": "12c8bfaf920543786a85150b03f68d5f1aa982fc",
+      "_from": ".",
+      "_npmVersion": "2.7.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "12c8bfaf920543786a85150b03f68d5f1aa982fc",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "3.0.5": {
+      "name": "pbkdf2",
+      "version": "3.0.5",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "files": [
+        "browser.js",
+        "index.js",
+        "node-shim-async.js",
+        "node-shim.js",
+        "precondition.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 100 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "045ae58e4d0b4511a1b3d86770973cc007dad228",
+      "_id": "pbkdf2@3.0.5",
+      "_shasum": "10d907817f11d1191c11499bd067f04330a0aec3",
+      "_from": ".",
+      "_npmVersion": "3.10.7",
+      "_nodeVersion": "6.5.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "10d907817f11d1191c11499bd067f04330a0aec3",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/pbkdf2-3.0.5.tgz_1473652985203_0.7829968291334808"
+      },
+      "directories": {}
+    },
+    "3.0.6": {
+      "name": "pbkdf2",
+      "version": "3.0.6",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": "browser.js",
+      "files": [
+        "browser.js",
+        "index.js",
+        "node-shim-async.js",
+        "node-shim.js",
+        "precondition.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 100 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "49aa0e657a144bc017a7402c7e6952055ddacb34",
+      "_id": "pbkdf2@3.0.6",
+      "_shasum": "943d289ccd92b3dec55cc77dd696d44d6087e8bd",
+      "_from": ".",
+      "_npmVersion": "3.10.7",
+      "_nodeVersion": "6.5.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "943d289ccd92b3dec55cc77dd696d44d6087e8bd",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/pbkdf2-3.0.6.tgz_1473810361377_0.6315572482999414"
+      },
+      "directories": {}
+    },
+    "3.0.7": {
+      "name": "pbkdf2",
+      "version": "3.0.7",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": "browser.js",
+      "files": [
+        "browser.js",
+        "index.js",
+        "node-shim-async.js",
+        "node-shim.js",
+        "precondition.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 100 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "f08556a9084f2bb87827648f86d4ceb0113f6b6a",
+      "_id": "pbkdf2@3.0.7",
+      "_shasum": "4c12a995caa1ba34bb08d7e98e5aca3cf3767d31",
+      "_from": ".",
+      "_npmVersion": "3.10.7",
+      "_nodeVersion": "6.5.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "4c12a995caa1ba34bb08d7e98e5aca3cf3767d31",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/pbkdf2-3.0.7.tgz_1474001312557_0.6997686207760125"
+      },
+      "directories": {}
+    },
+    "3.0.8": {
+      "name": "pbkdf2",
+      "version": "3.0.8",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": "browser.js",
+      "files": [
+        "browser.js",
+        "index.js",
+        "node-shim-async.js",
+        "node-shim.js",
+        "precondition.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 90 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "gitHead": "b218da3867aa6a1aa941cf0a8b3520bacbb6c75f",
+      "_id": "pbkdf2@3.0.8",
+      "_shasum": "2f8abf16ebecc82277945d748aba1d78761f61e2",
+      "_from": ".",
+      "_npmVersion": "3.10.7",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "2f8abf16ebecc82277945d748aba1d78761f61e2",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pbkdf2-3.0.8.tgz_1474494107572_0.40838201879523695"
+      },
+      "directories": {}
+    },
+    "3.0.9": {
+      "name": "pbkdf2",
+      "version": "3.0.9",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": "browser.js",
+      "files": [
+        "browser.js",
+        "index.js",
+        "node-shim-async.js",
+        "node-shim.js",
+        "precondition.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 90 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "gitHead": "188f9b0aca397f2937249504f72d1d7e4b2f7bd3",
+      "_id": "pbkdf2@3.0.9",
+      "_shasum": "f2c4b25a600058b3c3773c086c37dbbee1ffe693",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "f2c4b25a600058b3c3773c086c37dbbee1ffe693",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pbkdf2-3.0.9.tgz_1475671782268_0.27150986436754465"
+      },
+      "directories": {}
+    },
+    "3.0.10": {
+      "name": "pbkdf2",
+      "version": "3.0.10",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "files": [
+        "browser.js",
+        "index.js",
+        "node-shim-async.js",
+        "node-shim.js",
+        "precondition.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 90 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8",
+        "microtime": "^2.1.3"
+      },
+      "optionalDependencies": {
+        "microtime": "^2.1.3"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "a0a9abc8989e53d358cad22c7a2fd20f60cd9ebe",
+      "_id": "pbkdf2@3.0.10",
+      "_shasum": "24b5b4a97c86bfa50c6921c656c4182ce6d96ba5",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "24b5b4a97c86bfa50c6921c656c4182ce6d96ba5",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/pbkdf2-3.0.10.tgz_1494508196430_0.008772527100518346"
+      },
+      "directories": {}
+    },
+    "3.0.11": {
+      "name": "pbkdf2",
+      "version": "3.0.11",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "files": [
+        "browser.js",
+        "index.js",
+        "lib/async.js",
+        "lib/default-encoding.js",
+        "lib/precondition.js",
+        "lib/sync.js",
+        "lib/sync-browser.js"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 90 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8",
+        "microtime": "^2.1.3"
+      },
+      "optionalDependencies": {
+        "microtime": "^2.1.3"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "2c68fd5a7a0bb4f4622ae3948147a2c9b0ebed5c",
+      "_id": "pbkdf2@3.0.11",
+      "_shasum": "791b7414e50c848438976e12ea2651003037ca6b",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "791b7414e50c848438976e12ea2651003037ca6b",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.11.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pbkdf2-3.0.11.tgz_1494514151614_0.986040003830567"
+      },
+      "directories": {}
+    },
+    "3.0.12": {
+      "name": "pbkdf2",
+      "version": "3.0.12",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./index.js": "./browser.js",
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "files": [
+        "browser.js",
+        "index.js",
+        "lib/"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 90 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1",
+        "microtime": "^2.1.3"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "10fdc4da88bcb88a4afff51ad5d4efae4ce50530",
+      "_id": "pbkdf2@3.0.12",
+      "_shasum": "be36785c5067ea48d806ff923288c5f750b6b8a2",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "be36785c5067ea48d806ff923288c5f750b6b8a2",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pbkdf2-3.0.12.tgz_1494528738349_0.19753079675137997"
+      },
+      "directories": {}
+    },
+    "3.0.13": {
+      "name": "pbkdf2",
+      "version": "3.0.13",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./index.js": "./browser.js",
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "files": [
+        "browser.js",
+        "index.js",
+        "lib/"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 90 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "b4500e52d3dd5eaa44b069a069dae7642100efe4",
+      "_id": "pbkdf2@3.0.13",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.2",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+        "shasum": "c37d295531e786b1da3e3eadc840426accb0ae25",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pbkdf2-3.0.13.tgz_1501678421763_0.5266327981371433"
+      },
+      "directories": {}
+    },
+    "3.0.14": {
+      "name": "pbkdf2",
+      "version": "3.0.14",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./index.js": "./browser.js",
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "files": [
+        "browser.js",
+        "index.js",
+        "lib/"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage": "nyc --check-coverage --branches 90 --functions 100 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "bd438b002303ad3407790b8e57b922dc2f71df4b",
+      "_id": "pbkdf2@3.0.14",
+      "_npmVersion": "5.4.1",
+      "_nodeVersion": "6.11.3",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+        "shasum": "a35e13c64799b06ce15320f459c230e68e73bade",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pbkdf2-3.0.14.tgz_1504890461178_0.35618158197030425"
+      },
+      "directories": {}
+    },
+    "3.0.16": {
+      "name": "pbkdf2",
+      "version": "3.0.16",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./index.js": "./browser.js",
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "files": [
+        "browser.js",
+        "index.js",
+        "lib/"
+      ],
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage-report": "nyc report --reporter=lcov",
+        "coverage-html": "nyc report --reporter=html",
+        "coverage": "nyc --check-coverage --branches 95 --functions 95 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "6c0b9049ab83517de9cc2e17f516cc893c8054cd",
+      "_id": "pbkdf2@3.0.16",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.11.1",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+        "shasum": "7404208ec6b01b62d85bf83853a8064f8d9c2a5c",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+        "fileCount": 10,
+        "unpackedSize": 12836,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2TQWCRA9TVsSAnZWagAA0O0P/3r6y0M6VB9legSbh/iX\nSjbNsfrx7HRuulyegi9yiQ2w8dK6SxYw2xYgS+pKttltsgrCGuFXYO2uaZlf\nE3YmTRu4wiGgKBqmEa6mIeNtnhMx6TjnM5mkN1oWLo8SUURjiHwF4cWwBTmn\nslTPvR1v/eJ7ys3dKPMc8FSC0aRJ79dSMFwnQWHsB0adEXsrpTOAtnJ+xfRD\nhTpYazJl2WMSv8RPGK45QCHPIuW77hmNwKYYTcTSQdjDGrr7kwbh2JeKOqDB\nJCApIIkHZSobT2RAEb91QMMNI7wfiyjLjUBA2LjR/29n1iatADVk6dzqAMCb\nWs2tyMol0z5XMy4QRbxK9ehga3DZ+HczKVtaATY6vVCfjMZDY5ApbkWvft4h\nxVst141+7BzpaSwoLm/g7qGYJ0XLIlBMeeeavfILk50fxDJCsCLHJL/OZ0/d\nJTgLKAvXbEYfjyzv0fmXm7z8eIJpMkBR5npDoZt9vUqMv3Osp7YYQFDd0bzb\nKTikQynJiBXR+7xq9nAwiUam8HCCjveP1udR2N60jAUAR05OMF3aGgm5bjtg\nXJoL4LzCFcgJCzcOA994XXjP1S63yzphdVux8U4//hqghDQ4/GQknGsSlGvr\nh04GfchniWG6oMqP6Qx580Cpmqf495Nxwn/Lmo4dTNYe50k6Z93WkrH9QQqm\n/8Xg\r\n=95nC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "fundon",
+          "email": "cfddream@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pbkdf2_3.0.16_1524184085510_0.8071036494702566"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.17": {
+      "name": "pbkdf2",
+      "version": "3.0.17",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./index.js": "./browser.js",
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage-report": "nyc report --reporter=lcov",
+        "coverage-html": "nyc report --reporter=html",
+        "coverage": "nyc --check-coverage --branches 95 --functions 95 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "dadbcb741111f0ed165951d53028f2358e0e0a1c",
+      "_id": "pbkdf2@3.0.17",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+        "shasum": "976c206530617b14ebb32114239f7b09336e93a6",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+        "fileCount": 10,
+        "unpackedSize": 12927,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqi9QCRA9TVsSAnZWagAATtcP/jydiGnt8YdK/hXpZijw\nxiB4zgKRxu4NsIKAv3YzjlsoP3x2GkrGyCQ5x4AOWjrkUn+vHZtePhxvsxcg\nRUKz1b5nkjmz8SdsycU8p25u881SvTfLDAMISBaIFdXMR1fOoCzwF2nSXfoh\nBhByl9jsx3Hv5A6/t82X/8phC3m3MFmE1z8ZyaptVWsJAxf16bfUYT7WsY8r\nf6cM5+EENnLvyI7MTVewlzdW4mtcZbRx4v4MyZzj+gLpPBiWKR6KrPNSzBtK\ntoClSbd+vrb8FKmktSyXIi6PCSsi2RNhjZ2JonJiyWgwJABe13drHZ5YLlr3\nnlBlsVuhyXgwF6P2tXUyKvZOgVdCAbXl9sJbPjLyS+hPEit+HjG6Rm8kv2jj\nDa6r8o1ndccXIsCB0KTOvju+toGXfUGIYrZEAPqwMoHO41pachWuVFi1DWC0\nTiXD7WYQaZSPurMc2pe//BEyF3T86cEufnoF7qxPZ0HmWLINt1yGQ1AnKHbi\n0C+4nfWfkYerkZiaBsYXHiA5D1B46dXR5G+E5vT3UujZqm0K6P/Atcsd+51+\nP9qcxM1b2S+5mwEmV4SIhXc+opzxed6RrWz611IhObGPFtlLJnkm9VP/DYJg\n5U9Jqw7yrDOrpXctVk3weplZ59JczmhcZtX/s23od5Vl8WDIvcb29gPGwp53\n6Bsw\r\n=HKsg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "cfddream@gmail.com",
+          "name": "fundon"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pbkdf2_3.0.17_1537879887360_0.9800817100870836"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "pbkdf2",
+      "version": "3.1.0",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./index.js": "./browser.js",
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage-report": "nyc report --reporter=lcov",
+        "coverage-html": "nyc report --reporter=html",
+        "coverage": "nyc --check-coverage --branches 95 --functions 95 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "1c337af3ab19d2540a1edb492f54a439a7118109",
+      "_id": "pbkdf2@3.1.0",
+      "_nodeVersion": "12.16.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-wHMFZ6HTLGlB9f/WsQBs5OwMQJoLXYuJUzbA+j+hRBf7+Y8KcXpatzIviIcTy1OAyhWQp08nyiPO8Dnv0z4Sww==",
+        "shasum": "8839d778223e922164803a411dc62fddb57d3b02",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13347,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe1+TfCRA9TVsSAnZWagAA7CQP/jU6Weup2SFRZwYGa29E\nNav700Lxc6j4nM9cFJ9IkpHBXiWA6USgdoQ8KxREVgikYZLRBJeROcXTA1ZW\ncfCWy2qVhFT1e9P0bmHht2L0QaL2vDnt0vgIKBw8yh8rA2XNcdFmZ8sjQ0ex\nfYS/x5aX7L/I/cFwlUGz9JXloDtnWLojCc4V8TN/uyLxjD+ujrzYf8wpBmey\nGCiNmONXnyCZGGr9ZRaRcvOgjZJi5+KfbF74FUTZ6jMtclo625dhSP5LPDcZ\nvQiLJmhXloTkdesCy+MCezL+6xjMn8aLFuWBAwWFtabCtM6wz7OV9fShh98L\nNXnw5CM410d3f689ofF9bgZeiLYnvXg6N1SKeIdKzZPtDTE1Z8Ep3EooA9/1\n9GSDGGoal67OGuvAFJsDU60hryPGcUBmjiemIsr5YKG7wynq5W0NW6v5Jz/H\n0dHcVlO0GY3ncWfuddaulhT/5iw1LqGgrbvWGGZ2ZglEmQQw76eWZuf/ojqO\nAs6rCyyx3o2kzDYZq6xGlzLlvOcJZmLcRD34gH+KzxUpWQMNNyACt6IdnoOb\nfXgsK1DLyA6NxCn/JP/rox6j8y5xry6IPtmtgmLh1T2lUImwuvbqNnEunbmE\nNJIMCeWq7u4+bgnZcmoCj9KqSv9ApZl5bx01gFqUeAHw/Hx4proeUY3cc+ZS\nlNJE\r\n=LuRr\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "cfddream@gmail.com",
+          "name": "fundon"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pbkdf2_3.1.0_1591207134662_0.37145187853610406"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.1": {
+      "name": "pbkdf2",
+      "version": "3.1.1",
+      "description": "This library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from crypto.getHashes()",
+      "keywords": [
+        "pbkdf2",
+        "kdf",
+        "salt",
+        "hash"
+      ],
+      "homepage": "https://github.com/crypto-browserify/pbkdf2",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+      },
+      "license": "MIT",
+      "author": {
+        "name": "Daniel Cousens"
+      },
+      "browser": {
+        "./index.js": "./browser.js",
+        "./lib/sync.js": "./lib/sync-browser.js"
+      },
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+      },
+      "scripts": {
+        "prepublish": "npm run test",
+        "coverage-report": "nyc report --reporter=lcov",
+        "coverage-html": "nyc report --reporter=html",
+        "coverage": "nyc --check-coverage --branches 95 --functions 95 tape test/*.js",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "bundle-test": "browserify test/index.js > test/bundle.js",
+        "unit": "tape test/*.js",
+        "bench": "node bench/"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "standard": {
+        "ignore": [
+          "test/bundle.js"
+        ]
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "nyc": {
+        "exclude": [
+          "lib/async.js",
+          "test/bundle.js"
+        ]
+      },
+      "gitHead": "4a0bc7bc576418f6d0e7f47339b6054f00d07718",
+      "_id": "pbkdf2@3.1.1",
+      "_nodeVersion": "12.16.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+        "shasum": "cb8724b0fada984596856d1a6ebafd3584654b94",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13353,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe2PC4CRA9TVsSAnZWagAAxlAP/jhwcAIiS/l7qfNdzpRe\nPpMDnBR3VqkpIa9cF+TF2EYr7H/bgRVuV1g2N6XR1QmgJfGQQPHmuwcKCxxx\nCEMbSD4f8T2zVo1EIuea2qOcwjDj0QKZwUd0PGQ/eq0ARU9+gjKC3LBow5dY\n0VN5AhT38CUn+IVFnIbaR4mWvrrxdCBIru8hFBZoV9nEIOwOP0RIn9NpcvOu\nVkqlIra5BDuBF7+6uJ2+/B6mLoVSHc0kDrEmJRvIl1E1RT2lL6yjarLBDErW\nw8ADBpMkIbQ+Z8FrUaYa1E+HM2cICd7x8+sSY6ScMpbQj/ERN1yQoSRtv1nS\nW+ECI1m5bENNNr8YFQTtpu2r3hrxiKSy19G5oURjhwFddDBcbqCn21eboyXk\n8fecTCK0coA+L9Mv+gowDmYDkx+HWnGMDkG/n9DZG5lNXvI4KwEPpWuBtO1t\nyHkyUCU5JuzImtPpkpN/O/t2KpjAz7EG0kjKQFlVle0O50C5RFRAJyp76f3P\ncnYqEidntxem1v2VRs/GzaqHC14pL6FQsDDXNrrnLoeNhsPymZjSRNQWNZCn\n56cUaH3rPFYMHbqIJ/YO0FjnR2W7sUJENzhRRsDTECfxfq+EIWetOC527g37\nql4Tgj4vxazjslmwpEhSX52yq8RuX94jNz/6R4tCGLrf4g4rWYN+3uaM94RW\nadM2\r\n=I4mP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "cfddream@gmail.com",
+          "name": "fundon"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pbkdf2_3.1.1_1591275704304_0.21657740641701118"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# pbkdf2\n\n[![NPM Package](https://img.shields.io/npm/v/pbkdf2.svg?style=flat-square)](https://www.npmjs.org/package/pbkdf2)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/pbkdf2.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/pbkdf2)\n[![Dependency status](https://img.shields.io/david/crypto-browserify/pbkdf2.svg?style=flat-square)](https://david-dm.org/crypto-browserify/pbkdf2#info=dependencies)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nThis library provides the functionality of PBKDF2 with the ability to use any supported hashing algorithm returned from `crypto.getHashes()`\n\n\n## Usage\n\n```js\nvar pbkdf2 = require('pbkdf2')\nvar derivedKey = pbkdf2.pbkdf2Sync('password', 'salt', 1, 32, 'sha512')\n\n...\n```\n\nFor more information on the API,  please see the relevant [Node documentation](https://nodejs.org/api/crypto.html#crypto_crypto_pbkdf2_password_salt_iterations_keylen_digest_callback).\n\nFor high performance,  use the `async` variant (`pbkdf2.pbkdf2`),  not `pbkdf2.pbkdf2Sync`,  this variant has the oppurtunity to use `window.crypto.subtle` when browserified.\n\n\n## Credits\n\nThis module is a derivative of [cryptocoinjs/pbkdf2-sha256](https://github.com/cryptocoinjs/pbkdf2-sha256/), so thanks to [JP Richardson](https://github.com/jprichardson/) for laying the ground work.\n\nThank you to [FangDun Cai](https://github.com/fundon) for donating the package name on npm, if you're looking for his previous module it is located at [fundon/pbkdf2](https://github.com/fundon/pbkdf2).\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "cfddream@gmail.com",
+      "name": "fundon"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2020-06-04T13:01:46.600Z",
+    "created": "2014-02-03T01:03:39.147Z",
+    "0.0.1": "2014-02-03T01:03:39.147Z",
+    "0.0.2": "2014-02-05T09:10:15.325Z",
+    "0.0.3": "2014-02-13T02:06:03.451Z",
+    "0.0.4": "2014-04-18T09:45:12.503Z",
+    "0.0.5": "2014-04-24T02:20:22.187Z",
+    "3.0.3": "2015-02-15T14:34:10.155Z",
+    "3.0.4": "2015-03-27T03:48:06.234Z",
+    "3.0.5": "2016-09-12T04:03:07.894Z",
+    "3.0.6": "2016-09-13T23:46:03.404Z",
+    "3.0.7": "2016-09-16T04:48:35.226Z",
+    "3.0.8": "2016-09-21T21:41:47.788Z",
+    "3.0.9": "2016-10-05T12:49:42.513Z",
+    "3.0.10": "2017-05-11T13:09:58.796Z",
+    "3.0.11": "2017-05-11T14:49:13.589Z",
+    "3.0.12": "2017-05-11T18:52:20.323Z",
+    "3.0.13": "2017-08-02T12:53:42.742Z",
+    "3.0.14": "2017-09-08T17:07:42.064Z",
+    "3.0.16": "2018-04-20T00:28:05.596Z",
+    "3.0.17": "2018-09-25T12:51:27.528Z",
+    "3.1.0": "2020-06-03T17:58:54.796Z",
+    "3.1.1": "2020-06-04T13:01:44.432Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/crypto-browserify/pbkdf2",
+  "keywords": [
+    "pbkdf2",
+    "kdf",
+    "salt",
+    "hash"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/pbkdf2.git"
+  },
+  "author": {
+    "name": "Daniel Cousens"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/pbkdf2/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "reecegoddard": true,
+    "abdihaikal": true,
+    "gerst20051": true,
+    "sintaxi": true,
+    "cheapsteak": true,
+    "nickeljew": true,
+    "hugovila": true,
+    "bumsuk": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/pbkdf2.min.json
+++ b/test/fixtures/registry-mocks/content/pbkdf2.min.json
@@ -1,0 +1,458 @@
+{
+  "name": "pbkdf2",
+  "dist-tags": {
+    "latest": "3.1.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "pbkdf2",
+      "version": "0.0.1",
+      "dist": {
+        "shasum": "ff706d83cba1e0543de1862e5c788aba1828c002",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.11.11"
+      }
+    },
+    "0.0.2": {
+      "name": "pbkdf2",
+      "version": "0.0.2",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "should": "~3.1.2"
+      },
+      "dist": {
+        "shasum": "8397b43c9dc057f71f6a01e01ea8a90f8d9cfb1c",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.11.11"
+      }
+    },
+    "0.0.3": {
+      "name": "pbkdf2",
+      "version": "0.0.3",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "should": "~3.1.2"
+      },
+      "dist": {
+        "shasum": "08be85c48743961ca5e3f8a514e73a4e77f2f8d3",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.11.11"
+      }
+    },
+    "0.0.4": {
+      "name": "pbkdf2",
+      "version": "0.0.4",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "should": "~3.1.2"
+      },
+      "dist": {
+        "shasum": "eeaa34181987c4e12c89077baeae41f9cec96b33",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.11.11"
+      }
+    },
+    "0.0.5": {
+      "name": "pbkdf2",
+      "version": "0.0.5",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "should": "~3.1.2"
+      },
+      "dist": {
+        "shasum": "8e6f6e559873196fba5be1202caed7bb439fdf49",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-0.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.11.11"
+      }
+    },
+    "3.0.3": {
+      "name": "pbkdf2",
+      "version": "3.0.3",
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "devDependencies": {
+        "browserify": "^8.1.1",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "standard": "^1.3.0"
+      },
+      "dist": {
+        "shasum": "a4ad0f23f81d6b71f82a03ffebf3ec82ab8ea8f7",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.3.tgz"
+      }
+    },
+    "3.0.4": {
+      "name": "pbkdf2",
+      "version": "3.0.4",
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "devDependencies": {
+        "browserify": "^8.1.1",
+        "coveralls": "^2.11.2",
+        "istanbul": "^0.3.5",
+        "mocha": "^2.1.0",
+        "standard": "^3.0.0"
+      },
+      "dist": {
+        "shasum": "12c8bfaf920543786a85150b03f68d5f1aa982fc",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.4.tgz"
+      }
+    },
+    "3.0.5": {
+      "name": "pbkdf2",
+      "version": "3.0.5",
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "devDependencies": {
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "10d907817f11d1191c11499bd067f04330a0aec3",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.5.tgz"
+      }
+    },
+    "3.0.6": {
+      "name": "pbkdf2",
+      "version": "3.0.6",
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "943d289ccd92b3dec55cc77dd696d44d6087e8bd",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.6.tgz"
+      }
+    },
+    "3.0.7": {
+      "name": "pbkdf2",
+      "version": "3.0.7",
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "4c12a995caa1ba34bb08d7e98e5aca3cf3767d31",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.7.tgz"
+      }
+    },
+    "3.0.8": {
+      "name": "pbkdf2",
+      "version": "3.0.8",
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "2f8abf16ebecc82277945d748aba1d78761f61e2",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.8.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.0.9": {
+      "name": "pbkdf2",
+      "version": "3.0.9",
+      "dependencies": {
+        "create-hmac": "^1.1.2"
+      },
+      "devDependencies": {
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "f2c4b25a600058b3c3773c086c37dbbee1ffe693",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.0.10": {
+      "name": "pbkdf2",
+      "version": "3.0.10",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8",
+        "microtime": "^2.1.3"
+      },
+      "optionalDependencies": {
+        "microtime": "^2.1.3"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "24b5b4a97c86bfa50c6921c656c4182ce6d96ba5",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.10.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.0.11": {
+      "name": "pbkdf2",
+      "version": "3.0.11",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8",
+        "microtime": "^2.1.3"
+      },
+      "optionalDependencies": {
+        "microtime": "^2.1.3"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "791b7414e50c848438976e12ea2651003037ca6b",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.11.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.0.12": {
+      "name": "pbkdf2",
+      "version": "3.0.12",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1",
+        "microtime": "^2.1.3"
+      },
+      "dist": {
+        "shasum": "be36785c5067ea48d806ff923288c5f750b6b8a2",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.0.13": {
+      "name": "pbkdf2",
+      "version": "3.0.13",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+        "shasum": "c37d295531e786b1da3e3eadc840426accb0ae25",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.0.14": {
+      "name": "pbkdf2",
+      "version": "3.0.14",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+        "shasum": "a35e13c64799b06ce15320f459c230e68e73bade",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.0.16": {
+      "name": "pbkdf2",
+      "version": "3.0.16",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
+        "shasum": "7404208ec6b01b62d85bf83853a8064f8d9c2a5c",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+        "fileCount": 10,
+        "unpackedSize": 12836,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2TQWCRA9TVsSAnZWagAA0O0P/3r6y0M6VB9legSbh/iX\nSjbNsfrx7HRuulyegi9yiQ2w8dK6SxYw2xYgS+pKttltsgrCGuFXYO2uaZlf\nE3YmTRu4wiGgKBqmEa6mIeNtnhMx6TjnM5mkN1oWLo8SUURjiHwF4cWwBTmn\nslTPvR1v/eJ7ys3dKPMc8FSC0aRJ79dSMFwnQWHsB0adEXsrpTOAtnJ+xfRD\nhTpYazJl2WMSv8RPGK45QCHPIuW77hmNwKYYTcTSQdjDGrr7kwbh2JeKOqDB\nJCApIIkHZSobT2RAEb91QMMNI7wfiyjLjUBA2LjR/29n1iatADVk6dzqAMCb\nWs2tyMol0z5XMy4QRbxK9ehga3DZ+HczKVtaATY6vVCfjMZDY5ApbkWvft4h\nxVst141+7BzpaSwoLm/g7qGYJ0XLIlBMeeeavfILk50fxDJCsCLHJL/OZ0/d\nJTgLKAvXbEYfjyzv0fmXm7z8eIJpMkBR5npDoZt9vUqMv3Osp7YYQFDd0bzb\nKTikQynJiBXR+7xq9nAwiUam8HCCjveP1udR2N60jAUAR05OMF3aGgm5bjtg\nXJoL4LzCFcgJCzcOA994XXjP1S63yzphdVux8U4//hqghDQ4/GQknGsSlGvr\nh04GfchniWG6oMqP6Qx580Cpmqf495Nxwn/Lmo4dTNYe50k6Z93WkrH9QQqm\n/8Xg\r\n=95nC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.0.17": {
+      "name": "pbkdf2",
+      "version": "3.0.17",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+        "shasum": "976c206530617b14ebb32114239f7b09336e93a6",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
+        "fileCount": 10,
+        "unpackedSize": 12927,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqi9QCRA9TVsSAnZWagAATtcP/jydiGnt8YdK/hXpZijw\nxiB4zgKRxu4NsIKAv3YzjlsoP3x2GkrGyCQ5x4AOWjrkUn+vHZtePhxvsxcg\nRUKz1b5nkjmz8SdsycU8p25u881SvTfLDAMISBaIFdXMR1fOoCzwF2nSXfoh\nBhByl9jsx3Hv5A6/t82X/8phC3m3MFmE1z8ZyaptVWsJAxf16bfUYT7WsY8r\nf6cM5+EENnLvyI7MTVewlzdW4mtcZbRx4v4MyZzj+gLpPBiWKR6KrPNSzBtK\ntoClSbd+vrb8FKmktSyXIi6PCSsi2RNhjZ2JonJiyWgwJABe13drHZ5YLlr3\nnlBlsVuhyXgwF6P2tXUyKvZOgVdCAbXl9sJbPjLyS+hPEit+HjG6Rm8kv2jj\nDa6r8o1ndccXIsCB0KTOvju+toGXfUGIYrZEAPqwMoHO41pachWuVFi1DWC0\nTiXD7WYQaZSPurMc2pe//BEyF3T86cEufnoF7qxPZ0HmWLINt1yGQ1AnKHbi\n0C+4nfWfkYerkZiaBsYXHiA5D1B46dXR5G+E5vT3UujZqm0K6P/Atcsd+51+\nP9qcxM1b2S+5mwEmV4SIhXc+opzxed6RrWz611IhObGPFtlLJnkm9VP/DYJg\n5U9Jqw7yrDOrpXctVk3weplZ59JczmhcZtX/s23od5Vl8WDIvcb29gPGwp53\n6Bsw\r\n=HKsg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.1.0": {
+      "name": "pbkdf2",
+      "version": "3.1.0",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-wHMFZ6HTLGlB9f/WsQBs5OwMQJoLXYuJUzbA+j+hRBf7+Y8KcXpatzIviIcTy1OAyhWQp08nyiPO8Dnv0z4Sww==",
+        "shasum": "8839d778223e922164803a411dc62fddb57d3b02",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13347,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe1+TfCRA9TVsSAnZWagAA7CQP/jU6Weup2SFRZwYGa29E\nNav700Lxc6j4nM9cFJ9IkpHBXiWA6USgdoQ8KxREVgikYZLRBJeROcXTA1ZW\ncfCWy2qVhFT1e9P0bmHht2L0QaL2vDnt0vgIKBw8yh8rA2XNcdFmZ8sjQ0ex\nfYS/x5aX7L/I/cFwlUGz9JXloDtnWLojCc4V8TN/uyLxjD+ujrzYf8wpBmey\nGCiNmONXnyCZGGr9ZRaRcvOgjZJi5+KfbF74FUTZ6jMtclo625dhSP5LPDcZ\nvQiLJmhXloTkdesCy+MCezL+6xjMn8aLFuWBAwWFtabCtM6wz7OV9fShh98L\nNXnw5CM410d3f689ofF9bgZeiLYnvXg6N1SKeIdKzZPtDTE1Z8Ep3EooA9/1\n9GSDGGoal67OGuvAFJsDU60hryPGcUBmjiemIsr5YKG7wynq5W0NW6v5Jz/H\n0dHcVlO0GY3ncWfuddaulhT/5iw1LqGgrbvWGGZ2ZglEmQQw76eWZuf/ojqO\nAs6rCyyx3o2kzDYZq6xGlzLlvOcJZmLcRD34gH+KzxUpWQMNNyACt6IdnoOb\nfXgsK1DLyA6NxCn/JP/rox6j8y5xry6IPtmtgmLh1T2lUImwuvbqNnEunbmE\nNJIMCeWq7u4+bgnZcmoCj9KqSv9ApZl5bx01gFqUeAHw/Hx4proeUY3cc+ZS\nlNJE\r\n=LuRr\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "3.1.1": {
+      "name": "pbkdf2",
+      "version": "3.1.1",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "devDependencies": {
+        "benchmark": "^2.1.4",
+        "browserify": "*",
+        "nyc": "^6.4.0",
+        "standard": "*",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+        "shasum": "cb8724b0fada984596856d1a6ebafd3584654b94",
+        "tarball": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 13353,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe2PC4CRA9TVsSAnZWagAAxlAP/jhwcAIiS/l7qfNdzpRe\nPpMDnBR3VqkpIa9cF+TF2EYr7H/bgRVuV1g2N6XR1QmgJfGQQPHmuwcKCxxx\nCEMbSD4f8T2zVo1EIuea2qOcwjDj0QKZwUd0PGQ/eq0ARU9+gjKC3LBow5dY\n0VN5AhT38CUn+IVFnIbaR4mWvrrxdCBIru8hFBZoV9nEIOwOP0RIn9NpcvOu\nVkqlIra5BDuBF7+6uJ2+/B6mLoVSHc0kDrEmJRvIl1E1RT2lL6yjarLBDErW\nw8ADBpMkIbQ+Z8FrUaYa1E+HM2cICd7x8+sSY6ScMpbQj/ERN1yQoSRtv1nS\nW+ECI1m5bENNNr8YFQTtpu2r3hrxiKSy19G5oURjhwFddDBcbqCn21eboyXk\n8fecTCK0coA+L9Mv+gowDmYDkx+HWnGMDkG/n9DZG5lNXvI4KwEPpWuBtO1t\nyHkyUCU5JuzImtPpkpN/O/t2KpjAz7EG0kjKQFlVle0O50C5RFRAJyp76f3P\ncnYqEidntxem1v2VRs/GzaqHC14pL6FQsDDXNrrnLoeNhsPymZjSRNQWNZCn\n56cUaH3rPFYMHbqIJ/YO0FjnR2W7sUJENzhRRsDTECfxfq+EIWetOC527g37\nql4Tgj4vxazjslmwpEhSX52yq8RuX94jNz/6R4tCGLrf4g4rWYN+3uaM94RW\nadM2\r\n=I4mP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    }
+  },
+  "modified": "2020-06-04T13:01:46.600Z"
+}

--- a/test/fixtures/registry-mocks/content/portfinder.json
+++ b/test/fixtures/registry-mocks/content/portfinder.json
@@ -1,0 +1,2402 @@
+{
+  "_id": "portfinder",
+  "_rev": "60-650b2aa4abd60479e99860d9140934d7",
+  "name": "portfinder",
+  "description": "A simple tool to find an open port on the current machine",
+  "dist-tags": {
+    "latest": "1.0.28"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "portfinder",
+      "version": "0.1.0",
+      "description": "A simple tool to find an open port on the current machine",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indexzero/nconf-redis.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "0.1.x"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/portfinder/0.1.0/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "portfinder@0.1.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.9",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "07ef1c071b93737e952b8a53fdde5127aafe4b47",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "portfinder",
+      "version": "0.2.0",
+      "description": "A simple tool to find an open port on the current machine",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "mkdirp": "0.0.x"
+      },
+      "devDependencies": {
+        "async": "0.1.x",
+        "vows": "0.5.x"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/Charlie/.npm/portfinder/0.2.0/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "portfinder@0.2.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.15",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "96fdf989e246ea7876c20356aeaecb4c83c9b6a2",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "portfinder",
+      "version": "0.2.1",
+      "description": "A simple tool to find an open port on the current machine",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "mkdirp": "0.0.x"
+      },
+      "devDependencies": {
+        "async": "0.1.x",
+        "vows": "0.5.x"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "_id": "portfinder@0.2.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.103",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "b2b9b0164f9e17fa3a9c7db2304d0a75140c71ad",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "portfinder",
+      "version": "0.3.0",
+      "description": "A simple tool to find an open port on the current machine",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "mkdirp": "0.0.x"
+      },
+      "devDependencies": {
+        "async": "0.1.x",
+        "vows": "0.5.x"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "license": "MIT/X11",
+      "gitHead": "711121557c2f9fee81ff3dc12042007875b65aec",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder",
+      "_id": "portfinder@0.3.0",
+      "_shasum": "f9f2c96894440c5b5113b84e0ad1013042b7c2a0",
+      "_from": ".",
+      "_npmVersion": "2.1.5",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f9f2c96894440c5b5113b84e0ad1013042b7c2a0",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "portfinder",
+      "version": "0.4.0",
+      "description": "A simple tool to find an open port on the current machine",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "0.9.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "license": "MIT/X11",
+      "gitHead": "8c3f20bf1d5ec399262c592f61129a65727004a9",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder",
+      "_id": "portfinder@0.4.0",
+      "_shasum": "a3ffadffafe4fb98e0601a85eda27c27ce84ca1e",
+      "_from": ".",
+      "_npmVersion": "2.2.0",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a3ffadffafe4fb98e0601a85eda27c27ce84ca1e",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.0",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "120b4175efbfd11c65f0344f51606a2e80fb2e1e",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.0",
+      "_shasum": "5bcb212ff52874d76c99bf8408094c153ccf2b95",
+      "_from": ".",
+      "_npmVersion": "2.14.17",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5bcb212ff52874d76c99bf8408094c153ccf2b95",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.0.tgz_1454482380124_0.1727100380230695"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.1",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "669ed062561cff1c522341977e9b9cdb1688d3cf",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.1",
+      "_shasum": "de84effc166ec86d73a22f51c173d886cd89a529",
+      "_from": ".",
+      "_npmVersion": "2.14.1",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "de84effc166ec86d73a22f51c173d886cd89a529",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.1.tgz_1455095292823_0.15774197573773563"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.2",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "51bb0c79e1eaf3d6d593aa68e94f7c9d31cfd4cf",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.2",
+      "_shasum": "7ab68b4aee0ceda34925ef0af34732afa29059d0",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7ab68b4aee0ceda34925ef0af34732afa29059d0",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.2.tgz_1456889346627_0.3661695315968245"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.3",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "e1dba743c3e545970f1127b1a21c0b73d96ef679",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.3",
+      "_shasum": "77944c1049271215fda7452cb1152bb9c3f05ba7",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "indexzero",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "77944c1049271215fda7452cb1152bb9c3f05ba7",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.3.tgz_1458762791212_0.5817707516252995"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.4",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "3c5ba8205433b2d3756adb4ea29407e3c0bcd391",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.4",
+      "_shasum": "db3f2f354624cbe79ec933d03a8ba58f5022d2f8",
+      "_from": ".",
+      "_npmVersion": "3.9.2",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "db3f2f354624cbe79ec933d03a8ba58f5022d2f8",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.4.tgz_1468539599515_0.5078083828557283"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.5",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "477e737ee9b70daac1af26b29ea1b6371dd61b42",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.5",
+      "_shasum": "71551c57af898fff89e2875d42dce843ed7e2ab4",
+      "_from": ".",
+      "_npmVersion": "3.9.2",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "71551c57af898fff89e2875d42dce843ed7e2ab4",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.5.tgz_1468642872704_0.4795233248732984"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.6",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "b215f125f9c693f4ddd2fef151ad00e96388467d",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.6",
+      "_shasum": "3f1922c8e2063714787d3d38992aa263471c9afc",
+      "_from": ".",
+      "_npmVersion": "3.9.2",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "3f1922c8e2063714787d3d38992aa263471c9afc",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.6.tgz_1470595161645_0.8010770883411169"
+      },
+      "directories": {}
+    },
+    "1.0.7-beta.0": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.7-beta.0",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "a2aa5c8dff5b74df1dd89ac5d027e5a7022a543b",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.7-beta.0",
+      "_shasum": "d32e2b6b40bd396a2971badafadfb2812fdccff0",
+      "_from": ".",
+      "_npmVersion": "3.10.5",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "d32e2b6b40bd396a2971badafadfb2812fdccff0",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.7-beta.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.7-beta.0.tgz_1471331522140_0.8923570814076811"
+      },
+      "directories": {}
+    },
+    "1.0.7": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.7",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "39e39603ec1f5dd27d5fafa9ea1dc7d2e5a558fd",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.7",
+      "_shasum": "d486d2553c85ad22667f5c7841f477c64c7c1b38",
+      "_from": ".",
+      "_npmVersion": "3.10.6",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "d486d2553c85ad22667f5c7841f477c64c7c1b38",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.7.tgz_1471365625716_0.8825314422138035"
+      },
+      "directories": {}
+    },
+    "1.0.8": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.8",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "5972fbf86c9cffb21f39a79156779c5234ead7b4",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.8",
+      "_shasum": "b08b2ed226719d682b6f4158eb8e5b69a2561f71",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "b08b2ed226719d682b6f4158eb8e5b69a2561f71",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.8.tgz_1476742507432_0.70188731350936"
+      },
+      "directories": {}
+    },
+    "1.0.9": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.9",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "6be611bfb9602b4ea7a8729c94cc96b45084feac",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.9",
+      "_shasum": "b1ac8755d092afc0433f1c4832fa17d6d1f5d830",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "b1ac8755d092afc0433f1c4832fa17d6d1f5d830",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.9.tgz_1476834312144_0.7961409303825349"
+      },
+      "directories": {}
+    },
+    "1.0.10": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.10",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "c5dd2cc76bd26d4771cee9e0637dfa27a7f89f24",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.10",
+      "_shasum": "7a4de9d98553c315da6f1e1ed05138eeb2d16bb8",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "7a4de9d98553c315da6f1e1ed05138eeb2d16bb8",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.10.tgz_1478824320733_0.8213196084834635"
+      },
+      "directories": {}
+    },
+    "1.0.11": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.11",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "3e92c594578d2f3f20502e964f08b5cb4a45260e",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.11",
+      "_shasum": "0163f3ec84d61f7604fc90121e53985ef30f0323",
+      "_from": ".",
+      "_npmVersion": "4.1.1",
+      "_nodeVersion": "7.3.0",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "0163f3ec84d61f7604fc90121e53985ef30f0323",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.11.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.11.tgz_1484679284465_0.22177174501121044"
+      },
+      "directories": {}
+    },
+    "1.0.12": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.12",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "ffe3f01ba29c5e72789ce3640e1e5052c9a3e199",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.12",
+      "_shasum": "94a65114bec64433f9ce2116da33158238ce7ab4",
+      "_from": ".",
+      "_npmVersion": "4.1.1",
+      "_nodeVersion": "7.3.0",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "94a65114bec64433f9ce2116da33158238ce7ab4",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.12.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.12.tgz_1484683935100_0.0860381000675261"
+      },
+      "directories": {}
+    },
+    "1.0.13": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.13",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "20161e8e00355099c90062a069a7aa68dc9bcf9b",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.13",
+      "_shasum": "bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9",
+      "_from": ".",
+      "_npmVersion": "4.1.1",
+      "_nodeVersion": "7.3.0",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "shasum": "bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/portfinder-1.0.13.tgz_1485873781112_0.17709231283515692"
+      },
+      "directories": {}
+    },
+    "1.0.15": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.15",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "955298c827cc662c3f9319ddd4f59952812b35bb",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.15",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-THpr3TlxP1bPXp7jtuxk43cs7zyckFyO5AiNf93X7e67xs26BULEqaBxXILG9LULOHaKQwkR4cvrlhzVyHV/TA==",
+        "shasum": "28990f8a1d2794a5709010b25d9f6d90fcc2fa14",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.15.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18613,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaG35CRA9TVsSAnZWagAAKHIP/3Zi2puvHWuwFfcjnS54\neyEKu6yKOq59vxfkc0hCGvr7JKZTUzuzOr+pKWC8sq2NjzZstxQ5nX8fgvpb\nf4d9J5L7XHe2NvrZHmJfhfemfr6KHni/0dDH2GOh1O3pp98M4xAbPubJHb7j\ni38cuBJ+RzvPGda5xkrIUy82V3Kq5OEdhCZQ8nOUUQ/Zw9wgwB+O1WEBkUgH\nsJgO9CFGZ56EUPDqXonIr793FrMe5bYs1EPQOZamuaxJpjRIdatqGdv2Gbm7\nfwpHrodqDRYaBaalZgoNeEaaa9ExdXJZH+5LVaOIdutzsmKJJZjDNAdLzMmY\nQM+lvPBcTxh59iTxQgJdaYybCZBJv182FCzv6jgIQBWZu/rkEQHI2lU4dszx\nZgar3gbdlhvdNa9LAHzP8xe1tuVgnZhz+8MrHThHZ9yk61nifXrxz7scYqWf\no/B8RAIYaGlx6WQ018zRWIpa0WcLyJ2jKQoOay7NNg7Y82E2dOfq7Pgiyuui\nFIuz4+pvQIjwFwKUqU4nktUS+xa3GNhH/7ft6kSaMzoZNe3FpybNY7rnch6g\njfrYuZBIYJ/NYyooYH/opmoTSoaLHZOFcQt6qSCB6rnanF3OqDLCrWgeddvk\nvXVQyol7Ad8qouWp3/Gwj0qChLAU8tICEYIAFGn1r9bTFwmvA1zA1VZIJwVw\nQjJe\r\n=W6Ip\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.15_1533570522158_0.5360536961453843"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.16": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.16",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "8189856aac0f50656224393bf61cdb7cba950ace",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.16",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-icBXCFQxzlK2PMepOM0QeEdPPFSLAaXXeuKOv5AClJlMy1oVCBrkDGJ12IZYesI/BF8mpeVco3vRCmgeBb4+hw==",
+        "shasum": "a6a68be9c352bc66c1a4c17a261f661f3facaf52",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.16.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18607,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbacOzCRA9TVsSAnZWagAArIUP+wVgAkgPYZW9WM83x+/Y\nBdzhmJaEEYNaepF0aYe9XkbAsrNMFFeq87sB63PC44HXRbTFi1/mpey2gP/y\nv69RtmOOimBxbNDZlvMhGtkI0KIEx9GbvyucOJ7wL8eXbeqXn+PWc0iXqLW5\nY+aOp0Row5E9v1t9+e2jFVgE6QwZCCDQIipiKPrq+3V4XWeJuoa1y6CpHehm\nIdsBewAnknTS/5Z50Af1lFj+SVbUpt8jnC36ByL4dgtpk8WUMbl7cB+iy2yN\nO1veMkh8mWJOViHzUqfmiQFiko0Z7dypRvI0nkDHMOyDmrevtqYbQ0CKnHhh\niHfJW7Pa0ZU2s2WzRwRt2QHptT1b1Au1PtrVNdTWLmNy6PwEcvDlX4t10dTx\nwAtWrRy12bIpKgvQXjuGP0Y4lN8NrP+E7ZO3Urf27WPf/GOWjaKmRiuy4amK\nyEKncTMZ2ekESO7rgIEfT9IYdZQ7G5iFYOcIhxZq9ZvZceat6gHlPahEYnrT\nqdgaETIyE16RJHl3h5lNUW+fXLvfhoTYY4h159GcngveAV+7YuqZavfYAfmk\nQ2yxdyghKekQBNbXxtqxTFSBLR6cBtoJEQ+STkiiHqJZZbhShioz/iZ8Nl89\nT+gd2vACvR+bzjgHRUfyIQQNfosS/srZbQJEiODzNM7P9JgfTIUwSpqxz+IP\n5C9K\r\n=D1Ey\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.16_1533658034239_0.738972112551346"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.17": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.17",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "files": [
+        "lib"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "a4e69434de304b6094111eeaa559c8075bd0660d",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.17",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
+        "shasum": "a8a1691143e46c4735edefcf4fbcccedad26456a",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18789,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbeiU8CRA9TVsSAnZWagAAmDMP/0WBlSqPvbodilXnwTOC\nTMXCUZ3ar49r2HXjv5Axh3bXmnqPbLMblAgEVvWklMcGLl3v0rundxYmNy/V\nDnbegtobigReq1NWcTOtNnXtH301SK2SRxEVbepQ65GV6ascytFaxfKv6D+E\nmm4MqZ5lzAuWqWKnGj/6wPXZ8el9aE5dfNrmC/oqFlA6TE94Ueqrad2S45yS\nzJnPLt63MrfytWnc/kf7Rl05U8WKJ0y/DRLRC58FbdS5olTI/0aSVmwISb3z\nNMox+wWgzjLiY3ym57V5AHcekC/Qo17OUsPIxIayDZdJlFq9rqqurmhfNvGq\n9TWUwz/J6x+wrbMexAViI3hmZ0ULHTVu2phAW/E9lJXKlxh4WOpOZZuys8fq\n3xJLXGrjOUyIYtftHcRj1utq7F0br0hggVdml9EQiCB35AuIEiasCOe9J6ip\nO7+yqIEy+t7xkoS/U2W/FuFytFKfJdmJo9onyJp6ID3XQlBVBR+dm35P823o\ntHZIHTH6MwRqxUDRxTkQGklBcMjQaEezxsFpjgObmnWwWjjToEQ/ZVu0Exxq\nhYkC1otF3XP9XMesRZfa5kockZkzfyTlX6DkrF6KNtE7RqCP2NgFpktVbWke\n6fapOBVGkbNHV/0ruKw/Bwh0Ap69oteJGakQzUHmHX7jPLCccCDWZZBXr9eR\nEJ/M\r\n=+j7M\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.17_1534731579734_0.6744418147856364"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.18": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.18",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "22113f250004874a00c714f14ff6121b221c20d0",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.18",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-KanzLOERzKoX3En5yTiV8K/arnU1ykYVokmtEn0PgCzqKZG9489tqW8ifp9+v3/VJZ5YDjvDt/PAP5WaPgk7FA==",
+        "shasum": "cf1106ff336fd4329b7ce32fda7d17d62c6bcf37",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.18.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18790,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbx8gDCRA9TVsSAnZWagAAsa8P+gKyjKiFmNJrhQiw+kVK\nWhc2YdcxNPUY4XLbww6znml5oyB0EiX1o8KeTMH4TsrDBq47vbFpPA0mvfNd\noBgKQi1uIcHMslpwUOEUc1zmDFg6Xi5y3LOMI/Rh1DWmqVRaLPbJZU9lN2rx\nq5Kg+fCCN+vvvUz1srwBoS10XD5F3VEc2owzZy5ceKOWFz8t6TfJ0VijZOMZ\ntc5iu2Y55x8asjXcJqmkc4K4ewZKR6zRlpSZQvlPn4b8g22mDlX2jY4qw8XT\nb+nmkI3QNeAf/uIW8kZxdU1JWDM64qKBryHY4S7r9yJScmKeJsYjddyNrT3p\ncml6OuM9/YYs2jldSqkbQ/MQgt8l5zFz49F+Tnp0DhJNMTWV8TGVnOR/4or0\ntW2MwPg60tbCf/xmB+NDdUB/buesaoLtVmstfOEpcTXs7xbT+A+SkIqx82ff\nUuQ010PzYaRJfOyu6ztoSz5M1hGw0/ePwmDuAEUPYsEcSf+1hvXnsbs0Tsq0\nhxp31XB3K2DA2FCEmW8l1ZrgKEuCIhLi19NS3Fxt3T6BKPicbXJbkVLU5OLR\nkrsv3qptSBn1NwRAV7aoaVBxlAeNtsJRiPvo5Or9kJrHvEnSrfscgsqm5TTW\nWBo7aRLu6exEjLQLa0s0zIM6dIyMi7DmMtRdrB4d4PEkWPBpewONiL27P61t\ngOCx\r\n=yZD8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.18_1539819522685_0.5335505842980621"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.19": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.19",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "f0f71e38e563742565006a538573076d8375a0cc",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.19",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
+        "shasum": "07e87914a55242dcda5b833d42f018d6875b595f",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19148,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbzoYKCRA9TVsSAnZWagAA8kIP/1EJUzTVfAm6J/QxtNQ9\nbO//2C5Bhq9sok0BK7i9qGSYV2IqcWEBc4fOP4zQOU5Y0kf7VJCzi9Gv78vb\nX1ui7j/eJZgRLoWpjohYpzH9M7NaiEluHZ18Xj5OJCiH9oROXa1oEC91N1tn\nskZQlNmIBL5iZyIbmQBfHjFKojjhg3uO0sZhd0iADS36FHp+DShqW1qpiHGh\nEfGL4T2+cghvwtB4JyIbAEsWQxK4xqL1rUXgZKyZ8nV1eNmacl/enoqzbOki\nkIBWNz9LrdSavrcN96CReZmPupvC/SXY9lJNSxPVkVIsuOzIVJDCQ2QRu4Jg\nV3HbTf7cWAvVRiPjV7wsI5MED0p/8TCtdGxwvIyJ9UrddeH0YRtgtclo2XNh\nkf0eE82ioIqFHbJaQqmbXvG0fPornEgBFFQzAxlmeCHCE/Opqe11P7Tp+zOy\nKe16Fuh/hgvbYTyxXBd4iSRUTJBIM2f7HN11HDQiy/eDFj9c5zWED5eqm+Fv\nh2D5AatOs+R9JAJxf6QBnldwPBq9yAMzrYrKqTh2ZGPtitX4MZUcRJcp42A/\nb9l660XyNojp3YWwIJZ3IcFH/DCP56jTMEFiKumPRKct7VFquJKeGBqdfsqg\npgA3zCsWHW8h3DKCbS1cDbjTXrRt7uk+yYFtmIIpW95RFcQh8MitjXzQ0E6D\nSLgu\r\n=8ZuZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.19_1540261385866_0.15080079056810458"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.20": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.20",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "8d0b757c3c318499f9fd1f8d865e8e7784801204",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.20",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
+        "shasum": "bea68632e54b2e13ab7b0c4775e9b41bf270e44a",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19279,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcAcKGCRA9TVsSAnZWagAARs4P/jZxKfnJ1yAfsGPhu43h\nORZ4r+09ewUOx6frGlbrYSe2iszuJQMUT8BYZxSUmQfzie+NKX9Zz1tNysld\njRncivEGGk2pBIC99/IkCXnOFw3V4HEfqTEqgsE8eIx2Mzfn4WB5vm3IhnAt\nBXpwB2O06j/cTJDVfLAS1dAAdNdl71u1xRqeCUxqJPr7Sa4zzTCA3sANxNnv\naWQ4Q5hk4PpprJrZc27b5LS6A+f3ycQNnvs9NqYFjJUkC/psgeA9icWNRDM/\ne/KQWn0Hfjvw7zTMRqd201OcZ573Z1jhd+d6CfvkZxXYAFUN8kFfWIL80jb1\nFaNDCYq98ACJ/PjFkMKVN8srKF3qWABYEISlkrYhY1TcilrjS0QV0DOuvxTR\nCqj20CIVkcl1XRHfat+y1cD/OsV4kL6AyTKAKo1Snba3qulcj4UKCrebbbYJ\nyYB4yIn6uRkv98rj7PBD6WyWEFy3lKk3pcRhjDMZzujS0/ajoNIPkY+SGqee\ndUSUNyjYSN4u+MRP1cf1L6CjdB4LmBhEaoASjltJEcrYjZBuEFJSauJQzDlS\nNoS27BZmRfSu5eBCIjD989lb0u7kM2/b6PiHsALi2mOCb+x1XL9zuaYXubnl\nzQwgS9ea5kAxPGJUNjp2+Z49Pg8pBj6IIggZQ9Ry4mQTZtbBPGx/2NiZcag/\n/cw1\r\n=wFih\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.20_1543619206224_0.999012403569189"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.21": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.21",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "25556862945514cf890d9b8cee9020ab3bbe6c5f",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.21",
+      "_nodeVersion": "10.15.3",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
+        "shasum": "60e1397b95ac170749db70034ece306b9a27e324",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19419,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdKJhlCRA9TVsSAnZWagAARMMP/3ADs4Knwf6pfUHJoRAd\nwTFCqtmweDMfYww7i+RWDv6P1yZh4nyFvKhb0a7AYIQurbKx28advkjB1irt\n6QKACRPOTxChyLG4KYNogAre+NFls+TDtn/eiY+pE9l+fhJGakaToj6Nm0hX\napSd7VxOHojTnRsml0wCndpPs6XDWxM8+TJaziKCRf4x9IXHpwTT+8O0SFwV\nJC3sp8Z2AQ0OppdThB0if6V5LdpYZ7LlHKKNlmdww7UuR5dwlyl/IbRNuMVM\n8NhqaaqK8MF8uA5GkjT9zAIxfchzqZata7JAtF1nOmhu2uLxWTLwTNSy+VtJ\nkn5BhkL3DxTUWRpykeozXHcGh43W5SFkqPtJnIfApSSqEghAlSL6mhR9ERpH\n3EKoEpJBGXfNFbNL3aLS0SfaplY4UjMHz9w4Ay23wqnYrT/53qjXaQys4qJ9\nszgV+O0q2eolkqaxJOdO+ObS8R1NjYbVhnWXv4jxhXdIroxla14kUpju/4De\n/ByeqBZBNDCF92Xc/l2wEMDgK8pbOBpwFaetM32W0J+tFuhBUnKZt4EWm+aY\nb8+1gPpejGZmCsU4os6gvaJeddquBgaMCFYCuerhVKKoW/0qgv/Z+/Rxw8aH\npNYsTPoVpDQ9YINZmyjrF1HWUIzhRMnKniuBuAP087u9tO38c33pK5RfzNIg\nd/oU\r\n=QZZc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.21_1562941540245_0.5450296733377984"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.22": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.22",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "f2fa9d8a0c7144bb23ebc81269cbf92d9f462946",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.22",
+      "_nodeVersion": "12.8.0",
+      "_npmVersion": "6.10.3",
+      "dist": {
+        "integrity": "sha512-aZuwaz9ujJsyE8C5kurXAD8UmRxsJr+RtZWyQRvRk19Z2ri5uuHw5YS4tDBZrJlOS9Zw96uAbBuPb6W4wgvV5A==",
+        "shasum": "abd10a488b5696e98ee25c60731f8ae0b76f8ddd",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.22.tgz",
+        "fileCount": 5,
+        "unpackedSize": 20531,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdV9PpCRA9TVsSAnZWagAApbUQAIhz5zMWLdxF6gKCNNq6\nhP1IVSjLsgn7JHGUvAYUKppVW589o2uzMulpeH5qu7lm79W2cKhXkuqB5Iaz\nZnESx5IU5QKok03RiN5WxRDxo1JmB8uFNKL+nk5Xxe4L2daF6LG1BM0ZYURa\nnyQ20sxMUELfMttwwZEPc15JMpeyoSqaIByIeW3b0P+k0zCU49g9mo/YShXs\nnrBon++VXJBelk8X6oxsxXxfkBwo/LCEAWMWi/txJhMrcfK825SDA2T4lXEN\nnKrgRIxifbw+Ryet5P3OevyeiK0F1yTuMHWm5WNx62KQqAdGOKd3xJNVkL7r\n/mSQs7/qbu5AbMEeKxoc8KhnfBKieDTR8SRODtApvFS6YxcqF/nkP7N8x03w\nfYvUd7QbOITVcydAG3rBL92g+ZasXDRkOhQuIm2EvWpI+Czwl0AqRbGgYQ3q\nfXRZhbGbnlyZegatPd35ALkYY84Nlbf41wwHX9BVeYFExZfelxvLG6QDJ9EB\nPkVW3e3MUrsmt7Lkv4baDH7woZ6qZ5HjWZX4UKh08lGvzJC1YmWnSFaL2xuD\nayfwW8q0Bg4RE4nuba+xhzDKtirdE+n2LYpQvWUSWwgYmERec7PEhYvQPpMe\nIu2zdxLrrEyUc2WOPGLh+t4mfNiMs6Kcpr652d5WjPdg6izfibSYcYhFmNWC\nqiSH\r\n=I6yd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.22_1566036968795_0.8818524221746387"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.23": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.23",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "727ee4e6943ed0b25a8e1a5fb93c8ebd65729ef2",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.23",
+      "_nodeVersion": "12.8.0",
+      "_npmVersion": "6.10.3",
+      "dist": {
+        "integrity": "sha512-B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==",
+        "shasum": "894db4bcc5daf02b6614517ce89cd21a38226b82",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19419,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdWwSGCRA9TVsSAnZWagAAbdAP/2SBoOTbJZuzrJcfan36\nZaan4sI5PItTmX4i1I5yI1Nd1hEhKmhN4pZCD5IdyckI5nulTnIOzT5/5nKl\nopFmXiJuJ4/+ePplHlWnet7+IYKr3p4ZvF9F6NhtJ5tD9+rJ5aHjvurrMSOd\nyKN00nNf2LetN/w5TZ+ypws8CjoGSOgworp3n/AJDt4J6MrMmE67dwcys5Wv\nblzDUffqK8ti1Ju6bN9IZXFK585QJI5ayy1HZwJ9nlu0IjBpk2xYNMbyKrVD\nB4RbTmLFFznguwLpJOs6GSXH7c2U8mtWqXHxvpXqc7DWFe2VI6aXqSkDSf6Z\n7b4HaPbrip+jc2ASscsjbOheMOJSWRKG4KDPQ/JIWcD/hG44PACiu4fVWpVl\nlEm8pUYwtkT86XtM+E6DSFE4fi96d5/lad5nelGAZdLKdk7CuXkTf0XUCugS\nJ2zHpDiW9h4M/IyF4KbwrqjKO7ucBXA54R3e/o7/aqkHw/R8+sq7ecjIE8lM\nNSoqIbzNBUnOXMrqMczY7FOfZ9ksh0ZBDmUM3fIaWjET386kxHkpntc4eAZi\nRKhRaQXiEWDAfSICXIvSCx2zPL+vXkAtVR2KaHJmyyQ0skuRWUmdBHjpUcBJ\njpqEsV3DrOmL333pLL23ZQCRPAHMf3sjEy+IZtwok6okLDJEqwv1h0IR6/o4\nF3H/\r\n=1JNa\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.23_1566246021540_0.4401182672890174"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.24": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.24",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "f4e4ebed357ac0e1f3df8dab413133e565523a26",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.24",
+      "_nodeVersion": "12.8.0",
+      "_npmVersion": "6.10.3",
+      "dist": {
+        "integrity": "sha512-ekRl7zD2qxYndYflwiryJwMioBI7LI7rVXg3EnLK3sjkouT5eOuhS3gS255XxBksa30VG8UPZYZCdgfGOfkSUg==",
+        "shasum": "11efbc6865f12f37624b6531ead1d809ed965cfa",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.24.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19421,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdcWJsCRA9TVsSAnZWagAAyMEQAI6U2EC/hUTu4Jud2+xR\n/5C6dfeJxYeNia9zTFVuRd6Oj5fBaFCpofKLMZTCIXYAcuSp4Vz1W0Rr2izu\natEZ7wadRa7lP/0oVMDkjjTQFoQHZrTZSyQUTEhPbBou63w6qgtJ8oHdYBgo\nS9Ab3w3YOl1ZQB0rSgoSiiqSSyeoJpHzbfK/o+BnpbBPp2GsPAGpYYi2Guy4\nidZw9INI6u9+nltkb/g8tRYIoK5Kwlotz7R6gKn9iPBGDU/rgaqMYB3wzK5G\nYhpgY9GMouul3YFgCv5EneIqcGZj26SmrsSmrT4niJ4rH6BGYdRUbSJU9wiq\nzfaIoy82q/l7oc0nmk3TnWtau6nPkctQq2i3qtxUrA4cnoulrzKGoi4C5AW2\nAV+DhvUBUKNyZ+TW7GOr37c8GAeO3eJ9TgZVVLei8aCc9Gre4ORHSjPF38uv\nXLYNTBMYb+H2ijLjBMPWRni/FApfv7zk4kkpj2IaKl5UD7ryLUqpAChx7rPT\nCCVAFHlwiDflJS7V73qPkyEglZletH8RNR/wPOp5NoPJiezBnoFUU3vyMGfe\n5wWTznMh4F2PsM0RlXgWY5O2X+sKOgjO5sUq9QPRSvL3nmXXnjpvbvGa2tso\n/ld/idRi5aKyLyue0KX9ukVNtKnjy9Mo6manumKoy7ioB0StBCy6N0Jk1OFS\nXTnl\r\n=tM5z\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.24_1567711851492_0.07352392535543406"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.25": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.25",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indexzero/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
+      },
+      "devDependencies": {
+        "glob": "^7.1.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "e89425234f6794bad6ef0dea1e7d13b834fb3c01",
+      "bugs": {
+        "url": "https://github.com/indexzero/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/indexzero/node-portfinder#readme",
+      "_id": "portfinder@1.0.25",
+      "_nodeVersion": "12.8.0",
+      "_npmVersion": "6.10.3",
+      "dist": {
+        "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+        "shasum": "254fd337ffba869f4b9d37edc298059cb4d35eca",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19425,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdpkA2CRA9TVsSAnZWagAACmUP/107q/fcQoJZZfLiqF1k\nmlQXZzy6Qz1RrgJUoA/LxhrVh38C9P1yTMemwolvXgNQ87hvbj/Xj21X4P3k\ngYRZ2Ce3nNYwImMpFem4CNz3w/+rTRwJWCdTiVLV8iYeDdeKlGKjED0gg1K9\n2Xq1rKYNjZQlkL9r3ASAU6LTOe0T+gkvCPEM+vPHiQsDhBk9Xf0xSsO8MoSY\n9tw5qTV6BIMgLLmJWKOU8gTomLvQlEV5YU1mhdDQxAFsJuZbY9qpN7Vum0AV\ngunCfNFMJ8HUDO8W4O4Ko7wonGPveEu4KftrNBRkWTNCaEwR6GUyPfLBvjJr\nw5rSinFMwhMWoxZHIDBeHYZn0VKeF+SpTB/06/Dq+c2f+OP6IJJRfj4LDiyL\nVrZDmz2rGTs/4ccD0JcFyt9oKXKxJ01lfx2UgISEBC9GRPiPo9YL0d1GGgaw\nuAeqMZjw1TXkmfp+my/5GkZoojwsjkQcL4lPgATD6CmJhgqOegOAOfaOKjxG\nzMV0YFBpmJHdBP09n87jVxqKBwdX8D2sDteyZzCJjYtLWNuyPf4UNS9ZomHq\nlLmSG1lDEcZI8u6L0MTyHohkqgAe5sK1TM4go6K2OOO2ztYkXi1DLwMMhm7J\nSof1tnBoDB93ctZ5ZlRHkb6uyKdA8cr/GIw6v1r80RmEyoAV6QngU2Ng7Q94\ndXIh\r\n=Cyn4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.25_1571176501472_0.2935766816563923"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.26": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.26",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/http-party/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
+      },
+      "devDependencies": {
+        "glob": "^7.1.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "3709e43085335c9ffa462b64a0733740b9a21d1e",
+      "bugs": {
+        "url": "https://github.com/http-party/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/http-party/node-portfinder#readme",
+      "_id": "portfinder@1.0.26",
+      "_nodeVersion": "14.0.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
+        "shasum": "475658d56ca30bed72ac7f1378ed350bd1b64e70",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19427,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeqJkBCRA9TVsSAnZWagAA/4MQAIqdFso6sAK+lOodo0d4\nyh4MEqHviwpqP14+MQdN6IK+FTtKO87+JpTIyd9ZC+lIVP8fQ3xZbwx20qtl\nLaQr0z1cw5Ax479Ml+9G8iyuYjLsQDqOJ7JPfOo0kzuThIV/mcWxHz9fqLys\nhJVFh+qgS4+pwAsLEki/lqviD2kQmKBlC4MqTkW2d/CWzimIn15UiEpOm2QX\ngxcUmApha83loURIGVLkAeNI+gN/T4Ca4yAVtLOygNjk2TjZUyaT8gUuRFWz\nEyto+LU4MLojFdxNUBqzMp+Ao92x8b2p8aEAd6DHSPel66tdJ4CsHIAAHtEk\nJPOKE6+0xH7VoqQQN2kBPCKsEil+hqN7XDs1HrLea3ETlsnmQ8Yfi6EOhvmB\n7ExaFw1PfUdqqazDa13jvcBioxOG9IL20Awyf+zqc2AlBray2QZOO4iOWk0B\nN4SM56axRq0iV69zGLhmsGOlgk+APOKTOCUQSCe3si2J7ZrayBm7QS9llpgZ\nxIZy7jP+YEr4WgFBiN+bT8ad1rhHxeZuJ9UYPiKgO7VVus2N3OezSBwJ++uc\ng6wBOxW8hpGs4ZN22fOpXpHNPI9Rc13NuIjEfB9HaDlUEv5xqANU+kVzo7kr\nb2EiwPjuF/pWtCw6l3ZQmmDrMI4ASLbHrQ7fDsXM+UIr805QdlqR+nQmn2M5\nxYN2\r\n=Pwiv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.26_1588107520962_0.8334711827775307"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.27": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.27",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/http-party/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
+      },
+      "devDependencies": {
+        "glob": "^7.1.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "170ac7f28cbcf2f81eff902e129baeb3f93fe81f",
+      "bugs": {
+        "url": "https://github.com/http-party/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/http-party/node-portfinder#readme",
+      "_id": "portfinder@1.0.27",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-bJ3U3MThKnyJ9Dx1Idtm5pQmxXqw08+XOHhi/Lie8OF1OlhVaBFhsntAIhkZYjfDcCzszSr0w1yCbccThhzgxQ==",
+        "shasum": "a41333c116b5e5f3d380f9745ac2f35084c4c758",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.27.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19427,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFPTjCRA9TVsSAnZWagAA4y0P/1AOTG6oqT96UCJn7gn7\nbCSOZPwTUfxJCH7Of/US7OYRW0NE+xZlqRcd9e5KD2n8FiAsRIwn9PcEvDr1\nK4N5IYUfKd440wAEbKX6WvBiEu2JD3+N+xcsXdt2cqkI91RTBSFnVR97XTJZ\n5q8rI4lxL84Vn0FoGOkvSzWrLHzvSk1Pk+LW/2R1M7v8e6JW+YV+9Wxe0RfI\nU1p4qmufLTMeeB/iDKi4P84o4dHHWhtyuWlMOdFSDX45kRJevwIhiTBmWwd7\nuFRYzsEYx8EILs9a4ERJjy04e5wQPOnhdAfcwrAANshNoNqmNW2ZpP4xDtXm\nBBoCkJZpzNWh5ZLoizaeVzV86LfTyQBjck4zzOnJzYwIdxu3w1bGVbX8DNdk\nL6SNvRKpdlZep9JVS3kaYvJUJ+iZre2atWrebSN59IH8ARTwapTCCFAR7Sjn\nFdAdG9L8MSO3Mv18Z2KC/4WbDWKumTuOtF8c0fEuetvgmnl3326ypLf6S8oK\nQEsnXYHM0vTtYIhWzb/H7MycSyTSc8kdhng+raX/uyYUwp+XI0mbRs8ObvW/\n0lyKxnSkwgfUt99CpvC2XPFa/cVknEV/BsPJ1d0yp309l3IIiWLydSq09yRZ\nOqe4zE6KlAuk6H1t/bb1u0Funyi0cRnPHbvJXgqNXOGTgnfGI7dQz1V55rQZ\njSbC\r\n=JZKL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.27_1595208931065_0.5102827953009685"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.28": {
+      "name": "portfinder",
+      "description": "A simple tool to find an open port on the current machine",
+      "version": "1.0.28",
+      "author": {
+        "name": "Charlie Robbins",
+        "email": "charlie.robbins@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/http-party/node-portfinder.git"
+      },
+      "keywords": [
+        "http",
+        "ports",
+        "utilities"
+      ],
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "devDependencies": {
+        "glob": "^7.1.4",
+        "vows": "^0.8.2"
+      },
+      "main": "./lib/portfinder",
+      "types": "./lib/portfinder.d.ts",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      },
+      "license": "MIT",
+      "gitHead": "8895293a96a41a454b6648b50ecc7bff7f13fc22",
+      "bugs": {
+        "url": "https://github.com/http-party/node-portfinder/issues"
+      },
+      "homepage": "https://github.com/http-party/node-portfinder#readme",
+      "_id": "portfinder@1.0.28",
+      "_nodeVersion": "14.5.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+        "shasum": "67c4622852bd5374dd1dd900f779f53462fac778",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19427,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfIRf/CRA9TVsSAnZWagAACrIP/3/umAyiNj7dFpIpmx8u\nbZ2ZiBRsarYLtS6OOYDmNn3BfQlLblnIIfmAAIRToNKWtKdAkXaRhn+YfIXW\nN8z5rPIY2RYqefxKgDOxBeyofKrw9LHlSB3u4BAXbET5nFKGNcGhAAVgfrWi\nuz2veBCefkKYjkjQqqWG/1mx3AuMLrfE10t9FYwoHNQuqT1HLwLe8C/mZf36\nNGUN51MOdssFF/NlLfX+nUtML1ZL18sUOMGNdpC8K7tvuLopqlofst/tmrlE\nxtKtZx6654Q2x8it72H0MThsky+3IEogJCrKA6n51e6TJT0dymZjdr9xkauq\nhshZ7jlDyGRPTrB5u7TsCnOcFkKsgzg466nC/t8BotRHAk9kD23RRscI8AOI\n35JhsipVS1wpWYdUZpHUlN77VwzHdBl8TL2pUYz1X8vtLVNZTQduVRWGDTUI\nlpzRAKrfeYlsEl/z/YWI689a1YiZgG4WKphgh1wHhVq8ZZplMzUcdlNccbWV\naNqxOhXoQLUzFST+9C5mlEHzqAtRYnltTP0V7Slj6gJ2PFaAsdjxv2f2kh3j\nZB0POe2uEuBzwEoAS+pCZx+Wz0iwaynEyaHGsOGkBAOn9zV66vZDCMc1NF4/\nlwl+FMekfioeyyB7SKakj9/jFtSCyMXBSc/bYC516CrsTfqYSqfX383V+J+2\nxeLT\r\n=496T\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "eriktrom",
+          "email": "erik.trom.github@gmail.com"
+        },
+        {
+          "name": "indexzero",
+          "email": "charlie.robbins@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "eriktrom",
+        "email": "erik.trom.github@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/portfinder_1.0.28_1596004351259_0.8561920579977917"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "name": "eriktrom",
+      "email": "erik.trom.github@gmail.com"
+    },
+    {
+      "name": "indexzero",
+      "email": "charlie.robbins@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-07-29T06:32:33.553Z",
+    "created": "2011-07-08T19:30:31.334Z",
+    "0.1.0": "2011-07-08T19:30:31.474Z",
+    "0.2.0": "2011-07-11T00:13:17.919Z",
+    "0.2.1": "2011-11-20T19:30:29.396Z",
+    "0.3.0": "2014-12-17T17:27:35.231Z",
+    "0.4.0": "2015-02-06T04:18:37.956Z",
+    "1.0.0": "2016-02-03T06:53:02.521Z",
+    "1.0.1": "2016-02-10T09:08:14.800Z",
+    "1.0.2": "2016-03-02T03:29:08.900Z",
+    "1.0.3": "2016-03-23T19:53:14.197Z",
+    "1.0.4": "2016-07-14T23:40:03.827Z",
+    "1.0.5": "2016-07-16T04:21:12.961Z",
+    "1.0.6": "2016-08-07T18:39:24.865Z",
+    "1.0.7-0": "2016-08-16T07:01:46.083Z",
+    "1.0.7-beta.0": "2016-08-16T07:12:06.047Z",
+    "1.0.7": "2016-08-16T16:40:25.968Z",
+    "1.0.8": "2016-10-17T22:15:07.692Z",
+    "1.0.9": "2016-10-18T23:45:12.351Z",
+    "1.0.10": "2016-11-11T00:32:02.536Z",
+    "1.0.11": "2017-01-17T18:54:46.223Z",
+    "1.0.12": "2017-01-17T20:12:16.928Z",
+    "1.0.13": "2017-01-31T14:43:01.735Z",
+    "1.0.15": "2018-08-06T15:49:01.673Z",
+    "1.0.16": "2018-08-07T16:07:14.646Z",
+    "1.0.17": "2018-08-20T02:19:39.819Z",
+    "1.0.18": "2018-10-17T23:38:42.864Z",
+    "1.0.19": "2018-10-23T02:23:06.047Z",
+    "1.0.20": "2018-11-30T23:06:46.327Z",
+    "1.0.21": "2019-07-12T14:25:40.405Z",
+    "1.0.22": "2019-08-17T10:16:08.974Z",
+    "1.0.23": "2019-08-19T20:20:21.652Z",
+    "1.0.24": "2019-09-05T19:30:51.583Z",
+    "1.0.25": "2019-10-15T21:55:01.612Z",
+    "1.0.26": "2020-04-28T20:58:41.104Z",
+    "1.0.27": "2020-07-20T01:35:31.279Z",
+    "1.0.28": "2020-07-29T06:32:31.366Z"
+  },
+  "author": {
+    "name": "Charlie Robbins",
+    "email": "charlie.robbins@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/http-party/node-portfinder.git"
+  },
+  "readme": "# node-portfinder [![Build Status](https://api.travis-ci.org/http-party/node-portfinder.svg)](https://travis-ci.org/http-party/node-portfinder)\n\n## Installation\n\n``` bash\n  $ [sudo] npm install portfinder\n```\n\n## Usage\nThe `portfinder` module has a simple interface:\n\n``` js\n  var portfinder = require('portfinder');\n\n  portfinder.getPort(function (err, port) {\n    //\n    // `port` is guaranteed to be a free port\n    // in this scope.\n    //\n  });\n```\n\nOr with promise (if Promise are supported) :\n\n``` js\n  const portfinder = require('portfinder');\n\n  portfinder.getPortPromise()\n    .then((port) => {\n        //\n        // `port` is guaranteed to be a free port\n        // in this scope.\n        //\n    })\n    .catch((err) => {\n        //\n        // Could not get a free port, `err` contains the reason.\n        //\n    });\n```\n\nIf `portfinder.getPortPromise()` is called on a Node version without Promise (<4), it will throw an Error unless [Bluebird](http://bluebirdjs.com/docs/getting-started.html) or any Promise pollyfill is used.\n\n### Ports search scope \n\nBy default `portfinder` will start searching from `8000` and scan until maximum port number (`65535`) is reached. \n\nYou can change this globally by setting:\n\n```js\nportfinder.basePort = 3000;    // default: 8000\nportfinder.highestPort = 3333; // default: 65535\n```\n\nor by passing optional options object on each invocation:\n\n```js\nportfinder.getPort({\n    port: 3000,    // minimum port\n    stopPort: 3333 // maximum port\n}, callback);\n```\n\n## Run Tests\n``` bash\n  $ npm test\n```\n\n#### Author: [Charlie Robbins][0]\n#### Maintainer: [Erik Trom][1]\n#### License: MIT/X11\n[0]: http://nodejitsu.com\n[1]: https://github.com/eriktrom\n",
+  "homepage": "https://github.com/http-party/node-portfinder#readme",
+  "keywords": [
+    "http",
+    "ports",
+    "utilities"
+  ],
+  "bugs": {
+    "url": "https://github.com/http-party/node-portfinder/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "nelix": true,
+    "nickeltobias": true,
+    "octod": true,
+    "tobiasnickel": true,
+    "abdihaikal": true,
+    "evan-king": true,
+    "ivangaravito": true,
+    "krickray": true,
+    "danielpavelic": true,
+    "d-band": true,
+    "cheapsteak": true,
+    "yikuo": true,
+    "naokikimura": true,
+    "daizch": true,
+    "zuojiang": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/portfinder.min.json
+++ b/test/fixtures/registry-mocks/content/portfinder.min.json
@@ -1,0 +1,725 @@
+{
+  "name": "portfinder",
+  "dist-tags": {
+    "latest": "1.0.28"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "portfinder",
+      "version": "0.1.0",
+      "dependencies": {
+        "async": "0.1.x"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "dist": {
+        "shasum": "07ef1c071b93737e952b8a53fdde5127aafe4b47",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "0.2.0": {
+      "name": "portfinder",
+      "version": "0.2.0",
+      "dependencies": {
+        "mkdirp": "0.0.x"
+      },
+      "devDependencies": {
+        "async": "0.1.x",
+        "vows": "0.5.x"
+      },
+      "dist": {
+        "shasum": "96fdf989e246ea7876c20356aeaecb4c83c9b6a2",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "0.2.1": {
+      "name": "portfinder",
+      "version": "0.2.1",
+      "dependencies": {
+        "mkdirp": "0.0.x"
+      },
+      "devDependencies": {
+        "async": "0.1.x",
+        "vows": "0.5.x"
+      },
+      "dist": {
+        "shasum": "b2b9b0164f9e17fa3a9c7db2304d0a75140c71ad",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "0.3.0": {
+      "name": "portfinder",
+      "version": "0.3.0",
+      "dependencies": {
+        "mkdirp": "0.0.x"
+      },
+      "devDependencies": {
+        "async": "0.1.x",
+        "vows": "0.5.x"
+      },
+      "dist": {
+        "shasum": "f9f2c96894440c5b5113b84e0ad1013042b7c2a0",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "0.4.0": {
+      "name": "portfinder",
+      "version": "0.4.0",
+      "dependencies": {
+        "async": "0.9.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "a3ffadffafe4fb98e0601a85eda27c27ce84ca1e",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.0": {
+      "name": "portfinder",
+      "version": "1.0.0",
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "5bcb212ff52874d76c99bf8408094c153ccf2b95",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.1": {
+      "name": "portfinder",
+      "version": "1.0.1",
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "de84effc166ec86d73a22f51c173d886cd89a529",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.2": {
+      "name": "portfinder",
+      "version": "1.0.2",
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "7ab68b4aee0ceda34925ef0af34732afa29059d0",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.3": {
+      "name": "portfinder",
+      "version": "1.0.3",
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "77944c1049271215fda7452cb1152bb9c3f05ba7",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.4": {
+      "name": "portfinder",
+      "version": "1.0.4",
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "db3f2f354624cbe79ec933d03a8ba58f5022d2f8",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.5": {
+      "name": "portfinder",
+      "version": "1.0.5",
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "71551c57af898fff89e2875d42dce843ed7e2ab4",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.6": {
+      "name": "portfinder",
+      "version": "1.0.6",
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "3f1922c8e2063714787d3d38992aa263471c9afc",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.7-beta.0": {
+      "name": "portfinder",
+      "version": "1.0.7-beta.0",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "d32e2b6b40bd396a2971badafadfb2812fdccff0",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.7-beta.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.7": {
+      "name": "portfinder",
+      "version": "1.0.7",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "d486d2553c85ad22667f5c7841f477c64c7c1b38",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.8": {
+      "name": "portfinder",
+      "version": "1.0.8",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "b08b2ed226719d682b6f4158eb8e5b69a2561f71",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.9": {
+      "name": "portfinder",
+      "version": "1.0.9",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "b1ac8755d092afc0433f1c4832fa17d6d1f5d830",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.10": {
+      "name": "portfinder",
+      "version": "1.0.10",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "7a4de9d98553c315da6f1e1ed05138eeb2d16bb8",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.11": {
+      "name": "portfinder",
+      "version": "1.0.11",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "0163f3ec84d61f7604fc90121e53985ef30f0323",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.11.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.12": {
+      "name": "portfinder",
+      "version": "1.0.12",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "94a65114bec64433f9ce2116da33158238ce7ab4",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.12.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.13": {
+      "name": "portfinder",
+      "version": "1.0.13",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "shasum": "bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.15": {
+      "name": "portfinder",
+      "version": "1.0.15",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-THpr3TlxP1bPXp7jtuxk43cs7zyckFyO5AiNf93X7e67xs26BULEqaBxXILG9LULOHaKQwkR4cvrlhzVyHV/TA==",
+        "shasum": "28990f8a1d2794a5709010b25d9f6d90fcc2fa14",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.15.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18613,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbaG35CRA9TVsSAnZWagAAKHIP/3Zi2puvHWuwFfcjnS54\neyEKu6yKOq59vxfkc0hCGvr7JKZTUzuzOr+pKWC8sq2NjzZstxQ5nX8fgvpb\nf4d9J5L7XHe2NvrZHmJfhfemfr6KHni/0dDH2GOh1O3pp98M4xAbPubJHb7j\ni38cuBJ+RzvPGda5xkrIUy82V3Kq5OEdhCZQ8nOUUQ/Zw9wgwB+O1WEBkUgH\nsJgO9CFGZ56EUPDqXonIr793FrMe5bYs1EPQOZamuaxJpjRIdatqGdv2Gbm7\nfwpHrodqDRYaBaalZgoNeEaaa9ExdXJZH+5LVaOIdutzsmKJJZjDNAdLzMmY\nQM+lvPBcTxh59iTxQgJdaYybCZBJv182FCzv6jgIQBWZu/rkEQHI2lU4dszx\nZgar3gbdlhvdNa9LAHzP8xe1tuVgnZhz+8MrHThHZ9yk61nifXrxz7scYqWf\no/B8RAIYaGlx6WQ018zRWIpa0WcLyJ2jKQoOay7NNg7Y82E2dOfq7Pgiyuui\nFIuz4+pvQIjwFwKUqU4nktUS+xa3GNhH/7ft6kSaMzoZNe3FpybNY7rnch6g\njfrYuZBIYJ/NYyooYH/opmoTSoaLHZOFcQt6qSCB6rnanF3OqDLCrWgeddvk\nvXVQyol7Ad8qouWp3/Gwj0qChLAU8tICEYIAFGn1r9bTFwmvA1zA1VZIJwVw\nQjJe\r\n=W6Ip\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.16": {
+      "name": "portfinder",
+      "version": "1.0.16",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-icBXCFQxzlK2PMepOM0QeEdPPFSLAaXXeuKOv5AClJlMy1oVCBrkDGJ12IZYesI/BF8mpeVco3vRCmgeBb4+hw==",
+        "shasum": "a6a68be9c352bc66c1a4c17a261f661f3facaf52",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.16.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18607,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbacOzCRA9TVsSAnZWagAArIUP+wVgAkgPYZW9WM83x+/Y\nBdzhmJaEEYNaepF0aYe9XkbAsrNMFFeq87sB63PC44HXRbTFi1/mpey2gP/y\nv69RtmOOimBxbNDZlvMhGtkI0KIEx9GbvyucOJ7wL8eXbeqXn+PWc0iXqLW5\nY+aOp0Row5E9v1t9+e2jFVgE6QwZCCDQIipiKPrq+3V4XWeJuoa1y6CpHehm\nIdsBewAnknTS/5Z50Af1lFj+SVbUpt8jnC36ByL4dgtpk8WUMbl7cB+iy2yN\nO1veMkh8mWJOViHzUqfmiQFiko0Z7dypRvI0nkDHMOyDmrevtqYbQ0CKnHhh\niHfJW7Pa0ZU2s2WzRwRt2QHptT1b1Au1PtrVNdTWLmNy6PwEcvDlX4t10dTx\nwAtWrRy12bIpKgvQXjuGP0Y4lN8NrP+E7ZO3Urf27WPf/GOWjaKmRiuy4amK\nyEKncTMZ2ekESO7rgIEfT9IYdZQ7G5iFYOcIhxZq9ZvZceat6gHlPahEYnrT\nqdgaETIyE16RJHl3h5lNUW+fXLvfhoTYY4h159GcngveAV+7YuqZavfYAfmk\nQ2yxdyghKekQBNbXxtqxTFSBLR6cBtoJEQ+STkiiHqJZZbhShioz/iZ8Nl89\nT+gd2vACvR+bzjgHRUfyIQQNfosS/srZbQJEiODzNM7P9JgfTIUwSpqxz+IP\n5C9K\r\n=D1Ey\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.17": {
+      "name": "portfinder",
+      "version": "1.0.17",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "0.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-syFcRIRzVI1BoEFOCaAiizwDolh1S1YXSodsVhncbhjzjZQulhczNRbqnUl9N31Q4dKGOXsNDqxC2BWBgSMqeQ==",
+        "shasum": "a8a1691143e46c4735edefcf4fbcccedad26456a",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.17.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18789,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbeiU8CRA9TVsSAnZWagAAmDMP/0WBlSqPvbodilXnwTOC\nTMXCUZ3ar49r2HXjv5Axh3bXmnqPbLMblAgEVvWklMcGLl3v0rundxYmNy/V\nDnbegtobigReq1NWcTOtNnXtH301SK2SRxEVbepQ65GV6ascytFaxfKv6D+E\nmm4MqZ5lzAuWqWKnGj/6wPXZ8el9aE5dfNrmC/oqFlA6TE94Ueqrad2S45yS\nzJnPLt63MrfytWnc/kf7Rl05U8WKJ0y/DRLRC58FbdS5olTI/0aSVmwISb3z\nNMox+wWgzjLiY3ym57V5AHcekC/Qo17OUsPIxIayDZdJlFq9rqqurmhfNvGq\n9TWUwz/J6x+wrbMexAViI3hmZ0ULHTVu2phAW/E9lJXKlxh4WOpOZZuys8fq\n3xJLXGrjOUyIYtftHcRj1utq7F0br0hggVdml9EQiCB35AuIEiasCOe9J6ip\nO7+yqIEy+t7xkoS/U2W/FuFytFKfJdmJo9onyJp6ID3XQlBVBR+dm35P823o\ntHZIHTH6MwRqxUDRxTkQGklBcMjQaEezxsFpjgObmnWwWjjToEQ/ZVu0Exxq\nhYkC1otF3XP9XMesRZfa5kockZkzfyTlX6DkrF6KNtE7RqCP2NgFpktVbWke\n6fapOBVGkbNHV/0ruKw/Bwh0Ap69oteJGakQzUHmHX7jPLCccCDWZZBXr9eR\nEJ/M\r\n=+j7M\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.18": {
+      "name": "portfinder",
+      "version": "1.0.18",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-KanzLOERzKoX3En5yTiV8K/arnU1ykYVokmtEn0PgCzqKZG9489tqW8ifp9+v3/VJZ5YDjvDt/PAP5WaPgk7FA==",
+        "shasum": "cf1106ff336fd4329b7ce32fda7d17d62c6bcf37",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.18.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18790,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbx8gDCRA9TVsSAnZWagAAsa8P+gKyjKiFmNJrhQiw+kVK\nWhc2YdcxNPUY4XLbww6znml5oyB0EiX1o8KeTMH4TsrDBq47vbFpPA0mvfNd\noBgKQi1uIcHMslpwUOEUc1zmDFg6Xi5y3LOMI/Rh1DWmqVRaLPbJZU9lN2rx\nq5Kg+fCCN+vvvUz1srwBoS10XD5F3VEc2owzZy5ceKOWFz8t6TfJ0VijZOMZ\ntc5iu2Y55x8asjXcJqmkc4K4ewZKR6zRlpSZQvlPn4b8g22mDlX2jY4qw8XT\nb+nmkI3QNeAf/uIW8kZxdU1JWDM64qKBryHY4S7r9yJScmKeJsYjddyNrT3p\ncml6OuM9/YYs2jldSqkbQ/MQgt8l5zFz49F+Tnp0DhJNMTWV8TGVnOR/4or0\ntW2MwPg60tbCf/xmB+NDdUB/buesaoLtVmstfOEpcTXs7xbT+A+SkIqx82ff\nUuQ010PzYaRJfOyu6ztoSz5M1hGw0/ePwmDuAEUPYsEcSf+1hvXnsbs0Tsq0\nhxp31XB3K2DA2FCEmW8l1ZrgKEuCIhLi19NS3Fxt3T6BKPicbXJbkVLU5OLR\nkrsv3qptSBn1NwRAV7aoaVBxlAeNtsJRiPvo5Or9kJrHvEnSrfscgsqm5TTW\nWBo7aRLu6exEjLQLa0s0zIM6dIyMi7DmMtRdrB4d4PEkWPBpewONiL27P61t\ngOCx\r\n=yZD8\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.19": {
+      "name": "portfinder",
+      "version": "1.0.19",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-23aeQKW9KgHe6citUrG3r9HjeX6vls0h713TAa+CwTKZwNIr/pD2ApaxYF4Um3ZZyq4ar+Siv3+fhoHaIwSOSw==",
+        "shasum": "07e87914a55242dcda5b833d42f018d6875b595f",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.19.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19148,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbzoYKCRA9TVsSAnZWagAA8kIP/1EJUzTVfAm6J/QxtNQ9\nbO//2C5Bhq9sok0BK7i9qGSYV2IqcWEBc4fOP4zQOU5Y0kf7VJCzi9Gv78vb\nX1ui7j/eJZgRLoWpjohYpzH9M7NaiEluHZ18Xj5OJCiH9oROXa1oEC91N1tn\nskZQlNmIBL5iZyIbmQBfHjFKojjhg3uO0sZhd0iADS36FHp+DShqW1qpiHGh\nEfGL4T2+cghvwtB4JyIbAEsWQxK4xqL1rUXgZKyZ8nV1eNmacl/enoqzbOki\nkIBWNz9LrdSavrcN96CReZmPupvC/SXY9lJNSxPVkVIsuOzIVJDCQ2QRu4Jg\nV3HbTf7cWAvVRiPjV7wsI5MED0p/8TCtdGxwvIyJ9UrddeH0YRtgtclo2XNh\nkf0eE82ioIqFHbJaQqmbXvG0fPornEgBFFQzAxlmeCHCE/Opqe11P7Tp+zOy\nKe16Fuh/hgvbYTyxXBd4iSRUTJBIM2f7HN11HDQiy/eDFj9c5zWED5eqm+Fv\nh2D5AatOs+R9JAJxf6QBnldwPBq9yAMzrYrKqTh2ZGPtitX4MZUcRJcp42A/\nb9l660XyNojp3YWwIJZ3IcFH/DCP56jTMEFiKumPRKct7VFquJKeGBqdfsqg\npgA3zCsWHW8h3DKCbS1cDbjTXrRt7uk+yYFtmIIpW95RFcQh8MitjXzQ0E6D\nSLgu\r\n=8ZuZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.20": {
+      "name": "portfinder",
+      "version": "1.0.20",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-Yxe4mTyDzTd59PZJY4ojZR8F+E5e97iq2ZOHPz3HDgSvYC5siNad2tLooQ5y5QHyQhc3xVqvyk/eNA3wuoa7Sw==",
+        "shasum": "bea68632e54b2e13ab7b0c4775e9b41bf270e44a",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.20.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19279,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcAcKGCRA9TVsSAnZWagAARs4P/jZxKfnJ1yAfsGPhu43h\nORZ4r+09ewUOx6frGlbrYSe2iszuJQMUT8BYZxSUmQfzie+NKX9Zz1tNysld\njRncivEGGk2pBIC99/IkCXnOFw3V4HEfqTEqgsE8eIx2Mzfn4WB5vm3IhnAt\nBXpwB2O06j/cTJDVfLAS1dAAdNdl71u1xRqeCUxqJPr7Sa4zzTCA3sANxNnv\naWQ4Q5hk4PpprJrZc27b5LS6A+f3ycQNnvs9NqYFjJUkC/psgeA9icWNRDM/\ne/KQWn0Hfjvw7zTMRqd201OcZ573Z1jhd+d6CfvkZxXYAFUN8kFfWIL80jb1\nFaNDCYq98ACJ/PjFkMKVN8srKF3qWABYEISlkrYhY1TcilrjS0QV0DOuvxTR\nCqj20CIVkcl1XRHfat+y1cD/OsV4kL6AyTKAKo1Snba3qulcj4UKCrebbbYJ\nyYB4yIn6uRkv98rj7PBD6WyWEFy3lKk3pcRhjDMZzujS0/ajoNIPkY+SGqee\ndUSUNyjYSN4u+MRP1cf1L6CjdB4LmBhEaoASjltJEcrYjZBuEFJSauJQzDlS\nNoS27BZmRfSu5eBCIjD989lb0u7kM2/b6PiHsALi2mOCb+x1XL9zuaYXubnl\nzQwgS9ea5kAxPGJUNjp2+Z49Pg8pBj6IIggZQ9Ry4mQTZtbBPGx/2NiZcag/\n/cw1\r\n=wFih\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.21": {
+      "name": "portfinder",
+      "version": "1.0.21",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
+        "shasum": "60e1397b95ac170749db70034ece306b9a27e324",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19419,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdKJhlCRA9TVsSAnZWagAARMMP/3ADs4Knwf6pfUHJoRAd\nwTFCqtmweDMfYww7i+RWDv6P1yZh4nyFvKhb0a7AYIQurbKx28advkjB1irt\n6QKACRPOTxChyLG4KYNogAre+NFls+TDtn/eiY+pE9l+fhJGakaToj6Nm0hX\napSd7VxOHojTnRsml0wCndpPs6XDWxM8+TJaziKCRf4x9IXHpwTT+8O0SFwV\nJC3sp8Z2AQ0OppdThB0if6V5LdpYZ7LlHKKNlmdww7UuR5dwlyl/IbRNuMVM\n8NhqaaqK8MF8uA5GkjT9zAIxfchzqZata7JAtF1nOmhu2uLxWTLwTNSy+VtJ\nkn5BhkL3DxTUWRpykeozXHcGh43W5SFkqPtJnIfApSSqEghAlSL6mhR9ERpH\n3EKoEpJBGXfNFbNL3aLS0SfaplY4UjMHz9w4Ay23wqnYrT/53qjXaQys4qJ9\nszgV+O0q2eolkqaxJOdO+ObS8R1NjYbVhnWXv4jxhXdIroxla14kUpju/4De\n/ByeqBZBNDCF92Xc/l2wEMDgK8pbOBpwFaetM32W0J+tFuhBUnKZt4EWm+aY\nb8+1gPpejGZmCsU4os6gvaJeddquBgaMCFYCuerhVKKoW/0qgv/Z+/Rxw8aH\npNYsTPoVpDQ9YINZmyjrF1HWUIzhRMnKniuBuAP087u9tO38c33pK5RfzNIg\nd/oU\r\n=QZZc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.22": {
+      "name": "portfinder",
+      "version": "1.0.22",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-aZuwaz9ujJsyE8C5kurXAD8UmRxsJr+RtZWyQRvRk19Z2ri5uuHw5YS4tDBZrJlOS9Zw96uAbBuPb6W4wgvV5A==",
+        "shasum": "abd10a488b5696e98ee25c60731f8ae0b76f8ddd",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.22.tgz",
+        "fileCount": 5,
+        "unpackedSize": 20531,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdV9PpCRA9TVsSAnZWagAApbUQAIhz5zMWLdxF6gKCNNq6\nhP1IVSjLsgn7JHGUvAYUKppVW589o2uzMulpeH5qu7lm79W2cKhXkuqB5Iaz\nZnESx5IU5QKok03RiN5WxRDxo1JmB8uFNKL+nk5Xxe4L2daF6LG1BM0ZYURa\nnyQ20sxMUELfMttwwZEPc15JMpeyoSqaIByIeW3b0P+k0zCU49g9mo/YShXs\nnrBon++VXJBelk8X6oxsxXxfkBwo/LCEAWMWi/txJhMrcfK825SDA2T4lXEN\nnKrgRIxifbw+Ryet5P3OevyeiK0F1yTuMHWm5WNx62KQqAdGOKd3xJNVkL7r\n/mSQs7/qbu5AbMEeKxoc8KhnfBKieDTR8SRODtApvFS6YxcqF/nkP7N8x03w\nfYvUd7QbOITVcydAG3rBL92g+ZasXDRkOhQuIm2EvWpI+Czwl0AqRbGgYQ3q\nfXRZhbGbnlyZegatPd35ALkYY84Nlbf41wwHX9BVeYFExZfelxvLG6QDJ9EB\nPkVW3e3MUrsmt7Lkv4baDH7woZ6qZ5HjWZX4UKh08lGvzJC1YmWnSFaL2xuD\nayfwW8q0Bg4RE4nuba+xhzDKtirdE+n2LYpQvWUSWwgYmERec7PEhYvQPpMe\nIu2zdxLrrEyUc2WOPGLh+t4mfNiMs6Kcpr652d5WjPdg6izfibSYcYhFmNWC\nqiSH\r\n=I6yd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.23": {
+      "name": "portfinder",
+      "version": "1.0.23",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-B729mL/uLklxtxuiJKfQ84WPxNw5a7Yhx3geQZdcA4GjNjZSTSSMMWyoennMVnTWSmAR0lMdzWYN0JLnHrg1KQ==",
+        "shasum": "894db4bcc5daf02b6614517ce89cd21a38226b82",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.23.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19419,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdWwSGCRA9TVsSAnZWagAAbdAP/2SBoOTbJZuzrJcfan36\nZaan4sI5PItTmX4i1I5yI1Nd1hEhKmhN4pZCD5IdyckI5nulTnIOzT5/5nKl\nopFmXiJuJ4/+ePplHlWnet7+IYKr3p4ZvF9F6NhtJ5tD9+rJ5aHjvurrMSOd\nyKN00nNf2LetN/w5TZ+ypws8CjoGSOgworp3n/AJDt4J6MrMmE67dwcys5Wv\nblzDUffqK8ti1Ju6bN9IZXFK585QJI5ayy1HZwJ9nlu0IjBpk2xYNMbyKrVD\nB4RbTmLFFznguwLpJOs6GSXH7c2U8mtWqXHxvpXqc7DWFe2VI6aXqSkDSf6Z\n7b4HaPbrip+jc2ASscsjbOheMOJSWRKG4KDPQ/JIWcD/hG44PACiu4fVWpVl\nlEm8pUYwtkT86XtM+E6DSFE4fi96d5/lad5nelGAZdLKdk7CuXkTf0XUCugS\nJ2zHpDiW9h4M/IyF4KbwrqjKO7ucBXA54R3e/o7/aqkHw/R8+sq7ecjIE8lM\nNSoqIbzNBUnOXMrqMczY7FOfZ9ksh0ZBDmUM3fIaWjET386kxHkpntc4eAZi\nRKhRaQXiEWDAfSICXIvSCx2zPL+vXkAtVR2KaHJmyyQ0skuRWUmdBHjpUcBJ\njpqEsV3DrOmL333pLL23ZQCRPAHMf3sjEy+IZtwok6okLDJEqwv1h0IR6/o4\nF3H/\r\n=1JNa\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.24": {
+      "name": "portfinder",
+      "version": "1.0.24",
+      "dependencies": {
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
+      },
+      "devDependencies": {
+        "glob": "^6.0.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-ekRl7zD2qxYndYflwiryJwMioBI7LI7rVXg3EnLK3sjkouT5eOuhS3gS255XxBksa30VG8UPZYZCdgfGOfkSUg==",
+        "shasum": "11efbc6865f12f37624b6531ead1d809ed965cfa",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.24.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19421,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdcWJsCRA9TVsSAnZWagAAyMEQAI6U2EC/hUTu4Jud2+xR\n/5C6dfeJxYeNia9zTFVuRd6Oj5fBaFCpofKLMZTCIXYAcuSp4Vz1W0Rr2izu\natEZ7wadRa7lP/0oVMDkjjTQFoQHZrTZSyQUTEhPbBou63w6qgtJ8oHdYBgo\nS9Ab3w3YOl1ZQB0rSgoSiiqSSyeoJpHzbfK/o+BnpbBPp2GsPAGpYYi2Guy4\nidZw9INI6u9+nltkb/g8tRYIoK5Kwlotz7R6gKn9iPBGDU/rgaqMYB3wzK5G\nYhpgY9GMouul3YFgCv5EneIqcGZj26SmrsSmrT4niJ4rH6BGYdRUbSJU9wiq\nzfaIoy82q/l7oc0nmk3TnWtau6nPkctQq2i3qtxUrA4cnoulrzKGoi4C5AW2\nAV+DhvUBUKNyZ+TW7GOr37c8GAeO3eJ9TgZVVLei8aCc9Gre4ORHSjPF38uv\nXLYNTBMYb+H2ijLjBMPWRni/FApfv7zk4kkpj2IaKl5UD7ryLUqpAChx7rPT\nCCVAFHlwiDflJS7V73qPkyEglZletH8RNR/wPOp5NoPJiezBnoFUU3vyMGfe\n5wWTznMh4F2PsM0RlXgWY5O2X+sKOgjO5sUq9QPRSvL3nmXXnjpvbvGa2tso\n/ld/idRi5aKyLyue0KX9ukVNtKnjy9Mo6manumKoy7ioB0StBCy6N0Jk1OFS\nXTnl\r\n=tM5z\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.25": {
+      "name": "portfinder",
+      "version": "1.0.25",
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
+      },
+      "devDependencies": {
+        "glob": "^7.1.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+        "shasum": "254fd337ffba869f4b9d37edc298059cb4d35eca",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19425,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdpkA2CRA9TVsSAnZWagAACmUP/107q/fcQoJZZfLiqF1k\nmlQXZzy6Qz1RrgJUoA/LxhrVh38C9P1yTMemwolvXgNQ87hvbj/Xj21X4P3k\ngYRZ2Ce3nNYwImMpFem4CNz3w/+rTRwJWCdTiVLV8iYeDdeKlGKjED0gg1K9\n2Xq1rKYNjZQlkL9r3ASAU6LTOe0T+gkvCPEM+vPHiQsDhBk9Xf0xSsO8MoSY\n9tw5qTV6BIMgLLmJWKOU8gTomLvQlEV5YU1mhdDQxAFsJuZbY9qpN7Vum0AV\ngunCfNFMJ8HUDO8W4O4Ko7wonGPveEu4KftrNBRkWTNCaEwR6GUyPfLBvjJr\nw5rSinFMwhMWoxZHIDBeHYZn0VKeF+SpTB/06/Dq+c2f+OP6IJJRfj4LDiyL\nVrZDmz2rGTs/4ccD0JcFyt9oKXKxJ01lfx2UgISEBC9GRPiPo9YL0d1GGgaw\nuAeqMZjw1TXkmfp+my/5GkZoojwsjkQcL4lPgATD6CmJhgqOegOAOfaOKjxG\nzMV0YFBpmJHdBP09n87jVxqKBwdX8D2sDteyZzCJjYtLWNuyPf4UNS9ZomHq\nlLmSG1lDEcZI8u6L0MTyHohkqgAe5sK1TM4go6K2OOO2ztYkXi1DLwMMhm7J\nSof1tnBoDB93ctZ5ZlRHkb6uyKdA8cr/GIw6v1r80RmEyoAV6QngU2Ng7Q94\ndXIh\r\n=Cyn4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.26": {
+      "name": "portfinder",
+      "version": "1.0.26",
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
+      },
+      "devDependencies": {
+        "glob": "^7.1.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
+        "shasum": "475658d56ca30bed72ac7f1378ed350bd1b64e70",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19427,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeqJkBCRA9TVsSAnZWagAA/4MQAIqdFso6sAK+lOodo0d4\nyh4MEqHviwpqP14+MQdN6IK+FTtKO87+JpTIyd9ZC+lIVP8fQ3xZbwx20qtl\nLaQr0z1cw5Ax479Ml+9G8iyuYjLsQDqOJ7JPfOo0kzuThIV/mcWxHz9fqLys\nhJVFh+qgS4+pwAsLEki/lqviD2kQmKBlC4MqTkW2d/CWzimIn15UiEpOm2QX\ngxcUmApha83loURIGVLkAeNI+gN/T4Ca4yAVtLOygNjk2TjZUyaT8gUuRFWz\nEyto+LU4MLojFdxNUBqzMp+Ao92x8b2p8aEAd6DHSPel66tdJ4CsHIAAHtEk\nJPOKE6+0xH7VoqQQN2kBPCKsEil+hqN7XDs1HrLea3ETlsnmQ8Yfi6EOhvmB\n7ExaFw1PfUdqqazDa13jvcBioxOG9IL20Awyf+zqc2AlBray2QZOO4iOWk0B\nN4SM56axRq0iV69zGLhmsGOlgk+APOKTOCUQSCe3si2J7ZrayBm7QS9llpgZ\nxIZy7jP+YEr4WgFBiN+bT8ad1rhHxeZuJ9UYPiKgO7VVus2N3OezSBwJ++uc\ng6wBOxW8hpGs4ZN22fOpXpHNPI9Rc13NuIjEfB9HaDlUEv5xqANU+kVzo7kr\nb2EiwPjuF/pWtCw6l3ZQmmDrMI4ASLbHrQ7fDsXM+UIr805QdlqR+nQmn2M5\nxYN2\r\n=Pwiv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.27": {
+      "name": "portfinder",
+      "version": "1.0.27",
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.1"
+      },
+      "devDependencies": {
+        "glob": "^7.1.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-bJ3U3MThKnyJ9Dx1Idtm5pQmxXqw08+XOHhi/Lie8OF1OlhVaBFhsntAIhkZYjfDcCzszSr0w1yCbccThhzgxQ==",
+        "shasum": "a41333c116b5e5f3d380f9745ac2f35084c4c758",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.27.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19427,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfFPTjCRA9TVsSAnZWagAA4y0P/1AOTG6oqT96UCJn7gn7\nbCSOZPwTUfxJCH7Of/US7OYRW0NE+xZlqRcd9e5KD2n8FiAsRIwn9PcEvDr1\nK4N5IYUfKd440wAEbKX6WvBiEu2JD3+N+xcsXdt2cqkI91RTBSFnVR97XTJZ\n5q8rI4lxL84Vn0FoGOkvSzWrLHzvSk1Pk+LW/2R1M7v8e6JW+YV+9Wxe0RfI\nU1p4qmufLTMeeB/iDKi4P84o4dHHWhtyuWlMOdFSDX45kRJevwIhiTBmWwd7\nuFRYzsEYx8EILs9a4ERJjy04e5wQPOnhdAfcwrAANshNoNqmNW2ZpP4xDtXm\nBBoCkJZpzNWh5ZLoizaeVzV86LfTyQBjck4zzOnJzYwIdxu3w1bGVbX8DNdk\nL6SNvRKpdlZep9JVS3kaYvJUJ+iZre2atWrebSN59IH8ARTwapTCCFAR7Sjn\nFdAdG9L8MSO3Mv18Z2KC/4WbDWKumTuOtF8c0fEuetvgmnl3326ypLf6S8oK\nQEsnXYHM0vTtYIhWzb/H7MycSyTSc8kdhng+raX/uyYUwp+XI0mbRs8ObvW/\n0lyKxnSkwgfUt99CpvC2XPFa/cVknEV/BsPJ1d0yp309l3IIiWLydSq09yRZ\nOqe4zE6KlAuk6H1t/bb1u0Funyi0cRnPHbvJXgqNXOGTgnfGI7dQz1V55rQZ\njSbC\r\n=JZKL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "1.0.28": {
+      "name": "portfinder",
+      "version": "1.0.28",
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "devDependencies": {
+        "glob": "^7.1.4",
+        "vows": "^0.8.2"
+      },
+      "dist": {
+        "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+        "shasum": "67c4622852bd5374dd1dd900f779f53462fac778",
+        "tarball": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+        "fileCount": 5,
+        "unpackedSize": 19427,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfIRf/CRA9TVsSAnZWagAACrIP/3/umAyiNj7dFpIpmx8u\nbZ2ZiBRsarYLtS6OOYDmNn3BfQlLblnIIfmAAIRToNKWtKdAkXaRhn+YfIXW\nN8z5rPIY2RYqefxKgDOxBeyofKrw9LHlSB3u4BAXbET5nFKGNcGhAAVgfrWi\nuz2veBCefkKYjkjQqqWG/1mx3AuMLrfE10t9FYwoHNQuqT1HLwLe8C/mZf36\nNGUN51MOdssFF/NlLfX+nUtML1ZL18sUOMGNdpC8K7tvuLopqlofst/tmrlE\nxtKtZx6654Q2x8it72H0MThsky+3IEogJCrKA6n51e6TJT0dymZjdr9xkauq\nhshZ7jlDyGRPTrB5u7TsCnOcFkKsgzg466nC/t8BotRHAk9kD23RRscI8AOI\n35JhsipVS1wpWYdUZpHUlN77VwzHdBl8TL2pUYz1X8vtLVNZTQduVRWGDTUI\nlpzRAKrfeYlsEl/z/YWI689a1YiZgG4WKphgh1wHhVq8ZZplMzUcdlNccbWV\naNqxOhXoQLUzFST+9C5mlEHzqAtRYnltTP0V7Slj6gJ2PFaAsdjxv2f2kh3j\nZB0POe2uEuBzwEoAS+pCZx+Wz0iwaynEyaHGsOGkBAOn9zV66vZDCMc1NF4/\nlwl+FMekfioeyyB7SKakj9/jFtSCyMXBSc/bYC516CrsTfqYSqfX383V+J+2\nxeLT\r\n=496T\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    }
+  },
+  "modified": "2020-07-29T06:32:33.553Z"
+}

--- a/test/fixtures/registry-mocks/content/posix-character-classes.json
+++ b/test/fixtures/registry-mocks/content/posix-character-classes.json
@@ -1,0 +1,296 @@
+{
+  "_id": "posix-character-classes",
+  "_rev": "3-f8c7cc7ef8acfc41a109416024a82541",
+  "name": "posix-character-classes",
+  "description": "POSIX character classes for creating regular expressions.",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "posix-character-classes",
+      "description": "POSIX character classes for creating regular expressions.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/posix-character-classes",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/posix-character-classes.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/posix-character-classes/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11"
+      },
+      "keywords": [
+        "character",
+        "classes",
+        "posix"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "282c377615b62cce69c57d4153c8b0adbf326880",
+      "_id": "posix-character-classes@0.1.0",
+      "_shasum": "a6c4c72c5a7a494d94d56267f368e3b8978bcc6b",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a6c4c72c5a7a494d94d56267f368e3b8978bcc6b",
+        "tarball": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/posix-character-classes-0.1.0.tgz_1474958178067_0.18115027388557792"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "posix-character-classes",
+      "description": "POSIX character classes for creating regular expressions.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/posix-character-classes",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/posix-character-classes.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/posix-character-classes/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "character",
+        "classes",
+        "posix"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related-list": [
+          "micromatch",
+          "nanomatch",
+          "extglob",
+          "expand-brackets"
+        ]
+      },
+      "gitHead": "93acda996350d0b1571592765e45c31da9376aa7",
+      "_id": "posix-character-classes@0.1.1",
+      "_shasum": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+        "tarball": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/posix-character-classes-0.1.1.tgz_1492663375848_0.9031167267821729"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "posix-character-classes",
+      "description": "POSIX character classes for creating regular expressions.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/posix-character-classes",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/posix-character-classes.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/posix-character-classes/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "character",
+        "classes",
+        "posix"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related-list": [
+          "micromatch",
+          "nanomatch",
+          "extglob",
+          "expand-brackets"
+        ]
+      },
+      "gitHead": "93acda996350d0b1571592765e45c31da9376aa7",
+      "_id": "posix-character-classes@1.0.0",
+      "_shasum": "86917ab2d252f7ea78e157bf009b9b6ea35c6cad",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "86917ab2d252f7ea78e157bf009b9b6ea35c6cad",
+        "tarball": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/posix-character-classes-1.0.0.tgz_1492663392659_0.2984538341406733"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# posix-character-classes [![NPM version](https://img.shields.io/npm/v/posix-character-classes.svg?style=flat)](https://www.npmjs.com/package/posix-character-classes) [![NPM monthly downloads](https://img.shields.io/npm/dm/posix-character-classes.svg?style=flat)](https://npmjs.org/package/posix-character-classes)  [![NPM total downloads](https://img.shields.io/npm/dt/posix-character-classes.svg?style=flat)](https://npmjs.org/package/posix-character-classes) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/posix-character-classes.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/posix-character-classes)\n\n> POSIX character classes for creating regular expressions.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save posix-character-classes\n```\n\nInstall with [yarn](https://yarnpkg.com):\n\n```sh\n$ yarn add posix-character-classes\n```\n\n## Usage\n\n```js\nvar posix = require('posix-character-classes');\nconsole.log(posix.alpha);\n//=> 'A-Za-z'\n```\n\n## POSIX Character classes\n\nThe POSIX standard supports the following classes or categories of charactersh (note that classes must be defined within brackets)<sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\">[1]</a></sup>:\n\n| **POSIX class** | **Equivalent to** | **Matches** | \n| --- | --- | --- |\n| `[:alnum:]` | `[A-Za-z0-9]` | digits, uppercase and lowercase letters |\n| `[:alpha:]` | `[A-Za-z]` | upper- and lowercase letters |\n| `[:ascii:]` | `[\\x00-\\x7F]` | ASCII characters |\n| `[:blank:]` | `[ \\t]` | space and TAB characters only |\n| `[:cntrl:]` | `[\\x00-\\x1F\\x7F]` | Control characters |\n| `[:digit:]` | `[0-9]` | digits |\n| `[:graph:]` | `[^[:cntrl:]]` | graphic characters (all characters which have graphic representation) |\n| `[:lower:]` | `[a-z]` | lowercase letters |\n| `[:print:]` | `[[:graph] ]` | graphic characters and space |\n| `[:punct:]` | ``[-!\"#$%&'()*+,./:;<=>?@[]^_`{ | }~]`` | all punctuation characters (all graphic characters except letters and digits) |\n| `[:space:]` | `[ \\t\\n\\r\\f\\v]` | all blank (whitespace) characters, including spaces, tabs, new lines, carriage returns, form feeds, and vertical tabs |\n| `[:upper:]` | `[A-Z]` | uppercase letters |\n| `[:word:]` | `[A-Za-z0-9_]` | word characters |\n| `[:xdigit:]` | `[0-9A-Fa-f]` | hexadecimal digits |\n\n## Examples\n\n* `a[[:digit:]]b` matches `a0b`, `a1b`, ..., `a9b`.\n* `a[:digit:]b` is invalid, character classes must be enclosed in brackets\n* `[[:digit:]abc]` matches any digit, as well as `a`, `b`, and `c`.\n* `[abc[:digit:]]` is the same as the previous, matching any digit, as well as `a`, `b`, and `c`\n* `[^ABZ[:lower:]]` matches any character except lowercase letters, `A`, `B`, and `Z`.\n\n## About\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Building docs\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n### Running tests\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2017, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.5.0, on April 20, 2017._\n\n<hr class=\"footnotes-sep\">\n<section class=\"footnotes\">\n<ol class=\"footnotes-list\">\n<li id=\"fn1\"  class=\"footnote-item\">table and examples are based on the WikiBooks page for [Regular Expressions/POSIX Basic Regular Expressions](https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions), which is available under the [Creative Commons Attribution-ShareAlike License](https://creativecommons.org/licenses/by-sa/3.0/). <a href=\"#fnref1\" class=\"footnote-backref\">↩</a>\n\n</li>\n</ol>\n</section>",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-04-20T04:43:13.188Z",
+    "created": "2016-09-27T06:36:20.553Z",
+    "0.1.0": "2016-09-27T06:36:20.553Z",
+    "0.1.1": "2017-04-20T04:42:56.382Z",
+    "1.0.0": "2017-04-20T04:43:13.188Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/posix-character-classes",
+  "keywords": [
+    "character",
+    "classes",
+    "posix"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/posix-character-classes.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/posix-character-classes/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/posix-character-classes.min.json
+++ b/test/fixtures/registry-mocks/content/posix-character-classes.min.json
@@ -1,0 +1,53 @@
+{
+  "name": "posix-character-classes",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "posix-character-classes",
+      "version": "0.1.0",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11"
+      },
+      "dist": {
+        "shasum": "a6c4c72c5a7a494d94d56267f368e3b8978bcc6b",
+        "tarball": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "posix-character-classes",
+      "version": "0.1.1",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab",
+        "tarball": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "posix-character-classes",
+      "version": "1.0.0",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.12",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "86917ab2d252f7ea78e157bf009b9b6ea35c6cad",
+        "tarball": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-04-20T04:43:13.188Z"
+}

--- a/test/fixtures/registry-mocks/content/process.json
+++ b/test/fixtures/registry-mocks/content/process.json
@@ -1,0 +1,1244 @@
+{
+  "_id": "process",
+  "_rev": "54-eb017a15dbaea3e552108129af2a9a4a",
+  "name": "process",
+  "description": "process information for node.js and browsers",
+  "dist-tags": {
+    "latest": "0.11.10"
+  },
+  "versions": {
+    "0.4.9": {
+      "author": {
+        "name": "AJ ONeal",
+        "email": "coolaj86@gmail.com",
+        "url": "http://coolaj86.info"
+      },
+      "name": "process",
+      "description": "aliases `window` as `global` and adds `process`",
+      "keywords": [
+        "ender",
+        "global",
+        "process"
+      ],
+      "version": "0.4.9",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/coolaj86/nodejs-libs-4-browser.git"
+      },
+      "main": "./process.js",
+      "directories": {
+        "lib": "."
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "_npmJsonOpts": {
+        "file": "/Users/coolaj86/.npm/process/0.4.9/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "process@0.4.9",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.15",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "42adda3c6c577ea0c9763fb52698f5702b40c056",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.4.9.tgz"
+      },
+      "scripts": {}
+    },
+    "0.5.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.5.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "_id": "process@0.5.0",
+      "dist": {
+        "shasum": "f82e05372efa5035715da6622d22f0a06b6f053e",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.5.0.tgz"
+      },
+      "_npmVersion": "1.1.70",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.1": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.5.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "browserify": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "_id": "process@0.5.1",
+      "dist": {
+        "shasum": "f9af36059dfe99556bd43fd220aabb617c1ef4a3",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.5.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.2": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.5.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process",
+      "_id": "process@0.5.2",
+      "dist": {
+        "shasum": "1638d8a8e34c2f440a91db95ab9aeb677fc185cf",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.6.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process",
+      "_id": "process@0.6.0",
+      "dist": {
+        "shasum": "7dd9be80ffaaedd4cb628f1827f1cbab6dc0918f",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.7.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process",
+      "_id": "process@0.7.0",
+      "dist": {
+        "shasum": "c52208161a34adf3812344ae85d3e6150469389d",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.8.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "gitHead": "67e233fe6cd92869dfdf3ed305e969c4bc803ef9",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process",
+      "_id": "process@0.8.0",
+      "scripts": {},
+      "_shasum": "7bbaf7187fe6ded3fd5be0cb6103fba9cacb9798",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7bbaf7187fe6ded3fd5be0cb6103fba9cacb9798",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.9.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "gitHead": "79c897b5bf244125266353310fb30ca2863f8602",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process",
+      "_id": "process@0.9.0",
+      "scripts": {},
+      "_shasum": "47d6a6acf51b879428c3269608992c7c5a790be4",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "47d6a6acf51b879428c3269608992c7c5a790be4",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.10.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "gitHead": "181030e3bd47dbc3fc1914b5635ff6242e8e2e5b",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process",
+      "_id": "process@0.10.0",
+      "scripts": {},
+      "_shasum": "99b375aaab5c0d3bbb59f774edc69df574da8dd4",
+      "_from": ".",
+      "_npmVersion": "2.1.9",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "99b375aaab5c0d3bbb59f774edc69df574da8dd4",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.1": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "version": "0.10.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "gitHead": "b723f82028b12e94abfe732e9f432a3fb2b5cece",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process",
+      "_id": "process@0.10.1",
+      "scripts": {},
+      "_shasum": "842457cc51cfed72dc775afeeafb8c6034372725",
+      "_from": ".",
+      "_npmVersion": "2.6.1",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "842457cc51cfed72dc775afeeafb8c6034372725",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.0": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js"
+      },
+      "version": "0.11.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "gitHead": "8ed5a16c8b9ecb1cf8e32727ce36ed69ee4cee44",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process",
+      "_id": "process@0.11.0",
+      "_shasum": "3eaaece62d56719a25bfa4198ca74c27b25960f3",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3eaaece62d56719a25bfa4198ca74c27b25960f3",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.1": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js"
+      },
+      "version": "0.11.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "gitHead": "2d0290765eef8f977298a8313460c85d3964d84b",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process#readme",
+      "_id": "process@0.11.1",
+      "_shasum": "ee3becb4335edf3c8b14ccbf7e17a1125a4431ae",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "defunctzombie",
+        "email": "shtylman@gmail.com"
+      },
+      "dist": {
+        "shasum": "ee3becb4335edf3c8b14ccbf7e17a1125a4431ae",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.11.2": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js"
+      },
+      "version": "0.11.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "gitHead": "4b996b1e3281aa38d46294f33b9772771f53272d",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process#readme",
+      "_id": "process@0.11.2",
+      "_shasum": "8a58d1d12c573f3f890da9848a4fe8e16ca977b2",
+      "_from": ".",
+      "_npmVersion": "2.11.1",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "defunctzombie",
+        "email": "shtylman@gmail.com"
+      },
+      "dist": {
+        "shasum": "8a58d1d12c573f3f890da9848a4fe8e16ca977b2",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.11.3": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js"
+      },
+      "version": "0.11.3",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "gitHead": "09adde8cb8bd9c61097c5742cd870d4c4708a223",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process#readme",
+      "_id": "process@0.11.3",
+      "_shasum": "d7d8fb7b3db3c0bfa9658b0dd9a4fa11e691ef3a",
+      "_from": ".",
+      "_npmVersion": "3.8.8",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "d7d8fb7b3db3c0bfa9658b0dd9a4fa11e691ef3a",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/process-0.11.3.tgz_1462649988786_0.6088946990203112"
+      },
+      "directories": {}
+    },
+    "0.11.4": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js"
+      },
+      "version": "0.11.4",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "gitHead": "5de5d427da885c6c618d3b3a009f8c4470215e30",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "_id": "process@0.11.4",
+      "_shasum": "a6e6d49f0833d36571c0b9492c0f4b90bac96cd3",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.11.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "a6e6d49f0833d36571c0b9492c0f4b90bac96cd3",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/process-0.11.4.tgz_1465568417025_0.5683431040961295"
+      },
+      "directories": {}
+    },
+    "0.11.5": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js"
+      },
+      "version": "0.11.5",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "gitHead": "dbaeeb81fe68d00c0a5201f22dca56009b948202",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "_id": "process@0.11.5",
+      "_shasum": "de49788f60e706f333adeea57a187ea9cc4c8495",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.11.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "de49788f60e706f333adeea57a187ea9cc4c8495",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/process-0.11.5.tgz_1465844241330_0.7085902339313179"
+      },
+      "directories": {}
+    },
+    "0.11.6": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js"
+      },
+      "version": "0.11.6",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "gitHead": "331de4d3b8cab1bb41ffea954e7971aa3f96d1f1",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "_id": "process@0.11.6",
+      "_shasum": "f234a1fbfddd0a64f8347e1ab52184453d7347af",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.12.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "f234a1fbfddd0a64f8347e1ab52184453d7347af",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/process-0.11.6.tgz_1469540140351_0.07442293269559741"
+      },
+      "directories": {}
+    },
+    "0.11.7": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js"
+      },
+      "version": "0.11.7",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "gitHead": "5997b18064fab7821cfce36a5d2c531771709de7",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "_id": "process@0.11.7",
+      "_shasum": "9f19d4803c1091c7f87e853f812a419f22b1fa45",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.12.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "9f19d4803c1091c7f87e853f812a419f22b1fa45",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/process-0.11.7.tgz_1470082128030_0.5076596953440458"
+      },
+      "directories": {}
+    },
+    "0.11.8": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js",
+        "browser": "zuul --no-coverage --ui mocha-bdd --local 8080 -- test.js"
+      },
+      "version": "0.11.8",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "1c4943a088579d57cc82876e6ed3972fd2595e84",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "_id": "process@0.11.8",
+      "_shasum": "58ff3d04ae0641be72c5a6e60ce8f7822d64eb3c",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.12.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "58ff3d04ae0641be72c5a6e60ce8f7822d64eb3c",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/process-0.11.8.tgz_1470663916796_0.6756675334181637"
+      },
+      "directories": {}
+    },
+    "0.11.9": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js",
+        "browser": "zuul --no-coverage --ui mocha-bdd --local 8080 -- test.js"
+      },
+      "version": "0.11.9",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "7d8c3702a8bbc43fa55f4bab74b150aef37001dd",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "_id": "process@0.11.9",
+      "_shasum": "7bd5ad21aa6253e7da8682264f1e11d11c0318c1",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.12.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "7bd5ad21aa6253e7da8682264f1e11d11c0318c1",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/process-0.11.9.tgz_1472587751718_0.8843140550889075"
+      },
+      "directories": {}
+    },
+    "0.11.10": {
+      "author": {
+        "name": "Roman Shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "name": "process",
+      "description": "process information for node.js and browsers",
+      "keywords": [
+        "process"
+      ],
+      "scripts": {
+        "test": "mocha test.js",
+        "browser": "zuul --no-coverage --ui mocha-bdd --local 8080 -- test.js"
+      },
+      "version": "0.11.10",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/shtylman/node-process.git"
+      },
+      "license": "MIT",
+      "browser": "./browser.js",
+      "main": "./index.js",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "devDependencies": {
+        "mocha": "2.2.1",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "557aa46f283caccce603dbb9c376b3d81067c510",
+      "bugs": {
+        "url": "https://github.com/shtylman/node-process/issues"
+      },
+      "homepage": "https://github.com/shtylman/node-process#readme",
+      "_id": "process@0.11.10",
+      "_shasum": "7332300e840161bda3e69a1d1d91a7d4bc16f182",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "7332300e840161bda3e69a1d1d91a7d4bc16f182",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/process-0.11.10.tgz_1493210065468_0.9640797527972609"
+      },
+      "directories": {}
+    }
+  },
+  "maintainers": [
+    {
+      "name": "coolaj86",
+      "email": "coolaj86@gmail.com"
+    },
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    },
+    {
+      "name": "defunctzombie",
+      "email": "shtylman@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-02-28T03:32:20.095Z",
+    "created": "2011-06-30T01:07:03.273Z",
+    "0.4.9": "2011-06-30T01:07:03.645Z",
+    "0.5.0": "2013-01-21T18:28:53.789Z",
+    "0.5.1": "2013-02-16T23:33:34.663Z",
+    "0.5.2": "2014-01-02T15:45:50.078Z",
+    "0.6.0": "2014-02-01T15:17:00.901Z",
+    "0.7.0": "2014-04-29T19:57:50.021Z",
+    "0.8.0": "2014-09-13T18:06:49.355Z",
+    "0.9.0": "2014-10-11T05:55:44.245Z",
+    "0.10.0": "2014-12-10T19:09:32.584Z",
+    "0.10.1": "2015-03-05T16:50:05.662Z",
+    "0.11.0": "2015-04-24T19:01:16.544Z",
+    "0.11.1": "2015-05-21T21:26:30.512Z",
+    "0.11.2": "2015-09-09T00:51:40.285Z",
+    "0.11.3": "2016-05-07T19:39:49.834Z",
+    "0.11.4": "2016-06-10T14:20:19.867Z",
+    "0.11.5": "2016-06-13T18:57:24.351Z",
+    "0.11.6": "2016-07-26T13:35:42.977Z",
+    "0.11.7": "2016-08-01T20:08:48.819Z",
+    "0.11.8": "2016-08-08T13:45:19.072Z",
+    "0.11.9": "2016-08-30T20:09:13.289Z",
+    "0.11.10": "2017-04-26T12:34:27.448Z"
+  },
+  "author": {
+    "name": "Roman Shtylman",
+    "email": "shtylman@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/shtylman/node-process.git"
+  },
+  "users": {
+    "326060588": true,
+    "m42am": true,
+    "luk": true,
+    "simplyianm": true,
+    "monsterkodi": true,
+    "dac2205": true,
+    "blitzprog": true,
+    "coalesce": true,
+    "ahme-t": true,
+    "shanewholloway": true,
+    "mojaray2k": true,
+    "dzhou777": true,
+    "langri-sha": true,
+    "chinawolf_wyp": true,
+    "advence-liz": true,
+    "kkho595": true,
+    "subinvarghesein": true,
+    "tedyhy": true
+  },
+  "readme": "# process\n\n```require('process');``` just like any other module.\n\nWorks in node.js and browsers via the browser.js shim provided with the module.\n\n## browser implementation\n\nThe goal of this module is not to be a full-fledged alternative to the builtin process module. This module mostly exists to provide the nextTick functionality and little more. We keep this module lean because it will often be included by default by tools like browserify when it detects a module has used the `process` global.\n\nIt also exposes a \"browser\" member (i.e. `process.browser`) which is `true` in this implementation but `undefined` in node. This can be used in isomorphic code that adjusts it's behavior depending on which environment it's running in. \n\nIf you are looking to provide other process methods, I suggest you monkey patch them onto the process global in your app. A list of user created patches is below.\n\n* [hrtime](https://github.com/kumavis/browser-process-hrtime)\n* [stdout](https://github.com/kumavis/browser-stdout)\n\n## package manager notes\n\nIf you are writing a bundler to package modules for client side use, make sure you use the ```browser``` field hint in package.json.\n\nSee https://gist.github.com/4339901 for details.\n\nThe [browserify](https://github.com/substack/node-browserify) module will properly handle this field when bundling your files.\n\n\n",
+  "readmeFilename": "README.md",
+  "keywords": [
+    "process"
+  ],
+  "bugs": {
+    "url": "https://github.com/shtylman/node-process/issues"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/shtylman/node-process#readme",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/process.min.json
+++ b/test/fixtures/registry-mocks/content/process.min.json
@@ -1,0 +1,280 @@
+{
+  "name": "process",
+  "dist-tags": {
+    "latest": "0.11.10"
+  },
+  "versions": {
+    "0.4.9": {
+      "name": "process",
+      "version": "0.4.9",
+      "directories": {
+        "lib": "."
+      },
+      "dist": {
+        "shasum": "42adda3c6c577ea0c9763fb52698f5702b40c056",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.4.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      }
+    },
+    "0.5.0": {
+      "name": "process",
+      "version": "0.5.0",
+      "dist": {
+        "shasum": "f82e05372efa5035715da6622d22f0a06b6f053e",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.5.1": {
+      "name": "process",
+      "version": "0.5.1",
+      "dist": {
+        "shasum": "f9af36059dfe99556bd43fd220aabb617c1ef4a3",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.5.2": {
+      "name": "process",
+      "version": "0.5.2",
+      "dist": {
+        "shasum": "1638d8a8e34c2f440a91db95ab9aeb677fc185cf",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.6.0": {
+      "name": "process",
+      "version": "0.6.0",
+      "dist": {
+        "shasum": "7dd9be80ffaaedd4cb628f1827f1cbab6dc0918f",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.7.0": {
+      "name": "process",
+      "version": "0.7.0",
+      "dist": {
+        "shasum": "c52208161a34adf3812344ae85d3e6150469389d",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.8.0": {
+      "name": "process",
+      "version": "0.8.0",
+      "dist": {
+        "shasum": "7bbaf7187fe6ded3fd5be0cb6103fba9cacb9798",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.9.0": {
+      "name": "process",
+      "version": "0.9.0",
+      "dist": {
+        "shasum": "47d6a6acf51b879428c3269608992c7c5a790be4",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.9.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.10.0": {
+      "name": "process",
+      "version": "0.10.0",
+      "dist": {
+        "shasum": "99b375aaab5c0d3bbb59f774edc69df574da8dd4",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.10.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.10.1": {
+      "name": "process",
+      "version": "0.10.1",
+      "dist": {
+        "shasum": "842457cc51cfed72dc775afeeafb8c6034372725",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.0": {
+      "name": "process",
+      "version": "0.11.0",
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "dist": {
+        "shasum": "3eaaece62d56719a25bfa4198ca74c27b25960f3",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.1": {
+      "name": "process",
+      "version": "0.11.1",
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "dist": {
+        "shasum": "ee3becb4335edf3c8b14ccbf7e17a1125a4431ae",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.2": {
+      "name": "process",
+      "version": "0.11.2",
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "dist": {
+        "shasum": "8a58d1d12c573f3f890da9848a4fe8e16ca977b2",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.3": {
+      "name": "process",
+      "version": "0.11.3",
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "dist": {
+        "shasum": "d7d8fb7b3db3c0bfa9658b0dd9a4fa11e691ef3a",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.4": {
+      "name": "process",
+      "version": "0.11.4",
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "dist": {
+        "shasum": "a6e6d49f0833d36571c0b9492c0f4b90bac96cd3",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.5": {
+      "name": "process",
+      "version": "0.11.5",
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "dist": {
+        "shasum": "de49788f60e706f333adeea57a187ea9cc4c8495",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.6": {
+      "name": "process",
+      "version": "0.11.6",
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "dist": {
+        "shasum": "f234a1fbfddd0a64f8347e1ab52184453d7347af",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.7": {
+      "name": "process",
+      "version": "0.11.7",
+      "devDependencies": {
+        "mocha": "2.2.1"
+      },
+      "dist": {
+        "shasum": "9f19d4803c1091c7f87e853f812a419f22b1fa45",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.8": {
+      "name": "process",
+      "version": "0.11.8",
+      "devDependencies": {
+        "mocha": "2.2.1",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "58ff3d04ae0641be72c5a6e60ce8f7822d64eb3c",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.9": {
+      "name": "process",
+      "version": "0.11.9",
+      "devDependencies": {
+        "mocha": "2.2.1",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "7bd5ad21aa6253e7da8682264f1e11d11c0318c1",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "0.11.10": {
+      "name": "process",
+      "version": "0.11.10",
+      "devDependencies": {
+        "mocha": "2.2.1",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "7332300e840161bda3e69a1d1d91a7d4bc16f182",
+        "tarball": "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    }
+  },
+  "modified": "2018-02-28T03:32:20.095Z"
+}

--- a/test/fixtures/registry-mocks/content/promise-inflight.json
+++ b/test/fixtures/registry-mocks/content/promise-inflight.json
@@ -1,0 +1,153 @@
+{
+  "_id": "promise-inflight",
+  "_rev": "3-7eb34267282ff91218ae3c9ec106229a",
+  "name": "promise-inflight",
+  "description": "One promise for multiple requests in flight to avoid async duplication",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "promise-inflight",
+      "version": "1.0.0",
+      "description": "One promise for multiple requests in flight to avoid async duplication",
+      "main": "inflight.js",
+      "files": [
+        "inflight.js"
+      ],
+      "license": "ISC",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "dependencies": {
+        "bluebird": "^3.4.7"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/promise-inflight.git"
+      },
+      "bugs": {
+        "url": "https://github.com/iarna/promise-inflight/issues"
+      },
+      "homepage": "https://github.com/iarna/promise-inflight#readme",
+      "gitHead": "38661dbd9f72c10f0553aa3c090a1c2bac7982f5",
+      "_id": "promise-inflight@1.0.0",
+      "_shasum": "94d19b043a508a584969bb15f675810569dbbb50",
+      "_from": ".",
+      "_npmVersion": "4.4.0",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "94d19b043a508a584969bb15f675810569dbbb50",
+        "tarball": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/promise-inflight-1.0.0.tgz_1487994041894_0.7610008751507849"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "promise-inflight",
+      "version": "1.0.1",
+      "description": "One promise for multiple requests in flight to avoid async duplication",
+      "main": "inflight.js",
+      "files": [
+        "inflight.js"
+      ],
+      "license": "ISC",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "devDependencies": {},
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/promise-inflight.git"
+      },
+      "bugs": {
+        "url": "https://github.com/iarna/promise-inflight/issues"
+      },
+      "homepage": "https://github.com/iarna/promise-inflight#readme",
+      "gitHead": "9de9f26d8ecfe28d067cbd84630676dfea415e4a",
+      "_id": "promise-inflight@1.0.1",
+      "_shasum": "98472870bf228132fcbdd868129bad12c3c029e3",
+      "_from": ".",
+      "_npmVersion": "4.4.0",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "98472870bf228132fcbdd868129bad12c3c029e3",
+        "tarball": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/promise-inflight-1.0.1.tgz_1488077339544_0.4008405189961195"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# promise-inflight\n\nOne promise for multiple requests in flight to avoid async duplication\n\n## USAGE\n\n```javascript\nconst inflight = require('promise-inflight')\n\n// some request that does some stuff\nfunction req(key) {\n  // key is any random string.  like a url or filename or whatever.\n  return inflight(key, () => {\n    // this is where you'd fetch the url or whatever\n    return Promise.delay(100)\n  })\n}\n\n// only assigns a single setTimeout\n// when it dings, all thens get called with the same result.  (There's only\n// one underlying promise.)\nreq('foo').then(…)\nreq('foo').then(…)\nreq('foo').then(…)\nreq('foo').then(…)\n```\n\n## SEE ALSO\n\n* [inflight](https://npmjs.com/package/inflight) - For the callback based function on which this is based.\n\n## STILL NEEDS\n\nTests!\n",
+  "maintainers": [
+    {
+      "name": "iarna",
+      "email": "me@re-becca.org"
+    }
+  ],
+  "time": {
+    "modified": "2017-08-14T22:43:57.269Z",
+    "created": "2017-02-25T03:40:42.163Z",
+    "1.0.0": "2017-02-25T03:40:42.163Z",
+    "1.0.1": "2017-02-26T02:48:59.798Z"
+  },
+  "homepage": "https://github.com/iarna/promise-inflight#readme",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iarna/promise-inflight.git"
+  },
+  "author": {
+    "name": "Rebecca Turner",
+    "email": "me@re-becca.org",
+    "url": "http://re-becca.org/"
+  },
+  "bugs": {
+    "url": "https://github.com/iarna/promise-inflight/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "iarna": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/promise-inflight.min.json
+++ b/test/fixtures/registry-mocks/content/promise-inflight.min.json
@@ -1,0 +1,28 @@
+{
+  "name": "promise-inflight",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "promise-inflight",
+      "version": "1.0.0",
+      "dependencies": {
+        "bluebird": "^3.4.7"
+      },
+      "dist": {
+        "shasum": "94d19b043a508a584969bb15f675810569dbbb50",
+        "tarball": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "promise-inflight",
+      "version": "1.0.1",
+      "dist": {
+        "shasum": "98472870bf228132fcbdd868129bad12c3c029e3",
+        "tarball": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2017-08-14T22:43:57.269Z"
+}

--- a/test/fixtures/registry-mocks/content/proxy-addr.json
+++ b/test/fixtures/registry-mocks/content/proxy-addr.json
@@ -1,0 +1,2152 @@
+{
+  "_id": "proxy-addr",
+  "_rev": "68-26d015a4f9cc12c8d9ca86395a87ee29",
+  "name": "proxy-addr",
+  "description": "Determine address of proxied request",
+  "dist-tags": {
+    "latest": "2.0.6"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "0.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/proxy-ip.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/proxy-ip/issues"
+      },
+      "dependencies": {
+        "ip": "0.3.0"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/"
+      },
+      "homepage": "https://github.com/expressjs/proxy-ip",
+      "_id": "proxy-addr@0.0.0",
+      "dist": {
+        "shasum": "37ab96289d7a98de73b9e485141638c9c9971c49",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "0.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/proxy-ip.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/proxy-ip/issues"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/"
+      },
+      "homepage": "https://github.com/expressjs/proxy-ip",
+      "_id": "proxy-addr@0.0.1",
+      "dist": {
+        "shasum": "452212b85e83fbca3d5ad80c7316620a3bd36cc3",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/proxy-ip.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/proxy-ip/issues"
+      },
+      "dependencies": {
+        "ipaddr.js": "0.1.2"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec test/"
+      },
+      "homepage": "https://github.com/expressjs/proxy-ip",
+      "_id": "proxy-addr@1.0.0",
+      "dist": {
+        "shasum": "478617ab0fba70e0c3dae9cf57469e36dd2febaf",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/proxy-addr.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/proxy-addr/issues"
+      },
+      "dependencies": {
+        "ipaddr.js": "0.1.2"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "homepage": "https://github.com/expressjs/proxy-addr",
+      "_id": "proxy-addr@1.0.1",
+      "dist": {
+        "shasum": "c7c566d5eb4e3fad67eeb9c77c5558ccc39b88a8",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "ipaddr.js": "0.1.3"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "63a0f679bd4b074b7391fa464cb779275f24b1da",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.2",
+      "_shasum": "b322f905aa4f4bd3ce60550295eabbbb07c92143",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b322f905aa4f4bd3ce60550295eabbbb07c92143",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.3"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0a9006a64de938d879f1e4b38b275c1c46524dfd",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.3",
+      "_shasum": "17d824aac844707441249da6d1ea5e889007cdd6",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "17d824aac844707441249da6d1ea5e889007cdd6",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.5"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f72c40adfeeb81fa905f017030d2ecd1cd4d1821",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.4",
+      "_shasum": "51dbebbb22cc0eb04b77a76d871b75970f198cdd",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "51dbebbb22cc0eb04b77a76d871b75970f198cdd",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.6"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "dd768c48b99fb65b2b753269b8eea675e86da3fd",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.5",
+      "_shasum": "17ad518b637a21a64746319f39fbc72c8628f63b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "17ad518b637a21a64746319f39fbc72c8628f63b",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.6",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.8"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "550cade433f7a7d7cbcdebbd0f9e1cb94aed5e26",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.6",
+      "_shasum": "fce3a4c486bf2e188ad1e76e18399a79d02c0e72",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fce3a4c486bf2e188ad1e76e18399a79d02c0e72",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.7": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.7",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.9"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.8",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "917fa69ae1a4c3e2962d89461b6945538b763b28",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.7",
+      "_shasum": "6e2655aa9c56b014f09734a7e6d558cc77751939",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6e2655aa9c56b014f09734a7e6d558cc77751939",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.8": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.8",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "b32d9bda51c92f67a5c2c7b4f81971dbef41783c",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.8",
+      "_shasum": "db54ec878bcc1053d57646609219b3715678bafe",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "db54ec878bcc1053d57646609219b3715678bafe",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.9": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.9",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.0.4"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.1",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "3941f1bbfb34b746b0dc01d8563c56b2a3464789",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.9",
+      "_shasum": "8ac877a230f80f10bf9e5bf42584cde87bd219a6",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8ac877a230f80f10bf9e5bf42584cde87bd219a6",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.9.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.10": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.0.10",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/proxy-addr"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.0.5"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.1",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0cdb6444100a7930285ed2555d0c3c687690a7a5",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr",
+      "_id": "proxy-addr@1.0.10",
+      "_shasum": "0d40a82f801fc355567d2ecb65efe3f077f121c5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0d40a82f801fc355567d2ecb65efe3f077f121c5",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "78d203e77642698359390ef4fb03028ed5437a7e",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@1.1.0",
+      "_shasum": "dbbd6aa8c37108889193a37d92e78fd3da6d1a2d",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "dbbd6aa8c37108889193a37d92e78fd3da6d1a2d",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/proxy-addr-1.1.0.tgz_1462170012661_0.9743298299144953"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.1.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "fc4ee6765b6fbde5600be60d45bb5585424899a5",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@1.1.1",
+      "_shasum": "cfc323b3c0f55ca0df72d820f6e8836cd4507e2f",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "cfc323b3c0f55ca0df72d820f6e8836cd4507e2f",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/proxy-addr-1.1.1.tgz_1462335155814_0.404950185213238"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.1.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "28c34525632884a6d5e69a9165d7420b3f972d8b",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@1.1.2",
+      "_shasum": "b4cc5f22610d9535824c123aef9d3cf73c40ba37",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "b4cc5f22610d9535824c123aef9d3cf73c40ba37",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/proxy-addr-1.1.2.tgz_1464573376704_0.6896329398732632"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.1.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.2.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.3",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0724490937983255e7687812594c97c36ebca90b",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@1.1.3",
+      "_shasum": "dc97502f5722e888467b3fa2297a7b1ff47df074",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "dc97502f5722e888467b3fa2297a7b1ff47df074",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/proxy-addr-1.1.3.tgz_1484460061440_0.03347301739268005"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.1.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.3.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.3",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "4c636264c036d9825e8a3cf50555a272e3246fe6",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@1.1.4",
+      "_shasum": "27e545f6960a44a627d9b44467e35c1b6b4ce2f3",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "27e545f6960a44a627d9b44467e35c1b6b4ce2f3",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/proxy-addr-1.1.4.tgz_1490396252699_0.9566438721958548"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "1.1.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.4.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f40ceab074ec2f92399d112793d9ad1c9d96e146",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@1.1.5",
+      "_shasum": "71c0ee3b102de3f202f3b64f608d173fcba1a918",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "71c0ee3b102de3f202f3b64f608d173fcba1a918",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/proxy-addr-1.1.5.tgz_1501030838206_0.9159589342307299"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "2.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.4.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "3.5.0",
+        "nyc": "10.3.2"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=text npm test",
+        "test-travis": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "2fd80a9bf9152854e94ce36b47f8078aa72145fd",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@2.0.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.2",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-YgNn8vg3bnNTTANKor3DXPl5khodlFKOGSyg2Wss5Lp6B76CPiQPsRR+RC0Jz+tntPKuJyvzuiTEKYkdagn7ag==",
+        "shasum": "f816044dcce8b830d4b43809705be3637cbb3c4a",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/proxy-addr-2.0.0.tgz_1502247616459_0.6272426785435528"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "2.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.1",
+        "ipaddr.js": "1.5.2"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "3.5.2",
+        "nyc": "10.3.2"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=text npm test",
+        "test-travis": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "461898d3c6f950fe954ecd9121ec63cfcd88cd28",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@2.0.1",
+      "_shasum": "a6f82fdbcaf6fea35d635b0be0997b79a8feef66",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "a6f82fdbcaf6fea35d635b0be0997b79a8feef66",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/proxy-addr-2.0.1.tgz_1505092292777_0.8947560833767056"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "2.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.5.2"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "3.5.3",
+        "nyc": "10.3.2"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=text npm test",
+        "test-travis": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "7c1bc4c5c05bd5285af710baabf87421d950f689",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@2.0.2",
+      "_shasum": "6571504f47bb988ec8180253f85dd7e14952bdec",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "6571504f47bb988ec8180253f85dd7e14952bdec",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/proxy-addr-2.0.2.tgz_1506303664796_0.10817809496074915"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "2.0.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.6.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "4.18.0",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "3.5.3",
+        "nyc": "10.3.2"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=text npm test",
+        "test-travis": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "d841ab7a2150963793ad2dc121df014f426f2964",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@2.0.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "6.13.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+        "shasum": "355f262505a621646b3130a728eb647e22055341",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15421
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/proxy-addr_2.0.3_1519101976942_0.28350766039209363"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.4": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "2.0.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.8.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.13.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.8.0",
+        "eslint-plugin-standard": "3.1.0",
+        "mocha": "3.5.3",
+        "nyc": "10.3.2"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=text npm test",
+        "test-travis": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "0942626d371d6d4e4cd5c59f4be7e55c81efd357",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@2.0.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+        "shasum": "ecfc733bf22ff8c6f407fa275327b9ab67e48b93",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15487,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbWhQfCRA9TVsSAnZWagAAFskP/iUjllmYavgjxF64jpeM\nraRtpxz4dYvgZKb0Shf45w/ljvtBz5yo5y6B+jKYleSwjO5pX68VK4yfor0C\nJ2o86btV0NvLjNxBduVw3kTDW+kOPPpmQKE4BrcpYN9otM/ZpBCN6BWhA4Gs\nyFb8U++i/ZbF2S+Yj3vCCcRCo6SYmALTm6jQb9hAoV5nlAJq2rLutZrrh5H5\ntrQkblvVZaepYn+CV8Kb6VpHJW0JrrFN5lqMBlSEWVOTfDPTthgoL9E2WzAQ\nJuOkHpUiccObb+8fO2UpYXvfuSQdkTGSQ1lVkNIIdXfVUepGuUVzkVoHq4Bc\nqIlo5pjXBuvx53B1/aPwozHVqaxB/0j56whqmCyp83fazPJrZCqjeYq1sUP0\nrT7sZLL/5cpzwZMKAsso3KGdwNyK0tQytutKq57Z/STENFu7QocY4m/T03KM\nDVdERzPRotEWuFzIoG77KqX1Cb/kmfi2O7YI4XwBWM9MmQ1Ru5/bHkyUErkC\nbMM+6A1oa8j+J8udfHxvLs84O4blHZeY0Lx5lkMpV8N1CNRDe4nB2d1fAj1M\nAkbA2G8ykH6lNnlyFUlw8Vse8I+JvZKb5JTw+FFUqMsgTMX9pQzR+F2yunJk\nlF8cwLVVH5QHBPlm9tp2AUjUD/NeRg3ozOnOrtne7muuFSsTOi+L7+cbdrue\nG1Oi\r\n=AGmG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/proxy-addr_2.0.4_1532630047681_0.018082968185300086"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.5": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "2.0.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "deep-equal": "1.0.1",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.1",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.3",
+        "nyc": "13.3.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=text npm test",
+        "test-travis": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "6dec756fafa35a2666e0f298a82ea6b1ac504f52",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@2.0.5",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+        "shasum": "34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15475,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJctgL5CRA9TVsSAnZWagAA/YQP/2wTt4ACbgaN+8tJspqr\nIAPCxN9E559sCCjGf3fneSCUOl0IvxT32Ao9Ue8vYyWyCjf+YIBbp1TO9ZAL\nJc54x/0mKjozz0pKideKOaUGv5R8BLDsxH+bWhXNkcgROj0TDYpUHmDVH89n\n/0/7auhigu++wbh8Fhcq7bciUhfCeajUprc1zjeqvTfSnDywl4ZhgM1EKvcL\nddXoczeIXiXgf1yC5ZNqVZSl8umaVbCC9MUnW0/zRWmzFN4sFPa5cHfMdiN0\nPK4cKqvrzu7RFQQSRKbp8DhI87/RS/r84AoJWSNoHWFfzYNZLArdqf0Ry5Cm\n2zmTlzfKyeLeK5kyCBmzc6JRlaseMDb0S8owIxDM0rIcWzyYsfrTTc4f6yNF\naFaPU/cPdYYuzdFnV8HelkO+04/NCVMl21oHuBhdL20mrWi4g03lfWPnovE4\nI8p4MTaxAlbDTmYOcpevz3Dytl5m2xE4zu0kRrC9j35r9Yrr1Xf3tTphi8bF\nIBE53bbY4Yq79AM17O8WiKETPI+bx398e++5PBFB/6m/tzU1lsRE61GNqM90\nGxUqmc/vG+xIPZUYPvGIhJ+l0VIDrcCIKWdvVQTYinN6nmTnQZwNLMpuRDWH\nL6IxtUF7Bq5hPku9BMa58UhqkBdJ7dIC12+NO9/XGgA80nHaURTNvAXWOxMY\nssnp\r\n=fWr9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/proxy-addr_2.0.5_1555432184327_0.9083476593014095"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.6": {
+      "name": "proxy-addr",
+      "description": "Determine address of proxied request",
+      "version": "2.0.6",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "ip",
+        "proxy",
+        "x-forwarded-for"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/proxy-addr.git"
+      },
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "deep-equal": "1.0.1",
+        "eslint": "6.8.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-plugin-import": "2.20.1",
+        "eslint-plugin-markdown": "1.0.1",
+        "eslint-plugin-node": "11.0.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.1",
+        "mocha": "7.0.1",
+        "nyc": "15.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=text npm test",
+        "test-travis": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "9f78739c5333ebea49442235ce720f1d37605706",
+      "bugs": {
+        "url": "https://github.com/jshttp/proxy-addr/issues"
+      },
+      "homepage": "https://github.com/jshttp/proxy-addr#readme",
+      "_id": "proxy-addr@2.0.6",
+      "_nodeVersion": "13.8.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+        "shasum": "fdc2336505447d3f2f2c638ed272caf614bbb2bf",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15564,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeU3j6CRA9TVsSAnZWagAAdk8P/3dpsRRiz8JVDo5LtJXD\nTPfDdmnVCDglO77aWEiW7Q0EJVj1Vb8IINxXJTeXbRMYtHokWpulc8Qd9ucl\nxaJc1CkZscZ3UxxauTkuIQXcdq25htpwOpS12fhV1MsHpIIrDoZ1sa6pUyTj\nJz3O6x5dWPY3KRjaMrl2UBFVvqc7VbDEZrwgRUJ2D04nW3xN3mWQDPU/WqBA\nFtslR3qUR5zNlNsdkLQrmMd+HZ1IiOdmZ2l9mJAiHoKgDBmhASB5Zra3dXuO\nAhDuDd9CHZ1Mvw2NgaugIN3/EBw7KDBqqsZTb7EbZEoZJF+MBTlRvsRUERP5\nkYXrGuxTklRRwrmSC3I9730P17JsySsTI9Nj/NPfTtZwIwL1Pz4jrJ/F3hiS\n3c2WrnWmXGNKwRV6gXK+ik4QgES7LtwmSh7TAv5Juka7aR1jmCs/5FRUezIW\nwNCKTj7KqN8v0xlPKu3gsfymMrmbKngmmA9BfH9xWjmno+s2tHX8Bh0C6jUq\nFUT9eaTrBFCAil64wIcFFgHrljtsRn47+naw8vexCARKZL9rf1ZAaqY5PXps\nhVQcRXieZyljiEt0sG260M4rZhXrBTPdao9UnoEypYRMANZzlc3D7ae4spgy\nS0aA0P63G6TMsQqAr58q1Xqe5S8QoWW/wkUvcDAK/EZj9ApfGK0CRHg0IoNL\nY6Br\r\n=Ww5y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/proxy-addr_2.0.6_1582528762078_0.9304045391970575"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# proxy-addr\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-image]][node-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nDetermine address of proxied request\n\n## Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install proxy-addr\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar proxyaddr = require('proxy-addr')\n```\n\n### proxyaddr(req, trust)\n\nReturn the address of the request, using the given `trust` parameter.\n\nThe `trust` argument is a function that returns `true` if you trust\nthe address, `false` if you don't. The closest untrusted address is\nreturned.\n\n<!-- eslint-disable no-undef -->\n\n```js\nproxyaddr(req, function (addr) { return addr === '127.0.0.1' })\nproxyaddr(req, function (addr, i) { return i < 1 })\n```\n\nThe `trust` arugment may also be a single IP address string or an\narray of trusted addresses, as plain IP addresses, CIDR-formatted\nstrings, or IP/netmask strings.\n\n<!-- eslint-disable no-undef -->\n\n```js\nproxyaddr(req, '127.0.0.1')\nproxyaddr(req, ['127.0.0.0/8', '10.0.0.0/8'])\nproxyaddr(req, ['127.0.0.0/255.0.0.0', '192.168.0.0/255.255.0.0'])\n```\n\nThis module also supports IPv6. Your IPv6 addresses will be normalized\nautomatically (i.e. `fe80::00ed:1` equals `fe80:0:0:0:0:0:ed:1`).\n\n<!-- eslint-disable no-undef -->\n\n```js\nproxyaddr(req, '::1')\nproxyaddr(req, ['::1/128', 'fe80::/10'])\n```\n\nThis module will automatically work with IPv4-mapped IPv6 addresses\nas well to support node.js in IPv6-only mode. This means that you do\nnot have to specify both `::ffff:a00:1` and `10.0.0.1`.\n\nAs a convenience, this module also takes certain pre-defined names\nin addition to IP addresses, which expand into IP addresses:\n\n<!-- eslint-disable no-undef -->\n\n```js\nproxyaddr(req, 'loopback')\nproxyaddr(req, ['loopback', 'fc00:ac:1ab5:fff::1/64'])\n```\n\n  * `loopback`: IPv4 and IPv6 loopback addresses (like `::1` and\n    `127.0.0.1`).\n  * `linklocal`: IPv4 and IPv6 link-local addresses (like\n    `fe80::1:1:1:1` and `169.254.0.1`).\n  * `uniquelocal`: IPv4 private addresses and IPv6 unique-local\n    addresses (like `fc00:ac:1ab5:fff::1` and `192.168.0.1`).\n\nWhen `trust` is specified as a function, it will be called for each\naddress to determine if it is a trusted address. The function is\ngiven two arguments: `addr` and `i`, where `addr` is a string of\nthe address to check and `i` is a number that represents the distance\nfrom the socket address.\n\n### proxyaddr.all(req, [trust])\n\nReturn all the addresses of the request, optionally stopping at the\nfirst untrusted. This array is ordered from closest to furthest\n(i.e. `arr[0] === req.connection.remoteAddress`).\n\n<!-- eslint-disable no-undef -->\n\n```js\nproxyaddr.all(req)\n```\n\nThe optional `trust` argument takes the same arguments as `trust`\ndoes in `proxyaddr(req, trust)`.\n\n<!-- eslint-disable no-undef -->\n\n```js\nproxyaddr.all(req, 'loopback')\n```\n\n### proxyaddr.compile(val)\n\nCompiles argument `val` into a `trust` function. This function takes\nthe same arguments as `trust` does in `proxyaddr(req, trust)` and\nreturns a function suitable for `proxyaddr(req, trust)`.\n\n<!-- eslint-disable no-undef, no-unused-vars -->\n\n```js\nvar trust = proxyaddr.compile('loopback')\nvar addr = proxyaddr(req, trust)\n```\n\nThis function is meant to be optimized for use against every request.\nIt is recommend to compile a trust function up-front for the trusted\nconfiguration and pass that to `proxyaddr(req, trust)` for each request.\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## Benchmarks\n\n```sh\n$ npm run-script bench\n```\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/proxy-addr/master\n[coveralls-url]: https://coveralls.io/r/jshttp/proxy-addr?branch=master\n[node-image]: https://badgen.net/npm/node/proxy-addr\n[node-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/proxy-addr\n[npm-url]: https://npmjs.org/package/proxy-addr\n[npm-version-image]: https://badgen.net/npm/v/proxy-addr\n[travis-image]: https://badgen.net/travis/jshttp/proxy-addr/master\n[travis-url]: https://travis-ci.org/jshttp/proxy-addr\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-02-24T07:19:24.953Z",
+    "created": "2014-05-05T02:38:49.512Z",
+    "0.0.0": "2014-05-05T02:38:49.512Z",
+    "0.0.1": "2014-05-05T02:44:46.419Z",
+    "1.0.0": "2014-05-08T14:52:39.430Z",
+    "1.0.1": "2014-06-03T14:49:59.893Z",
+    "1.0.2": "2014-09-18T17:32:14.933Z",
+    "1.0.3": "2014-09-21T19:40:43.122Z",
+    "1.0.4": "2014-11-23T20:35:27.606Z",
+    "1.0.5": "2015-01-09T03:16:54.215Z",
+    "1.0.6": "2015-02-01T19:54:32.976Z",
+    "1.0.7": "2015-03-17T04:47:05.972Z",
+    "1.0.8": "2015-05-11T02:56:29.699Z",
+    "1.0.9": "2015-12-01T20:55:36.227Z",
+    "1.0.10": "2015-12-10T03:27:48.082Z",
+    "1.1.0": "2016-05-02T06:20:13.693Z",
+    "1.1.1": "2016-05-04T04:12:38.179Z",
+    "1.1.2": "2016-05-30T01:56:19.142Z",
+    "1.1.3": "2017-01-15T06:01:02.224Z",
+    "1.1.4": "2017-03-24T22:57:34.521Z",
+    "1.1.5": "2017-07-26T01:00:40.146Z",
+    "2.0.0": "2017-08-09T03:00:17.324Z",
+    "2.0.1": "2017-09-11T01:11:33.860Z",
+    "2.0.2": "2017-09-25T01:41:05.676Z",
+    "2.0.3": "2018-02-20T04:46:17.003Z",
+    "2.0.4": "2018-07-26T18:34:07.754Z",
+    "2.0.5": "2019-04-16T16:29:44.431Z",
+    "2.0.6": "2020-02-24T07:19:22.199Z"
+  },
+  "homepage": "https://github.com/jshttp/proxy-addr#readme",
+  "keywords": [
+    "ip",
+    "proxy",
+    "x-forwarded-for"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/proxy-addr.git"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/proxy-addr/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "nathantu": true,
+    "robermac": true,
+    "markthethomas": true,
+    "simplyianm": true,
+    "nex": true,
+    "mojaray2k": true,
+    "wangnan0610": true,
+    "rocket0191": true,
+    "quafoo": true,
+    "mariusc23": true,
+    "zzz1233210731": true,
+    "ganeshkbhat": true,
+    "isayme": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/proxy-addr.min.json
+++ b/test/fixtures/registry-mocks/content/proxy-addr.min.json
@@ -1,0 +1,611 @@
+{
+  "name": "proxy-addr",
+  "dist-tags": {
+    "latest": "2.0.6"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "proxy-addr",
+      "version": "0.0.0",
+      "dependencies": {
+        "ip": "0.3.0"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1"
+      },
+      "dist": {
+        "shasum": "37ab96289d7a98de73b9e485141638c9c9971c49",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.0.1": {
+      "name": "proxy-addr",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1"
+      },
+      "dist": {
+        "shasum": "452212b85e83fbca3d5ad80c7316620a3bd36cc3",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-0.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.0": {
+      "name": "proxy-addr",
+      "version": "1.0.0",
+      "dependencies": {
+        "ipaddr.js": "0.1.2"
+      },
+      "devDependencies": {
+        "mocha": "~1.18.2",
+        "should": "~3.3.1"
+      },
+      "dist": {
+        "shasum": "478617ab0fba70e0c3dae9cf57469e36dd2febaf",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.1": {
+      "name": "proxy-addr",
+      "version": "1.0.1",
+      "dependencies": {
+        "ipaddr.js": "0.1.2"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "c7c566d5eb4e3fad67eeb9c77c5558ccc39b88a8",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.2": {
+      "name": "proxy-addr",
+      "version": "1.0.2",
+      "dependencies": {
+        "ipaddr.js": "0.1.3"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "b322f905aa4f4bd3ce60550295eabbbb07c92143",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.3": {
+      "name": "proxy-addr",
+      "version": "1.0.3",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.3"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.4",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "17d824aac844707441249da6d1ea5e889007cdd6",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.4": {
+      "name": "proxy-addr",
+      "version": "1.0.4",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.5"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "51dbebbb22cc0eb04b77a76d871b75970f198cdd",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.5": {
+      "name": "proxy-addr",
+      "version": "1.0.5",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.6"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "17ad518b637a21a64746319f39fbc72c8628f63b",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.6": {
+      "name": "proxy-addr",
+      "version": "1.0.6",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.8"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "fce3a4c486bf2e188ad1e76e18399a79d02c0e72",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.7": {
+      "name": "proxy-addr",
+      "version": "1.0.7",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "0.1.9"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.8",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "6e2655aa9c56b014f09734a7e6d558cc77751939",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.8": {
+      "name": "proxy-addr",
+      "version": "1.0.8",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.0.1"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "db54ec878bcc1053d57646609219b3715678bafe",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.9": {
+      "name": "proxy-addr",
+      "version": "1.0.9",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.0.4"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.1",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "8ac877a230f80f10bf9e5bf42584cde87bd219a6",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.10": {
+      "name": "proxy-addr",
+      "version": "1.0.10",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.0.5"
+      },
+      "devDependencies": {
+        "benchmark": "1.0.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.1",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "0d40a82f801fc355567d2ecb65efe3f077f121c5",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.0": {
+      "name": "proxy-addr",
+      "version": "1.1.0",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "dbbd6aa8c37108889193a37d92e78fd3da6d1a2d",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.1": {
+      "name": "proxy-addr",
+      "version": "1.1.1",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.1.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "cfc323b3c0f55ca0df72d820f6e8836cd4507e2f",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.2": {
+      "name": "proxy-addr",
+      "version": "1.1.2",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.1.1"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.0",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.3",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "b4cc5f22610d9535824c123aef9d3cf73c40ba37",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.3": {
+      "name": "proxy-addr",
+      "version": "1.1.3",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.2.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.3",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "dc97502f5722e888467b3fa2297a7b1ff47df074",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.4": {
+      "name": "proxy-addr",
+      "version": "1.1.4",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.3.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.3",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "27e545f6960a44a627d9b44467e35c1b6b4ce2f3",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.5": {
+      "name": "proxy-addr",
+      "version": "1.1.5",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.4.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "istanbul": "0.4.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "71c0ee3b102de3f202f3b64f608d173fcba1a918",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.0": {
+      "name": "proxy-addr",
+      "version": "2.0.0",
+      "dependencies": {
+        "forwarded": "~0.1.0",
+        "ipaddr.js": "1.4.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "3.5.0",
+        "nyc": "10.3.2"
+      },
+      "dist": {
+        "integrity": "sha512-YgNn8vg3bnNTTANKor3DXPl5khodlFKOGSyg2Wss5Lp6B76CPiQPsRR+RC0Jz+tntPKuJyvzuiTEKYkdagn7ag==",
+        "shasum": "f816044dcce8b830d4b43809705be3637cbb3c4a",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.0.1": {
+      "name": "proxy-addr",
+      "version": "2.0.1",
+      "dependencies": {
+        "forwarded": "~0.1.1",
+        "ipaddr.js": "1.5.2"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "3.5.2",
+        "nyc": "10.3.2"
+      },
+      "dist": {
+        "shasum": "a6f82fdbcaf6fea35d635b0be0997b79a8feef66",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.0.2": {
+      "name": "proxy-addr",
+      "version": "2.0.2",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.5.2"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "3.5.3",
+        "nyc": "10.3.2"
+      },
+      "dist": {
+        "shasum": "6571504f47bb988ec8180253f85dd7e14952bdec",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.0.3": {
+      "name": "proxy-addr",
+      "version": "2.0.3",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.6.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "4.18.0",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "mocha": "3.5.3",
+        "nyc": "10.3.2"
+      },
+      "dist": {
+        "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+        "shasum": "355f262505a621646b3130a728eb647e22055341",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15421
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.0.4": {
+      "name": "proxy-addr",
+      "version": "2.0.4",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.8.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.13.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.8.0",
+        "eslint-plugin-standard": "3.1.0",
+        "mocha": "3.5.3",
+        "nyc": "10.3.2"
+      },
+      "dist": {
+        "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+        "shasum": "ecfc733bf22ff8c6f407fa275327b9ab67e48b93",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15487,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbWhQfCRA9TVsSAnZWagAAFskP/iUjllmYavgjxF64jpeM\nraRtpxz4dYvgZKb0Shf45w/ljvtBz5yo5y6B+jKYleSwjO5pX68VK4yfor0C\nJ2o86btV0NvLjNxBduVw3kTDW+kOPPpmQKE4BrcpYN9otM/ZpBCN6BWhA4Gs\nyFb8U++i/ZbF2S+Yj3vCCcRCo6SYmALTm6jQb9hAoV5nlAJq2rLutZrrh5H5\ntrQkblvVZaepYn+CV8Kb6VpHJW0JrrFN5lqMBlSEWVOTfDPTthgoL9E2WzAQ\nJuOkHpUiccObb+8fO2UpYXvfuSQdkTGSQ1lVkNIIdXfVUepGuUVzkVoHq4Bc\nqIlo5pjXBuvx53B1/aPwozHVqaxB/0j56whqmCyp83fazPJrZCqjeYq1sUP0\nrT7sZLL/5cpzwZMKAsso3KGdwNyK0tQytutKq57Z/STENFu7QocY4m/T03KM\nDVdERzPRotEWuFzIoG77KqX1Cb/kmfi2O7YI4XwBWM9MmQ1Ru5/bHkyUErkC\nbMM+6A1oa8j+J8udfHxvLs84O4blHZeY0Lx5lkMpV8N1CNRDe4nB2d1fAj1M\nAkbA2G8ykH6lNnlyFUlw8Vse8I+JvZKb5JTw+FFUqMsgTMX9pQzR+F2yunJk\nlF8cwLVVH5QHBPlm9tp2AUjUD/NeRg3ozOnOrtne7muuFSsTOi+L7+cbdrue\nG1Oi\r\n=AGmG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.0.5": {
+      "name": "proxy-addr",
+      "version": "2.0.5",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.0"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "deep-equal": "1.0.1",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.1",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.3",
+        "nyc": "13.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+        "shasum": "34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15475,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJctgL5CRA9TVsSAnZWagAA/YQP/2wTt4ACbgaN+8tJspqr\nIAPCxN9E559sCCjGf3fneSCUOl0IvxT32Ao9Ue8vYyWyCjf+YIBbp1TO9ZAL\nJc54x/0mKjozz0pKideKOaUGv5R8BLDsxH+bWhXNkcgROj0TDYpUHmDVH89n\n/0/7auhigu++wbh8Fhcq7bciUhfCeajUprc1zjeqvTfSnDywl4ZhgM1EKvcL\nddXoczeIXiXgf1yC5ZNqVZSl8umaVbCC9MUnW0/zRWmzFN4sFPa5cHfMdiN0\nPK4cKqvrzu7RFQQSRKbp8DhI87/RS/r84AoJWSNoHWFfzYNZLArdqf0Ry5Cm\n2zmTlzfKyeLeK5kyCBmzc6JRlaseMDb0S8owIxDM0rIcWzyYsfrTTc4f6yNF\naFaPU/cPdYYuzdFnV8HelkO+04/NCVMl21oHuBhdL20mrWi4g03lfWPnovE4\nI8p4MTaxAlbDTmYOcpevz3Dytl5m2xE4zu0kRrC9j35r9Yrr1Xf3tTphi8bF\nIBE53bbY4Yq79AM17O8WiKETPI+bx398e++5PBFB/6m/tzU1lsRE61GNqM90\nGxUqmc/vG+xIPZUYPvGIhJ+l0VIDrcCIKWdvVQTYinN6nmTnQZwNLMpuRDWH\nL6IxtUF7Bq5hPku9BMa58UhqkBdJ7dIC12+NO9/XGgA80nHaURTNvAXWOxMY\nssnp\r\n=fWr9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "2.0.6": {
+      "name": "proxy-addr",
+      "version": "2.0.6",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      },
+      "devDependencies": {
+        "benchmark": "2.1.4",
+        "beautify-benchmark": "0.2.4",
+        "deep-equal": "1.0.1",
+        "eslint": "6.8.0",
+        "eslint-config-standard": "14.1.0",
+        "eslint-plugin-import": "2.20.1",
+        "eslint-plugin-markdown": "1.0.1",
+        "eslint-plugin-node": "11.0.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.1",
+        "mocha": "7.0.1",
+        "nyc": "15.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+        "shasum": "fdc2336505447d3f2f2c638ed272caf614bbb2bf",
+        "tarball": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+        "fileCount": 5,
+        "unpackedSize": 15564,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeU3j6CRA9TVsSAnZWagAAdk8P/3dpsRRiz8JVDo5LtJXD\nTPfDdmnVCDglO77aWEiW7Q0EJVj1Vb8IINxXJTeXbRMYtHokWpulc8Qd9ucl\nxaJc1CkZscZ3UxxauTkuIQXcdq25htpwOpS12fhV1MsHpIIrDoZ1sa6pUyTj\nJz3O6x5dWPY3KRjaMrl2UBFVvqc7VbDEZrwgRUJ2D04nW3xN3mWQDPU/WqBA\nFtslR3qUR5zNlNsdkLQrmMd+HZ1IiOdmZ2l9mJAiHoKgDBmhASB5Zra3dXuO\nAhDuDd9CHZ1Mvw2NgaugIN3/EBw7KDBqqsZTb7EbZEoZJF+MBTlRvsRUERP5\nkYXrGuxTklRRwrmSC3I9730P17JsySsTI9Nj/NPfTtZwIwL1Pz4jrJ/F3hiS\n3c2WrnWmXGNKwRV6gXK+ik4QgES7LtwmSh7TAv5Juka7aR1jmCs/5FRUezIW\nwNCKTj7KqN8v0xlPKu3gsfymMrmbKngmmA9BfH9xWjmno+s2tHX8Bh0C6jUq\nFUT9eaTrBFCAil64wIcFFgHrljtsRn47+naw8vexCARKZL9rf1ZAaqY5PXps\nhVQcRXieZyljiEt0sG260M4rZhXrBTPdao9UnoEypYRMANZzlc3D7ae4spgy\nS0aA0P63G6TMsQqAr58q1Xqe5S8QoWW/wkUvcDAK/EZj9ApfGK0CRHg0IoNL\nY6Br\r\n=Ww5y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    }
+  },
+  "modified": "2020-02-24T07:19:24.953Z"
+}

--- a/test/fixtures/registry-mocks/content/prr.json
+++ b/test/fixtures/registry-mocks/content/prr.json
@@ -1,0 +1,202 @@
+{
+  "_id": "prr",
+  "_rev": "8-f95632b8c11e433840694a6124d7a71e",
+  "name": "prr",
+  "description": "A better Object.defineProperty()",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "prr",
+      "description": "A better Object.defineProperty()",
+      "version": "0.0.0",
+      "homepage": "https://github.com/rvagg/prr",
+      "authors": [
+        "Rod Vagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "property",
+        "properties",
+        "defineProperty",
+        "ender"
+      ],
+      "main": "./prr.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/prr.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tap": "*"
+      },
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "license": "MIT",
+      "_id": "prr@0.0.0",
+      "dist": {
+        "shasum": "1a84b85908325501411853d0081ee3fa86e2926a",
+        "tarball": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "prr",
+      "description": "A better Object.defineProperty()",
+      "version": "1.0.0",
+      "homepage": "https://github.com/rvagg/prr",
+      "author": {
+        "name": "Rod Vagg",
+        "email": "rod@vagg.org",
+        "url": "https://github.com/rvagg"
+      },
+      "keywords": [
+        "property",
+        "properties",
+        "defineProperty",
+        "ender"
+      ],
+      "main": "./prr.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/prr.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tap": "*"
+      },
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "license": "MIT",
+      "gitHead": "1e29e003b01b3ce877c2b81f2dd0b102a789aa06",
+      "bugs": {
+        "url": "https://github.com/rvagg/prr/issues"
+      },
+      "_id": "prr@1.0.0",
+      "_shasum": "1301fbed1f9f92414e988eda0c0afdb85ae9d402",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "1301fbed1f9f92414e988eda0c0afdb85ae9d402",
+        "tarball": "https://registry.npmjs.org/prr/-/prr-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "prr",
+      "description": "A better Object.defineProperty()",
+      "version": "1.0.1",
+      "homepage": "https://github.com/rvagg/prr",
+      "author": {
+        "name": "Rod Vagg",
+        "email": "rod@vagg.org",
+        "url": "https://github.com/rvagg"
+      },
+      "keywords": [
+        "property",
+        "properties",
+        "defineProperty",
+        "ender"
+      ],
+      "main": "./prr.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/prr.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tap": "*"
+      },
+      "scripts": {
+        "test": "node ./test.js"
+      },
+      "license": "MIT",
+      "gitHead": "b69ba0edc7aacbda0c98d550579e452b8597c126",
+      "bugs": {
+        "url": "https://github.com/rvagg/prr/issues"
+      },
+      "_id": "prr@1.0.1",
+      "_shasum": "d3fc114ba06995a45ec6893f484ceb1d78f5f476",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "d3fc114ba06995a45ec6893f484ceb1d78f5f476",
+        "tarball": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# prr [![Build Status](https://secure.travis-ci.org/rvagg/prr.png)](http://travis-ci.org/rvagg/prr)\n\nAn sensible alternative to `Object.defineProperty()`. Available in npm and Ender as **prr**.\n\n## Usage\n\nSet the property `'foo'` (`obj.foo`) to have the value `'bar'` with default options (`'enumerable'`, `'configurable'` and `'writable'` are all `false`):\n\n```js\nprr(obj, 'foo', 'bar')\n```\n\nAdjust the default options:\n\n```js\nprr(obj, 'foo', 'bar', { enumerable: true, writable: true })\n```\n\nDo the same operation for multiple properties:\n\n```js\nprr(obj, { one: 'one', two: 'two' })\n// or with options:\nprr(obj, { one: 'one', two: 'two' }, { enumerable: true, writable: true })\n```\n\n### Simplify!\n\nBut obviously, having to write out the full options object makes it nearly as bad as the original `Object.defineProperty()` so we can simplify.\n\nAs an alternative method we can use an options string where each character represents a option: `'e'=='enumerable'`, `'c'=='configurable'` and `'w'=='writable'`:\n\n```js\nprr(obj, 'foo', 'bar', 'ew') // enumerable and writable but not configurable\n// muliple properties:\nprr(obj, { one: 'one', two: 'two' }, 'ewc') // configurable too\n```\n\n## Where can I use it?\n\nAnywhere! For pre-ES5 environments *prr* will simply fall-back to an `object[property] = value` so you can get close to what you want.\n\n*prr* is Ender-compatible so you can include it in your Ender build and `$.prr(...)` or `var prr = require('prr'); prr(...)`.\n\n## Licence\n\nprr is Copyright (c) 2013 Rod Vagg [@rvagg](https://twitter.com/rvagg) and licensed under the MIT licence. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.\n",
+  "maintainers": [
+    {
+      "name": "rvagg",
+      "email": "rod@vagg.org"
+    }
+  ],
+  "time": {
+    "modified": "2017-01-08T05:15:41.845Z",
+    "created": "2013-04-01T17:21:27.562Z",
+    "0.0.0": "2013-04-01T17:21:30.886Z",
+    "1.0.0": "2014-06-29T07:19:44.640Z",
+    "1.0.1": "2014-07-22T06:50:49.598Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rvagg/prr.git"
+  },
+  "homepage": "https://github.com/rvagg/prr",
+  "keywords": [
+    "property",
+    "properties",
+    "defineProperty",
+    "ender"
+  ],
+  "author": {
+    "name": "Rod Vagg",
+    "email": "rod@vagg.org",
+    "url": "https://github.com/rvagg"
+  },
+  "bugs": {
+    "url": "https://github.com/rvagg/prr/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "tungv": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/prr.min.json
+++ b/test/fixtures/registry-mocks/content/prr.min.json
@@ -1,0 +1,42 @@
+{
+  "name": "prr",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "prr",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tap": "*"
+      },
+      "dist": {
+        "shasum": "1a84b85908325501411853d0081ee3fa86e2926a",
+        "tarball": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "prr",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tap": "*"
+      },
+      "dist": {
+        "shasum": "1301fbed1f9f92414e988eda0c0afdb85ae9d402",
+        "tarball": "https://registry.npmjs.org/prr/-/prr-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "prr",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tap": "*"
+      },
+      "dist": {
+        "shasum": "d3fc114ba06995a45ec6893f484ceb1d78f5f476",
+        "tarball": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2017-01-08T05:15:41.845Z"
+}

--- a/test/fixtures/registry-mocks/content/public-encrypt.json
+++ b/test/fixtures/registry-mocks/content/public-encrypt.json
@@ -1,0 +1,746 @@
+{
+  "_id": "public-encrypt",
+  "_rev": "26-99c0668bd18e215637db51b7ce20037c",
+  "name": "public-encrypt",
+  "description": "browserify version of publicEncrypt & privateDecrypt",
+  "dist-tags": {
+    "latest": "4.0.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "public-encrypt",
+      "version": "1.0.0",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "parse-asn1": "^1.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "a9d35865a5a54e01c1cc42625a21aadeb9e759cd",
+      "_id": "public-encrypt@1.0.0",
+      "_shasum": "56179751a5eb00137fe63f825049ae4504da44c8",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "56179751a5eb00137fe63f825049ae4504da44c8",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "public-encrypt",
+      "version": "1.0.1",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "fe7471ff6f2fad33008f4fe1d5ca69bf949bbb5e",
+      "_id": "public-encrypt@1.0.1",
+      "_shasum": "f4d881f0068cdd24017ef4baa4f49b9d8d055c46",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f4d881f0068cdd24017ef4baa4f49b9d8d055c46",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "public-encrypt",
+      "version": "1.1.0",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "browserify-rsa": "^1.1.0",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "5c099fbcf23ff28a573052d80241c529a5b0e706",
+      "_id": "public-encrypt@1.1.0",
+      "_shasum": "dfaadb4b3edb35c826f4002820637dca1f6b48b9",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dfaadb4b3edb35c826f4002820637dca1f6b48b9",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "public-encrypt",
+      "version": "1.1.1",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "7be181d7851b5b988daeb9b2bb6890e5d009e853",
+      "_id": "public-encrypt@1.1.1",
+      "_shasum": "2be5a4963e6814102c6d2baad2d40a0a88e9587d",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2be5a4963e6814102c6d2baad2d40a0a88e9587d",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "public-encrypt",
+      "version": "1.1.2",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/calvinmetcalf/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/calvinmetcalf/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/calvinmetcalf/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "parse-asn1": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "1624152e382c11db811db30bbd5ebcfd89b8b279",
+      "_id": "public-encrypt@1.1.2",
+      "_shasum": "90711147083bc5bfbe2b51964f9a6b038adb0d4b",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "90711147083bc5bfbe2b51964f9a6b038adb0d4b",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.2.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "public-encrypt",
+      "version": "2.0.0",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "browser": "browser.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^3.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "51e36739287358dd4e9d9272bfe1bed8ccb580eb",
+      "_id": "public-encrypt@2.0.0",
+      "_shasum": "9e49010bf021d33f6597c77abd939612a82767fc",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.36",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9e49010bf021d33f6597c77abd939612a82767fc",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "public-encrypt",
+      "version": "2.0.1",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "browser": "browser.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/crypto-browserify/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^3.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "317270f847994330e07bc91d6f8ae9dd8048798a",
+      "_id": "public-encrypt@2.0.1",
+      "_shasum": "ef150418728a93e70700fa5c6a94016e0e596493",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ef150418728a93e70700fa5c6a94016e0e596493",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "public-encrypt",
+      "version": "3.0.0",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "browser": "browser.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^3.2.0",
+        "browserify-rsa": "^3.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^4.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "dc25973941f7a405eeeb80d6e102520987db8e2a",
+      "_id": "public-encrypt@3.0.0",
+      "_shasum": "ae483d0f551ba125f12540e20ecfc9d00f4e60ea",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "3.3.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "ae483d0f551ba125f12540e20ecfc9d00f4e60ea",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ]
+    },
+    "4.0.0": {
+      "name": "public-encrypt",
+      "version": "4.0.0",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "browser": "browser.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/publicEncrypt.git"
+      },
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "e7654c62f2929caeae09bcf6e3572b1aafcbd8b1",
+      "_id": "public-encrypt@4.0.0",
+      "_shasum": "39f699f3a46560dd5ebacbca693caf7c65c18cc6",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "shasum": "39f699f3a46560dd5ebacbca693caf7c65c18cc6",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ]
+    },
+    "4.0.2": {
+      "name": "public-encrypt",
+      "version": "4.0.2",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "browser": "browser.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/publicEncrypt.git"
+      },
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "gitHead": "8dc63aee4d4da0539bd579eaf9f2e86ec394d613",
+      "_id": "public-encrypt@4.0.2",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
+        "shasum": "46eb9107206bf73489f8b85b69d91334c6610994",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+        "fileCount": 31,
+        "unpackedSize": 27801
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/public-encrypt_4.0.2_1523449480930_0.42773762674143434"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.3": {
+      "name": "public-encrypt",
+      "version": "4.0.3",
+      "description": "browserify version of publicEncrypt & privateDecrypt",
+      "main": "index.js",
+      "browser": "browser.js",
+      "directories": {
+        "test": "test"
+      },
+      "scripts": {
+        "test": "node test/index.js | tspec",
+        "lint": "standard"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/publicEncrypt.git"
+      },
+      "author": {
+        "name": "Calvin Metcalf"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/publicEncrypt/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/publicEncrypt",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "standard": "^12.0.0",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "gitHead": "aff236f8921dd1309bf61b4f56d14385ec40cbaf",
+      "_id": "public-encrypt@4.0.3",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+        "shasum": "4fcc9d77a07e48ba7527e7cbe0de33d0701331e0",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+        "fileCount": 31,
+        "unpackedSize": 27803,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbsnnECRA9TVsSAnZWagAAXz8P/i2hUVyWz477HJ5gtXrp\n110L14kltYplvOCNvh/PGkVapMFo/ObJ5Siynpn1NKAAVXM0KHQXvhaezLtk\nbzxxY1JE+sLEVmDNmwddGKZ0/8UIRlx9nw8cMEex/HhJyhVDe1rnkqOO/iER\nloT+N4WX5umDtop1BKl4rzeGNSjZgGyk2M+xvMN5tXKzfV/2HW3+FHYLcy3Z\nsyvBZmnfLDrmN9pK/E3hw9oqekM1FfoxkL+0XnIW5H2ybkV6CDZbqTxV/0gE\nbZB0i54I+t1OA9BAh/LtR4tas+xolgH5WqF2NB9MmjaTxWZAxHPGGhKuQ/i5\nxRLuJej37gIN7CZfVoEABHZ8QX3mgBK+yVlk4osOxiALAOxuqCh/Lm0NlQ0q\nprlJ5FGk0i7ZUvohTsJNasBXGS3z9HdCxKW+v4NR22WAfwmCnzm5oumpLROw\n6nKh3YHsw92Mv3UZq2VHK5GPObQKVpaTyuEGq1uKoiwFHsrGM5RvFIT21PxU\nmXkVLpXUSUxmUGqJU9VRJVuhgNjGV5o+egzW9tEXJCD8/V0PrOuN5qL09U3u\nM6/jUPWiKUuxLwMS/tCYF9fTdpQzVWx+nWypP/pbuyq4n0xFqN1aWxx7X7HK\nQOcJU0PjMGHiHHHlWYL1cZvLq1sUWBUxOwpZwc4LE8maZF7h0BrYYvKhBPoT\nb+tq\r\n=gJHG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/public-encrypt_4.0.3_1538423236125_0.6978435794264757"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "publicEncrypt\n===\n\n[![Build Status](https://travis-ci.org/crypto-browserify/publicEncrypt.svg)](https://travis-ci.org/crypto-browserify/publicEncrypt)\n\npublicEncrypt/privateDecrypt for browserify\n\n[Blog post about the moving parts that have gone into this.](http://calvinmetcalf.com/post/109301244759/porting-nodejs-crypto-to-the-browser-part-3)\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-05T05:24:46.308Z",
+    "created": "2014-12-17T12:32:20.274Z",
+    "1.0.0": "2014-12-17T12:32:20.274Z",
+    "1.0.1": "2014-12-18T21:43:23.402Z",
+    "1.1.0": "2014-12-22T19:43:34.256Z",
+    "1.1.1": "2015-01-06T12:36:39.495Z",
+    "1.1.2": "2015-01-06T12:52:08.469Z",
+    "2.0.0": "2015-02-12T13:31:38.132Z",
+    "2.0.1": "2015-05-21T02:58:45.148Z",
+    "3.0.0": "2015-10-27T01:30:15.140Z",
+    "4.0.0": "2015-11-02T14:18:31.325Z",
+    "4.0.2": "2018-04-11T12:24:40.993Z",
+    "4.0.3": "2018-10-01T19:47:16.256Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/publicEncrypt",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/publicEncrypt.git"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/publicEncrypt/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "author": {
+    "name": "Calvin Metcalf"
+  }
+}

--- a/test/fixtures/registry-mocks/content/public-encrypt.min.json
+++ b/test/fixtures/registry-mocks/content/public-encrypt.min.json
@@ -1,0 +1,248 @@
+{
+  "name": "public-encrypt",
+  "dist-tags": {
+    "latest": "4.0.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "public-encrypt",
+      "version": "1.0.0",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "parse-asn1": "^1.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "56179751a5eb00137fe63f825049ae4504da44c8",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "public-encrypt",
+      "version": "1.0.1",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "f4d881f0068cdd24017ef4baa4f49b9d8d055c46",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "public-encrypt",
+      "version": "1.1.0",
+      "dependencies": {
+        "bn.js": "^0.16.0",
+        "browserify-rsa": "^1.1.0",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "dfaadb4b3edb35c826f4002820637dca1f6b48b9",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "public-encrypt",
+      "version": "1.1.1",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "parse-asn1": "^1.2.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "2be5a4963e6814102c6d2baad2d40a0a88e9587d",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "public-encrypt",
+      "version": "1.1.2",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^1.1.0",
+        "parse-asn1": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "90711147083bc5bfbe2b51964f9a6b038adb0d4b",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-1.1.2.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "public-encrypt",
+      "version": "2.0.0",
+      "dependencies": {
+        "bn.js": "^1.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^3.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "9e49010bf021d33f6597c77abd939612a82767fc",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "public-encrypt",
+      "version": "2.0.1",
+      "dependencies": {
+        "bn.js": "^2.0.0",
+        "browserify-rsa": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^3.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "ef150418728a93e70700fa5c6a94016e0e596493",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-2.0.1.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "public-encrypt",
+      "version": "3.0.0",
+      "dependencies": {
+        "bn.js": "^3.2.0",
+        "browserify-rsa": "^3.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^4.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "ae483d0f551ba125f12540e20ecfc9d00f4e60ea",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-3.0.0.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "public-encrypt",
+      "version": "4.0.0",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "39f699f3a46560dd5ebacbca693caf7c65c18cc6",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
+      }
+    },
+    "4.0.2": {
+      "name": "public-encrypt",
+      "version": "4.0.2",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
+      },
+      "devDependencies": {
+        "tape": "^3.0.3",
+        "tap-spec": "^2.1.2"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
+        "shasum": "46eb9107206bf73489f8b85b69d91334c6610994",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
+        "fileCount": 31,
+        "unpackedSize": 27801
+      }
+    },
+    "4.0.3": {
+      "name": "public-encrypt",
+      "version": "4.0.3",
+      "dependencies": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "standard": "^12.0.0",
+        "tap-spec": "^2.1.2",
+        "tape": "^3.0.3"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+        "shasum": "4fcc9d77a07e48ba7527e7cbe0de33d0701331e0",
+        "tarball": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+        "fileCount": 31,
+        "unpackedSize": 27803,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbsnnECRA9TVsSAnZWagAAXz8P/i2hUVyWz477HJ5gtXrp\n110L14kltYplvOCNvh/PGkVapMFo/ObJ5Siynpn1NKAAVXM0KHQXvhaezLtk\nbzxxY1JE+sLEVmDNmwddGKZ0/8UIRlx9nw8cMEex/HhJyhVDe1rnkqOO/iER\nloT+N4WX5umDtop1BKl4rzeGNSjZgGyk2M+xvMN5tXKzfV/2HW3+FHYLcy3Z\nsyvBZmnfLDrmN9pK/E3hw9oqekM1FfoxkL+0XnIW5H2ybkV6CDZbqTxV/0gE\nbZB0i54I+t1OA9BAh/LtR4tas+xolgH5WqF2NB9MmjaTxWZAxHPGGhKuQ/i5\nxRLuJej37gIN7CZfVoEABHZ8QX3mgBK+yVlk4osOxiALAOxuqCh/Lm0NlQ0q\nprlJ5FGk0i7ZUvohTsJNasBXGS3z9HdCxKW+v4NR22WAfwmCnzm5oumpLROw\n6nKh3YHsw92Mv3UZq2VHK5GPObQKVpaTyuEGq1uKoiwFHsrGM5RvFIT21PxU\nmXkVLpXUSUxmUGqJU9VRJVuhgNjGV5o+egzW9tEXJCD8/V0PrOuN5qL09U3u\nM6/jUPWiKUuxLwMS/tCYF9fTdpQzVWx+nWypP/pbuyq4n0xFqN1aWxx7X7HK\nQOcJU0PjMGHiHHHlWYL1cZvLq1sUWBUxOwpZwc4LE8maZF7h0BrYYvKhBPoT\nb+tq\r\n=gJHG\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-01-05T05:24:46.308Z"
+}

--- a/test/fixtures/registry-mocks/content/pumpify.json
+++ b/test/fixtures/registry-mocks/content/pumpify.json
@@ -1,0 +1,1399 @@
+{
+  "_id": "pumpify",
+  "_rev": "45-f80539374858420f6d14265681338815",
+  "name": "pumpify",
+  "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "pumpify",
+      "version": "0.0.0",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^1.1.0",
+        "pump": "^0.3.2"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@0.0.0",
+      "_shasum": "a95a918be74e1465f625c220216ddbc326ffbb79",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a95a918be74e1465f625c220216ddbc326ffbb79",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-0.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "pumpify",
+      "version": "1.0.0",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^1.1.0",
+        "pump": "^0.3.2"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@1.0.0",
+      "_shasum": "929602629ac362f3b91da6055a803e6d58867602",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "929602629ac362f3b91da6055a803e6d58867602",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "pumpify",
+      "version": "1.0.1",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^1.1.0",
+        "pump": "^0.3.2"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@1.0.1",
+      "_shasum": "b75a06c219882d310ff1effb6ecf8161a6326151",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b75a06c219882d310ff1effb6ecf8161a6326151",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "pumpify",
+      "version": "1.0.2",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^1.2.1",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@1.0.2",
+      "_shasum": "b4b1d7368b73f391b242ba6c16f6657ea1da232e",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b4b1d7368b73f391b242ba6c16f6657ea1da232e",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "pumpify",
+      "version": "1.1.0",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^1.3.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@1.1.0",
+      "_shasum": "b6e91e6c7d64259cd0fcc7d891662834fd1f8e89",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b6e91e6c7d64259cd0fcc7d891662834fd1f8e89",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "pumpify",
+      "version": "1.1.1",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^1.3.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@1.1.1",
+      "_shasum": "d0546c6c80779e7619cc2a64351b2a683bfc01f2",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d0546c6c80779e7619cc2a64351b2a683bfc01f2",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "pumpify",
+      "version": "1.1.2",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^1.5.2",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@1.1.2",
+      "_shasum": "fd2219cff731c5427f18b4795356f474853b46e5",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fd2219cff731c5427f18b4795356f474853b46e5",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "pumpify",
+      "version": "1.1.3",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^2.0.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@1.1.3",
+      "_shasum": "9679987eb0ce5fe800cc4f889544e32002a8aa5e",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9679987eb0ce5fe800cc4f889544e32002a8aa5e",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "pumpify",
+      "version": "1.2.0",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.0.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "_id": "pumpify@1.2.0",
+      "_shasum": "679a986661869d4ba55ee08465f24a1e18ab8a4b",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "679a986661869d4ba55ee08465f24a1e18ab8a4b",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "pumpify",
+      "version": "1.2.1",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.0.1",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "18edbb96418f115a8339270b1949e66622e1ebff",
+      "_id": "pumpify@1.2.1",
+      "_shasum": "e1b31923176b8eea983a23ead7788dad72a63d98",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e1b31923176b8eea983a23ead7788dad72a63d98",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "pumpify",
+      "version": "1.3.0",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.1.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "43bed1c9fcc593b750e73a3f28fa95a504e6a677",
+      "_id": "pumpify@1.3.0",
+      "_shasum": "fbc5b917d35cc8b3dfb094dc7ba66f2b6559a992",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fbc5b917d35cc8b3dfb094dc7ba66f2b6559a992",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "pumpify",
+      "version": "1.3.1",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.1.1",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "6a248dedac5c5124707d02f0cb98bcc691767113",
+      "_id": "pumpify@1.3.1",
+      "_shasum": "e0c99377ee2297283adc15a6944ab7942cd74306",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e0c99377ee2297283adc15a6944ab7942cd74306",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "pumpify",
+      "version": "1.3.2",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.1.2",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "296209d25c56dbb48eb0be7c7827e15be1e52196",
+      "_id": "pumpify@1.3.2",
+      "_shasum": "255ca58bf7a816cac879473cf5d069171e55d2bc",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "255ca58bf7a816cac879473cf5d069171e55d2bc",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.3": {
+      "name": "pumpify",
+      "version": "1.3.3",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.1.2",
+        "pump": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "d78c814aa8625755c1e7823b7b46a40bcaab7c20",
+      "_id": "pumpify@1.3.3",
+      "_shasum": "f6d27bb71d32871ff6d0868859dbacfeb2ebdbfe",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f6d27bb71d32871ff6d0868859dbacfeb2ebdbfe",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.4": {
+      "name": "pumpify",
+      "version": "1.3.4",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.1.2",
+        "inherits": "^2.0.1",
+        "pump": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "12dbcbe973cd62a4be39c5880d21624a6dfc892f",
+      "_id": "pumpify@1.3.4",
+      "_shasum": "33418bdaf200b8fd55276c39eefb1bb842e4a606",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "33418bdaf200b8fd55276c39eefb1bb842e4a606",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/pumpify-1.3.4.tgz_1456243488194_0.6747447045054287"
+      },
+      "directories": {}
+    },
+    "1.3.5": {
+      "name": "pumpify",
+      "version": "1.3.5",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.1.2",
+        "inherits": "^2.0.1",
+        "pump": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "b3eb78d20b310409beca86de87a4fba68bc9656e",
+      "_id": "pumpify@1.3.5",
+      "_shasum": "1b671c619940abcaeac0ad0e3a3c164be760993b",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "1b671c619940abcaeac0ad0e3a3c164be760993b",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/pumpify-1.3.5.tgz_1465886760120_0.06353981443680823"
+      },
+      "directories": {}
+    },
+    "1.3.6": {
+      "name": "pumpify",
+      "version": "1.3.6",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.5.3",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.8.0",
+        "through2": "^2.0.3"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify.git"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "9e0a9d37705f48a3ee30c4905ae3df8d2cd04d60",
+      "_id": "pumpify@1.3.6",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-BurGAcvezsINL5US9T9wGHHcLNrG6MCp//ECtxron3vcR+Rfx5Anqq7HbZXNJvFQli8FGVsWCAvywEJFV5Hx/Q==",
+        "shasum": "00d40e5ded0a3bf1e0788b1c0cf426a42882ab64",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pumpify-1.3.6.tgz_1515600989535_0.029653461882844567"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "pumpify",
+      "version": "1.4.0",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.5.3",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.8.0",
+        "through2": "^2.0.3"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify.git"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "627c67a0e9934cf039b1dd5a6a7add597f04e08a",
+      "_id": "pumpify@1.4.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+        "shasum": "80b7c5df7e24153d03f0e7ac8a05a5d068bd07fb",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pumpify-1.4.0.tgz_1516184777649_0.24492035922594368"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "pumpify",
+      "version": "1.5.0",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.8.0",
+        "through2": "^2.0.3"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify.git"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "cc2ffee09e39fa52f77c2dbf1a901a62b7b56e12",
+      "_id": "pumpify@1.5.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.11.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
+        "shasum": "30c905a26c88fa0074927af07256672b474b1c15",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 9417,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa7DsPCRA9TVsSAnZWagAAbXAQAKMxpOeT7Zs5trKADFEx\n/NCNA5wWc2xsRLafbTXxFiEGz1C7hI03n0Tp2vIsOwlSSNqAuNkAAQ3MvB8X\ngNrdim20/w2O0N2lzdr9bdQSVeXCnZ4ooZzbEuX1/57I6XJ/CB1QQwb4ylpl\n7SDliIvjR4PiO1GPzpLd9cTk1ytO8/ijb5UcGxYSjnhmIC0OcaYbNJNUe3Kq\n21vd4c5yBa/aveSLRyBedMyMQ9FSrjh1avk80vRub1ibhENoumchsC9mKFCF\ng3myRjE1UeY1jPJzfyXpmqGm7xiMBiUpJAA6eHFyrxuDb+kykfLv/Dd8JzNf\nxZc5tsp+Q0Si6LHtS2Z0ea58MllnMEVKJIpQEvNfey16SfWDFRjoQifcNdxD\nMXON4477AKqbuQEOtnO5uOtGJPRFrUc7KtYbEwZrlh+FfwyXz1gvJfklmjsD\nO7kZZ9qYdywUwr54H7lEz0xKvT6EjrcqC0wq8QdzxFrN2zbDOYgogX31zzXQ\n8TpyoEqqFioRfM0mT8fYMrfpFu1j9kHAcV/+P16juQMvwGFzorNE8hp8TiC/\nYmqhj6NOgByyeziblZEK1zfp3xpJCV7hFqqlazYsIFmOqTELEO+U6SLdt01/\nQg0+zLv1yMuVhNbiBgXCwkqOG34DaEwFIZIyHBLKpLrWj8TdsHp8xJurxH1e\nl+w2\r\n=VAVF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pumpify_1.5.0_1525431054074_0.523666047767994"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.1": {
+      "name": "pumpify",
+      "version": "1.5.1",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.8.0",
+        "through2": "^2.0.3"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify.git"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "10f2659c137e291648c7179f69cfe50c3a726a2b",
+      "_id": "pumpify@1.5.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.11.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+        "shasum": "36513be246ab27570b1a374a5ce278bfd74370ce",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 10155,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa/D4yCRA9TVsSAnZWagAArkwP/0pfiaVudH+qySK2mz4y\nrFW1vPmRWeB/8xiAXufvhpQdsDVqEXp9395ha5G1ug9lQu+Xa90rBNWHY0nS\nyaXFplSJ+6wEFdfOj34Rz4FK001Xr0BPuzXxSOKLmzDElA79X7zzK4xaxdF9\npgt0gl3vJhbPCK/PlPvKZz6ltmt/u/od47P5dwdZFWzF4kCeeNJJ2FfpyDh2\nHLT5bhEXdAQML3u4D7aAVOyIda0ZKWO3oSGRNbRzVfamf6a03IwwRYHTnajH\nrM5wwKohclQTi4AxxgKpf4ZZrkMhhJCftmfSxqlLtpXYsep+7WoH0ZFBLL3+\nkb1SMt0PYZFwOs60ubWw8TjugWAzeUQQcMWe//nvpYYm7ZJsgCNDpQx+0iWO\n28/13IQiqjgsCjhKVYDsFOWYP2kCiFMHOfhnxqEpDb+q7DRAwt8tL573n7CQ\negun0TZrak9rr6N02uHK0VJZTs4Msrovaqf687AYDWYLhQRARVRjA3XotNgl\nip+rh9dUytyYGZRyu42t1yv3vNq1VekZbKs/P7comMgxJcoxgqFFHTALJ97Z\nqWY11S2bdiK8qDZcJfiHIZzsXiM4j9kisIPJdyrKnhtyvYD3dcCQaGGt85g0\nQEvLglx9ygdhmAWEzTDLwAw4TbdrGryXGwa9YQMR+a+DjUGyUgE1oSlqsXl5\ns5ZM\r\n=dN62\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pumpify_1.5.1_1526480433622_0.7662524993524624"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "pumpify",
+      "version": "2.0.0",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.10.2",
+        "through2": "^3.0.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify.git"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "c5c4d8d4bb7c50829ac388ce27d66b799dc7e2fe",
+      "_id": "pumpify@2.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.15.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-ieN9HmpFPt4J4U4qnjN4BxrnqpPPXJyp3qFErxfwBtFOec6ewpIHdS2eu3TkmGW6S+RzFGEOGpm5ih/X/onRPQ==",
+        "shasum": "975519e5a9890ae0fb4724274e3fec97e43a30b6",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 10156,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAV28CRA9TVsSAnZWagAAYL8P/jlOXfgcDE3PPBKHZGHN\nnW+Qx+CP8aZu6s27VjRXTiriBqguLGoWeeBHcYDbBzHxi/apHQJBNRzs3TFK\nA+4YTFIndYaKuQr77s5ZGkUcj//2Xjh+oRjTtn6wyrPFcyd9iJd3QJLxy1kZ\nd4SrftLTkj/VXYhvZpFDGsA3SMR46uBKqao/rElpW8jl1RyDtWC0J3a0KXTJ\nNeCNSTEdXo0b1uaCbERGX74pBZhMsGjQjExxJ9c5XUBn/1a+ZtZgBrQQXmBg\njuptpUAuhVUGaptffLxFGp1l3eSKxnojfwCd1ra1Tubf0nlDo3Q634ORbNbA\nM9ryfzNJPeL0O/FDUFJUNVZFWdmESY24cQaX9wT5+Q6HWkOKoS/JQldm3AsO\n1Q5lg0eSY5mC9oQ6S/yO0fThq7/dNmIHCDyoWyhXeTEH/k/UHuiO83CdkQ9t\nAxr4xOUsf0mHXO58zjlQ6tappSQBJqGSNyAtKTiotWg3q3YF8OIKaF7rFjaT\nkJe++S12qPgRrjcsKIpLm05UPo19G3fyykZJd0yfW+AFIode4vVZ4pHLojdC\nfEliUuoomGQobrO6HwlyvtjorDNVLsrX3mGEFM+BZAnGAgu8KVexVGqoLnDy\nQ1yrekpBeae7HukugbKNgYvIwhecP1GjRC0jBrAANVNel4IhVgJ+PGBebFSM\ncnPd\r\n=FA/v\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pumpify_2.0.0_1560370620134_0.5095998575487775"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "pumpify",
+      "version": "2.0.1",
+      "description": "Combine an array of streams into a single duplex stream using pump and duplexify",
+      "main": "index.js",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.10.2",
+        "through2": "^3.0.1"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/pumpify.git"
+      },
+      "keywords": [
+        "pump",
+        "duplexify",
+        "duplex",
+        "streams",
+        "stream",
+        "pipeline",
+        "combine"
+      ],
+      "author": {
+        "name": "Mathias Buus"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/pumpify/issues"
+      },
+      "homepage": "https://github.com/mafintosh/pumpify",
+      "gitHead": "106097fbb7a09edf7c5f6f387ea2533fde4d0d47",
+      "_id": "pumpify@2.0.1",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+        "shasum": "abfc7b5a621307c728b551decbbefb51f0e4aa1e",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 10208,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdk1pgCRA9TVsSAnZWagAA+J4P/jcN/RwROcN1mJ3+WIrz\nEjyhJHlYc4Z7YFLZkRZr/vql+HH5+29mozjWkGo2Ombz5yZ/ut64j4CbOLxd\nAa4sgfWrJyZAuNbtyIAPusXV8NSXkA9E1OkQG0kwPoYXMtehGt9Lt//NJUzq\nInin4XhlNhugQtUn12HRuWwB3rPnc8G6c9ZXLEAGt839aaohUadCIXjHurAa\nmln96dNA4KmUHSLrsoLrMJld7fH8psdETW8Qf5pAVWvoqcr+ytg12Y1hFt/K\nmBnZH0yZmVgZCOWL27XDeZrwYDCBW3mWIsgvH/OxALGHt7zgMgqRkVsE+rGO\nhbCeFDtArBS1sZQ+F3Upv8jonEi2sXw0i7QADk5Irc1a0TUfoYloqXp46noX\nH23utviojPaBna8qHf35QdGcXMFeQJYC/NWFBJxA8FbCge18pTccTUuoSCbw\n+JMbvn/gHG2MN6624ceZdVUYe0pmF6VZoBAU0rFNG7Okb8qgjmuQP4mXf3M1\nw8/MXgOELO8QS9YoA+S2dPQstWcSjUPzOnd7Ea4IP8e9lfPpL8eG30vGsaJ6\n2VGdFEauftI3raHFbOocrCa3pOhsbVVgECzc9eJpt0BG3e8nFah7cjRJnzOf\nCtELQsPLkp43MC1xHt8HP6+OCIE3sWM6fqTq1riaCnGHzHlF7xEW0G2bNvkb\nS/Y/\r\n=7iau\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/pumpify_2.0.1_1569938015896_0.2381461797676594"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# pumpify\n\nCombine an array of streams into a single duplex stream using [pump](https://github.com/mafintosh/pump) and [duplexify](https://github.com/mafintosh/duplexify).\nIf one of the streams closes/errors all streams in the pipeline will be destroyed.\n\n```\nnpm install pumpify\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/pumpify.svg?style=flat)](http://travis-ci.org/mafintosh/pumpify)\n\n## Usage\n\nPass the streams you want to pipe together to pumpify `pipeline = pumpify(s1, s2, s3, ...)`.\n`pipeline` is a duplex stream that writes to the first streams and reads from the last one.\nStreams are piped together using [pump](https://github.com/mafintosh/pump) so if one of them closes\nall streams will be destroyed.\n\n``` js\nvar pumpify = require('pumpify')\nvar tar = require('tar-fs')\nvar zlib = require('zlib')\nvar fs = require('fs')\n\nvar untar = pumpify(zlib.createGunzip(), tar.extract('output-folder'))\n// you can also pass an array instead\n// var untar = pumpify([zlib.createGunzip(), tar.extract('output-folder')])\n\nfs.createReadStream('some-gzipped-tarball.tgz').pipe(untar)\n```\n\nIf you are pumping object streams together use `pipeline = pumpify.obj(s1, s2, ...)`.\nCall `pipeline.destroy()` to destroy the pipeline (including the streams passed to pumpify).\n\n### Using `setPipeline(s1, s2, ...)`\n\nSimilar to [duplexify](https://github.com/mafintosh/duplexify) you can also define the pipeline asynchronously using `setPipeline(s1, s2, ...)`\n\n``` js\nvar untar = pumpify()\n\nsetTimeout(function() {\n  // will start draining the input now\n  untar.setPipeline(zlib.createGunzip(), tar.extract('output-folder'))\n}, 1000)\n\nfs.createReadStream('some-gzipped-tarball.tgz').pipe(untar)\n```\n\n## License\n\nMIT\n\n## Related\n\n`pumpify` is part of the [mississippi stream utility collection](https://github.com/maxogden/mississippi) which includes more useful stream modules similar to this one.\n",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-10-01T13:53:38.672Z",
+    "created": "2014-07-11T16:24:33.760Z",
+    "0.0.0": "2014-07-11T16:24:33.760Z",
+    "1.0.0": "2014-07-11T18:47:43.826Z",
+    "1.0.1": "2014-07-12T15:55:49.813Z",
+    "1.0.2": "2014-07-12T21:49:06.092Z",
+    "1.1.0": "2014-07-13T12:49:47.982Z",
+    "1.1.1": "2014-07-13T15:06:42.187Z",
+    "1.1.2": "2014-07-22T18:34:36.582Z",
+    "1.1.3": "2014-07-23T00:05:49.033Z",
+    "1.2.0": "2014-07-23T13:11:20.356Z",
+    "1.2.1": "2014-07-25T19:10:54.926Z",
+    "1.3.0": "2014-08-07T20:21:07.249Z",
+    "1.3.1": "2014-08-15T23:10:24.605Z",
+    "1.3.2": "2014-08-15T23:25:06.744Z",
+    "1.3.3": "2014-09-24T04:19:01.263Z",
+    "1.3.4": "2016-02-23T16:04:52.055Z",
+    "1.3.5": "2016-06-14T06:46:02.261Z",
+    "1.3.6": "2018-01-10T16:16:30.486Z",
+    "1.4.0": "2018-01-17T10:26:18.524Z",
+    "1.5.0": "2018-05-04T10:50:54.453Z",
+    "1.5.1": "2018-05-16T14:20:33.728Z",
+    "2.0.0": "2019-06-12T20:17:00.232Z",
+    "2.0.1": "2019-10-01T13:53:36.066Z"
+  },
+  "homepage": "https://github.com/mafintosh/pumpify",
+  "keywords": [
+    "pump",
+    "duplexify",
+    "duplex",
+    "streams",
+    "stream",
+    "pipeline",
+    "combine"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mafintosh/pumpify.git"
+  },
+  "author": {
+    "name": "Mathias Buus"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/pumpify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "timhudson": true,
+    "tclay": true,
+    "timdp": true,
+    "mreinstein": true,
+    "jrop": true,
+    "monjer": true,
+    "ganeshkbhat": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/pumpify.min.json
+++ b/test/fixtures/registry-mocks/content/pumpify.min.json
@@ -1,0 +1,386 @@
+{
+  "name": "pumpify",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "pumpify",
+      "version": "0.0.0",
+      "dependencies": {
+        "duplexify": "^1.1.0",
+        "pump": "^0.3.2"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3"
+      },
+      "dist": {
+        "shasum": "a95a918be74e1465f625c220216ddbc326ffbb79",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-0.0.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "pumpify",
+      "version": "1.0.0",
+      "dependencies": {
+        "duplexify": "^1.1.0",
+        "pump": "^0.3.2"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "929602629ac362f3b91da6055a803e6d58867602",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "pumpify",
+      "version": "1.0.1",
+      "dependencies": {
+        "duplexify": "^1.1.0",
+        "pump": "^0.3.2"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "b75a06c219882d310ff1effb6ecf8161a6326151",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "pumpify",
+      "version": "1.0.2",
+      "dependencies": {
+        "duplexify": "^1.2.1",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "b4b1d7368b73f391b242ba6c16f6657ea1da232e",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "pumpify",
+      "version": "1.1.0",
+      "dependencies": {
+        "duplexify": "^1.3.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "b6e91e6c7d64259cd0fcc7d891662834fd1f8e89",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "pumpify",
+      "version": "1.1.1",
+      "dependencies": {
+        "duplexify": "^1.3.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "d0546c6c80779e7619cc2a64351b2a683bfc01f2",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "pumpify",
+      "version": "1.1.2",
+      "dependencies": {
+        "duplexify": "^1.5.2",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "fd2219cff731c5427f18b4795356f474853b46e5",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "pumpify",
+      "version": "1.1.3",
+      "dependencies": {
+        "duplexify": "^2.0.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "9679987eb0ce5fe800cc4f889544e32002a8aa5e",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.1.3.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "pumpify",
+      "version": "1.2.0",
+      "dependencies": {
+        "duplexify": "^3.0.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "679a986661869d4ba55ee08465f24a1e18ab8a4b",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "pumpify",
+      "version": "1.2.1",
+      "dependencies": {
+        "duplexify": "^3.0.1",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "e1b31923176b8eea983a23ead7788dad72a63d98",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.2.1.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "pumpify",
+      "version": "1.3.0",
+      "dependencies": {
+        "duplexify": "^3.1.0",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "fbc5b917d35cc8b3dfb094dc7ba66f2b6559a992",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.0.tgz"
+      }
+    },
+    "1.3.1": {
+      "name": "pumpify",
+      "version": "1.3.1",
+      "dependencies": {
+        "duplexify": "^3.1.1",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "e0c99377ee2297283adc15a6944ab7942cd74306",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.1.tgz"
+      }
+    },
+    "1.3.2": {
+      "name": "pumpify",
+      "version": "1.3.2",
+      "dependencies": {
+        "duplexify": "^3.1.2",
+        "pump": "^0.3.3"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "255ca58bf7a816cac879473cf5d069171e55d2bc",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.2.tgz"
+      }
+    },
+    "1.3.3": {
+      "name": "pumpify",
+      "version": "1.3.3",
+      "dependencies": {
+        "duplexify": "^3.1.2",
+        "pump": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "f6d27bb71d32871ff6d0868859dbacfeb2ebdbfe",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.3.tgz"
+      }
+    },
+    "1.3.4": {
+      "name": "pumpify",
+      "version": "1.3.4",
+      "dependencies": {
+        "duplexify": "^3.1.2",
+        "inherits": "^2.0.1",
+        "pump": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "33418bdaf200b8fd55276c39eefb1bb842e4a606",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.4.tgz"
+      }
+    },
+    "1.3.5": {
+      "name": "pumpify",
+      "version": "1.3.5",
+      "dependencies": {
+        "duplexify": "^3.1.2",
+        "inherits": "^2.0.1",
+        "pump": "^1.0.0"
+      },
+      "devDependencies": {
+        "tape": "^2.13.3",
+        "through2": "^0.5.1"
+      },
+      "dist": {
+        "shasum": "1b671c619940abcaeac0ad0e3a3c164be760993b",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz"
+      }
+    },
+    "1.3.6": {
+      "name": "pumpify",
+      "version": "1.3.6",
+      "dependencies": {
+        "duplexify": "^3.5.3",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.8.0",
+        "through2": "^2.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-BurGAcvezsINL5US9T9wGHHcLNrG6MCp//ECtxron3vcR+Rfx5Anqq7HbZXNJvFQli8FGVsWCAvywEJFV5Hx/Q==",
+        "shasum": "00d40e5ded0a3bf1e0788b1c0cf426a42882ab64",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.6.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "pumpify",
+      "version": "1.4.0",
+      "dependencies": {
+        "duplexify": "^3.5.3",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.8.0",
+        "through2": "^2.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+        "shasum": "80b7c5df7e24153d03f0e7ac8a05a5d068bd07fb",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "pumpify",
+      "version": "1.5.0",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.8.0",
+        "through2": "^2.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
+        "shasum": "30c905a26c88fa0074927af07256672b474b1c15",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 9417,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa7DsPCRA9TVsSAnZWagAAbXAQAKMxpOeT7Zs5trKADFEx\n/NCNA5wWc2xsRLafbTXxFiEGz1C7hI03n0Tp2vIsOwlSSNqAuNkAAQ3MvB8X\ngNrdim20/w2O0N2lzdr9bdQSVeXCnZ4ooZzbEuX1/57I6XJ/CB1QQwb4ylpl\n7SDliIvjR4PiO1GPzpLd9cTk1ytO8/ijb5UcGxYSjnhmIC0OcaYbNJNUe3Kq\n21vd4c5yBa/aveSLRyBedMyMQ9FSrjh1avk80vRub1ibhENoumchsC9mKFCF\ng3myRjE1UeY1jPJzfyXpmqGm7xiMBiUpJAA6eHFyrxuDb+kykfLv/Dd8JzNf\nxZc5tsp+Q0Si6LHtS2Z0ea58MllnMEVKJIpQEvNfey16SfWDFRjoQifcNdxD\nMXON4477AKqbuQEOtnO5uOtGJPRFrUc7KtYbEwZrlh+FfwyXz1gvJfklmjsD\nO7kZZ9qYdywUwr54H7lEz0xKvT6EjrcqC0wq8QdzxFrN2zbDOYgogX31zzXQ\n8TpyoEqqFioRfM0mT8fYMrfpFu1j9kHAcV/+P16juQMvwGFzorNE8hp8TiC/\nYmqhj6NOgByyeziblZEK1zfp3xpJCV7hFqqlazYsIFmOqTELEO+U6SLdt01/\nQg0+zLv1yMuVhNbiBgXCwkqOG34DaEwFIZIyHBLKpLrWj8TdsHp8xJurxH1e\nl+w2\r\n=VAVF\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.5.1": {
+      "name": "pumpify",
+      "version": "1.5.1",
+      "dependencies": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.8.0",
+        "through2": "^2.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+        "shasum": "36513be246ab27570b1a374a5ce278bfd74370ce",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 10155,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa/D4yCRA9TVsSAnZWagAArkwP/0pfiaVudH+qySK2mz4y\nrFW1vPmRWeB/8xiAXufvhpQdsDVqEXp9395ha5G1ug9lQu+Xa90rBNWHY0nS\nyaXFplSJ+6wEFdfOj34Rz4FK001Xr0BPuzXxSOKLmzDElA79X7zzK4xaxdF9\npgt0gl3vJhbPCK/PlPvKZz6ltmt/u/od47P5dwdZFWzF4kCeeNJJ2FfpyDh2\nHLT5bhEXdAQML3u4D7aAVOyIda0ZKWO3oSGRNbRzVfamf6a03IwwRYHTnajH\nrM5wwKohclQTi4AxxgKpf4ZZrkMhhJCftmfSxqlLtpXYsep+7WoH0ZFBLL3+\nkb1SMt0PYZFwOs60ubWw8TjugWAzeUQQcMWe//nvpYYm7ZJsgCNDpQx+0iWO\n28/13IQiqjgsCjhKVYDsFOWYP2kCiFMHOfhnxqEpDb+q7DRAwt8tL573n7CQ\negun0TZrak9rr6N02uHK0VJZTs4Msrovaqf687AYDWYLhQRARVRjA3XotNgl\nip+rh9dUytyYGZRyu42t1yv3vNq1VekZbKs/P7comMgxJcoxgqFFHTALJ97Z\nqWY11S2bdiK8qDZcJfiHIZzsXiM4j9kisIPJdyrKnhtyvYD3dcCQaGGt85g0\nQEvLglx9ygdhmAWEzTDLwAw4TbdrGryXGwa9YQMR+a+DjUGyUgE1oSlqsXl5\ns5ZM\r\n=dN62\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.0": {
+      "name": "pumpify",
+      "version": "2.0.0",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.10.2",
+        "through2": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-ieN9HmpFPt4J4U4qnjN4BxrnqpPPXJyp3qFErxfwBtFOec6ewpIHdS2eu3TkmGW6S+RzFGEOGpm5ih/X/onRPQ==",
+        "shasum": "975519e5a9890ae0fb4724274e3fec97e43a30b6",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 10156,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAV28CRA9TVsSAnZWagAAYL8P/jlOXfgcDE3PPBKHZGHN\nnW+Qx+CP8aZu6s27VjRXTiriBqguLGoWeeBHcYDbBzHxi/apHQJBNRzs3TFK\nA+4YTFIndYaKuQr77s5ZGkUcj//2Xjh+oRjTtn6wyrPFcyd9iJd3QJLxy1kZ\nd4SrftLTkj/VXYhvZpFDGsA3SMR46uBKqao/rElpW8jl1RyDtWC0J3a0KXTJ\nNeCNSTEdXo0b1uaCbERGX74pBZhMsGjQjExxJ9c5XUBn/1a+ZtZgBrQQXmBg\njuptpUAuhVUGaptffLxFGp1l3eSKxnojfwCd1ra1Tubf0nlDo3Q634ORbNbA\nM9ryfzNJPeL0O/FDUFJUNVZFWdmESY24cQaX9wT5+Q6HWkOKoS/JQldm3AsO\n1Q5lg0eSY5mC9oQ6S/yO0fThq7/dNmIHCDyoWyhXeTEH/k/UHuiO83CdkQ9t\nAxr4xOUsf0mHXO58zjlQ6tappSQBJqGSNyAtKTiotWg3q3YF8OIKaF7rFjaT\nkJe++S12qPgRrjcsKIpLm05UPo19G3fyykZJd0yfW+AFIode4vVZ4pHLojdC\nfEliUuoomGQobrO6HwlyvtjorDNVLsrX3mGEFM+BZAnGAgu8KVexVGqoLnDy\nQ1yrekpBeae7HukugbKNgYvIwhecP1GjRC0jBrAANVNel4IhVgJ+PGBebFSM\ncnPd\r\n=FA/v\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.1": {
+      "name": "pumpify",
+      "version": "2.0.1",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      },
+      "devDependencies": {
+        "tape": "^4.10.2",
+        "through2": "^3.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+        "shasum": "abfc7b5a621307c728b551decbbefb51f0e4aa1e",
+        "tarball": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 10208,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdk1pgCRA9TVsSAnZWagAA+J4P/jcN/RwROcN1mJ3+WIrz\nEjyhJHlYc4Z7YFLZkRZr/vql+HH5+29mozjWkGo2Ombz5yZ/ut64j4CbOLxd\nAa4sgfWrJyZAuNbtyIAPusXV8NSXkA9E1OkQG0kwPoYXMtehGt9Lt//NJUzq\nInin4XhlNhugQtUn12HRuWwB3rPnc8G6c9ZXLEAGt839aaohUadCIXjHurAa\nmln96dNA4KmUHSLrsoLrMJld7fH8psdETW8Qf5pAVWvoqcr+ytg12Y1hFt/K\nmBnZH0yZmVgZCOWL27XDeZrwYDCBW3mWIsgvH/OxALGHt7zgMgqRkVsE+rGO\nhbCeFDtArBS1sZQ+F3Upv8jonEi2sXw0i7QADk5Irc1a0TUfoYloqXp46noX\nH23utviojPaBna8qHf35QdGcXMFeQJYC/NWFBJxA8FbCge18pTccTUuoSCbw\n+JMbvn/gHG2MN6624ceZdVUYe0pmF6VZoBAU0rFNG7Okb8qgjmuQP4mXf3M1\nw8/MXgOELO8QS9YoA+S2dPQstWcSjUPzOnd7Ea4IP8e9lfPpL8eG30vGsaJ6\n2VGdFEauftI3raHFbOocrCa3pOhsbVVgECzc9eJpt0BG3e8nFah7cjRJnzOf\nCtELQsPLkp43MC1xHt8HP6+OCIE3sWM6fqTq1riaCnGHzHlF7xEW0G2bNvkb\nS/Y/\r\n=7iau\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-10-01T13:53:38.672Z"
+}

--- a/test/fixtures/registry-mocks/content/querystring-es3.json
+++ b/test/fixtures/registry-mocks/content/querystring-es3.json
@@ -1,0 +1,418 @@
+{
+  "_id": "querystring-es3",
+  "_rev": "8-ebc2dcbf0b2f8329092c102a87a4b2c5",
+  "name": "querystring-es3",
+  "description": "Node's querystring module for all engines. (ES3 compat fork)",
+  "dist-tags": {
+    "latest": "0.2.1",
+    "next": "1.0.0-0"
+  },
+  "versions": {
+    "0.2.0": {
+      "name": "querystring-es3",
+      "id": "querystring-es3",
+      "version": "0.2.0",
+      "description": "Node's querystring module for all engines.",
+      "keywords": [
+        "commonjs",
+        "query",
+        "querystring"
+      ],
+      "author": {
+        "name": "Irakli Gozalishvili",
+        "email": "rfobic@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/Gozala/querystring.git",
+        "web": "https://github.com/Gozala/querystring"
+      },
+      "bugs": {
+        "url": "http://github.com/Gozala/querystring/issues/"
+      },
+      "devDependencies": {
+        "test": "~0.x.0",
+        "phantomify": "~0.x.0",
+        "retape": "~0.x.0",
+        "tape": "~0.1.5"
+      },
+      "engines": {
+        "node": ">=0.4.x"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser && npm run test-tap",
+        "test-browser": "node ./node_modules/phantomify/bin/cmd.js ./test/common-index.js",
+        "test-node": "node ./test/common-index.js",
+        "test-tap": "node ./test/tap-index.js"
+      },
+      "testling": {
+        "files": "test/tap-index.js",
+        "browsers": {
+          "iexplore": [
+            8,
+            9,
+            10
+          ],
+          "chrome": [
+            16,
+            20,
+            25,
+            "canary"
+          ],
+          "firefox": [
+            10,
+            15,
+            16,
+            17,
+            18,
+            "nightly"
+          ],
+          "safari": [
+            5,
+            6
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/Gozala/enchain/License.md"
+        }
+      ],
+      "homepage": "https://github.com/Gozala/querystring",
+      "_id": "querystring-es3@0.2.0",
+      "dist": {
+        "shasum": "c365a08a69c443accfeb3a9deab35e3f0abaa476",
+        "tarball": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "spaintrain",
+        "email": "mc.s.pain.how.er+npm@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "spaintrain",
+          "email": "mc.s.pain.how.er+npm@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1-0": {
+      "name": "querystring-es3",
+      "id": "querystring-es3",
+      "version": "0.2.1-0",
+      "description": "Node's querystring module for all engines. (ES3 compat fork)",
+      "keywords": [
+        "commonjs",
+        "query",
+        "querystring"
+      ],
+      "author": {
+        "name": "Irakli Gozalishvili",
+        "email": "rfobic@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mike-spainhower/querystring.git",
+        "web": "https://github.com/mike-spainhower/querystring"
+      },
+      "bugs": {
+        "url": "http://github.com/mike-spainhower/querystring/issues/"
+      },
+      "devDependencies": {
+        "test": "~0.x.0",
+        "phantomify": "~0.x.0",
+        "retape": "~0.x.0",
+        "tape": "~0.1.5"
+      },
+      "engines": {
+        "node": ">=0.4.x"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser && npm run test-tap",
+        "test-browser": "node ./node_modules/phantomify/bin/cmd.js ./test/common-index.js",
+        "test-node": "node ./test/common-index.js",
+        "test-tap": "node ./test/tap-index.js"
+      },
+      "testling": {
+        "files": "test/tap-index.js",
+        "browsers": {
+          "iexplore": [
+            9,
+            10
+          ],
+          "chrome": [
+            16,
+            20,
+            25,
+            "canary"
+          ],
+          "firefox": [
+            10,
+            15,
+            16,
+            17,
+            18,
+            "nightly"
+          ],
+          "safari": [
+            5,
+            6
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/Gozala/enchain/License.md"
+        }
+      ],
+      "homepage": "https://github.com/mike-spainhower/querystring",
+      "_id": "querystring-es3@0.2.1-0",
+      "_shasum": "bd38cbd701040e7ef66c94a93db4a5b45be39565",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "spaintrain",
+        "email": "mc.s.pain.how.er+npm@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "spaintrain",
+          "email": "mc.s.pain.how.er+npm@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bd38cbd701040e7ef66c94a93db4a5b45be39565",
+        "tarball": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1-0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "querystring-es3",
+      "id": "querystring-es3",
+      "version": "0.2.1",
+      "description": "Node's querystring module for all engines. (ES3 compat fork)",
+      "keywords": [
+        "commonjs",
+        "query",
+        "querystring"
+      ],
+      "author": {
+        "name": "Irakli Gozalishvili",
+        "email": "rfobic@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mike-spainhower/querystring.git",
+        "web": "https://github.com/mike-spainhower/querystring"
+      },
+      "bugs": {
+        "url": "http://github.com/mike-spainhower/querystring/issues/"
+      },
+      "devDependencies": {
+        "test": "~0.x.0",
+        "phantomify": "~0.x.0",
+        "retape": "~0.x.0",
+        "tape": "~0.1.5"
+      },
+      "engines": {
+        "node": ">=0.4.x"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser && npm run test-tap",
+        "test-browser": "node ./node_modules/phantomify/bin/cmd.js ./test/common-index.js",
+        "test-node": "node ./test/common-index.js",
+        "test-tap": "node ./test/tap-index.js"
+      },
+      "testling": {
+        "files": "test/tap-index.js",
+        "browsers": {
+          "iexplore": [
+            9,
+            10
+          ],
+          "chrome": [
+            16,
+            20,
+            25,
+            "canary"
+          ],
+          "firefox": [
+            10,
+            15,
+            16,
+            17,
+            18,
+            "nightly"
+          ],
+          "safari": [
+            5,
+            6
+          ],
+          "opera": [
+            12
+          ]
+        }
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/Gozala/enchain/License.md"
+        }
+      ],
+      "gitHead": "c58e18a37d9970e13a84dcc421ab682c7836fad2",
+      "homepage": "https://github.com/mike-spainhower/querystring",
+      "_id": "querystring-es3@0.2.1",
+      "_shasum": "9ec61f79049875707d69414596fd907a4d711e73",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.10.26",
+      "_npmUser": {
+        "name": "spaintrain",
+        "email": "mc.s.pain.how.er+npm@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "spaintrain",
+          "email": "mc.s.pain.how.er+npm@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9ec61f79049875707d69414596fd907a4d711e73",
+        "tarball": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-0": {
+      "name": "querystring-es3",
+      "id": "querystring-es3",
+      "version": "1.0.0-0",
+      "main": "dist/index.js",
+      "description": "Node API compliant querystring module for all browsers. (ES3 compatible)",
+      "scripts": {
+        "build": "babel src -d dist",
+        "prepare": "npm run build",
+        "prepublish": "npm run build",
+        "test": "npm-run-all build test:*",
+        "test:mocha": "mocha --require babel-register ./test/index.js",
+        "test:zuul": "zuul --no-coverage -- test"
+      },
+      "keywords": [
+        "commonjs",
+        "query",
+        "querystring",
+        "es3"
+      ],
+      "author": {
+        "name": "SpainTrain",
+        "email": "mcspainhower+npm@gmail.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/SpainTrain/querystring-es3.git",
+        "web": "https://github.com/SpainTrain/querystring-es3"
+      },
+      "bugs": {
+        "url": "http://github.com/SpainTrain/querystring-es3/issues/"
+      },
+      "devDependencies": {
+        "assert": "~1.4.1",
+        "babel-cli": "~6.24.0",
+        "babel-preset-es2015": "~6.24.0",
+        "babel-preset-es2016": "~6.22.0",
+        "babel-preset-es2017": "~6.22.0",
+        "babel-preset-es3": "~1.0.1",
+        "babel-register": "~6.24.0",
+        "babelify": "~7.3.0",
+        "browserify": "~14.1.0",
+        "eslint": "~3.13.0",
+        "json3": "~3.3.2",
+        "mocha": "~3.2.0",
+        "npm-run-all": "~4.0.2",
+        "object-inspect": "~1.2.2",
+        "zuul": "~3.11.1",
+        "zuul-ngrok": "~4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "5.0.5"
+      },
+      "gitHead": "76baa10afbbc7a46461c06748e8c1b183802d105",
+      "homepage": "https://github.com/SpainTrain/querystring-es3#readme",
+      "_id": "querystring-es3@1.0.0-0",
+      "_shasum": "ff5ba4d36155be9cf11178ba2ebb1c08ad69d4bb",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "6.10.2",
+      "_npmUser": {
+        "name": "spaintrain",
+        "email": "mc.s.pain.how.er+npm@gmail.com"
+      },
+      "dist": {
+        "shasum": "ff5ba4d36155be9cf11178ba2ebb1c08ad69d4bb",
+        "tarball": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-1.0.0-0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "spaintrain",
+          "email": "mc.s.pain.how.er+npm@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/querystring-es3-1.0.0-0.tgz_1491509385443_0.8288666685111821"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# querystring\n\n[![Build Status](https://secure.travis-ci.org/mike-spainhower/querystring.png)](http://travis-ci.org/mike-spainhower/querystring)\n\n\n[![Browser support](http://ci.testling.com/mike-spainhower/querystring.png)](http://ci.testling.com/mike-spainhower/querystring)\n\n\n\nNode's querystring module for all engines.\n\n## Install ##\n\n    npm install querystring\n\n",
+  "maintainers": [
+    {
+      "name": "spaintrain",
+      "email": "mc.s.pain.how.er+npm@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-04-06T20:09:46.240Z",
+    "created": "2014-02-28T19:12:22.567Z",
+    "0.2.0": "2014-02-28T19:12:22.567Z",
+    "0.2.1-0": "2014-05-15T17:48:35.350Z",
+    "0.2.1": "2014-10-13T19:06:08.473Z",
+    "1.0.0-0": "2017-04-06T20:09:46.240Z"
+  },
+  "homepage": "https://github.com/mike-spainhower/querystring",
+  "keywords": [
+    "commonjs",
+    "query",
+    "querystring"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mike-spainhower/querystring.git",
+    "web": "https://github.com/mike-spainhower/querystring"
+  },
+  "author": {
+    "name": "Irakli Gozalishvili",
+    "email": "rfobic@gmail.com"
+  },
+  "bugs": {
+    "url": "http://github.com/mike-spainhower/querystring/issues/"
+  },
+  "readmeFilename": "Readme.md",
+  "users": {
+    "simplyianm": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/querystring-es3.min.json
+++ b/test/fixtures/registry-mocks/content/querystring-es3.min.json
@@ -1,0 +1,93 @@
+{
+  "name": "querystring-es3",
+  "dist-tags": {
+    "latest": "0.2.1",
+    "next": "1.0.0-0"
+  },
+  "versions": {
+    "0.2.0": {
+      "name": "querystring-es3",
+      "version": "0.2.0",
+      "devDependencies": {
+        "test": "~0.x.0",
+        "phantomify": "~0.x.0",
+        "retape": "~0.x.0",
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "c365a08a69c443accfeb3a9deab35e3f0abaa476",
+        "tarball": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "0.2.1-0": {
+      "name": "querystring-es3",
+      "version": "0.2.1-0",
+      "devDependencies": {
+        "test": "~0.x.0",
+        "phantomify": "~0.x.0",
+        "retape": "~0.x.0",
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "bd38cbd701040e7ef66c94a93db4a5b45be39565",
+        "tarball": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1-0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "0.2.1": {
+      "name": "querystring-es3",
+      "version": "0.2.1",
+      "devDependencies": {
+        "test": "~0.x.0",
+        "phantomify": "~0.x.0",
+        "retape": "~0.x.0",
+        "tape": "~0.1.5"
+      },
+      "dist": {
+        "shasum": "9ec61f79049875707d69414596fd907a4d711e73",
+        "tarball": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "1.0.0-0": {
+      "name": "querystring-es3",
+      "version": "1.0.0-0",
+      "dependencies": {
+        "buffer": "5.0.5"
+      },
+      "devDependencies": {
+        "assert": "~1.4.1",
+        "babel-cli": "~6.24.0",
+        "babel-preset-es2015": "~6.24.0",
+        "babel-preset-es2016": "~6.22.0",
+        "babel-preset-es2017": "~6.22.0",
+        "babel-preset-es3": "~1.0.1",
+        "babel-register": "~6.24.0",
+        "babelify": "~7.3.0",
+        "browserify": "~14.1.0",
+        "eslint": "~3.13.0",
+        "json3": "~3.3.2",
+        "mocha": "~3.2.0",
+        "npm-run-all": "~4.0.2",
+        "object-inspect": "~1.2.2",
+        "zuul": "~3.11.1",
+        "zuul-ngrok": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "ff5ba4d36155be9cf11178ba2ebb1c08ad69d4bb",
+        "tarball": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-1.0.0-0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
+  "modified": "2017-04-06T20:09:46.240Z"
+}

--- a/test/fixtures/registry-mocks/content/querystringify.json
+++ b/test/fixtures/registry-mocks/content/querystringify.json
@@ -1,0 +1,807 @@
+{
+  "_id": "querystringify",
+  "_rev": "29-09cb45477ad13e19b2988c851ddcc4a8",
+  "name": "querystringify",
+  "description": "Querystringify - Small, simple but powerful query string parser.",
+  "dist-tags": {
+    "latest": "2.2.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "querystringify",
+      "version": "0.0.0",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "watch": "mocha --watch --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshift/querystringify"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshift/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshift/querystringify",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "bbb15d7e86737f459aa81965d485b368508922b2",
+      "_id": "querystringify@0.0.0",
+      "_shasum": "1da77087d6e3fff4fbb4dcc432fe634d9121ec37",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1da77087d6e3fff4fbb4dcc432fe634d9121ec37",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "querystringify",
+      "version": "0.0.1",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "watch": "mocha --watch --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/querystringify"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "1720a11fe66fba85f113b750a1b5cf7512dd9f4c",
+      "_id": "querystringify@0.0.1",
+      "_shasum": "893009e744e9f7b51d1c142454512db2c2faccc5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "893009e744e9f7b51d1c142454512db2c2faccc5",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "querystringify",
+      "version": "0.0.2",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "watch": "mocha --watch --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/querystringify"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "12e7a0e6824369276f89fb147b6b7883a390cb22",
+      "_id": "querystringify@0.0.2",
+      "_shasum": "827069d290b3e044c85136985458e6d1bf183aa5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "827069d290b3e044c85136985458e6d1bf183aa5",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "querystringify",
+      "version": "0.0.3",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "watch": "mocha --watch --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/querystringify"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "gitHead": "0e53b2049f1d3390b577283ab913d4825ce67987",
+      "_id": "querystringify@0.0.3",
+      "_shasum": "0c9d36fbf8c7a4f71eb370857763577a63335be7",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0c9d36fbf8c7a4f71eb370857763577a63335be7",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "querystringify",
+      "version": "0.0.4",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/querystringify.git"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.4.x",
+        "pre-commit": "1.1.x"
+      },
+      "gitHead": "b206ebd5928c1f39df68bb89bbd8875675dbcef0",
+      "_id": "querystringify@0.0.4",
+      "_shasum": "0cf7f84f9463ff0ae51c4c4b142d95be37724d9c",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0cf7f84f9463ff0ae51c4c4b142d95be37724d9c",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/querystringify-0.0.4.tgz_1471247528293_0.9502724173944443"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "querystringify",
+      "version": "1.0.0",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/querystringify.git"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "~3.2.0",
+        "pre-commit": "~1.2.0"
+      },
+      "gitHead": "027cfb18f94053604412ef834333374bd3e52d85",
+      "_id": "querystringify@1.0.0",
+      "_shasum": "6286242112c5b712fa654e526652bf6a13ff05cb",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "lpinca",
+          "email": "luigipinca@gmail.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6286242112c5b712fa654e526652bf6a13ff05cb",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/querystringify-1.0.0.tgz_1490037189929_0.4786026736255735"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "querystringify",
+      "version": "2.0.0",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/querystringify.git"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "^2.0.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.1.1",
+        "pre-commit": "^1.2.2"
+      },
+      "gitHead": "020c30fe7691bed7889e6fc7a75b1879c2c58c21",
+      "_id": "querystringify@2.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
+        "shasum": "fa3ed6e68eb15159457c89b37bc6472833195755",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6242,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2JsvCRA9TVsSAnZWagAAbWUP/2FulN+mJeZmHU05T3Ft\nZ+SbWrdlEeyG/Clo6PNbOFiMU/hPt6m1AlST5hhVxHr2FPzoyWSWGyKj5WE6\nXNdA5vkKnT1W2ColgNmfcoSPwoLwklhHnTF1qLid2QoYwGTKiE90xUz3pGws\nJs77blGaDy4NjI55JmPTxpMczNaBnKNHFHYZKoHoPEk6N1eo8RKhvLMQftyo\nrfnqy0ytwNthYkoaap5AT1nxuOv/z3aU8lWIpTliMv4+HmoRUYqBzhdJs0pF\ntabvKqmJ9zUDG2gh5ikOwcKpjML0iIZHQd1duCn+Yeo/0clYnYnzkVFRFWEj\n8k7g2r9BE383PpuBMjJTkxyljQUCbLaUox3GgJMYuQ/KeJJWayWCyAPK5hri\naqGnUVoUiUY+36abKCQ0Mtk29C1egOqvno0Mda82lm9KvZY3A0HojvAuM5Fa\n2Vh+BsmkHeEwaAXwiPYfsVeCWaew1IgvDCswpFcQcMXGTgOBf5bMb++zIfqF\n2VvbiU7YcNz8o/4ryHjVwTnU2lOI+LVkwTxd8FVgSLELqYrAxBKCwIcClfW8\nK4tOZ+yxGZLJ6F3eZ93TKjersLXudzQ91/NMslKEVePuqWwdklT+io/2OZb3\n7X8zCFX1D83lN767OYYIbQVb8GZiV/6Bkrscg8EuP7ETDi3yLM590L6i4Uw5\nLlsh\r\n=gKJD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/querystringify_2.0.0_1524144942625_0.30547538180576495"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.1.0": {
+      "name": "querystringify",
+      "version": "2.1.0",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/querystringify.git"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "^2.1.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2"
+      },
+      "gitHead": "e619535472a7e77312a244402df6dd1f60e365e4",
+      "_id": "querystringify@2.1.0",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+        "shasum": "7ded8dfbf7879dcc60d0a644ac6754b283ad17ef",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6539,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbvfOPCRA9TVsSAnZWagAAK2kP/1Ac90PsW2EsC3ArTJdb\nr0SOVp9dvthN3xuDWGfd4omGcpVoDP1nyw1PDLvnWNuIE+oiBFRGuC4ZBAk8\n0dPYyn2KnBlvjTHW/9nsTJaPUzuKN2uujlrzachbf5M0wI6rksMhN4NiQRUJ\nnJSruPZcbvvcWdoo2A5rH49g28mhrgPYksX7pqHCNF6UhPu07BJiagNZLn5z\nYhZrvmqRKM4z5cGaSP7ILh9yS4q1NES9ah6Zz0J0jOWCB53/9tMlT+B9Pt7B\nW58F0Hz2hcy6V3tCujV8M2QhiDxoATJrzuU9eOe2xvIESO24rfBrQ8VKNZ3m\nFlE83DyfdqdiYpllY229aW8n08S0KjJsllnpfT1wJWQu1Q8tKHiqsAdHagjU\n+Gn7g6gvENEZpjz3WMFhK4sjrzX1fUDcgkUX9jdL5G6S5lyppwzHNIAtIMT7\n7Ml/LZ0K8V9A/xX+DS6UqiTfsBU4s58ksn7M/BWcV4HTH2hOG5nVbnJuu+Ds\nNXCaXI+XUg2cTcmPBd+2BQ3DwsLkXC5Oo2/O7Qj0e+mVogOgMxAPzUXA8h+J\nCzMB9+f9t/QlobaS40VdCVMSnC8GVr+x/eu4tfdQUlilkl4rFV2Z+UFtkv6a\ncZClZ1/60VwfpwK3Dcfh4JUGldL6UNyPdGpIZKJhhuogfUehv/gVJfIgduY9\ntfpC\r\n=ftMQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/querystringify_2.1.0_1539175311144_0.07847184583126476"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.1.1": {
+      "name": "querystringify",
+      "version": "2.1.1",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/querystringify.git"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "^2.1.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2"
+      },
+      "gitHead": "88d23367882db2a3a13bc9fdd823f5018914a1bd",
+      "_id": "querystringify@2.1.1",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+        "shasum": "60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7250,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJckm2aCRA9TVsSAnZWagAA0ooP/1yxW9I7mbvatWOJg9qP\nzLFT+R09VgJsVh4EqM0EtiLuLMOTE01BwhygKaPVmIEHVuSltTE7lgO4h+Sp\nyxE879yZ77XkyQq7MToOgd5mVF9fPW1744Ya8OKGKJmLRAGBJnV+9+7pTJIi\nuq6Vku1TjpENxsT7QnZEUybRkv0/fOn/jncEAtlpyxp9ENE+Qid/wAQOH+yr\nSqPjTobJfXwUCLa8rDHxNrz4Pp1cgmQ2VL/yIuPB0tKrg0JjrqVgsvnop+zb\nU+dgrJxaaFzhccfWqerwm/fpf1CRIK46RBoTi7MFtL9b/10N1xVWq88Lcqd8\nE+ql8uBRr1lsI6mVJoSPTUfBA+A8PPMNMy7wrjcOpbHBJ7DAoR481w9A5KNS\nKUIUceNrYRI904CpdlsBtlvu4JRMB6gUzERXLyP+rq1aLbe1Z0yo9n0KnKgN\nnuCVeVszLPrHyIN9WgCsaCcoaA28Ch8pwVOJ9Bh0rQxZ2tt+jYptNSGZq4pW\nvd1ok664ZqUlhFXR3JfunhoRXVQR+ZN6TbiN3zHq8krlqj5MxNJlpRaAM52t\ndCRtzQojWH4/+zzKJbci5zoBKaiCOxhUu60ki/r0dxjAQ/GjtlkG/fLHleCd\ntBLfVnh1uBVKIV8VmwYSl0lFOP7n4Y2EEjNX6rdcIxVruUgKAfBLz/AILRJl\nU3iw\r\n=isZa\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/querystringify_2.1.1_1553100184933_0.3438038163884982"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.2.0": {
+      "name": "querystringify",
+      "version": "2.2.0",
+      "description": "Querystringify - Small, simple but powerful query string parser.",
+      "main": "index.js",
+      "scripts": {
+        "test": "nyc --reporter=html --reporter=text mocha test.js",
+        "watch": "mocha --watch test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/querystringify.git"
+      },
+      "keywords": [
+        "query",
+        "string",
+        "query-string",
+        "querystring",
+        "qs",
+        "stringify",
+        "parse",
+        "decode",
+        "encode"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/querystringify/issues"
+      },
+      "homepage": "https://github.com/unshiftio/querystringify",
+      "devDependencies": {
+        "assume": "^2.1.0",
+        "coveralls": "^3.1.0",
+        "mocha": "^8.1.1",
+        "nyc": "^15.1.0",
+        "pre-commit": "^1.2.2"
+      },
+      "gitHead": "73db95a504f988dce3f790e174e298ceb2b46a8e",
+      "_id": "querystringify@2.2.0",
+      "_nodeVersion": "14.8.0",
+      "_npmVersion": "6.14.7",
+      "dist": {
+        "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+        "shasum": "3345941b4153cb9d082d8eee4cda2016a9aef7f6",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6959,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfOsoHCRA9TVsSAnZWagAAtxIP/At/yftx2h/UrExRxWj4\npOdwJWa20HOfFynkdFpyVOItXJWp3/Bvg108IjILi1x8eAqCwWpjfe7xXQBh\nFEvyXXrufgW8MNkwvEOMzs9D/d6lE4Ux3v8P7tZeSZX/q0GmAzr4p0C0kqXE\nI+CtkG49K54zOFSAp8Vy//9fxEzSK5VxMSXs5djKQAY+Jhh5NE+wvgEQuSIS\npwRq+g8tNVh15W9DflvD7/SO/McHhz7RYlufOhVtnoK5IkSi1WxALN80G3mx\nI2QCyo/NF54yh9zv5lqhkbGQrgM6JL39iBnEXla2ItkcHMDGIyhd1yJ57sVQ\nLdO4l6sEp6SkWpLztCkW2bDYHvj+0GgvJsNV/mkY34x3J6ncVmo1AQEqIItn\nVcuYmKB3DqOmqO8u4A1V1/eZC73SsTF+nt+U9JV6urWR2xcIyCulw07+QCG9\nY7MOfqbtr9MxssYiw90FZwzMBBPZE32U51m5RN4j9eBia9FaU6z2rxAutWiH\ncnlqVSC1qUJD/6/6hgWSnoqgH687J1ON4AeNjh2ZIK+IIgW7kPu9SkkWCGSR\ngx2mJG2+F+/0KmEg+y0opSSfstfLbNvh/Vy/MM398fNMCM/XLyq7P7FQIt8T\n4TCR9tKUqVCN9OmCMoP5u37LydnOHasjWhzLe9JZ6/Z8/hsR5wopQcWoKHw1\njUVR\r\n=Xtj6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "luigipinca@gmail.com",
+          "name": "lpinca"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "_npmUser": {
+        "name": "lpinca",
+        "email": "luigipinca@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/querystringify_2.2.0_1597688326791_0.55082279140105"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# querystringify\n\n[![Version npm](http://img.shields.io/npm/v/querystringify.svg?style=flat-square)](https://www.npmjs.com/package/querystringify)[![Build Status](http://img.shields.io/travis/unshiftio/querystringify/master.svg?style=flat-square)](https://travis-ci.org/unshiftio/querystringify)[![Dependencies](https://img.shields.io/david/unshiftio/querystringify.svg?style=flat-square)](https://david-dm.org/unshiftio/querystringify)[![Coverage Status](http://img.shields.io/coveralls/unshiftio/querystringify/master.svg?style=flat-square)](https://coveralls.io/r/unshiftio/querystringify?branch=master)\n\nA somewhat JSON compatible interface for query string parsing. This query string\nparser is dumb, don't expect to much from it as it only wants to parse simple\nquery strings. If you want to parse complex, multi level and deeply nested\nquery strings then you should ask your self. WTF am I doing?\n\n## Installation\n\nThis module is released in npm as `querystringify`. It's also compatible with\n`browserify` so it can be used on the server as well as on the client. To\ninstall it simply run the following command from your CLI:\n\n```\nnpm install --save querystringify\n```\n\n## Usage\n\nIn the following examples we assume that you've already required the library as:\n\n```js\n'use strict';\n\nvar qs = require('querystringify');\n```\n\n### qs.parse()\n\nThe parse method transforms a given query string in to an object. Parameters\nwithout values are set to empty strings. It does not care if your query string\nis prefixed with a `?`, a `#`, or not prefixed. It just extracts the parts\nbetween the `=` and `&`:\n\n```js\nqs.parse('?foo=bar');         // { foo: 'bar' }\nqs.parse('#foo=bar');         // { foo: 'bar' }\nqs.parse('foo=bar');          // { foo: 'bar' }\nqs.parse('foo=bar&bar=foo');  // { foo: 'bar', bar: 'foo' }\nqs.parse('foo&bar=foo');      // { foo: '', bar: 'foo' }\n```\n\n### qs.stringify()\n\nThis transforms a given object in to a query string. By default we return the\nquery string without a `?` prefix. If you want to prefix it by default simply\nsupply `true` as second argument. If it should be prefixed by something else\nsimply supply a string with the prefix value as second argument:\n\n```js\nqs.stringify({ foo: bar });       // foo=bar\nqs.stringify({ foo: bar }, true); // ?foo=bar\nqs.stringify({ foo: bar }, '#');  // #foo=bar\nqs.stringify({ foo: '' }, '&');   // &foo=\n```\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "3rdeden"
+    },
+    {
+      "email": "luigipinca@gmail.com",
+      "name": "lpinca"
+    },
+    {
+      "email": "npm@unshift.io",
+      "name": "unshift"
+    },
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "v1"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-17T18:18:49.181Z",
+    "created": "2014-11-03T09:41:59.779Z",
+    "0.0.0": "2014-11-03T09:41:59.779Z",
+    "0.0.1": "2014-11-03T10:08:37.191Z",
+    "0.0.2": "2014-12-16T12:39:56.903Z",
+    "0.0.3": "2015-04-29T14:54:18.503Z",
+    "0.0.4": "2016-08-15T07:52:09.992Z",
+    "1.0.0": "2017-03-20T19:13:10.580Z",
+    "2.0.0": "2018-04-19T13:35:42.728Z",
+    "2.1.0": "2018-10-10T12:41:51.256Z",
+    "2.1.1": "2019-03-20T16:43:05.099Z",
+    "2.2.0": "2020-08-17T18:18:46.969Z"
+  },
+  "homepage": "https://github.com/unshiftio/querystringify",
+  "keywords": [
+    "query",
+    "string",
+    "query-string",
+    "querystring",
+    "qs",
+    "stringify",
+    "parse",
+    "decode",
+    "encode"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unshiftio/querystringify.git"
+  },
+  "author": {
+    "name": "Arnout Kazemier"
+  },
+  "bugs": {
+    "url": "https://github.com/unshiftio/querystringify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "pandao": true,
+    "staydan": true,
+    "shuoshubao": true,
+    "jerrywu12": true,
+    "hugojosefson": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/querystringify.min.json
+++ b/test/fixtures/registry-mocks/content/querystringify.min.json
@@ -1,0 +1,166 @@
+{
+  "name": "querystringify",
+  "dist-tags": {
+    "latest": "2.2.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "querystringify",
+      "version": "0.0.0",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "1da77087d6e3fff4fbb4dcc432fe634d9121ec37",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "querystringify",
+      "version": "0.0.1",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "893009e744e9f7b51d1c142454512db2c2faccc5",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "querystringify",
+      "version": "0.0.2",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "827069d290b3e044c85136985458e6d1bf183aa5",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "querystringify",
+      "version": "0.0.3",
+      "devDependencies": {
+        "assume": "1.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "pre-commit": "1.0.x"
+      },
+      "dist": {
+        "shasum": "0c9d36fbf8c7a4f71eb370857763577a63335be7",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "querystringify",
+      "version": "0.0.4",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.4.x",
+        "pre-commit": "1.1.x"
+      },
+      "dist": {
+        "shasum": "0cf7f84f9463ff0ae51c4c4b142d95be37724d9c",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "querystringify",
+      "version": "1.0.0",
+      "devDependencies": {
+        "assume": "1.4.x",
+        "istanbul": "0.4.x",
+        "mocha": "~3.2.0",
+        "pre-commit": "~1.2.0"
+      },
+      "dist": {
+        "shasum": "6286242112c5b712fa654e526652bf6a13ff05cb",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "querystringify",
+      "version": "2.0.0",
+      "devDependencies": {
+        "assume": "^2.0.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.1.1",
+        "pre-commit": "^1.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
+        "shasum": "fa3ed6e68eb15159457c89b37bc6472833195755",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6242,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2JsvCRA9TVsSAnZWagAAbWUP/2FulN+mJeZmHU05T3Ft\nZ+SbWrdlEeyG/Clo6PNbOFiMU/hPt6m1AlST5hhVxHr2FPzoyWSWGyKj5WE6\nXNdA5vkKnT1W2ColgNmfcoSPwoLwklhHnTF1qLid2QoYwGTKiE90xUz3pGws\nJs77blGaDy4NjI55JmPTxpMczNaBnKNHFHYZKoHoPEk6N1eo8RKhvLMQftyo\nrfnqy0ytwNthYkoaap5AT1nxuOv/z3aU8lWIpTliMv4+HmoRUYqBzhdJs0pF\ntabvKqmJ9zUDG2gh5ikOwcKpjML0iIZHQd1duCn+Yeo/0clYnYnzkVFRFWEj\n8k7g2r9BE383PpuBMjJTkxyljQUCbLaUox3GgJMYuQ/KeJJWayWCyAPK5hri\naqGnUVoUiUY+36abKCQ0Mtk29C1egOqvno0Mda82lm9KvZY3A0HojvAuM5Fa\n2Vh+BsmkHeEwaAXwiPYfsVeCWaew1IgvDCswpFcQcMXGTgOBf5bMb++zIfqF\n2VvbiU7YcNz8o/4ryHjVwTnU2lOI+LVkwTxd8FVgSLELqYrAxBKCwIcClfW8\nK4tOZ+yxGZLJ6F3eZ93TKjersLXudzQ91/NMslKEVePuqWwdklT+io/2OZb3\n7X8zCFX1D83lN767OYYIbQVb8GZiV/6Bkrscg8EuP7ETDi3yLM590L6i4Uw5\nLlsh\r\n=gKJD\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.1.0": {
+      "name": "querystringify",
+      "version": "2.1.0",
+      "devDependencies": {
+        "assume": "^2.1.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+        "shasum": "7ded8dfbf7879dcc60d0a644ac6754b283ad17ef",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6539,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbvfOPCRA9TVsSAnZWagAAK2kP/1Ac90PsW2EsC3ArTJdb\nr0SOVp9dvthN3xuDWGfd4omGcpVoDP1nyw1PDLvnWNuIE+oiBFRGuC4ZBAk8\n0dPYyn2KnBlvjTHW/9nsTJaPUzuKN2uujlrzachbf5M0wI6rksMhN4NiQRUJ\nnJSruPZcbvvcWdoo2A5rH49g28mhrgPYksX7pqHCNF6UhPu07BJiagNZLn5z\nYhZrvmqRKM4z5cGaSP7ILh9yS4q1NES9ah6Zz0J0jOWCB53/9tMlT+B9Pt7B\nW58F0Hz2hcy6V3tCujV8M2QhiDxoATJrzuU9eOe2xvIESO24rfBrQ8VKNZ3m\nFlE83DyfdqdiYpllY229aW8n08S0KjJsllnpfT1wJWQu1Q8tKHiqsAdHagjU\n+Gn7g6gvENEZpjz3WMFhK4sjrzX1fUDcgkUX9jdL5G6S5lyppwzHNIAtIMT7\n7Ml/LZ0K8V9A/xX+DS6UqiTfsBU4s58ksn7M/BWcV4HTH2hOG5nVbnJuu+Ds\nNXCaXI+XUg2cTcmPBd+2BQ3DwsLkXC5Oo2/O7Qj0e+mVogOgMxAPzUXA8h+J\nCzMB9+f9t/QlobaS40VdCVMSnC8GVr+x/eu4tfdQUlilkl4rFV2Z+UFtkv6a\ncZClZ1/60VwfpwK3Dcfh4JUGldL6UNyPdGpIZKJhhuogfUehv/gVJfIgduY9\ntfpC\r\n=ftMQ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.1.1": {
+      "name": "querystringify",
+      "version": "2.1.1",
+      "devDependencies": {
+        "assume": "^2.1.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
+        "shasum": "60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7250,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJckm2aCRA9TVsSAnZWagAA0ooP/1yxW9I7mbvatWOJg9qP\nzLFT+R09VgJsVh4EqM0EtiLuLMOTE01BwhygKaPVmIEHVuSltTE7lgO4h+Sp\nyxE879yZ77XkyQq7MToOgd5mVF9fPW1744Ya8OKGKJmLRAGBJnV+9+7pTJIi\nuq6Vku1TjpENxsT7QnZEUybRkv0/fOn/jncEAtlpyxp9ENE+Qid/wAQOH+yr\nSqPjTobJfXwUCLa8rDHxNrz4Pp1cgmQ2VL/yIuPB0tKrg0JjrqVgsvnop+zb\nU+dgrJxaaFzhccfWqerwm/fpf1CRIK46RBoTi7MFtL9b/10N1xVWq88Lcqd8\nE+ql8uBRr1lsI6mVJoSPTUfBA+A8PPMNMy7wrjcOpbHBJ7DAoR481w9A5KNS\nKUIUceNrYRI904CpdlsBtlvu4JRMB6gUzERXLyP+rq1aLbe1Z0yo9n0KnKgN\nnuCVeVszLPrHyIN9WgCsaCcoaA28Ch8pwVOJ9Bh0rQxZ2tt+jYptNSGZq4pW\nvd1ok664ZqUlhFXR3JfunhoRXVQR+ZN6TbiN3zHq8krlqj5MxNJlpRaAM52t\ndCRtzQojWH4/+zzKJbci5zoBKaiCOxhUu60ki/r0dxjAQ/GjtlkG/fLHleCd\ntBLfVnh1uBVKIV8VmwYSl0lFOP7n4Y2EEjNX6rdcIxVruUgKAfBLz/AILRJl\nU3iw\r\n=isZa\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.2.0": {
+      "name": "querystringify",
+      "version": "2.2.0",
+      "devDependencies": {
+        "assume": "^2.1.0",
+        "coveralls": "^3.1.0",
+        "mocha": "^8.1.1",
+        "nyc": "^15.1.0",
+        "pre-commit": "^1.2.2"
+      },
+      "dist": {
+        "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+        "shasum": "3345941b4153cb9d082d8eee4cda2016a9aef7f6",
+        "tarball": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6959,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfOsoHCRA9TVsSAnZWagAAtxIP/At/yftx2h/UrExRxWj4\npOdwJWa20HOfFynkdFpyVOItXJWp3/Bvg108IjILi1x8eAqCwWpjfe7xXQBh\nFEvyXXrufgW8MNkwvEOMzs9D/d6lE4Ux3v8P7tZeSZX/q0GmAzr4p0C0kqXE\nI+CtkG49K54zOFSAp8Vy//9fxEzSK5VxMSXs5djKQAY+Jhh5NE+wvgEQuSIS\npwRq+g8tNVh15W9DflvD7/SO/McHhz7RYlufOhVtnoK5IkSi1WxALN80G3mx\nI2QCyo/NF54yh9zv5lqhkbGQrgM6JL39iBnEXla2ItkcHMDGIyhd1yJ57sVQ\nLdO4l6sEp6SkWpLztCkW2bDYHvj+0GgvJsNV/mkY34x3J6ncVmo1AQEqIItn\nVcuYmKB3DqOmqO8u4A1V1/eZC73SsTF+nt+U9JV6urWR2xcIyCulw07+QCG9\nY7MOfqbtr9MxssYiw90FZwzMBBPZE32U51m5RN4j9eBia9FaU6z2rxAutWiH\ncnlqVSC1qUJD/6/6hgWSnoqgH687J1ON4AeNjh2ZIK+IIgW7kPu9SkkWCGSR\ngx2mJG2+F+/0KmEg+y0opSSfstfLbNvh/Vy/MM398fNMCM/XLyq7P7FQIt8T\n4TCR9tKUqVCN9OmCMoP5u37LydnOHasjWhzLe9JZ6/Z8/hsR5wopQcWoKHw1\njUVR\r\n=Xtj6\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-08-17T18:18:49.181Z"
+}

--- a/test/fixtures/registry-mocks/content/randomfill.json
+++ b/test/fixtures/registry-mocks/content/randomfill.json
@@ -1,0 +1,349 @@
+{
+  "_id": "randomfill",
+  "_rev": "5-308e8f02d5b61f55097b04a57a8be5cb",
+  "name": "randomfill",
+  "description": "random fill from browserify stand alone",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "randomfill",
+      "version": "1.0.0",
+      "description": "random fill from browserify stand alone",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec",
+        "phantom": "zuul --phantom -- test.js",
+        "local": "zuul --local --no-coverage -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/randombytes.git"
+      },
+      "keywords": [
+        "crypto",
+        "random"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/randombytes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/randombytes",
+      "browser": "browser.js",
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "gitHead": "599aa62dede66ada6ca578513652d177290c4d1b",
+      "_id": "randomfill@1.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-sbiyFeoqJGvLlMIo2NTsXs9xlFyscSE2lk53bM0Nd093TcnQcy83KPGdluArR0lhs5GZLcKkHjZ9MAq7tuWsTA==",
+        "shasum": "bb12982cc577a23e957f1573084b57c1182b94e4",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/randomfill-1.0.0.tgz_1508337666616_0.2894369529094547"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "randomfill",
+      "version": "1.0.1",
+      "description": "random fill from browserify stand alone",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec",
+        "phantom": "zuul --phantom -- test.js",
+        "local": "zuul --local --no-coverage -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/randombytes.git"
+      },
+      "keywords": [
+        "crypto",
+        "random"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/randombytes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/randombytes",
+      "browser": "browser.js",
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "gitHead": "a747b6a4283a45b3e0985f3d6e9e584e44284de7",
+      "_id": "randomfill@1.0.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-k80JBNyUqE9d3+ML+rsGtcQx0MS8OHQaPHIQupVQo8OSrwwei/p55UigT0drIu6Mr2LaQjh0c6Q/eIifOyhH/A==",
+        "shasum": "db03bd8e8810088218e1df2845e8dea64f9bc8ee",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/randomfill-1.0.1.tgz_1508339723599_0.12161199818365276"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "randomfill",
+      "version": "1.0.2",
+      "description": "random fill from browserify stand alone",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec",
+        "phantom": "zuul --phantom -- test.js",
+        "local": "zuul --local --no-coverage -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/randombytes.git"
+      },
+      "keywords": [
+        "crypto",
+        "random"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/randombytes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/randombytes",
+      "browser": "browser.js",
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "gitHead": "75ae4b2d20244c64fff9644cedc8eb8960ad1371",
+      "_id": "randomfill@1.0.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Ufa+fvlA4sMPF2P+dyxsHMZQYKzgNPasWSkK6hIjp0AkzmbbpevGfroRBBuZLmVDDA0UmSax8aV2NlljOJhnuA==",
+        "shasum": "61b1e10311f294e2a4a0b0ced120b33355445458",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/randomfill-1.0.2.tgz_1508341434410_0.16996331932023168"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "randomfill",
+      "version": "1.0.3",
+      "description": "random fill from browserify stand alone",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec",
+        "phantom": "zuul --phantom -- test.js",
+        "local": "zuul --local --no-coverage -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/crypto-browserify/randombytes.git"
+      },
+      "keywords": [
+        "crypto",
+        "random"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/randombytes/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/randombytes",
+      "browser": "browser.js",
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "gitHead": "3e471b7aea4d6e2380c633e7452685d56786570c",
+      "_id": "randomfill@1.0.3",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+        "shasum": "b96b7df587f01dd91726c418f30553b1418e3d62",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/randomfill-1.0.3.tgz_1508342198510_0.7042635742109269"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "randomfill",
+      "version": "1.0.4",
+      "description": "random fill from browserify stand alone",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && node test.js | tspec",
+        "phantom": "zuul --phantom -- test.js",
+        "local": "zuul --local --no-coverage -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/randomfill.git"
+      },
+      "keywords": [
+        "crypto",
+        "random"
+      ],
+      "author": "",
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/randomfill/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/randomfill",
+      "browser": "browser.js",
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "gitHead": "f0c99be53fbb798afc0879cf8dcb13db3a7266f2",
+      "_id": "randomfill@1.0.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "cwmma",
+        "email": "calvin.metcalf@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+        "shasum": "c92196fc86ab42be983f1bf31778224931d61458",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+        "fileCount": 8,
+        "unpackedSize": 6844
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/randomfill_1.0.4_1518786236724_0.926847415068788"
+      }
+    }
+  },
+  "readme": "randomfill\n===\n\n[![Version](http://img.shields.io/npm/v/randomfill.svg)](https://www.npmjs.org/package/randomfill)\n\nrandomfill from node that works in the browser.  In node you just get crypto.randomBytes, but in the browser it uses .crypto/msCrypto.getRandomValues\n\n```js\nvar randomFill = require('randomfill');\nvar buf\nrandomFill.randomFillSync(16);//get 16 random bytes\nrandomFill.randomFill(16, function (err, resp) {\n  // resp is 16 random bytes\n});\n```\n",
+  "maintainers": [
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-02-16T13:03:58.444Z",
+    "created": "2017-10-18T14:41:07.520Z",
+    "1.0.0": "2017-10-18T14:41:07.520Z",
+    "1.0.1": "2017-10-18T15:15:24.473Z",
+    "1.0.2": "2017-10-18T15:43:55.284Z",
+    "1.0.3": "2017-10-18T15:56:39.444Z",
+    "1.0.4": "2018-02-16T13:03:56.771Z"
+  },
+  "homepage": "https://github.com/crypto-browserify/randomfill",
+  "keywords": [
+    "crypto",
+    "random"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/crypto-browserify/randomfill.git"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/randomfill/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/randomfill.min.json
+++ b/test/fixtures/registry-mocks/content/randomfill.min.json
@@ -1,0 +1,111 @@
+{
+  "name": "randomfill",
+  "dist-tags": {
+    "latest": "1.0.4"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "randomfill",
+      "version": "1.0.0",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-sbiyFeoqJGvLlMIo2NTsXs9xlFyscSE2lk53bM0Nd093TcnQcy83KPGdluArR0lhs5GZLcKkHjZ9MAq7tuWsTA==",
+        "shasum": "bb12982cc577a23e957f1573084b57c1182b94e4",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "randomfill",
+      "version": "1.0.1",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-k80JBNyUqE9d3+ML+rsGtcQx0MS8OHQaPHIQupVQo8OSrwwei/p55UigT0drIu6Mr2LaQjh0c6Q/eIifOyhH/A==",
+        "shasum": "db03bd8e8810088218e1df2845e8dea64f9bc8ee",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "randomfill",
+      "version": "1.0.2",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-Ufa+fvlA4sMPF2P+dyxsHMZQYKzgNPasWSkK6hIjp0AkzmbbpevGfroRBBuZLmVDDA0UmSax8aV2NlljOJhnuA==",
+        "shasum": "61b1e10311f294e2a4a0b0ced120b33355445458",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "randomfill",
+      "version": "1.0.3",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
+        "shasum": "b96b7df587f01dd91726c418f30553b1418e3d62",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "randomfill",
+      "version": "1.0.4",
+      "dependencies": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "phantomjs": "^1.9.9",
+        "standard": "^10.0.2",
+        "tap-spec": "^2.1.2",
+        "tape": "^4.6.3",
+        "zuul": "^3.7.2"
+      },
+      "dist": {
+        "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+        "shasum": "c92196fc86ab42be983f1bf31778224931d61458",
+        "tarball": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+        "fileCount": 8,
+        "unpackedSize": 6844
+      }
+    }
+  },
+  "modified": "2018-02-16T13:03:58.444Z"
+}

--- a/test/fixtures/registry-mocks/content/range-parser.json
+++ b/test/fixtures/registry-mocks/content/range-parser.json
@@ -1,0 +1,803 @@
+{
+  "_id": "range-parser",
+  "_rev": "37-b40ccccaf5dbba422755f7105073a391",
+  "name": "range-parser",
+  "description": "Range header field string parser",
+  "dist-tags": {
+    "latest": "1.2.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "0.0.1",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "range-parser@0.0.1",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.24",
+      "_nodeVersion": "v0.6.19",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "dec6a8b9792caaef485e733b75b5b73fc7095770",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "0.0.2",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "range-parser@0.0.2",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.19",
+      "_nodeVersion": "v0.6.16",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "034fafbd8b266f64d8effe8fa638392b2290b288",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "0.0.3",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "range-parser@0.0.3",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.19",
+      "_nodeVersion": "v0.6.16",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "6e6488fb73843bd4bd626797f76b870da9765ae9",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "0.0.4",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "_id": "range-parser@0.0.4",
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.19",
+      "_nodeVersion": "v0.6.16",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "c0427ffef51c10acba0782a46c9602e744ff620b",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "1.0.0",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/node-range-parser.git"
+      },
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/visionmedia/node-range-parser#license"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/visionmedia/node-range-parser/issues"
+      },
+      "_id": "range-parser@1.0.0",
+      "dist": {
+        "shasum": "a4b264cfe0be5ce36abe3765ac9c2a248746dbc0",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "1.0.1",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/range-parser"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1",
+        "should": "2"
+      },
+      "license": "MIT",
+      "scripts": {
+        "test": "mocha --reporter spec --require should",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --require should"
+      },
+      "keywords": [
+        "range",
+        "parser",
+        "http"
+      ],
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "9d84686c20af96aef0941d90cf254b31d6172049",
+      "bugs": {
+        "url": "https://github.com/jshttp/range-parser/issues"
+      },
+      "homepage": "https://github.com/jshttp/range-parser",
+      "_id": "range-parser@1.0.1",
+      "_shasum": "f9da15b7451fe1b261959b63342dd92921d34da2",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f9da15b7451fe1b261959b63342dd92921d34da2",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "1.0.2",
+      "license": "MIT",
+      "keywords": [
+        "range",
+        "parser",
+        "http"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/range-parser"
+      },
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1",
+        "should": "2"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --require should"
+      },
+      "gitHead": "ae23b02ce705b56e7f7c48e832d41fa710227ecc",
+      "bugs": {
+        "url": "https://github.com/jshttp/range-parser/issues"
+      },
+      "homepage": "https://github.com/jshttp/range-parser",
+      "_id": "range-parser@1.0.2",
+      "_shasum": "06a12a42e5131ba8e457cd892044867f2344e549",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "06a12a42e5131ba8e457cd892044867f2344e549",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "1.0.3",
+      "license": "MIT",
+      "keywords": [
+        "range",
+        "parser",
+        "http"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/range-parser"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.0",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "gitHead": "18e46a3de74afff9f4e22717f11ddd6e9aa6d845",
+      "bugs": {
+        "url": "https://github.com/jshttp/range-parser/issues"
+      },
+      "homepage": "https://github.com/jshttp/range-parser",
+      "_id": "range-parser@1.0.3",
+      "_shasum": "6872823535c692e2c2a0103826afd82c2e0ff175",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6872823535c692e2c2a0103826afd82c2e0ff175",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "1.1.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "range",
+        "parser",
+        "http"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/range-parser"
+      },
+      "devDependencies": {
+        "eslint": "2.9.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "gitHead": "82089bc84646dc4165985f77798e91d3afc97f3c",
+      "bugs": {
+        "url": "https://github.com/jshttp/range-parser/issues"
+      },
+      "homepage": "https://github.com/jshttp/range-parser",
+      "_id": "range-parser@1.1.0",
+      "_shasum": "425c2c5bf8b159d89513fe55f26c29d07b88512b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "425c2c5bf8b159d89513fe55f26c29d07b88512b",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/range-parser-1.1.0.tgz_1463166914433_0.4869228946045041"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "1.2.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "wyatt.cready@lanetix.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "range",
+        "parser",
+        "http"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/range-parser"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot"
+      },
+      "gitHead": "0665aca31639d799dee1d35fb10970799559ec48",
+      "bugs": {
+        "url": "https://github.com/jshttp/range-parser/issues"
+      },
+      "homepage": "https://github.com/jshttp/range-parser",
+      "_id": "range-parser@1.2.0",
+      "_shasum": "f49be6b487894ddc40dcc94a322f611092e00d5e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jonathanong",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "f49be6b487894ddc40dcc94a322f611092e00d5e",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/range-parser-1.2.0.tgz_1464803293097_0.6830497414339334"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "range-parser",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca",
+        "url": "http://tjholowaychuk.com"
+      },
+      "description": "Range header field string parser",
+      "version": "1.2.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "wyatt.cready@lanetix.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "keywords": [
+        "range",
+        "parser",
+        "http"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/range-parser.git"
+      },
+      "devDependencies": {
+        "deep-equal": "1.0.1",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.1.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "gitHead": "0f56ff8d4b579599f9f225f0a19f4ef1628c585f",
+      "bugs": {
+        "url": "https://github.com/jshttp/range-parser/issues"
+      },
+      "homepage": "https://github.com/jshttp/range-parser#readme",
+      "_id": "range-parser@1.2.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+        "shasum": "3cf37023d199e1c24d1a55b84800c2f3e6468031",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8457,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1hb6CRA9TVsSAnZWagAA6MIP/2aFx73ToT5iGRN0mgZw\nLy7BEmRQkblBxo81k9Cvjt8jucfv/PtDUllITbke596JI/jHnb5oU5XV5Fzd\nK1WklG8rJC9z1y9iEaEe4pRcnvkPvkHtFMmPcYS9dm5XQyYw9fYcApRl/6zH\neuV/1CtwzQnCCErvfmolfSQ13v1d4LyWwrMRcG79uOGYBm8XSuTb3fKrEbBj\n3Gms6SQA2mC5ntKrf6VQRXzWvGIvWp2Q3RGFkgI1fnEPFfq7DbNqvHiD+KV4\nXV2wOD6B8pBlpbpSdNMHfUBSVSMHqFv9rOJqJumBAEZeUcwQzO06/2kUw5/f\nWCaFTHYTMCvSNX9qg71EoRZuuvNS0E53quFagdmTxq2vf04vz01PgRc5G64m\nTlz07gVHos3CQ9fU4NP0Aim1rtgOLJj15IF+z/kSSQoQZ6DhW5aTs8zCa3AS\nk4xWFafBuzyG1ApCSJrRCsqzY+oRqHPyTSZx5fBv75qZIEKe4moBpJ6EkaqZ\nRc6EqCpJjwOZVOssoPN3RiP+f/g43ytkVmUoYSXTs2bpkwNQUJShg2ItsT55\nkxkfZx8YbNxkFKp8S/uwUGQjbmXXspWozrkKNHikpzWMgDmuj9k2fx3LPo0c\nDSEq295fDQlKdxcfuGpOkH1PSzMHuIef26IGNDjMlOyBSY2FrQJaxpYtpQYq\nw1FC\r\n=GGKV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jonathanong"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "tj@vision-media.ca",
+          "name": "tjholowaychuk"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/range-parser_1.2.1_1557534457659_0.5973624508825055"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# range-parser\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-image]][node-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nRange header field parser.\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install range-parser\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar parseRange = require('range-parser')\n```\n\n### parseRange(size, header, options)\n\nParse the given `header` string where `size` is the maximum size of the resource.\nAn array of ranges will be returned or negative numbers indicating an error parsing.\n\n  * `-2` signals a malformed header string\n  * `-1` signals an unsatisfiable range\n\n<!-- eslint-disable no-undef -->\n\n```js\n// parse header from request\nvar range = parseRange(size, req.headers.range)\n\n// the type of the range\nif (range.type === 'bytes') {\n  // the ranges\n  range.forEach(function (r) {\n    // do something with r.start and r.end\n  })\n}\n```\n\n#### Options\n\nThese properties are accepted in the options object.\n\n##### combine\n\nSpecifies if overlapping & adjacent ranges should be combined, defaults to `false`.\nWhen `true`, ranges will be combined and returned as if they were specified that\nway in the header.\n\n<!-- eslint-disable no-undef -->\n\n```js\nparseRange(100, 'bytes=50-55,0-10,5-10,56-60', { combine: true })\n// => [\n//      { start: 0,  end: 10 },\n//      { start: 50, end: 60 }\n//    ]\n```\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/range-parser/master\n[coveralls-url]: https://coveralls.io/r/jshttp/range-parser?branch=master\n[node-image]: https://badgen.net/npm/node/range-parser\n[node-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/range-parser\n[npm-url]: https://npmjs.org/package/range-parser\n[npm-version-image]: https://badgen.net/npm/v/range-parser\n[travis-image]: https://badgen.net/travis/jshttp/range-parser/master\n[travis-url]: https://travis-ci.org/jshttp/range-parser\n",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jonathanong"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    },
+    {
+      "email": "tj@vision-media.ca",
+      "name": "tjholowaychuk"
+    }
+  ],
+  "time": {
+    "modified": "2019-05-11T00:27:40.264Z",
+    "created": "2012-06-11T16:08:20.957Z",
+    "0.0.1": "2012-06-11T16:08:22.373Z",
+    "0.0.2": "2012-06-18T00:15:02.069Z",
+    "0.0.3": "2012-06-18T00:28:29.754Z",
+    "0.0.4": "2012-06-18T00:56:34.968Z",
+    "1.0.0": "2013-12-11T20:35:49.123Z",
+    "1.0.1": "2014-09-08T01:00:41.796Z",
+    "1.0.2": "2014-09-09T02:45:20.606Z",
+    "1.0.3": "2015-10-29T23:12:00.478Z",
+    "1.1.0": "2016-05-13T19:15:16.506Z",
+    "1.2.0": "2016-06-01T17:48:14.367Z",
+    "1.2.1": "2019-05-11T00:27:37.805Z"
+  },
+  "author": {
+    "name": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca",
+    "url": "http://tjholowaychuk.com"
+  },
+  "users": {
+    "m42am": true,
+    "abdul": true,
+    "simplyianm": true,
+    "shavyg2": true,
+    "glebec": true,
+    "mojaray2k": true,
+    "gpuente": true,
+    "hualei": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/range-parser.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/range-parser/issues"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jshttp/range-parser#readme",
+  "keywords": [
+    "range",
+    "parser",
+    "http"
+  ],
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "James Wyatt Cready",
+      "email": "wyatt.cready@lanetix.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/range-parser.min.json
+++ b/test/fixtures/registry-mocks/content/range-parser.min.json
@@ -1,0 +1,190 @@
+{
+  "name": "range-parser",
+  "dist-tags": {
+    "latest": "1.2.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "range-parser",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "dec6a8b9792caaef485e733b75b5b73fc7095770",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.2": {
+      "name": "range-parser",
+      "version": "0.0.2",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "034fafbd8b266f64d8effe8fa638392b2290b288",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.3": {
+      "name": "range-parser",
+      "version": "0.0.3",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "6e6488fb73843bd4bd626797f76b870da9765ae9",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.4": {
+      "name": "range-parser",
+      "version": "0.0.4",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "c0427ffef51c10acba0782a46c9602e744ff620b",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.0": {
+      "name": "range-parser",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "a4b264cfe0be5ce36abe3765ac9c2a248746dbc0",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "range-parser",
+      "version": "1.0.1",
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1",
+        "should": "2"
+      },
+      "dist": {
+        "shasum": "f9da15b7451fe1b261959b63342dd92921d34da2",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "range-parser",
+      "version": "1.0.2",
+      "devDependencies": {
+        "istanbul": "0",
+        "mocha": "1",
+        "should": "2"
+      },
+      "dist": {
+        "shasum": "06a12a42e5131ba8e457cd892044867f2344e549",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.0.3": {
+      "name": "range-parser",
+      "version": "1.0.3",
+      "devDependencies": {
+        "istanbul": "0.4.0",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "6872823535c692e2c2a0103826afd82c2e0ff175",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.1.0": {
+      "name": "range-parser",
+      "version": "1.1.0",
+      "devDependencies": {
+        "eslint": "2.9.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "425c2c5bf8b159d89513fe55f26c29d07b88512b",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.0": {
+      "name": "range-parser",
+      "version": "1.2.0",
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "f49be6b487894ddc40dcc94a322f611092e00d5e",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.2.1": {
+      "name": "range-parser",
+      "version": "1.2.1",
+      "devDependencies": {
+        "deep-equal": "1.0.1",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+        "shasum": "3cf37023d199e1c24d1a55b84800c2f3e6468031",
+        "tarball": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 8457,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1hb6CRA9TVsSAnZWagAA6MIP/2aFx73ToT5iGRN0mgZw\nLy7BEmRQkblBxo81k9Cvjt8jucfv/PtDUllITbke596JI/jHnb5oU5XV5Fzd\nK1WklG8rJC9z1y9iEaEe4pRcnvkPvkHtFMmPcYS9dm5XQyYw9fYcApRl/6zH\neuV/1CtwzQnCCErvfmolfSQ13v1d4LyWwrMRcG79uOGYBm8XSuTb3fKrEbBj\n3Gms6SQA2mC5ntKrf6VQRXzWvGIvWp2Q3RGFkgI1fnEPFfq7DbNqvHiD+KV4\nXV2wOD6B8pBlpbpSdNMHfUBSVSMHqFv9rOJqJumBAEZeUcwQzO06/2kUw5/f\nWCaFTHYTMCvSNX9qg71EoRZuuvNS0E53quFagdmTxq2vf04vz01PgRc5G64m\nTlz07gVHos3CQ9fU4NP0Aim1rtgOLJj15IF+z/kSSQoQZ6DhW5aTs8zCa3AS\nk4xWFafBuzyG1ApCSJrRCsqzY+oRqHPyTSZx5fBv75qZIEKe4moBpJ6EkaqZ\nRc6EqCpJjwOZVOssoPN3RiP+f/g43ytkVmUoYSXTs2bpkwNQUJShg2ItsT55\nkxkfZx8YbNxkFKp8S/uwUGQjbmXXspWozrkKNHikpzWMgDmuj9k2fx3LPo0c\nDSEq295fDQlKdxcfuGpOkH1PSzMHuIef26IGNDjMlOyBSY2FrQJaxpYtpQYq\nw1FC\r\n=GGKV\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2019-05-11T00:27:40.264Z"
+}

--- a/test/fixtures/registry-mocks/content/raw-body.json
+++ b/test/fixtures/registry-mocks/content/raw-body.json
@@ -1,0 +1,3091 @@
+{
+  "_id": "raw-body",
+  "_rev": "96-8d264044ea23269d2222572bfbcc080a",
+  "name": "raw-body",
+  "description": "Get and validate the raw body of a readable stream.",
+  "dist-tags": {
+    "latest": "2.4.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "0.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonathanong/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonathanong/raw-body/issues"
+      },
+      "devDependencies": {
+        "mocha": "~1.12"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "_id": "raw-body@0.0.1",
+      "dist": {
+        "shasum": "5fdd13390c80a4ac185423e7b7bd10b5b789adb1",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "0.0.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonathanong/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonathanong/raw-body/issues"
+      },
+      "devDependencies": {
+        "mocha": "~1.12"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "_id": "raw-body@0.0.2",
+      "dist": {
+        "shasum": "319164ced50f628676fc0dd6a381cd52041a337c",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "0.0.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "devDependencies": {
+        "mocha": "~1.12"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "_id": "raw-body@0.0.3",
+      "dist": {
+        "shasum": "0cb3eb22ced1ca607d32dd8fd94a6eb383f3eb8a",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@0.1.0",
+      "dist": {
+        "shasum": "6526df32068353d5c3e9d09cdbc5efda59b4a479",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.13",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "0.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@0.1.1",
+      "dist": {
+        "shasum": "320ec72bea7f602b4ed71c044bc0c88eb1124051",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "0.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@0.2.0",
+      "dist": {
+        "shasum": "e77884ce593be387f8d36cb97d37c2e2e9a818ae",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.0.0",
+      "dist": {
+        "shasum": "a2ebd450b9d2833b73b110064f032b1a8109509f",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.0.1",
+      "dist": {
+        "shasum": "946c23ce4716180e5bdc94ae402b0d398aeb6c86",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "2",
+        "gnode": "~0.0.4",
+        "mocha": "~1.14.0",
+        "through": "~2.3.4",
+        "request": "~2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test && node ./test/acceptance.js"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.1.0",
+      "dist": {
+        "shasum": "0a86c4864cc0773ba93ee31d102aa62b61fc818e",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "2",
+        "gnode": "~0.0.4",
+        "mocha": "~1.14.0",
+        "through": "~2.3.4",
+        "request": "~2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test && node ./test/acceptance.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "_id": "raw-body@1.1.1",
+      "dist": {
+        "shasum": "915917d78595f7fc4c391c6563aef69b740cb960",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.1.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "2",
+        "gnode": "~0.0.4",
+        "mocha": "~1.14.0",
+        "through": "~2.3.4",
+        "request": "~2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test && node ./test/acceptance.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.1.2",
+      "dist": {
+        "shasum": "c74b3004dea5defd1696171106ac740ec31d62be",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.1.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "3",
+        "gnode": "~0.0.4",
+        "mocha": "^1.14.0",
+        "through2": "~0.4.1",
+        "request": "^2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test && node ./test/acceptance.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.1.3",
+      "dist": {
+        "shasum": "3d2f91e2449259cc67b8c3ce9f061db5b987935b",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.1.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "~0.3.0"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "3",
+        "gnode": "~0.0.4",
+        "mocha": "^1.14.0",
+        "through2": "~0.4.1",
+        "request": "^2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test && node ./test/acceptance.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.1.4",
+      "dist": {
+        "shasum": "f0b5624388d031f63da07f870c86cb9ccadcb67d",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.1.5",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "3",
+        "gnode": "~0.0.4",
+        "mocha": "^1.14.0",
+        "through2": "~0.4.1",
+        "request": "^2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test && node ./test/acceptance.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.1.5",
+      "_shasum": "a54b735c205f0876d4b2428543ac9555d39eba73",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a54b735c205f0876d4b2428543ac9555d39eba73",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.6": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.1.6",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body.git"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "dependencies": {
+        "bytes": "1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "3",
+        "gnode": "~0.0.4",
+        "mocha": "^1.14.0",
+        "through2": "~0.4.1",
+        "request": "^2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "scripts": {
+        "test": "NODE=gnode make test && node ./test/acceptance.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.1.6",
+      "dist": {
+        "shasum": "98e9df9a7e2df994931b7cdb4b2a6b9694a74f02",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.7": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.1.7",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1",
+        "string_decoder": "0.10"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "request": ">= 2.36.0 < 3",
+        "through2": "~0.4.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "gitHead": "8c594465290b09de925deb6fca17de9046b6d601",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.1.7",
+      "_shasum": "1d027c2bfa116acc6623bca8f00016572a87d425",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1d027c2bfa116acc6623bca8f00016572a87d425",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "request": ">= 2.36.0 < 3",
+        "through2": "~0.4.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.2.0",
+      "dist": {
+        "shasum": "523e605803f9551a4314268ea6defd2b396c16a4",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.2.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "request": ">= 2.36.0 < 3",
+        "through2": "~0.5.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.2.1",
+      "dist": {
+        "shasum": "3ff628df74ee2ad3632a061d3cd19698b1e23d5a",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.2.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "request": ">= 2.36.0 < 3",
+        "through2": "~0.5.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.2.2",
+      "dist": {
+        "shasum": "0c68e1ee28cfed7dba4822234aec6078461cbc1f",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.2.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "through2": "~0.5.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.2.3",
+      "dist": {
+        "shasum": "af497b1f1bb5ce77e20855ab9244f87eaa9220d6",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.3.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "through2": "~0.5.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.3.0",
+      "dist": {
+        "shasum": "978230a156a5548f42eef14de22d0f4f610083d1",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.3.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.1",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "gitHead": "ab2621145bf74d3966947e60c9ae60bd1ee89336",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.3.1",
+      "_shasum": "26a1491059086fd121942232d16758cd2817f815",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "26a1491059086fd121942232d16758cd2817f815",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.3.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "iconv-lite": "0.4.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "gitHead": "8a5d04462f753f106eaaa762af552e5303a2c26e",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.3.2",
+      "_shasum": "0e186f27c5fbfe326d8b3062774804564a0ecf93",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0e186f27c5fbfe326d8b3062774804564a0ecf93",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.3": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.3.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "iconv-lite": "0.4.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "gitHead": "54a27e595f513e03007be907dca4e7e57c88257f",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.3.3",
+      "_shasum": "8841af3f64ad50a351dc77f229118b40c28fa58c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8841af3f64ad50a351dc77f229118b40c28fa58c",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.4": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "1.3.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "1.0.0",
+        "iconv-lite": "0.4.8"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "gitHead": "cb1e3ed184c07198085cd59278ad93c6787ceb22",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@1.3.4",
+      "_shasum": "ccc7ddfc46b72861cdd5bb433c840b70b6f27f54",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ccc7ddfc46b72861cdd5bb433c840b70b6f27f54",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.0.1",
+        "iconv-lite": "0.4.8"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.25",
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "gitHead": "1470b16f8edb8bcdf3b42db1470308aa10cac0c2",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.0.0",
+      "_shasum": "86ec5cb5863b82e6a57d3a5b442ddae8563d6dc5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "86ec5cb5863b82e6a57d3a5b442ddae8563d6dc5",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.0.1",
+        "iconv-lite": "0.4.8"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.25",
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "cae2af49f382f75994c6251e31692d5eabbb4b8f",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.0.1",
+      "_shasum": "2b70a3ffd1681c0521bae73454e0ccbc785d378e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2b70a3ffd1681c0521bae73454e0ccbc785d378e",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.0.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.8"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.25",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "529a371f138c6f236256fe7c7e3bfac7ee836a59",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.0.2",
+      "_shasum": "a2c2f98c8531cee99c63d8d238b7de97bb659fca",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a2c2f98c8531cee99c63d8d238b7de97bb659fca",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.10"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.26",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d7b04ba7a03d6294a1b477e93cccca62419b0401",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.1.0",
+      "_shasum": "8091f844de4380cbd2a7ef457d57091161d4af18",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8091f844de4380cbd2a7ef457d57091161d4af18",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.10",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.30",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.0",
+        "through2": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "7d0808bfcda9ec8a435db3cead98005cfff5759c",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.1.1",
+      "_shasum": "9b6378223aa2e2ef41348bae55264e44f2850417",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9b6378223aa2e2ef41348bae55264e44f2850417",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.2": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.1.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.11",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.32",
+        "istanbul": "0.3.17",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.1",
+        "through2": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "a0490f86b259038c85e99097cade70ee78aa5e1e",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.1.2",
+      "_shasum": "63481a805ba30ed7d59ad4433b20eb850f95e887",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "63481a805ba30ed7d59ad4433b20eb850f95e887",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.3": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.1.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.11",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "2.10.0",
+        "istanbul": "0.3.19",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.2",
+        "through2": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "26388be8e9a5792f8e63d544e90e574302de80eb",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.1.3",
+      "_shasum": "3b3fd88599d7e361b37d4f2bb11edc9d28c647f5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3b3fd88599d7e361b37d4f2bb11edc9d28c647f5",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.4": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.1.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.12",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "2.10.1",
+        "istanbul": "0.3.21",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.2",
+        "through2": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "66f380f89b1975b3e6c670faa8ebdb67919652ee",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.1.4",
+      "_shasum": "dcc3afe2e1fdfc620a812376f8e0fc3d2e62cb50",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dcc3afe2e1fdfc620a812376f8e0fc3d2e62cb50",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.5": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.1.5",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.2.0",
+        "iconv-lite": "0.4.13",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.0.5",
+        "istanbul": "0.4.1",
+        "mocha": "2.3.4",
+        "readable-stream": "2.0.4",
+        "through2": "2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0467d63d4e66c212ec08bfc826ba565be15c523a",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.1.5",
+      "_shasum": "8be8f09ddefd0d72ad99d883ab7f0cc350420956",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8be8f09ddefd0d72ad99d883ab7f0cc350420956",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.6": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.1.6",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/raw-body"
+      },
+      "dependencies": {
+        "bytes": "2.3.0",
+        "iconv-lite": "0.4.13",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.3.4",
+        "istanbul": "0.4.2",
+        "mocha": "2.4.5",
+        "readable-stream": "2.0.5",
+        "through2": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f4ec2a5f6e9573c1ed126111b831c246b6ca580e",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body",
+      "_id": "raw-body@2.1.6",
+      "_shasum": "9c050737fe07ced6d94a4fd09c61b6ad874d310f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9c050737fe07ced6d94a4fd09c61b6ad874d310f",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/raw-body-2.1.6.tgz_1457406406626_0.1825208596419543"
+      },
+      "directories": {}
+    },
+    "2.1.7": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.1.7",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stream-utils/raw-body.git"
+      },
+      "dependencies": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.13",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.4.1",
+        "eslint": "2.13.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "through2": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "9d13a27048cc97958fc14fc12418c6aa76f0b1f9",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body#readme",
+      "_id": "raw-body@2.1.7",
+      "_shasum": "adfeace2e4fb3098058014d08c072dcc59758774",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "adfeace2e4fb3098058014d08c072dcc59758774",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/raw-body-2.1.7.tgz_1466363663010_0.38383363327011466"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stream-utils/raw-body.git"
+      },
+      "dependencies": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.4.7",
+        "eslint": "3.12.2",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "through2": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "02fac48ae40b8452629bcd310d19dbea543f7c3c",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body#readme",
+      "_id": "raw-body@2.2.0",
+      "_shasum": "994976cf6a5096a41162840492f0bdc5d6e7fb96",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "994976cf6a5096a41162840492f0bdc5d6e7fb96",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/raw-body-2.2.0.tgz_1483409502596_0.06903165532276034"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.3.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stream-utils/raw-body.git"
+      },
+      "dependencies": {
+        "bytes": "2.5.0",
+        "http-errors": "1.6.1",
+        "iconv-lite": "0.4.18",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.0",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.d.ts",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "f03b382601d123cac4d39a757586d56cb47d4882",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body#readme",
+      "_id": "raw-body@2.3.0",
+      "_shasum": "f79ce1acacaba5b6362d33454d785d7129f4bc67",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "f79ce1acacaba5b6362d33454d785d7129f4bc67",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/raw-body-2.3.0.tgz_1501902537444_0.793671916006133"
+      },
+      "directories": {}
+    },
+    "2.3.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.3.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stream-utils/raw-body.git"
+      },
+      "dependencies": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.18",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.0",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.d.ts",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "57a675fb7ba80539d2119d0ea95edc94c61d2fb3",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body#readme",
+      "_id": "raw-body@2.3.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-sxkd1uqaSj41SG5Vet9sNAxBMCMsmZ3LVhRkDlK8SbCpelTUB7JiMGHG70AZS6cFiCRgfNQhU2eLnTHYRFf7LA==",
+        "shasum": "30f95e2a67a14e2e4413d8d51fdd92c877e8f2ed",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/raw-body-2.3.1.tgz_1504840921033_0.39329306967556477"
+      },
+      "directories": {}
+    },
+    "2.3.2": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.3.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stream-utils/raw-body.git"
+      },
+      "dependencies": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.0",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.d.ts",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "3093b95b4ab376dc3b28ce0e5102d2c7ab694533",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body#readme",
+      "_id": "raw-body@2.3.2",
+      "_shasum": "bcd60c77d3eb93cde0050295c3f379389bc88f89",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "bcd60c77d3eb93cde0050295c3f379389bc88f89",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/raw-body-2.3.2.tgz_1505019564808_0.33962342143058777"
+      },
+      "directories": {}
+    },
+    "2.3.3": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.3.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stream-utils/raw-body.git"
+      },
+      "dependencies": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.1",
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.11.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.7.0",
+        "eslint-plugin-standard": "3.1.0",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.d.ts",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "c7a9b0a0012e96975bc6a380ef0e26fbf58e4c4e",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body#readme",
+      "_id": "raw-body@2.3.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+        "shasum": "1b324ece6b5706e153855bc1148c65bb7f6ea0c3",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22411,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa8cS5CRA9TVsSAnZWagAAR48P/2RtvIAfwrPtyGIJAnrt\nJOSPTZaj3zQd0Ort5qbS+gNU1fyjbMtetTPAFt3Aw2BeAN8z7CeDfUkfg8BM\nhUkD1P1f2nwM9TEQzq39mdB9s1TrDiFobaLuLasZ1uFU2lb/X8LkXshrK3up\n+edfrVl552xoLkipHSwRB3X90F8JJHvOq7crw5PphMzMDYlpW9hzZwA0L6n+\ni1CCqTOOD+ER0ntZNoQmEjZGueK/aelOyTpAw4MLfZcure3ALwB5xiRVO/wY\neaVmpLJW6fAIJOH9MQcQ6k/il6HHplG+rG4Tk4tA4m9/5nlw/HxTu+Icb6bG\nfHnriKNW2qi32WtUHQbgg5SQaFIvLS6VA2up0xVXml+9tnQj+G0Z9SBlHpuj\nOyO3VsIQONB0yqu5Owb+X6Y6d+TM5FiofPT0XpIyM0Zn2GUYqtKU8XRUmreT\nrZAIOdXw0mGtQ2GcOMGHBapOBlHrE1YrjX68/f+4vmdNKj1sFUZaeoG5vu46\naYKIuzVV2Y6qf0GhTVRF1yaYMNTADM25WMm/+arTnmVHfer2keYLdViZwC3A\nEhu1489+RNCTpcw65RA8RaO8BfIM2xep0v2GbwNiwh3majiEvmLgV3z7PlwL\nOQG/HoamXgql/E6Q4LVBxPQ8fQzbWnSQr10M1dl6cabayDSc6w8dBvQDEWcD\nnJh6\r\n=LAnA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/raw-body_2.3.3_1525793976291_0.41085437495863264"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.0": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.4.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stream-utils/raw-body.git"
+      },
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.4",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.3",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "bf4f3d1ef5d7277233f08f31d52a5ff36337d573",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body#readme",
+      "_id": "raw-body@2.4.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.15.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+        "shasum": "a1ce6fb9c9bc356ca52e89256ab59059e13d0332",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22692,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJct+Q2CRA9TVsSAnZWagAA+AUP/j/tdf22dLOY3EdroYrl\n3uSn8SGTFCLW4Cn/c+tPggviFnSSxRTHADnDc72FLgOEf7Knz/VvW3dvkd4w\nemFCj9AuAO2zhc8BXYiJqAlQivL99dLM21OfBfn/QlLm+AM6dJgqQBp83lTs\nomzh8iu73RqjLKmAGwIXiGlubwq7FgXdEExZWwGIFFZaMw51PxG2knmtp0Wg\nJrbCvsoymvrhjkxDR7yLCdSb/2Z8FfgAFYuxSIMKAQjBQlb+CAbcImt+b4Jp\n5mGakb6XY8cz9+EhPxeodjBNcWiNt2TXt8rbbT1Zvwwdu8+GG76RyKSAChZP\nkVNAX77XWgiCVtpyIwXn729l42x6J+WL6jEjFjflP8pjPstgwbT9R9LL/xai\nn+XcPpUxJ/6ryyeS+cEZbYI371pAWMWt0LfFhJ2HJkEV1Ur5+lAqnI9JKHIu\nDZ1fsrivXULtTYAFjPSBPDl4SGblS6P88//kSWYkQfPgGMe/yGJorhmcexeM\nDb/kRxKUTi/j8ZIMNLcBvMtWs1xVkKIRdy03i0n1PCQB0d3mBseFMN4z9mfI\nn7yWVc8HluRSIjsLZBUrWipJ7UvTC+XQn+x0mP2cVXu4KTag5/727Yy225ms\nrx80AKAZJ9IqyFbGOKGAul1rsQwcrmrakko0+rzmrXyhKa2QUL9BOfSvme+Q\nY5u7\r\n=0DCd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/raw-body_2.4.0_1555555382269_0.543352115642082"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.4.1": {
+      "name": "raw-body",
+      "description": "Get and validate the raw body of a readable stream.",
+      "version": "2.4.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Raynos",
+          "email": "raynos2@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/stream-utils/raw-body.git"
+      },
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.3",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.5",
+        "eslint": "6.0.1",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.18.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "9.1.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --trace-deprecation --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --trace-deprecation --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --trace-deprecation --reporter spec --check-leaks test/"
+      },
+      "gitHead": "0e1291f1d6cbc9ee8e16f893d091e417841c95e5",
+      "bugs": {
+        "url": "https://github.com/stream-utils/raw-body/issues"
+      },
+      "homepage": "https://github.com/stream-utils/raw-body#readme",
+      "_id": "raw-body@2.4.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+        "shasum": "30ac82f98bb5ae8c152e67149dac8d55153b168c",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22786,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdEutqCRA9TVsSAnZWagAAhlMQAJrPS2EH/dZOsGFOl6aA\nAtrK4/lY8PaEUFt4FwnCwkvOXtK70VFMZSDtXks7qDu4v+IzPuDs2LZwN6RO\nmdrQatT1M8MDQ6JPVEPzX4iXFL6j6vkXqpYypsT1dzk97ACpUtCNkyYdZDzW\n9FnyMmdjlCT+MlGu7m2NZeuaaJv5TCkAGqkgmbfDAQE/QwiOlIVHD2oQCju4\n1W60tWupFRxQQqNEYZL1Jt3a4q0AoFB5gagwlrI0la/hjNBecjXVaTULaa73\nmrhYY77p9wGAjWOg8ZAr1TRhKzkOzjkQ483+4mPRgDj3kwkWNZaIqo+CCELP\nKih6yQ9v18rkPtSryUTTkO1K7O0K1MFH9DBus/Ea90LB4F0gUko+4z7zWQbD\nICfZe5r4AEO54mXbZ7vD1NGstXm1vRsNO6xGysTWYIf57rX0dQQDXzhu0u/x\nGgAk2COBnwmtoCL97ND37xxZwF6vjfhTszUztzcIbCPzQbELm0gcxNa2XUpX\nCkvgyBGiCxuLpeQdECFP7q6TM1HCFSojLvp7RzacLaltoFBa7LwTNNMO86sV\nmq8RJGHUJO7h1K5PGdkQ1duN/IGgjVmk5JWuyHScbRsfz6ZjYABCWKAbep1N\nYNtuBEimhNtiDzorPNOZJZoAn5eVqP1sWWHqKefXWtrjtM7EVBtn8G/tAWjG\nxBgf\r\n=1FPP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/raw-body_2.4.1_1561520999545_0.14458885802275256"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# raw-body\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build status][travis-image]][travis-url]\n[![Test coverage][coveralls-image]][coveralls-url]\n\nGets the entire buffer of a stream either as a `Buffer` or a string.\nValidates the stream's length against an expected length and maximum limit.\nIdeal for parsing request bodies.\n\n## Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install raw-body\n```\n\n### TypeScript\n\nThis module includes a [TypeScript](https://www.typescriptlang.org/)\ndeclaration file to enable auto complete in compatible editors and type\ninformation for TypeScript projects. This module depends on the Node.js\ntypes, so install `@types/node`:\n\n```sh\n$ npm install @types/node\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar getRawBody = require('raw-body')\n```\n\n### getRawBody(stream, [options], [callback])\n\n**Returns a promise if no callback specified and global `Promise` exists.**\n\nOptions:\n\n- `length` - The length of the stream.\n  If the contents of the stream do not add up to this length,\n  an `400` error code is returned.\n- `limit` - The byte limit of the body.\n  This is the number of bytes or any string format supported by\n  [bytes](https://www.npmjs.com/package/bytes),\n  for example `1000`, `'500kb'` or `'3mb'`.\n  If the body ends up being larger than this limit,\n  a `413` error code is returned.\n- `encoding` - The encoding to use to decode the body into a string.\n  By default, a `Buffer` instance will be returned when no encoding is specified.\n  Most likely, you want `utf-8`, so setting `encoding` to `true` will decode as `utf-8`.\n  You can use any type of encoding supported by [iconv-lite](https://www.npmjs.org/package/iconv-lite#readme).\n\nYou can also pass a string in place of options to just specify the encoding.\n\nIf an error occurs, the stream will be paused, everything unpiped,\nand you are responsible for correctly disposing the stream.\nFor HTTP requests, no handling is required if you send a response.\nFor streams that use file descriptors, you should `stream.destroy()` or `stream.close()` to prevent leaks.\n\n## Errors\n\nThis module creates errors depending on the error condition during reading.\nThe error may be an error from the underlying Node.js implementation, but is\notherwise an error created by this module, which has the following attributes:\n\n  * `limit` - the limit in bytes\n  * `length` and `expected` - the expected length of the stream\n  * `received` - the received bytes\n  * `encoding` - the invalid encoding\n  * `status` and `statusCode` - the corresponding status code for the error\n  * `type` - the error type\n\n### Types\n\nThe errors from this module have a `type` property which allows for the progamatic\ndetermination of the type of error returned.\n\n#### encoding.unsupported\n\nThis error will occur when the `encoding` option is specified, but the value does\nnot map to an encoding supported by the [iconv-lite](https://www.npmjs.org/package/iconv-lite#readme)\nmodule.\n\n#### entity.too.large\n\nThis error will occur when the `limit` option is specified, but the stream has\nan entity that is larger.\n\n#### request.aborted\n\nThis error will occur when the request stream is aborted by the client before\nreading the body has finished.\n\n#### request.size.invalid\n\nThis error will occur when the `length` option is specified, but the stream has\nemitted more bytes.\n\n#### stream.encoding.set\n\nThis error will occur when the given stream has an encoding set on it, making it\na decoded stream. The stream should not have an encoding set and is expected to\nemit `Buffer` objects.\n\n## Examples\n\n### Simple Express example\n\n```js\nvar contentType = require('content-type')\nvar express = require('express')\nvar getRawBody = require('raw-body')\n\nvar app = express()\n\napp.use(function (req, res, next) {\n  getRawBody(req, {\n    length: req.headers['content-length'],\n    limit: '1mb',\n    encoding: contentType.parse(req).parameters.charset\n  }, function (err, string) {\n    if (err) return next(err)\n    req.text = string\n    next()\n  })\n})\n\n// now access req.text\n```\n\n### Simple Koa example\n\n```js\nvar contentType = require('content-type')\nvar getRawBody = require('raw-body')\nvar koa = require('koa')\n\nvar app = koa()\n\napp.use(function * (next) {\n  this.text = yield getRawBody(this.req, {\n    length: this.req.headers['content-length'],\n    limit: '1mb',\n    encoding: contentType.parse(this.req).parameters.charset\n  })\n  yield next\n})\n\n// now access this.text\n```\n\n### Using as a promise\n\nTo use this library as a promise, simply omit the `callback` and a promise is\nreturned, provided that a global `Promise` is defined.\n\n```js\nvar getRawBody = require('raw-body')\nvar http = require('http')\n\nvar server = http.createServer(function (req, res) {\n  getRawBody(req)\n    .then(function (buf) {\n      res.statusCode = 200\n      res.end(buf.length + ' bytes submitted')\n    })\n    .catch(function (err) {\n      res.statusCode = 500\n      res.end(err.message)\n    })\n})\n\nserver.listen(3000)\n```\n\n### Using with TypeScript\n\n```ts\nimport * as getRawBody from 'raw-body';\nimport * as http from 'http';\n\nconst server = http.createServer((req, res) => {\n  getRawBody(req)\n  .then((buf) => {\n    res.statusCode = 200;\n    res.end(buf.length + ' bytes submitted');\n  })\n  .catch((err) => {\n    res.statusCode = err.statusCode;\n    res.end(err.message);\n  });\n});\n\nserver.listen(3000);\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/raw-body.svg\n[npm-url]: https://npmjs.org/package/raw-body\n[node-version-image]: https://img.shields.io/node/v/raw-body.svg\n[node-version-url]: https://nodejs.org/en/download/\n[travis-image]: https://img.shields.io/travis/stream-utils/raw-body/master.svg\n[travis-url]: https://travis-ci.org/stream-utils/raw-body\n[coveralls-image]: https://img.shields.io/coveralls/stream-utils/raw-body/master.svg\n[coveralls-url]: https://coveralls.io/r/stream-utils/raw-body?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/raw-body.svg\n[downloads-url]: https://npmjs.org/package/raw-body\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "jongleberry",
+      "email": "jonathanrichardong@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-06-26T03:50:04.556Z",
+    "created": "2013-09-14T03:21:48.702Z",
+    "0.0.1": "2013-09-14T03:21:49.810Z",
+    "0.0.2": "2013-09-14T07:31:56.628Z",
+    "0.0.3": "2013-10-10T18:54:24.885Z",
+    "0.1.0": "2013-11-11T05:48:13.166Z",
+    "0.1.1": "2013-11-15T04:33:32.055Z",
+    "0.2.0": "2013-11-15T04:53:57.332Z",
+    "1.0.0": "2013-11-17T19:08:41.627Z",
+    "1.0.1": "2013-11-19T00:07:17.557Z",
+    "1.1.0": "2013-11-27T03:53:18.270Z",
+    "1.1.1": "2013-11-27T20:39:25.331Z",
+    "1.1.2": "2013-12-01T20:17:00.635Z",
+    "1.1.3": "2014-03-02T20:52:28.866Z",
+    "1.1.4": "2014-04-19T08:17:23.207Z",
+    "1.1.5": "2014-05-14T01:50:49.137Z",
+    "1.1.6": "2014-05-27T13:42:01.085Z",
+    "1.1.7": "2014-06-13T02:52:47.692Z",
+    "1.2.0": "2014-06-13T20:52:34.118Z",
+    "1.2.1": "2014-06-15T16:40:07.888Z",
+    "1.2.2": "2014-06-19T19:32:23.842Z",
+    "1.2.3": "2014-07-20T17:30:32.310Z",
+    "1.3.0": "2014-07-21T01:22:05.842Z",
+    "1.3.1": "2014-11-22T03:53:08.492Z",
+    "1.3.2": "2015-01-21T06:21:33.709Z",
+    "1.3.3": "2015-02-09T06:43:13.366Z",
+    "1.3.4": "2015-04-16T02:35:48.941Z",
+    "2.0.0": "2015-05-08T13:44:08.773Z",
+    "2.0.1": "2015-05-11T04:24:17.907Z",
+    "2.0.2": "2015-05-22T03:07:32.179Z",
+    "2.1.0": "2015-05-28T17:40:51.813Z",
+    "2.1.1": "2015-06-14T22:00:08.427Z",
+    "2.1.2": "2015-07-06T03:06:38.297Z",
+    "2.1.3": "2015-09-12T20:56:21.003Z",
+    "2.1.4": "2015-09-28T03:44:59.198Z",
+    "2.1.5": "2015-12-01T03:56:48.358Z",
+    "2.1.6": "2016-03-08T03:06:50.286Z",
+    "2.1.7": "2016-06-19T19:14:25.247Z",
+    "2.2.0": "2017-01-03T02:11:44.637Z",
+    "2.3.0": "2017-08-05T03:08:58.515Z",
+    "2.3.1": "2017-09-08T03:22:02.056Z",
+    "2.3.2": "2017-09-10T04:59:25.753Z",
+    "2.3.3": "2018-05-08T15:39:36.374Z",
+    "2.4.0": "2019-04-18T02:43:02.394Z",
+    "2.4.1": "2019-06-26T03:50:01.465Z"
+  },
+  "author": {
+    "name": "Jonathan Ong",
+    "email": "me@jongleberry.com",
+    "url": "http://jongleberry.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stream-utils/raw-body.git"
+  },
+  "homepage": "https://github.com/stream-utils/raw-body#readme",
+  "bugs": {
+    "url": "https://github.com/stream-utils/raw-body/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "matteospampani": true,
+    "oceanswave": true,
+    "rsp": true,
+    "itonyyo": true,
+    "qqqppp9998": true,
+    "buzzalderaan": true,
+    "amio": true,
+    "kparkov": true,
+    "sopepos": true,
+    "iisii": true,
+    "finico": true,
+    "a3.ivanenko": true,
+    "recursion_excursion": true,
+    "craigpatten": true,
+    "kehanshi": true,
+    "mojaray2k": true,
+    "dzhou777": true,
+    "poppowerlb2": true,
+    "chirag8642": true,
+    "maemichi-monosense": true,
+    "justdomepaul": true,
+    "azusa0127": true,
+    "zhenguo.zhao": true
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Raynos",
+      "email": "raynos2@gmail.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/raw-body.min.json
+++ b/test/fixtures/registry-mocks/content/raw-body.min.json
@@ -1,0 +1,971 @@
+{
+  "name": "raw-body",
+  "dist-tags": {
+    "latest": "2.4.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "raw-body",
+      "version": "0.0.1",
+      "devDependencies": {
+        "mocha": "~1.12"
+      },
+      "dist": {
+        "shasum": "5fdd13390c80a4ac185423e7b7bd10b5b789adb1",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "raw-body",
+      "version": "0.0.2",
+      "devDependencies": {
+        "mocha": "~1.12"
+      },
+      "dist": {
+        "shasum": "319164ced50f628676fc0dd6a381cd52041a337c",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "raw-body",
+      "version": "0.0.3",
+      "devDependencies": {
+        "mocha": "~1.12"
+      },
+      "dist": {
+        "shasum": "0cb3eb22ced1ca607d32dd8fd94a6eb383f3eb8a",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.0.3.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "raw-body",
+      "version": "0.1.0",
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "6526df32068353d5c3e9d09cdbc5efda59b4a479",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "raw-body",
+      "version": "0.1.1",
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "320ec72bea7f602b4ed71c044bc0c88eb1124051",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.1.1.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "raw-body",
+      "version": "0.2.0",
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "e77884ce593be387f8d36cb97d37c2e2e9a818ae",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-0.2.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "raw-body",
+      "version": "1.0.0",
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "a2ebd450b9d2833b73b110064f032b1a8109509f",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "raw-body",
+      "version": "1.0.1",
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "co": "*",
+        "gnode": "*",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "946c23ce4716180e5bdc94ae402b0d398aeb6c86",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "raw-body",
+      "version": "1.1.0",
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "2",
+        "gnode": "~0.0.4",
+        "mocha": "~1.14.0",
+        "through": "~2.3.4",
+        "request": "~2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "dist": {
+        "shasum": "0a86c4864cc0773ba93ee31d102aa62b61fc818e",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "raw-body",
+      "version": "1.1.1",
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "2",
+        "gnode": "~0.0.4",
+        "mocha": "~1.14.0",
+        "through": "~2.3.4",
+        "request": "~2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "dist": {
+        "shasum": "915917d78595f7fc4c391c6563aef69b740cb960",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.2": {
+      "name": "raw-body",
+      "version": "1.1.2",
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "2",
+        "gnode": "~0.0.4",
+        "mocha": "~1.14.0",
+        "through": "~2.3.4",
+        "request": "~2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "dist": {
+        "shasum": "c74b3004dea5defd1696171106ac740ec31d62be",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.3": {
+      "name": "raw-body",
+      "version": "1.1.3",
+      "dependencies": {
+        "bytes": "~0.2.1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "3",
+        "gnode": "~0.0.4",
+        "mocha": "^1.14.0",
+        "through2": "~0.4.1",
+        "request": "^2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "dist": {
+        "shasum": "3d2f91e2449259cc67b8c3ce9f061db5b987935b",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.4": {
+      "name": "raw-body",
+      "version": "1.1.4",
+      "dependencies": {
+        "bytes": "~0.3.0"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "3",
+        "gnode": "~0.0.4",
+        "mocha": "^1.14.0",
+        "through2": "~0.4.1",
+        "request": "^2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "dist": {
+        "shasum": "f0b5624388d031f63da07f870c86cb9ccadcb67d",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.5": {
+      "name": "raw-body",
+      "version": "1.1.5",
+      "dependencies": {
+        "bytes": "1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "3",
+        "gnode": "~0.0.4",
+        "mocha": "^1.14.0",
+        "through2": "~0.4.1",
+        "request": "^2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "dist": {
+        "shasum": "a54b735c205f0876d4b2428543ac9555d39eba73",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.6": {
+      "name": "raw-body",
+      "version": "1.1.6",
+      "dependencies": {
+        "bytes": "1"
+      },
+      "devDependencies": {
+        "readable-stream": "~1.0.17",
+        "co": "3",
+        "gnode": "~0.0.4",
+        "mocha": "^1.14.0",
+        "through2": "~0.4.1",
+        "request": "^2.27.0",
+        "assert-tap": "~0.1.4"
+      },
+      "dist": {
+        "shasum": "98e9df9a7e2df994931b7cdb4b2a6b9694a74f02",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.7": {
+      "name": "raw-body",
+      "version": "1.1.7",
+      "dependencies": {
+        "bytes": "1",
+        "string_decoder": "0.10"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "request": ">= 2.36.0 < 3",
+        "through2": "~0.4.1"
+      },
+      "dist": {
+        "shasum": "1d027c2bfa116acc6623bca8f00016572a87d425",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.0": {
+      "name": "raw-body",
+      "version": "1.2.0",
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "request": ">= 2.36.0 < 3",
+        "through2": "~0.4.1"
+      },
+      "dist": {
+        "shasum": "523e605803f9551a4314268ea6defd2b396c16a4",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.1": {
+      "name": "raw-body",
+      "version": "1.2.1",
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "request": ">= 2.36.0 < 3",
+        "through2": "~0.5.1"
+      },
+      "dist": {
+        "shasum": "3ff628df74ee2ad3632a061d3cd19698b1e23d5a",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.2": {
+      "name": "raw-body",
+      "version": "1.2.2",
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "request": ">= 2.36.0 < 3",
+        "through2": "~0.5.1"
+      },
+      "dist": {
+        "shasum": "0c68e1ee28cfed7dba4822234aec6078461cbc1f",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.3": {
+      "name": "raw-body",
+      "version": "1.2.3",
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "through2": "~0.5.1"
+      },
+      "dist": {
+        "shasum": "af497b1f1bb5ce77e20855ab9244f87eaa9220d6",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.2.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.0": {
+      "name": "raw-body",
+      "version": "1.3.0",
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.1",
+        "readable-stream": "~1.0.17",
+        "through2": "~0.5.1"
+      },
+      "dist": {
+        "shasum": "978230a156a5548f42eef14de22d0f4f610083d1",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.1": {
+      "name": "raw-body",
+      "version": "1.3.1",
+      "dependencies": {
+        "bytes": "1",
+        "iconv-lite": "0.4.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.1",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.3"
+      },
+      "dist": {
+        "shasum": "26a1491059086fd121942232d16758cd2817f815",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.2": {
+      "name": "raw-body",
+      "version": "1.3.2",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "iconv-lite": "0.4.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.3"
+      },
+      "dist": {
+        "shasum": "0e186f27c5fbfe326d8b3062774804564a0ecf93",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.3": {
+      "name": "raw-body",
+      "version": "1.3.3",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "iconv-lite": "0.4.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.3"
+      },
+      "dist": {
+        "shasum": "8841af3f64ad50a351dc77f229118b40c28fa58c",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.4": {
+      "name": "raw-body",
+      "version": "1.3.4",
+      "dependencies": {
+        "bytes": "1.0.0",
+        "iconv-lite": "0.4.8"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "dist": {
+        "shasum": "ccc7ddfc46b72861cdd5bb433c840b70b6f27f54",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "2.0.0": {
+      "name": "raw-body",
+      "version": "2.0.0",
+      "dependencies": {
+        "bytes": "2.0.1",
+        "iconv-lite": "0.4.8"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.25",
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "dist": {
+        "shasum": "86ec5cb5863b82e6a57d3a5b442ddae8563d6dc5",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "2.0.1": {
+      "name": "raw-body",
+      "version": "2.0.1",
+      "dependencies": {
+        "bytes": "2.0.1",
+        "iconv-lite": "0.4.8"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.25",
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "dist": {
+        "shasum": "2b70a3ffd1681c0521bae73454e0ccbc785d378e",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.0.2": {
+      "name": "raw-body",
+      "version": "2.0.2",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.8"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.25",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "dist": {
+        "shasum": "a2c2f98c8531cee99c63d8d238b7de97bb659fca",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.1.0": {
+      "name": "raw-body",
+      "version": "2.1.0",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.10"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.26",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "readable-stream": "~1.0.33",
+        "through2": "0.6.5"
+      },
+      "dist": {
+        "shasum": "8091f844de4380cbd2a7ef457d57091161d4af18",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.1.1": {
+      "name": "raw-body",
+      "version": "2.1.1",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.10",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.30",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.0",
+        "through2": "2.0.0"
+      },
+      "dist": {
+        "shasum": "9b6378223aa2e2ef41348bae55264e44f2850417",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.1.2": {
+      "name": "raw-body",
+      "version": "2.1.2",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.11",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "2.9.32",
+        "istanbul": "0.3.17",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.1",
+        "through2": "2.0.0"
+      },
+      "dist": {
+        "shasum": "63481a805ba30ed7d59ad4433b20eb850f95e887",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.1.3": {
+      "name": "raw-body",
+      "version": "2.1.3",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.11",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "2.10.0",
+        "istanbul": "0.3.19",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.2",
+        "through2": "2.0.0"
+      },
+      "dist": {
+        "shasum": "3b3fd88599d7e361b37d4f2bb11edc9d28c647f5",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.1.4": {
+      "name": "raw-body",
+      "version": "2.1.4",
+      "dependencies": {
+        "bytes": "2.1.0",
+        "iconv-lite": "0.4.12",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "2.10.1",
+        "istanbul": "0.3.21",
+        "mocha": "2.2.5",
+        "readable-stream": "2.0.2",
+        "through2": "2.0.0"
+      },
+      "dist": {
+        "shasum": "dcc3afe2e1fdfc620a812376f8e0fc3d2e62cb50",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.1.5": {
+      "name": "raw-body",
+      "version": "2.1.5",
+      "dependencies": {
+        "bytes": "2.2.0",
+        "iconv-lite": "0.4.13",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.0.5",
+        "istanbul": "0.4.1",
+        "mocha": "2.3.4",
+        "readable-stream": "2.0.4",
+        "through2": "2.0.0"
+      },
+      "dist": {
+        "shasum": "8be8f09ddefd0d72ad99d883ab7f0cc350420956",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.1.6": {
+      "name": "raw-body",
+      "version": "2.1.6",
+      "dependencies": {
+        "bytes": "2.3.0",
+        "iconv-lite": "0.4.13",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.3.4",
+        "istanbul": "0.4.2",
+        "mocha": "2.4.5",
+        "readable-stream": "2.0.5",
+        "through2": "2.0.1"
+      },
+      "dist": {
+        "shasum": "9c050737fe07ced6d94a4fd09c61b6ad874d310f",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.1.7": {
+      "name": "raw-body",
+      "version": "2.1.7",
+      "dependencies": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.13",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.4.1",
+        "eslint": "2.13.0",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "through2": "2.0.1"
+      },
+      "dist": {
+        "shasum": "adfeace2e4fb3098058014d08c072dcc59758774",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.2.0": {
+      "name": "raw-body",
+      "version": "2.2.0",
+      "dependencies": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.4.7",
+        "eslint": "3.12.2",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.1.2",
+        "through2": "2.0.1"
+      },
+      "dist": {
+        "shasum": "994976cf6a5096a41162840492f0bdc5d6e7fb96",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.3.0": {
+      "name": "raw-body",
+      "version": "2.3.0",
+      "dependencies": {
+        "bytes": "2.5.0",
+        "http-errors": "1.6.1",
+        "iconv-lite": "0.4.18",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.0",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1"
+      },
+      "dist": {
+        "shasum": "f79ce1acacaba5b6362d33454d785d7129f4bc67",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.3.1": {
+      "name": "raw-body",
+      "version": "2.3.1",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.18",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.0",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-sxkd1uqaSj41SG5Vet9sNAxBMCMsmZ3LVhRkDlK8SbCpelTUB7JiMGHG70AZS6cFiCRgfNQhU2eLnTHYRFf7LA==",
+        "shasum": "30f95e2a67a14e2e4413d8d51fdd92c877e8f2ed",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.3.2": {
+      "name": "raw-body",
+      "version": "2.3.2",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.0",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.3",
+        "safe-buffer": "5.1.1"
+      },
+      "dist": {
+        "shasum": "bcd60c77d3eb93cde0050295c3f379389bc88f89",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.3.3": {
+      "name": "raw-body",
+      "version": "2.3.3",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.1",
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.11.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.7.0",
+        "eslint-plugin-standard": "3.1.0",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+        "shasum": "1b324ece6b5706e153855bc1148c65bb7f6ea0c3",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22411,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa8cS5CRA9TVsSAnZWagAAR48P/2RtvIAfwrPtyGIJAnrt\nJOSPTZaj3zQd0Ort5qbS+gNU1fyjbMtetTPAFt3Aw2BeAN8z7CeDfUkfg8BM\nhUkD1P1f2nwM9TEQzq39mdB9s1TrDiFobaLuLasZ1uFU2lb/X8LkXshrK3up\n+edfrVl552xoLkipHSwRB3X90F8JJHvOq7crw5PphMzMDYlpW9hzZwA0L6n+\ni1CCqTOOD+ER0ntZNoQmEjZGueK/aelOyTpAw4MLfZcure3ALwB5xiRVO/wY\neaVmpLJW6fAIJOH9MQcQ6k/il6HHplG+rG4Tk4tA4m9/5nlw/HxTu+Icb6bG\nfHnriKNW2qi32WtUHQbgg5SQaFIvLS6VA2up0xVXml+9tnQj+G0Z9SBlHpuj\nOyO3VsIQONB0yqu5Owb+X6Y6d+TM5FiofPT0XpIyM0Zn2GUYqtKU8XRUmreT\nrZAIOdXw0mGtQ2GcOMGHBapOBlHrE1YrjX68/f+4vmdNKj1sFUZaeoG5vu46\naYKIuzVV2Y6qf0GhTVRF1yaYMNTADM25WMm/+arTnmVHfer2keYLdViZwC3A\nEhu1489+RNCTpcw65RA8RaO8BfIM2xep0v2GbwNiwh3majiEvmLgV3z7PlwL\nOQG/HoamXgql/E6Q4LVBxPQ8fQzbWnSQr10M1dl6cabayDSc6w8dBvQDEWcD\nnJh6\r\n=LAnA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.4.0": {
+      "name": "raw-body",
+      "version": "2.4.0",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.4",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.3",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+        "shasum": "a1ce6fb9c9bc356ca52e89256ab59059e13d0332",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22692,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJct+Q2CRA9TVsSAnZWagAA+AUP/j/tdf22dLOY3EdroYrl\n3uSn8SGTFCLW4Cn/c+tPggviFnSSxRTHADnDc72FLgOEf7Knz/VvW3dvkd4w\nemFCj9AuAO2zhc8BXYiJqAlQivL99dLM21OfBfn/QlLm+AM6dJgqQBp83lTs\nomzh8iu73RqjLKmAGwIXiGlubwq7FgXdEExZWwGIFFZaMw51PxG2knmtp0Wg\nJrbCvsoymvrhjkxDR7yLCdSb/2Z8FfgAFYuxSIMKAQjBQlb+CAbcImt+b4Jp\n5mGakb6XY8cz9+EhPxeodjBNcWiNt2TXt8rbbT1Zvwwdu8+GG76RyKSAChZP\nkVNAX77XWgiCVtpyIwXn729l42x6J+WL6jEjFjflP8pjPstgwbT9R9LL/xai\nn+XcPpUxJ/6ryyeS+cEZbYI371pAWMWt0LfFhJ2HJkEV1Ur5+lAqnI9JKHIu\nDZ1fsrivXULtTYAFjPSBPDl4SGblS6P88//kSWYkQfPgGMe/yGJorhmcexeM\nDb/kRxKUTi/j8ZIMNLcBvMtWs1xVkKIRdy03i0n1PCQB0d3mBseFMN4z9mfI\nn7yWVc8HluRSIjsLZBUrWipJ7UvTC+XQn+x0mP2cVXu4KTag5/727Yy225ms\nrx80AKAZJ9IqyFbGOKGAul1rsQwcrmrakko0+rzmrXyhKa2QUL9BOfSvme+Q\nY5u7\r\n=0DCd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "2.4.1": {
+      "name": "raw-body",
+      "version": "2.4.1",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.3",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "devDependencies": {
+        "bluebird": "3.5.5",
+        "eslint": "6.0.1",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.18.0",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "9.1.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
+        "shasum": "30ac82f98bb5ae8c152e67149dac8d55153b168c",
+        "tarball": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 22786,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdEutqCRA9TVsSAnZWagAAhlMQAJrPS2EH/dZOsGFOl6aA\nAtrK4/lY8PaEUFt4FwnCwkvOXtK70VFMZSDtXks7qDu4v+IzPuDs2LZwN6RO\nmdrQatT1M8MDQ6JPVEPzX4iXFL6j6vkXqpYypsT1dzk97ACpUtCNkyYdZDzW\n9FnyMmdjlCT+MlGu7m2NZeuaaJv5TCkAGqkgmbfDAQE/QwiOlIVHD2oQCju4\n1W60tWupFRxQQqNEYZL1Jt3a4q0AoFB5gagwlrI0la/hjNBecjXVaTULaa73\nmrhYY77p9wGAjWOg8ZAr1TRhKzkOzjkQ483+4mPRgDj3kwkWNZaIqo+CCELP\nKih6yQ9v18rkPtSryUTTkO1K7O0K1MFH9DBus/Ea90LB4F0gUko+4z7zWQbD\nICfZe5r4AEO54mXbZ7vD1NGstXm1vRsNO6xGysTWYIf57rX0dQQDXzhu0u/x\nGgAk2COBnwmtoCL97ND37xxZwF6vjfhTszUztzcIbCPzQbELm0gcxNa2XUpX\nCkvgyBGiCxuLpeQdECFP7q6TM1HCFSojLvp7RzacLaltoFBa7LwTNNMO86sV\nmq8RJGHUJO7h1K5PGdkQ1duN/IGgjVmk5JWuyHScbRsfz6ZjYABCWKAbep1N\nYNtuBEimhNtiDzorPNOZJZoAn5eVqP1sWWHqKefXWtrjtM7EVBtn8G/tAWjG\nxBgf\r\n=1FPP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2019-06-26T03:50:04.556Z"
+}

--- a/test/fixtures/registry-mocks/content/regex-not.json
+++ b/test/fixtures/registry-mocks/content/regex-not.json
@@ -1,0 +1,609 @@
+{
+  "_id": "regex-not",
+  "_rev": "8-ab1df1484140d702b3be91caecf5b007",
+  "name": "regex-not",
+  "description": "Create a javascript regular expression for matching everything except for the given string.",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "regex-not",
+      "description": "Create a regex to match every except for the given string.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/regex-not",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/regex-not.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/regex-not/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "keywords": [
+        "exec",
+        "match",
+        "negate",
+        "negation",
+        "not",
+        "regex",
+        "regular expression",
+        "test"
+      ],
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "mocha": "^3.0.2"
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "to-regex",
+            "regex-cache"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "_id": "regex-not@0.1.0",
+      "_shasum": "33c1b703b596f42e720768b94af6479b4393a704",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "33c1b703b596f42e720768b94af6479b4393a704",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/regex-not-0.1.0.tgz_1474948229934_0.9674226979259402"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "regex-not",
+      "description": "Create a javascript regular expression for matching everything except for the given string.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/regex-not",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/regex-not.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/regex-not/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "keywords": [
+        "exec",
+        "match",
+        "negate",
+        "negation",
+        "not",
+        "regex",
+        "regular expression",
+        "test"
+      ],
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "mocha": "^3.0.2"
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "to-regex",
+            "regex-cache"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "e54c3681ff2212640ab8201b4c835cbe25dbf0dd",
+      "_id": "regex-not@0.1.1",
+      "_shasum": "f9f6c90afced5324044354d7e9ad1c8bda7c2ab4",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f9f6c90afced5324044354d7e9ad1c8bda7c2ab4",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/regex-not-0.1.1.tgz_1474948484514_0.6983254891820252"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "regex-not",
+      "description": "Create a javascript regular expression for matching everything except for the given string.",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/regex-not",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/regex-not.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/regex-not/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "exec",
+        "match",
+        "negate",
+        "negation",
+        "not",
+        "regex",
+        "regular expression",
+        "test"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "regex-cache",
+            "to-regex"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "bc6a4dbce9aa1f610f898105a2e6422db5596d7f",
+      "_id": "regex-not@0.1.2",
+      "_shasum": "bc7f1c4944b1188353d07deeb912b94e0ade25db",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bc7f1c4944b1188353d07deeb912b94e0ade25db",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/regex-not-0.1.2.tgz_1474949899655_0.21038869419135153"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "regex-not",
+      "description": "Create a javascript regular expression for matching everything except for the given string.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/regex-not",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/regex-not.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/regex-not/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "exec",
+        "match",
+        "negate",
+        "negation",
+        "not",
+        "regex",
+        "regular expression",
+        "test"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "regex-cache",
+            "to-regex"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "89320311834104e22dd3e5c468d17f6662c35259",
+      "_id": "regex-not@1.0.0",
+      "_shasum": "42f83e39771622df826b02af176525d6a5f157f9",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "42f83e39771622df826b02af176525d6a5f157f9",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/regex-not-1.0.0.tgz_1475895569600_0.9545667197089642"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "regex-not",
+      "description": "Create a javascript regular expression for matching everything except for the given string.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jonschlinkert/regex-not",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/regex-not.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/regex-not/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "exec",
+        "match",
+        "negate",
+        "negation",
+        "not",
+        "regex",
+        "regular expression",
+        "test"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "regex-cache",
+            "to-regex"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "fb77cca62926d3176c4e4bb7441e62b6b6bd80a1",
+      "_id": "regex-not@1.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-9gH3iyUkkKg5jFP2vWaElWn7SVGxAlrE75IRCe9wi6/nR7yN+bJOkTz2taRBaG2sYxsPsyToIRJLpnjuDdFB/w==",
+        "shasum": "4b8273f3e5c06e79a1b23fec221557bd5fb3c50f",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8460
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/regex-not_1.0.1_1519091357855_0.5534107028344075"
+      }
+    },
+    "1.0.2": {
+      "name": "regex-not",
+      "description": "Create a javascript regular expression for matching everything except for the given string.",
+      "version": "1.0.2",
+      "homepage": "https://github.com/jonschlinkert/regex-not",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/regex-not.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/regex-not/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "exec",
+        "match",
+        "negate",
+        "negation",
+        "not",
+        "regex",
+        "regular expression",
+        "test"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "regex-cache",
+            "to-regex"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "7e368998898e1fc7428596636ef5412ede414f3e",
+      "_id": "regex-not@1.0.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+        "shasum": "1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8459
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/regex-not_1.0.2_1519093874391_0.48484026521777035"
+      }
+    }
+  },
+  "readme": "# regex-not [![NPM version](https://img.shields.io/npm/v/regex-not.svg?style=flat)](https://www.npmjs.com/package/regex-not) [![NPM monthly downloads](https://img.shields.io/npm/dm/regex-not.svg?style=flat)](https://npmjs.org/package/regex-not) [![NPM total downloads](https://img.shields.io/npm/dt/regex-not.svg?style=flat)](https://npmjs.org/package/regex-not) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/regex-not.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/regex-not)\n\n> Create a javascript regular expression for matching everything except for the given string.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save regex-not\n```\n\n## Usage\n\n```js\nvar not = require('regex-not');\n```\n\nThe main export is a function that takes a string an options object.\n\n```js\nnot(string[, options]);\n```\n\n**Example**\n\n```js\nvar not = require('regex-not');\nconsole.log(not('foo'));\n//=> /^(?:(?!^(?:foo)$).)+$/\n```\n\n**Strict matching**\n\nBy default, the returned regex is for strictly (not) matching the exact given pattern (in other words, \"match this string if it does NOT _exactly equal_ `foo`\"):\n\n```js\nvar re = not('foo');\nconsole.log(re.test('foo'));     //=> false\nconsole.log(re.test('bar'));     //=> true\nconsole.log(re.test('foobar'));  //=> true\nconsole.log(re.test('barfoo'));  //=> true\n```\n\n### .create\n\nReturns a string to allow you to create your own regex:\n\n```js\nconsole.log(not.create('foo'));\n//=> '(?:(?!^(?:foo)$).)+'\n```\n\n### Options\n\n**options.contains**\n\nYou can relax strict matching by setting `options.contains` to true (in other words, \"match this string if it does NOT _contain_ `foo`\"):\n\n```js\nvar re = not('foo');\nconsole.log(re.test('foo', {contains: true}));     //=> false\nconsole.log(re.test('bar', {contains: true}));     //=> true\nconsole.log(re.test('foobar', {contains: true}));  //=> false\nconsole.log(re.test('barfoo', {contains: true}));  //=> false\n```\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [regex-cache](https://www.npmjs.com/package/regex-cache): Memoize the results of a call to the RegExp constructor, avoiding repetitious runtime compilation of… [more](https://github.com/jonschlinkert/regex-cache) | [homepage](https://github.com/jonschlinkert/regex-cache \"Memoize the results of a call to the RegExp constructor, avoiding repetitious runtime compilation of the same string and options, resulting in surprising performance improvements.\")\n* [to-regex](https://www.npmjs.com/package/to-regex): Generate a regex from a string or array of strings. | [homepage](https://github.com/jonschlinkert/to-regex \"Generate a regex from a string or array of strings.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 9 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 1 | [doowb](https://github.com/doowb) |\n| 1 | [EdwardBetts](https://github.com/EdwardBetts) |\n\n### Author\n\n**Jon Schlinkert**\n\n* [linkedin/in/jonschlinkert](https://linkedin.com/in/jonschlinkert)\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on February 19, 2018._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-02-20T02:31:15.333Z",
+    "created": "2016-09-27T03:50:31.394Z",
+    "0.1.0": "2016-09-27T03:50:31.394Z",
+    "0.1.1": "2016-09-27T03:54:45.992Z",
+    "0.1.2": "2016-09-27T04:18:21.404Z",
+    "1.0.0": "2016-10-08T02:59:30.201Z",
+    "1.0.1": "2018-02-20T01:49:17.954Z",
+    "1.0.2": "2018-02-20T02:31:14.441Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/regex-not",
+  "keywords": [
+    "exec",
+    "match",
+    "negate",
+    "negation",
+    "not",
+    "regex",
+    "regular expression",
+    "test"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/regex-not.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/regex-not/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "arteffeckt": true,
+    "rocket0191": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/regex-not.min.json
+++ b/test/fixtures/registry-mocks/content/regex-not.min.json
@@ -1,0 +1,116 @@
+{
+  "name": "regex-not",
+  "dist-tags": {
+    "latest": "1.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "regex-not",
+      "version": "0.1.0",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "33c1b703b596f42e720768b94af6479b4393a704",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "regex-not",
+      "version": "0.1.1",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "f9f6c90afced5324044354d7e9ad1c8bda7c2ab4",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "regex-not",
+      "version": "0.1.2",
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "bc7f1c4944b1188353d07deeb912b94e0ade25db",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "regex-not",
+      "version": "1.0.0",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.10",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "42f83e39771622df826b02af176525d6a5f157f9",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "regex-not",
+      "version": "1.0.1",
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-9gH3iyUkkKg5jFP2vWaElWn7SVGxAlrE75IRCe9wi6/nR7yN+bJOkTz2taRBaG2sYxsPsyToIRJLpnjuDdFB/w==",
+        "shasum": "4b8273f3e5c06e79a1b23fec221557bd5fb3c50f",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8460
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.2": {
+      "name": "regex-not",
+      "version": "1.0.2",
+      "dependencies": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+        "shasum": "1f4ece27e00b0b65e0247a6810e6a85d83a5752c",
+        "tarball": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 8459
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2018-02-20T02:31:15.333Z"
+}

--- a/test/fixtures/registry-mocks/content/regexp.prototype.flags.json
+++ b/test/fixtures/registry-mocks/content/regexp.prototype.flags.json
@@ -1,0 +1,634 @@
+{
+  "_id": "regexp.prototype.flags",
+  "_rev": "10-e76e4adf52aaac6d5265cf5cd07bfa67",
+  "name": "regexp.prototype.flags",
+  "description": "ES6 spec-compliant RegExp.prototype.flags shim.",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "regexp.prototype.flags",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "description": "ES6 spec-compliant RegExp.prototype.flags shim.",
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run lint && node test/index.js && npm run security",
+        "coverage": "covert test/*.js",
+        "coverage-quiet": "covert test/*.js --quiet",
+        "lint": "npm run jscs",
+        "eslint": "eslint --env=node test/*.js *.js",
+        "jscs": "jscs test/*.js *.js",
+        "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+        "security": "nsp package"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/RegExp.prototype.flags.git"
+      },
+      "keywords": [
+        "RegExp.prototype.flags",
+        "regex",
+        "ES6",
+        "shim",
+        "flags",
+        "regexp",
+        "RegExp#flags",
+        "polyfill"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~3.0.3",
+        "covert": "1.0.0",
+        "jscs": "~1.8.1",
+        "editorconfig-tools": "~0.0.1",
+        "nsp": "~0.5.2",
+        "eslint": "~0.10.1"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": [
+          "iexplore/9.0..latest",
+          "firefox/4.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/11.6..latest",
+          "opera/next",
+          "safari/5.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "gitHead": "0e13fc12df09f3a7ac30116ef13bba820c220730",
+      "bugs": {
+        "url": "https://github.com/es-shims/RegExp.prototype.flags/issues"
+      },
+      "homepage": "https://github.com/es-shims/RegExp.prototype.flags",
+      "_id": "regexp.prototype.flags@1.0.0",
+      "_shasum": "088904e2a540aa77b55e5344561d5e24d7145594",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "088904e2a540aa77b55e5344561d5e24d7145594",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "regexp.prototype.flags",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "description": "ES6 spec-compliant RegExp.prototype.flags shim.",
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run lint && node test/index.js && npm run security",
+        "coverage": "covert test/*.js",
+        "coverage-quiet": "covert test/*.js --quiet",
+        "lint": "npm run jscs",
+        "eslint": "eslint --env=node test/*.js *.js",
+        "jscs": "jscs test/*.js *.js",
+        "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+        "security": "nsp package"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/RegExp.prototype.flags.git"
+      },
+      "keywords": [
+        "RegExp.prototype.flags",
+        "regex",
+        "ES6",
+        "shim",
+        "flags",
+        "regexp",
+        "RegExp#flags",
+        "polyfill"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~3.0.3",
+        "covert": "1.0.0",
+        "jscs": "~1.8.1",
+        "editorconfig-tools": "~0.0.1",
+        "nsp": "~0.5.2",
+        "eslint": "~0.10.1"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": [
+          "iexplore/9.0..latest",
+          "firefox/4.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/11.6..latest",
+          "opera/next",
+          "safari/5.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "gitHead": "aa57c95172cd6059fc412b90f25d9cfc52180a40",
+      "bugs": {
+        "url": "https://github.com/es-shims/RegExp.prototype.flags/issues"
+      },
+      "homepage": "https://github.com/es-shims/RegExp.prototype.flags",
+      "_id": "regexp.prototype.flags@1.0.1",
+      "_shasum": "54a06afd02cf5892de05ec73f5b7ad4b71c2682f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "54a06afd02cf5892de05ec73f5b7ad4b71c2682f",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "regexp.prototype.flags",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "description": "ES6 spec-compliant RegExp.prototype.flags shim.",
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run lint && es-shim-api --bound && node test/index.js && npm run security",
+        "coverage": "covert test/*.js",
+        "coverage-quiet": "covert test/*.js --quiet",
+        "lint": "npm run jscs && npm run eslint",
+        "eslint": "eslint test/*.js *.js",
+        "jscs": "jscs test/*.js *.js",
+        "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+        "security": "nsp package"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/RegExp.prototype.flags.git"
+      },
+      "keywords": [
+        "RegExp.prototype.flags",
+        "regex",
+        "ES6",
+        "shim",
+        "flags",
+        "regexp",
+        "RegExp#flags",
+        "polyfill"
+      ],
+      "dependencies": {
+        "define-properties": "^1.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.0",
+        "covert": "^1.1.0",
+        "jscs": "^2.1.0",
+        "editorconfig-tools": "^0.1.1",
+        "nsp": "^1.0.3",
+        "eslint": "^1.1.0",
+        "@ljharb/eslint-config": "^1.0.4",
+        "@es-shims/api": "^1.0.0"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": [
+          "iexplore/9.0..latest",
+          "firefox/4.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/11.6..latest",
+          "opera/next",
+          "safari/5.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "gitHead": "cf59c1814d6a9e2039d09f046d24d1549bf613aa",
+      "bugs": {
+        "url": "https://github.com/es-shims/RegExp.prototype.flags/issues"
+      },
+      "homepage": "https://github.com/es-shims/RegExp.prototype.flags#readme",
+      "_id": "regexp.prototype.flags@1.1.0",
+      "_shasum": "79e7b15c70505b295d20711a7cad580a43d97d7f",
+      "_from": ".",
+      "_npmVersion": "2.14.0",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "dist": {
+        "shasum": "79e7b15c70505b295d20711a7cad580a43d97d7f",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "regexp.prototype.flags",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "description": "ES6 spec-compliant RegExp.prototype.flags shim.",
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run lint && es-shim-api --bound && node test/index.js && npm run security",
+        "coverage": "covert test/*.js",
+        "coverage-quiet": "covert test/*.js --quiet",
+        "lint": "npm run jscs && npm run eslint",
+        "eslint": "eslint test/*.js *.js",
+        "jscs": "jscs test/*.js *.js",
+        "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+        "security": "nsp package"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/RegExp.prototype.flags.git"
+      },
+      "keywords": [
+        "RegExp.prototype.flags",
+        "regex",
+        "regular expression",
+        "ES6",
+        "shim",
+        "flag",
+        "flags",
+        "regexp",
+        "RegExp#flags",
+        "polyfill",
+        "es-shim API"
+      ],
+      "dependencies": {
+        "define-properties": "^1.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.0",
+        "covert": "^1.1.0",
+        "jscs": "^2.1.0",
+        "editorconfig-tools": "^0.1.1",
+        "nsp": "^1.0.3",
+        "eslint": "^1.1.0",
+        "@ljharb/eslint-config": "^1.0.4",
+        "@es-shims/api": "^1.0.0"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": [
+          "iexplore/9.0..latest",
+          "firefox/4.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/11.6..latest",
+          "opera/next",
+          "safari/5.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "gitHead": "de150bb4e689785a11d6898eefefcc1875bd0b4e",
+      "bugs": {
+        "url": "https://github.com/es-shims/RegExp.prototype.flags/issues"
+      },
+      "homepage": "https://github.com/es-shims/RegExp.prototype.flags#readme",
+      "_id": "regexp.prototype.flags@1.1.1",
+      "_shasum": "4b45162251d73bbd1a73555ad2f109be1f4c2f4a",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "dist": {
+        "shasum": "4b45162251d73bbd1a73555ad2f109be1f4c2f4a",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "regexp.prototype.flags",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jordan Harband"
+      },
+      "description": "ES6 spec-compliant RegExp.prototype.flags shim.",
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "pretest": "npm run --silent lint",
+        "test": "npm run --silent tests-only",
+        "posttest": "npm run --silent security",
+        "tests-only": "es-shim-api --bound && node --harmony --es-staging test/index.js",
+        "coverage": "covert test/*.js",
+        "coverage-quiet": "covert test/*.js --quiet",
+        "lint": "npm run --silent jscs && npm run --silent eslint",
+        "eslint": "eslint test/*.js *.js",
+        "jscs": "jscs test/*.js *.js",
+        "eccheck": "editorconfig-tools check *.js **/*.js > /dev/null",
+        "security": "nsp check"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/RegExp.prototype.flags.git"
+      },
+      "keywords": [
+        "RegExp.prototype.flags",
+        "regex",
+        "regular expression",
+        "ES6",
+        "shim",
+        "flag",
+        "flags",
+        "regexp",
+        "RegExp#flags",
+        "polyfill",
+        "es-shim API"
+      ],
+      "dependencies": {
+        "define-properties": "^1.1.2"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^1.3.0",
+        "@ljharb/eslint-config": "^12.2.1",
+        "covert": "^1.1.0",
+        "editorconfig-tools": "^0.1.1",
+        "eslint": "^4.9.0",
+        "has": "^1.0.1",
+        "jscs": "^3.0.7",
+        "nsp": "^2.8.1",
+        "tape": "^4.8.0"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": [
+          "iexplore/9.0..latest",
+          "firefox/4.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/11.6..latest",
+          "opera/next",
+          "safari/5.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "gitHead": "e629ce3d469060bdfff837eb556bfa94bc80c092",
+      "bugs": {
+        "url": "https://github.com/es-shims/RegExp.prototype.flags/issues"
+      },
+      "homepage": "https://github.com/es-shims/RegExp.prototype.flags#readme",
+      "_id": "regexp.prototype.flags@1.2.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.8.0",
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+        "shasum": "6b30724e306a27833eeb171b66ac8890ba37e41c",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "ljharb",
+          "email": "ljharb@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/regexp.prototype.flags-1.2.0.tgz_1508908451848_0.3062057360075414"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "regexp.prototype.flags",
+      "version": "1.3.0",
+      "author": {
+        "name": "Jordan Harband",
+        "email": "ljharb@gmail.com"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "description": "ES6 spec-compliant RegExp.prototype.flags shim.",
+      "license": "MIT",
+      "main": "index.js",
+      "scripts": {
+        "pretest": "npm run lint",
+        "test": "npm run tests-only",
+        "posttest": "npx aud",
+        "tests-only": "es-shim-api --bound && node --harmony --es-staging test/index.js",
+        "coverage": "covert test/*.js",
+        "coverage-quiet": "covert test/*.js --quiet",
+        "lint": "eslint .",
+        "eccheck": "eclint check *.js **/*.js > /dev/null"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/es-shims/RegExp.prototype.flags.git"
+      },
+      "keywords": [
+        "RegExp.prototype.flags",
+        "regex",
+        "regular expression",
+        "ES6",
+        "shim",
+        "flag",
+        "flags",
+        "regexp",
+        "RegExp#flags",
+        "polyfill",
+        "es-shim API"
+      ],
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^15.0.2",
+        "covert": "^1.1.1",
+        "eclint": "^2.8.1",
+        "eslint": "^6.7.2",
+        "has": "^1.0.3",
+        "tape": "^4.11.0"
+      },
+      "testling": {
+        "files": "test/index.js",
+        "browsers": [
+          "iexplore/9.0..latest",
+          "firefox/4.0..6.0",
+          "firefox/15.0..latest",
+          "firefox/nightly",
+          "chrome/4.0..10.0",
+          "chrome/20.0..latest",
+          "chrome/canary",
+          "opera/11.6..latest",
+          "opera/next",
+          "safari/5.0..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2"
+        ]
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "gitHead": "f1b1ec0c2e036840204766ecbc8a3a1ff095f163",
+      "bugs": {
+        "url": "https://github.com/es-shims/RegExp.prototype.flags/issues"
+      },
+      "homepage": "https://github.com/es-shims/RegExp.prototype.flags#readme",
+      "_id": "regexp.prototype.flags@1.3.0",
+      "_nodeVersion": "13.3.0",
+      "_npmVersion": "6.13.1",
+      "dist": {
+        "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+        "shasum": "7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 15793,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd9b05CRA9TVsSAnZWagAAf9oP/RFyX+2qmpcZqZh9TyDt\nsOUwPKgHagv6we2crsWxkALCZbsktWC5JTxPsDsDxeYt09oBRG1vY8t0mADd\nMCPXVYmsmjCaZcG2pUP/KhP50LupAb6gqfAqsilmziGPD+D5zTDGjvfRwmk2\nSYTdntJ7JHmV+FOs7EogR9CxoDNmF6MxR10md0fXrr8gqcX4WCXTjAkBbH8O\nyqeBtlhl51ttWY1DmAKn6lDx7nSXnkvYiiCzISMJZ5Fxsd23q+N500g6rYDJ\njlrYvlCUD1on9bfOIs7C8e4pehxWr8V7QVzQ8sK3KZxO1Cm/pgJ/F+2ehG4u\ngbtZX68sZH6iM/IbeIvt/2VgPB7YXoTJLhHCbdI8ec0q/AGtPwZNtEhTDgSM\nNO9xbASsYduK6imuCJzxqQuhJL09IpTPfD7Q0+e9n9VCvs9uj9kFvTXxqvnL\n5aPUoA4NhQ8hnIBIre9GUVC9c7Y298+ddgq1waGT1wEIJhVyzhHrzVEnpHOB\nDnxdhEUSd0CKnKpjO81/OBy4IVFn53rN1u9NOhLHYzokuakOgG1xgf/4tTdZ\n8vh7k9AU+hNhnWRdfjYub4IxJu/Tw1Q95U+cg+hnZw4ZrF9IwsecdLIxRiuJ\nVpNgE8WAK1gY2fRc1lUR/i+b9M8NYktB9T15kyQhSCostL97Hso1rp+Rcg14\n3wgd\r\n=AS4C\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ljharb+esshims@gmail.com",
+          "name": "es-shims-owner"
+        },
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        }
+      ],
+      "_npmUser": {
+        "name": "ljharb",
+        "email": "ljharb@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/regexp.prototype.flags_1.3.0_1576385849027_0.23217087361572486"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "RegExp.prototype.flags <sup>[![Version Badge][npm-version-svg]][package-url]</sup>\n\n[![Build Status][travis-svg]][travis-url]\n[![dependency status][deps-svg]][deps-url]\n[![dev dependency status][dev-deps-svg]][dev-deps-url]\n[![License][license-image]][license-url]\n[![Downloads][downloads-image]][downloads-url]\n\n[![npm badge][npm-badge-png]][package-url]\n\n[![browser support][testling-svg]][testling-url]\n\nAn ES6 spec-compliant `RegExp.prototype.flags` shim. Invoke its \"shim\" method to shim RegExp.prototype.flags if it is unavailable.\n*Note*: `RegExp#flags` requires a true ES5 environment - specifically, one with ES5 getters.\n\nThis package implements the [es-shim API](https://github.com/es-shims/api) interface. It works in an ES5-supported environment and complies with the [spec](http://www.ecma-international.org/ecma-262/6.0/#sec-get-regexp.prototype.flags).\n\nMost common usage:\n```js\nvar flags = require('regexp.prototype.flags');\n\nassert(flags(/a/) === '');\nassert(flags(new RegExp('a') === '');\nassert(flags(/a/mig) === 'gim');\nassert(flags(new RegExp('a', 'mig')) === 'gim');\n\nif (!RegExp.prototype.flags) {\n\tflags.shim();\n}\n\nassert(flags(/a/) === /a/.flags);\nassert(flags(new RegExp('a') === new RegExp('a').flags);\nassert(flags(/a/mig) === /a/mig.flags);\nassert(flags(new RegExp('a', 'mig')) === new RegExp('a', 'mig').flags);\n```\n\n## Tests\nSimply clone the repo, `npm install`, and run `npm test`\n\n[package-url]: https://npmjs.com/package/regexp.prototype.flags\n[npm-version-svg]: http://versionbadg.es/es-shims/RegExp.prototype.flags.svg\n[travis-svg]: https://travis-ci.org/es-shims/RegExp.prototype.flags.svg\n[travis-url]: https://travis-ci.org/es-shims/RegExp.prototype.flags\n[deps-svg]: https://david-dm.org/es-shims/RegExp.prototype.flags.svg\n[deps-url]: https://david-dm.org/es-shims/RegExp.prototype.flags\n[dev-deps-svg]: https://david-dm.org/es-shims/RegExp.prototype.flags/dev-status.svg\n[dev-deps-url]: https://david-dm.org/es-shims/RegExp.prototype.flags#info=devDependencies\n[testling-svg]: https://ci.testling.com/es-shims/RegExp.prototype.flags.png\n[testling-url]: https://ci.testling.com/es-shims/RegExp.prototype.flags\n[npm-badge-png]: https://nodei.co/npm/regexp.prototype.flags.png?downloads=true&stars=true\n[license-image]: http://img.shields.io/npm/l/regexp.prototype.flags.svg\n[license-url]: LICENSE\n[downloads-image]: http://img.shields.io/npm/dm/regexp.prototype.flags.svg\n[downloads-url]: http://npm-stat.com/charts.html?package=regexp.prototype.flags\n",
+  "maintainers": [
+    {
+      "email": "ljharb@gmail.com",
+      "name": "ljharb"
+    }
+  ],
+  "time": {
+    "modified": "2020-03-28T22:26:51.148Z",
+    "created": "2014-12-10T10:13:36.850Z",
+    "1.0.0": "2014-12-10T10:13:36.850Z",
+    "1.0.1": "2014-12-13T09:55:25.846Z",
+    "1.1.0": "2015-08-16T09:08:44.729Z",
+    "1.1.1": "2015-08-16T19:55:02.345Z",
+    "1.2.0": "2017-10-25T05:14:12.819Z",
+    "1.3.0": "2019-12-15T04:57:29.158Z"
+  },
+  "homepage": "https://github.com/es-shims/RegExp.prototype.flags#readme",
+  "keywords": [
+    "RegExp.prototype.flags",
+    "regex",
+    "regular expression",
+    "ES6",
+    "shim",
+    "flag",
+    "flags",
+    "regexp",
+    "RegExp#flags",
+    "polyfill",
+    "es-shim API"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/es-shims/RegExp.prototype.flags.git"
+  },
+  "author": {
+    "name": "Jordan Harband",
+    "email": "ljharb@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/es-shims/RegExp.prototype.flags/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/regexp.prototype.flags.min.json
+++ b/test/fixtures/registry-mocks/content/regexp.prototype.flags.min.json
@@ -1,0 +1,152 @@
+{
+  "name": "regexp.prototype.flags",
+  "dist-tags": {
+    "latest": "1.3.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "regexp.prototype.flags",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "~3.0.3",
+        "covert": "1.0.0",
+        "jscs": "~1.8.1",
+        "editorconfig-tools": "~0.0.1",
+        "nsp": "~0.5.2",
+        "eslint": "~0.10.1"
+      },
+      "dist": {
+        "shasum": "088904e2a540aa77b55e5344561d5e24d7145594",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.0.1": {
+      "name": "regexp.prototype.flags",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tape": "~3.0.3",
+        "covert": "1.0.0",
+        "jscs": "~1.8.1",
+        "editorconfig-tools": "~0.0.1",
+        "nsp": "~0.5.2",
+        "eslint": "~0.10.1"
+      },
+      "dist": {
+        "shasum": "54a06afd02cf5892de05ec73f5b7ad4b71c2682f",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.1.0": {
+      "name": "regexp.prototype.flags",
+      "version": "1.1.0",
+      "dependencies": {
+        "define-properties": "^1.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.0",
+        "covert": "^1.1.0",
+        "jscs": "^2.1.0",
+        "editorconfig-tools": "^0.1.1",
+        "nsp": "^1.0.3",
+        "eslint": "^1.1.0",
+        "@ljharb/eslint-config": "^1.0.4",
+        "@es-shims/api": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "79e7b15c70505b295d20711a7cad580a43d97d7f",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.1.1": {
+      "name": "regexp.prototype.flags",
+      "version": "1.1.1",
+      "dependencies": {
+        "define-properties": "^1.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.0",
+        "covert": "^1.1.0",
+        "jscs": "^2.1.0",
+        "editorconfig-tools": "^0.1.1",
+        "nsp": "^1.0.3",
+        "eslint": "^1.1.0",
+        "@ljharb/eslint-config": "^1.0.4",
+        "@es-shims/api": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "4b45162251d73bbd1a73555ad2f109be1f4c2f4a",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.2.0": {
+      "name": "regexp.prototype.flags",
+      "version": "1.2.0",
+      "dependencies": {
+        "define-properties": "^1.1.2"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^1.3.0",
+        "@ljharb/eslint-config": "^12.2.1",
+        "covert": "^1.1.0",
+        "editorconfig-tools": "^0.1.1",
+        "eslint": "^4.9.0",
+        "has": "^1.0.1",
+        "jscs": "^3.0.7",
+        "nsp": "^2.8.1",
+        "tape": "^4.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+        "shasum": "6b30724e306a27833eeb171b66ac8890ba37e41c",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "1.3.0": {
+      "name": "regexp.prototype.flags",
+      "version": "1.3.0",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "devDependencies": {
+        "@es-shims/api": "^2.1.2",
+        "@ljharb/eslint-config": "^15.0.2",
+        "covert": "^1.1.1",
+        "eclint": "^2.8.1",
+        "eslint": "^6.7.2",
+        "has": "^1.0.3",
+        "tape": "^4.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+        "shasum": "7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75",
+        "tarball": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+        "fileCount": 14,
+        "unpackedSize": 15793,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd9b05CRA9TVsSAnZWagAAf9oP/RFyX+2qmpcZqZh9TyDt\nsOUwPKgHagv6we2crsWxkALCZbsktWC5JTxPsDsDxeYt09oBRG1vY8t0mADd\nMCPXVYmsmjCaZcG2pUP/KhP50LupAb6gqfAqsilmziGPD+D5zTDGjvfRwmk2\nSYTdntJ7JHmV+FOs7EogR9CxoDNmF6MxR10md0fXrr8gqcX4WCXTjAkBbH8O\nyqeBtlhl51ttWY1DmAKn6lDx7nSXnkvYiiCzISMJZ5Fxsd23q+N500g6rYDJ\njlrYvlCUD1on9bfOIs7C8e4pehxWr8V7QVzQ8sK3KZxO1Cm/pgJ/F+2ehG4u\ngbtZX68sZH6iM/IbeIvt/2VgPB7YXoTJLhHCbdI8ec0q/AGtPwZNtEhTDgSM\nNO9xbASsYduK6imuCJzxqQuhJL09IpTPfD7Q0+e9n9VCvs9uj9kFvTXxqvnL\n5aPUoA4NhQ8hnIBIre9GUVC9c7Y298+ddgq1waGT1wEIJhVyzhHrzVEnpHOB\nDnxdhEUSd0CKnKpjO81/OBy4IVFn53rN1u9NOhLHYzokuakOgG1xgf/4tTdZ\n8vh7k9AU+hNhnWRdfjYub4IxJu/Tw1Q95U+cg+hnZw4ZrF9IwsecdLIxRiuJ\nVpNgE8WAK1gY2fRc1lUR/i+b9M8NYktB9T15kyQhSCostL97Hso1rp+Rcg14\n3wgd\r\n=AS4C\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    }
+  },
+  "modified": "2020-03-28T22:26:51.148Z"
+}

--- a/test/fixtures/registry-mocks/content/requires-port.json
+++ b/test/fixtures/registry-mocks/content/requires-port.json
@@ -1,0 +1,281 @@
+{
+  "_id": "requires-port",
+  "_rev": "13-164915816c888506fc15ef5b22dddce0",
+  "name": "requires-port",
+  "description": "Check if a protocol requires a certain port number to be added to an URL.",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "requires-port",
+      "version": "0.0.0",
+      "description": "Check if a protocol requires a certain port number to be added to an URL.",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "watch": "mocha --watch --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/requries-port"
+      },
+      "keywords": [
+        "port",
+        "require",
+        "http",
+        "https",
+        "ws",
+        "wss",
+        "gopher",
+        "file",
+        "ftp",
+        "requires",
+        "requried",
+        "portnumber",
+        "url",
+        "parsing",
+        "validation",
+        "cows"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/requries-port/issues"
+      },
+      "homepage": "https://github.com/unshiftio/requries-port",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "cdd88d620507e79c4b5d57c3b353d5da8ac66988",
+      "_id": "requires-port@0.0.0",
+      "_shasum": "d9914dce124d3d5e75ceda38ca5434069f7132b3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d9914dce124d3d5e75ceda38ca5434069f7132b3",
+        "tarball": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "requires-port",
+      "version": "0.0.1",
+      "description": "Check if a protocol requires a certain port number to be added to an URL.",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/requires-port.git"
+      },
+      "keywords": [
+        "port",
+        "require",
+        "http",
+        "https",
+        "ws",
+        "wss",
+        "gopher",
+        "file",
+        "ftp",
+        "requires",
+        "requried",
+        "portnumber",
+        "url",
+        "parsing",
+        "validation",
+        "cows"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/requires-port/issues"
+      },
+      "homepage": "https://github.com/unshiftio/requires-port",
+      "devDependencies": {
+        "assume": "1.1.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.1.x",
+        "pre-commit": "1.0.x"
+      },
+      "gitHead": "d6235df7aa7e8d08e9ac72c842e1e2c6c366376f",
+      "_id": "requires-port@0.0.1",
+      "_shasum": "4b4414411d9df7c855995dd899a8c78a2951c16d",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4b4414411d9df7c855995dd899a8c78a2951c16d",
+        "tarball": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "requires-port",
+      "version": "1.0.0",
+      "description": "Check if a protocol requires a certain port number to be added to an URL.",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test-travis": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/requires-port.git"
+      },
+      "keywords": [
+        "port",
+        "require",
+        "http",
+        "https",
+        "ws",
+        "wss",
+        "gopher",
+        "file",
+        "ftp",
+        "requires",
+        "requried",
+        "portnumber",
+        "url",
+        "parsing",
+        "validation",
+        "cows"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/unshiftio/requires-port/issues"
+      },
+      "homepage": "https://github.com/unshiftio/requires-port",
+      "devDependencies": {
+        "assume": "1.3.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.3.x",
+        "pre-commit": "1.1.x"
+      },
+      "gitHead": "3a552b935dd2ddba8f2ddf9096932f0f2024edfd",
+      "_id": "requires-port@1.0.0",
+      "_shasum": "925d2601d39ac485e091cf0da5c6e694dc3dcaff",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "925d2601d39ac485e091cf0da5c6e694dc3dcaff",
+        "tarball": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# requires-port\n\n[![Made by unshift](https://img.shields.io/badge/made%20by-unshift-00ffcc.svg?style=flat-square)](http://unshift.io)[![Version npm](http://img.shields.io/npm/v/requires-port.svg?style=flat-square)](http://browsenpm.org/package/requires-port)[![Build Status](http://img.shields.io/travis/unshiftio/requires-port/master.svg?style=flat-square)](https://travis-ci.org/unshiftio/requires-port)[![Dependencies](https://img.shields.io/david/unshiftio/requires-port.svg?style=flat-square)](https://david-dm.org/unshiftio/requires-port)[![Coverage Status](http://img.shields.io/coveralls/unshiftio/requires-port/master.svg?style=flat-square)](https://coveralls.io/r/unshiftio/requires-port?branch=master)[![IRC channel](http://img.shields.io/badge/IRC-irc.freenode.net%23unshift-00a8ff.svg?style=flat-square)](http://webchat.freenode.net/?channels=unshift)\n\nThe module name says it all, check if a protocol requires a given port.\n\n## Installation\n\nThis module is intended to be used with browserify or Node.js and is distributed\nin the public npm registry. To install it simply run the following command from\nyour CLI:\n\n```j\nnpm install --save requires-port\n```\n\n## Usage\n\nThe module exports it self as function and requires 2 arguments:\n\n1. The port number, can be a string or number.\n2. Protocol, can be `http`, `http:` or even `https://yomoma.com`. We just split\n   it at `:` and use the first result. We currently accept the following\n   protocols:\n   - `http`\n   - `https`\n   - `ws`\n   - `wss`\n   - `ftp`\n   - `gopher`\n   - `file`\n\nIt returns a boolean that indicates if protocol requires this port to be added\nto your URL.\n\n```js\n'use strict';\n\nvar required = require('requires-port');\n\nconsole.log(required('8080', 'http')) // true\nconsole.log(required('80', 'http'))   // false\n```\n\n# License\n\nMIT\n",
+  "maintainers": [
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "v1"
+    },
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "3rdeden"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-29T03:01:28.972Z",
+    "created": "2014-11-07T11:03:17.791Z",
+    "0.0.0": "2014-11-07T11:03:17.791Z",
+    "0.0.1": "2015-05-26T09:31:22.078Z",
+    "1.0.0": "2015-10-30T14:42:33.794Z"
+  },
+  "homepage": "https://github.com/unshiftio/requires-port",
+  "keywords": [
+    "port",
+    "require",
+    "http",
+    "https",
+    "ws",
+    "wss",
+    "gopher",
+    "file",
+    "ftp",
+    "requires",
+    "requried",
+    "portnumber",
+    "url",
+    "parsing",
+    "validation",
+    "cows"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unshiftio/requires-port.git"
+  },
+  "author": {
+    "name": "Arnout Kazemier"
+  },
+  "bugs": {
+    "url": "https://github.com/unshiftio/requires-port/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "mojaray2k": true,
+    "staydan": true,
+    "papasavva": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/requires-port.min.json
+++ b/test/fixtures/registry-mocks/content/requires-port.min.json
@@ -1,0 +1,51 @@
+{
+  "name": "requires-port",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "requires-port",
+      "version": "0.0.0",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "d9914dce124d3d5e75ceda38ca5434069f7132b3",
+        "tarball": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "requires-port",
+      "version": "0.0.1",
+      "devDependencies": {
+        "assume": "1.1.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.1.x",
+        "pre-commit": "1.0.x"
+      },
+      "dist": {
+        "shasum": "4b4414411d9df7c855995dd899a8c78a2951c16d",
+        "tarball": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "requires-port",
+      "version": "1.0.0",
+      "devDependencies": {
+        "assume": "1.3.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.3.x",
+        "pre-commit": "1.1.x"
+      },
+      "dist": {
+        "shasum": "925d2601d39ac485e091cf0da5c6e694dc3dcaff",
+        "tarball": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+      }
+    }
+  },
+  "modified": "2019-01-29T03:01:28.972Z"
+}

--- a/test/fixtures/registry-mocks/content/resolve-cwd.json
+++ b/test/fixtures/registry-mocks/content/resolve-cwd.json
@@ -1,0 +1,269 @@
+{
+  "_id": "resolve-cwd",
+  "_rev": "3-23beff3e876db0720b1b462c0fbea057",
+  "name": "resolve-cwd",
+  "description": "Resolve the path of a module like `require.resolve()` but from the current working directory",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "resolve-cwd",
+      "version": "1.0.0",
+      "description": "Resolve the path of a module like `require.resolve()` but from the current working directory",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sindresorhus/resolve-cwd"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "require",
+        "resolve",
+        "path",
+        "module",
+        "from",
+        "like",
+        "path",
+        "cwd",
+        "current",
+        "working",
+        "directory"
+      ],
+      "dependencies": {
+        "resolve-from": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "cdf0ae71148bb01e796165b1799996ae1ff2fa18",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/resolve-cwd/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/resolve-cwd",
+      "_id": "resolve-cwd@1.0.0",
+      "_shasum": "4eaeea41ed040d1702457df64a42b2b07d246f9f",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "4eaeea41ed040d1702457df64a42b2b07d246f9f",
+        "tarball": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "resolve-cwd",
+      "version": "2.0.0",
+      "description": "Resolve the path of a module like `require.resolve()` but from the current working directory",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/resolve-cwd.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "xo && ava"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "require",
+        "resolve",
+        "path",
+        "module",
+        "from",
+        "like",
+        "cwd",
+        "current",
+        "working",
+        "directory",
+        "import"
+      ],
+      "dependencies": {
+        "resolve-from": "^3.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "gitHead": "8c41f4b51c0b12792127ca2974101f8cac800a3b",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/resolve-cwd/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/resolve-cwd#readme",
+      "_id": "resolve-cwd@2.0.0",
+      "_shasum": "00a9f7387556e27038eae232caa372a6a59b665a",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "shasum": "00a9f7387556e27038eae232caa372a6a59b665a",
+        "tarball": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/resolve-cwd-2.0.0.tgz_1493370863917_0.16202757763676345"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "resolve-cwd",
+      "version": "3.0.0",
+      "description": "Resolve the path of a module like `require.resolve()` but from the current working directory",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sindresorhus/resolve-cwd.git"
+      },
+      "author": {
+        "name": "Sindre Sorhus",
+        "email": "sindresorhus@gmail.com",
+        "url": "sindresorhus.com"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "xo && ava && tsd"
+      },
+      "keywords": [
+        "require",
+        "resolve",
+        "path",
+        "module",
+        "from",
+        "like",
+        "cwd",
+        "current",
+        "working",
+        "directory",
+        "import"
+      ],
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "gitHead": "55afe697667744f61fd78787526d6c4d989d75fc",
+      "bugs": {
+        "url": "https://github.com/sindresorhus/resolve-cwd/issues"
+      },
+      "homepage": "https://github.com/sindresorhus/resolve-cwd#readme",
+      "_id": "resolve-cwd@3.0.0",
+      "_nodeVersion": "10.15.3",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "sindresorhus",
+        "email": "sindresorhus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+        "shasum": "0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d",
+        "tarball": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 4984,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcyEVECRA9TVsSAnZWagAAuD8QAIYlycAr3jQxT+pyQrA3\nYA2rYG6peBfZUdagDFOLMY+8z8BWgTDoCip9PSMqUCcUF79oHgYrso3xbO5C\nDUYnStY3bNqsoP50YPbvbo5dkbwh6lMrEWuOM2/0LpqrmzYaScT3YBR6EcNz\nyO762gsxVpecLNlDVHP55LCrB9m5dFCfuN0SUAizNj6qH6Lgaw7jjtX1BUnH\nXhTi95SAgPm8uKwPx/N1X4ffouaa6vKYBDaRZ/qOQtLEqL2l+yPWl7Tin+4d\n2dlrKH/WIowKGoPA2jZT2XO9JWb8hNg5zgOK9ILkQRmNcjGPAqI91DiGeyNF\nOxJcXtq5/w+z2iAJCRZvahJuyj2Rx1nUGsV1Utl4Vpdv4KBpVgwzpl47epIY\nm587ogdMvPFfCxjBpmY1w6CPb7wqUUY7i/MwjpAQY4QHkRTxOpkxSo8gJZ9y\nj5CL3EM9kr9LrB7zpTNCSsx9q1UBsXo4HuJJZ2wiXC8b5cJYT0gr4+dhXKTQ\nSCWZLg0/oHJ4N6t80bAHs7qC5OYj3szKscKyFkFCQoDQmsbd8+DIEhraWMmt\nLBctFgf/zWPOEiWEbGjs6CNoR7e0wwwHoNcHCkWaOPOb5fMzEn4kJI4Q4oWv\nEmS5A7wYPBrYJ+9mPv534Oyxcoqs+pkUx2KATvoym6MONHuEl7v+KY/j3Vi8\nvDha\r\n=FN61\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sindresorhus",
+          "email": "sindresorhus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/resolve-cwd_3.0.0_1556628803761_0.5546372287820458"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# resolve-cwd [![Build Status](https://travis-ci.org/sindresorhus/resolve-cwd.svg?branch=master)](https://travis-ci.org/sindresorhus/resolve-cwd)\n\n> Resolve the path of a module like [`require.resolve()`](https://nodejs.org/api/globals.html#globals_require_resolve) but from the current working directory\n\n\n## Install\n\n```\n$ npm install resolve-cwd\n```\n\n\n## Usage\n\n```js\nconst resolveCwd = require('resolve-cwd');\n\nconsole.log(__dirname);\n//=> '/Users/sindresorhus/rainbow'\n\nconsole.log(process.cwd());\n//=> '/Users/sindresorhus/unicorn'\n\nconsole.log(resolveCwd('./foo'));\n//=> '/Users/sindresorhus/unicorn/foo.js'\n```\n\n\n## API\n\n### resolveCwd(moduleId)\n\nLike `require()`, throws when the module can't be found.\n\n### resolveCwd.silent(moduleId)\n\nReturns `undefined` instead of throwing when the module can't be found.\n\n#### moduleId\n\nType: `string`\n\nWhat you would use in `require()`.\n\n\n## Related\n\n- [resolve-from](https://github.com/sindresorhus/resolve-from) - Resolve the path of a module from a given path\n- [import-from](https://github.com/sindresorhus/import-from) - Import a module from a given path\n- [import-cwd](https://github.com/sindresorhus/import-cwd) - Import a module from the current working directory\n- [resolve-pkg](https://github.com/sindresorhus/resolve-pkg) - Resolve the path of a package regardless of it having an entry point\n- [import-lazy](https://github.com/sindresorhus/import-lazy) - Import a module lazily\n- [resolve-global](https://github.com/sindresorhus/resolve-global) - Resolve the path of a globally installed module\n\n\n## License\n\nMIT © [Sindre Sorhus](https://sindresorhus.com)\n",
+  "maintainers": [
+    {
+      "name": "sindresorhus",
+      "email": "sindresorhus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-30T12:53:26.424Z",
+    "created": "2015-12-06T16:26:27.080Z",
+    "1.0.0": "2015-12-06T16:26:27.080Z",
+    "2.0.0": "2017-04-28T09:14:24.319Z",
+    "3.0.0": "2019-04-30T12:53:23.953Z"
+  },
+  "homepage": "https://github.com/sindresorhus/resolve-cwd#readme",
+  "keywords": [
+    "require",
+    "resolve",
+    "path",
+    "module",
+    "from",
+    "like",
+    "cwd",
+    "current",
+    "working",
+    "directory",
+    "import"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sindresorhus/resolve-cwd.git"
+  },
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "sindresorhus.com"
+  },
+  "bugs": {
+    "url": "https://github.com/sindresorhus/resolve-cwd/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md"
+}

--- a/test/fixtures/registry-mocks/content/resolve-cwd.min.json
+++ b/test/fixtures/registry-mocks/content/resolve-cwd.min.json
@@ -1,0 +1,68 @@
+{
+  "name": "resolve-cwd",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "resolve-cwd",
+      "version": "1.0.0",
+      "dependencies": {
+        "resolve-from": "^2.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "4eaeea41ed040d1702457df64a42b2b07d246f9f",
+        "tarball": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "resolve-cwd",
+      "version": "2.0.0",
+      "dependencies": {
+        "resolve-from": "^3.0.0"
+      },
+      "devDependencies": {
+        "ava": "*",
+        "xo": "*"
+      },
+      "dist": {
+        "shasum": "00a9f7387556e27038eae232caa372a6a59b665a",
+        "tarball": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "3.0.0": {
+      "name": "resolve-cwd",
+      "version": "3.0.0",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "devDependencies": {
+        "ava": "^1.4.1",
+        "tsd": "^0.7.2",
+        "xo": "^0.24.0"
+      },
+      "dist": {
+        "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+        "shasum": "0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d",
+        "tarball": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 4984,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcyEVECRA9TVsSAnZWagAAuD8QAIYlycAr3jQxT+pyQrA3\nYA2rYG6peBfZUdagDFOLMY+8z8BWgTDoCip9PSMqUCcUF79oHgYrso3xbO5C\nDUYnStY3bNqsoP50YPbvbo5dkbwh6lMrEWuOM2/0LpqrmzYaScT3YBR6EcNz\nyO762gsxVpecLNlDVHP55LCrB9m5dFCfuN0SUAizNj6qH6Lgaw7jjtX1BUnH\nXhTi95SAgPm8uKwPx/N1X4ffouaa6vKYBDaRZ/qOQtLEqL2l+yPWl7Tin+4d\n2dlrKH/WIowKGoPA2jZT2XO9JWb8hNg5zgOK9ILkQRmNcjGPAqI91DiGeyNF\nOxJcXtq5/w+z2iAJCRZvahJuyj2Rx1nUGsV1Utl4Vpdv4KBpVgwzpl47epIY\nm587ogdMvPFfCxjBpmY1w6CPb7wqUUY7i/MwjpAQY4QHkRTxOpkxSo8gJZ9y\nj5CL3EM9kr9LrB7zpTNCSsx9q1UBsXo4HuJJZ2wiXC8b5cJYT0gr4+dhXKTQ\nSCWZLg0/oHJ4N6t80bAHs7qC5OYj3szKscKyFkFCQoDQmsbd8+DIEhraWMmt\nLBctFgf/zWPOEiWEbGjs6CNoR7e0wwwHoNcHCkWaOPOb5fMzEn4kJI4Q4oWv\nEmS5A7wYPBrYJ+9mPv534Oyxcoqs+pkUx2KATvoym6MONHuEl7v+KY/j3Vi8\nvDha\r\n=FN61\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  },
+  "modified": "2019-04-30T12:53:26.424Z"
+}

--- a/test/fixtures/registry-mocks/content/resolve-url.json
+++ b/test/fixtures/registry-mocks/content/resolve-url.json
@@ -1,0 +1,233 @@
+{
+  "_id": "resolve-url",
+  "_rev": "8-49847d7493cb8922de6b716042c527ae",
+  "name": "resolve-url",
+  "description": "Like Node.js’ `path.resolve`/`url.resolve` for the browser.",
+  "dist-tags": {
+    "latest": "0.2.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "resolve-url",
+      "version": "0.1.0",
+      "description": "Like Node.js’ `path.resolve`/`url.resolve` for the browser.",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "main": "resolve-url.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/resolve-url"
+      },
+      "keywords": [
+        "resolve",
+        "url"
+      ],
+      "scripts": {
+        "test": "jshint resolve-url.js test/ && testling -u"
+      },
+      "devDependencies": {
+        "testling": "~1.6.0",
+        "mocha": "~1.17.1",
+        "chai": "~1.9.0",
+        "jshint": "~2.4.3"
+      },
+      "testling": {
+        "harness": "mocha",
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/resolve-url/issues"
+      },
+      "homepage": "https://github.com/lydell/resolve-url",
+      "_id": "resolve-url@0.1.0",
+      "dist": {
+        "shasum": "f7d376cb5784b0b0fbf54d822b3d516666358fca",
+        "tarball": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {},
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+    },
+    "0.2.0": {
+      "name": "resolve-url",
+      "version": "0.2.0",
+      "description": "Like Node.js’ `path.resolve`/`url.resolve` for the browser.",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "main": "resolve-url.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/resolve-url"
+      },
+      "keywords": [
+        "resolve",
+        "url"
+      ],
+      "scripts": {
+        "test": "jshint resolve-url.js test/ && testling -u"
+      },
+      "devDependencies": {
+        "testling": "~1.6.0",
+        "jshint": "~2.4.3",
+        "tape": "~2.5.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/resolve-url/issues"
+      },
+      "homepage": "https://github.com/lydell/resolve-url",
+      "_id": "resolve-url@0.2.0",
+      "dist": {
+        "shasum": "9479e58d94ea036d13f550d6ca14c3938cebbf67",
+        "tarball": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {},
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+    },
+    "0.2.1": {
+      "name": "resolve-url",
+      "version": "0.2.1",
+      "description": "Like Node.js’ `path.resolve`/`url.resolve` for the browser.",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "main": "resolve-url.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/resolve-url"
+      },
+      "keywords": [
+        "resolve",
+        "url"
+      ],
+      "scripts": {
+        "test": "jshint resolve-url.js test/ && testling -u"
+      },
+      "devDependencies": {
+        "testling": "~1.6.0",
+        "jshint": "~2.4.3",
+        "tape": "~2.5.0"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/resolve-url/issues"
+      },
+      "homepage": "https://github.com/lydell/resolve-url",
+      "_id": "resolve-url@0.2.1",
+      "dist": {
+        "shasum": "2c637fe77c893afd2a663fe21aa9080068e2052a",
+        "tarball": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {},
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+    }
+  },
+  "readme": "Overview\r\n========\r\n\r\n[![browser support](https://ci.testling.com/lydell/resolve-url.png)](https://ci.testling.com/lydell/resolve-url)\r\n\r\nLike Node.js’ [`path.resolve`]/[`url.resolve`] for the browser.\r\n\r\n```js\r\nvar resolveUrl = require(\"resolve-url\")\r\n\r\nwindow.location\r\n// https://example.com/articles/resolving-urls/edit\r\n\r\nresolveUrl(\"remove\")\r\n// https://example.com/articles/resolving-urls/remove\r\n\r\nresolveUrl(\"/static/scripts/app.js\")\r\n// https://example.com/static/scripts/app.js\r\n\r\n// Imagine /static/scripts/app.js contains `//# sourceMappingURL=../source-maps/app.js.map`\r\nresolveUrl(\"/static/scripts/app.js\", \"../source-maps/app.js.map\")\r\n// https://example.com/static/source-maps/app.js.map\r\n\r\nresolveUrl(\"/static/scripts/app.js\", \"../source-maps/app.js.map\", \"../coffee/app.coffee\")\r\n// https://example.com/static/coffee/app.coffee\r\n\r\nresolveUrl(\"//cdn.example.com/jquery.js\")\r\n// https://cdn.example.com/jquery.js\r\n\r\nresolveUrl(\"http://foo.org/\")\r\n// http://foo.org/\r\n```\r\n\r\n\r\nInstallation\r\n============\r\n\r\n- `npm install resolve-url`\r\n- `bower install resolve-url`\r\n- `component install lydell/resolve-url`\r\n\r\nWorks with CommonJS, AMD and browser globals, through UMD.\r\n\r\n\r\nUsage\r\n=====\r\n\r\n### `resolveUrl(...urls)` ###\r\n\r\nPass one or more urls. Resolves the last one to an absolute url, using the\r\nprevious ones and `window.location`.\r\n\r\nIt’s like starting out on `window.location`, and then clicking links with the\r\nurls as `href` attributes in order, from left to right.\r\n\r\nUnlike Node.js’ [`path.resolve`], this function always goes through all of the\r\narguments, from left to right. `path.resolve` goes from right to left and only\r\nin the worst case goes through them all. Should that matter.\r\n\r\nActually, the function is _really_ like clicking a lot of links in series: An\r\nactual `<a>` gets its `href` attribute set for each url! This means that the\r\nurl resolution of the browser is used, which makes this module really\r\nlight-weight.\r\n\r\nAlso note that this functions deals with urls, not paths, so in that respect it\r\nhas more in common with Node.js’ [`url.resolve`]. But the arguments are more\r\nlike [`path.resolve`].\r\n\r\n[`path.resolve`]: http://nodejs.org/api/path.html#path_path_resolve_from_to\r\n[`url.resolve`]: http://nodejs.org/api/url.html#url_url_resolve_from_to\r\n\r\n\r\nTests\r\n=====\r\n\r\nRun `npm test`, which lints the code and then gives you a link to open in a\r\nbrowser of choice (using `testling`).\r\n\r\n\r\nLicense\r\n=======\r\n\r\n[The X11 (“MIT”) License](LICENSE).\r\n",
+  "maintainers": [
+    {
+      "name": "lydell",
+      "email": "simon.lydell@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-03-28T23:10:48.836Z",
+    "created": "2014-02-23T20:21:23.451Z",
+    "0.1.0": "2014-02-23T20:21:23.452Z",
+    "0.2.0": "2014-02-24T20:38:15.897Z",
+    "0.2.1": "2014-02-25T18:48:50.732Z"
+  },
+  "readmeFilename": "readme.md",
+  "homepage": "https://github.com/lydell/resolve-url",
+  "keywords": [
+    "resolve",
+    "url"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/lydell/resolve-url"
+  },
+  "author": {
+    "name": "Simon Lydell"
+  },
+  "bugs": {
+    "url": "https://github.com/lydell/resolve-url/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "brandonpapworth": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/resolve-url.min.json
+++ b/test/fixtures/registry-mocks/content/resolve-url.min.json
@@ -1,0 +1,52 @@
+{
+  "name": "resolve-url",
+  "dist-tags": {
+    "latest": "0.2.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "resolve-url",
+      "version": "0.1.0",
+      "devDependencies": {
+        "testling": "~1.6.0",
+        "mocha": "~1.17.1",
+        "chai": "~1.9.0",
+        "jshint": "~2.4.3"
+      },
+      "dist": {
+        "shasum": "f7d376cb5784b0b0fbf54d822b3d516666358fca",
+        "tarball": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.1.0.tgz"
+      },
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+    },
+    "0.2.0": {
+      "name": "resolve-url",
+      "version": "0.2.0",
+      "devDependencies": {
+        "testling": "~1.6.0",
+        "jshint": "~2.4.3",
+        "tape": "~2.5.0"
+      },
+      "dist": {
+        "shasum": "9479e58d94ea036d13f550d6ca14c3938cebbf67",
+        "tarball": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.0.tgz"
+      },
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+    },
+    "0.2.1": {
+      "name": "resolve-url",
+      "version": "0.2.1",
+      "devDependencies": {
+        "testling": "~1.6.0",
+        "jshint": "~2.4.3",
+        "tape": "~2.5.0"
+      },
+      "dist": {
+        "shasum": "2c637fe77c893afd2a663fe21aa9080068e2052a",
+        "tarball": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
+      },
+      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
+    }
+  },
+  "modified": "2020-03-28T23:10:48.836Z"
+}

--- a/test/fixtures/registry-mocks/content/ret.json
+++ b/test/fixtures/registry-mocks/content/ret.json
@@ -1,0 +1,1355 @@
+{
+  "_id": "ret",
+  "_rev": "40-728dee40b4455c53520ae3d2eafcf228",
+  "name": "ret",
+  "description": "Tokenizes a string that represents a regular expression.",
+  "dist-tags": {
+    "latest": "0.3.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "ret",
+      "description": "Tokenizes a string that represetns a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "_npmUser": {
+        "name": "neat",
+        "email": "roly426@gmail.com"
+      },
+      "_id": "ret@0.1.0",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "98f230ea7de86169ad00c0e0d8880cb0a9c3c494",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "neat",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.1": {
+      "name": "ret",
+      "description": "Tokenizes a string that represetns a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "_npmUser": {
+        "name": "neat",
+        "email": "roly426@gmail.com"
+      },
+      "_id": "ret@0.1.1",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f3955511aca1146dd1db776fd4a098c43336934f",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "neat",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.2": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "_npmUser": {
+        "name": "neat",
+        "email": "roly426@gmail.com"
+      },
+      "_id": "ret@0.1.2",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e0c1c5c5d324c9ba9ed6d2f35a32cebda3b71e92",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "neat",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.3": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.3",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "_npmUser": {
+        "name": "neat",
+        "email": "roly426@gmail.com"
+      },
+      "_id": "ret@0.1.3",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "0b7595b10bff95dcc735fb3c9b959e3519427302",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "neat",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.4": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.4",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "_npmUser": {
+        "name": "neat",
+        "email": "roly426@gmail.com"
+      },
+      "_id": "ret@0.1.4",
+      "dependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.6.6",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "af433670339787fc592b7ea4a0346332bf6b4263",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "neat",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.5": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.5",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "_npmUser": {
+        "name": "neat",
+        "email": "roly426@gmail.com"
+      },
+      "_id": "ret@0.1.5",
+      "dependencies": {},
+      "optionalDependencies": {},
+      "_engineSupported": true,
+      "_npmVersion": "1.1.16",
+      "_nodeVersion": "v0.6.15",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "7f53d82221b9a29a2f51e5803a1c1b2b3f5d3b6f",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "neat",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.6": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.6",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "_id": "ret@0.1.6",
+      "dist": {
+        "shasum": "c98f948fb8b7f795cb411e4c292bac10c82a4232",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.6.tgz"
+      },
+      "_npmVersion": "1.1.49",
+      "_npmUser": {
+        "name": "neat",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "neat",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.7": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.7",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "_id": "ret@0.1.7",
+      "dist": {
+        "shasum": "2dc5b181c17c208284e154de1b5c4d17068b8e76",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.8": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.8",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js",
+      "_id": "ret@0.1.8",
+      "dist": {
+        "shasum": "76da219725eeda8a7ac3b83248ab8f7119846cce",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ]
+    },
+    "0.1.9": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.9",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "vows": "0.7.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "gitHead": "0f93cd577ddea079f2dab81fe2cb04f37bdf1eba",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js",
+      "_id": "ret@0.1.9",
+      "_shasum": "369aae90ab4450ab1ddf3a64db9f38c0d033e624",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "369aae90ab4450ab1ddf3a64db9f38c0d033e624",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.9.tgz"
+      }
+    },
+    "0.1.10": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.10",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "vows": "0.7.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "gitHead": "7059a6ca2b12ca170cd3eba73be70f4837611d06",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js",
+      "_id": "ret@0.1.10",
+      "_shasum": "7bda7048cb6b0566617d3b15a3345f712060a1a4",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7bda7048cb6b0566617d3b15a3345f712060a1a4",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.10.tgz"
+      }
+    },
+    "0.1.11": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.11",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "vows": "*"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "gitHead": "d3f48960a2a701d964ec94e31c5b0e6073f74aeb",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.1.11",
+      "_shasum": "281bbd5bd0e2a935181a503ec5ca60e3faa9c4a9",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.1.0",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "281bbd5bd0e2a935181a503ec5ca60e3faa9c4a9",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.11.tgz"
+      }
+    },
+    "0.1.12": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.12",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "istanbul cover vows test/*-test.js --spec"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "*",
+        "vows": "*"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://github.com/fent/ret.js/raw/master/LICENSE"
+        }
+      ],
+      "gitHead": "12d1f8173d6be85135eb749cd70dc68782352039",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.1.12",
+      "_shasum": "29348dc8b879393692dc47574494c38a26bf648f",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "29348dc8b879393692dc47574494c38a26bf648f",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.12.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/ret-0.1.12.tgz_1468810244810_0.24253487680107355"
+      }
+    },
+    "0.1.13": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.13",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "istanbul cover vows -- --spec test/*-test.js"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "*",
+        "vows": "*"
+      },
+      "license": "MIT",
+      "gitHead": "81b521982f6574b22f174ba47e3456aab0e9741b",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.1.13",
+      "_shasum": "38c2702ece654978941edd8b7dfac6aeeef4067d",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "38c2702ece654978941edd8b7dfac6aeeef4067d",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.13.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ret-0.1.13.tgz_1480905347916_0.20543619222007692"
+      }
+    },
+    "0.1.14": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.14",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "scripts": {
+        "test": "istanbul cover vows -- --spec test/*-test.js"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "*",
+        "vows": "*"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "license": "MIT",
+      "gitHead": "3883f40c3eb4a379e67b374358efcb68fb2e677e",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.1.14",
+      "_shasum": "58c636837b12e161f8a380cf081c6a230fd1664e",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.1",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "58c636837b12e161f8a380cf081c6a230fd1664e",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.14.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ret-0.1.14.tgz_1488515797286_0.22940291627310216"
+      }
+    },
+    "0.1.15": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.1.15",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "istanbul cover vows -- --spec test/*-test.js"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "*",
+        "vows": "*"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "license": "MIT",
+      "gitHead": "7f7c436e2a85fbc068e6d94e2611ce78b3e9ad10",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.1.15",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.3.0",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+        "shasum": "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ret-0.1.15.tgz_1502337231422_0.8702190876938403"
+      }
+    },
+    "0.2.0": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.2.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "istanbul cover vows -- --spec test/*-test.js"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "license": "MIT",
+      "gitHead": "5fbe198d6820a06c1e42505e292ea72ef5ac1f2e",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.2.0",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "8.8.1",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-EeoE0lijTMBvPaBPSXhZzW6ODKvT/XcIy+Xn4W7TO7bNKixuyPNU1xo/XOKTRVZ4aT3A/XlzY+8VNkHZGq4swA==",
+        "shasum": "2df0d34a638d13812ddf8a2c3e22cc6c04994fc9",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ret-0.2.0.tgz_1509313037033_0.6622188813053071"
+      }
+    },
+    "0.2.1": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.2.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "Roly Fentanes",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "istanbul cover vows -- --spec test/*-test.js"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "license": "MIT",
+      "gitHead": "ff351f56171d48c67a85c2f7f4c23c68076f37f4",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.2.1",
+      "_shasum": "900dda400b6220d8d429f4ef8557710e544825ce",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.8.4",
+      "_npmUser": {
+        "name": "fent",
+        "email": "roly426@gmail.com"
+      },
+      "dist": {
+        "shasum": "900dda400b6220d8d429f4ef8557710e544825ce",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ret-0.2.1.tgz_1509502975682_0.30610496643930674"
+      }
+    },
+    "0.2.2": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.2.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "fent",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "test": "istanbul cover vows -- --spec test/*-test.js"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "license": "MIT",
+      "gitHead": "c856e909be0ea5b4518c722b3481c4c52ce839fe",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.2.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "fent",
+        "email": "fentbox@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+        "shasum": "b6861782a1f4762dce43402a71eb7a283f44573c",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 17038
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ret_0.2.2_1519359185580_0.9368461462852189"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.3.0": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.3.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "fent",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "types": "./typings/index.d.ts",
+      "scripts": {
+        "test": "istanbul cover vows -- --spec test/*-test.js"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.2"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "license": "MIT",
+      "gitHead": "90f393d4644f1e83445fe0ecbb31517e5047e104",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.3.0",
+      "_nodeVersion": "11.10.1",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "fent",
+        "email": "fentbox@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-Bsce3XWwlM8YUKQMFidavX9Lt2QGJK4NdvOBNw6ubXltWB/I8lrRVBpnnOtsQkX7ICnnEQw5sAxzr3Es+BGz1g==",
+        "shasum": "bb23d7a8a1ec44ecc2bdcf843e3ded137cf4cf71",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.3.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 22249,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcqn6TCRA9TVsSAnZWagAAdWQQAIvhoDbehDO56zzbxcnY\njHnQZdEK0LrTDBwIaafJu++HqqQzmgGMsBIkf8NC4lqcvxngKLN4OzUOKRyM\nWXSTVl3S7KLsMw+hRw1NExIPf/9TecEVyAsYzXRMbHZWxtagDMFDx9IYM6uI\nXMD86Zq3BQ4a2DIxdnI93d0AZ8NVdrvNvIQ2eg2eridTpSoEQ1LaiVLlFMIu\npXQfZ1wFRTxEenKQnRhk46ANxUdju0/QEgxJtHbQ0g2pD2v53P/s/vfN3hDt\nsVI/etGEvYCzreqo0uqHcNiKW0LD4SxgEaFpKNBWUQOxLcHfI0JazPrDsXP0\nWSpOcg8/FIPNJrm99DaNt7h2j78UZ+OcQta7CweJzfg8b8FO2ZJrUPnsUsBh\nBgRtkyRLHbg5GpT4U9322UeW9chTZxDB1vKknRz1bLC2gE2pbzuYAEQbS8OH\nZmjq+v5UiO1/p5tbtAARdILjdqV0mLQJeywO/ZHmLumNEW26CAO6ykqy/hDp\nbY9onLkOeu5vWjq8q+XBvfDUdf1Qxr9JPrge8YlwI0isuKSeHhuz3GJsXalp\n22jvR8xRzFJR9U64eOKLaokiQF+9GDXuaxuagRpA9SweRNYYSzTgPvqyf/54\nKbWlcziyMgQTQ2AmAUOFhbfm+Neva1GJVj8O7VRNK4OXi9Xz3HhBnt9zrpoN\naUnm\r\n=mWdc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ret_0.3.0_1554677394285_0.3187567201337915"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.3.1": {
+      "name": "ret",
+      "description": "Tokenizes a string that represents a regular expression.",
+      "keywords": [
+        "regex",
+        "regexp",
+        "regular expression",
+        "parser",
+        "tokenizer"
+      ],
+      "version": "0.3.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/fent/ret.js.git"
+      },
+      "author": {
+        "name": "fent",
+        "url": "https://github.com/fent"
+      },
+      "main": "./lib/index.js",
+      "types": "./typings/index.d.ts",
+      "scripts": {
+        "test": "istanbul cover vows -- --spec test/*-test.js"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.2"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "license": "MIT",
+      "gitHead": "bc25727c578e48cb3e36c357bcbe3558b10ebda5",
+      "bugs": {
+        "url": "https://github.com/fent/ret.js/issues"
+      },
+      "homepage": "https://github.com/fent/ret.js#readme",
+      "_id": "ret@0.3.1",
+      "_nodeVersion": "11.10.1",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "fent",
+        "email": "fentbox@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-I/Evl5NrbgURNN0zts1dtI0ItI9pBg53jicdv9JqGumyOX+K7FELFcr2k3ED0hT7t9GsHctZj2in+tXDJfXypw==",
+        "shasum": "74655c3d876a4b6c2576c592431c7b0a84d2b82d",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.3.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 23399,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcq1NiCRA9TVsSAnZWagAA6TIQAIVk2wMJHCQy6JKak2eh\nyQlbzUih6P8c7E52Naqv3q6cb+ASENnSQbdDThffd3eGI0FzOjZ3os8HLGIm\n5PC/CkmpSi7wIN/MjCPD6D2gxsnlCc8Fn6gp/ahBg8fAWXYxUOOr6vINU5zW\nzaSChBOstz71lP09hiwhblpVgdpRRHener/6ws9vwydOQiJPLGPJNlLd0gO9\npwpFwJE9gT1PMgeUG5O/WmPp3ldBSgKKdrBGAMGtT+PjErxWDc++wIVeAaTT\n/msC1Be4zjCFPqa3Bw3rPIAdTdDCpVy3DuBUN7UI9H8ZJVpc/6r+054NrQAA\nlIZURN0Xjk7DdDMNMCOi5UK3S+io8oHWOd4t06yaV7VSeaCIwE2M/qB/wOXl\nBFbR7PuBAE1H22AGqAPPlNhV08t/uhMCdZfRGdJnTQlzypM5eW3FEbm9KnoX\n95ikFwgm1cTnc1N8SEQ+p/wXNbVODNZJ05ubf+oS0MQh+xlXoOl7HlpEYbyB\nJ0P8fO4n6SPkROINyJ7vzKNnWOPDmn03x5ppdjnrTWNHaJe9n/Of9L+9g/PH\ngjI/CnUh9F0L583C/OvDEbsS7oQhg3YuT3eyoHc9P4Yv9fSlwLr9+eNMTre1\nicEQxHdKsHVpPvZA5fjM2PInGXJ3AYHmgkDob1vM3H5RE/5Hk9SPXyyMHq6U\nN1DJ\r\n=ix/b\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "fent",
+          "email": "roly426@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ret_0.3.1_1554731873990_0.9768631938719019"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Regular Expression Tokenizer\n\nTokenizes strings that represent a regular expressions.\n\n[![Build Status](https://secure.travis-ci.org/fent/ret.js.svg)](http://travis-ci.org/fent/ret.js)\n[![Dependency Status](https://david-dm.org/fent/ret.js.svg)](https://david-dm.org/fent/ret.js)\n[![codecov](https://codecov.io/gh/fent/ret.js/branch/master/graph/badge.svg)](https://codecov.io/gh/fent/ret.js)\n\n# Usage\n\n```js\nconst ret = require('ret');\n\nvar tokens = ret(/foo|bar/.source);\n```\n\n`tokens` will contain the following object\n\n```js\n{\n  \"type\": ret.types.ROOT\n  \"options\": [\n    [ { \"type\": ret.types.CHAR, \"value\", 102 },\n      { \"type\": ret.types.CHAR, \"value\", 111 },\n      { \"type\": ret.types.CHAR, \"value\", 111 } ],\n    [ { \"type\": ret.types.CHAR, \"value\",  98 },\n      { \"type\": ret.types.CHAR, \"value\",  97 },\n      { \"type\": ret.types.CHAR, \"value\", 114 } ]\n  ]\n}\n```\n\n# Token Types\n\n`ret.types` is a collection of the various token types exported by ret.\n\n### ROOT\n\nOnly used in the root of the regexp. This is needed due to the posibility of the root containing a pipe `|` character. In that case, the token will have an `options` key that will be an array of arrays of tokens. If not, it will contain a `stack` key that is an array of tokens.\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [token1, token2...],\n}\n```\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"options\" [\n    [token1, token2...],\n    [othertoken1, othertoken2...]\n    ...\n  ],\n}\n```\n\n### GROUP\n\nGroups contain tokens that are inside of a parenthesis. If the group begins with `?` followed by another character, it's a special type of group. A ':' tells the group not to be remembered when `exec` is used. '=' means the previous token matches only if followed by this group, and '!' means the previous token matches only if NOT followed.\n\nLike root, it can contain an `options` key instead of `stack` if there is a pipe.\n\n```js\n{\n  \"type\": ret.types.GROUP,\n  \"remember\" true,\n  \"followedBy\": false,\n  \"notFollowedBy\": false,\n  \"stack\": [token1, token2...],\n}\n```\n\n```js\n{\n  \"type\": ret.types.GROUP,\n  \"remember\" true,\n  \"followedBy\": false,\n  \"notFollowedBy\": false,\n  \"options\" [\n    [token1, token2...],\n    [othertoken1, othertoken2...]\n    ...\n  ],\n}\n```\n\n### POSITION\n\n`\\b`, `\\B`, `^`, and `$` specify positions in the regexp.\n\n```js\n{\n  \"type\": ret.types.POSITION,\n  \"value\": \"^\",\n}\n```\n\n### SET\n\nContains a key `set` specifying what tokens are allowed and a key `not` specifying if the set should be negated. A set can contain other sets, ranges, and characters.\n\n```js\n{\n  \"type\": ret.types.SET,\n  \"set\": [token1, token2...],\n  \"not\": false,\n}\n```\n\n### RANGE\n\nUsed in set tokens to specify a character range. `from` and `to` are character codes.\n\n```js\n{\n  \"type\": ret.types.RANGE,\n  \"from\": 97,\n  \"to\": 122,\n}\n```\n\n### REPETITION\n\n```js\n{\n  \"type\": ret.types.REPETITION,\n  \"min\": 0,\n  \"max\": Infinity,\n  \"value\": token,\n}\n```\n\n### REFERENCE\n\nReferences a group token. `value` is 1-9.\n\n```js\n{\n  \"type\": ret.types.REFERENCE,\n  \"value\": 1,\n}\n```\n\n### CHAR\n\nRepresents a single character token. `value` is the character code. This might seem a bit cluttering instead of concatenating characters together. But since repetition tokens only repeat the last token and not the last clause like the pipe, it's simpler to do it this way.\n\n```js\n{\n  \"type\": ret.types.CHAR,\n  \"value\": 123,\n}\n```\n\n## Errors\n\nret.js will throw errors if given a string with an invalid regular expression. All possible errors are\n\n* Invalid group. When a group with an immediate `?` character is followed by an invalid character. It can only be followed by `!`, `=`, or `:`. Example: `/(?_abc)/`\n* Nothing to repeat. Thrown when a repetitional token is used as the first token in the current clause, as in right in the beginning of the regexp or group, or right after a pipe. Example: `/foo|?bar/`, `/{1,3}foo|bar/`, `/foo(+bar)/`\n* Unmatched ). A group was not opened, but was closed. Example: `/hello)2u/`\n* Unterminated group. A group was not closed. Example: `/(1(23)4/`\n* Unterminated character class. A custom character set was not closed. Example: `/[abc/`\n\n# Regular Expression Syntax\n\nRegular expressions follow the [JavaScript syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp).\n\nThe following latest JavaScript additions are not supported yet:\n* `\\p` and `\\P`: [Unicode property escapes](https://github.com/tc39/proposal-regexp-unicode-property-escapes)\n* `(?<group>)` and `\\k<group>`: [Named groups](https://github.com/tc39/proposal-regexp-named-groups)\n* `(?<=)` and `(?<!)`: [Negative lookbehind assertions](https://github.com/tc39/proposal-regexp-lookbehind)\n\n# Examples\n\n`/abc/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [\n    { \"type\": ret.types.CHAR, \"value\": 97 },\n    { \"type\": ret.types.CHAR, \"value\": 98 },\n    { \"type\": ret.types.CHAR, \"value\": 99 }\n  ]\n}\n```\n\n`/[abc]/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.SET,\n    \"set\": [\n      { \"type\": ret.types.CHAR, \"value\": 97 },\n      { \"type\": ret.types.CHAR, \"value\": 98 },\n      { \"type\": ret.types.CHAR, \"value\": 99 }\n    ],\n    \"not\": false\n  }]\n}\n```\n\n`/[^abc]/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.SET,\n    \"set\": [\n      { \"type\": ret.types.CHAR, \"value\": 97 },\n      { \"type\": ret.types.CHAR, \"value\": 98 },\n      { \"type\": ret.types.CHAR, \"value\": 99 }\n    ],\n    \"not\": true\n  }]\n}\n```\n\n`/[a-z]/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.SET,\n    \"set\": [\n      { \"type\": ret.types.RANGE, \"from\": 97, \"to\": 122 }\n    ],\n    \"not\": false\n  }]\n}\n```\n\n`/\\w/`\n\n```js\n// Similar logic for `\\W`, `\\d`, `\\D`, `\\s` and `\\S`    \n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.SET,\n    \"set\": [{\n      { \"type\": ret.types.CHAR, \"value\": 95 },\n      { \"type\": ret.types.RANGE, \"from\": 97, \"to\": 122 },\n      { \"type\": ret.types.RANGE, \"from\": 65, \"to\": 90 },\n      { \"type\": ret.types.RANGE, \"from\": 48, \"to\": 57 }\n    }],\n    \"not\": false\n  }]\n}\n```\n\n`/./`\n\n```js\n// any character but CR, LF, U+2028 or U+2029\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.SET,\n    \"set\": [ \n      { \"type\": ret.types.CHAR, \"value\": 10 },\n      { \"type\": ret.types.CHAR, \"value\": 13 },\n      { \"type\": ret.types.CHAR, \"value\": 8232 },\n      { \"type\": ret.types.CHAR, \"value\": 8233 }\n    ],\n    \"not\": true\n  }]\n}\n```\n\n`/a*/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.REPETITION, \n    \"min\": 0,\n    \"max\": Infinity,\n    \"value\": { \"type\": ret.types.CHAR, \"value\": 97 }\n  }]\n}\n```\n\n`/a+/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.REPETITION, \n    \"min\": 1,\n    \"max\": Infinity,\n    \"value\": { \"type\": ret.types.CHAR, \"value\": 97 },\n  }]\n}\n```\n\n`/a?/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.REPETITION, \n    \"min\": 0,\n    \"max\": 1,\n    \"value\": { \"type\": ret.types.CHAR, \"value\": 97 }\n  }]\n}\n```\n\n`/a{3}/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.REPETITION, \n    \"min\": 3,\n    \"max\": 3,\n    \"value\": { \"type\": ret.types.CHAR, \"value\": 97 }\n  }]\n}\n```\n\n`/a{3,5}/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.REPETITION, \n    \"min\": 3,\n    \"max\": 5,\n    \"value\": { \"type\": ret.types.CHAR, \"value\": 97 }\n  }]\n}\n```\n\n`/a{3,}/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.REPETITION, \n    \"min\": 3,\n    \"max\": Infinity,\n    \"value\": { \"type\": ret.types.CHAR, \"value\": 97 }\n  }]\n}\n```\n\n`/(a)/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.GROUP, \n    \"stack\": { \"type\": ret.types.CHAR, \"value\": 97 },\n    \"remember\": true\n  }]\n}\n```\n\n`/(?:a)/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.GROUP, \n    \"stack\": { \"type\": ret.types.CHAR, \"value\": 97 },\n    \"remember\": false\n  }]\n}\n```\n\n`/(?=a)/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.GROUP, \n    \"stack\": { \"type\": ret.types.CHAR, \"value\": 97 },\n    \"remember\": false,\n    \"followedBy\": true\n  }]\n}\n```\n\n`/(?!a)/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{ \n    \"type\": ret.types.GROUP, \n    \"stack\": { \"type\": ret.types.CHAR, \"value\": 97 },\n    \"remember\": false,\n    \"notFollowedBy\": true\n  }]\n}\n```\n\n`/a|b/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"options\": [\n    [{ \"type\": ret.types.CHAR, \"value\": 97 }], \n    [{ \"type\": ret.types.CHAR, \"value\": 98 }] \n  ]\n}\n```\n\n`/(a|b)/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [\n    \"type\": ret.types.GROUP,\n    \"remember\": true,\n    \"options\": [\n      [{ \"type\": ret.types.CHAR, \"value\": 97 }], \n      [{ \"type\": ret.types.CHAR, \"value\": 98 }] \n    ]\n  ]\n}\n```\n\n`/^/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.POSITION,\n    \"value\": \"^\"\n  }]\n}\n```\n\n`/$/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.POSITION,\n    \"value\": \"$\"\n  }]\n}\n```\n\n`/\\b/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.POSITION,\n    \"value\": \"b\"\n  }]\n}\n```\n\n`/\\B/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.POSITION,\n    \"value\": \"B\"\n  }]\n}\n```\n\n`/\\1/`\n\n```js\n{\n  \"type\": ret.types.ROOT,\n  \"stack\": [{\n    \"type\": ret.types.REFERENCE,\n    \"value\": 1\n  }]\n}\n```\n\n# Install\n\n    npm install ret\n\n\n# Tests\n\nTests are written with [vows](http://vowsjs.org/)\n\n```bash\nnpm test\n```\n",
+  "maintainers": [
+    {
+      "name": "fent",
+      "email": "roly426@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-08T13:57:56.795Z",
+    "created": "2011-12-21T07:45:21.262Z",
+    "0.1.0": "2011-12-21T07:45:24.249Z",
+    "0.1.1": "2011-12-21T10:01:48.540Z",
+    "0.1.2": "2011-12-28T12:49:33.268Z",
+    "0.1.3": "2011-12-31T09:04:54.162Z",
+    "0.1.4": "2012-01-02T11:52:21.652Z",
+    "0.1.5": "2012-04-12T07:52:50.583Z",
+    "0.1.6": "2012-08-19T06:39:46.300Z",
+    "0.1.7": "2013-09-29T06:00:25.742Z",
+    "0.1.8": "2013-12-12T15:36:27.849Z",
+    "0.1.9": "2014-09-16T23:58:37.805Z",
+    "0.1.10": "2014-09-17T23:11:32.171Z",
+    "0.1.11": "2015-11-20T05:36:28.241Z",
+    "0.1.12": "2016-07-18T02:50:45.904Z",
+    "0.1.13": "2016-12-05T02:35:49.924Z",
+    "0.1.14": "2017-03-03T04:36:39.240Z",
+    "0.1.15": "2017-08-10T03:53:52.328Z",
+    "0.2.0": "2017-10-29T21:37:17.943Z",
+    "0.2.1": "2017-11-01T02:22:56.660Z",
+    "0.2.2": "2018-02-23T04:13:05.650Z",
+    "0.3.0": "2019-04-07T22:49:54.476Z",
+    "0.3.1": "2019-04-08T13:57:54.174Z"
+  },
+  "author": {
+    "name": "fent",
+    "url": "https://github.com/fent"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/fent/ret.js.git"
+  },
+  "users": {
+    "substack": true,
+    "scottfreecode": true,
+    "hibrahimsafak": true,
+    "meeh": true,
+    "bluelovers": true
+  },
+  "homepage": "https://github.com/fent/ret.js#readme",
+  "keywords": [
+    "regex",
+    "regexp",
+    "regular expression",
+    "parser",
+    "tokenizer"
+  ],
+  "bugs": {
+    "url": "https://github.com/fent/ret.js/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/ret.min.json
+++ b/test/fixtures/registry-mocks/content/ret.min.json
@@ -1,0 +1,364 @@
+{
+  "name": "ret",
+  "dist-tags": {
+    "latest": "0.3.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "ret",
+      "version": "0.1.0",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "98f230ea7de86169ad00c0e0d8880cb0a9c3c494",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.1": {
+      "name": "ret",
+      "version": "0.1.1",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "f3955511aca1146dd1db776fd4a098c43336934f",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.2": {
+      "name": "ret",
+      "version": "0.1.2",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "e0c1c5c5d324c9ba9ed6d2f35a32cebda3b71e92",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.3": {
+      "name": "ret",
+      "version": "0.1.3",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "0b7595b10bff95dcc735fb3c9b959e3519427302",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.4": {
+      "name": "ret",
+      "version": "0.1.4",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "af433670339787fc592b7ea4a0346332bf6b4263",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.5": {
+      "name": "ret",
+      "version": "0.1.5",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "7f53d82221b9a29a2f51e5803a1c1b2b3f5d3b6f",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.6": {
+      "name": "ret",
+      "version": "0.1.6",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "c98f948fb8b7f795cb411e4c292bac10c82a4232",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.6.tgz"
+      }
+    },
+    "0.1.7": {
+      "name": "ret",
+      "version": "0.1.7",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "2dc5b181c17c208284e154de1b5c4d17068b8e76",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.7.tgz"
+      }
+    },
+    "0.1.8": {
+      "name": "ret",
+      "version": "0.1.8",
+      "devDependencies": {
+        "vows": "0.5.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "76da219725eeda8a7ac3b83248ab8f7119846cce",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.8.tgz"
+      }
+    },
+    "0.1.9": {
+      "name": "ret",
+      "version": "0.1.9",
+      "devDependencies": {
+        "vows": "0.7.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "369aae90ab4450ab1ddf3a64db9f38c0d033e624",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.9.tgz"
+      }
+    },
+    "0.1.10": {
+      "name": "ret",
+      "version": "0.1.10",
+      "devDependencies": {
+        "vows": "0.7.x"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "7bda7048cb6b0566617d3b15a3345f712060a1a4",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.10.tgz"
+      }
+    },
+    "0.1.11": {
+      "name": "ret",
+      "version": "0.1.11",
+      "devDependencies": {
+        "vows": "*"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "281bbd5bd0e2a935181a503ec5ca60e3faa9c4a9",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.11.tgz"
+      }
+    },
+    "0.1.12": {
+      "name": "ret",
+      "version": "0.1.12",
+      "devDependencies": {
+        "istanbul": "*",
+        "vows": "*"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "29348dc8b879393692dc47574494c38a26bf648f",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.12.tgz"
+      }
+    },
+    "0.1.13": {
+      "name": "ret",
+      "version": "0.1.13",
+      "devDependencies": {
+        "istanbul": "*",
+        "vows": "*"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "38c2702ece654978941edd8b7dfac6aeeef4067d",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.13.tgz"
+      }
+    },
+    "0.1.14": {
+      "name": "ret",
+      "version": "0.1.14",
+      "devDependencies": {
+        "istanbul": "*",
+        "vows": "*"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "58c636837b12e161f8a380cf081c6a230fd1664e",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.14.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "0.1.15": {
+      "name": "ret",
+      "version": "0.1.15",
+      "devDependencies": {
+        "istanbul": "*",
+        "vows": "*"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+        "shasum": "b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "0.2.0": {
+      "name": "ret",
+      "version": "0.2.0",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-EeoE0lijTMBvPaBPSXhZzW6ODKvT/XcIy+Xn4W7TO7bNKixuyPNU1xo/XOKTRVZ4aT3A/XlzY+8VNkHZGq4swA==",
+        "shasum": "2df0d34a638d13812ddf8a2c3e22cc6c04994fc9",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "0.2.1": {
+      "name": "ret",
+      "version": "0.2.1",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "900dda400b6220d8d429f4ef8557710e544825ce",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "0.2.2": {
+      "name": "ret",
+      "version": "0.2.2",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+        "shasum": "b6861782a1f4762dce43402a71eb7a283f44573c",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 17038
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "0.3.0": {
+      "name": "ret",
+      "version": "0.3.0",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.2"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-Bsce3XWwlM8YUKQMFidavX9Lt2QGJK4NdvOBNw6ubXltWB/I8lrRVBpnnOtsQkX7ICnnEQw5sAxzr3Es+BGz1g==",
+        "shasum": "bb23d7a8a1ec44ecc2bdcf843e3ded137cf4cf71",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.3.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 22249,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcqn6TCRA9TVsSAnZWagAAdWQQAIvhoDbehDO56zzbxcnY\njHnQZdEK0LrTDBwIaafJu++HqqQzmgGMsBIkf8NC4lqcvxngKLN4OzUOKRyM\nWXSTVl3S7KLsMw+hRw1NExIPf/9TecEVyAsYzXRMbHZWxtagDMFDx9IYM6uI\nXMD86Zq3BQ4a2DIxdnI93d0AZ8NVdrvNvIQ2eg2eridTpSoEQ1LaiVLlFMIu\npXQfZ1wFRTxEenKQnRhk46ANxUdju0/QEgxJtHbQ0g2pD2v53P/s/vfN3hDt\nsVI/etGEvYCzreqo0uqHcNiKW0LD4SxgEaFpKNBWUQOxLcHfI0JazPrDsXP0\nWSpOcg8/FIPNJrm99DaNt7h2j78UZ+OcQta7CweJzfg8b8FO2ZJrUPnsUsBh\nBgRtkyRLHbg5GpT4U9322UeW9chTZxDB1vKknRz1bLC2gE2pbzuYAEQbS8OH\nZmjq+v5UiO1/p5tbtAARdILjdqV0mLQJeywO/ZHmLumNEW26CAO6ykqy/hDp\nbY9onLkOeu5vWjq8q+XBvfDUdf1Qxr9JPrge8YlwI0isuKSeHhuz3GJsXalp\n22jvR8xRzFJR9U64eOKLaokiQF+9GDXuaxuagRpA9SweRNYYSzTgPvqyf/54\nKbWlcziyMgQTQ2AmAUOFhbfm+Neva1GJVj8O7VRNK4OXi9Xz3HhBnt9zrpoN\naUnm\r\n=mWdc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "0.3.1": {
+      "name": "ret",
+      "version": "0.3.1",
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "vows": "^0.8.2"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "integrity": "sha512-I/Evl5NrbgURNN0zts1dtI0ItI9pBg53jicdv9JqGumyOX+K7FELFcr2k3ED0hT7t9GsHctZj2in+tXDJfXypw==",
+        "shasum": "74655c3d876a4b6c2576c592431c7b0a84d2b82d",
+        "tarball": "https://registry.npmjs.org/ret/-/ret-0.3.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 23399,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcq1NiCRA9TVsSAnZWagAA6TIQAIVk2wMJHCQy6JKak2eh\nyQlbzUih6P8c7E52Naqv3q6cb+ASENnSQbdDThffd3eGI0FzOjZ3os8HLGIm\n5PC/CkmpSi7wIN/MjCPD6D2gxsnlCc8Fn6gp/ahBg8fAWXYxUOOr6vINU5zW\nzaSChBOstz71lP09hiwhblpVgdpRRHener/6ws9vwydOQiJPLGPJNlLd0gO9\npwpFwJE9gT1PMgeUG5O/WmPp3ldBSgKKdrBGAMGtT+PjErxWDc++wIVeAaTT\n/msC1Be4zjCFPqa3Bw3rPIAdTdDCpVy3DuBUN7UI9H8ZJVpc/6r+054NrQAA\nlIZURN0Xjk7DdDMNMCOi5UK3S+io8oHWOd4t06yaV7VSeaCIwE2M/qB/wOXl\nBFbR7PuBAE1H22AGqAPPlNhV08t/uhMCdZfRGdJnTQlzypM5eW3FEbm9KnoX\n95ikFwgm1cTnc1N8SEQ+p/wXNbVODNZJ05ubf+oS0MQh+xlXoOl7HlpEYbyB\nJ0P8fO4n6SPkROINyJ7vzKNnWOPDmn03x5ppdjnrTWNHaJe9n/Of9L+9g/PH\ngjI/CnUh9F0L583C/OvDEbsS7oQhg3YuT3eyoHc9P4Yv9fSlwLr9+eNMTre1\nicEQxHdKsHVpPvZA5fjM2PInGXJ3AYHmgkDob1vM3H5RE/5Hk9SPXyyMHq6U\nN1DJ\r\n=ix/b\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
+  "modified": "2019-04-08T13:57:56.795Z"
+}

--- a/test/fixtures/registry-mocks/content/retry.json
+++ b/test/fixtures/registry-mocks/content/retry.json
@@ -1,0 +1,747 @@
+{
+  "_id": "retry",
+  "_rev": "81-6a604ceaf006dabb1cd26da88c432852",
+  "name": "retry",
+  "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+  "dist-tags": {
+    "latest": "0.12.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "version": "0.0.1",
+      "homepage": "https://github.com/felixge/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/felixge/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {},
+      "_id": "retry@0.0.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.5",
+      "_nodeVersion": "v0.4.8-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "d47a1e527644e131e8f54785452ec7cd410808fe",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.0.1.tgz"
+      },
+      "scripts": {}
+    },
+    "0.1.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/felixge/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/felixge/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "_id": "retry@0.1.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.5",
+      "_nodeVersion": "v0.4.8-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e97a7b06a889a62b3f7ea16003f52a699c3651a5",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.1.0.tgz"
+      },
+      "scripts": {}
+    },
+    "0.2.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/felixge/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/felixge/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "_id": "retry@0.2.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.5",
+      "_nodeVersion": "v0.4.8-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "9598e6667c197772ea24ab5fc9e5445c0a4ac9a5",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.2.0.tgz"
+      },
+      "scripts": {}
+    },
+    "0.3.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/felixge/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/felixge/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "_id": "retry@0.3.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.5",
+      "_nodeVersion": "v0.4.8-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "902e4fc3e6c48d52badfec738be656b8ca23844c",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.3.0.tgz"
+      },
+      "scripts": {}
+    },
+    "0.4.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "version": "0.4.0",
+      "homepage": "https://github.com/felixge/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/felixge/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "_id": "retry@0.4.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.5",
+      "_nodeVersion": "v0.4.8-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f6a0107aee4d4e5bd5469e1d31c780e438d154bd",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.4.0.tgz"
+      },
+      "scripts": {}
+    },
+    "0.5.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "version": "0.5.0",
+      "homepage": "https://github.com/felixge/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/felixge/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@debuggable.com"
+      },
+      "_id": "retry@0.5.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.103",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "71e2793cd3e2ee9cce1182e173183af959decc3d",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ]
+    },
+    "0.6.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "version": "0.6.0",
+      "homepage": "https://github.com/tim-kos/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/felixge/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@debuggable.com"
+      },
+      "_id": "retry@0.6.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.103",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "1c010713279a6fd1e8def28af0c3ff1871caa537",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ]
+    },
+    "0.6.1": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "version": "0.6.1",
+      "homepage": "https://github.com/tim-kos/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/tim-kos/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "bugs": {
+        "url": "https://github.com/tim-kos/node-retry/issues"
+      },
+      "_id": "retry@0.6.1",
+      "_shasum": "fdc90eed943fde11b893554b8cc63d0e899ba918",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@debuggable.com"
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fdc90eed943fde11b893554b8cc63d0e899ba918",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
+      }
+    },
+    "0.7.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "license": "MIT",
+      "version": "0.7.0",
+      "homepage": "https://github.com/tim-kos/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/tim-kos/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "gitHead": "24d1e61f57423286e2d47fedd48876450a19a923",
+      "bugs": {
+        "url": "https://github.com/tim-kos/node-retry/issues"
+      },
+      "_id": "retry@0.7.0",
+      "scripts": {},
+      "_shasum": "dc86eeb960af9acb662896918be4254c1acf6379",
+      "_from": ".",
+      "_npmVersion": "2.1.7",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@debuggable.com"
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dc86eeb960af9acb662896918be4254c1acf6379",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.7.0.tgz"
+      }
+    },
+    "0.8.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "license": "MIT",
+      "version": "0.8.0",
+      "homepage": "https://github.com/tim-kos/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/tim-kos/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "gitHead": "9446e803d6a41ae08732a4a215ae5bf1ff1ccfdd",
+      "bugs": {
+        "url": "https://github.com/tim-kos/node-retry/issues"
+      },
+      "_id": "retry@0.8.0",
+      "scripts": {},
+      "_shasum": "2367628dc0edb247b1eab649dc53ac8628ac2d5f",
+      "_from": ".",
+      "_npmVersion": "2.1.7",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@debuggable.com"
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2367628dc0edb247b1eab649dc53ac8628ac2d5f",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz"
+      }
+    },
+    "0.9.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "license": "MIT",
+      "version": "0.9.0",
+      "homepage": "https://github.com/tim-kos/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/tim-kos/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "gitHead": "1b621cf499ef7647d005e3650006b93a8dbeb986",
+      "bugs": {
+        "url": "https://github.com/tim-kos/node-retry/issues"
+      },
+      "_id": "retry@0.9.0",
+      "scripts": {},
+      "_shasum": "6f697e50a0e4ddc8c8f7fb547a9b60dead43678d",
+      "_from": ".",
+      "_npmVersion": "2.1.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@debuggable.com"
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6f697e50a0e4ddc8c8f7fb547a9b60dead43678d",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz"
+      }
+    },
+    "0.10.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "license": "MIT",
+      "version": "0.10.0",
+      "homepage": "https://github.com/tim-kos/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/tim-kos/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "gitHead": "0616e6a6ebc49b5a36b619c8f7c414ced8c3813b",
+      "bugs": {
+        "url": "https://github.com/tim-kos/node-retry/issues"
+      },
+      "_id": "retry@0.10.0",
+      "scripts": {},
+      "_shasum": "649e15ca408422d98318161935e7f7d652d435dd",
+      "_from": ".",
+      "_npmVersion": "2.1.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@debuggable.com"
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ],
+      "dist": {
+        "shasum": "649e15ca408422d98318161935e7f7d652d435dd",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/retry-0.10.0.tgz_1471682099847_0.5031970851123333"
+      }
+    },
+    "0.10.1": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "license": "MIT",
+      "version": "0.10.1",
+      "homepage": "https://github.com/tim-kos/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/tim-kos/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": "*"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "gitHead": "3dbe5189b48786e56d1d1807731adfc53a70eeae",
+      "bugs": {
+        "url": "https://github.com/tim-kos/node-retry/issues"
+      },
+      "_id": "retry@0.10.1",
+      "scripts": {},
+      "_shasum": "e76388d217992c252750241d3d3956fed98d8ff4",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.0",
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@debuggable.com"
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e76388d217992c252750241d3d3956fed98d8ff4",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/retry-0.10.1.tgz_1481556523726_0.45345148630440235"
+      }
+    },
+    "0.12.0": {
+      "author": {
+        "name": "Tim Koschützki",
+        "email": "tim@debuggable.com",
+        "url": "http://debuggable.com/"
+      },
+      "name": "retry",
+      "description": "Abstraction for exponential and custom retry strategies for failed operations.",
+      "license": "MIT",
+      "version": "0.12.0",
+      "homepage": "https://github.com/tim-kos/node-retry",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/tim-kos/node-retry.git"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "main": "index",
+      "engines": {
+        "node": ">= 4"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "fake": "0.2.0",
+        "istanbul": "^0.4.5",
+        "tape": "^4.8.0"
+      },
+      "scripts": {
+        "test": "istanbul cover ./node_modules/tape/bin/tape ./test/integration/*.js",
+        "release:major": "env SEMANTIC=major npm run release",
+        "release:minor": "env SEMANTIC=minor npm run release",
+        "release:patch": "env SEMANTIC=patch npm run release",
+        "release": "npm version ${SEMANTIC:-patch} -m \"Release %s\" && git push && git push --tags && npm publish"
+      },
+      "gitHead": "f802d9edc2fdbca727d3e368234b6d714db06f8e",
+      "bugs": {
+        "url": "https://github.com/tim-kos/node-retry/issues"
+      },
+      "_id": "retry@0.12.0",
+      "_shasum": "1b42a6266a21f07421d1b0b54b7dc167b01c013b",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "tim-kos",
+        "email": "tim@transloadit.com"
+      },
+      "dist": {
+        "shasum": "1b42a6266a21f07421d1b0b54b7dc167b01c013b",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 32210
+      },
+      "maintainers": [
+        {
+          "name": "tim-kos",
+          "email": "tim@debuggable.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/retry_0.12.0_1523266527484_0.8738449656621592"
+      }
+    }
+  },
+  "maintainers": [
+    {
+      "name": "tim-kos",
+      "email": "tim@debuggable.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-08-03T00:39:14.881Z",
+    "created": "2011-05-13T11:26:52.829Z",
+    "0.0.1": "2011-05-13T11:26:53.515Z",
+    "0.1.0": "2011-05-16T08:10:27.648Z",
+    "0.2.0": "2011-05-16T14:32:52.025Z",
+    "0.3.0": "2011-05-31T14:19:32.882Z",
+    "0.4.0": "2011-06-05T08:07:17.763Z",
+    "0.5.0": "2011-11-03T10:55:32.772Z",
+    "0.6.0": "2012-02-14T08:34:18.028Z",
+    "0.6.1": "2014-06-26T12:00:56.230Z",
+    "0.7.0": "2015-09-01T10:16:42.770Z",
+    "0.8.0": "2015-09-16T18:34:56.522Z",
+    "0.9.0": "2016-01-26T12:02:25.243Z",
+    "0.10.0": "2016-08-20T08:35:01.550Z",
+    "0.10.1": "2016-12-12T15:28:45.566Z",
+    "0.12.0": "2018-04-09T09:35:27.678Z"
+  },
+  "author": {
+    "name": "Tim Koschützki",
+    "email": "tim@debuggable.com",
+    "url": "http://debuggable.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/tim-kos/node-retry.git"
+  },
+  "users": {
+    "carlos8f": true,
+    "gdbtek": true,
+    "subchen": true,
+    "jperdereau": true,
+    "j3kz": true,
+    "brandonpapworth": true,
+    "bret": true,
+    "markstos": true,
+    "fotooo": true,
+    "passcod": true,
+    "progmer": true,
+    "mccoyjordan": true,
+    "andris": true,
+    "btd": true,
+    "yetithefoot": true,
+    "shiningray": true,
+    "bsnote": true,
+    "laggingreflex": true,
+    "surajs21": true,
+    "hisabimbola": true,
+    "fatore": true,
+    "crowelch": true,
+    "mattmcfarland": true,
+    "chriszs": true,
+    "asaupup": true,
+    "iwasawafag": true,
+    "crewmoss": true,
+    "manikantag": true,
+    "vladimir.shushkov": true,
+    "moiyer": true,
+    "rajiff": true,
+    "quafoo": true,
+    "nuwaio": true,
+    "mjurincic": true,
+    "floriannagel": true,
+    "knksmith57": true,
+    "johnloy": true,
+    "losymear": true
+  },
+  "readme": "<!-- badges/ -->\n[![Build Status](https://secure.travis-ci.org/tim-kos/node-retry.png?branch=master)](http://travis-ci.org/tim-kos/node-retry \"Check this project's build status on TravisCI\")\n[![codecov](https://codecov.io/gh/tim-kos/node-retry/branch/master/graph/badge.svg)](https://codecov.io/gh/tim-kos/node-retry)\n<!-- /badges -->\n\n# retry\n\nAbstraction for exponential and custom retry strategies for failed operations.\n\n## Installation\n\n    npm install retry\n\n## Current Status\n\nThis module has been tested and is ready to be used.\n\n## Tutorial\n\nThe example below will retry a potentially failing `dns.resolve` operation\n`10` times using an exponential backoff strategy. With the default settings, this\nmeans the last attempt is made after `17 minutes and 3 seconds`.\n\n``` javascript\nvar dns = require('dns');\nvar retry = require('retry');\n\nfunction faultTolerantResolve(address, cb) {\n  var operation = retry.operation();\n\n  operation.attempt(function(currentAttempt) {\n    dns.resolve(address, function(err, addresses) {\n      if (operation.retry(err)) {\n        return;\n      }\n\n      cb(err ? operation.mainError() : null, addresses);\n    });\n  });\n}\n\nfaultTolerantResolve('nodejs.org', function(err, addresses) {\n  console.log(err, addresses);\n});\n```\n\nOf course you can also configure the factors that go into the exponential\nbackoff. See the API documentation below for all available settings.\ncurrentAttempt is an int representing the number of attempts so far.\n\n``` javascript\nvar operation = retry.operation({\n  retries: 5,\n  factor: 3,\n  minTimeout: 1 * 1000,\n  maxTimeout: 60 * 1000,\n  randomize: true,\n});\n```\n\n## API\n\n### retry.operation([options])\n\nCreates a new `RetryOperation` object. `options` is the same as `retry.timeouts()`'s `options`, with two additions:\n\n* `forever`: Whether to retry forever, defaults to `false`.\n* `unref`: Whether to [unref](https://nodejs.org/api/timers.html#timers_unref) the setTimeout's, defaults to `false`.\n* `maxRetryTime`: The maximum time (in milliseconds) that the retried operation is allowed to run. Default is `Infinity`.  \n\n### retry.timeouts([options])\n\nReturns an array of timeouts. All time `options` and return values are in\nmilliseconds. If `options` is an array, a copy of that array is returned.\n\n`options` is a JS object that can contain any of the following keys:\n\n* `retries`: The maximum amount of times to retry the operation. Default is `10`. Seting this to `1` means `do it once, then retry it once`.\n* `factor`: The exponential factor to use. Default is `2`.\n* `minTimeout`: The number of milliseconds before starting the first retry. Default is `1000`.\n* `maxTimeout`: The maximum number of milliseconds between two retries. Default is `Infinity`.\n* `randomize`: Randomizes the timeouts by multiplying with a factor between `1` to `2`. Default is `false`.\n\nThe formula used to calculate the individual timeouts is:\n\n```\nMath.min(random * minTimeout * Math.pow(factor, attempt), maxTimeout)\n```\n\nHave a look at [this article][article] for a better explanation of approach.\n\nIf you want to tune your `factor` / `times` settings to attempt the last retry\nafter a certain amount of time, you can use wolfram alpha. For example in order\nto tune for `10` attempts in `5 minutes`, you can use this equation:\n\n![screenshot](https://github.com/tim-kos/node-retry/raw/master/equation.gif)\n\nExplaining the various values from left to right:\n\n* `k = 0 ... 9`:  The `retries` value (10)\n* `1000`: The `minTimeout` value in ms (1000)\n* `x^k`: No need to change this, `x` will be your resulting factor\n* `5 * 60 * 1000`: The desired total amount of time for retrying in ms (5 minutes)\n\nTo make this a little easier for you, use wolfram alpha to do the calculations:\n\n<http://www.wolframalpha.com/input/?i=Sum%5B1000*x^k%2C+{k%2C+0%2C+9}%5D+%3D+5+*+60+*+1000>\n\n[article]: http://dthain.blogspot.com/2009/02/exponential-backoff-in-distributed.html\n\n### retry.createTimeout(attempt, opts)\n\nReturns a new `timeout` (integer in milliseconds) based on the given parameters.\n\n`attempt` is an integer representing for which retry the timeout should be calculated. If your retry operation was executed 4 times you had one attempt and 3 retries. If you then want to calculate a new timeout, you should set `attempt` to 4 (attempts are zero-indexed).\n\n`opts` can include `factor`, `minTimeout`, `randomize` (boolean) and `maxTimeout`. They are documented above.\n\n`retry.createTimeout()` is used internally by `retry.timeouts()` and is public for you to be able to create your own timeouts for reinserting an item, see [issue #13](https://github.com/tim-kos/node-retry/issues/13).\n\n### retry.wrap(obj, [options], [methodNames])\n\nWrap all functions of the `obj` with retry. Optionally you can pass operation options and\nan array of method names which need to be wrapped.\n\n```\nretry.wrap(obj)\n\nretry.wrap(obj, ['method1', 'method2'])\n\nretry.wrap(obj, {retries: 3})\n\nretry.wrap(obj, {retries: 3}, ['method1', 'method2'])\n```\nThe `options` object can take any options that the usual call to `retry.operation` can take.\n\n### new RetryOperation(timeouts, [options])\n\nCreates a new `RetryOperation` where `timeouts` is an array where each value is\na timeout given in milliseconds.\n\nAvailable options:\n* `forever`: Whether to retry forever, defaults to `false`.\n* `unref`: Wether to [unref](https://nodejs.org/api/timers.html#timers_unref) the setTimeout's, defaults to `false`.\n\nIf `forever` is true, the following changes happen:\n* `RetryOperation.errors()` will only output an array of one item: the last error.\n* `RetryOperation` will repeatedly use the `timeouts` array. Once all of its timeouts have been used up, it restarts with the first timeout, then uses the second and so on.\n\n#### retryOperation.errors()\n\nReturns an array of all errors that have been passed to `retryOperation.retry()` so far. The\nreturning array has the errors ordered chronologically based on when they were passed to\n`retryOperation.retry()`, which means the first passed error is at index zero and the last is\nat the last index.\n\n#### retryOperation.mainError()\n\nA reference to the error object that occured most frequently. Errors are\ncompared using the `error.message` property.\n\nIf multiple error messages occured the same amount of time, the last error\nobject with that message is returned.\n\nIf no errors occured so far, the value is `null`.\n\n#### retryOperation.attempt(fn, timeoutOps)\n\nDefines the function `fn` that is to be retried and executes it for the first\ntime right away. The `fn` function can receive an optional `currentAttempt` callback that represents the number of attempts to execute `fn` so far.\n\nOptionally defines `timeoutOps` which is an object having a property `timeout` in miliseconds and a property `cb` callback function.\nWhenever your retry operation takes longer than `timeout` to execute, the timeout callback function `cb` is called.\n\n\n#### retryOperation.try(fn)\n\nThis is an alias for `retryOperation.attempt(fn)`. This is deprecated. Please use `retryOperation.attempt(fn)` instead.\n\n#### retryOperation.start(fn)\n\nThis is an alias for `retryOperation.attempt(fn)`. This is deprecated. Please use `retryOperation.attempt(fn)` instead.\n\n#### retryOperation.retry(error)\n\nReturns `false` when no `error` value is given, or the maximum amount of retries\nhas been reached.\n\nOtherwise it returns `true`, and retries the operation after the timeout for\nthe current attempt number.\n\n#### retryOperation.stop()\n\nAllows you to stop the operation being retried. Useful for aborting the operation on a fatal error etc.\n\n#### retryOperation.reset()\n\nResets the internal state of the operation object, so that you can call `attempt()` again as if this was a new operation object.\n\n#### retryOperation.attempts()\n\nReturns an int representing the number of attempts it took to call `fn` before it was successful.\n\n## License\n\nretry is licensed under the MIT license.\n\n\n# Changelog\n\n0.10.0 Adding `stop` functionality, thanks to @maxnachlinger.\n\n0.9.0 Adding `unref` functionality, thanks to @satazor.\n\n0.8.0 Implementing retry.wrap.\n\n0.7.0 Some bug fixes and made retry.createTimeout() public. Fixed issues [#10](https://github.com/tim-kos/node-retry/issues/10), [#12](https://github.com/tim-kos/node-retry/issues/12), and [#13](https://github.com/tim-kos/node-retry/issues/13).\n\n0.6.0 Introduced optional timeOps parameter for the attempt() function which is an object having a property timeout in milliseconds and a property cb callback function. Whenever your retry operation takes longer than timeout to execute, the timeout callback function cb is called.\n\n0.5.0 Some minor refactoring.\n\n0.4.0 Changed retryOperation.try() to retryOperation.attempt(). Deprecated the aliases start() and try() for it.\n\n0.3.0 Added retryOperation.start() which is an alias for retryOperation.try().\n\n0.2.0 Added attempts() function and parameter to retryOperation.try() representing the number of attempts it took to call fn().\n",
+  "homepage": "https://github.com/tim-kos/node-retry",
+  "bugs": {
+    "url": "https://github.com/tim-kos/node-retry/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/retry.min.json
+++ b/test/fixtures/registry-mocks/content/retry.min.json
@@ -1,0 +1,260 @@
+{
+  "name": "retry",
+  "dist-tags": {
+    "latest": "0.12.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "retry",
+      "version": "0.0.1",
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "d47a1e527644e131e8f54785452ec7cd410808fe",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "retry",
+      "version": "0.1.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "e97a7b06a889a62b3f7ea16003f52a699c3651a5",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.0": {
+      "name": "retry",
+      "version": "0.2.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "9598e6667c197772ea24ab5fc9e5445c0a4ac9a5",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.3.0": {
+      "name": "retry",
+      "version": "0.3.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "902e4fc3e6c48d52badfec738be656b8ca23844c",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.3.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.4.0": {
+      "name": "retry",
+      "version": "0.4.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "f6a0107aee4d4e5bd5469e1d31c780e438d154bd",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.4.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.5.0": {
+      "name": "retry",
+      "version": "0.5.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "71e2793cd3e2ee9cce1182e173183af959decc3d",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.5.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.0": {
+      "name": "retry",
+      "version": "0.6.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "1c010713279a6fd1e8def28af0c3ff1871caa537",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.6.1": {
+      "name": "retry",
+      "version": "0.6.1",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "fdc90eed943fde11b893554b8cc63d0e899ba918",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.7.0": {
+      "name": "retry",
+      "version": "0.7.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "dc86eeb960af9acb662896918be4254c1acf6379",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.7.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.8.0": {
+      "name": "retry",
+      "version": "0.8.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "2367628dc0edb247b1eab649dc53ac8628ac2d5f",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.8.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.9.0": {
+      "name": "retry",
+      "version": "0.9.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "6f697e50a0e4ddc8c8f7fb547a9b60dead43678d",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.9.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.10.0": {
+      "name": "retry",
+      "version": "0.10.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "649e15ca408422d98318161935e7f7d652d435dd",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.10.1": {
+      "name": "retry",
+      "version": "0.10.1",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "far": "0.0.1"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "e76388d217992c252750241d3d3956fed98d8ff4",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.12.0": {
+      "name": "retry",
+      "version": "0.12.0",
+      "devDependencies": {
+        "fake": "0.2.0",
+        "istanbul": "^0.4.5",
+        "tape": "^4.8.0"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "1b42a6266a21f07421d1b0b54b7dc167b01c013b",
+        "tarball": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 32210
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    }
+  },
+  "modified": "2018-08-03T00:39:14.881Z"
+}

--- a/test/fixtures/registry-mocks/content/ripemd160.json
+++ b/test/fixtures/registry-mocks/content/ripemd160.json
@@ -1,0 +1,654 @@
+{
+  "_id": "ripemd160",
+  "_rev": "22-22af937fb5f2359f1103e916ce689ec3",
+  "name": "ripemd160",
+  "description": "Compute ripemd160 of bytes or strings.",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "ripemd160",
+      "version": "0.1.0",
+      "description": "Compute RIPEMD160 of bytes or strings.",
+      "keywords": [
+        "string",
+        "strings",
+        "ripemd160",
+        "bytes",
+        "cryptography"
+      ],
+      "devDependencies": {
+        "mocha": "1.*",
+        "terst": "0.0.1"
+      },
+      "repository": {
+        "url": "https://github.com/cryptocoinjs/ripemd160",
+        "type": "git"
+      },
+      "main": "./lib/ripemd160.js",
+      "dependencies": {
+        "convert-hex": "~0.1.0",
+        "convert-string": "~0.1.0"
+      },
+      "bugs": {
+        "url": "https://github.com/cryptocoinjs/ripemd160/issues"
+      },
+      "_id": "ripemd160@0.1.0",
+      "dist": {
+        "shasum": "b0d1df089a7eb8bdb364920beaad7a91c533a84e",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "jp",
+        "email": "jprichardson@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "ripemd160",
+      "version": "0.2.0",
+      "description": "Compute RIPEMD160 of bytes or strings.",
+      "keywords": [
+        "string",
+        "strings",
+        "ripemd160",
+        "ripe160",
+        "bitcoin",
+        "bytes",
+        "cryptography"
+      ],
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "terst": "~0.1.0",
+        "mochify": "~0.4.2"
+      },
+      "repository": {
+        "url": "https://github.com/cryptocoinjs/ripemd160",
+        "type": "git"
+      },
+      "main": "./lib/ripemd160.js",
+      "dependencies": {},
+      "bugs": {
+        "url": "https://github.com/cryptocoinjs/ripemd160/issues"
+      },
+      "homepage": "https://github.com/cryptocoinjs/ripemd160",
+      "_id": "ripemd160@0.2.0",
+      "dist": {
+        "shasum": "2bf198bde167cacfa51c0a928e84b68bbe171fce",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "jp",
+        "email": "jprichardson@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "vbuterin",
+          "email": "vbuterin@gmail.com"
+        },
+        {
+          "name": "midnightlightning",
+          "email": "boydb@midnightdesign.ws"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "ripemd160",
+      "version": "0.2.1",
+      "description": "Compute RIPEMD160 of bytes or strings.",
+      "keywords": [
+        "string",
+        "strings",
+        "ripemd160",
+        "ripe160",
+        "bitcoin",
+        "bytes",
+        "cryptography"
+      ],
+      "license": "BSD-3",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "mochify": "^2.1.0"
+      },
+      "repository": {
+        "url": "https://github.com/cryptocoinjs/ripemd160",
+        "type": "git"
+      },
+      "main": "./lib/ripemd160.js",
+      "dependencies": {},
+      "scripts": {
+        "test": "mocha test",
+        "browser-test": "mochify --wd -R spec"
+      },
+      "gitHead": "891faf2117d7c56b370224b442bc1035b0b0ba47",
+      "bugs": {
+        "url": "https://github.com/cryptocoinjs/ripemd160/issues"
+      },
+      "homepage": "https://github.com/cryptocoinjs/ripemd160",
+      "_id": "ripemd160@0.2.1",
+      "_shasum": "dee19248a3e1c815ff9aea39e753a337f56a243d",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.26",
+      "_npmUser": {
+        "name": "jp",
+        "email": "jprichardson@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "vbuterin",
+          "email": "vbuterin@gmail.com"
+        },
+        {
+          "name": "midnightlightning",
+          "email": "boydb@midnightdesign.ws"
+        },
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "dist": {
+        "shasum": "dee19248a3e1c815ff9aea39e753a337f56a243d",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "ripemd160",
+      "version": "1.0.0",
+      "description": "Compute ripemd160 of bytes or strings.",
+      "keywords": [
+        "string",
+        "strings",
+        "ripemd160",
+        "ripe160",
+        "bitcoin",
+        "bytes",
+        "cryptography"
+      ],
+      "license": "BSD-3-Clause",
+      "devDependencies": {
+        "mocha": "^2.1.0",
+        "mochify": "^2.1.1"
+      },
+      "repository": {
+        "url": "https://github.com/crypto-browserify/ripemd160",
+        "type": "git"
+      },
+      "main": "./lib/ripemd160.js",
+      "dependencies": {},
+      "scripts": {
+        "test": "mocha test",
+        "browser-test": "mochify --wd -R spec"
+      },
+      "gitHead": "60345ba3ca19874b2066ac430e492cff387ad7c5",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/ripemd160/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/ripemd160",
+      "_id": "ripemd160@1.0.0",
+      "_shasum": "15fd251d56e58848840f3d5864a5cfbb259114c7",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.26",
+      "_npmUser": {
+        "name": "jp",
+        "email": "jprichardson@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jp",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "vbuterin",
+          "email": "vbuterin@gmail.com"
+        },
+        {
+          "name": "midnightlightning",
+          "email": "boydb@midnightdesign.ws"
+        },
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        }
+      ],
+      "dist": {
+        "shasum": "15fd251d56e58848840f3d5864a5cfbb259114c7",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "ripemd160",
+      "version": "1.0.1",
+      "description": "Compute ripemd160 of bytes or strings.",
+      "keywords": [
+        "string",
+        "strings",
+        "ripemd160",
+        "ripe160",
+        "bitcoin",
+        "bytes",
+        "cryptography"
+      ],
+      "license": "BSD-3-Clause",
+      "devDependencies": {
+        "mocha": "^2.1.0",
+        "mochify": "^2.1.1",
+        "standard": "3.x"
+      },
+      "repository": {
+        "url": "https://github.com/crypto-browserify/ripemd160",
+        "type": "git"
+      },
+      "main": "./lib/ripemd160.js",
+      "dependencies": {},
+      "scripts": {
+        "test": "mocha test",
+        "browser-test": "mochify --wd -R spec"
+      },
+      "gitHead": "42172c6527a55a24a9ee306996b4a8578d4780db",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/ripemd160/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/ripemd160",
+      "_id": "ripemd160@1.0.1",
+      "_shasum": "93a4bbd4942bc574b69a8fa57c71de10ecca7d6e",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "jprichardson",
+        "email": "jprichardson@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "vbuterin",
+          "email": "vbuterin@gmail.com"
+        },
+        {
+          "name": "midnightlightning",
+          "email": "boydb@midnightdesign.ws"
+        },
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "93a4bbd4942bc574b69a8fa57c71de10ecca7d6e",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "ripemd160",
+      "version": "2.0.0",
+      "description": "Compute ripemd160 of bytes or strings.",
+      "keywords": [
+        "string",
+        "strings",
+        "ripemd160",
+        "ripe160",
+        "bitcoin",
+        "bytes",
+        "cryptography"
+      ],
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "./index",
+      "repository": {
+        "url": "git+https://github.com/crypto-browserify/ripemd160.git",
+        "type": "git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.7",
+        "tape": "^4.5.1"
+      },
+      "gitHead": "b459a37be2140aba46d64fdf2e97dd34f7c032dd",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/ripemd160/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/ripemd160#readme",
+      "_id": "ripemd160@2.0.0",
+      "_shasum": "828b37c63202a5875439cdca3b3f89e0bc0fe365",
+      "_from": ".",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jprichardson",
+        "email": "jprichardson@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "vbuterin",
+          "email": "vbuterin@gmail.com"
+        },
+        {
+          "name": "midnightlightning",
+          "email": "boydb@midnightdesign.ws"
+        },
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "828b37c63202a5875439cdca3b3f89e0bc0fe365",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ripemd160-2.0.0.tgz_1460413279960_0.744993690168485"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "ripemd160",
+      "version": "2.0.1",
+      "description": "Compute ripemd160 of bytes or strings.",
+      "keywords": [
+        "string",
+        "strings",
+        "ripemd160",
+        "ripe160",
+        "bitcoin",
+        "bytes",
+        "cryptography"
+      ],
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "./index",
+      "repository": {
+        "url": "git+https://github.com/crypto-browserify/ripemd160.git",
+        "type": "git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.7",
+        "tape": "^4.5.1"
+      },
+      "gitHead": "d20c06069e24dfbd8d8ccd141cad316bac38cdae",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/ripemd160/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/ripemd160#readme",
+      "_id": "ripemd160@2.0.1",
+      "_shasum": "0f4584295c53a3628af7e6d79aca21ce57d1c6e7",
+      "_from": ".",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jprichardson",
+        "email": "jprichardson@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "vbuterin",
+          "email": "vbuterin@gmail.com"
+        },
+        {
+          "name": "midnightlightning",
+          "email": "boydb@midnightdesign.ws"
+        },
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0f4584295c53a3628af7e6d79aca21ce57d1c6e7",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/ripemd160-2.0.1.tgz_1466601956349_0.07215552148409188"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "ripemd160",
+      "version": "2.0.2",
+      "description": "Compute ripemd160 of bytes or strings.",
+      "keywords": [
+        "string",
+        "strings",
+        "ripemd160",
+        "ripe160",
+        "bitcoin",
+        "bytes",
+        "cryptography"
+      ],
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "./index",
+      "repository": {
+        "url": "git+https://github.com/crypto-browserify/ripemd160.git",
+        "type": "git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "node test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.7",
+        "tape": "^4.5.1"
+      },
+      "gitHead": "3419c6409799d37e0323a556c94d040154657d9d",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/ripemd160/issues"
+      },
+      "homepage": "https://github.com/crypto-browserify/ripemd160#readme",
+      "_id": "ripemd160@2.0.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.11.1",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+        "shasum": "a1c1a6f624751577ba5d07914cbc92850585890c",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9785,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2DHzCRA9TVsSAnZWagAAzCQP/3kZvjChttzlBYv95jGg\nxZ0TLu54WUizVYS7XwwErbiJnP+dQ/5gOUGIuwXUmFFHTVgSeJOTFNV2JonE\n2ZjKeavN66zazLmp1qNaK/apkkZXJfIHZ37qS2WOxL1POnLptG9wwEHJscZq\nXFVTIVMy/u0Ym9PlXZKGEYnNwwOyF/fOnU/57chLuWF0gjUVf+MTFSQw6X6B\n0LRwbK4V77YK16T9VdFeBhCLZ1zc3Asaa0I3aGp/1KE/seIcqUg+LdeYeGEN\nfpTHpa4Ns3ZoV8ENTukbzrokXVyGUY1MJiDsFXodXyPuBk1HngYETxISnHhY\niNocP5UFwupgmboF7ivR/af0BylQdtOY2EKoEEsF2zCD/jo6ZNknvbmUlgVq\nqBSLc7GtjA6ORuDrMJCqJNyCRc41JJS4z4Fbx6fYEsJg2H7wj0uyoccQmgcj\nkBTGz2qkQEBG4WvHyZti9L3Z+5OVsiv0KrAFKCOlJytYiYZ/LVBkBJc09KPR\nwc42rM8gZlhLMEw/+pLKWD4P10CKIobGGQRNSzbcv+afahwyydesVDvsEgya\ngoAUSFWmz5SUS15F7mu0BgSHBRyna5Rs8AeepQ2fSHe215g4Q0wgfr71HYp5\nYXP5B23sIizvYkkhnOY3hkWIzLPSpUWCv8bMv1G+DL1IPFqBkeO48L1i21zI\nT2OA\r\n=viwy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "midnightlightning",
+          "email": "boydb@midnightdesign.ws"
+        },
+        {
+          "name": "nadav",
+          "email": "npm@shesek.info"
+        },
+        {
+          "name": "vbuterin",
+          "email": "vbuterin@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ripemd160_2.0.2_1524118003074_0.9548482732312533"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# ripemd160\n\n[![NPM Package](https://img.shields.io/npm/v/ripemd160.svg?style=flat-square)](https://www.npmjs.org/package/ripemd160)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/ripemd160.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/ripemd160)\n[![Dependency status](https://img.shields.io/david/crypto-browserify/ripemd160.svg?style=flat-square)](https://david-dm.org/crypto-browserify/ripemd160#info=dependencies)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nNode style `ripemd160` on pure JavaScript.\n\n## Example\n\n```js\nvar RIPEMD160 = require('ripemd160')\n\nconsole.log(new RIPEMD160().update('42').digest('hex'))\n// => 0df020ba32aa9b8b904471ff582ce6b579bf8bc8\n\nvar ripemd160stream = new RIPEMD160()\nripemd160stream.end('42')\nconsole.log(ripemd160stream.read().toString('hex'))\n// => 0df020ba32aa9b8b904471ff582ce6b579bf8bc8\n```\n\n## LICENSE\n\nMIT\n",
+  "maintainers": [
+    {
+      "email": "vbuterin@gmail.com",
+      "name": "vbuterin"
+    },
+    {
+      "email": "npm@shesek.info",
+      "name": "nadav"
+    },
+    {
+      "email": "boydb@midnightdesign.ws",
+      "name": "midnightlightning"
+    },
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "npm@dcousens.com",
+      "name": "dcousens"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-05T10:04:39.283Z",
+    "created": "2013-11-21T06:48:40.846Z",
+    "0.1.0": "2013-11-21T06:48:41.483Z",
+    "0.2.0": "2014-03-09T16:32:03.743Z",
+    "0.2.1": "2014-12-31T11:09:01.435Z",
+    "1.0.0": "2015-01-14T13:06:00.313Z",
+    "1.0.1": "2015-05-05T12:21:31.689Z",
+    "2.0.0": "2016-04-11T22:21:22.356Z",
+    "2.0.1": "2016-06-22T13:25:58.036Z",
+    "2.0.2": "2018-04-19T06:06:43.125Z"
+  },
+  "repository": {
+    "url": "git+https://github.com/crypto-browserify/ripemd160.git",
+    "type": "git"
+  },
+  "homepage": "https://github.com/crypto-browserify/ripemd160#readme",
+  "keywords": [
+    "string",
+    "strings",
+    "ripemd160",
+    "ripe160",
+    "bitcoin",
+    "bytes",
+    "cryptography"
+  ],
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/ripemd160/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/ripemd160.min.json
+++ b/test/fixtures/registry-mocks/content/ripemd160.min.json
@@ -1,0 +1,130 @@
+{
+  "name": "ripemd160",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "ripemd160",
+      "version": "0.1.0",
+      "dependencies": {
+        "convert-hex": "~0.1.0",
+        "convert-string": "~0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "1.*",
+        "terst": "0.0.1"
+      },
+      "dist": {
+        "shasum": "b0d1df089a7eb8bdb364920beaad7a91c533a84e",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "ripemd160",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "terst": "~0.1.0",
+        "mochify": "~0.4.2"
+      },
+      "dist": {
+        "shasum": "2bf198bde167cacfa51c0a928e84b68bbe171fce",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "ripemd160",
+      "version": "0.2.1",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "mochify": "^2.1.0"
+      },
+      "dist": {
+        "shasum": "dee19248a3e1c815ff9aea39e753a337f56a243d",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "ripemd160",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "^2.1.0",
+        "mochify": "^2.1.1"
+      },
+      "dist": {
+        "shasum": "15fd251d56e58848840f3d5864a5cfbb259114c7",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "ripemd160",
+      "version": "1.0.1",
+      "devDependencies": {
+        "mocha": "^2.1.0",
+        "mochify": "^2.1.1",
+        "standard": "3.x"
+      },
+      "dist": {
+        "shasum": "93a4bbd4942bc574b69a8fa57c71de10ecca7d6e",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "ripemd160",
+      "version": "2.0.0",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.7",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "828b37c63202a5875439cdca3b3f89e0bc0fe365",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "ripemd160",
+      "version": "2.0.1",
+      "dependencies": {
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.7",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "shasum": "0f4584295c53a3628af7e6d79aca21ce57d1c6e7",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "ripemd160",
+      "version": "2.0.2",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.2",
+        "standard": "^6.0.7",
+        "tape": "^4.5.1"
+      },
+      "dist": {
+        "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+        "shasum": "a1c1a6f624751577ba5d07914cbc92850585890c",
+        "tarball": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9785,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2DHzCRA9TVsSAnZWagAAzCQP/3kZvjChttzlBYv95jGg\nxZ0TLu54WUizVYS7XwwErbiJnP+dQ/5gOUGIuwXUmFFHTVgSeJOTFNV2JonE\n2ZjKeavN66zazLmp1qNaK/apkkZXJfIHZ37qS2WOxL1POnLptG9wwEHJscZq\nXFVTIVMy/u0Ym9PlXZKGEYnNwwOyF/fOnU/57chLuWF0gjUVf+MTFSQw6X6B\n0LRwbK4V77YK16T9VdFeBhCLZ1zc3Asaa0I3aGp/1KE/seIcqUg+LdeYeGEN\nfpTHpa4Ns3ZoV8ENTukbzrokXVyGUY1MJiDsFXodXyPuBk1HngYETxISnHhY\niNocP5UFwupgmboF7ivR/af0BylQdtOY2EKoEEsF2zCD/jo6ZNknvbmUlgVq\nqBSLc7GtjA6ORuDrMJCqJNyCRc41JJS4z4Fbx6fYEsJg2H7wj0uyoccQmgcj\nkBTGz2qkQEBG4WvHyZti9L3Z+5OVsiv0KrAFKCOlJytYiYZ/LVBkBJc09KPR\nwc42rM8gZlhLMEw/+pLKWD4P10CKIobGGQRNSzbcv+afahwyydesVDvsEgya\ngoAUSFWmz5SUS15F7mu0BgSHBRyna5Rs8AeepQ2fSHe215g4Q0wgfr71HYp5\nYXP5B23sIizvYkkhnOY3hkWIzLPSpUWCv8bMv1G+DL1IPFqBkeO48L1i21zI\nT2OA\r\n=viwy\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-01-05T10:04:39.283Z"
+}

--- a/test/fixtures/registry-mocks/content/run-queue.json
+++ b/test/fixtures/registry-mocks/content/run-queue.json
@@ -1,0 +1,414 @@
+{
+  "_id": "run-queue",
+  "_rev": "6-152e9fa845e18d5defdb06fe10849a0b",
+  "name": "run-queue",
+  "description": "A promise based, dynamic priority queue runner, with concurrency limiting.",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "run-queue",
+      "version": "1.0.0",
+      "description": "Process a dynamic queue of data, possibly concurrently",
+      "main": "queue.js",
+      "scripts": {
+        "test": "standard && tap -J test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "files": [
+        "queue.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "standard": "^8.6.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/run-queue.git"
+      },
+      "bugs": {
+        "url": "https://github.com/iarna/run-queue/issues"
+      },
+      "homepage": "https://npmjs.com/package/run-queue",
+      "gitHead": "f0e7a12f9720352ee386e2c2ce5be9c0bd4c3b7f",
+      "_id": "run-queue@1.0.0",
+      "_shasum": "5d4da75ba1589e9aec294d3fce987dd60f1def3d",
+      "_from": ".",
+      "_npmVersion": "4.4.0",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "5d4da75ba1589e9aec294d3fce987dd60f1def3d",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/run-queue-1.0.0.tgz_1488149007258_0.8681126337032765"
+      }
+    },
+    "1.0.1": {
+      "name": "run-queue",
+      "version": "1.0.1",
+      "description": "Process a dynamic queue of data, possibly concurrently",
+      "main": "queue.js",
+      "scripts": {
+        "test": "standard && tap -J test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "files": [
+        "queue.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "standard": "^8.6.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/run-queue.git"
+      },
+      "bugs": {
+        "url": "https://github.com/iarna/run-queue/issues"
+      },
+      "homepage": "https://npmjs.com/package/run-queue",
+      "gitHead": "2fc7ffce3f7ed31ecd17ae16a792beab43b948ad",
+      "_id": "run-queue@1.0.1",
+      "_shasum": "f4b0ab80b75f416aea140b13f059af1224844710",
+      "_from": ".",
+      "_npmVersion": "4.4.0",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "f4b0ab80b75f416aea140b13f059af1224844710",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/run-queue-1.0.1.tgz_1488154288448_0.6650912221521139"
+      }
+    },
+    "1.0.2": {
+      "name": "run-queue",
+      "version": "1.0.2",
+      "description": "A promise based, dynamic priority queue runner, with concurrency limiting.",
+      "main": "queue.js",
+      "scripts": {
+        "test": "standard && tap -J test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "files": [
+        "queue.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "standard": "^8.6.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/run-queue.git"
+      },
+      "bugs": {
+        "url": "https://github.com/iarna/run-queue/issues"
+      },
+      "homepage": "https://npmjs.com/package/run-queue",
+      "gitHead": "1fb0c4025eb91fb65b0492d626f9f876432b4a50",
+      "_id": "run-queue@1.0.2",
+      "_shasum": "a9396e5962a5b0b022a81c125017e95302a6f76a",
+      "_from": ".",
+      "_npmVersion": "4.4.0",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "a9396e5962a5b0b022a81c125017e95302a6f76a",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/run-queue-1.0.2.tgz_1488154367416_0.6272554455790669"
+      }
+    },
+    "1.0.3": {
+      "name": "run-queue",
+      "version": "1.0.3",
+      "description": "A promise based, dynamic priority queue runner, with concurrency limiting.",
+      "main": "queue.js",
+      "scripts": {
+        "test": "standard && tap -J test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "files": [
+        "queue.js"
+      ],
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "aproba": "^1.1.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/run-queue.git"
+      },
+      "bugs": {
+        "url": "https://github.com/iarna/run-queue/issues"
+      },
+      "homepage": "https://npmjs.com/package/run-queue",
+      "gitHead": "3c315b738d0578c2c54be2beb0469d00ccf1dc25",
+      "_id": "run-queue@1.0.3",
+      "_shasum": "e848396f057d223f24386924618e25694161ec47",
+      "_from": ".",
+      "_npmVersion": "2.15.0",
+      "_nodeVersion": "0.12.13",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "e848396f057d223f24386924618e25694161ec47",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/run-queue-1.0.3.tgz_1488161288446_0.14580746600404382"
+      }
+    },
+    "2.0.0": {
+      "name": "run-queue",
+      "version": "2.0.0",
+      "description": "A promise based, dynamic priority queue runner, with concurrency limiting.",
+      "main": "queue.js",
+      "scripts": {
+        "test": "standard && tap -J --100 test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "aproba": "^1.1.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/run-queue.git"
+      },
+      "bugs": {
+        "url": "https://github.com/iarna/run-queue/issues"
+      },
+      "homepage": "https://npmjs.com/package/run-queue",
+      "gitHead": "a302a574191ae2c7a184d1479216f47725efbd0e",
+      "_id": "run-queue@2.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.6.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-/9w+VOBVduLMu6x6GBF2C4YgRX3xHGFu/Nyzk61y0mLZb6tAeDP9rZ9hX7r3AbheR2lx2tltqjXaKfuOuul7Ow==",
+        "shasum": "6d6a48c5291fa50b0ccb0b60ae5fdf77c9979643",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6488,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbjvrHCRA9TVsSAnZWagAAI3wP/0tmfFyw6nD2sY3GwBsa\nu3MeZ7kcHdmCvl1IwgfB63Y/B3WOf9aeJQqzwSbxpI6OyfbX9hvqQqM/Jnxn\ninpHV5QEf1j6ud7giucM7uiZaFGQc+A/0Xjok52+TaL9xeZFV4jtIR1MBxEy\nd8EzpaDRd56bHpdRR/gJH7MvFo6adErx0oRQez54HbT5w9CnR2zk31t8eWVD\n+O8RIp9bq0fGU8fg1FhsrJvY8u1i0fHqlrvMQliatPCXlGZAGOrbxtUzNTyV\nXo1/zat150zifAHW7FQxw59G/rWAyPN6q8ULEGR/KGZMUl6SFFJPgMHEvX3n\nvsrGHGM59LQzzwhq+IO/qepES6CVRLJUdQt40LkTxIgUxWo/NzN4oiy2RVnB\nqcy4hZF+oiYlQs3JhdaBazwkNYTuCnJfApkUacp2XFYVznMGpwFpzojYV5go\nAOCXON2JOfRczahUOJ5JyW0uPwXcmNoCEN//hNWQ5D84L0kMt4kh3NeDOIn4\nj6KP64fwELl82lWb5+zIADuNJFq0Msua4Bm7FspmiVa/99VceVvzIRT3j/1M\np4TVGWtqp9tNVD3p0r45Hxjno9vwWGED+dxxm961PwWh64WWd3QmUt3Zjyve\nRmUlFFAKplKGBLsxsICeLTLdZGbzZPQv7Kd4zRxRPSpr+/ZjSiio/3yHo1C6\n55Y2\r\n=xIko\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/run-queue_2.0.0_1536096967105_0.7691035061880602"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "run-queue",
+      "version": "2.0.1",
+      "description": "A promise based, dynamic priority queue runner, with concurrency limiting.",
+      "main": "queue.js",
+      "scripts": {
+        "test": "iarna-standard && tap --100 test",
+        "test-v4": "tap --100 test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "@iarna/standard": "^2.0.0",
+        "tap": "^12.4.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dependencies": {
+        "aproba": "^2.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/run-queue.git"
+      },
+      "bugs": {
+        "url": "https://github.com/iarna/run-queue/issues"
+      },
+      "homepage": "https://npmjs.com/package/run-queue",
+      "gitHead": "cbbe521279426e1786fc494ee1b9b695e1b9bd9e",
+      "_id": "run-queue@2.0.1",
+      "_nodeVersion": "10.11.0",
+      "_npmVersion": "6.6.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-dkU5pUwpmeNKdsApBU6eBdUdkoSwx+yRnoi3Ax745evJDNx7NQRsE2o3AsXbye5GqbKqZ9HJFYxZ2laOoNE1Dg==",
+        "shasum": "2fa9302a32897f3d7bd8b2267842272804d7db11",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-2.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6535,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcS7IzCRA9TVsSAnZWagAAFKMP/Rn6Mou/8CX1FDzhk5Ph\nxhKUWeu//52pQdrKLuoFEALrZd2TIUGIr2n37GIdw79e4wK9hilj7Z6onSKG\nz65fKtr2rd8S3YxvpATynDj+xc+B8RuWnHi3BJULlThNf3/+/nglBVbbe9qg\nAgssiI343GICCM0eldGa74srZxzE9Ypjk9U/MmuBDFJBvWBsnv6mm5YsHJix\nDcmfkSj9/v/JOldmilFk2E4O8kUC0DMl5z9mjq7RMiHc8iKyUoNDO+snWgHF\nPmcAO/xrZt7wIt4Jfgbi2tIXX85hoemUtVC7TRstnuEJYU+nLrhWmPdfUdC8\nOhdinWT8UcBPX8V3fyEoSrmXaIjeAOyC8vYuFBx+ucIR70hkT8SPqt2odqRw\n3kJIGJ6XyG54ul8QAGrEuVKx6RSMi7nJHOZ4/mtHWoIbMFo27lcLyVIfd2RN\np3cK3YgY7yFkFG0G6/vHZWtL5OxmJE0PMBbaK3d0McUkjw/YPC69+VKAoh9x\nR8rFdWCbVig3WQxzJ98D0QNYlFA3TQ67v4E9u6XN2Epwq3lJrLEVsWrpAm9k\nEdXm8imQs1UlZz3ejjsM/2P8U0uZSp/jb94W+eT3zYg1BR3j3J/eWJiHKKTa\nJeLOFP2xI9pNUEB4l4yHyS2Yw56S4MJ4OUsWwsuMPKwVnJPivp7HJNckxeLM\nP3Ub\r\n=k5D9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/run-queue_2.0.1_1548464690940_0.443462412986239"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# run-queue\n\nA promise based, dynamic priority queue runner, with concurrency limiting.\n\n```js\nconst RunQueue = require('run-queue')\n\nconst queue = new RunQueue({\n  maxConcurrency: 1\n})\n\nqueue.add(1, example, [-1])\nfor (let ii = 0; ii < 5; ++ii) {\n  queue.add(0, example, [ii])\n}\nconst finished = []\nqueue.run().then(\n  console.log(finished)\n})\n\nfunction example (num, next) {\n  setTimeout(() => {\n    finished.push(num)\n    next()\n  }, 5 - Math.abs(num))\n}\n```\n\nwould output\n\n```\n[ 0, 1, 2, 3, 4, -1 ]\n```\n\nIf you bump concurrency to `2`, then you get:\n\n```\n[ 1, 0, 3, 2, 4, -1 ]\n```\n\nThe concurrency means that they don't finish in order, because some take\nlonger than others.  Each priority level must finish entirely before the\nnext priority level is run.  See\n[PRIORITIES](https://github.com/iarna/run-queue#priorities) below.  This is\neven true if concurrency is set high enough that all of the regular queue\ncan execute at once, for instance, with `maxConcurrency: 10`:\n\n```\n[ 4, 3, 2, 1, 0, -1 ]\n```\n\n## API\n\n### const queue = new RunQueue(options)\n\nCreate a new queue. Options may contain:\n\n* maxConcurrency - (Default: `1`) The maximum number of jobs to execute at once.\n* Promise - (Default: global.Promise) The promise implementation to use.\n\n### queue.add (prio, fn, args)\n\nAdd a new job to the end of the queue at priority `prio` that will run `fn`\nwith `args`. If `fn` is async then it should return a Promise.\n\n### queue.run ()\n\nStart running the job queue.  Returns a Promise that resolves when either\nall the jobs are complete or a job ends in error (throws or returns a\nrejected promise). If a job ended in error then this Promise will be rejected\nwith that error and no further queue running will be done.\n\n## PRIORITIES\n\nPriorities are any integer value >= 0.\n\nLowest is executed first.\n\nPriorities essentially represent distinct job queues.  All jobs in a queue\nmust complete before the next highest priority job queue is executed.\n\nThis means that if you have two queues, `0` and `1` then ALL jobs in `0`\nmust complete before ANY execute in `1`.  If you add new `0` level jobs\nwhile `1` level jobs are running then it will switch back processing the `0`\nqueue and won't execute any more `1` jobs till all of the new `0` jobs\ncomplete.\n",
+  "maintainers": [
+    {
+      "name": "iarna",
+      "email": "me@re-becca.org"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-26T01:04:53.736Z",
+    "created": "2017-02-26T22:43:27.507Z",
+    "1.0.0": "2017-02-26T22:43:27.507Z",
+    "1.0.1": "2017-02-27T00:11:28.664Z",
+    "1.0.2": "2017-02-27T00:12:47.664Z",
+    "1.0.3": "2017-02-27T02:08:10.231Z",
+    "2.0.0": "2018-09-04T21:36:07.290Z",
+    "2.0.1": "2019-01-26T01:04:51.121Z"
+  },
+  "homepage": "https://npmjs.com/package/run-queue",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iarna/run-queue.git"
+  },
+  "author": {
+    "name": "Rebecca Turner",
+    "email": "me@re-becca.org",
+    "url": "http://re-becca.org/"
+  },
+  "bugs": {
+    "url": "https://github.com/iarna/run-queue/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "iarna": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/run-queue.min.json
+++ b/test/fixtures/registry-mocks/content/run-queue.min.json
@@ -1,0 +1,125 @@
+{
+  "name": "run-queue",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "run-queue",
+      "version": "1.0.0",
+      "dependencies": {
+        "standard": "^8.6.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "5d4da75ba1589e9aec294d3fce987dd60f1def3d",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "run-queue",
+      "version": "1.0.1",
+      "dependencies": {
+        "standard": "^8.6.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "f4b0ab80b75f416aea140b13f059af1224844710",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "run-queue",
+      "version": "1.0.2",
+      "dependencies": {
+        "standard": "^8.6.0"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "a9396e5962a5b0b022a81c125017e95302a6f76a",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "run-queue",
+      "version": "1.0.3",
+      "dependencies": {
+        "aproba": "^1.1.1"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "e848396f057d223f24386924618e25694161ec47",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "run-queue",
+      "version": "2.0.0",
+      "dependencies": {
+        "aproba": "^1.1.1"
+      },
+      "devDependencies": {
+        "standard": "^8.6.0",
+        "tap": "^10.2.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-/9w+VOBVduLMu6x6GBF2C4YgRX3xHGFu/Nyzk61y0mLZb6tAeDP9rZ9hX7r3AbheR2lx2tltqjXaKfuOuul7Ow==",
+        "shasum": "6d6a48c5291fa50b0ccb0b60ae5fdf77c9979643",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-2.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6488,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbjvrHCRA9TVsSAnZWagAAI3wP/0tmfFyw6nD2sY3GwBsa\nu3MeZ7kcHdmCvl1IwgfB63Y/B3WOf9aeJQqzwSbxpI6OyfbX9hvqQqM/Jnxn\ninpHV5QEf1j6ud7giucM7uiZaFGQc+A/0Xjok52+TaL9xeZFV4jtIR1MBxEy\nd8EzpaDRd56bHpdRR/gJH7MvFo6adErx0oRQez54HbT5w9CnR2zk31t8eWVD\n+O8RIp9bq0fGU8fg1FhsrJvY8u1i0fHqlrvMQliatPCXlGZAGOrbxtUzNTyV\nXo1/zat150zifAHW7FQxw59G/rWAyPN6q8ULEGR/KGZMUl6SFFJPgMHEvX3n\nvsrGHGM59LQzzwhq+IO/qepES6CVRLJUdQt40LkTxIgUxWo/NzN4oiy2RVnB\nqcy4hZF+oiYlQs3JhdaBazwkNYTuCnJfApkUacp2XFYVznMGpwFpzojYV5go\nAOCXON2JOfRczahUOJ5JyW0uPwXcmNoCEN//hNWQ5D84L0kMt4kh3NeDOIn4\nj6KP64fwELl82lWb5+zIADuNJFq0Msua4Bm7FspmiVa/99VceVvzIRT3j/1M\np4TVGWtqp9tNVD3p0r45Hxjno9vwWGED+dxxm961PwWh64WWd3QmUt3Zjyve\nRmUlFFAKplKGBLsxsICeLTLdZGbzZPQv7Kd4zRxRPSpr+/ZjSiio/3yHo1C6\n55Y2\r\n=xIko\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.1": {
+      "name": "run-queue",
+      "version": "2.0.1",
+      "dependencies": {
+        "aproba": "^2.0.0"
+      },
+      "devDependencies": {
+        "@iarna/standard": "^2.0.0",
+        "tap": "^12.4.0"
+      },
+      "directories": {
+        "test": "test"
+      },
+      "dist": {
+        "integrity": "sha512-dkU5pUwpmeNKdsApBU6eBdUdkoSwx+yRnoi3Ax745evJDNx7NQRsE2o3AsXbye5GqbKqZ9HJFYxZ2laOoNE1Dg==",
+        "shasum": "2fa9302a32897f3d7bd8b2267842272804d7db11",
+        "tarball": "https://registry.npmjs.org/run-queue/-/run-queue-2.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6535,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcS7IzCRA9TVsSAnZWagAAFKMP/Rn6Mou/8CX1FDzhk5Ph\nxhKUWeu//52pQdrKLuoFEALrZd2TIUGIr2n37GIdw79e4wK9hilj7Z6onSKG\nz65fKtr2rd8S3YxvpATynDj+xc+B8RuWnHi3BJULlThNf3/+/nglBVbbe9qg\nAgssiI343GICCM0eldGa74srZxzE9Ypjk9U/MmuBDFJBvWBsnv6mm5YsHJix\nDcmfkSj9/v/JOldmilFk2E4O8kUC0DMl5z9mjq7RMiHc8iKyUoNDO+snWgHF\nPmcAO/xrZt7wIt4Jfgbi2tIXX85hoemUtVC7TRstnuEJYU+nLrhWmPdfUdC8\nOhdinWT8UcBPX8V3fyEoSrmXaIjeAOyC8vYuFBx+ucIR70hkT8SPqt2odqRw\n3kJIGJ6XyG54ul8QAGrEuVKx6RSMi7nJHOZ4/mtHWoIbMFo27lcLyVIfd2RN\np3cK3YgY7yFkFG0G6/vHZWtL5OxmJE0PMBbaK3d0McUkjw/YPC69+VKAoh9x\nR8rFdWCbVig3WQxzJ98D0QNYlFA3TQ67v4E9u6XN2Epwq3lJrLEVsWrpAm9k\nEdXm8imQs1UlZz3ejjsM/2P8U0uZSp/jb94W+eT3zYg1BR3j3J/eWJiHKKTa\nJeLOFP2xI9pNUEB4l4yHyS2Yw56S4MJ4OUsWwsuMPKwVnJPivp7HJNckxeLM\nP3Ub\r\n=k5D9\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-01-26T01:04:53.736Z"
+}

--- a/test/fixtures/registry-mocks/content/safe-regex.json
+++ b/test/fixtures/registry-mocks/content/safe-regex.json
@@ -1,0 +1,747 @@
+{
+  "_id": "safe-regex",
+  "_rev": "39-8cc87500ee57f5c169a346988301dea8",
+  "name": "safe-regex",
+  "description": "detect possibly catastrophic, exponential-time regular expressions",
+  "dist-tags": {
+    "latest": "2.1.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "safe-regex",
+      "version": "0.0.0",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "ret": "~0.1.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8",
+          "ie/9",
+          "ie/10",
+          "firefox/latest",
+          "chrome/latest",
+          "opera/latest",
+          "safari/latest"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/safe-regex.git"
+      },
+      "homepage": "https://github.com/substack/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/safe-regex/issues"
+      },
+      "_id": "safe-regex@0.0.0",
+      "dist": {
+        "shasum": "9a9ae1f35a6ea8047b6ea6ecf9c05143e1efc3ab",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.0",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "safe-regex",
+      "version": "0.0.1",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "ret": "~0.1.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8",
+          "ie/9",
+          "ie/10",
+          "firefox/latest",
+          "chrome/latest",
+          "opera/latest",
+          "safari/latest"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/safe-regex.git"
+      },
+      "homepage": "https://github.com/substack/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/safe-regex/issues"
+      },
+      "_id": "safe-regex@0.0.1",
+      "dist": {
+        "shasum": "350ae32b49b7dc75d1cac3a18cb8b375a94ef15c",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "safe-regex",
+      "version": "1.0.0",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "ret": "~0.1.10"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8",
+          "ie/9",
+          "ie/10",
+          "firefox/latest",
+          "chrome/latest",
+          "opera/latest",
+          "safari/latest"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/safe-regex.git"
+      },
+      "homepage": "https://github.com/substack/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "gitHead": "4ffa3f1b0ffe993ecaee97a622fb17469db2c2c6",
+      "bugs": {
+        "url": "https://github.com/substack/safe-regex/issues"
+      },
+      "_id": "safe-regex@1.0.0",
+      "_shasum": "2a88b57eb36396bb4c69218a3acd3334c5570123",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dist": {
+        "shasum": "2a88b57eb36396bb4c69218a3acd3334c5570123",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "safe-regex",
+      "version": "1.1.0",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "ret": "~0.1.10"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8",
+          "ie/9",
+          "ie/10",
+          "firefox/latest",
+          "chrome/latest",
+          "opera/latest",
+          "safari/latest"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/safe-regex.git"
+      },
+      "homepage": "https://github.com/substack/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "gitHead": "d2570f31bd9d779515015917bb8297c753e46572",
+      "bugs": {
+        "url": "https://github.com/substack/safe-regex/issues"
+      },
+      "_id": "safe-regex@1.1.0",
+      "_shasum": "40a3669f3b077d1e943d44629e157dd48023bf2e",
+      "_from": ".",
+      "_npmVersion": "2.3.0",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "dist": {
+        "shasum": "40a3669f3b077d1e943d44629e157dd48023bf2e",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "safe-regex",
+      "version": "2.0.0",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "regexp-tree": "~0.0.85"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8",
+          "ie/9",
+          "ie/10",
+          "firefox/latest",
+          "chrome/latest",
+          "opera/latest",
+          "safari/latest"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/davisjam/safe-regex.git"
+      },
+      "homepage": "https://github.com/davisjam/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James C.",
+        "email": "davisjam@vt.edu",
+        "url": "Jamie"
+      },
+      "license": "MIT",
+      "gitHead": "cd95cff13de26a3065a97eeb90dba360a95790d8",
+      "bugs": {
+        "url": "https://github.com/davisjam/safe-regex/issues"
+      },
+      "_id": "safe-regex@2.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "davisjam",
+        "email": "davisjam@vt.edu"
+      },
+      "dist": {
+        "integrity": "sha512-thCAfpaDb/DuCwidgS2h5BGyNx+vcN9F8fPLLhOrDndirBhOAwPkB4V28LMc+/Km1uHOg0APIIXdSg1Ck8BHjw==",
+        "shasum": "1c021d0d55ee116bf6caeeb1d7d0a388509f7112",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 6297,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb01YTCRA9TVsSAnZWagAA6eYP/RGb8XTt77idCZ+SIMT+\nsxoXkclnotDuOvnjje2mMzL5idYn6QQuFe+pTeBtFcaVCUMx3rpKVVd/+z46\nG5Z8qUJc8mrHf9bajUIgwpFVufEVGXmNFGH5fmC7nJQhm18c8ze4SDl1mU+y\nCwdteHQE0PkRtRwF3f8LyzkKg8U6n6c2hGDTZIRYcZa+KHOpXrDwdBbbAdyQ\nF0ZUyPyNRO4kF8t8q/gWs17I56EcvSpdBAnw2je2Ow8HCTh4UD27Y9mF2K6c\nMvSqoUlx5FNf1CO4Wb0kjAYbmh7+5NX2njZa1KUB+jnAa/0jm0oTDg4g5dIh\nFDA02BqRlTZ5uGZv/s3mJQi645Q1L5CVDeOySfvoVG59sNV8hiTOzWisHNxD\nj+Tguiq+88xISuUJJqA9DmVtUvg8LLgJ/o+9Re6C7TziUpR28Cshrbjd9FS7\nV85NZxtLgRHI+Ogm9aZsx8NU8NnElMT+45BFf+7twop/CMhZj6eYS05kZ0Es\n+8EtPulPyX7VBAZb85rPnVX46LNLMCWRqgl6gvkHzDlZjPLqrqA9RCDlhE9x\nxq1qt6DTXRArxWwt6DlPGXNV0Gm3VFr4IqdaRUrchdYj/RbTuE79BO5MTQMa\njInQ1jpb/9z9q+lxim7JX/7ow51htlPc8HusbQsYRVA68poYGmyA4KPyO34i\nXeX0\r\n=3u4b\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "davisjam@vt.edu",
+          "name": "davisjam"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/safe-regex_2.0.0_1540576786474_0.40345973051344486"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "safe-regex",
+      "version": "2.0.1",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "regexp-tree": "~0.0.85"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8",
+          "ie/9",
+          "ie/10",
+          "firefox/latest",
+          "chrome/latest",
+          "opera/latest",
+          "safari/latest"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/davisjam/safe-regex.git"
+      },
+      "homepage": "https://github.com/davisjam/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James C.",
+        "email": "davisjam@vt.edu",
+        "url": "Jamie"
+      },
+      "license": "MIT",
+      "gitHead": "db1568fee2072aa532919b0899490b4a4492efd4",
+      "bugs": {
+        "url": "https://github.com/davisjam/safe-regex/issues"
+      },
+      "_id": "safe-regex@2.0.1",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "davisjam",
+        "email": "davisjam@vt.edu"
+      },
+      "dist": {
+        "integrity": "sha512-4tbOl0xq/cxbhEhdvxKaCZgzwOKeqt2tnHc2OPBkMsVdZ0s0C5oJwI6voRI9XzPSzeN35PECDNDK946x4d/0eA==",
+        "shasum": "676c791d97f31fadb8958d64300f7760606fa0a1",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 6466,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb3G6CCRA9TVsSAnZWagAA05QP/AspKkR4cFKY0Ep0zeNr\nB/q0yj32KJKdsTRI597w3VN/7X6Cnvs63mRpVu8+9nvTCoDRscLMRG9jnZl2\nChM06cOzj5MsoxxMZO+7hal87ykMbDfic31wrPccQZNPGqXb5Sz1RhUVWvQu\nWyVODcZwOJy/vqVchIUF19Unr0KNchxKQGQ8rE7/CmzgsG/Xl3U98Ghz00h7\nzpvra0bpCqwm1O0kCKbC+EQyAaUYUaJMCbIwO2ASIZi2Kj7ECVxFR6MNcEMa\np+HmwTWF0lfVQvnQT624fVLuOhfeHPkdoQ2a06/D6l0Wd77glmg6PfViRGDs\n7p+PcnDgzBp6EpS6S2BX0JkIjISSTBtO4RFZkkZGngldt01XWb98DSMC63wW\nWLpNBfizShoQvYxLHVpIM4M/2Md3+tQvomdD85hzDr4q9WyKbPMBwOkUY+BZ\n5KA70oEbJ1JSJgMYf+mjoYMxCx1pp5FEFqih9fOkhHovTGbD4yhwXeKO0uDP\nLxWXp8YxozXGMSg7Yg1I0ilO95F6qa2X0/XonS+ecmKvR/4I8u1YwgtaIj3g\nCoucZBEHwYXREOT9NIeg/+DGXJ9sSaraAvf+LZON8qkeuHiuXw12JHO90tWR\nPKqaNXaOFZ26j4Egof7vHQzZ/Y0JW+bawTRnOp6veXSFtBipVmeQ94ugwjsj\nDl3s\r\n=X2u1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "davisjam@vt.edu",
+          "name": "davisjam"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/safe-regex_2.0.1_1541172865225_0.8604165785745475"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.2": {
+      "name": "safe-regex",
+      "version": "2.0.2",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.10.1"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8",
+          "ie/9",
+          "ie/10",
+          "firefox/latest",
+          "chrome/latest",
+          "opera/latest",
+          "safari/latest"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/davisjam/safe-regex.git"
+      },
+      "homepage": "https://github.com/davisjam/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James C.",
+        "email": "davisjam@vt.edu",
+        "url": "Jamie"
+      },
+      "license": "MIT",
+      "gitHead": "132c9b9d9efbf0ba5a85bfcd1b2bbd365d95b1b1",
+      "bugs": {
+        "url": "https://github.com/davisjam/safe-regex/issues"
+      },
+      "_id": "safe-regex@2.0.2",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "davisjam",
+        "email": "davisjam@vt.edu"
+      },
+      "dist": {
+        "integrity": "sha512-rRALJT0mh4qVFIJ9HvfjKDN77F9vp7kltOpFFI/8e6oKyHFmmxz4aSkY/YVauRDe7U0RrHdw9Lsxdel3E19s0A==",
+        "shasum": "3601b28d3aefe4b963d42f6c2cdb241265cbd63c",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 6684,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcdE1VCRA9TVsSAnZWagAAPaMP/2/YYMhPlbkRjDOD0Ixs\nf5A3mmk1k4AXxlXIC9EPu8aInNtrbBycqfIdTT6e/QUAmByT3lJlxMUGHHde\noOJ+nGNwqiNea8O9sOLWgFmr630RmvYCayupGeFKqhpM2Sw75VilIcCHdHbq\nyzWzHgUpjGcdPVuXM0MJ3S/Hk2tG/yHCAKBxmoWKwgMaJf/Ps92/sDaPflwQ\nndx2zzOkk/i/uurwzKnpiaMZfK0u9LbsJbTXvXtNoWaJLhaJNNsoZwcyb0PY\nEhKDw24dWuuCJ2UJLEhRREar+EJnl70FmJpJfQjlV451VNw4PEiJiOFgmwag\nS0dtALEGXkXnoQuIFJkw1rOTIA9YIl3vXWasO9tojruZ9qp7lt915poYIr5y\nNYvtzf3hzhl3/3fkNqU2YhofhL3hOMd7GhtXaGaAo/IQf/X90exTBftTDtvw\n6aX6/OsfPawggM1QxLy/4qLIQIQcxJHhXTJKDctzw9pIKXxjRsmui0B04b8E\njCPWdHRnA+oBgnkGwL3My8ofCwa+eErszudl/Ee6OOUjvy/c+qmQvJpeMaH0\nW5+y2JC5j5uEj8ILsokwdQz4PTlZdrRhvtXKiz5415v5ut+ayEoN7s/fveiF\nBAf5sINDxHOjw3qjidBKXUyIP71VPpL+gJxFU6f3tgMIsJ7MH9NpneaYhhq4\nf3o1\r\n=On78\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "davisjam@vt.edu",
+          "name": "davisjam"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/safe-regex_2.0.2_1551125844844_0.438144546598763"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.1.0": {
+      "name": "safe-regex",
+      "version": "2.1.0",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      },
+      "devDependencies": {
+        "jest": "^24.9.0"
+      },
+      "scripts": {
+        "test": "jest"
+      },
+      "jest": {
+        "moduleFileExtensions": [
+          "js"
+        ],
+        "testRegex": "test.*\\.spec\\.js$",
+        "collectCoverage": true,
+        "coverageReporters": [
+          "text-summary",
+          "html",
+          "lcov"
+        ],
+        "collectCoverageFrom": [
+          "*.js"
+        ],
+        "coverageThreshold": {
+          "global": {
+            "statements": 100,
+            "branches": 100,
+            "functions": 100,
+            "lines": 100
+          }
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/davisjam/safe-regex.git"
+      },
+      "homepage": "https://github.com/davisjam/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James C.",
+        "email": "davisjam@vt.edu",
+        "url": "Jamie"
+      },
+      "license": "MIT",
+      "gitHead": "329afeae8e8acae78dd86d104ea758533895219f",
+      "bugs": {
+        "url": "https://github.com/davisjam/safe-regex/issues"
+      },
+      "_id": "safe-regex@2.1.0",
+      "_nodeVersion": "12.10.0",
+      "_npmVersion": "6.10.3",
+      "dist": {
+        "integrity": "sha512-C2EKpE6DIkQRrVhqMG4NcA3/ekUJBy6YZaGw+77RaO3Odtkm+wb9kNjnM9LHSKwxWr6YYLrGk/MqGg5rOPzElA==",
+        "shasum": "3c8c4481278b21d030f6272b8c663de6776130ac",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 14937,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdrgokCRA9TVsSAnZWagAAgIsP/2MJ95jEs1UD5g2zUpm3\nDYxXbYLBcD2LV/DfoElSR+6zdGSaoBQAqq9I+wdzmHZD4GR782hXyjy2dWQl\nUvqcXtmdzbKHYFWEi6psiw5x5N4NzzTwLIPIeEvLcqZpToX18KVKftW3eED4\n0HhaL0ABFvSKWM4NCsi2jkG85x9tFlSiX1oa1iAssDR87cDCFR7QAFxAqaCL\nVnvQCpWxrwz/V0fEHG1hSM97VhvCyz6yGNOXYLmZGz8JyWmSFRLl+WSHQqnh\na3dYGg899HAEwBceb7sM+F09mFym1kUncaH64uUAwuhulhHqT+MAJXkUSHhe\ngPBorf5C1YlSmQuLMZNwRF7/l2bsWq7XGniTr0JIFrJsBAW05LEOcMkujhjz\naVJR2+pP4eaLAI6Yl+z6ULM4PPE6FAxFsUGrvAsDflehvG3PWYLzwcMzsub3\ns2CvmpqJCT6H5wNT4cf7eb56oaOtAsDdDHIRR5XNxMquk+du+dBLtTPPdGC/\nN5eDTW26hjZ8VmjybmIRWgA9AP9wU83GRrQ062xJ68y6ztBHn2CVspQ7j6U3\nIh4uAv3Zq+cAc7Q4k8X/9nW5UM7UgCE3hHwevM6HwZY/LTpICxDFGNc6AM+D\nx9lIetUT62urPk82KDpVnEoXFF5dfiWbykxsIuf6J7n3RzDKRdUOr2GFz9ko\nsbjj\r\n=E4W+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "davisjam@vt.edu",
+          "name": "davisjam"
+        }
+      ],
+      "_npmUser": {
+        "name": "davisjam",
+        "email": "davisjam@vt.edu"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/safe-regex_2.1.0_1571686947761_0.11552026867530052"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.1.1": {
+      "name": "safe-regex",
+      "version": "2.1.1",
+      "description": "detect possibly catastrophic, exponential-time regular expressions",
+      "main": "index.js",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      },
+      "devDependencies": {
+        "jest": "^24.9.0"
+      },
+      "scripts": {
+        "test": "jest"
+      },
+      "jest": {
+        "moduleFileExtensions": [
+          "js"
+        ],
+        "testRegex": "test.*\\.spec\\.js$",
+        "collectCoverage": true,
+        "coverageReporters": [
+          "text-summary",
+          "html",
+          "lcov"
+        ],
+        "collectCoverageFrom": [
+          "*.js"
+        ],
+        "coverageThreshold": {
+          "global": {
+            "statements": 100,
+            "branches": 100,
+            "functions": 100,
+            "lines": 100
+          }
+        }
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/davisjam/safe-regex.git"
+      },
+      "homepage": "https://github.com/davisjam/safe-regex",
+      "keywords": [
+        "catastrophic",
+        "exponential",
+        "regex",
+        "safe",
+        "sandbox"
+      ],
+      "author": {
+        "name": "James C.",
+        "email": "davisjam@vt.edu",
+        "url": "Jamie"
+      },
+      "license": "MIT",
+      "gitHead": "9070d9459dac17e281d06e50110fec2cb40cfc67",
+      "bugs": {
+        "url": "https://github.com/davisjam/safe-regex/issues"
+      },
+      "_id": "safe-regex@2.1.1",
+      "_nodeVersion": "12.10.0",
+      "_npmVersion": "6.10.3",
+      "dist": {
+        "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+        "shasum": "f7128f00d056e2fe5c11e81a1324dd974aadced2",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16453,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdrgq+CRA9TVsSAnZWagAATfEQAIJO5L5SSbRfHveBd3zB\nN29CKk0NG/A1JNgbGZQdwIawa9jflOQG/MhoHaUN3os+p9fcJVzJscj2hbR+\nUaIYcvtHAiep3z9J8K2I06amkfmIV6hi3H1XciTcVL+6lvxeYz5uK1Nu8jdj\nP7GSWnn4q8vdtd/adFTJvF3JaZjilMXRiL+FQ7WFP1yjD2xWItPm6AUSEsdj\nD659F89LN60Ru2cjuvQVBBtnrxGxdvXk+EUzdYLMR/3oI1wNYQ61JNJPzF73\nViq8X/9taqbdz36ZfZRFpJy8fnldSoHmcIB2xrxyjGCtrfc7kYp4Rp4bqqSI\nXb1Vvp1FDKVHftqGtau8RnvpwoNi58PuXyLq1DmvqLDN3clcenbKVAdoLUKI\ngrwvCbtGyADJoHUZTT6mu0h0bJYl5/i4Q5rxlQJmB6W9VI028x3kMyTOV6O9\np6vED9/MSVLgLJlvgx6eLE4U3STCNNkmvkntyWuQmLfPIxWk009EWBbrqEd7\nCtH6JCIWh/sUjFfL689RyWNenYk2X/fX1dYlX3D3vuI4BVyHtgomiKy7W/rg\nApORC5/RXeQ4iWXKaw6jQGPPID/ZfLGU5oEBUSwZokyjZTlLN9EwKL0CirdG\nDM8bOw7zxqUatxzNuZlmMXYME20ojFs0XFhPSG7Ltw54rhmmPi6FVpEyA2zU\nr52j\r\n=ZyaJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "davisjam@vt.edu",
+          "name": "davisjam"
+        }
+      ],
+      "_npmUser": {
+        "name": "davisjam",
+        "email": "davisjam@vt.edu"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/safe-regex_2.1.1_1571687101795_0.5043143354036861"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# safe-regex\n\nDetect potentially\n[catastrophic](http://regular-expressions.mobi/catastrophic.html)\n[exponential-time](http://perlgeek.de/blog-en/perl-tips/in-search-of-an-exponetial-regexp.html)\nregular expressions by limiting the\n[star height](https://en.wikipedia.org/wiki/Star_height) to 1.\n\nWARNING: This module has both false positives and false negatives.\nUse [vuln-regex-detector](https://github.com/davisjam/vuln-regex-detector) for improved accuracy.\n\n[![Build Status](https://travis-ci.org/davisjam/safe-regex.svg?branch=master)](https://travis-ci.org/davisjam/safe-regex)\n\n## Example\n\nSuppose you have a script named `safe.js`:\n\n``` js\nvar safe = require('safe-regex');\nvar regex = process.argv.slice(2).join(' ');\nconsole.log(safe(regex));\n```\n\nThis is its behavior:\n\n```\n$ node safe.js '(x+x+)+y'\nfalse\n$ node safe.js '(beep|boop)*'\ntrue\n$ node safe.js '(a+){10}'\nfalse\n$ node safe.js '\\blocation\\s*:[^:\\n]+\\b(Oakland|San Francisco)\\b'\ntrue\n```\n\n## Methods\n\n``` js\nconst safe = require('safe-regex')\n```\n\n### const ok = safe(re, opts={})\n\nReturn a boolean `ok` whether or not the regex `re` is safe and not possibly\ncatastrophic.\n\n`re` can be a `RegExp` object or just a string.\n\nIf the `re` is a string and is an invalid regex, returns `false`.\n\n* `opts.limit` - maximum number of allowed repetitions in the entire regex.\nDefault: `25`.\n\n## Install\n\nWith [npm](https://npmjs.org) do:\n\n```\nnpm install safe-regex\n```\n\n## Resources\n\n### What should I do if my project has a super-linear regex?\n\n1. Confirm that it is *reachable* by untrusted input.\n2. If it is, you can consider whether you can prevent worst-case behavior by trimming the input, revising the regex, or replacing the regex with another algorithm like string functions. For examples, see Table 5 in [this article](http://people.cs.vt.edu/davisjam/downloads/publications/DavisCoghlanServantLee-EcosystemREDOS-ESECFSE18.pdf).\n3. If none of those solutions looks feasible, you might also consider changing regex engines. The [RE2 bindings](https://www.npmjs.com/package/re2) might work, though test carefully to confirm there are no [semantic portability problems](https://medium.com/@davisjam/why-arent-regexes-a-lingua-franca-esecfse19-a36348df3a2?source=friends_link&sk=d21be7f8f723e2080dc993385c6973d1).\n\n### Further reading\n\nThe following documents may be edifying:\n\n- [Research brief on the extent of super-linear regexes in practice](https://medium.com/@davisjam/introduction-987fdc4c7b0?source=friends_link&sk=ceefa4a4ca9617e08ab782c3b1580aea)\n- [Research brief on the variability of super-linear regex behavior across programming languages](https://medium.com/@davisjam/why-arent-regexes-a-lingua-franca-esecfse19-a36348df3a2?source=friends_link&sk=d21be7f8f723e2080dc993385c6973d1)\n- [Comparing regex matching algorithms](https://swtch.com/~rsc/regexp/regexp1.html)\n\n## Project policies\n\n### Versioning\n\nThis project follows [Semantic Versioning 2.0 (semver)](https://semver.org/).\n\nHere are the project-specific meanings of MAJOR, MINOR, and PATCH updates:\n\n- MAJOR: \"Incompatible\" API changes were introduced. There are two types in this module:\n  - Changes that modify the interface\n  - Changes that cause any regexes to be marked as unsafe that were formerly marked as safe\n- MINOR: Functionality was added in a backwards-compatible manner. There are two types in this module:\n  - Refactoring the analyses but not changing their results\n  - Modifying the analyses to reduce false positives, without affecting negatives (false or true)\n- PATCH: I don't anticipate using PATCH for this module\n\n### License\n\n[MIT](https://github.com/davisjam/safe-regex/blob/master/LICENSE)",
+  "maintainers": [
+    {
+      "email": "davisjam@vt.edu",
+      "name": "davisjam"
+    }
+  ],
+  "time": {
+    "modified": "2019-10-21T19:45:04.555Z",
+    "created": "2013-07-13T02:56:00.967Z",
+    "0.0.0": "2013-07-13T02:56:02.406Z",
+    "0.0.1": "2013-11-22T08:44:01.232Z",
+    "1.0.0": "2015-02-06T16:36:31.893Z",
+    "1.1.0": "2015-03-19T00:30:21.780Z",
+    "2.0.0": "2018-10-26T17:59:46.642Z",
+    "2.0.1": "2018-11-02T15:34:25.412Z",
+    "2.0.2": "2019-02-25T20:17:25.012Z",
+    "2.1.0": "2019-10-21T19:42:27.934Z",
+    "2.1.1": "2019-10-21T19:45:01.945Z"
+  },
+  "author": {
+    "name": "James C.",
+    "email": "davisjam@vt.edu",
+    "url": "Jamie"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/davisjam/safe-regex.git"
+  },
+  "users": {
+    "julien-f": true,
+    "cilindrox": true,
+    "openam": true,
+    "davidcai": true,
+    "stretchgz": true,
+    "csbun": true,
+    "kobleistvan": true,
+    "disqus": true,
+    "scottfreecode": true,
+    "lonjoy": true,
+    "anchnk": true,
+    "hibrahimsafak": true,
+    "kikar": true,
+    "joseph320": true,
+    "raydog": true,
+    "vishwasc": true,
+    "dpjayasekara": true,
+    "ngpvnk": true,
+    "tkalfigo": true,
+    "donecharlton": true
+  },
+  "homepage": "https://github.com/davisjam/safe-regex",
+  "keywords": [
+    "catastrophic",
+    "exponential",
+    "regex",
+    "safe",
+    "sandbox"
+  ],
+  "bugs": {
+    "url": "https://github.com/davisjam/safe-regex/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/safe-regex.min.json
+++ b/test/fixtures/registry-mocks/content/safe-regex.min.json
@@ -1,0 +1,155 @@
+{
+  "name": "safe-regex",
+  "dist-tags": {
+    "latest": "2.1.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "safe-regex",
+      "version": "0.0.0",
+      "dependencies": {
+        "ret": "~0.1.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "9a9ae1f35a6ea8047b6ea6ecf9c05143e1efc3ab",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "safe-regex",
+      "version": "0.0.1",
+      "dependencies": {
+        "ret": "~0.1.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "350ae32b49b7dc75d1cac3a18cb8b375a94ef15c",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-0.0.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "safe-regex",
+      "version": "1.0.0",
+      "dependencies": {
+        "ret": "~0.1.10"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "dist": {
+        "shasum": "2a88b57eb36396bb4c69218a3acd3334c5570123",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "safe-regex",
+      "version": "1.1.0",
+      "dependencies": {
+        "ret": "~0.1.10"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "dist": {
+        "shasum": "40a3669f3b077d1e943d44629e157dd48023bf2e",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "safe-regex",
+      "version": "2.0.0",
+      "dependencies": {
+        "regexp-tree": "~0.0.85"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-thCAfpaDb/DuCwidgS2h5BGyNx+vcN9F8fPLLhOrDndirBhOAwPkB4V28LMc+/Km1uHOg0APIIXdSg1Ck8BHjw==",
+        "shasum": "1c021d0d55ee116bf6caeeb1d7d0a388509f7112",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 6297,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb01YTCRA9TVsSAnZWagAA6eYP/RGb8XTt77idCZ+SIMT+\nsxoXkclnotDuOvnjje2mMzL5idYn6QQuFe+pTeBtFcaVCUMx3rpKVVd/+z46\nG5Z8qUJc8mrHf9bajUIgwpFVufEVGXmNFGH5fmC7nJQhm18c8ze4SDl1mU+y\nCwdteHQE0PkRtRwF3f8LyzkKg8U6n6c2hGDTZIRYcZa+KHOpXrDwdBbbAdyQ\nF0ZUyPyNRO4kF8t8q/gWs17I56EcvSpdBAnw2je2Ow8HCTh4UD27Y9mF2K6c\nMvSqoUlx5FNf1CO4Wb0kjAYbmh7+5NX2njZa1KUB+jnAa/0jm0oTDg4g5dIh\nFDA02BqRlTZ5uGZv/s3mJQi645Q1L5CVDeOySfvoVG59sNV8hiTOzWisHNxD\nj+Tguiq+88xISuUJJqA9DmVtUvg8LLgJ/o+9Re6C7TziUpR28Cshrbjd9FS7\nV85NZxtLgRHI+Ogm9aZsx8NU8NnElMT+45BFf+7twop/CMhZj6eYS05kZ0Es\n+8EtPulPyX7VBAZb85rPnVX46LNLMCWRqgl6gvkHzDlZjPLqrqA9RCDlhE9x\nxq1qt6DTXRArxWwt6DlPGXNV0Gm3VFr4IqdaRUrchdYj/RbTuE79BO5MTQMa\njInQ1jpb/9z9q+lxim7JX/7ow51htlPc8HusbQsYRVA68poYGmyA4KPyO34i\nXeX0\r\n=3u4b\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.1": {
+      "name": "safe-regex",
+      "version": "2.0.1",
+      "dependencies": {
+        "regexp-tree": "~0.0.85"
+      },
+      "devDependencies": {
+        "tape": "^3.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-4tbOl0xq/cxbhEhdvxKaCZgzwOKeqt2tnHc2OPBkMsVdZ0s0C5oJwI6voRI9XzPSzeN35PECDNDK946x4d/0eA==",
+        "shasum": "676c791d97f31fadb8958d64300f7760606fa0a1",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 6466,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb3G6CCRA9TVsSAnZWagAA05QP/AspKkR4cFKY0Ep0zeNr\nB/q0yj32KJKdsTRI597w3VN/7X6Cnvs63mRpVu8+9nvTCoDRscLMRG9jnZl2\nChM06cOzj5MsoxxMZO+7hal87ykMbDfic31wrPccQZNPGqXb5Sz1RhUVWvQu\nWyVODcZwOJy/vqVchIUF19Unr0KNchxKQGQ8rE7/CmzgsG/Xl3U98Ghz00h7\nzpvra0bpCqwm1O0kCKbC+EQyAaUYUaJMCbIwO2ASIZi2Kj7ECVxFR6MNcEMa\np+HmwTWF0lfVQvnQT624fVLuOhfeHPkdoQ2a06/D6l0Wd77glmg6PfViRGDs\n7p+PcnDgzBp6EpS6S2BX0JkIjISSTBtO4RFZkkZGngldt01XWb98DSMC63wW\nWLpNBfizShoQvYxLHVpIM4M/2Md3+tQvomdD85hzDr4q9WyKbPMBwOkUY+BZ\n5KA70oEbJ1JSJgMYf+mjoYMxCx1pp5FEFqih9fOkhHovTGbD4yhwXeKO0uDP\nLxWXp8YxozXGMSg7Yg1I0ilO95F6qa2X0/XonS+ecmKvR/4I8u1YwgtaIj3g\nCoucZBEHwYXREOT9NIeg/+DGXJ9sSaraAvf+LZON8qkeuHiuXw12JHO90tWR\nPKqaNXaOFZ26j4Egof7vHQzZ/Y0JW+bawTRnOp6veXSFtBipVmeQ94ugwjsj\nDl3s\r\n=X2u1\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.2": {
+      "name": "safe-regex",
+      "version": "2.0.2",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "^4.10.1"
+      },
+      "dist": {
+        "integrity": "sha512-rRALJT0mh4qVFIJ9HvfjKDN77F9vp7kltOpFFI/8e6oKyHFmmxz4aSkY/YVauRDe7U0RrHdw9Lsxdel3E19s0A==",
+        "shasum": "3601b28d3aefe4b963d42f6c2cdb241265cbd63c",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.0.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 6684,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcdE1VCRA9TVsSAnZWagAAPaMP/2/YYMhPlbkRjDOD0Ixs\nf5A3mmk1k4AXxlXIC9EPu8aInNtrbBycqfIdTT6e/QUAmByT3lJlxMUGHHde\noOJ+nGNwqiNea8O9sOLWgFmr630RmvYCayupGeFKqhpM2Sw75VilIcCHdHbq\nyzWzHgUpjGcdPVuXM0MJ3S/Hk2tG/yHCAKBxmoWKwgMaJf/Ps92/sDaPflwQ\nndx2zzOkk/i/uurwzKnpiaMZfK0u9LbsJbTXvXtNoWaJLhaJNNsoZwcyb0PY\nEhKDw24dWuuCJ2UJLEhRREar+EJnl70FmJpJfQjlV451VNw4PEiJiOFgmwag\nS0dtALEGXkXnoQuIFJkw1rOTIA9YIl3vXWasO9tojruZ9qp7lt915poYIr5y\nNYvtzf3hzhl3/3fkNqU2YhofhL3hOMd7GhtXaGaAo/IQf/X90exTBftTDtvw\n6aX6/OsfPawggM1QxLy/4qLIQIQcxJHhXTJKDctzw9pIKXxjRsmui0B04b8E\njCPWdHRnA+oBgnkGwL3My8ofCwa+eErszudl/Ee6OOUjvy/c+qmQvJpeMaH0\nW5+y2JC5j5uEj8ILsokwdQz4PTlZdrRhvtXKiz5415v5ut+ayEoN7s/fveiF\nBAf5sINDxHOjw3qjidBKXUyIP71VPpL+gJxFU6f3tgMIsJ7MH9NpneaYhhq4\nf3o1\r\n=On78\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.1.0": {
+      "name": "safe-regex",
+      "version": "2.1.0",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      },
+      "devDependencies": {
+        "jest": "^24.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-C2EKpE6DIkQRrVhqMG4NcA3/ekUJBy6YZaGw+77RaO3Odtkm+wb9kNjnM9LHSKwxWr6YYLrGk/MqGg5rOPzElA==",
+        "shasum": "3c8c4481278b21d030f6272b8c663de6776130ac",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 14937,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdrgokCRA9TVsSAnZWagAAgIsP/2MJ95jEs1UD5g2zUpm3\nDYxXbYLBcD2LV/DfoElSR+6zdGSaoBQAqq9I+wdzmHZD4GR782hXyjy2dWQl\nUvqcXtmdzbKHYFWEi6psiw5x5N4NzzTwLIPIeEvLcqZpToX18KVKftW3eED4\n0HhaL0ABFvSKWM4NCsi2jkG85x9tFlSiX1oa1iAssDR87cDCFR7QAFxAqaCL\nVnvQCpWxrwz/V0fEHG1hSM97VhvCyz6yGNOXYLmZGz8JyWmSFRLl+WSHQqnh\na3dYGg899HAEwBceb7sM+F09mFym1kUncaH64uUAwuhulhHqT+MAJXkUSHhe\ngPBorf5C1YlSmQuLMZNwRF7/l2bsWq7XGniTr0JIFrJsBAW05LEOcMkujhjz\naVJR2+pP4eaLAI6Yl+z6ULM4PPE6FAxFsUGrvAsDflehvG3PWYLzwcMzsub3\ns2CvmpqJCT6H5wNT4cf7eb56oaOtAsDdDHIRR5XNxMquk+du+dBLtTPPdGC/\nN5eDTW26hjZ8VmjybmIRWgA9AP9wU83GRrQ062xJ68y6ztBHn2CVspQ7j6U3\nIh4uAv3Zq+cAc7Q4k8X/9nW5UM7UgCE3hHwevM6HwZY/LTpICxDFGNc6AM+D\nx9lIetUT62urPk82KDpVnEoXFF5dfiWbykxsIuf6J7n3RzDKRdUOr2GFz9ko\nsbjj\r\n=E4W+\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.1.1": {
+      "name": "safe-regex",
+      "version": "2.1.1",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      },
+      "devDependencies": {
+        "jest": "^24.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+        "shasum": "f7128f00d056e2fe5c11e81a1324dd974aadced2",
+        "tarball": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+        "fileCount": 12,
+        "unpackedSize": 16453,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdrgq+CRA9TVsSAnZWagAATfEQAIJO5L5SSbRfHveBd3zB\nN29CKk0NG/A1JNgbGZQdwIawa9jflOQG/MhoHaUN3os+p9fcJVzJscj2hbR+\nUaIYcvtHAiep3z9J8K2I06amkfmIV6hi3H1XciTcVL+6lvxeYz5uK1Nu8jdj\nP7GSWnn4q8vdtd/adFTJvF3JaZjilMXRiL+FQ7WFP1yjD2xWItPm6AUSEsdj\nD659F89LN60Ru2cjuvQVBBtnrxGxdvXk+EUzdYLMR/3oI1wNYQ61JNJPzF73\nViq8X/9taqbdz36ZfZRFpJy8fnldSoHmcIB2xrxyjGCtrfc7kYp4Rp4bqqSI\nXb1Vvp1FDKVHftqGtau8RnvpwoNi58PuXyLq1DmvqLDN3clcenbKVAdoLUKI\ngrwvCbtGyADJoHUZTT6mu0h0bJYl5/i4Q5rxlQJmB6W9VI028x3kMyTOV6O9\np6vED9/MSVLgLJlvgx6eLE4U3STCNNkmvkntyWuQmLfPIxWk009EWBbrqEd7\nCtH6JCIWh/sUjFfL689RyWNenYk2X/fX1dYlX3D3vuI4BVyHtgomiKy7W/rg\nApORC5/RXeQ4iWXKaw6jQGPPID/ZfLGU5oEBUSwZokyjZTlLN9EwKL0CirdG\nDM8bOw7zxqUatxzNuZlmMXYME20ojFs0XFhPSG7Ltw54rhmmPi6FVpEyA2zU\nr52j\r\n=ZyaJ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-10-21T19:45:04.555Z"
+}

--- a/test/fixtures/registry-mocks/content/scheduler.json
+++ b/test/fixtures/registry-mocks/content/scheduler.json
@@ -1,11 +1,11 @@
 {
   "_id": "scheduler",
-  "_rev": "208-0d23ce5fcddc02b5f121efe54b09cb5f",
+  "_rev": "211-64b323cebb47c10bb4af017802e51433",
   "name": "scheduler",
   "description": "Cooperative scheduler for the browser environment.",
   "dist-tags": {
-    "latest": "0.19.1",
-    "next": "0.20.0-rc.3",
+    "latest": "0.20.1",
+    "next": "0.0.0-8e5adfbd7",
     "experimental": "0.0.0-experimental-4ead6b530"
   },
   "versions": {
@@ -12321,6 +12321,257 @@
         "tmp": "tmp/scheduler_0.0.0-experimental-4ead6b530_1602081658122_0.904876709235543"
       },
       "_hasShrinkwrap": false
+    },
+    "0.20.0": {
+      "name": "scheduler",
+      "version": "0.20.0",
+      "description": "Cooperative scheduler for the browser environment.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/facebook/react.git",
+        "directory": "packages/scheduler"
+      },
+      "license": "MIT",
+      "keywords": [
+        "react"
+      ],
+      "bugs": {
+        "url": "https://github.com/facebook/react/issues"
+      },
+      "homepage": "https://reactjs.org/",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "browserify": {
+        "transform": [
+          "loose-envify"
+        ]
+      },
+      "_id": "scheduler@0.20.0",
+      "_nodeVersion": "12.18.3",
+      "_npmVersion": "6.14.6",
+      "dist": {
+        "integrity": "sha512-XegIgta1bIaz2LdaL6eg1GEcE42g0BY9qFXCqlZ/+s2MuEKfigFCW6DEGBlZzeVFlwDmVusrWEyFtBo4sbkkdA==",
+        "shasum": "3ff543696b169613afadb09d3fb3fe998d234dd2",
+        "tarball": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.0.tgz",
+        "fileCount": 26,
+        "unpackedSize": 130274,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfj0PgCRA9TVsSAnZWagAAYfIP/RO8EjBoAMK5avQ3uENd\n2K53CvNlshenZbbrwdh39dOgc6IcGO7wha+gz3l3jpFKFN3KYbFqVR9/IYkw\nYj+1b2fCFZGEGhHiSNo2eunlcywhFjoxNdQxY67yQCuqypUDkMEmjDbkpdlh\ne+MllKqii6/HLi9l3U0gShGMdHSKWZz5etx9YOXg1lS+Wy4abRbgy7iGASHc\nYfz7+YtaYbq05YveMVJPKqeVI+IOmOd23HFe0xzhQ2Hl/PF5fYIcSBC75DIT\nUjBpEN4oiytI4MG6flfym0dERHx/9IBMpSuFl/jloeU7tmYlEdtiZbxFlXHo\nEqkgzSV6QNY0eOeczf3bZgTs50W31HpXyHWGC1KyCTiyCygrJ9bq6N0a7cVs\nFl8lUjtV/5eIsY30hmnpTqzFI7w6sIsrx1kZBLQyLWtMSB9JbXhbARgtHhgN\nnQfqis4gUgFmpaER8cJTvKg0rchyZjMBiV/qVPTe/mVBpwFe4Z+JtjPauorD\nANz2wlL5jFO28GA4IVhDUVfJJqmE1A3bDo1FCNhuQywcH8hvXqQD0Goy6vII\n0wpOS9uzRzHdasRzwqoNU/xdPXDOyhHLlJTAjBiXOr6h4l8sKYFbW8L8RGfJ\n9gE3CEUtCy31EgAPus04T4SUE6ECSRXpqIL9UiY5VQJS3FpC/RI5/CIqSTLl\nsV8e\r\n=E45E\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sebmarkbage",
+          "email": "sebastian@calyptus.eu"
+        },
+        {
+          "name": "gaearon",
+          "email": "dan.abramov@gmail.com"
+        },
+        {
+          "name": "acdlite",
+          "email": "npm@andrewclark.io"
+        },
+        {
+          "name": "brianvaughn",
+          "email": "briandavidvaughn@gmail.com"
+        },
+        {
+          "name": "fb",
+          "email": "opensource+npm@fb.com"
+        },
+        {
+          "name": "trueadm",
+          "email": "dg@domgan.com"
+        },
+        {
+          "name": "sophiebits",
+          "email": "npm@sophiebits.com"
+        },
+        {
+          "name": "lunaruan",
+          "email": "lunaris.ruan@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "gaearon",
+        "email": "dan.abramov@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/scheduler_0.20.0_1603224544160_0.022044052860771934"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.0.0-8e5adfbd7": {
+      "name": "scheduler",
+      "version": "0.0.0-8e5adfbd7",
+      "description": "Cooperative scheduler for the browser environment.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/facebook/react.git",
+        "directory": "packages/scheduler"
+      },
+      "license": "MIT",
+      "keywords": [
+        "react"
+      ],
+      "bugs": {
+        "url": "https://github.com/facebook/react/issues"
+      },
+      "homepage": "https://reactjs.org/",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "browserify": {
+        "transform": [
+          "loose-envify"
+        ]
+      },
+      "readme": "# `scheduler`\n\nThis is a package for cooperative scheduling in a browser environment. It is currently used internally by React, but we plan to make it more generic.\n\nThe public API for this package is not yet finalized.\n\n### Thanks\n\nThe React team thanks [Anton Podviaznikov](https://podviaznikov.com/) for donating the `scheduler` package name.\n",
+      "readmeFilename": "README.md",
+      "_id": "scheduler@0.0.0-8e5adfbd7",
+      "_nodeVersion": "12.18.3",
+      "_npmVersion": "6.14.6",
+      "dist": {
+        "integrity": "sha512-Q5ipj3teMJXYf+8FTBWyVGSAnRyxXPlGQ5mpS+G56/aKdo9Ky9CM2/g1NCaYJGdnoUTjFpwG/Ws5gD5S7azK4Q==",
+        "shasum": "2ff67c3a13f6cd7336faf8832c4a1cce001e3108",
+        "tarball": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-8e5adfbd7.tgz",
+        "fileCount": 26,
+        "unpackedSize": 130374,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfkXc3CRA9TVsSAnZWagAAuk8P/3gQBZs43LHfSbIvvJCu\nGhlfIBKUQ1POJxmx4amKxQ5hpQYsNcqI8y13HsZWmWnqWhJn+SIWcDozl1Vv\nbEL5hASDskdqA5S2ENc7977vHPec4OKk8T0uckJNpJQzrjcWv2QeYFdxX4Dy\nY+OdD5M+gdpVjhEq2EXrY+MUUec7i+rIitlZsIkUncAyEBDEaYLyTEFq5HTG\nSgAtLX+P9GG6FZd35/OtdU/4UIA5+oIy3loEGyxMB2ZkAZ76zAeeTdWKfOEy\n/lPK953to1sbYml2gt39Du0yJ8IqaTcMOt+MaitPrdfiyjLbrPEHCZhcZDYc\ntRPpRwkS2C4P+WRfpnh+vcMLh3IasSOBAd4D479wZv34OGmcCBHyb/JGMQCB\nEhHQNa9P/lBv9FXfW3BFas70WEyBSJ/uUCiUySbEnitBZnnXGp462WrWRE7l\nGsOrYPz3qPaTGtNWiRqmabuHTab/pW+e2XFVmjq2VtKyA7jm4B1HMWB8OzxM\ni1mLZn8WX8vB0lAc6Leq5zZZIVzGxm85JItdHtsOy4us6+lhMlITC5j3YHZ3\nh78NVPpFCE/8j/yEuCtUZbuW8Z8hewQ30fLgm0ywUorjrlZTxkrOsx6+tUm+\n+Iru5VQEqvVx9wsy2+QDXwr2y9WhY9DvgNb6/VJ1MBdG4wTi2+iM0geGbm4R\nEJyU\r\n=8szD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sebmarkbage",
+          "email": "sebastian@calyptus.eu"
+        },
+        {
+          "name": "gaearon",
+          "email": "dan.abramov@gmail.com"
+        },
+        {
+          "name": "acdlite",
+          "email": "npm@andrewclark.io"
+        },
+        {
+          "name": "brianvaughn",
+          "email": "briandavidvaughn@gmail.com"
+        },
+        {
+          "name": "fb",
+          "email": "opensource+npm@fb.com"
+        },
+        {
+          "name": "trueadm",
+          "email": "dg@domgan.com"
+        },
+        {
+          "name": "sophiebits",
+          "email": "npm@sophiebits.com"
+        },
+        {
+          "name": "lunaruan",
+          "email": "lunaris.ruan@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "gaearon",
+        "email": "dan.abramov@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/scheduler_0.0.0-8e5adfbd7_1603368758879_0.5667051462678618"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.20.1": {
+      "name": "scheduler",
+      "version": "0.20.1",
+      "description": "Cooperative scheduler for the browser environment.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/facebook/react.git",
+        "directory": "packages/scheduler"
+      },
+      "license": "MIT",
+      "keywords": [
+        "react"
+      ],
+      "bugs": {
+        "url": "https://github.com/facebook/react/issues"
+      },
+      "homepage": "https://reactjs.org/",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "browserify": {
+        "transform": [
+          "loose-envify"
+        ]
+      },
+      "_id": "scheduler@0.20.1",
+      "_nodeVersion": "12.18.3",
+      "_npmVersion": "6.14.6",
+      "dist": {
+        "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+        "shasum": "da0b907e24026b01181ecbc75efdc7f27b5a000c",
+        "tarball": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+        "fileCount": 26,
+        "unpackedSize": 130266,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfkXl7CRA9TVsSAnZWagAABx0P/iPE49eLVWbrV3YrS0fU\nfcQaHBRMIhJ4eoFJAF41eWIuPZ7gK8ELrBtSTjDB9e6MaSDaqSY9attQZzgl\nIrtoa7spadUrXGYNmc17YpQJhVGsHCDIYHLV1jcHwGatd5eS5r34q/pbimE3\nwvcutUjBorIiaWNiysrvs1daZ1QSu8qxfEGYEY9Z8wc1C/uWhhAzNAPdmzfJ\nDoFWIrdFiLVLBrTjGmETdeoyqhE6tillZgusmWot7YhvJfgZmQpnN0Sluw4f\nY5DHxeZwKtymtBrCcM2fDsVxwzYz0nhAEWVnBvBpEw2X0cYgqHiOPFq72ZjJ\nDhuuVGSgw5vCCgvEg1+uGgJG2HzeGmV9PYi/svnRfnQjdhILMkaTjzI7T1P6\nsl5HWhzbWxQ6RFzQ9vcKl0Fqgvn/XVSsWGBH4N7+Y2oB4zDVi4yc4lEeEZ61\noNZzBF2+Jx5VbUXN+nwC171W8V4lD6IjoUim9FVq6D7LYk8SjaNRBJt9xMcZ\n7TgBX7PX5NT4UZHDI02219szIhAJpRdFkyPOc2pAHyZRWLLIp56iUF+WKEj8\nl7tOXQpSefZc87Srmv/zx46fBigOpKq2NlW1VQZC6vn3fDhI2NqyqMTZm7Y8\navKOilDFNQYJzOMQ5BZI9tVCk8OJDDzr/hGw2PaS9fm9PgmuorOh4LGZZLPx\nxpNZ\r\n=rm+g\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sebmarkbage",
+          "email": "sebastian@calyptus.eu"
+        },
+        {
+          "name": "gaearon",
+          "email": "dan.abramov@gmail.com"
+        },
+        {
+          "name": "acdlite",
+          "email": "npm@andrewclark.io"
+        },
+        {
+          "name": "brianvaughn",
+          "email": "briandavidvaughn@gmail.com"
+        },
+        {
+          "name": "fb",
+          "email": "opensource+npm@fb.com"
+        },
+        {
+          "name": "trueadm",
+          "email": "dg@domgan.com"
+        },
+        {
+          "name": "sophiebits",
+          "email": "npm@sophiebits.com"
+        },
+        {
+          "name": "lunaruan",
+          "email": "lunaris.ruan@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "gaearon",
+        "email": "dan.abramov@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/scheduler_0.20.1_1603369339128_0.7549729994473013"
+      },
+      "_hasShrinkwrap": false
     }
   },
   "maintainers": [
@@ -12358,7 +12609,7 @@
     }
   ],
   "time": {
-    "modified": "2020-10-07T14:41:02.671Z",
+    "modified": "2020-10-22T12:22:23.173Z",
     "created": "2011-01-11T11:22:36.888Z",
     "0.1.0": "2011-01-11T11:22:36.888Z",
     "0.1.1": "2011-01-11T11:22:36.888Z",
@@ -12509,7 +12760,10 @@
     "0.20.0-rc.2": "2020-09-22T00:14:37.891Z",
     "0.0.0-4ead6b530": "2020-10-07T13:11:01.496Z",
     "0.20.0-rc.3": "2020-10-07T13:38:10.775Z",
-    "0.0.0-experimental-4ead6b530": "2020-10-07T14:40:58.233Z"
+    "0.0.0-experimental-4ead6b530": "2020-10-07T14:40:58.233Z",
+    "0.20.0": "2020-10-20T20:09:04.343Z",
+    "0.0.0-8e5adfbd7": "2020-10-22T12:12:39.024Z",
+    "0.20.1": "2020-10-22T12:22:19.306Z"
   },
   "repository": {
     "type": "git",
@@ -12527,6 +12781,6 @@
     "url": "https://github.com/facebook/react/issues"
   },
   "license": "MIT",
-  "readme": "",
-  "readmeFilename": ""
+  "readme": "# `scheduler`\n\nThis is a package for cooperative scheduling in a browser environment. It is currently used internally by React, but we plan to make it more generic.\n\nThe public API for this package is not yet finalized.\n\n### Thanks\n\nThe React team thanks [Anton Podviaznikov](https://podviaznikov.com/) for donating the `scheduler` package name.\n",
+  "readmeFilename": "README.md"
 }

--- a/test/fixtures/registry-mocks/content/scheduler.min.json
+++ b/test/fixtures/registry-mocks/content/scheduler.min.json
@@ -1,8 +1,8 @@
 {
   "name": "scheduler",
   "dist-tags": {
-    "latest": "0.19.1",
-    "next": "0.20.0-rc.3",
+    "latest": "0.20.1",
+    "next": "0.0.0-8e5adfbd7",
     "experimental": "0.0.0-experimental-4ead6b530"
   },
   "versions": {
@@ -2378,7 +2378,55 @@
         "unpackedSize": 130551,
         "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJffdN6CRA9TVsSAnZWagAA63YQAJYjZFWh6Ys5nBh5l342\nVq4zRJtasozkdCjKNNHe1Jjufk7R0vP8zvx9OQ9Jz6tK9YMklCVryqxAd5CV\n6loau02Cjco29yp2A6Acp86XawRmIMGx4zFAMhgLp6Y475oLqbBKn4TA1xP3\nzN7D0v/N3E9bDnBKkWJb2AC1WEdbdoVzfdItS0HMm9qvJqmRhflphlTPOjP7\nRK3NhNBOoceActZY85KFrhdpHYaXONQ+YWq/HOysiUOzptYCvPRSMyfjCbOI\ny0y3AfsKqyoXqlZGfptNzPXir/4QtF8vMVSMNZIQdFZK0RmkBZ+y9PJ9VL4S\nMpwPomoWLvsHHOKO+DtNf1bYijtNIOeTDIads44GTQ+WMtdT+VJowSZxG/VG\n9f2dXlf9+PARx80/Zqsqf5oXKhHrVFGUbMKbY8M6skeE0bkB1+fTkknv1iwt\n+4vom+Ut3CCa5SB2Mom1ONSDKCkSx13gQI4zybs+2nt+VWW6lTRz4U5PgCyl\nqMdlnkMO/tvPueEWMYIsMG8097aK9DKILdu+m9WUfM9/XyxuHtVYq6hTkS2r\ni1LLrKdauZL4zMQWyh8DAmW4t6vEWgbQvYUmBkp21jVFzlLLQk/fQMg5JEkr\nA15Fs6mS+GIUr8qqxmXuKYgGDB3VVrhLtrKsn4gheAIrbehZGkoYCMKpGgQg\nDm5S\r\n=wz0e\r\n-----END PGP SIGNATURE-----\r\n"
       }
+    },
+    "0.20.0": {
+      "name": "scheduler",
+      "version": "0.20.0",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-XegIgta1bIaz2LdaL6eg1GEcE42g0BY9qFXCqlZ/+s2MuEKfigFCW6DEGBlZzeVFlwDmVusrWEyFtBo4sbkkdA==",
+        "shasum": "3ff543696b169613afadb09d3fb3fe998d234dd2",
+        "tarball": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.0.tgz",
+        "fileCount": 26,
+        "unpackedSize": 130274,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfj0PgCRA9TVsSAnZWagAAYfIP/RO8EjBoAMK5avQ3uENd\n2K53CvNlshenZbbrwdh39dOgc6IcGO7wha+gz3l3jpFKFN3KYbFqVR9/IYkw\nYj+1b2fCFZGEGhHiSNo2eunlcywhFjoxNdQxY67yQCuqypUDkMEmjDbkpdlh\ne+MllKqii6/HLi9l3U0gShGMdHSKWZz5etx9YOXg1lS+Wy4abRbgy7iGASHc\nYfz7+YtaYbq05YveMVJPKqeVI+IOmOd23HFe0xzhQ2Hl/PF5fYIcSBC75DIT\nUjBpEN4oiytI4MG6flfym0dERHx/9IBMpSuFl/jloeU7tmYlEdtiZbxFlXHo\nEqkgzSV6QNY0eOeczf3bZgTs50W31HpXyHWGC1KyCTiyCygrJ9bq6N0a7cVs\nFl8lUjtV/5eIsY30hmnpTqzFI7w6sIsrx1kZBLQyLWtMSB9JbXhbARgtHhgN\nnQfqis4gUgFmpaER8cJTvKg0rchyZjMBiV/qVPTe/mVBpwFe4Z+JtjPauorD\nANz2wlL5jFO28GA4IVhDUVfJJqmE1A3bDo1FCNhuQywcH8hvXqQD0Goy6vII\n0wpOS9uzRzHdasRzwqoNU/xdPXDOyhHLlJTAjBiXOr6h4l8sKYFbW8L8RGfJ\n9gE3CEUtCy31EgAPus04T4SUE6ECSRXpqIL9UiY5VQJS3FpC/RI5/CIqSTLl\nsV8e\r\n=E45E\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.0.0-8e5adfbd7": {
+      "name": "scheduler",
+      "version": "0.0.0-8e5adfbd7",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-Q5ipj3teMJXYf+8FTBWyVGSAnRyxXPlGQ5mpS+G56/aKdo9Ky9CM2/g1NCaYJGdnoUTjFpwG/Ws5gD5S7azK4Q==",
+        "shasum": "2ff67c3a13f6cd7336faf8832c4a1cce001e3108",
+        "tarball": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-8e5adfbd7.tgz",
+        "fileCount": 26,
+        "unpackedSize": 130374,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfkXc3CRA9TVsSAnZWagAAuk8P/3gQBZs43LHfSbIvvJCu\nGhlfIBKUQ1POJxmx4amKxQ5hpQYsNcqI8y13HsZWmWnqWhJn+SIWcDozl1Vv\nbEL5hASDskdqA5S2ENc7977vHPec4OKk8T0uckJNpJQzrjcWv2QeYFdxX4Dy\nY+OdD5M+gdpVjhEq2EXrY+MUUec7i+rIitlZsIkUncAyEBDEaYLyTEFq5HTG\nSgAtLX+P9GG6FZd35/OtdU/4UIA5+oIy3loEGyxMB2ZkAZ76zAeeTdWKfOEy\n/lPK953to1sbYml2gt39Du0yJ8IqaTcMOt+MaitPrdfiyjLbrPEHCZhcZDYc\ntRPpRwkS2C4P+WRfpnh+vcMLh3IasSOBAd4D479wZv34OGmcCBHyb/JGMQCB\nEhHQNa9P/lBv9FXfW3BFas70WEyBSJ/uUCiUySbEnitBZnnXGp462WrWRE7l\nGsOrYPz3qPaTGtNWiRqmabuHTab/pW+e2XFVmjq2VtKyA7jm4B1HMWB8OzxM\ni1mLZn8WX8vB0lAc6Leq5zZZIVzGxm85JItdHtsOy4us6+lhMlITC5j3YHZ3\nh78NVPpFCE/8j/yEuCtUZbuW8Z8hewQ30fLgm0ywUorjrlZTxkrOsx6+tUm+\n+Iru5VQEqvVx9wsy2+QDXwr2y9WhY9DvgNb6/VJ1MBdG4wTi2+iM0geGbm4R\nEJyU\r\n=8szD\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.20.1": {
+      "name": "scheduler",
+      "version": "0.20.1",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+        "shasum": "da0b907e24026b01181ecbc75efdc7f27b5a000c",
+        "tarball": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+        "fileCount": 26,
+        "unpackedSize": 130266,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfkXl7CRA9TVsSAnZWagAABx0P/iPE49eLVWbrV3YrS0fU\nfcQaHBRMIhJ4eoFJAF41eWIuPZ7gK8ELrBtSTjDB9e6MaSDaqSY9attQZzgl\nIrtoa7spadUrXGYNmc17YpQJhVGsHCDIYHLV1jcHwGatd5eS5r34q/pbimE3\nwvcutUjBorIiaWNiysrvs1daZ1QSu8qxfEGYEY9Z8wc1C/uWhhAzNAPdmzfJ\nDoFWIrdFiLVLBrTjGmETdeoyqhE6tillZgusmWot7YhvJfgZmQpnN0Sluw4f\nY5DHxeZwKtymtBrCcM2fDsVxwzYz0nhAEWVnBvBpEw2X0cYgqHiOPFq72ZjJ\nDhuuVGSgw5vCCgvEg1+uGgJG2HzeGmV9PYi/svnRfnQjdhILMkaTjzI7T1P6\nsl5HWhzbWxQ6RFzQ9vcKl0Fqgvn/XVSsWGBH4N7+Y2oB4zDVi4yc4lEeEZ61\noNZzBF2+Jx5VbUXN+nwC171W8V4lD6IjoUim9FVq6D7LYk8SjaNRBJt9xMcZ\n7TgBX7PX5NT4UZHDI02219szIhAJpRdFkyPOc2pAHyZRWLLIp56iUF+WKEj8\nl7tOXQpSefZc87Srmv/zx46fBigOpKq2NlW1VQZC6vn3fDhI2NqyqMTZm7Y8\navKOilDFNQYJzOMQ5BZI9tVCk8OJDDzr/hGw2PaS9fm9PgmuorOh4LGZZLPx\nxpNZ\r\n=rm+g\r\n-----END PGP SIGNATURE-----\r\n"
+      }
     }
   },
-  "modified": "2020-10-07T14:41:02.671Z"
+  "modified": "2020-10-22T12:22:23.173Z"
 }

--- a/test/fixtures/registry-mocks/content/select-hose.json
+++ b/test/fixtures/registry-mocks/content/select-hose.json
@@ -1,0 +1,154 @@
+{
+  "_id": "select-hose",
+  "_rev": "2-7475937d6c2631c0933136c353093462",
+  "name": "select-hose",
+  "description": "Select protocol using first bytes of incoming data and hose stuff to the handler",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "select-hose",
+      "version": "1.0.1",
+      "description": "Select protocol using first bytes of incoming data and hose stuff to the handler",
+      "main": "lib/hose.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/select-hose.git"
+      },
+      "keywords": [
+        "hose",
+        "select",
+        "balance"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/select-hose/issues"
+      },
+      "homepage": "https://github.com/indutny/select-hose#readme",
+      "devDependencies": {
+        "handle-thing": "^1.2.0",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.3"
+      },
+      "gitHead": "fc8c6c27bf823f89b8a0a4e5ab95981f7ef2e6f3",
+      "_id": "select-hose@1.0.1",
+      "_shasum": "f2e89274989c779139c451f2a3d139d7958911fa",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f2e89274989c779139c451f2a3d139d7958911fa",
+        "tarball": "https://registry.npmjs.org/select-hose/-/select-hose-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "select-hose",
+      "version": "2.0.0",
+      "description": "Select protocol using first bytes of incoming data and hose stuff to the handler",
+      "main": "lib/hose.js",
+      "scripts": {
+        "test": "jscs lib/*.js test/*.js && jshint lib/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/select-hose.git"
+      },
+      "keywords": [
+        "hose",
+        "select",
+        "balance"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/select-hose/issues"
+      },
+      "homepage": "https://github.com/indutny/select-hose#readme",
+      "devDependencies": {
+        "handle-thing": "^1.2.0",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.3"
+      },
+      "gitHead": "ee7caf9d58e519b736197c65c1b07f5e3d2715b4",
+      "_id": "select-hose@2.0.0",
+      "_shasum": "625d8658f865af43ec962bfc376a37359a4994ca",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "625d8658f865af43ec962bfc376a37359a4994ca",
+        "tarball": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# Select Hose\n\n[![Build Status](https://secure.travis-ci.org/indutny/select-hose.png)](http://travis-ci.org/indutny/select-hose)\n[![NPM version](https://badge.fury.io/js/select-hose.svg)](http://badge.fury.io/js/select-hose)\n\nHose the data to the handler\n\n## LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2015.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2015-07-14T18:02:25.026Z",
+    "created": "2015-07-14T06:46:47.764Z",
+    "1.0.1": "2015-07-14T06:46:47.764Z",
+    "2.0.0": "2015-07-14T18:02:25.026Z"
+  },
+  "homepage": "https://github.com/indutny/select-hose#readme",
+  "keywords": [
+    "hose",
+    "select",
+    "balance"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/select-hose.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/select-hose/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/select-hose.min.json
+++ b/test/fixtures/registry-mocks/content/select-hose.min.json
@@ -1,0 +1,39 @@
+{
+  "name": "select-hose",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "select-hose",
+      "version": "1.0.1",
+      "devDependencies": {
+        "handle-thing": "^1.2.0",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "shasum": "f2e89274989c779139c451f2a3d139d7958911fa",
+        "tarball": "https://registry.npmjs.org/select-hose/-/select-hose-1.0.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "select-hose",
+      "version": "2.0.0",
+      "devDependencies": {
+        "handle-thing": "^1.2.0",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "shasum": "625d8658f865af43ec962bfc376a37359a4994ca",
+        "tarball": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz"
+      }
+    }
+  },
+  "modified": "2015-07-14T18:02:25.026Z"
+}

--- a/test/fixtures/registry-mocks/content/selfsigned.json
+++ b/test/fixtures/registry-mocks/content/selfsigned.json
@@ -1,0 +1,1557 @@
+{
+  "_id": "selfsigned",
+  "_rev": "37-afe13ee3b3423c66125d5e771fcf8c24",
+  "name": "selfsigned",
+  "description": "Generate self signed certificates private and public keys",
+  "dist-tags": {
+    "latest": "1.10.8"
+  },
+  "versions": {
+    "0.0.2": {
+      "name": "selfsigned",
+      "version": "0.0.2",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "_id": "selfsigned@0.0.2",
+      "dist": {
+        "shasum": "313d782ad5ca0a60407e713f8bc9b4f790181af5",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "selfsigned",
+      "version": "0.0.3",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "_id": "selfsigned@0.0.3",
+      "dist": {
+        "shasum": "178570bf43bb1acd9896b37a342430cdf0b807ac",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "selfsigned",
+      "version": "0.0.4",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "_id": "selfsigned@0.0.4",
+      "dist": {
+        "shasum": "2ee56fa12500add3632bd8c7d2da3f958a967520",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "selfsigned",
+      "version": "0.0.5",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "_id": "selfsigned@0.0.5",
+      "dist": {
+        "shasum": "7299f40f21b8cd4b091780d16a1cdaddd80c26d6",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.6": {
+      "name": "selfsigned",
+      "version": "0.0.6",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "_id": "selfsigned@0.0.6",
+      "dist": {
+        "shasum": "6df529e0e341047254d3b8c1a99dcc28ba1f6564",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "selfsigned",
+      "version": "1.1.1",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "node ./test/tests.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contirbutors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "~0.1.15"
+      },
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "_id": "selfsigned@1.1.1",
+      "dist": {
+        "shasum": "17ff051cc330213522099c0b613b2bbc9116d0d4",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "selfsigned",
+      "version": "1.2.0",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "node ./test/tests.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contirbutors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "_id": "selfsigned@1.2.0",
+      "dist": {
+        "shasum": "45ca012e5dda2e7a7ee4692ed6d2e7499fce75af",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "selfsigned",
+      "version": "1.4.0",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "node ./test/tests.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "gitHead": "4e69f295dac6b980a35668d772f0b7b3c3bf2cac",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.4.0",
+      "_shasum": "1af8e003f50a99347af38bd2d7a9e4540d7bd5a0",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1af8e003f50a99347af38bd2d7a9e4540d7bd5a0",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "selfsigned",
+      "version": "1.4.1",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "node ./test/tests.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "gitHead": "4496bdf9e9d295afbc41b9b796e108079f55cc32",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.4.1",
+      "_shasum": "7e1a32bdd02119d08cbd7e307a3231c9425b1c2b",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e1a32bdd02119d08cbd7e307a3231c9425b1c2b",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "selfsigned",
+      "version": "1.5.0",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "node ./test/tests.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "gitHead": "0c338b87f79b6d190a2f9affbdc65ce48e3c31c7",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.5.0",
+      "_shasum": "7a373bf2cd4465f342c792e8b34b2d6e5c415b98",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7a373bf2cd4465f342c792e8b34b2d6e5c415b98",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "selfsigned",
+      "version": "1.6.0",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "gitHead": "1cac1a30c7ae07cf1ccef4d07cb5186bf3f00d40",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.6.0",
+      "_shasum": "6baa59493cc0c60f4bce470a68067c813741d3bb",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6baa59493cc0c60f4bce470a68067c813741d3bb",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "selfsigned",
+      "version": "1.7.0",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "gitHead": "e8d822127a37eaec7bc035df71d7e4beb92054a6",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.7.0",
+      "_shasum": "6b7df17a62879ff8df423f51704dc13d891d8352",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6b7df17a62879ff8df423f51704dc13d891d8352",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "selfsigned",
+      "version": "1.8.0",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "gitHead": "5eefacceae31667f190248c4694ff24968bf4e14",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.8.0",
+      "_shasum": "c8ddaee6fbcb6b2c46275163dbf62a8292aaa862",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.2.4",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c8ddaee6fbcb6b2c46275163dbf62a8292aaa862",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.1": {
+      "name": "selfsigned",
+      "version": "1.9.1",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "0.6.33"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "gitHead": "4c3a55a2fe9a67a04d19028676806d3744fd64d8",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.9.1",
+      "_shasum": "cdda4492d70d486570f87c65546023558e1dfa5a",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "shasum": "cdda4492d70d486570f87c65546023558e1dfa5a",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.9.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/selfsigned-1.9.1.tgz_1494618269817_0.1208974055480212"
+      },
+      "directories": {}
+    },
+    "1.10.0": {
+      "name": "selfsigned",
+      "version": "1.10.0",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "0.6.33"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "gitHead": "58f6a441446472b7cdefb66874d1fdba07ab598f",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.10.0",
+      "_shasum": "47412fc93e95e8376aed8d7184dc67a4a9873d52",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "shasum": "47412fc93e95e8376aed8d7184dc67a4a9873d52",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/selfsigned-1.10.0.tgz_1502374970579_0.35861022607423365"
+      },
+      "directories": {}
+    },
+    "1.10.1": {
+      "name": "selfsigned",
+      "version": "1.10.1",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com  ",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "0.6.33"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "gitHead": "90bd8aabfb6e4624ae48ebe6a63ad9912c000497",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.10.1",
+      "_shasum": "bf8cb7b83256c4551e31347c6311778db99eec52",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "shasum": "bf8cb7b83256c4551e31347c6311778db99eec52",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/selfsigned-1.10.1.tgz_1502375467115_0.2571015888825059"
+      },
+      "directories": {}
+    },
+    "1.10.2": {
+      "name": "selfsigned",
+      "version": "1.10.2",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "0.7.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "gitHead": "ec6ef7a04ca73e049472ab112b7e727c1de3308b",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.10.2",
+      "_shasum": "b4449580d99929b65b10a48389301a6592088758",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.4",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "shasum": "b4449580d99929b65b10a48389301a6592088758",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/selfsigned-1.10.2.tgz_1517230152097_0.3908937314990908"
+      },
+      "directories": {}
+    },
+    "1.10.3": {
+      "name": "selfsigned",
+      "version": "1.10.3",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "0.7.5"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "gitHead": "a7dc4f6c2d76bcc9d7f2760d688a4ec834295c90",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.10.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
+        "shasum": "d628ecf9e3735f84e8bafba936b3cf85bea43823",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21587,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa7HleCRA9TVsSAnZWagAAfzQP/jRdhPbyjptLms5EnWnO\n+pwnIlYKHBCKXQSRZJPEVbZybCj6RbjbQBrYMEhue2xtN9YJkj4/G4iN+AL2\nTb8F1bKo+Uf34xpp40XckkwE+6MYIcZUTYFeEBZSL8Ysi8FIpF3MVUxcnsbC\nnLQ3tnj5I8F20WcaEZjyncakgrSxSEMGo3arBXR++sZx88Q0efter1vgF7gR\nqPSXIimWSxRe1R9UEZpUbMrG4rv25q/B9Jm4C79WvzPXcTJFejlcULx1tJPP\n6gjOmica+z2qJh/DOH8Oaq2FUVkoF5naXnzY23HckzZOSty5McGq1AIZgd7J\n1QTaL0t5I/SVB618Qpf6d48zbyM7OuSMQXIMOScRN8ElLF91LEiUrZyN7Fnf\nAnpCb1XwReXXEJc4uNq21z2j/Mj6x/nPqKMtY7l4CU/31dftQXfMrfkWQa93\ny4A0Xg1qCE1sMOSDqpRTO0/tP0pEs0QMMG8gdThR2nghkoeJL8/UjLpUIbiU\nv8QAKuIfYc29AtaJqv25QGdSF4gga/Cm/p2jUr/5mlADjFYxTFssH6W7SnuF\ny8jQcA0uBr9+YOJzjmK2SzBhilcHOi7KzDGZTFwyMX2O5OWPJw5iGgQJkuZK\nnu/b57VytxQh7khtYV5R5ymGmbWNkumITtxGLZJVizeIdPz56BVzl+o9KaPY\nBT7g\r\n=tIIF\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/selfsigned_1.10.3_1525447004771_0.5284479652533043"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.10.4": {
+      "name": "selfsigned",
+      "version": "1.10.4",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "0.7.5"
+      },
+      "devDependencies": {
+        "mocha": "^5.1.1"
+      },
+      "gitHead": "a20f5d812b06a5769716b5a0c14b48dd6801aab8",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.10.4",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.12.0",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
+        "shasum": "cdd7eccfca4ed7635d47a08bf2d5d3074092e2cd",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
+        "fileCount": 7,
+        "unpackedSize": 22664,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbve5MCRA9TVsSAnZWagAAERMP/0LyiTvWHYLgNZTTIRxf\nJZ9Q2it3Z5UMl9MtUoZ8fOizkcj4/OCJwltCrCkPNKF7RfMLwGmFW/7jOSuX\ni3FyHjMCSInmP5h/TfL74pIu39/rpx2iEzyr/7JLQdl3+o48qYjZ14x4pApa\nkQQoUdvyd0TKOLumnEatQLQH5HfyLf2ZvRY5ICNCk8TSVGf0yXdPXeyare8Y\nqntkytAxkoXycKycztthePYRfQBxGKIWcmO+53dwA+690CfCwJsVie9rBclg\n/Y35YddBT843ys+C+FwQNMgOMd3Y4jQPV+Kcy843oUpGkKrwFcpyVGtJFVAn\n2M9NRfPfl/cyzheaOn9sG2GLOssv66gFVurHXLErMNe/6Ek+UNIoyAh+LVUH\naOeZKEsSaib7aidXbfv9c7UeJ81A6j+woAElwKO2OkkUPOT4MSOzKV/8KP19\nnEtdNI35Easn4NjbnG3AzT2Ug9UrI0EZDYGty1bwc1XPH6aLCxZzCxYgZ4Sq\n11wXbJ+l7BX1ukMw//6WAF/NJ2Wyei+wyIFXTjMa+UDkUk18A7sFvp9RRINo\n1+FaiyqTBl9n38SIlzrnS473OV0JxMRaIFQSyZh1QIz2NNuj1Bu75Q03p4ro\nfsP68cHA9+2giC04C/+gOxNB3qnI652BFxn2B59aqPM1WjLBjTpWYz5udGO4\nR8AB\r\n=7qvY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/selfsigned_1.10.4_1539173963353_0.11128511572157085"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.10.6": {
+      "name": "selfsigned",
+      "version": "1.10.6",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "0.8.2"
+      },
+      "devDependencies": {
+        "mocha": "^5.1.1"
+      },
+      "gitHead": "7bd58764439eee6198895338fd2f6e388f5833d0",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.10.6",
+      "_nodeVersion": "8.16.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-i3+CeqxL7DpAazgVpAGdKMwHuL63B5nhJMh9NQ7xmChGkA3jNFflq6Jyo1LLJYcr3idWiNOPWHCrm4zMayLG4w==",
+        "shasum": "7b3cd37ed9c2034261a173af1a1aae27d8169b67",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.6.tgz",
+        "fileCount": 7,
+        "unpackedSize": 22663,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdckzyCRA9TVsSAnZWagAA8NQP/3VX8673rx0OqTu8Pl4k\nh7PbEROGM9Rs7ACkm+ThPU0/tfYjW5LnWYWIHCbQwV5pvxW9SIi+WCdIDN/x\ngY2lo/IvZMTOoxms/gu6HnVfw9jYgMKK+nOSndt0OVOtuF5anv1YnHI7sT/t\n0InNYkt63uGrriEVvCs0GtuFBm83tL7UPiRpwu2Yln2ocMilKDzcd6B4O+SB\nzibGBnmSkNNmVytXq0lH+wCPak02yYr/l23lic42DRbAxVpya5BGblh/ym+x\nTn4ZJcgQUZyNFYoQ10Y4TtXbQ1cWyP8uWLDTQEEO82bVqlaBYDqZlnoKMqdL\nSIsrV8bSsx8rbM6Rz4FSVAM8An8l1+KFWBzcD2Brxf3LO4l7RJY83+rODDVk\nRBEpb0pjOmBmpDUthhRehEBvF3hPdYt8tsmCt13PYgc5mdBjF0X07/qB4cns\nVgSzRoYxepHgLzbwbil0nYt2ljdWylv7MrXr/7+2MkdZwiOvZjivvVzFkh/t\n4/DAcLDDd9gG7U0Ze9yUGMZO4K1a7xE8lofNHjy9gR6cesDjR5gxa1vhjbES\nV7M8eG5BVR5C1Ba7aXn5CiuYSexY6YPZbNZGpRcQxk1bTfRqGNsA5dpJIWJY\nwjoqyzdLqo6+ElgEEOx0ItuYiE5oEp+EiNJX5nsJJPeVTc/vW7bEHPaA/qcC\npHIw\r\n=uYXP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/selfsigned_1.10.6_1567771890158_0.6182029462818834"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.10.7": {
+      "name": "selfsigned",
+      "version": "1.10.7",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "0.9.0"
+      },
+      "devDependencies": {
+        "mocha": "^5.1.1"
+      },
+      "gitHead": "7b3fb86eab6307c29a6b8276b4e73197768c1f28",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.10.7",
+      "_nodeVersion": "8.16.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+        "shasum": "da5819fd049d5574f28e88a9bcc6dbc6e6f3906b",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
+        "fileCount": 7,
+        "unpackedSize": 22663,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdk5DlCRA9TVsSAnZWagAAIY8P/Aixx/FStOCQW3TwQfay\nhrsJ1uw3W/Ana/VuuV0d4UpRCjeT0stNLVhis0IEgQ1fE6a6mU4upy8EKTAp\n5GpNt976sNGcOm4D84rQVsruR+W4ofCVMT5AXq2i6Z5SgBB3WtX6KuO08Tnx\n2wyE7RvhWd+hxSAgpopWcE6D8tJiOu1rb5ppdtMbZ3p7uxd9w081Ox1ntOxu\n5qhCWaewAd0N8UmU0oxptCi+JCfG7DsrbqAnW9LS30Al1hH/RLjJVEyIJVA1\n1H4MT4qNBbvoX9Jr4HPZ2zDGt9ftMP1pfNRuWkoHvRQjCq4nWGCj/VgTB+B5\nGbjCNfOI+WZIrJ3Yn2yp+G4qbWBiXW7b+gmGKFHb8v6Ux0oSCq9FeNWM6eE+\n76g9kSJ/Or4AK3Um8Pc13n51N+Q4F+EtmKPB64fSabdyhyHOfKAcV9B3a3EH\nZe0/Vy9nP1FBY2JMZAHkmrsqtDOCdXI6mlMXjfmPBj/ePu3rKbqEaRkG8Yqi\nqeHFM6B/9L1zpjdaRSGLtJ4b23h5sDBb6sdiAb3fZGiVgPsh1l8IprM9BEur\nquuZhQGBCnHl5kZ6OYvrNkrcMHW3SngO8U0FQSZld4nT6nEnD2R5uvSFoejz\nw/8YsUY6efhoYvJQ8SQtzBFeZgwrK1OPh/ZGIZ0+3vjfAgzWnNHcmcC8xw/5\nyXBz\r\n=CIZC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        },
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/selfsigned_1.10.7_1569951972513_0.9456207682850342"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.10.8": {
+      "name": "selfsigned",
+      "version": "1.10.8",
+      "description": "Generate self signed certificates private and public keys",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha -t 5000"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jfromaniello/selfsigned.git"
+      },
+      "keywords": [
+        "openssl",
+        "self",
+        "signed",
+        "certificates"
+      ],
+      "author": {
+        "name": "José F. Romaniello",
+        "email": "jfromaniello@gmail.com",
+        "url": "http://joseoncode.com"
+      },
+      "contributors": [
+        {
+          "name": "Paolo Fragomeni",
+          "email": "paolo@async.ly",
+          "url": "http://async.ly"
+        },
+        {
+          "name": "Charles Bushong",
+          "email": "bushong1@gmail.com",
+          "url": "http://github.com/bushong1"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "^0.10.0"
+      },
+      "devDependencies": {
+        "mocha": "^5.1.1"
+      },
+      "gitHead": "b7f2afaf64574987c8c2cfccfbbfe84846b73b3f",
+      "bugs": {
+        "url": "https://github.com/jfromaniello/selfsigned/issues"
+      },
+      "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+      "_id": "selfsigned@1.10.8",
+      "_nodeVersion": "10.21.0",
+      "_npmVersion": "6.14.4",
+      "_npmUser": {
+        "name": "jfromaniello",
+        "email": "jfromaniello@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
+        "shasum": "0d17208b7d12c33f8eac85c41835f27fc3d81a30",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+        "fileCount": 7,
+        "unpackedSize": 22665,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfYO1/CRA9TVsSAnZWagAAlz8P/2C9sLnE3GLRemgtza6B\nxbufwbyo42EOGRjpHLZ6ZlXKPcL4lYwZuYhyZhlAIQc1uKQqKCS48/0itDQn\n7pYgQExAZ3O63U4MAwLL3gihKeaZ79a9/IMuyv3IsYm29u+2kckZVl0Np6sa\n3dTLoRkWXxXU1tzu69OHI/K5PjV+cpAQCbfUsOup66lH5yeinFps38tMT/8q\nVs/uCXOXpzciEQwToFUxD5C1eAtwG65w6vC9iKYHPQjWbX0QRu2TkqrZjFIu\n+bcsVo2I3TealncBeeKBI+AacHQwKuczKKIgz+7sWjmoEwwXyXYsCyvtxMEN\nsigTTUqtTtdE1kX1KNR5ypGH+GT6PQTDLGF5fFWbESyIBUN3au2AwQEdbWbs\nRuE/jj4MP3OgeD2oBl6qZNXzMZNM4frl7/HxUVJP78+imOXGff4ZTXiVRg4L\nqosEZBLDajqdyLqEoqYOmLyTiHM9ReDqeWZo+a0/UkvgDaarZNsyjxipF0d+\nig9qxo4GMqzHQnimzQLCYRxEe2psNVJXZrBFQhH93eQ07d8+bfh2Dlkyud5B\nU3Kst1X9ItmNPTqtBVAyOGEvXyPtyagc9vaWUb33NiCg/7NmPiw0mTuEy35+\ne0iF0992ycfVFrolmVf5hKNBV+c7lUS47gsYGxz846jEqmzqrg9N8SrVl8nA\nXqDB\r\n=Pg0A\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jfromaniello",
+          "email": "jfromaniello@gmail.com"
+        },
+        {
+          "name": "iaco",
+          "email": "sebastian.iacomuzzi@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/selfsigned_1.10.8_1600187774802_0.07166194090241818"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "Generate a self signed x509 certificate from node.js.\n\n[![Build Status](https://travis-ci.org/jfromaniello/selfsigned.png)](https://travis-ci.org/jfromaniello/selfsigned)\n\n## Install\n\n```bash\n  npm install selfsigned\n```\n\n## Usage\n\n```js\nvar selfsigned = require('selfsigned');\nvar attrs = [{ name: 'commonName', value: 'contoso.com' }];\nvar pems = selfsigned.generate(attrs, { days: 365 });\nconsole.log(pems)\n```\n\n#### Async\n\n```js\nselfsigned.generate(attrs, { days: 365 }, function (err, pems) {\n  console.log(pems)\n});\n```\n\nWill return the following like this:\n\n```js\n{\n  private: '-----BEGIN RSA PRIVATE KEY-----\\r\\nMIICXAIBAAKBgQCBFMXMYS/+RZz6+qzv+xeqXPdjw4YKZC4y3dPhSwgEwkecrCTX\\r\\nsR6boue+1MjIqPqWggXZnotIGldfEN0kn0Jbh2vMTrTx6YwqQ8tceBPoyuuqcYBO\\r\\nOONAcKOB3MLnZbyOgVtbyT3j68JE5V/lx6LhpIKAgY0m5WIuaKrW6mvLXQIDAQAB\\r\\nAoGAU6ODGxAqSecPdayyG/ml9vSwNAuAMgGB0eHcpZG5i2PbhRAh+0TAIXaoFQXJ\\r\\naAPeA2ISqlTJyRmQXYAO2uj61FzeyDzYCf0z3+yZEVz3cO7jB5Pl6iBvzbxWuuuA\\r\\ncbJtWLhWtW5/jioc8F0EAzZ+lkC/XuVJdwKHDmwt2qvJO+ECQQD+dvo1g3Sz9xGw\\r\\n21n+fDG5i4128+Qh+JPgh5AeLuXSofc1HMHaOXcC6Wu/Cloh7QAD934b7W0A7VoD\\r\\ndLd/JLyFAkEAgdwjryyvdhy69e516IrPB3b+m4rggtntBlZREMrk9tOzeIucVO3W\\r\\ntKI3FHm6JebN2gVcG+rZ+FaDPo+ifJkW+QJBAPojrMwEACmUevB2f9246gxx0UsY\\r\\nbq6yM3No71OsWEEY8/Bi53CEQqg7Gq5+F6H33qcHmBEN8LQTngN9rY+vZh0CQBg0\\r\\nqJImii5B/LeK03+dICoMDDmCEYdSh9P+ku3GZBd+Lp3xqBpMmxDgi9PNPN2DwCs7\\r\\nhIfPpwGbXqtyqp7/CkECQB4OdY+2FbCciI473eQkTu310RMf8jElU63iwnx4R/XN\\r\\n/mgqN589OfF4SS0U/MoRzYk9jF9IAJN1Mi/571T+nw4=\\r\\n-----END RSA PRIVATE KEY-----\\r\\n',\n  public: '-----BEGIN PUBLIC KEY-----\\r\\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCBFMXMYS/+RZz6+qzv+xeqXPdj\\r\\nw4YKZC4y3dPhSwgEwkecrCTXsR6boue+1MjIqPqWggXZnotIGldfEN0kn0Jbh2vM\\r\\nTrTx6YwqQ8tceBPoyuuqcYBOOONAcKOB3MLnZbyOgVtbyT3j68JE5V/lx6LhpIKA\\r\\ngY0m5WIuaKrW6mvLXQIDAQAB\\r\\n-----END PUBLIC KEY-----\\r\\n',\n  cert: '-----BEGIN CERTIFICATE-----\\r\\nMIICjTCCAfagAwIBAgIBATANBgkqhkiG9w0BAQUFADBpMRQwEgYDVQQDEwtleGFt\\r\\ncGxlLm9yZzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRMwEQYDVQQH\\r\\nEwpCbGFja3NidXJnMQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MB4XDTEz\\r\\nMDgxMzA1NDAyN1oXDTE0MDgxMzA1NDAyN1owaTEUMBIGA1UEAxMLZXhhbXBsZS5v\\r\\ncmcxCzAJBgNVBAYTAlVTMREwDwYDVQQIEwhWaXJnaW5pYTETMBEGA1UEBxMKQmxh\\r\\nY2tzYnVyZzENMAsGA1UEChMEVGVzdDENMAsGA1UECxMEVGVzdDCBnzANBgkqhkiG\\r\\n9w0BAQEFAAOBjQAwgYkCgYEAgRTFzGEv/kWc+vqs7/sXqlz3Y8OGCmQuMt3T4UsI\\r\\nBMJHnKwk17Eem6LnvtTIyKj6loIF2Z6LSBpXXxDdJJ9CW4drzE608emMKkPLXHgT\\r\\n6MrrqnGATjjjQHCjgdzC52W8joFbW8k94+vCROVf5cei4aSCgIGNJuViLmiq1upr\\r\\ny10CAwEAAaNFMEMwDAYDVR0TBAUwAwEB/zALBgNVHQ8EBAMCAvQwJgYDVR0RBB8w\\r\\nHYYbaHR0cDovL2V4YW1wbGUub3JnL3dlYmlkI21lMA0GCSqGSIb3DQEBBQUAA4GB\\r\\nAC9hGQlDh8anNo1YDJdG2mYqOQ5uybJV++kixblGaOkoDROPsWepUpL6kMDUtbAM\\r\\n4uXTyFkvlUQSaQkhNgOY5w/BRIAkCIu6u4D4XcjlCdwFq6vcKMEuWTHMAlBWFla3\\r\\nXJZAPO10PHuDen7JeMOUf1Re7lRFtwfRGAvVYmrvYFKv\\r\\n-----END CERTIFICATE-----\\r\\n'\n}\n```\n\n## Attributes\n\nfor attributes, please refer to: https://github.com/digitalbazaar/forge/blob/0.7.5/lib/x509.js#L129\n\n## Options\n\n```js\nvar pems = selfsigned.generate(null, {\n  keySize: 2048, // the size for the private key in bits (default: 1024)\n  days: 30, // how long till expiry of the signed certificate (default: 365)\n  algorithm: 'sha256', // sign the certificate with specified algorithm (default: 'sha1')\n  extensions: [{ name: 'basicConstraints', cA: true }], // certificate extensions array\n  pkcs7: true, // include PKCS#7 as part of the output (default: false)\n  clientCertificate: true, // generate client cert signed by the original key (default: false)\n  clientCertificateCN: 'jdoe' // client certificate's common name (default: 'John Doe jdoe123')\n});\n```\n\n> You can avoid key pair generation specifying your own keys (`{ keyPair: { publicKey: '-----BEGIN PUBLIC KEY-----...', privateKey: '-----BEGIN RSA PRIVATE KEY-----...' }`)\n\n### Generate Client Certificates\n\nIf you are in an environment where servers require client certificates, you can generate client keys signed by the original (server) key.\n\n```js\nvar pems = selfsigned.generate(null, { clientCertificate: true });\nconsole.log(pems)\n```\nWill return the following like this:\n\n```js\n{ private: '-----BEGIN RSA PRIVATE KEY-----\\r\\nMIICXQIBAAKBgQDLg/kS4dCPVu96sbK6MQuUPmhqnF8SeBXVHH18h+0BTj7HqnrA\\r\\nA75hNVIiSLTChvpzQ0qi2Ju7O2ESUOdx7cvGiftGuZLiI8uL2HVlYuX+wQTIoRHx\\r\\n9nxv56TIiqnPg5d05vSTLXoiJg5uac3a6+4vnhhTo0XRRXVVboZsfNpuGQIDAQAB\\r\\nAoGAfhCd9QhUPLZJWeNBJvzCg221GHUMn1Arlfsz8DPyp+BkGyKLLu4iu+xfmEUZ\\r\\nU3ZxJX0FeqJatTwvAT2EYJpAovx+F37PWFTLAS6T57WI1O5Lj1pTIKVkLrasNQgF\\r\\nl6qFD3cvEtCZve4LiwDoJ52FO2OtcDcMJ0r2oqbCXSDIlAECQQDnkkxKcTejBZGH\\r\\nyYEXG9hAznnEZ63LLzlHHF2cIPfxT+9826Wm0IzBxn8Wr4hcAbNx3bVKgsU9p7xA\\r\\nfKnSqObhAkEA4PwCjPQqxFpiYUmNt7htb8nCEvUDD/QSDyxAH/uJzfr6gOJOD5nT\\r\\n5gZYblC+CCMDkgDUpro6oATNyeRNoU3GOQJBANdaW26DWZ1WqV9hCpcGAxdJrT30\\r\\nuVASq66w93Ehy9LzZqFz1tqKacwvH7NmLGZ8AngrGdSgRnOvEMfb50aMYqECQDcG\\r\\nzCTnbzJZHOjIkaXWsMV/pjz2ugoD2wrk+sYXwoujj/NH5mnAaOhAsw5AJ0pcLfpe\\r\\nw6QHtmD+68ouUaJbIFkCQQDeu0AXAp6Kbk6570i2DpGUSnkRdGCGS+3ekqqJUpE7\\r\\nfVUSx1nCF1sPD0p+pO8Rj3i87iI4MlblQRm/wVkrkjiR\\r\\n-----END RSA PRIVATE KEY-----\\r\\n',\n  public: '-----BEGIN PUBLIC KEY-----\\r\\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLg/kS4dCPVu96sbK6MQuUPmhq\\r\\nnF8SeBXVHH18h+0BTj7HqnrAA75hNVIiSLTChvpzQ0qi2Ju7O2ESUOdx7cvGiftG\\r\\nuZLiI8uL2HVlYuX+wQTIoRHx9nxv56TIiqnPg5d05vSTLXoiJg5uac3a6+4vnhhT\\r\\no0XRRXVVboZsfNpuGQIDAQAB\\r\\n-----END PUBLIC KEY-----\\r\\n',\n  cert: '-----BEGIN CERTIFICATE-----\\r\\nMIIClTCCAf6gAwIBAgIJdMZqoEeGMVYKMA0GCSqGSIb3DQEBBQUAMGkxFDASBgNV\\r\\nBAMTC2V4YW1wbGUub3JnMQswCQYDVQQGEwJVUzERMA8GA1UECBMIVmlyZ2luaWEx\\r\\nEzARBgNVBAcTCkJsYWNrc2J1cmcxDTALBgNVBAoTBFRlc3QxDTALBgNVBAsTBFRl\\r\\nc3QwHhcNMTUxMDI5MTMwNjA1WhcNMTYxMDI4MTMwNjA1WjBpMRQwEgYDVQQDEwtl\\r\\neGFtcGxlLm9yZzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRMwEQYD\\r\\nVQQHEwpCbGFja3NidXJnMQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MIGf\\r\\nMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDLg/kS4dCPVu96sbK6MQuUPmhqnF8S\\r\\neBXVHH18h+0BTj7HqnrAA75hNVIiSLTChvpzQ0qi2Ju7O2ESUOdx7cvGiftGuZLi\\r\\nI8uL2HVlYuX+wQTIoRHx9nxv56TIiqnPg5d05vSTLXoiJg5uac3a6+4vnhhTo0XR\\r\\nRXVVboZsfNpuGQIDAQABo0UwQzAMBgNVHRMEBTADAQH/MAsGA1UdDwQEAwIC9DAm\\r\\nBgNVHREEHzAdhhtodHRwOi8vZXhhbXBsZS5vcmcvd2ViaWQjbWUwDQYJKoZIhvcN\\r\\nAQEFBQADgYEAj1Yyyb0R9KRFjIWNFi6RErB/riWylW4CdOK1hOyJZ+VRBWeYLKfX\\r\\ni///V+tqRvLlYY5x5DnrjXbDjBy0CZuN/J772/Srgp7Nl5cn92zynMJK1q4MEEs3\\r\\nAE/FO85R0HbGEp+IrwUwDOLR6omBFVdh1EUOTcQU2jLZNbWvLDiWbDo=\\r\\n-----END CERTIFICATE-----\\r\\n',\n  clientprivate: '-----BEGIN RSA PRIVATE KEY-----\\r\\nMIICWwIBAAKBgQDjR5FrrdZ1jirqkx3KMPnGjrcObj/vmztWTEZ1kX6gTskQugJU\\r\\noxktzwDZza4jYODC6Ud2jouFLWeAi5BDSAeLwAQb951qVD9zVsmQ+63V/mvSJUoj\\r\\nigwj7YjcxyReJ17F0YgjceqrkZaPM8YRo8h1fj1JdPc4ZOUgA5ASZ0h2ewIDAQAB\\r\\nAoGAfB5DbjibG8ut6Di7VgX1AdhCY+EVjXaKqxAwklgIfOdJqpbKWwpO39NiNY+7\\r\\nf5qSZB8dZcNmsi4fjfWprPSTGVkk1Qp2uibtFS4MhbLEeyy4cgZfMIBQY+HD0Asf\\r\\n1NU7WTY5QfzgH3HAKuWpUEWdar/jE+hDPA+wnsMg+TgGARECQQDzlc+5WA9JsG9f\\r\\nwNRzhMGRxDP4QLmL0iLWupF4BMP/k4OLMjDtzWl725WJ4FjCzML7mSmkWWe/P8f5\\r\\nwrbR+e8lAkEA7t0CEsiIw8BE55YMuGIz5xI0QDnuwNWmCEmq6+ZziW3L+EuAr1S4\\r\\nDORqBYm5DuRvBWkWE9Sld0a8vNqWh58tHwJAP1ZYEhicuQuAmkRYucTuVEnRPZ8O\\r\\n4BV+65jNlIigskcYMEyXvm3oHMWnJ5fHXLfDh4p28n4w5ODfzcjcotK7ZQJAE7bX\\r\\n8fbtGsLmrPp8aEdqozqkZ1ygsPexMWPrIHcvt/sA56hLoazrV90ORxC73lfKNfcb\\r\\nZF2bnoGPGEMuQ1lG3wJAPnHysm3DgbSHZQiXWMjF4YDRRV2AeOqX1fmlSeMErwdj\\r\\ncwIs+ikIBnOwUOh6liJ7yK1YnckDTZTOfUDyG+vdFQ==\\r\\n-----END RSA PRIVATE KEY-----\\r\\n',\n  clientpublic: '-----BEGIN PUBLIC KEY-----\\r\\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDjR5FrrdZ1jirqkx3KMPnGjrcO\\r\\nbj/vmztWTEZ1kX6gTskQugJUoxktzwDZza4jYODC6Ud2jouFLWeAi5BDSAeLwAQb\\r\\n951qVD9zVsmQ+63V/mvSJUojigwj7YjcxyReJ17F0YgjceqrkZaPM8YRo8h1fj1J\\r\\ndPc4ZOUgA5ASZ0h2ewIDAQAB\\r\\n-----END PUBLIC KEY-----\\r\\n',\n  clientcert: '-----BEGIN CERTIFICATE-----\\r\\nMIICSzCCAbSgAwIBAgIBAjANBgkqhkiG9w0BAQUFADBpMRQwEgYDVQQDEwtleGFt\\r\\ncGxlLm9yZzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRMwEQYDVQQH\\r\\nEwpCbGFja3NidXJnMQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MB4XDTE1\\r\\nMTAyOTEzMDYwNVoXDTE2MTAyOTEzMDYwNVowbjEZMBcGA1UEAxMQSm9obiBEb2Ug\\r\\namRvZTEyMzELMAkGA1UEBhMCVVMxETAPBgNVBAgTCFZpcmdpbmlhMRMwEQYDVQQH\\r\\nEwpCbGFja3NidXJnMQ0wCwYDVQQKEwRUZXN0MQ0wCwYDVQQLEwRUZXN0MIGfMA0G\\r\\nCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDjR5FrrdZ1jirqkx3KMPnGjrcObj/vmztW\\r\\nTEZ1kX6gTskQugJUoxktzwDZza4jYODC6Ud2jouFLWeAi5BDSAeLwAQb951qVD9z\\r\\nVsmQ+63V/mvSJUojigwj7YjcxyReJ17F0YgjceqrkZaPM8YRo8h1fj1JdPc4ZOUg\\r\\nA5ASZ0h2ewIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACOUglBxJ80jzR3DSSMrgRav\\r\\n7deKUPShEPC3tbVrc3LHPGpCEJUC309aK2mbMwz2jX78tr/ezePELKbyRggUvVgN\\r\\nB0XdIQkpR9X4mPdtFYkMiWKNVYKd79r0kolprgFPryhT3jsICIOnwE1Ur23Q+Fk2\\r\\nnizRS0HY4Q25JLCmsWWy\\r\\n-----END CERTIFICATE-----\\r\\n' }\n```\n\nTo override the default client CN of `john doe jdoe123`, add another option for `clientCertificateCN`:\n\n```js\nvar pems = selfsigned.generate(null, { clientCertificate: true, clientCertificateCN: 'FooBar' });\n```\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "jfromaniello",
+      "email": "jfromaniello@gmail.com"
+    },
+    {
+      "name": "iaco",
+      "email": "sebastian.iacomuzzi@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-09-15T16:36:18.654Z",
+    "created": "2013-03-12T20:23:33.914Z",
+    "0.0.2": "2013-03-12T20:23:54.178Z",
+    "0.0.3": "2013-03-12T20:32:42.069Z",
+    "0.0.4": "2013-03-12T20:42:44.306Z",
+    "0.0.5": "2013-03-12T20:59:54.353Z",
+    "0.0.6": "2013-03-27T14:17:51.605Z",
+    "1.1.1": "2013-08-13T23:43:35.458Z",
+    "1.2.0": "2013-08-14T20:00:19.551Z",
+    "1.4.0": "2015-10-26T11:57:59.213Z",
+    "1.4.1": "2015-10-26T12:00:35.879Z",
+    "1.5.0": "2015-10-29T14:21:45.677Z",
+    "1.6.0": "2015-10-29T19:17:21.197Z",
+    "1.7.0": "2015-10-30T16:04:36.585Z",
+    "1.8.0": "2015-12-28T15:41:19.504Z",
+    "1.9.1": "2017-05-12T19:44:32.733Z",
+    "1.10.0": "2017-08-10T14:22:50.654Z",
+    "1.10.1": "2017-08-10T14:31:07.188Z",
+    "1.10.2": "2018-01-29T12:49:12.486Z",
+    "1.10.3": "2018-05-04T15:16:44.916Z",
+    "1.10.4": "2018-10-10T12:19:23.516Z",
+    "1.10.6": "2019-09-06T12:11:30.384Z",
+    "1.10.7": "2019-10-01T17:46:12.626Z",
+    "1.10.8": "2020-09-15T16:36:14.975Z"
+  },
+  "author": {
+    "name": "José F. Romaniello",
+    "email": "jfromaniello@gmail.com",
+    "url": "http://joseoncode.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jfromaniello/selfsigned.git"
+  },
+  "users": {
+    "j3kz": true,
+    "ivangaravito": true,
+    "jrop": true,
+    "rocket0191": true,
+    "chimurai": true,
+    "daizch": true
+  },
+  "homepage": "https://github.com/jfromaniello/selfsigned#readme",
+  "keywords": [
+    "openssl",
+    "self",
+    "signed",
+    "certificates"
+  ],
+  "contributors": [
+    {
+      "name": "Paolo Fragomeni",
+      "email": "paolo@async.ly",
+      "url": "http://async.ly"
+    },
+    {
+      "name": "Charles Bushong",
+      "email": "bushong1@gmail.com",
+      "url": "http://github.com/bushong1"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/jfromaniello/selfsigned/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/selfsigned.min.json
+++ b/test/fixtures/registry-mocks/content/selfsigned.min.json
@@ -1,0 +1,337 @@
+{
+  "name": "selfsigned",
+  "dist-tags": {
+    "latest": "1.10.8"
+  },
+  "versions": {
+    "0.0.2": {
+      "name": "selfsigned",
+      "version": "0.0.2",
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dist": {
+        "shasum": "313d782ad5ca0a60407e713f8bc9b4f790181af5",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "selfsigned",
+      "version": "0.0.3",
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dist": {
+        "shasum": "178570bf43bb1acd9896b37a342430cdf0b807ac",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "selfsigned",
+      "version": "0.0.4",
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dist": {
+        "shasum": "2ee56fa12500add3632bd8c7d2da3f958a967520",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.4.tgz"
+      }
+    },
+    "0.0.5": {
+      "name": "selfsigned",
+      "version": "0.0.5",
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dist": {
+        "shasum": "7299f40f21b8cd4b091780d16a1cdaddd80c26d6",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.5.tgz"
+      }
+    },
+    "0.0.6": {
+      "name": "selfsigned",
+      "version": "0.0.6",
+      "dependencies": {
+        "tmp": "0.0.16",
+        "async": "~0.2.6"
+      },
+      "devDependencies": {
+        "chai": "~1.5.0",
+        "mocha": "~1.8.2",
+        "rimraf": "~2.1.4"
+      },
+      "dist": {
+        "shasum": "6df529e0e341047254d3b8c1a99dcc28ba1f6564",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-0.0.6.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "selfsigned",
+      "version": "1.1.1",
+      "dependencies": {
+        "node-forge": "~0.1.15"
+      },
+      "dist": {
+        "shasum": "17ff051cc330213522099c0b613b2bbc9116d0d4",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "selfsigned",
+      "version": "1.2.0",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "dist": {
+        "shasum": "45ca012e5dda2e7a7ee4692ed6d2e7499fce75af",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.2.0.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "selfsigned",
+      "version": "1.4.0",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "dist": {
+        "shasum": "1af8e003f50a99347af38bd2d7a9e4540d7bd5a0",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.4.0.tgz"
+      }
+    },
+    "1.4.1": {
+      "name": "selfsigned",
+      "version": "1.4.1",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "dist": {
+        "shasum": "7e1a32bdd02119d08cbd7e307a3231c9425b1c2b",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.4.1.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "selfsigned",
+      "version": "1.5.0",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "dist": {
+        "shasum": "7a373bf2cd4465f342c792e8b34b2d6e5c415b98",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.5.0.tgz"
+      }
+    },
+    "1.6.0": {
+      "name": "selfsigned",
+      "version": "1.6.0",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "dist": {
+        "shasum": "6baa59493cc0c60f4bce470a68067c813741d3bb",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.6.0.tgz"
+      }
+    },
+    "1.7.0": {
+      "name": "selfsigned",
+      "version": "1.7.0",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "dist": {
+        "shasum": "6b7df17a62879ff8df423f51704dc13d891d8352",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.7.0.tgz"
+      }
+    },
+    "1.8.0": {
+      "name": "selfsigned",
+      "version": "1.8.0",
+      "dependencies": {
+        "node-forge": "~0.2.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "dist": {
+        "shasum": "c8ddaee6fbcb6b2c46275163dbf62a8292aaa862",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.8.0.tgz"
+      }
+    },
+    "1.9.1": {
+      "name": "selfsigned",
+      "version": "1.9.1",
+      "dependencies": {
+        "node-forge": "0.6.33"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "dist": {
+        "shasum": "cdda4492d70d486570f87c65546023558e1dfa5a",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.9.1.tgz"
+      }
+    },
+    "1.10.0": {
+      "name": "selfsigned",
+      "version": "1.10.0",
+      "dependencies": {
+        "node-forge": "0.6.33"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "dist": {
+        "shasum": "47412fc93e95e8376aed8d7184dc67a4a9873d52",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.0.tgz"
+      }
+    },
+    "1.10.1": {
+      "name": "selfsigned",
+      "version": "1.10.1",
+      "dependencies": {
+        "node-forge": "0.6.33"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "dist": {
+        "shasum": "bf8cb7b83256c4551e31347c6311778db99eec52",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.1.tgz"
+      }
+    },
+    "1.10.2": {
+      "name": "selfsigned",
+      "version": "1.10.2",
+      "dependencies": {
+        "node-forge": "0.7.1"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "dist": {
+        "shasum": "b4449580d99929b65b10a48389301a6592088758",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.2.tgz"
+      }
+    },
+    "1.10.3": {
+      "name": "selfsigned",
+      "version": "1.10.3",
+      "dependencies": {
+        "node-forge": "0.7.5"
+      },
+      "devDependencies": {
+        "mocha": "^1.20.1"
+      },
+      "dist": {
+        "integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
+        "shasum": "d628ecf9e3735f84e8bafba936b3cf85bea43823",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 21587,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa7HleCRA9TVsSAnZWagAAfzQP/jRdhPbyjptLms5EnWnO\n+pwnIlYKHBCKXQSRZJPEVbZybCj6RbjbQBrYMEhue2xtN9YJkj4/G4iN+AL2\nTb8F1bKo+Uf34xpp40XckkwE+6MYIcZUTYFeEBZSL8Ysi8FIpF3MVUxcnsbC\nnLQ3tnj5I8F20WcaEZjyncakgrSxSEMGo3arBXR++sZx88Q0efter1vgF7gR\nqPSXIimWSxRe1R9UEZpUbMrG4rv25q/B9Jm4C79WvzPXcTJFejlcULx1tJPP\n6gjOmica+z2qJh/DOH8Oaq2FUVkoF5naXnzY23HckzZOSty5McGq1AIZgd7J\n1QTaL0t5I/SVB618Qpf6d48zbyM7OuSMQXIMOScRN8ElLF91LEiUrZyN7Fnf\nAnpCb1XwReXXEJc4uNq21z2j/Mj6x/nPqKMtY7l4CU/31dftQXfMrfkWQa93\ny4A0Xg1qCE1sMOSDqpRTO0/tP0pEs0QMMG8gdThR2nghkoeJL8/UjLpUIbiU\nv8QAKuIfYc29AtaJqv25QGdSF4gga/Cm/p2jUr/5mlADjFYxTFssH6W7SnuF\ny8jQcA0uBr9+YOJzjmK2SzBhilcHOi7KzDGZTFwyMX2O5OWPJw5iGgQJkuZK\nnu/b57VytxQh7khtYV5R5ymGmbWNkumITtxGLZJVizeIdPz56BVzl+o9KaPY\nBT7g\r\n=tIIF\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.10.4": {
+      "name": "selfsigned",
+      "version": "1.10.4",
+      "dependencies": {
+        "node-forge": "0.7.5"
+      },
+      "devDependencies": {
+        "mocha": "^5.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-9AukTiDmHXGXWtWjembZ5NDmVvP2695EtpgbCsxCa68w3c88B+alqbmZ4O3hZ4VWGXeGWzEVdvqgAJD8DQPCDw==",
+        "shasum": "cdd7eccfca4ed7635d47a08bf2d5d3074092e2cd",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.4.tgz",
+        "fileCount": 7,
+        "unpackedSize": 22664,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbve5MCRA9TVsSAnZWagAAERMP/0LyiTvWHYLgNZTTIRxf\nJZ9Q2it3Z5UMl9MtUoZ8fOizkcj4/OCJwltCrCkPNKF7RfMLwGmFW/7jOSuX\ni3FyHjMCSInmP5h/TfL74pIu39/rpx2iEzyr/7JLQdl3+o48qYjZ14x4pApa\nkQQoUdvyd0TKOLumnEatQLQH5HfyLf2ZvRY5ICNCk8TSVGf0yXdPXeyare8Y\nqntkytAxkoXycKycztthePYRfQBxGKIWcmO+53dwA+690CfCwJsVie9rBclg\n/Y35YddBT843ys+C+FwQNMgOMd3Y4jQPV+Kcy843oUpGkKrwFcpyVGtJFVAn\n2M9NRfPfl/cyzheaOn9sG2GLOssv66gFVurHXLErMNe/6Ek+UNIoyAh+LVUH\naOeZKEsSaib7aidXbfv9c7UeJ81A6j+woAElwKO2OkkUPOT4MSOzKV/8KP19\nnEtdNI35Easn4NjbnG3AzT2Ug9UrI0EZDYGty1bwc1XPH6aLCxZzCxYgZ4Sq\n11wXbJ+l7BX1ukMw//6WAF/NJ2Wyei+wyIFXTjMa+UDkUk18A7sFvp9RRINo\n1+FaiyqTBl9n38SIlzrnS473OV0JxMRaIFQSyZh1QIz2NNuj1Bu75Q03p4ro\nfsP68cHA9+2giC04C/+gOxNB3qnI652BFxn2B59aqPM1WjLBjTpWYz5udGO4\nR8AB\r\n=7qvY\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.10.6": {
+      "name": "selfsigned",
+      "version": "1.10.6",
+      "dependencies": {
+        "node-forge": "0.8.2"
+      },
+      "devDependencies": {
+        "mocha": "^5.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-i3+CeqxL7DpAazgVpAGdKMwHuL63B5nhJMh9NQ7xmChGkA3jNFflq6Jyo1LLJYcr3idWiNOPWHCrm4zMayLG4w==",
+        "shasum": "7b3cd37ed9c2034261a173af1a1aae27d8169b67",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.6.tgz",
+        "fileCount": 7,
+        "unpackedSize": 22663,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdckzyCRA9TVsSAnZWagAA8NQP/3VX8673rx0OqTu8Pl4k\nh7PbEROGM9Rs7ACkm+ThPU0/tfYjW5LnWYWIHCbQwV5pvxW9SIi+WCdIDN/x\ngY2lo/IvZMTOoxms/gu6HnVfw9jYgMKK+nOSndt0OVOtuF5anv1YnHI7sT/t\n0InNYkt63uGrriEVvCs0GtuFBm83tL7UPiRpwu2Yln2ocMilKDzcd6B4O+SB\nzibGBnmSkNNmVytXq0lH+wCPak02yYr/l23lic42DRbAxVpya5BGblh/ym+x\nTn4ZJcgQUZyNFYoQ10Y4TtXbQ1cWyP8uWLDTQEEO82bVqlaBYDqZlnoKMqdL\nSIsrV8bSsx8rbM6Rz4FSVAM8An8l1+KFWBzcD2Brxf3LO4l7RJY83+rODDVk\nRBEpb0pjOmBmpDUthhRehEBvF3hPdYt8tsmCt13PYgc5mdBjF0X07/qB4cns\nVgSzRoYxepHgLzbwbil0nYt2ljdWylv7MrXr/7+2MkdZwiOvZjivvVzFkh/t\n4/DAcLDDd9gG7U0Ze9yUGMZO4K1a7xE8lofNHjy9gR6cesDjR5gxa1vhjbES\nV7M8eG5BVR5C1Ba7aXn5CiuYSexY6YPZbNZGpRcQxk1bTfRqGNsA5dpJIWJY\nwjoqyzdLqo6+ElgEEOx0ItuYiE5oEp+EiNJX5nsJJPeVTc/vW7bEHPaA/qcC\npHIw\r\n=uYXP\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.10.7": {
+      "name": "selfsigned",
+      "version": "1.10.7",
+      "dependencies": {
+        "node-forge": "0.9.0"
+      },
+      "devDependencies": {
+        "mocha": "^5.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+        "shasum": "da5819fd049d5574f28e88a9bcc6dbc6e6f3906b",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
+        "fileCount": 7,
+        "unpackedSize": 22663,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdk5DlCRA9TVsSAnZWagAAIY8P/Aixx/FStOCQW3TwQfay\nhrsJ1uw3W/Ana/VuuV0d4UpRCjeT0stNLVhis0IEgQ1fE6a6mU4upy8EKTAp\n5GpNt976sNGcOm4D84rQVsruR+W4ofCVMT5AXq2i6Z5SgBB3WtX6KuO08Tnx\n2wyE7RvhWd+hxSAgpopWcE6D8tJiOu1rb5ppdtMbZ3p7uxd9w081Ox1ntOxu\n5qhCWaewAd0N8UmU0oxptCi+JCfG7DsrbqAnW9LS30Al1hH/RLjJVEyIJVA1\n1H4MT4qNBbvoX9Jr4HPZ2zDGt9ftMP1pfNRuWkoHvRQjCq4nWGCj/VgTB+B5\nGbjCNfOI+WZIrJ3Yn2yp+G4qbWBiXW7b+gmGKFHb8v6Ux0oSCq9FeNWM6eE+\n76g9kSJ/Or4AK3Um8Pc13n51N+Q4F+EtmKPB64fSabdyhyHOfKAcV9B3a3EH\nZe0/Vy9nP1FBY2JMZAHkmrsqtDOCdXI6mlMXjfmPBj/ePu3rKbqEaRkG8Yqi\nqeHFM6B/9L1zpjdaRSGLtJ4b23h5sDBb6sdiAb3fZGiVgPsh1l8IprM9BEur\nquuZhQGBCnHl5kZ6OYvrNkrcMHW3SngO8U0FQSZld4nT6nEnD2R5uvSFoejz\nw/8YsUY6efhoYvJQ8SQtzBFeZgwrK1OPh/ZGIZ0+3vjfAgzWnNHcmcC8xw/5\nyXBz\r\n=CIZC\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.10.8": {
+      "name": "selfsigned",
+      "version": "1.10.8",
+      "dependencies": {
+        "node-forge": "^0.10.0"
+      },
+      "devDependencies": {
+        "mocha": "^5.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
+        "shasum": "0d17208b7d12c33f8eac85c41835f27fc3d81a30",
+        "tarball": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+        "fileCount": 7,
+        "unpackedSize": 22665,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfYO1/CRA9TVsSAnZWagAAlz8P/2C9sLnE3GLRemgtza6B\nxbufwbyo42EOGRjpHLZ6ZlXKPcL4lYwZuYhyZhlAIQc1uKQqKCS48/0itDQn\n7pYgQExAZ3O63U4MAwLL3gihKeaZ79a9/IMuyv3IsYm29u+2kckZVl0Np6sa\n3dTLoRkWXxXU1tzu69OHI/K5PjV+cpAQCbfUsOup66lH5yeinFps38tMT/8q\nVs/uCXOXpzciEQwToFUxD5C1eAtwG65w6vC9iKYHPQjWbX0QRu2TkqrZjFIu\n+bcsVo2I3TealncBeeKBI+AacHQwKuczKKIgz+7sWjmoEwwXyXYsCyvtxMEN\nsigTTUqtTtdE1kX1KNR5ypGH+GT6PQTDLGF5fFWbESyIBUN3au2AwQEdbWbs\nRuE/jj4MP3OgeD2oBl6qZNXzMZNM4frl7/HxUVJP78+imOXGff4ZTXiVRg4L\nqosEZBLDajqdyLqEoqYOmLyTiHM9ReDqeWZo+a0/UkvgDaarZNsyjxipF0d+\nig9qxo4GMqzHQnimzQLCYRxEe2psNVJXZrBFQhH93eQ07d8+bfh2Dlkyud5B\nU3Kst1X9ItmNPTqtBVAyOGEvXyPtyagc9vaWUb33NiCg/7NmPiw0mTuEy35+\ne0iF0992ycfVFrolmVf5hKNBV+c7lUS47gsYGxz846jEqmzqrg9N8SrVl8nA\nXqDB\r\n=Pg0A\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-09-15T16:36:18.654Z"
+}

--- a/test/fixtures/registry-mocks/content/send.json
+++ b/test/fixtures/registry-mocks/content/send.json
@@ -1,0 +1,4769 @@
+{
+  "_id": "send",
+  "_rev": "131-7bc5ad70ee0e895d5bb294e6952b88cf",
+  "name": "send",
+  "description": "Better streaming static file server with Range and conditional-GET support",
+  "dist-tags": {
+    "latest": "0.17.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "send",
+      "version": "0.0.1",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "main": "index",
+      "_id": "send@0.0.1",
+      "dist": {
+        "shasum": "0d04102e8ac681fb635dc7030e9c9b41de683e00",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "send",
+      "version": "0.0.2",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "main": "index",
+      "_id": "send@0.0.2",
+      "dist": {
+        "shasum": "8792a53497bb91b62973b588179eb4c5ed0ff7fd",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "send",
+      "version": "0.0.3",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "main": "index",
+      "_id": "send@0.0.3",
+      "dist": {
+        "shasum": "4d5f843edf9d65dac31c8a5d2672c179ecb67184",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "send",
+      "version": "0.0.4",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "main": "index",
+      "_id": "send@0.0.4",
+      "dist": {
+        "shasum": "2d4cf79b189fcd09610e1302510ac9b0e4dde800",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "send",
+      "version": "0.1.0",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "main": "index",
+      "_id": "send@0.1.0",
+      "dist": {
+        "shasum": "cfb08ebd3cec9b7fc1a37d9ff9e875a971cf4640",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.0.tgz"
+      },
+      "_npmVersion": "1.1.61",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "send",
+      "version": "0.1.1",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send.git"
+      },
+      "main": "index",
+      "_id": "send@0.1.1",
+      "dist": {
+        "shasum": "0bcfcbd03def6e2d8612e1abf8f4895b450c60c8",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "send",
+      "version": "0.1.2",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send.git"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "_id": "send@0.1.2",
+      "dist": {
+        "shasum": "c2744e98111bf1bb62eb4996dfda8a9980752984",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "send",
+      "version": "0.1.3",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send.git"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "_id": "send@0.1.3",
+      "dist": {
+        "shasum": "a7875daa6802d31e2ce32fdad98d3664c51ecea3",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "send",
+      "version": "0.1.4",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "0.2.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send.git"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "_id": "send@0.1.4",
+      "dist": {
+        "shasum": "be70d8d1be01de61821af13780b50345a4f71abd",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.4",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "send",
+      "version": "0.2.0",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "~0.2.1",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send.git"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.2.0",
+      "dist": {
+        "shasum": "067abf45cff8bffb29cbdb7439725b32388a2c58",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.15",
+      "_npmUser": {
+        "name": "tjholowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "send",
+      "version": "0.3.0",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "debug": "0.8.0",
+        "fresh": "~0.2.1",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.10.0",
+        "connect": "2.x"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send.git"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.3.0",
+      "dist": {
+        "shasum": "9718324634806fc75bc4f8f5e51f57d9d66606e7",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.4.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "0.8.1",
+        "finished": "1.1.4",
+        "fresh": "~0.2.1",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.2",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.4.0",
+      "_shasum": "e7ec677072e5651f18712dd493732fcf422cec39",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e7ec677072e5651f18712dd493732fcf422cec39",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.4.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "0.8.1",
+        "finished": "1.1.4",
+        "fresh": "~0.2.1",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.4.1",
+      "_shasum": "6e9a5d41cb9c0fb3514226446fa319aed46d433d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6e9a5d41cb9c0fb3514226446fa319aed46d433d",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.4.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.1",
+        "finished": "1.2.1",
+        "fresh": "~0.2.1",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.4.2",
+      "dist": {
+        "shasum": "7641b23126fc54975d2be37674b36d6bb617b26c",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.3": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.4.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "gitHead": "ffac4f5c4eca470a041ff328e425a8050a4d792c",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.4.3",
+      "_shasum": "9627b23b7707fbf6373831cac5793330b594b640",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9627b23b7707fbf6373831cac5793330b594b640",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.5.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.5.0",
+      "dist": {
+        "shasum": "fc0f7e2f92e29aebfd8a1b2deb4a394e7a531a68",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.6.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.3",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.6.0",
+      "dist": {
+        "shasum": "a59da9265db7c35141e1079cf1f368ee0d59b3ab",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.7.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.7.0",
+      "dist": {
+        "shasum": "f479a05c57d36bf564311dd1e3825b84b26ae336",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.7.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.3",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.7.1",
+      "dist": {
+        "shasum": "fe02421cd5fb3bcc10287f72c18e94818e3f80fd",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.7.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.7.2",
+      "dist": {
+        "shasum": "3b5f696f701d56fe115b860cc6b3f0cdbfbf7804",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.3": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.7.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.7.3",
+      "dist": {
+        "shasum": "2caa2e2627d2f9c2d109d3f5c2942935480aa993",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.4": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.7.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "c7a90d47e2bc50a1aaabc0a28618a78a401daa65",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.7.4",
+      "_shasum": "c80a084cb8eb940345f3ab4ce9e4ee25cb6647cb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c80a084cb8eb940345f3ab4ce9e4ee25cb6647cb",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.8.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "7e8591cf07cbba182f60e1cf7cc7c4b66558ba4a",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.8.0",
+      "_shasum": "cbe98d58c1bdaa666bb95acb68ed1df92e1ae6e1",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cbe98d58c1bdaa666bb95acb68ed1df92e1ae6e1",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.8.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "d7c99ee941d73fe9a668fc4c673185bfd2167ce7",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.8.1",
+      "_shasum": "86bbdcc3fb0ce6ebc2d15af977d94c0b300d02eb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "86bbdcc3fb0ce6ebc2d15af977d94c0b300d02eb",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.8.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "dethroy": "1.0.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "80b8de10744b3dbfd10b31afc160bc3241ae7570",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.8.2",
+      "_shasum": "f67efb2e3c89bf5bcd90ccda8683b17f1cbfd0ac",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f67efb2e3c89bf5bcd90ccda8683b17f1cbfd0ac",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.3": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.8.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "463d1c92267d0b84e5df27f2aecad62859d5a57b",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.8.3",
+      "_shasum": "593886004fcb968a1b5727814a32b388b3b99083",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "593886004fcb968a1b5727814a32b388b3b99083",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.4": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.8.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "c00b287725234439237b0f70b94475ccd55e58f2",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.8.4",
+      "_shasum": "259cd04e507df26a70eaa5b66cb20a26d8f18d65",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "259cd04e507df26a70eaa5b66cb20a26d8f18d65",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.8.5": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.8.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "c4fcb5daaca40bf4cf73e28dadbbe095ba44eeb3",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.8.5",
+      "_shasum": "37f708216e6f50c175e74c69fec53484e2fd82c7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "37f708216e6f50c175e74c69fec53484e2fd82c7",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.9.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.0",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "18ec0938bbb0fcf9b395fa55a275b962099b78d8",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.9.0",
+      "_shasum": "778341d52134c895a4ecaf44a4a30d762f8ee3eb",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "778341d52134c895a4ecaf44a4a30d762f8ee3eb",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.9.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "4f1bebbe16964d5ac83832e1357e50c9118836b0",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.9.1",
+      "_shasum": "d93689f7c9ce36bd32f8ee572bb60bda032edc23",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d93689f7c9ce36bd32f8ee572bb60bda032edc23",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.9.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "c2b125b19c1f0f1f3c9bcd72be32d1ea54f2f620",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.9.2",
+      "_shasum": "77d22a0f462604451917075c6f52e69c2b3b6e25",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "77d22a0f462604451917075c6f52e69c2b3b6e25",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.9.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.9.3": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.9.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "3dbf47379d9077502208d8057022babcfc2f7cbc",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.9.3",
+      "_shasum": "b43a7414cd089b7fbec9b755246f7c37b7b85cc0",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b43a7414cd089b7fbec9b755246f7c37b7b85cc0",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.9.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.10.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/visionmedia/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "0b3d336e6c99e79af059560d63e46de51a17e96d",
+      "bugs": {
+        "url": "https://github.com/visionmedia/send/issues"
+      },
+      "homepage": "https://github.com/visionmedia/send",
+      "_id": "send@0.10.0",
+      "_shasum": "2f984b703934c628b72b72d70557b75ca906ea6c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2f984b703934c628b72b72d70557b75ca906ea6c",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.10.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/tj/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "~2.1.1",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "a5e6237f3e812a99d079e2100f6294251ef5f465",
+      "bugs": {
+        "url": "https://github.com/tj/send/issues"
+      },
+      "homepage": "https://github.com/tj/send",
+      "_id": "send@0.10.1",
+      "_shasum": "7745c50ec72f115115980e8fb179aec01900e08a",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7745c50ec72f115115980e8fb179aec01900e08a",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.11.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/tj/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "4768cf446683666f4d28931b80bda72b45687a70",
+      "bugs": {
+        "url": "https://github.com/tj/send/issues"
+      },
+      "homepage": "https://github.com/tj/send",
+      "_id": "send@0.11.0",
+      "_shasum": "d66b83b44576061ebd49551943b3c5c1f61cb308",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d66b83b44576061ebd49551943b3c5c1f61cb308",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.11.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.11.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/tj/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "History.md",
+        "LICENSE",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec"
+      },
+      "gitHead": "1e18c059e94879ededcea3d58f52eec6791560ee",
+      "bugs": {
+        "url": "https://github.com/tj/send/issues"
+      },
+      "homepage": "https://github.com/tj/send",
+      "_id": "send@0.11.1",
+      "_shasum": "1beabfd42f9e2709f99028af3078ac12b47092d5",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1beabfd42f9e2709f99028af3078ac12b47092d5",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.11.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.12.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.12.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.3.4",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "98d60d9949e25d81f2863ec75fd1d1264949f1f9",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send",
+      "_id": "send@0.12.0",
+      "_shasum": "d8c124a27797c47206d8fd52d37cd27ef15a506e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d8c124a27797c47206d8fd52d37cd27ef15a506e",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.12.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.12.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.12.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.3.4",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "700757e7aa065b58fb101bd149bedb8239fac228",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send",
+      "_id": "send@0.12.1",
+      "_shasum": "65e2e4330eae6b4d1082a921bfc8e9c9f1776b31",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "65e2e4330eae6b4d1082a921bfc8e9c9f1776b31",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.12.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.12.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.12.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.3.4",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.7",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "c9a4bf66fa7add5976b2fdbbf3ea20d7f83673f8",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send",
+      "_id": "send@0.12.2",
+      "_shasum": "ba6785e47ab41aa0358b9da401ab22ff0f58eab6",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ba6785e47ab41aa0358b9da401ab22ff0f58eab6",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.12.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.12.3": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.12.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.6.0",
+        "fresh": "0.2.4",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.2.1",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "db460d914de7114d267a55e2a2d60f869c8ddd33",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send",
+      "_id": "send@0.12.3",
+      "_shasum": "cd12dc58fde21e4f91902b39b2fda05a7a6d9bdc",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cd12dc58fde21e4f91902b39b2fda05a7a6d9bdc",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.12.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.13.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.3.1",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.0.2",
+        "statuses": "~1.2.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "80cfa7f54ce87c75e92619d5bc510406bd69133a",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send",
+      "_id": "send@0.13.0",
+      "_shasum": "518f921aeb0560aec7dcab2990b14cf6f3cce5de",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "518f921aeb0560aec7dcab2990b14cf6f3cce5de",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.13.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.13.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.3.1",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.0.3",
+        "statuses": "~1.2.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "dbce43fc7102c14b475c25cde918b726063cc991",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send",
+      "_id": "send@0.13.1",
+      "_shasum": "a30d5f4c82c8a9bae9ad00a1d9b1bdbe6f199ed7",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a30d5f4c82c8a9bae9ad00a1d9b1bdbe6f199ed7",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.13.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.13.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.13.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/pillarjs/send"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.3.1",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.0.3",
+        "statuses": "~1.2.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.4.2",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "5a089701b1c49d96084716bdb5465edefa08c906",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send",
+      "_id": "send@0.13.2",
+      "_shasum": "765e7607c8055452bba6f0b052595350986036de",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "765e7607c8055452bba6f0b052595350986036de",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.13.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/send-0.13.2.tgz_1457238386348_0.8199156709015369"
+      },
+      "directories": {}
+    },
+    "0.14.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.14.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.5.0",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.1",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "4b69813e46421a5884c986e9437ebd899abd2146",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.14.0",
+      "_shasum": "6b192d05c0b87c48263738bba9d50d04b2328b77",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "6b192d05c0b87c48263738bba9d50d04b2328b77",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.14.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/send-0.14.0.tgz_1465261751359_0.5311042286921293"
+      },
+      "directories": {}
+    },
+    "0.14.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.14.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.5.0",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.1",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "d6dd3b91bbb73ad89f1398fa227b200db9bff037",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.14.1",
+      "_shasum": "a954984325392f51532a7760760e459598c89f7a",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "a954984325392f51532a7760760e459598c89f7a",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/send-0.14.1.tgz_1465535036412_0.3431496580597013"
+      },
+      "directories": {}
+    },
+    "0.14.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.14.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.5.1",
+        "mime": "1.3.4",
+        "ms": "0.7.2",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.1",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "f3397bc0170fb9f2d84c45e81981dff6e58e102d",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.14.2",
+      "_shasum": "39b0438b3f510be5dc6f667a11f71689368cdeef",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "39b0438b3f510be5dc6f667a11f71689368cdeef",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.14.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/send-0.14.2.tgz_1485185381110_0.5022726391907781"
+      },
+      "directories": {}
+    },
+    "0.15.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.15.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.1",
+        "mime": "1.3.4",
+        "ms": "0.7.2",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.16.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "7196b1eb738b4e6fc075b3f48cdbec4f7659b22b",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.15.0",
+      "_shasum": "f0185d6466fa76424b866f3d533e2d19dd0aaa39",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "f0185d6466fa76424b866f3d533e2d19dd0aaa39",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/send-0.15.0.tgz_1488062687975_0.6238442889880389"
+      },
+      "directories": {}
+    },
+    "0.15.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.15.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.1",
+        "mime": "1.3.4",
+        "ms": "0.7.2",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.17.0",
+        "eslint-config-standard": "7.0.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "ea1748a3b3e00dbcbb0629cf368ced575c6ab7d6",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.15.1",
+      "_shasum": "8a02354c26e6f5cca700065f5f0cdeba90ec7b5f",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "8a02354c26e6f5cca700065f5f0cdeba90ec7b5f",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/send-0.15.1.tgz_1488683436582_0.6725058956071734"
+      },
+      "directories": {}
+    },
+    "0.15.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.15.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.4",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.1",
+        "mime": "1.3.4",
+        "ms": "1.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "93b86b2cf38c986858cb389c560f483b74b07544",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.15.2",
+      "_shasum": "f91fab4403bcf87e716f70ceb5db2f578bdc17d6",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "f91fab4403bcf87e716f70ceb5db2f578bdc17d6",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/send-0.15.2.tgz_1493182451670_0.7988206197042018"
+      },
+      "directories": {}
+    },
+    "0.15.3": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.15.3",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.7",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.1",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "a20f8f282bf392c610a07ec1fb042e33073dd3a2",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.15.3",
+      "_shasum": "5013f9f99023df50d1bd9892c19e3defd1d53309",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "5013f9f99023df50d1bd9892c19e3defd1d53309",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/send-0.15.3.tgz_1494996875701_0.7597074673976749"
+      },
+      "directories": {}
+    },
+    "0.15.4": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.15.4",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "bad2a468e4ff38c13ffb5a113ce74ba9a812f804",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.15.4",
+      "_shasum": "985faa3e284b0273c793364a35c6737bd93905b9",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "985faa3e284b0273c793364a35c6737bd93905b9",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/send-0.15.4.tgz_1501997109327_0.6382732526399195"
+      },
+      "directories": {}
+    },
+    "0.15.5": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.15.5",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "2d17fa124adc7f81f1d9bf4841fff42b674b8448",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.15.5",
+      "_shasum": "32ef6c8d820c9756597c3174b8c9dd51e3319be2",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "32ef6c8d820c9756597c3174b8c9dd51e3319be2",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/send-0.15.5.tgz_1505961403259_0.7260283746290952"
+      },
+      "directories": {}
+    },
+    "0.15.6": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.15.6",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "8b080c8c4e127fe3dd41a758f06f6b15899b39ec",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.15.6",
+      "_shasum": "20f23a9c925b762ab82705fe2f9db252ace47e34",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "20f23a9c925b762ab82705fe2f9db252ace47e34",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/send-0.15.6.tgz_1506119153076_0.4855279584880918"
+      },
+      "directories": {}
+    },
+    "0.16.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.16.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "b11c3a3feba4601e19885776c189b81ae763c7d5",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.16.0",
+      "_shasum": "16338dbb9a2ede4ad57b48420ec3b82d8e80a57b",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "16338dbb9a2ede4ad57b48420ec3b82d8e80a57b",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.16.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/send-0.16.0.tgz_1506559201485_0.3913189717568457"
+      },
+      "directories": {}
+    },
+    "0.16.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.16.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "3daa901cf731b86187e4449fa2c52f971e0b3dbc",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.16.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+        "shasum": "a70e1ca21d1382c11d0d9f6231deb281080d7ab3",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.16.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/send-0.16.1.tgz_1506713804078_0.7579168814700097"
+      },
+      "directories": {}
+    },
+    "0.16.2": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.16.2",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "c378e25a4212eb0fff2c869cbf5d0d6606bbc389",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.16.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "6.12.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+        "shasum": "6ecca1e0f8c156d141597559848df64730a6bbc1",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 46571
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/send_0.16.2_1518020786249_0.2212788549628577"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.17.0": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.17.0",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.5.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "supertest": "4.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "0ef8f0cb8d8f3875f034d04d16db37a85f6150d8",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.17.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-NYR0jCuwnBaGA2X5bO3+QDZmmJ+PUCvFCRTED5nx9l/BK3Pr8mD8Ryvk9bw08JJUdXxt2u+tVIGoqJPrHWGqSA==",
+        "shasum": "6d190beaaf08c5cf7e325ded024f1a7cd934ed9a",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.17.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 48043,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJczLPjCRA9TVsSAnZWagAAzrIP/30L3J0n3A7tIHr+BqYX\nvEBFSet7QNTYYmdiunNkEVZaiJtrJTRspaipTRtBrJw7Bmjhe9Fi5pvan3gi\nd1lLBQMWSfVJoSLAwpDtBzmq73e2QNs8e3tH9cmYNBX79oFKNa2CNoftiZtD\n1QMphhjmUD7Ead/YCS/lroNY2TvJjkOscsk7DiVFbu4YKGldqVDz/qLeQPV9\nMxpQcWkS0yKla9N8y4mrLBmEjKwKNsDiyWP5BJIhDWNLWcI3yICNpY3Z3pcz\n9X7VPZNMnpuFSpqZ37C/a5cfTjki0roBd4vGgNC4B72N+4MNF11HQzeMjNL1\neolCWtS6WDijOtUBuiV8+BHM4iElyDQ2PkelCM/23AXLC4wLxYH+JiLVsHNP\nm/gfHK7Y/Brr44r5zyKk4BP+HOgaRefzEPv0jJ+lkdH9N/R22Cw1yMn1FVZ0\nbRDCFlQyKRCbPgKIzEREGcU/3Z+KMbc8JDKs6RfCxQx5WXEjFKgx1aLM0inR\nIeBv/v6T+8Xjm6XbXZFNK5VOuP2ujKEjjK9JRp6lD3aJOe51XUzq/jwARnXr\n5h9adHpY4i55gxmBGKln/muQ3ADZG+bZp372JVT5nAJK83/Y4P0InuUrgoyj\nuVBSj+Fl5Xh1JP31D2aTEm3OAFUAKh2r8rn7qiAjevnByBC0X89EJTYzFiS6\nrNoQ\r\n=F+qh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/send_0.17.0_1556919266756_0.33347645446552265"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.17.1": {
+      "name": "send",
+      "description": "Better streaming static file server with Range and conditional-GET support",
+      "version": "0.17.1",
+      "author": {
+        "name": "TJ Holowaychuk",
+        "email": "tj@vision-media.ca"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "James Wyatt Cready",
+          "email": "jcready@gmail.com"
+        },
+        {
+          "name": "Jesús Leganés Combarro",
+          "email": "piranna@gmail.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/pillarjs/send.git"
+      },
+      "keywords": [
+        "static",
+        "file",
+        "server"
+      ],
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "supertest": "4.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --check-leaks --reporter spec --bail",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --check-leaks --reporter spec",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --check-leaks --reporter dot"
+      },
+      "gitHead": "de073ed3237ade9ff71c61673a34474b30e5d45b",
+      "bugs": {
+        "url": "https://github.com/pillarjs/send/issues"
+      },
+      "homepage": "https://github.com/pillarjs/send#readme",
+      "_id": "send@0.17.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+        "shasum": "c1d8b059f7900f7466dd4938bdc44e11ddb376c8",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 48173,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1igoCRA9TVsSAnZWagAA4xIP/RwpQJfYKVcRmNymna4k\n8R7ZXHoC9MyoxLCBvNuzZ5uy/HCYYVgPR7ilzmDfDQInJZJOZUBiMXFBs413\ntyXBv5Y0kXVARuXPBcy/pH6cVCn5nFlOneEj+ntNo5mrFCJxysxCR9xfoG7o\nuKfVrPmKRVm7dLJBuJzPzjQZEL1b6GqV3+aMypBNdGwK8E53MgJodwdZQbvg\nixSOMJ1D0e9qY4afOZII9Ejpoxk3+bu5+UadK++vYtWFCh2REhd+dzpD8FTu\nAah/Ub1jt7WHb2rJNclhxh+DsiIwWukCIpJ1dsPSBTQ+MQjoAXNrJdVxnMcj\n7uwXW/7wRho0o5q59JfUH98zv0GeIYjfjLfhS8uHm43niDtvnTLKe3ZTJqVY\nMPQz71+VfaTE5rHKpyrHxEhj1MGKFwAGQbNtrhx2HVvtLMz+qNLAeCa6rUPR\n48U9yJ2HfEhlm+y08i43lEtdY+Sk5oNtG+Wk1PUUlPdbXW/Hma13ALXK57pP\n09Q8IZwbTGufeJnK2maVByHc+08GZ4FclVAd8h3pUeFxyK2MR9hbtlQx27sg\n4KXbizzUuPx4tO7qp9aa+oS8wS1qLn/BkrFJPKuzExvnnsrTttEc1S1LHbhg\nlVFT6U1oGpXQlLiBwbzotePJeFXcLZsxovN+NfCZT0csI83ivh5bREiUImkH\nIWSh\r\n=fsxk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/send_0.17.1_1557538855803_0.6558032822355342"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# send\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Linux Build][travis-image]][travis-url]\n[![Windows Build][appveyor-image]][appveyor-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nSend is a library for streaming files from the file system as a http response\nsupporting partial responses (Ranges), conditional-GET negotiation (If-Match,\nIf-Unmodified-Since, If-None-Match, If-Modified-Since), high test coverage,\nand granular events which may be leveraged to take appropriate actions in your\napplication or framework.\n\nLooking to serve up entire folders mapped to URLs? Try [serve-static](https://www.npmjs.org/package/serve-static).\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```bash\n$ npm install send\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar send = require('send')\n```\n\n### send(req, path, [options])\n\nCreate a new `SendStream` for the given path to send to a `res`. The `req` is\nthe Node.js HTTP request and the `path` is a urlencoded path to send (urlencoded,\nnot the actual file-system path).\n\n#### Options\n\n##### acceptRanges\n\nEnable or disable accepting ranged requests, defaults to true.\nDisabling this will not send `Accept-Ranges` and ignore the contents\nof the `Range` request header.\n\n##### cacheControl\n\nEnable or disable setting `Cache-Control` response header, defaults to\ntrue. Disabling this will ignore the `immutable` and `maxAge` options.\n\n##### dotfiles\n\nSet how \"dotfiles\" are treated when encountered. A dotfile is a file\nor directory that begins with a dot (\".\"). Note this check is done on\nthe path itself without checking if the path actually exists on the\ndisk. If `root` is specified, only the dotfiles above the root are\nchecked (i.e. the root itself can be within a dotfile when when set\nto \"deny\").\n\n  - `'allow'` No special treatment for dotfiles.\n  - `'deny'` Send a 403 for any request for a dotfile.\n  - `'ignore'` Pretend like the dotfile does not exist and 404.\n\nThe default value is _similar_ to `'ignore'`, with the exception that\nthis default will not ignore the files within a directory that begins\nwith a dot, for backward-compatibility.\n\n##### end\n\nByte offset at which the stream ends, defaults to the length of the file\nminus 1. The end is inclusive in the stream, meaning `end: 3` will include\nthe 4th byte in the stream.\n\n##### etag\n\nEnable or disable etag generation, defaults to true.\n\n##### extensions\n\nIf a given file doesn't exist, try appending one of the given extensions,\nin the given order. By default, this is disabled (set to `false`). An\nexample value that will serve extension-less HTML files: `['html', 'htm']`.\nThis is skipped if the requested file already has an extension.\n\n##### immutable\n\nEnable or diable the `immutable` directive in the `Cache-Control` response\nheader, defaults to `false`. If set to `true`, the `maxAge` option should\nalso be specified to enable caching. The `immutable` directive will prevent\nsupported clients from making conditional requests during the life of the\n`maxAge` option to check if the file has changed.\n\n##### index\n\nBy default send supports \"index.html\" files, to disable this\nset `false` or to supply a new index pass a string or an array\nin preferred order.\n\n##### lastModified\n\nEnable or disable `Last-Modified` header, defaults to true. Uses the file\nsystem's last modified value.\n\n##### maxAge\n\nProvide a max-age in milliseconds for http caching, defaults to 0.\nThis can also be a string accepted by the\n[ms](https://www.npmjs.org/package/ms#readme) module.\n\n##### root\n\nServe files relative to `path`.\n\n##### start\n\nByte offset at which the stream starts, defaults to 0. The start is inclusive,\nmeaning `start: 2` will include the 3rd byte in the stream.\n\n#### Events\n\nThe `SendStream` is an event emitter and will emit the following events:\n\n  - `error` an error occurred `(err)`\n  - `directory` a directory was requested `(res, path)`\n  - `file` a file was requested `(path, stat)`\n  - `headers` the headers are about to be set on a file `(res, path, stat)`\n  - `stream` file streaming has started `(stream)`\n  - `end` streaming has completed\n\n#### .pipe\n\nThe `pipe` method is used to pipe the response into the Node.js HTTP response\nobject, typically `send(req, path, options).pipe(res)`.\n\n### .mime\n\nThe `mime` export is the global instance of of the\n[`mime` npm module](https://www.npmjs.com/package/mime).\n\nThis is used to configure the MIME types that are associated with file extensions\nas well as other options for how to resolve the MIME type of a file (like the\ndefault type to use for an unknown file extension).\n\n## Error-handling\n\nBy default when no `error` listeners are present an automatic response will be\nmade, otherwise you have full control over the response, aka you may show a 5xx\npage etc.\n\n## Caching\n\nIt does _not_ perform internal caching, you should use a reverse proxy cache\nsuch as Varnish for this, or those fancy things called CDNs. If your\napplication is small enough that it would benefit from single-node memory\ncaching, it's small enough that it does not need caching at all ;).\n\n## Debugging\n\nTo enable `debug()` instrumentation output export __DEBUG__:\n\n```\n$ DEBUG=send node app\n```\n\n## Running tests\n\n```\n$ npm install\n$ npm test\n```\n\n## Examples\n\n### Serve a specific file\n\nThis simple example will send a specific file to all requests.\n\n```js\nvar http = require('http')\nvar send = require('send')\n\nvar server = http.createServer(function onRequest (req, res) {\n  send(req, '/path/to/index.html')\n    .pipe(res)\n})\n\nserver.listen(3000)\n```\n\n### Serve all files from a directory\n\nThis simple example will just serve up all the files in a\ngiven directory as the top-level. For example, a request\n`GET /foo.txt` will send back `/www/public/foo.txt`.\n\n```js\nvar http = require('http')\nvar parseUrl = require('parseurl')\nvar send = require('send')\n\nvar server = http.createServer(function onRequest (req, res) {\n  send(req, parseUrl(req).pathname, { root: '/www/public' })\n    .pipe(res)\n})\n\nserver.listen(3000)\n```\n\n### Custom file types\n\n```js\nvar http = require('http')\nvar parseUrl = require('parseurl')\nvar send = require('send')\n\n// Default unknown types to text/plain\nsend.mime.default_type = 'text/plain'\n\n// Add a custom type\nsend.mime.define({\n  'application/x-my-type': ['x-mt', 'x-mtt']\n})\n\nvar server = http.createServer(function onRequest (req, res) {\n  send(req, parseUrl(req).pathname, { root: '/www/public' })\n    .pipe(res)\n})\n\nserver.listen(3000)\n```\n\n### Custom directory index view\n\nThis is a example of serving up a structure of directories with a\ncustom function to render a listing of a directory.\n\n```js\nvar http = require('http')\nvar fs = require('fs')\nvar parseUrl = require('parseurl')\nvar send = require('send')\n\n// Transfer arbitrary files from within /www/example.com/public/*\n// with a custom handler for directory listing\nvar server = http.createServer(function onRequest (req, res) {\n  send(req, parseUrl(req).pathname, { index: false, root: '/www/public' })\n    .once('directory', directory)\n    .pipe(res)\n})\n\nserver.listen(3000)\n\n// Custom directory handler\nfunction directory (res, path) {\n  var stream = this\n\n  // redirect to trailing slash for consistent url\n  if (!stream.hasTrailingSlash()) {\n    return stream.redirect(path)\n  }\n\n  // get directory list\n  fs.readdir(path, function onReaddir (err, list) {\n    if (err) return stream.error(err)\n\n    // render an index for the directory\n    res.setHeader('Content-Type', 'text/plain; charset=UTF-8')\n    res.end(list.join('\\n') + '\\n')\n  })\n}\n```\n\n### Serving from a root directory with custom error-handling\n\n```js\nvar http = require('http')\nvar parseUrl = require('parseurl')\nvar send = require('send')\n\nvar server = http.createServer(function onRequest (req, res) {\n  // your custom error-handling logic:\n  function error (err) {\n    res.statusCode = err.status || 500\n    res.end(err.message)\n  }\n\n  // your custom headers\n  function headers (res, path, stat) {\n    // serve all files for download\n    res.setHeader('Content-Disposition', 'attachment')\n  }\n\n  // your custom directory handling logic:\n  function redirect () {\n    res.statusCode = 301\n    res.setHeader('Location', req.url + '/')\n    res.end('Redirecting to ' + req.url + '/')\n  }\n\n  // transfer arbitrary files from within\n  // /www/example.com/public/*\n  send(req, parseUrl(req).pathname, { root: '/www/public' })\n    .on('error', error)\n    .on('directory', redirect)\n    .on('headers', headers)\n    .pipe(res)\n})\n\nserver.listen(3000)\n```\n\n## License\n\n[MIT](LICENSE)\n\n[appveyor-image]: https://badgen.net/appveyor/ci/dougwilson/send/master?label=windows\n[appveyor-url]: https://ci.appveyor.com/project/dougwilson/send\n[coveralls-image]: https://badgen.net/coveralls/c/github/pillarjs/send/master\n[coveralls-url]: https://coveralls.io/r/pillarjs/send?branch=master\n[node-image]: https://badgen.net/npm/node/send\n[node-url]: https://nodejs.org/en/download/\n[npm-downloads-image]: https://badgen.net/npm/dm/send\n[npm-url]: https://npmjs.org/package/send\n[npm-version-image]: https://badgen.net/npm/v/send\n[travis-image]: https://badgen.net/travis/pillarjs/send/master?label=linux\n[travis-url]: https://travis-ci.org/pillarjs/send\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-05-11T01:40:58.566Z",
+    "created": "2012-07-04T02:26:08.255Z",
+    "0.0.1": "2012-07-04T02:26:10.649Z",
+    "0.0.2": "2012-07-09T16:29:14.274Z",
+    "0.0.3": "2012-07-16T16:22:27.594Z",
+    "0.0.4": "2012-08-16T17:08:01.033Z",
+    "0.1.0": "2012-09-19T18:36:49.783Z",
+    "0.1.1": "2013-06-03T00:14:29.429Z",
+    "0.1.2": "2013-07-03T18:24:03.585Z",
+    "0.1.3": "2013-07-08T21:40:12.056Z",
+    "0.1.4": "2013-08-10T21:46:51.934Z",
+    "0.2.0": "2014-01-29T21:19:55.890Z",
+    "0.3.0": "2014-04-24T14:33:52.351Z",
+    "0.4.0": "2014-05-28T02:50:46.903Z",
+    "0.4.1": "2014-06-02T23:53:20.620Z",
+    "0.4.2": "2014-06-09T20:16:17.145Z",
+    "0.4.3": "2014-06-12T01:35:22.251Z",
+    "0.5.0": "2014-06-28T23:23:22.527Z",
+    "0.6.0": "2014-07-12T02:05:02.867Z",
+    "0.7.0": "2014-07-21T04:30:36.755Z",
+    "0.7.1": "2014-07-26T20:46:28.667Z",
+    "0.7.2": "2014-07-27T19:05:37.467Z",
+    "0.7.3": "2014-07-30T01:48:52.102Z",
+    "0.7.4": "2014-08-04T21:04:40.155Z",
+    "0.8.0": "2014-08-06T05:03:16.854Z",
+    "0.8.1": "2014-08-06T05:20:28.132Z",
+    "0.8.2": "2014-08-15T01:38:30.488Z",
+    "0.8.3": "2014-08-17T03:15:44.430Z",
+    "0.8.4": "2014-09-04T18:57:53.219Z",
+    "0.8.5": "2014-09-05T04:50:05.074Z",
+    "0.9.0": "2014-09-08T00:58:30.172Z",
+    "0.9.1": "2014-09-08T02:54:39.675Z",
+    "0.9.2": "2014-09-16T05:38:49.312Z",
+    "0.9.3": "2014-09-24T18:57:04.630Z",
+    "0.10.0": "2014-10-16T04:06:01.941Z",
+    "0.10.1": "2014-10-23T02:00:08.239Z",
+    "0.11.0": "2015-01-05T22:41:38.413Z",
+    "0.11.1": "2015-01-20T16:27:08.360Z",
+    "0.12.0": "2015-02-16T23:44:30.552Z",
+    "0.12.1": "2015-02-17T17:47:24.752Z",
+    "0.12.2": "2015-03-14T05:50:18.656Z",
+    "0.12.3": "2015-05-13T15:11:33.838Z",
+    "0.13.0": "2015-06-17T01:48:02.477Z",
+    "0.13.1": "2016-01-16T07:41:37.163Z",
+    "0.13.2": "2016-03-06T04:26:29.707Z",
+    "0.14.0": "2016-06-07T01:09:13.081Z",
+    "0.14.1": "2016-06-10T05:03:58.643Z",
+    "0.14.2": "2017-01-23T15:29:43.221Z",
+    "0.15.0": "2017-02-25T22:44:48.725Z",
+    "0.15.1": "2017-03-05T03:10:38.679Z",
+    "0.15.2": "2017-04-26T04:54:13.689Z",
+    "0.15.3": "2017-05-17T04:54:36.978Z",
+    "0.15.4": "2017-08-06T05:25:10.510Z",
+    "0.15.5": "2017-09-21T02:36:44.305Z",
+    "0.15.6": "2017-09-22T22:25:54.154Z",
+    "0.16.0": "2017-09-28T00:40:02.604Z",
+    "0.16.1": "2017-09-29T19:36:45.181Z",
+    "0.16.2": "2018-02-07T16:26:27.070Z",
+    "0.17.0": "2019-05-03T21:34:26.929Z",
+    "0.17.1": "2019-05-11T01:40:56.003Z"
+  },
+  "author": {
+    "name": "TJ Holowaychuk",
+    "email": "tj@vision-media.ca"
+  },
+  "users": {
+    "m42am": true,
+    "fgnass": true,
+    "gillesruppert": true,
+    "irae": true,
+    "anthonyvdg": true,
+    "finnpauls": true,
+    "master-1-": true,
+    "magemagic": true,
+    "esessoms": true,
+    "jakub.knejzlik": true,
+    "wangnan0610": true,
+    "donniereese": true,
+    "simplyianm": true,
+    "lwgojustgo": true,
+    "kankungyip": true,
+    "monjer": true,
+    "mojaray2k": true,
+    "jetthiago": true,
+    "heineiuo": true,
+    "devpaul": true,
+    "danhale05": true,
+    "itonyyo": true,
+    "kuzmicheff": true,
+    "shanewholloway": true,
+    "xuu": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pillarjs/send.git"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/pillarjs/send#readme",
+  "keywords": [
+    "static",
+    "file",
+    "server"
+  ],
+  "bugs": {
+    "url": "https://github.com/pillarjs/send/issues"
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "James Wyatt Cready",
+      "email": "jcready@gmail.com"
+    },
+    {
+      "name": "Jesús Leganés Combarro",
+      "email": "piranna@gmail.com"
+    }
+  ],
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/send.min.json
+++ b/test/fixtures/registry-mocks/content/send.min.json
@@ -1,0 +1,1695 @@
+{
+  "name": "send",
+  "dist-tags": {
+    "latest": "0.17.1"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "send",
+      "version": "0.0.1",
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "0d04102e8ac681fb635dc7030e9c9b41de683e00",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "send",
+      "version": "0.0.2",
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "8792a53497bb91b62973b588179eb4c5ed0ff7fd",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "send",
+      "version": "0.0.3",
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "4d5f843edf9d65dac31c8a5d2672c179ecb67184",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "send",
+      "version": "0.0.4",
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "2d4cf79b189fcd09610e1302510ac9b0e4dde800",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.0.4.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "send",
+      "version": "0.1.0",
+      "dependencies": {
+        "debug": "*",
+        "mime": "1.2.6",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "cfb08ebd3cec9b7fc1a37d9ff9e875a971cf4640",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "send",
+      "version": "0.1.1",
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "0bcfcbd03def6e2d8612e1abf8f4895b450c60c8",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "send",
+      "version": "0.1.2",
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "c2744e98111bf1bb62eb4996dfda8a9980752984",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "send",
+      "version": "0.1.3",
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "0.1.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "a7875daa6802d31e2ce32fdad98d3664c51ecea3",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "send",
+      "version": "0.1.4",
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "0.2.0",
+        "range-parser": "0.0.4"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "be70d8d1be01de61821af13780b50345a4f71abd",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.1.4.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "send",
+      "version": "0.2.0",
+      "dependencies": {
+        "debug": "*",
+        "mime": "~1.2.9",
+        "fresh": "~0.2.1",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.0.1",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "067abf45cff8bffb29cbdb7439725b32388a2c58",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "send",
+      "version": "0.3.0",
+      "dependencies": {
+        "buffer-crc32": "0.2.1",
+        "debug": "0.8.0",
+        "fresh": "~0.2.1",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*",
+        "supertest": "0.10.0",
+        "connect": "2.x"
+      },
+      "dist": {
+        "shasum": "9718324634806fc75bc4f8f5e51f57d9d66606e7",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.3.0.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "send",
+      "version": "0.4.0",
+      "dependencies": {
+        "debug": "0.8.1",
+        "finished": "1.1.4",
+        "fresh": "~0.2.1",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.19.0",
+        "should": "~3.3.2",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "e7ec677072e5651f18712dd493732fcf422cec39",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.1": {
+      "name": "send",
+      "version": "0.4.1",
+      "dependencies": {
+        "debug": "0.8.1",
+        "finished": "1.1.4",
+        "fresh": "~0.2.1",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "6e9a5d41cb9c0fb3514226446fa319aed46d433d",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.2": {
+      "name": "send",
+      "version": "0.4.2",
+      "dependencies": {
+        "debug": "1.0.1",
+        "finished": "1.2.1",
+        "fresh": "~0.2.1",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "7641b23126fc54975d2be37674b36d6bb617b26c",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.4.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.4.3": {
+      "name": "send",
+      "version": "0.4.3",
+      "dependencies": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "9627b23b7707fbf6373831cac5793330b594b640",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.4.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.5.0": {
+      "name": "send",
+      "version": "0.5.0",
+      "dependencies": {
+        "debug": "1.0.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "fc0f7e2f92e29aebfd8a1b2deb4a394e7a531a68",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.6.0": {
+      "name": "send",
+      "version": "0.6.0",
+      "dependencies": {
+        "debug": "1.0.3",
+        "depd": "0.3.0",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "a59da9265db7c35141e1079cf1f368ee0d59b3ab",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.7.0": {
+      "name": "send",
+      "version": "0.7.0",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "f479a05c57d36bf564311dd1e3825b84b26ae336",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.7.1": {
+      "name": "send",
+      "version": "0.7.1",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.3",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "fe02421cd5fb3bcc10287f72c18e94818e3f80fd",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.7.2": {
+      "name": "send",
+      "version": "0.7.2",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "3b5f696f701d56fe115b860cc6b3f0cdbfbf7804",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.7.3": {
+      "name": "send",
+      "version": "0.7.3",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "2caa2e2627d2f9c2d109d3f5c2942935480aa993",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.7.4": {
+      "name": "send",
+      "version": "0.7.4",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "c80a084cb8eb940345f3ab4ce9e4ee25cb6647cb",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.7.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.8.0": {
+      "name": "send",
+      "version": "0.8.0",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "cbe98d58c1bdaa666bb95acb68ed1df92e1ae6e1",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.8.1": {
+      "name": "send",
+      "version": "0.8.1",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "86bbdcc3fb0ce6ebc2d15af977d94c0b300d02eb",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.8.2": {
+      "name": "send",
+      "version": "0.8.2",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "dethroy": "1.0.2",
+        "escape-html": "1.0.1",
+        "finished": "1.2.2",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "f67efb2e3c89bf5bcd90ccda8683b17f1cbfd0ac",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.8.3": {
+      "name": "send",
+      "version": "0.8.3",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "593886004fcb968a1b5727814a32b388b3b99083",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.8.4": {
+      "name": "send",
+      "version": "0.8.4",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "259cd04e507df26a70eaa5b66cb20a26d8f18d65",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.8.5": {
+      "name": "send",
+      "version": "0.8.5",
+      "dependencies": {
+        "debug": "1.0.4",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "37f708216e6f50c175e74c69fec53484e2fd82c7",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.8.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.9.0": {
+      "name": "send",
+      "version": "0.9.0",
+      "dependencies": {
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.0",
+        "fresh": "0.2.2",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "778341d52134c895a4ecaf44a4a30d762f8ee3eb",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.9.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.9.1": {
+      "name": "send",
+      "version": "0.9.1",
+      "dependencies": {
+        "debug": "~2.0.0",
+        "depd": "0.4.4",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "d93689f7c9ce36bd32f8ee572bb60bda032edc23",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.9.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.9.2": {
+      "name": "send",
+      "version": "0.9.2",
+      "dependencies": {
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.3.1",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "77d22a0f462604451917075c6f52e69c2b3b6e25",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.9.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.9.3": {
+      "name": "send",
+      "version": "0.9.3",
+      "dependencies": {
+        "debug": "~2.0.0",
+        "depd": "0.4.5",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.4.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "b43a7414cd089b7fbec9b755246f7c37b7b85cc0",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.9.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.10.0": {
+      "name": "send",
+      "version": "0.10.0",
+      "dependencies": {
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "2.1.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "2f984b703934c628b72b72d70557b75ca906ea6c",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.10.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.10.1": {
+      "name": "send",
+      "version": "0.10.1",
+      "dependencies": {
+        "debug": "~2.1.0",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.0",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.6.2",
+        "on-finished": "~2.1.1",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "7745c50ec72f115115980e8fb179aec01900e08a",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.10.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.11.0": {
+      "name": "send",
+      "version": "0.11.0",
+      "dependencies": {
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "d66b83b44576061ebd49551943b3c5c1f61cb308",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.11.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.11.1": {
+      "name": "send",
+      "version": "0.11.1",
+      "dependencies": {
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.2.11",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "1beabfd42f9e2709f99028af3078ac12b47092d5",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.11.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.12.0": {
+      "name": "send",
+      "version": "0.12.0",
+      "dependencies": {
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.3.4",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "d8c124a27797c47206d8fd52d37cd27ef15a506e",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.12.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.12.1": {
+      "name": "send",
+      "version": "0.12.1",
+      "dependencies": {
+        "debug": "~2.1.1",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.3.4",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "65e2e4330eae6b4d1082a921bfc8e9c9f1776b31",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.12.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.12.2": {
+      "name": "send",
+      "version": "0.12.2",
+      "dependencies": {
+        "debug": "~2.1.3",
+        "depd": "~1.0.0",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.5.1",
+        "fresh": "0.2.4",
+        "mime": "1.3.4",
+        "ms": "0.7.0",
+        "on-finished": "~2.2.0",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.7",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "ba6785e47ab41aa0358b9da401ab22ff0f58eab6",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.12.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.12.3": {
+      "name": "send",
+      "version": "0.12.3",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.1",
+        "etag": "~1.6.0",
+        "fresh": "0.2.4",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.2.1",
+        "range-parser": "~1.0.2"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "cd12dc58fde21e4f91902b39b2fda05a7a6d9bdc",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.12.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.13.0": {
+      "name": "send",
+      "version": "0.13.0",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "destroy": "1.0.3",
+        "escape-html": "1.0.2",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.3.1",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.0.2",
+        "statuses": "~1.2.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "518f921aeb0560aec7dcab2990b14cf6f3cce5de",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.13.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.13.1": {
+      "name": "send",
+      "version": "0.13.1",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.3.1",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.0.3",
+        "statuses": "~1.2.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "a30d5f4c82c8a9bae9ad00a1d9b1bdbe6f199ed7",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.13.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.13.2": {
+      "name": "send",
+      "version": "0.13.2",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.3.1",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.0.3",
+        "statuses": "~1.2.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.4.2",
+        "mocha": "2.4.5",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "765e7607c8055452bba6f0b052595350986036de",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.13.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.14.0": {
+      "name": "send",
+      "version": "0.14.0",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.5.0",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.1",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "6b192d05c0b87c48263738bba9d50d04b2328b77",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.14.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.14.1": {
+      "name": "send",
+      "version": "0.14.1",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.5.0",
+        "mime": "1.3.4",
+        "ms": "0.7.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.1",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "a954984325392f51532a7760760e459598c89f7a",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.14.2": {
+      "name": "send",
+      "version": "0.14.2",
+      "dependencies": {
+        "debug": "~2.2.0",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.7.0",
+        "fresh": "0.3.0",
+        "http-errors": "~1.5.1",
+        "mime": "1.3.4",
+        "ms": "0.7.2",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.1",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "39b0438b3f510be5dc6f667a11f71689368cdeef",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.14.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.15.0": {
+      "name": "send",
+      "version": "0.15.0",
+      "dependencies": {
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.1",
+        "mime": "1.3.4",
+        "ms": "0.7.2",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.16.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "f0185d6466fa76424b866f3d533e2d19dd0aaa39",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.15.1": {
+      "name": "send",
+      "version": "0.15.1",
+      "dependencies": {
+        "debug": "2.6.1",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.1",
+        "mime": "1.3.4",
+        "ms": "0.7.2",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.17.0",
+        "eslint-config-standard": "7.0.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "8a02354c26e6f5cca700065f5f0cdeba90ec7b5f",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.15.2": {
+      "name": "send",
+      "version": "0.15.2",
+      "dependencies": {
+        "debug": "2.6.4",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.1",
+        "mime": "1.3.4",
+        "ms": "1.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "f91fab4403bcf87e716f70ceb5db2f578bdc17d6",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.15.3": {
+      "name": "send",
+      "version": "0.15.3",
+      "dependencies": {
+        "debug": "2.6.7",
+        "depd": "~1.1.0",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.1",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "5013f9f99023df50d1bd9892c19e3defd1d53309",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.15.4": {
+      "name": "send",
+      "version": "0.15.4",
+      "dependencies": {
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "~1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "985faa3e284b0273c793364a35c6737bd93905b9",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.15.5": {
+      "name": "send",
+      "version": "0.15.5",
+      "dependencies": {
+        "debug": "2.6.8",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "32ef6c8d820c9756597c3174b8c9dd51e3319be2",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.15.6": {
+      "name": "send",
+      "version": "0.15.6",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.3.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "20f23a9c925b762ab82705fe2f9db252ace47e34",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.15.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.16.0": {
+      "name": "send",
+      "version": "0.16.0",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "16338dbb9a2ede4ad57b48420ec3b82d8e80a57b",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.16.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.16.1": {
+      "name": "send",
+      "version": "0.16.1",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
+        "shasum": "a70e1ca21d1382c11d0d9f6231deb281080d7ab3",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.16.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.16.2": {
+      "name": "send",
+      "version": "0.16.2",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+        "shasum": "6ecca1e0f8c156d141597559848df64730a6bbc1",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 46571
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.17.0": {
+      "name": "send",
+      "version": "0.17.0",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.5.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "supertest": "4.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-NYR0jCuwnBaGA2X5bO3+QDZmmJ+PUCvFCRTED5nx9l/BK3Pr8mD8Ryvk9bw08JJUdXxt2u+tVIGoqJPrHWGqSA==",
+        "shasum": "6d190beaaf08c5cf7e325ded024f1a7cd934ed9a",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.17.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 48043,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJczLPjCRA9TVsSAnZWagAAzrIP/30L3J0n3A7tIHr+BqYX\nvEBFSet7QNTYYmdiunNkEVZaiJtrJTRspaipTRtBrJw7Bmjhe9Fi5pvan3gi\nd1lLBQMWSfVJoSLAwpDtBzmq73e2QNs8e3tH9cmYNBX79oFKNa2CNoftiZtD\n1QMphhjmUD7Ead/YCS/lroNY2TvJjkOscsk7DiVFbu4YKGldqVDz/qLeQPV9\nMxpQcWkS0yKla9N8y4mrLBmEjKwKNsDiyWP5BJIhDWNLWcI3yICNpY3Z3pcz\n9X7VPZNMnpuFSpqZ37C/a5cfTjki0roBd4vGgNC4B72N+4MNF11HQzeMjNL1\neolCWtS6WDijOtUBuiV8+BHM4iElyDQ2PkelCM/23AXLC4wLxYH+JiLVsHNP\nm/gfHK7Y/Brr44r5zyKk4BP+HOgaRefzEPv0jJ+lkdH9N/R22Cw1yMn1FVZ0\nbRDCFlQyKRCbPgKIzEREGcU/3Z+KMbc8JDKs6RfCxQx5WXEjFKgx1aLM0inR\nIeBv/v6T+8Xjm6XbXZFNK5VOuP2ujKEjjK9JRp6lD3aJOe51XUzq/jwARnXr\n5h9adHpY4i55gxmBGKln/muQ3ADZG+bZp372JVT5nAJK83/Y4P0InuUrgoyj\nuVBSj+Fl5Xh1JP31D2aTEm3OAFUAKh2r8rn7qiAjevnByBC0X89EJTYzFiS6\nrNoQ\r\n=F+qh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.17.1": {
+      "name": "send",
+      "version": "0.17.1",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "supertest": "4.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+        "shasum": "c1d8b059f7900f7466dd4938bdc44e11ddb376c8",
+        "tarball": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 48173,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1igoCRA9TVsSAnZWagAA4xIP/RwpQJfYKVcRmNymna4k\n8R7ZXHoC9MyoxLCBvNuzZ5uy/HCYYVgPR7ilzmDfDQInJZJOZUBiMXFBs413\ntyXBv5Y0kXVARuXPBcy/pH6cVCn5nFlOneEj+ntNo5mrFCJxysxCR9xfoG7o\nuKfVrPmKRVm7dLJBuJzPzjQZEL1b6GqV3+aMypBNdGwK8E53MgJodwdZQbvg\nixSOMJ1D0e9qY4afOZII9Ejpoxk3+bu5+UadK++vYtWFCh2REhd+dzpD8FTu\nAah/Ub1jt7WHb2rJNclhxh+DsiIwWukCIpJ1dsPSBTQ+MQjoAXNrJdVxnMcj\n7uwXW/7wRho0o5q59JfUH98zv0GeIYjfjLfhS8uHm43niDtvnTLKe3ZTJqVY\nMPQz71+VfaTE5rHKpyrHxEhj1MGKFwAGQbNtrhx2HVvtLMz+qNLAeCa6rUPR\n48U9yJ2HfEhlm+y08i43lEtdY+Sk5oNtG+Wk1PUUlPdbXW/Hma13ALXK57pP\n09Q8IZwbTGufeJnK2maVByHc+08GZ4FclVAd8h3pUeFxyK2MR9hbtlQx27sg\n4KXbizzUuPx4tO7qp9aa+oS8wS1qLn/BkrFJPKuzExvnnsrTttEc1S1LHbhg\nlVFT6U1oGpXQlLiBwbzotePJeFXcLZsxovN+NfCZT0csI83ivh5bREiUImkH\nIWSh\r\n=fsxk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    }
+  },
+  "modified": "2019-05-11T01:40:58.566Z"
+}

--- a/test/fixtures/registry-mocks/content/serve-index.json
+++ b/test/fixtures/registry-mocks/content/serve-index.json
@@ -1,0 +1,2716 @@
+{
+  "_id": "serve-index",
+  "_rev": "102-9a8f70c65751677b026735a16fbde77a",
+  "name": "serve-index",
+  "description": "Serve directory listings",
+  "dist-tags": {
+    "latest": "1.9.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "dependencies": {
+        "batch": "0.5.0",
+        "negotiator": "0.3.0"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "_id": "serve-index@1.0.0",
+      "dist": {
+        "shasum": "d4adf1c5719cdfcb73cf1b26450f0cd9760e1a6c",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "dependencies": {
+        "batch": "0.5.0",
+        "negotiator": "0.4.2"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "_id": "serve-index@1.0.1",
+      "dist": {
+        "shasum": "2782ee8ede6cccaae54957962c4715e8ce1921a6",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "dependencies": {
+        "batch": "0.5.0",
+        "negotiator": "0.4.3"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.17.1",
+        "should": "~3.1.3",
+        "supertest": "~0.9.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.0.2",
+      "dist": {
+        "shasum": "e0457bd44cf9f2dd4c7369af446b330e023ee2f1",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.0.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "dependencies": {
+        "batch": "0.5.0",
+        "negotiator": "0.4.3"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.17.1",
+        "should": "~3.1.3",
+        "supertest": "~0.9.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.0.3",
+      "dist": {
+        "shasum": "d32dc9ca04acc6eede3d563997ea2e97c7c87895",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "dependencies": {
+        "accepts": "1.0.2",
+        "batch": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.1.0",
+      "dist": {
+        "shasum": "4843b22d78eae51406adb8fa370c373b9499501d",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.1.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "1.0.3",
+        "batch": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "gitHead": "5037f808c077641c2766bf8f4418dbb5c3b8abcc",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.1.1",
+      "_shasum": "eadadd8fd07413add17a301c657f52fc05f19d2f",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "eadadd8fd07413add17a301c657f52fc05f19d2f",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.1.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "1.0.3",
+        "batch": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.1.2",
+      "dist": {
+        "shasum": "0742b480998257539c2d2acc6ca1f4aaf267f972",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.1.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "1.0.4",
+        "batch": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.1.3",
+      "dist": {
+        "shasum": "ff650557f235ce3e52ec1046eea823763ca30d2d",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.1.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.0.5",
+        "batch": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.1.4",
+      "dist": {
+        "shasum": "5aee90b78c0f6543af0df69f85c8443317fdd898",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.1.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "batch": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.1.5",
+      "dist": {
+        "shasum": "ae6671402ad9dc229bb64a3f0571e3a2647b06f7",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.6": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.1.6",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "batch": "0.5.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec"
+      },
+      "gitHead": "194663a06f1e2fd1cd7ac51daff006d267eaf64f",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.1.6",
+      "_shasum": "b758318fe781628383f66ac80dd447712ea7781f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b758318fe781628383f66ac80dd447712ea7781f",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.2.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "batch": "0.5.1",
+        "debug": "1.0.4",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "63456cccf22b003721e284b4e764a7577eea4972",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.2.0",
+      "_shasum": "8a4584e9334cee996a129d510a43e9acb4f20c27",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8a4584e9334cee996a129d510a43e9acb4f20c27",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.2.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "591fd9ca1300c3506f6f92a0814700cd2e19df6a",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.2.1",
+      "_shasum": "854daef00ac9ff2f5bfda1c019b78fb0ed6d2e6f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "854daef00ac9ff2f5bfda1c019b78fb0ed6d2e6f",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.3.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "mime-types": "~2.0.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "351c2267361179d25324bc6774868d58ad9e8eec",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.3.0",
+      "_shasum": "1a13a1111afc06e25ac58cb218df6a5235554b7f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1a13a1111afc06e25ac58cb218df6a5235554b7f",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.3.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "mime-types": "~2.0.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "5731ebee6b94f5508156aa21215d36ae68a6b446",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.3.1",
+      "_shasum": "7e15c475508a8476137ca80e6c689908ba8692e6",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e15c475508a8476137ca80e6c689908ba8692e6",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.4.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "mime-types": "~2.0.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ac94303941ffa08f13b9a73d10de5355a59f0dd2",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.4.0",
+      "_shasum": "cd3763ac2c1627cdbb2fa50b8b8d15238d8509cd",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cd3763ac2c1627cdbb2fa50b8b8d15238d8509cd",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.4.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "mime-types": "~2.0.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "838ee4cc02b8793b9281a70e3a19ba83d80ba103",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.4.1",
+      "_shasum": "f206095682ee3a0df043d0c9a2ec3d199df53a85",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f206095682ee3a0df043d0c9a2ec3d199df53a85",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.5.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "batch": "0.5.1",
+        "debug": "~2.1.0",
+        "http-errors": "~1.2.7",
+        "mime-types": "~2.0.2",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "47b3884bbe9d24faab480d30e0f79e250f135f1c",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.5.0",
+      "_shasum": "066a35ff1564146cceb2105014a5b070af68707e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "066a35ff1564146cceb2105014a5b070af68707e",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.5.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "batch": "0.5.1",
+        "debug": "~2.1.0",
+        "http-errors": "~1.2.7",
+        "mime-types": "~2.0.3",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "9a77df8c778449d072648f5b388153abb067716f",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.5.1",
+      "_shasum": "11e2cec8b7cdc801a8a766ebf36c1372c956e84a",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "11e2cec8b7cdc801a8a766ebf36c1372c956e84a",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.5.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "batch": "0.5.1",
+        "debug": "~2.1.0",
+        "http-errors": "~1.2.7",
+        "mime-types": "~2.0.3",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.3",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "12d7cb4a7d0a112b7dfcb2b59cdf876b65e38fd2",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.5.2",
+      "_shasum": "5b5c292838d16232a788a3f8a9b78e64c640dff6",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5b5c292838d16232a788a3f8a9b78e64c640dff6",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.3": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.5.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "batch": "0.5.1",
+        "debug": "~2.1.0",
+        "http-errors": "~1.2.8",
+        "mime-types": "~2.0.4",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "244f8a5541334997e5b0d5e4095cf570eb3e99f7",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.5.3",
+      "_shasum": "412cbc82bf6e2b97ba3247166cd1f425404e75e7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "412cbc82bf6e2b97ba3247166cd1f425404e75e7",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.6.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.2.2",
+        "batch": "0.5.2",
+        "debug": "~2.1.1",
+        "http-errors": "~1.2.8",
+        "mime-types": "~2.0.7",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "803e4154b2e7a2ccaa9f46011323a35e31a10f87",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.6.0",
+      "_shasum": "5a9216ee1fa50f5c49bba4842d041bb7970df0cd",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5a9216ee1fa50f5c49bba4842d041bb7970df0cd",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.6.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.2.3",
+        "batch": "0.5.2",
+        "debug": "~2.1.1",
+        "http-errors": "~1.2.8",
+        "mime-types": "~2.0.8",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "0bdab07acfda5c16def412f973af53f6be079a22",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.6.1",
+      "_shasum": "9c37aa60d5b65e21282450ffe11bbcecc20a0856",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9c37aa60d5b65e21282450ffe11bbcecc20a0856",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.6.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "batch": "0.5.2",
+        "debug": "~2.1.1",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.0.9",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "5ec9698c085cf11308e9ca2ed28d72835f191e97",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.6.2",
+      "_shasum": "f144a140b4500faf2e861c02bb7f160bd7dc3af1",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f144a140b4500faf2e861c02bb7f160bd7dc3af1",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.3": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.6.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.2.5",
+        "batch": "0.5.2",
+        "debug": "~2.1.3",
+        "escape-html": "1.0.1",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.0.10",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.7",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "e11f2532265a6cb172621541975a40b517f38f24",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.6.3",
+      "_shasum": "639056494ea59470a2c9518c28e7f225a342fd79",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "639056494ea59470a2c9518c28e7f225a342fd79",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.4": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.6.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.2.7",
+        "batch": "0.5.2",
+        "debug": "~2.2.0",
+        "escape-html": "1.0.1",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.0.11",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "636a8ae7bc60af24ac8a8323c9074feb99c746cc",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.6.4",
+      "_shasum": "8b1eccf1e947cf0d7fb33eac30d4659c0ddc543b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8b1eccf1e947cf0d7fb33eac30d4659c0ddc543b",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.7.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.2.9",
+        "batch": "0.5.2",
+        "debug": "~2.2.0",
+        "escape-html": "1.0.2",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "63b45e62087acdba321056b3cd622e5cfb327fb5",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.7.0",
+      "_shasum": "03960721b89661507283baa92499c80c9f366f0a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "03960721b89661507283baa92499c80c9f366f0a",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.7.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.2.10",
+        "batch": "0.5.2",
+        "debug": "~2.2.0",
+        "escape-html": "1.0.2",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.2",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "f17363a45dfe28859fc87abd065b5dca15cd1cb8",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.7.1",
+      "_shasum": "7bcc7093cc27827c3fc56357d3e34da64023a663",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7bcc7093cc27827c3fc56357d3e34da64023a663",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.2": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.7.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "batch": "0.5.2",
+        "debug": "~2.2.0",
+        "escape-html": "1.0.2",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.4",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "f39ad778ed5546fb94456544f92938f4b09b7a34",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.7.2",
+      "_shasum": "9a155d9c4f9d391e463970e7b4eb16c7672141c0",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9a155d9c4f9d391e463970e7b4eb16c7672141c0",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.3": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.7.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-index.git"
+      },
+      "dependencies": {
+        "accepts": "~1.2.13",
+        "batch": "0.5.3",
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.9",
+        "parseurl": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "fc9db6b56a5bd6ae37f635a7cc7230ab83343fc1",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index#readme",
+      "_id": "serve-index@1.7.3",
+      "_shasum": "7a057fc6ee28dc63f64566e5fa57b111a86aecd2",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "7a057fc6ee28dc63f64566e5fa57b111a86aecd2",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.8.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-index"
+      },
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "batch": "0.5.3",
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.5.0",
+        "mime-types": "~2.1.11",
+        "parseurl": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "357452911dce2d17fd90aea7c1b5e69781b7f464",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index",
+      "_id": "serve-index@1.8.0",
+      "_shasum": "7c5d96c13fb131101f93c1c5774f8516a1e78d3b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7c5d96c13fb131101f93c1c5774f8516a1e78d3b",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/serve-index-1.8.0.tgz_1466180024696_0.9007518284488469"
+      },
+      "directories": {}
+    },
+    "1.9.0": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.9.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-index.git"
+      },
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "batch": "0.6.1",
+        "debug": "2.6.8",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.1",
+        "mime-types": "~2.1.15",
+        "parseurl": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "bc077cbe29139041bd9ba174be2be4fc30f528a5",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index#readme",
+      "_id": "serve-index@1.9.0",
+      "_shasum": "d2b280fc560d616ee81b48bf0fa82abed2485ce7",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d2b280fc560d616ee81b48bf0fa82abed2485ce7",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-index-1.9.0.tgz_1495741621282_0.7122532310895622"
+      },
+      "directories": {}
+    },
+    "1.9.1": {
+      "name": "serve-index",
+      "description": "Serve directory listings",
+      "version": "1.9.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-index.git"
+      },
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "public/",
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "a399faa1801f02ee1885e5664ed21a9c7990b63a",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-index/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-index#readme",
+      "_id": "serve-index@1.9.1",
+      "_shasum": "d3768d69b1e7d82e5ce050fff5b453bea12a9239",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d3768d69b1e7d82e5ce050fff5b453bea12a9239",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-index-1.9.1.tgz_1506659829376_0.796724762301892"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# serve-index\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Linux Build][travis-image]][travis-url]\n[![Windows Build][appveyor-image]][appveyor-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n[![Gratipay][gratipay-image]][gratipay-url]\n\n  Serves pages that contain directory listings for a given path.\n\n## Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install serve-index\n```\n\n## API\n\n```js\nvar serveIndex = require('serve-index')\n```\n\n### serveIndex(path, options)\n\nReturns middlware that serves an index of the directory in the given `path`.\n\nThe `path` is based off the `req.url` value, so a `req.url` of `'/some/dir`\nwith a `path` of `'public'` will look at `'public/some/dir'`. If you are using\nsomething like `express`, you can change the URL \"base\" with `app.use` (see\nthe express example).\n\n#### Options\n\nServe index accepts these properties in the options object.\n\n##### filter\n\nApply this filter function to files. Defaults to `false`. The `filter` function\nis called for each file, with the signature `filter(filename, index, files, dir)`\nwhere `filename` is the name of the file, `index` is the array index, `files` is\nthe array of files and `dir` is the absolute path the file is located (and thus,\nthe directory the listing is for).\n\n##### hidden\n\nDisplay hidden (dot) files. Defaults to `false`.\n\n##### icons\n\nDisplay icons. Defaults to `false`.\n\n##### stylesheet\n\nOptional path to a CSS stylesheet. Defaults to a built-in stylesheet.\n\n##### template\n\nOptional path to an HTML template or a function that will render a HTML\nstring. Defaults to a built-in template.\n\nWhen given a string, the string is used as a file path to load and then the\nfollowing tokens are replaced in templates:\n\n  * `{directory}` with the name of the directory.\n  * `{files}` with the HTML of an unordered list of file links.\n  * `{linked-path}` with the HTML of a link to the directory.\n  * `{style}` with the specified stylesheet and embedded images.\n\nWhen given as a function, the function is called as `template(locals, callback)`\nand it needs to invoke `callback(error, htmlString)`. The following are the\nprovided locals:\n\n  * `directory` is the directory being displayed (where `/` is the root).\n  * `displayIcons` is a Boolean for if icons should be rendered or not.\n  * `fileList` is a sorted array of files in the directory. The array contains\n    objects with the following properties:\n    - `name` is the relative name for the file.\n    - `stat` is a `fs.Stats` object for the file.\n  * `path` is the full filesystem path to `directory`.\n  * `style` is the default stylesheet or the contents of the `stylesheet` option.\n  * `viewName` is the view name provided by the `view` option.\n\n##### view\n\nDisplay mode. `tiles` and `details` are available. Defaults to `tiles`.\n\n## Examples\n\n### Serve directory indexes with vanilla node.js http server\n\n```js\nvar finalhandler = require('finalhandler')\nvar http = require('http')\nvar serveIndex = require('serve-index')\nvar serveStatic = require('serve-static')\n\n// Serve directory indexes for public/ftp folder (with icons)\nvar index = serveIndex('public/ftp', {'icons': true})\n\n// Serve up public/ftp folder files\nvar serve = serveStatic('public/ftp')\n\n// Create server\nvar server = http.createServer(function onRequest(req, res){\n  var done = finalhandler(req, res)\n  serve(req, res, function onNext(err) {\n    if (err) return done(err)\n    index(req, res, done)\n  })\n})\n\n// Listen\nserver.listen(3000)\n```\n\n### Serve directory indexes with express\n\n```js\nvar express    = require('express')\nvar serveIndex = require('serve-index')\n\nvar app = express()\n\n// Serve URLs like /ftp/thing as public/ftp/thing\n// The express.static serves the file contents\n// The serveIndex is this module serving the directory\napp.use('/ftp', express.static('public/ftp'), serveIndex('public/ftp', {'icons': true}))\n\n// Listen\napp.listen(3000)\n```\n\n## License\n\n[MIT](LICENSE). The [Silk](http://www.famfamfam.com/lab/icons/silk/) icons\nare created by/copyright of [FAMFAMFAM](http://www.famfamfam.com/).\n\n[npm-image]: https://img.shields.io/npm/v/serve-index.svg\n[npm-url]: https://npmjs.org/package/serve-index\n[travis-image]: https://img.shields.io/travis/expressjs/serve-index/master.svg?label=linux\n[travis-url]: https://travis-ci.org/expressjs/serve-index\n[appveyor-image]: https://img.shields.io/appveyor/ci/dougwilson/serve-index/master.svg?label=windows\n[appveyor-url]: https://ci.appveyor.com/project/dougwilson/serve-index\n[coveralls-image]: https://img.shields.io/coveralls/expressjs/serve-index/master.svg\n[coveralls-url]: https://coveralls.io/r/expressjs/serve-index?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/serve-index.svg\n[downloads-url]: https://npmjs.org/package/serve-index\n[gratipay-image]: https://img.shields.io/gratipay/dougwilson.svg\n[gratipay-url]: https://www.gratipay.com/dougwilson/\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-03-08T23:35:50.875Z",
+    "created": "2014-03-05T23:49:37.465Z",
+    "1.0.0": "2014-03-05T23:49:39.508Z",
+    "1.0.1": "2014-03-06T14:59:20.096Z",
+    "1.0.2": "2014-04-28T18:44:13.164Z",
+    "1.0.3": "2014-05-20T14:23:16.229Z",
+    "1.1.0": "2014-05-29T23:32:06.116Z",
+    "1.1.1": "2014-06-12T04:01:05.230Z",
+    "1.1.2": "2014-06-19T15:12:03.916Z",
+    "1.1.3": "2014-06-20T17:50:04.358Z",
+    "1.1.4": "2014-06-20T19:39:26.630Z",
+    "1.1.5": "2014-07-27T22:17:08.777Z",
+    "1.1.6": "2014-08-10T21:46:05.114Z",
+    "1.2.0": "2014-08-25T23:14:08.646Z",
+    "1.2.1": "2014-09-06T04:02:14.819Z",
+    "1.3.0": "2014-09-21T04:27:43.945Z",
+    "1.3.1": "2014-10-01T15:41:20.747Z",
+    "1.4.0": "2014-10-03T16:06:59.044Z",
+    "1.4.1": "2014-10-16T03:25:12.916Z",
+    "1.5.0": "2014-10-17T05:34:17.207Z",
+    "1.5.1": "2014-11-23T04:23:53.938Z",
+    "1.5.2": "2014-12-03T22:28:26.353Z",
+    "1.5.3": "2014-12-11T03:44:15.937Z",
+    "1.6.0": "2015-01-02T03:19:41.884Z",
+    "1.6.1": "2015-02-01T08:27:24.402Z",
+    "1.6.2": "2015-02-17T03:56:46.655Z",
+    "1.6.3": "2015-03-14T05:24:28.356Z",
+    "1.6.4": "2015-05-13T03:26:48.731Z",
+    "1.7.0": "2015-06-15T22:09:55.424Z",
+    "1.7.1": "2015-07-06T03:58:10.179Z",
+    "1.7.2": "2015-07-31T04:42:38.028Z",
+    "1.7.3": "2016-01-24T23:33:28.474Z",
+    "1.8.0": "2016-06-17T16:13:47.479Z",
+    "1.9.0": "2017-05-25T19:47:02.458Z",
+    "1.9.1": "2017-09-29T04:37:10.468Z"
+  },
+  "readmeFilename": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/expressjs/serve-index.git"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/expressjs/serve-index/issues"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/expressjs/serve-index#readme",
+  "users": {
+    "season19840122": true,
+    "wkaifang": true,
+    "panlw": true,
+    "kparkov": true,
+    "wangnan0610": true,
+    "dj2bee": true,
+    "sammok2003": true,
+    "bapinney": true,
+    "mobeicaoyuan": true,
+    "scottfreecode": true,
+    "azevedo": true,
+    "kistoryg": true,
+    "staydan": true,
+    "bengi": true,
+    "stone_breaker": true,
+    "rocket0191": true,
+    "lbeff": true,
+    "mayq0422": true,
+    "rolandish": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/serve-index.min.json
+++ b/test/fixtures/registry-mocks/content/serve-index.min.json
@@ -1,0 +1,792 @@
+{
+  "name": "serve-index",
+  "dist-tags": {
+    "latest": "1.9.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "serve-index",
+      "version": "1.0.0",
+      "dependencies": {
+        "batch": "0.5.0",
+        "negotiator": "0.3.0"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "d4adf1c5719cdfcb73cf1b26450f0cd9760e1a6c",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.1": {
+      "name": "serve-index",
+      "version": "1.0.1",
+      "dependencies": {
+        "batch": "0.5.0",
+        "negotiator": "0.4.2"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "2782ee8ede6cccaae54957962c4715e8ce1921a6",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.2": {
+      "name": "serve-index",
+      "version": "1.0.2",
+      "dependencies": {
+        "batch": "0.5.0",
+        "negotiator": "0.4.3"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.17.1",
+        "should": "~3.1.3",
+        "supertest": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "e0457bd44cf9f2dd4c7369af446b330e023ee2f1",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.3": {
+      "name": "serve-index",
+      "version": "1.0.3",
+      "dependencies": {
+        "batch": "0.5.0",
+        "negotiator": "0.4.3"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.17.1",
+        "should": "~3.1.3",
+        "supertest": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "d32dc9ca04acc6eede3d563997ea2e97c7c87895",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.0": {
+      "name": "serve-index",
+      "version": "1.1.0",
+      "dependencies": {
+        "accepts": "1.0.2",
+        "batch": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "4843b22d78eae51406adb8fa370c373b9499501d",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.1": {
+      "name": "serve-index",
+      "version": "1.1.1",
+      "dependencies": {
+        "accepts": "1.0.3",
+        "batch": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "eadadd8fd07413add17a301c657f52fc05f19d2f",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.2": {
+      "name": "serve-index",
+      "version": "1.1.2",
+      "dependencies": {
+        "accepts": "1.0.3",
+        "batch": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "0742b480998257539c2d2acc6ca1f4aaf267f972",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.3": {
+      "name": "serve-index",
+      "version": "1.1.3",
+      "dependencies": {
+        "accepts": "1.0.4",
+        "batch": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "ff650557f235ce3e52ec1046eea823763ca30d2d",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.4": {
+      "name": "serve-index",
+      "version": "1.1.4",
+      "dependencies": {
+        "accepts": "~1.0.5",
+        "batch": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "5aee90b78c0f6543af0df69f85c8443317fdd898",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.5": {
+      "name": "serve-index",
+      "version": "1.1.5",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "batch": "0.5.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "ae6671402ad9dc229bb64a3f0571e3a2647b06f7",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.6": {
+      "name": "serve-index",
+      "version": "1.1.6",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "batch": "0.5.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "b758318fe781628383f66ac80dd447712ea7781f",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.1.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.0": {
+      "name": "serve-index",
+      "version": "1.2.0",
+      "dependencies": {
+        "accepts": "~1.0.7",
+        "batch": "0.5.1",
+        "debug": "1.0.4",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "8a4584e9334cee996a129d510a43e9acb4f20c27",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.1": {
+      "name": "serve-index",
+      "version": "1.2.1",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "854daef00ac9ff2f5bfda1c019b78fb0ed6d2e6f",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.0": {
+      "name": "serve-index",
+      "version": "1.3.0",
+      "dependencies": {
+        "accepts": "~1.1.0",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "mime-types": "~2.0.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "1a13a1111afc06e25ac58cb218df6a5235554b7f",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.1": {
+      "name": "serve-index",
+      "version": "1.3.1",
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "mime-types": "~2.0.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "7e15c475508a8476137ca80e6c689908ba8692e6",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.0": {
+      "name": "serve-index",
+      "version": "1.4.0",
+      "dependencies": {
+        "accepts": "~1.1.1",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "mime-types": "~2.0.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.1",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "cd3763ac2c1627cdbb2fa50b8b8d15238d8509cd",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.1": {
+      "name": "serve-index",
+      "version": "1.4.1",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "batch": "0.5.1",
+        "debug": "~2.0.0",
+        "mime-types": "~2.0.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "f206095682ee3a0df043d0c9a2ec3d199df53a85",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.0": {
+      "name": "serve-index",
+      "version": "1.5.0",
+      "dependencies": {
+        "accepts": "~1.1.2",
+        "batch": "0.5.1",
+        "debug": "~2.1.0",
+        "http-errors": "~1.2.7",
+        "mime-types": "~2.0.2",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "066a35ff1564146cceb2105014a5b070af68707e",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.1": {
+      "name": "serve-index",
+      "version": "1.5.1",
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "batch": "0.5.1",
+        "debug": "~2.1.0",
+        "http-errors": "~1.2.7",
+        "mime-types": "~2.0.3",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "11e2cec8b7cdc801a8a766ebf36c1372c956e84a",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.2": {
+      "name": "serve-index",
+      "version": "1.5.2",
+      "dependencies": {
+        "accepts": "~1.1.3",
+        "batch": "0.5.1",
+        "debug": "~2.1.0",
+        "http-errors": "~1.2.7",
+        "mime-types": "~2.0.3",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.3",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "5b5c292838d16232a788a3f8a9b78e64c640dff6",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.3": {
+      "name": "serve-index",
+      "version": "1.5.3",
+      "dependencies": {
+        "accepts": "~1.1.4",
+        "batch": "0.5.1",
+        "debug": "~2.1.0",
+        "http-errors": "~1.2.8",
+        "mime-types": "~2.0.4",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.0.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "412cbc82bf6e2b97ba3247166cd1f425404e75e7",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.5.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.0": {
+      "name": "serve-index",
+      "version": "1.6.0",
+      "dependencies": {
+        "accepts": "~1.2.2",
+        "batch": "0.5.2",
+        "debug": "~2.1.1",
+        "http-errors": "~1.2.8",
+        "mime-types": "~2.0.7",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "5a9216ee1fa50f5c49bba4842d041bb7970df0cd",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.1": {
+      "name": "serve-index",
+      "version": "1.6.1",
+      "dependencies": {
+        "accepts": "~1.2.3",
+        "batch": "0.5.2",
+        "debug": "~2.1.1",
+        "http-errors": "~1.2.8",
+        "mime-types": "~2.0.8",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "9c37aa60d5b65e21282450ffe11bbcecc20a0856",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.2": {
+      "name": "serve-index",
+      "version": "1.6.2",
+      "dependencies": {
+        "accepts": "~1.2.4",
+        "batch": "0.5.2",
+        "debug": "~2.1.1",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.0.9",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "f144a140b4500faf2e861c02bb7f160bd7dc3af1",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.3": {
+      "name": "serve-index",
+      "version": "1.6.3",
+      "dependencies": {
+        "accepts": "~1.2.5",
+        "batch": "0.5.2",
+        "debug": "~2.1.3",
+        "escape-html": "1.0.1",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.0.10",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.7",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "639056494ea59470a2c9518c28e7f225a342fd79",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.4": {
+      "name": "serve-index",
+      "version": "1.6.4",
+      "dependencies": {
+        "accepts": "~1.2.7",
+        "batch": "0.5.2",
+        "debug": "~2.2.0",
+        "escape-html": "1.0.1",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.0.11",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "~2.2.4",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "8b1eccf1e947cf0d7fb33eac30d4659c0ddc543b",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.0": {
+      "name": "serve-index",
+      "version": "1.7.0",
+      "dependencies": {
+        "accepts": "~1.2.9",
+        "batch": "0.5.2",
+        "debug": "~2.2.0",
+        "escape-html": "1.0.2",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.1",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "03960721b89661507283baa92499c80c9f366f0a",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.1": {
+      "name": "serve-index",
+      "version": "1.7.1",
+      "dependencies": {
+        "accepts": "~1.2.10",
+        "batch": "0.5.2",
+        "debug": "~2.2.0",
+        "escape-html": "1.0.2",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.2",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "7bcc7093cc27827c3fc56357d3e34da64023a663",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.2": {
+      "name": "serve-index",
+      "version": "1.7.2",
+      "dependencies": {
+        "accepts": "~1.2.12",
+        "batch": "0.5.2",
+        "debug": "~2.2.0",
+        "escape-html": "1.0.2",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.4",
+        "parseurl": "~1.3.0"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "9a155d9c4f9d391e463970e7b4eb16c7672141c0",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.3": {
+      "name": "serve-index",
+      "version": "1.7.3",
+      "dependencies": {
+        "accepts": "~1.2.13",
+        "batch": "0.5.3",
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.9",
+        "parseurl": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "7a057fc6ee28dc63f64566e5fa57b111a86aecd2",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.8.0": {
+      "name": "serve-index",
+      "version": "1.8.0",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "batch": "0.5.3",
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.5.0",
+        "mime-types": "~2.1.11",
+        "parseurl": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.1",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "7c5d96c13fb131101f93c1c5774f8516a1e78d3b",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.9.0": {
+      "name": "serve-index",
+      "version": "1.9.0",
+      "dependencies": {
+        "accepts": "~1.3.3",
+        "batch": "0.6.1",
+        "debug": "2.6.8",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.1",
+        "mime-types": "~2.1.15",
+        "parseurl": "~1.3.1"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "d2b280fc560d616ee81b48bf0fa82abed2485ce7",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.9.1": {
+      "name": "serve-index",
+      "version": "1.9.1",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "devDependencies": {
+        "after": "0.8.2",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "d3768d69b1e7d82e5ce050fff5b453bea12a9239",
+        "tarball": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    }
+  },
+  "modified": "2018-03-08T23:35:50.875Z"
+}

--- a/test/fixtures/registry-mocks/content/serve-static.json
+++ b/test/fixtures/registry-mocks/content/serve-static.json
@@ -1,0 +1,4522 @@
+{
+  "_id": "serve-static",
+  "_rev": "246-2c374ef23701f73c615acc51b399c5a5",
+  "name": "serve-static",
+  "description": "Serve static files",
+  "dist-tags": {
+    "latest": "1.14.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "dependencies": {
+        "send": "0.1.4"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "_id": "serve-static@1.0.0",
+      "dist": {
+        "shasum": "98efa31e6ae767b233bc44c77bd29140b2d31c6f",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "dependencies": {
+        "send": "0.1.4"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "_id": "serve-static@1.0.1",
+      "dist": {
+        "shasum": "10dcbfd44b3e0291a131fc9ab4ab25a9f5a78a42",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.0.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "dependencies": {
+        "send": "0.2.0"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "_id": "serve-static@1.0.2",
+      "dist": {
+        "shasum": "4129f6727b09fb031134fa6d185683e30bfbef54",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.0.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "dependencies": {
+        "send": "0.2.0"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.17.1",
+        "should": "~3.1.3",
+        "supertest": "~0.9.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "_id": "serve-static@1.0.3",
+      "dist": {
+        "shasum": "3443a4002fb50d7fa0a777bb53103301e4d0c38a",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.0.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "send": "0.2.0"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.18.2",
+        "should": "~3.3.0",
+        "supertest": "~0.10.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.0.4",
+      "dist": {
+        "shasum": "426fedebe77bad21f373f1efcae09746639fba06",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "send": "0.3.0"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.18.2",
+        "should": "~3.3.0",
+        "supertest": "~0.11.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.1.0",
+      "dist": {
+        "shasum": "454dfa05bb3ddd4e701a8915b83a278aa91c5643",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.2.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "send": "0.4.0"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.18.2",
+        "should": "~3.3.0",
+        "supertest": "~0.11.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require should"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.2.0",
+      "dist": {
+        "shasum": "b711bde722cad70686c1add385c6020bcdb7d295",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.2.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.4.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.2.1",
+      "_shasum": "a800a9de23dbd1ffb1258edb986128ee4a4ea03d",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a800a9de23dbd1ffb1258edb986128ee4a4ea03d",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.2.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.4.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.2.2",
+      "dist": {
+        "shasum": "6ffc6c23fad03bcd0710eceda844123bd71bc951",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.2.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.4.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "gitHead": "9b62eb425f96e421e324cbe23552c214153d6034",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.2.3",
+      "_shasum": "93cecbc340f079ecb8589281d1dc31c26c0cd158",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "93cecbc340f079ecb8589281d1dc31c26c0cd158",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.3.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.13",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.3.0",
+      "dist": {
+        "shasum": "0aba0b27c1b8264eee1a3f9c615886738d9727cb",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.3.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.1.3",
+        "send": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.3.1",
+      "dist": {
+        "shasum": "95489d1bcf491d54350d5aeeb2cca53cd3b12d4f",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.3.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.1.3",
+        "send": "0.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.3.2",
+      "dist": {
+        "shasum": "d904a6cbf55f511c78138f6f45ee6e69d9d105ca",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.4.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.4.0",
+      "dist": {
+        "shasum": "03c6608035158e3bb999129d9793cddc7e0db772",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.4.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.4.1",
+      "dist": {
+        "shasum": "6814dc11c575db0394883af5ec2202ff989491b6",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.4.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.4.2",
+      "dist": {
+        "shasum": "0153b12368318402827aad902d0f124e79145092",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.3": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.4.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.4.3",
+      "dist": {
+        "shasum": "9f08c7dea1b15e2eb1382ae0e12b8a0de295de52",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.4": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.4.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "90b8f98c641a4c26854754e405365b1d5a388e31",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.4.4",
+      "_shasum": "9dc99f37a2c5e28cda2fe6045114620a62032f29",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9dc99f37a2c5e28cda2fe6045114620a62032f29",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.5.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.8.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "b292a569848a3a7f60f6c87eabc87780c0954311",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.5.0",
+      "_shasum": "c0f19e3cb9bef0203258db282a3ddda9cb8e675c",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c0f19e3cb9bef0203258db282a3ddda9cb8e675c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.5.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.8.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "e9df84943e8104ca3cdbf75096964bbfedd3b180",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.5.1",
+      "_shasum": "86185e202015641a1f962447f5695605cd8aa9c2",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "86185e202015641a1f962447f5695605cd8aa9c2",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.5.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.8.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "72f7362176cf62172617cd795d6c94b295f0c610",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.5.2",
+      "_shasum": "565d369193a075edac7fa973550d88df154f7b66",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "565d369193a075edac7fa973550d88df154f7b66",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.3": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.5.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.8.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "7c237ec83ee199d181b5abfeab2ee986c1394dde",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.5.3",
+      "_shasum": "2e28efa5899686fd3ccdb97a80aa464002244581",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2e28efa5899686fd3ccdb97a80aa464002244581",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.4": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.5.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.8.5",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "8f3185f75261cc7b2e87c04cf1377e154bdae1a7",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.5.4",
+      "_shasum": "819fb37ae46bd02dd520b77fcf7fd8f5112f9782",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "819fb37ae46bd02dd520b77fcf7fd8f5112f9782",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.6.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "229f5486e87518ee88b4fd0c5563e02126032121",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.6.0",
+      "_shasum": "283f43b9051293691ab4979bf2e09b4482517677",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "283f43b9051293691ab4979bf2e09b4482517677",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.6.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "8c96c3815cd0c96cbe8af68f303c2d36189d3b88",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.6.1",
+      "_shasum": "2f257563afbe931d28cee4aa3dfeddc975a87193",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2f257563afbe931d28cee4aa3dfeddc975a87193",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.6.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "7053ce75b7091a891d3bcb88a2b19b1b0692396c",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.6.2",
+      "_shasum": "c1390ff43941867250296b091391d25be7c87571",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c1390ff43941867250296b091391d25be7c87571",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.3": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.6.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "14deeaf397728ee25119bf340eeb37e14ab620b3",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.6.3",
+      "_shasum": "b214235d4d4516db050ea9f7b429b46212e79132",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b214235d4d4516db050ea9f7b429b46212e79132",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.4": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.6.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "f1308134d21aeaf5849a3d41c3a04b1779819f3c",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.6.4",
+      "_shasum": "c512e4188d7a9366672db24e40d294f0c6212367",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c512e4188d7a9366672db24e40d294f0c6212367",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.7.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.10.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "25a23406b3447d7bc5af283f158da7c4ad05ba03",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.7.0",
+      "_shasum": "af2ad4e619fa2d46dcd19dd59e3b034c92510e4d",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "af2ad4e619fa2d46dcd19dd59e3b034c92510e4d",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.7.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "61f59894e6a3d41532383ca440a395772bcdc8ed",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.7.1",
+      "_shasum": "6ea54d5ba7ef563f00e5fad25d0e4f5307e9809b",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6ea54d5ba7ef563f00e5fad25d0e4f5307e9809b",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.7.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "40f88bd0269cd4f4ffcb52bded570ad57e4b56ba",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.7.2",
+      "_shasum": "3164ce06d4e6c3459bdcc9d6018fb4fb35e84b39",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3164ce06d4e6c3459bdcc9d6018fb4fb35e84b39",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.8.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.11.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "dadd5479f4316a1201817c6b39be67e2417f3a51",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.8.0",
+      "_shasum": "239e57bbfce030a8933d274e3fe7b55492ea267c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "239e57bbfce030a8933d274e3fe7b55492ea267c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.8.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.11.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "5a47eff4e550f30a7a1e5fb87c8656a1b8dbb249",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.8.1",
+      "_shasum": "08fabd39999f050fc311443f46d5888a77ecfc7c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "08fabd39999f050fc311443f46d5888a77ecfc7c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.5": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.6.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks --require should test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks --require should test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks --require should test/"
+      },
+      "gitHead": "07632f27cd7690f516f4f4994279cde4ad6c01d5",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.6.5",
+      "_shasum": "aca17e0deac4a87729f6078781b7d27f63aa3d9c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "aca17e0deac4a87729f6078781b7d27f63aa3d9c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.9.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.12.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "0909dce1eec7dd5cf0cc29ebc9deb3ea1fb56636",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.9.0",
+      "_shasum": "d304085813ee0a9b3e1c068c9062a56ad8424b44",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d304085813ee0a9b3e1c068c9062a56ad8424b44",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.9.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.12.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "8cce88d079c19cb8ace548f60bd216622de993e1",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.9.1",
+      "_shasum": "a611b2b8a2cfb5f89685f293cb365f3f5eb61451",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a611b2b8a2cfb5f89685f293cb365f3f5eb61451",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.9.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.12.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "6446e1c45de75f143b36ce60dd75c4daf52d2376",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.9.2",
+      "_shasum": "069fa32453557b218ec2e39140c82d8905d5672c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "069fa32453557b218ec2e39140c82d8905d5672c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.3": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.9.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.12.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "c76d20a9f51a15a467eab2b0610e5de60506dfbc",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.9.3",
+      "_shasum": "5f8da07323ad385ff3dc541f1a7917b2e436eb57",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5f8da07323ad385ff3dc541f1a7917b2e436eb57",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.10.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "1.0.2",
+        "parseurl": "~1.3.0",
+        "send": "0.13.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "856c5e0f796a8988525c356018594bfb8c51a4fa",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.10.0",
+      "_shasum": "be632faa685820e4a43ed3df1379135cc4f370d7",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "be632faa685820e4a43ed3df1379135cc4f370d7",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.10.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.0",
+        "send": "0.13.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "8a5da6bf09f515323fd4a669b8f8074762bdf678",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.10.1",
+      "_shasum": "7f80024368d7fcd7975d0c38844ec5d9b2c43ac4",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7f80024368d7fcd7975d0c38844ec5d9b2c43ac4",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.10.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/serve-static"
+      },
+      "dependencies": {
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.13.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "aec36c897a33c6c2421fa41cc4947042d67332f6",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static",
+      "_id": "serve-static@1.10.2",
+      "_shasum": "feb800d0e722124dd0b00333160c16e9caa8bcb3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "feb800d0e722124dd0b00333160c16e9caa8bcb3",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.3": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.10.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.13.2"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.1",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "8be028d005967471832109d777daa4b45bd1948b",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.10.3",
+      "_shasum": "ce5a6ecd3101fed5ec09827dac22a9c29bfb0535",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "ce5a6ecd3101fed5ec09827dac22a9c29bfb0535",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/serve-static-1.10.3.tgz_1464664781274_0.7150349044241011"
+      },
+      "directories": {}
+    },
+    "1.11.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.11.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.14.0"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "28022afd11828493521162287b550a508f60769f",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.11.0",
+      "_shasum": "dbe5fb4e4b63d4d11a824b5be3f368907e675bba",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "dbe5fb4e4b63d4d11a824b5be3f368907e675bba",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/serve-static-1.11.0.tgz_1465366666509_0.32959614507853985"
+      },
+      "directories": {}
+    },
+    "1.11.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.11.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.14.1"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "b3a24df138ea2f2c43afcbee0dcce5badf4c78ae",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.11.1",
+      "_shasum": "d6cce7693505f733c759de57befc1af76c0f0805",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "d6cce7693505f733c759de57befc1af76c0f0805",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/serve-static-1.11.1.tgz_1465608601758_0.0030737747438251972"
+      },
+      "directories": {}
+    },
+    "1.11.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.11.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.14.2"
+      },
+      "devDependencies": {
+        "eslint": "3.14.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "01f2a83d7456ef03a89e8c951c757dd79ae92522",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.11.2",
+      "_shasum": "2cf9889bd4435a320cc36895c9aa57bd662e6ac7",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "2cf9889bd4435a320cc36895c9aa57bd662e6ac7",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/serve-static-1.11.2.tgz_1485190261958_0.8670230756979436"
+      },
+      "directories": {}
+    },
+    "1.12.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.12.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.0"
+      },
+      "devDependencies": {
+        "eslint": "3.16.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "f75f96908b3b4add99352a59af13560859a1b10a",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.12.0",
+      "_shasum": "150eb8aa262c2dd1924e960373145446c069dad6",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "150eb8aa262c2dd1924e960373145446c069dad6",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/serve-static-1.12.0.tgz_1488068897344_0.12889141752384603"
+      },
+      "directories": {}
+    },
+    "1.12.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.12.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.1"
+      },
+      "devDependencies": {
+        "eslint": "3.17.0",
+        "eslint-config-standard": "7.0.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "3e6e778fcf6c88dcf659b8f1d5f06be2eebbe2db",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.12.1",
+      "_shasum": "7443a965e3ced647aceb5639fa06bf4d1bbe0039",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "7443a965e3ced647aceb5639fa06bf4d1bbe0039",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/serve-static-1.12.1.tgz_1488686352386_0.390035341726616"
+      },
+      "directories": {}
+    },
+    "1.12.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.12.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "cb296b7ddfa869590d5ce0acb3f4a96b66f1d2b7",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.12.2",
+      "_shasum": "e546e2726081b81b4bcec8e90808ebcdd323afba",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "e546e2726081b81b4bcec8e90808ebcdd323afba",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/serve-static-1.12.2.tgz_1493262384444_0.37266619759611785"
+      },
+      "directories": {}
+    },
+    "1.12.3": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.12.3",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.3"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "281475f89cf5b3f4801ed4e5767fce7b0976e411",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.12.3",
+      "_shasum": "9f4ba19e2f3030c547f8af99107838ec38d5b1e2",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "9f4ba19e2f3030c547f8af99107838ec38d5b1e2",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/serve-static-1.12.3.tgz_1494998781756_0.8577500546816736"
+      },
+      "directories": {}
+    },
+    "1.12.4": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.12.4",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.4"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.6.1",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "c16b4d1c2c7bc1aaf76194187f087549b63bf2f9",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.12.4",
+      "_shasum": "9b6aa98eeb7253c4eedc4c1f6fdbca609901a961",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "9b6aa98eeb7253c4eedc4c1f6fdbca609901a961",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-static-1.12.4.tgz_1501998894621_0.48076217574998736"
+      },
+      "directories": {}
+    },
+    "1.12.5": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.12.5",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.15.5"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "afd17c3a6ffe81085e606b89d103959a6dc1ef19",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.12.5",
+      "_shasum": "693a54118216f0310105c7180e5fdd6a50f654a5",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "693a54118216f0310105c7180e5fdd6a50f654a5",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-static-1.12.5.tgz_1506036076569_0.7109229087363929"
+      },
+      "directories": {}
+    },
+    "1.12.6": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.12.6",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.15.6"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "843d1eabfdef46396c4f6d59d19a955f14574aaa",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.12.6",
+      "_shasum": "b973773f63449934da54e5beba5e31d9f4211577",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "b973773f63449934da54e5beba5e31d9f4211577",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-static-1.12.6.tgz_1506126249562_0.78251140168868"
+      },
+      "directories": {}
+    },
+    "1.13.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.13.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "1c58cfdd2ab8bee9ed5d37bb5b54047f839349ed",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.13.0",
+      "_shasum": "810c91db800e94ba287eae6b4e06caab9fdc16f1",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "810c91db800e94ba287eae6b4e06caab9fdc16f1",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-static-1.13.0.tgz_1506561074296_0.6352248503826559"
+      },
+      "directories": {}
+    },
+    "1.13.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.13.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.1"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "f6f76136aa967f917886730c57efd4c9d3bc12f7",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.13.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "6.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+        "shasum": "4c57d53404a761d8f2e7c1e8a18a47dbf278a719",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-static-1.13.1.tgz_1506715867957_0.268530584173277"
+      },
+      "directories": {}
+    },
+    "1.13.2": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.13.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/"
+      },
+      "gitHead": "f287bd6c26ad2bfd0422c533b0358f2f4b16f7db",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.13.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "6.12.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+        "shasum": "095e8472fd5b46237db50ce486a43f4b86c6cec1",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 24364
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-static_1.13.2_1518028719917_0.8918243597229449"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.14.0": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.14.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.0"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "safe-buffer": "5.1.2",
+        "supertest": "4.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "a8918403e423da80993ecafdec5709d75e06e6c2",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.14.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-Kg15ayeXWLhAE5T9adD3xGcEHchIZsDUExIIfSTOzg6kgmIa86NP8NpuOAYKLbPEYU1OQ+KCQrtKh8AG3h7KAQ==",
+        "shasum": "fad67e9f36d8c670b93fffd0586afe634f6c88a5",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 24749,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc0k4NCRA9TVsSAnZWagAA7mkQAI7fJzKb8h9eZnXTjYY8\nZTg81cXUpO2bJnIx7ZQkiyL4KQaO62FVuVF/T0l2fAuaqE9MqUWVFGuqyYN7\nu0ZO2vHCf3SZqqNxdBw+xMFD8mIHHyCsAy1se1TyI1yXpo9nbuh5a5aCL4Tm\n0Ly+NazfLOtu/YX7JUj2qwI0BscPJuWB6sUiOZC1pQshiGmOomAbrD/6s7nr\nDkFMFSs5B6/GpiYkh5gHh+JI2NXFxzxciUpHcq2Ef0G5sDbPt3I1p+tuL/EV\noI9lugHSRh6P5hyB9M60a+SeQAS4sRea77VigXNjotHUw7krTUgVA4+pJUdA\no4fEAJg0+rxUK6SEcI4vADXDqRU1CG7FQBgYle+wJdp3IwbEWd47sfZE1ZIW\nVXgK5HWU9+Di8TCTSasM8JSiwqsIJZTL3C3Q2R0Jilsw8JE8EIsgrx/gSlyM\nXnWa/JWRVpj/w64IGf+gH2nl36B9Y938bjaTKMEYxiHpWnu9Yl0yWixsD3kw\nOSyoLv1ZvGLml4u6g+EzCsRup8pZOtT2+TJFI0IHsVYbskdTAE7q5H6R0Ra0\nlwqgdqMdS83Bf80wc/B6XRH5ZJINxWglV6kUfiOMp3Y2dBt83aiePOqsaOKI\nQKHrB1EtbjNjez0YVrqGH0rVsCenXD6pu5YHkO1Hg3YsoTUEeMzyET0AQ6tJ\nHaMq\r\n=44Cy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-static_1.14.0_1557286413079_0.3223911248244453"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.14.1": {
+      "name": "serve-static",
+      "description": "Serve static files",
+      "version": "1.14.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/expressjs/serve-static.git"
+      },
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "safe-buffer": "5.1.2",
+        "supertest": "4.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "94feedb81682f4503ed9f8dc6d51a5c1b9bfa091",
+      "bugs": {
+        "url": "https://github.com/expressjs/serve-static/issues"
+      },
+      "homepage": "https://github.com/expressjs/serve-static#readme",
+      "_id": "serve-static@1.14.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+        "shasum": "666e636dc4f010f7ef29970a88a674320898b2f9",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 24894,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1kQ5CRA9TVsSAnZWagAATzwP/j3OHYbfRHaSzvx+7R9w\nS65ncOxHfuv8DsFQRCJsWmkq1+px8WBIRCZiPePbZC4U/bH9ZnOSycKOWEn9\nc+YAWpOvR+JGFJjMI2KFn3kQgb//WFnD6Hg2d1wY9CeIGp5wfhyDpf7sl1oZ\n9MByAaTfHBxc46eoZ5w2drm7XlOseA5rk8r12NeN7q5JVVRJuPUS2k3Xu+sM\n4vv95+kKz9K4kNLxKfBxK28DNKk1zbtvfade6fMi24YfWVSJO+eiQZ2pCXXf\nx5I31i7gE6RMM2ijr/mwCsZn4zGMzWhnRgejTxEIQeEGm5skMP8MfeobUNon\nRb/XABMEAhWwYBssPwOccjlBPy+iK5KYxSihx28uIj++yreQIWqjdHaqeq7j\nZPdUitvLTfZ3PNCKwtjYqfbKQXZhGlMoT0fOIHYm7KXT2RRwi8XyZVR607xT\nBZVksFpf3K7uuoRWowRohNTpNRJZI90sUm08IBV3iL6XtJg4Rb/iGZCOUHnJ\nEcPKmQZxPKE/Af//RTqBQAOSfYSCoHrWzI7M07JEuGHsQSXB1eeXtZkVirqd\n9i9kSN/u1j7UMj6ml2OJTcH4mchvkPYTS+I+ailnzEPqyaXVZvYCOGTZ4OAl\ng5lKaWEDeYxdg2FwjWKRQCU39kaV7Ia47fTY0sDGfqXREPyJ3ZyhuMrBKHac\nMTiw\r\n=GE2J\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/serve-static_1.14.1_1557546040326_0.1307430777112919"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# serve-static\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Linux Build][travis-image]][travis-url]\n[![Windows Build][appveyor-image]][appveyor-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\n## Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install serve-static\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar serveStatic = require('serve-static')\n```\n\n### serveStatic(root, options)\n\nCreate a new middleware function to serve files from within a given root\ndirectory. The file to serve will be determined by combining `req.url`\nwith the provided root directory. When a file is not found, instead of\nsending a 404 response, this module will instead call `next()` to move on\nto the next middleware, allowing for stacking and fall-backs.\n\n#### Options\n\n##### acceptRanges\n\nEnable or disable accepting ranged requests, defaults to true.\nDisabling this will not send `Accept-Ranges` and ignore the contents\nof the `Range` request header.\n\n##### cacheControl\n\nEnable or disable setting `Cache-Control` response header, defaults to\ntrue. Disabling this will ignore the `immutable` and `maxAge` options.\n\n##### dotfiles\n\n Set how \"dotfiles\" are treated when encountered. A dotfile is a file\nor directory that begins with a dot (\".\"). Note this check is done on\nthe path itself without checking if the path actually exists on the\ndisk. If `root` is specified, only the dotfiles above the root are\nchecked (i.e. the root itself can be within a dotfile when set\nto \"deny\").\n\n  - `'allow'` No special treatment for dotfiles.\n  - `'deny'` Deny a request for a dotfile and 403/`next()`.\n  - `'ignore'` Pretend like the dotfile does not exist and 404/`next()`.\n\nThe default value is similar to `'ignore'`, with the exception that this\ndefault will not ignore the files within a directory that begins with a dot.\n\n##### etag\n\nEnable or disable etag generation, defaults to true.\n\n##### extensions\n\nSet file extension fallbacks. When set, if a file is not found, the given\nextensions will be added to the file name and search for. The first that\nexists will be served. Example: `['html', 'htm']`.\n\nThe default value is `false`.\n\n##### fallthrough\n\nSet the middleware to have client errors fall-through as just unhandled\nrequests, otherwise forward a client error. The difference is that client\nerrors like a bad request or a request to a non-existent file will cause\nthis middleware to simply `next()` to your next middleware when this value\nis `true`. When this value is `false`, these errors (even 404s), will invoke\n`next(err)`.\n\nTypically `true` is desired such that multiple physical directories can be\nmapped to the same web address or for routes to fill in non-existent files.\n\nThe value `false` can be used if this middleware is mounted at a path that\nis designed to be strictly a single file system directory, which allows for\nshort-circuiting 404s for less overhead. This middleware will also reply to\nall methods.\n\nThe default value is `true`.\n\n##### immutable\n\nEnable or disable the `immutable` directive in the `Cache-Control` response\nheader, defaults to `false`. If set to `true`, the `maxAge` option should\nalso be specified to enable caching. The `immutable` directive will prevent\nsupported clients from making conditional requests during the life of the\n`maxAge` option to check if the file has changed.\n\n##### index\n\nBy default this module will send \"index.html\" files in response to a request\non a directory. To disable this set `false` or to supply a new index pass a\nstring or an array in preferred order.\n\n##### lastModified\n\nEnable or disable `Last-Modified` header, defaults to true. Uses the file\nsystem's last modified value.\n\n##### maxAge\n\nProvide a max-age in milliseconds for http caching, defaults to 0. This\ncan also be a string accepted by the [ms](https://www.npmjs.org/package/ms#readme)\nmodule.\n\n##### redirect\n\nRedirect to trailing \"/\" when the pathname is a dir. Defaults to `true`.\n\n##### setHeaders\n\nFunction to set custom headers on response. Alterations to the headers need to\noccur synchronously. The function is called as `fn(res, path, stat)`, where\nthe arguments are:\n\n  - `res` the response object\n  - `path` the file path that is being sent\n  - `stat` the stat object of the file that is being sent\n\n## Examples\n\n### Serve files with vanilla node.js http server\n\n```js\nvar finalhandler = require('finalhandler')\nvar http = require('http')\nvar serveStatic = require('serve-static')\n\n// Serve up public/ftp folder\nvar serve = serveStatic('public/ftp', { 'index': ['index.html', 'index.htm'] })\n\n// Create server\nvar server = http.createServer(function onRequest (req, res) {\n  serve(req, res, finalhandler(req, res))\n})\n\n// Listen\nserver.listen(3000)\n```\n\n### Serve all files as downloads\n\n```js\nvar contentDisposition = require('content-disposition')\nvar finalhandler = require('finalhandler')\nvar http = require('http')\nvar serveStatic = require('serve-static')\n\n// Serve up public/ftp folder\nvar serve = serveStatic('public/ftp', {\n  'index': false,\n  'setHeaders': setHeaders\n})\n\n// Set header to force download\nfunction setHeaders (res, path) {\n  res.setHeader('Content-Disposition', contentDisposition(path))\n}\n\n// Create server\nvar server = http.createServer(function onRequest (req, res) {\n  serve(req, res, finalhandler(req, res))\n})\n\n// Listen\nserver.listen(3000)\n```\n\n### Serving using express\n\n#### Simple\n\nThis is a simple example of using Express.\n\n```js\nvar express = require('express')\nvar serveStatic = require('serve-static')\n\nvar app = express()\n\napp.use(serveStatic('public/ftp', { 'index': ['default.html', 'default.htm'] }))\napp.listen(3000)\n```\n\n#### Multiple roots\n\nThis example shows a simple way to search through multiple directories.\nFiles are look for in `public-optimized/` first, then `public/` second as\na fallback.\n\n```js\nvar express = require('express')\nvar path = require('path')\nvar serveStatic = require('serve-static')\n\nvar app = express()\n\napp.use(serveStatic(path.join(__dirname, 'public-optimized')))\napp.use(serveStatic(path.join(__dirname, 'public')))\napp.listen(3000)\n```\n\n#### Different settings for paths\n\nThis example shows how to set a different max age depending on the served\nfile type. In this example, HTML files are not cached, while everything else\nis for 1 day.\n\n```js\nvar express = require('express')\nvar path = require('path')\nvar serveStatic = require('serve-static')\n\nvar app = express()\n\napp.use(serveStatic(path.join(__dirname, 'public'), {\n  maxAge: '1d',\n  setHeaders: setCustomCacheControl\n}))\n\napp.listen(3000)\n\nfunction setCustomCacheControl (res, path) {\n  if (serveStatic.mime.lookup(path) === 'text/html') {\n    // Custom Cache-Control for HTML files\n    res.setHeader('Cache-Control', 'public, max-age=0')\n  }\n}\n```\n\n## License\n\n[MIT](LICENSE)\n\n[appveyor-image]: https://badgen.net/appveyor/ci/dougwilson/serve-static/master?label=windows\n[appveyor-url]: https://ci.appveyor.com/project/dougwilson/serve-static\n[coveralls-image]: https://badgen.net/coveralls/c/github/expressjs/serve-static/master\n[coveralls-url]: https://coveralls.io/r/expressjs/serve-static?branch=master\n[node-image]: https://badgen.net/npm/node/serve-static\n[node-url]: https://nodejs.org/en/download/\n[npm-downloads-image]: https://badgen.net/npm/dm/serve-static\n[npm-url]: https://npmjs.org/package/serve-static\n[npm-version-image]: https://badgen.net/npm/v/serve-static\n[travis-image]: https://badgen.net/travis/expressjs/serve-static/master?label=linux\n[travis-url]: https://travis-ci.org/expressjs/serve-static\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-05-11T03:40:43.146Z",
+    "created": "2014-03-06T03:09:28.171Z",
+    "1.0.0": "2014-03-06T03:09:32.347Z",
+    "1.0.1": "2014-03-06T03:26:54.332Z",
+    "1.0.2": "2014-03-06T15:03:41.948Z",
+    "1.0.3": "2014-03-20T18:09:49.893Z",
+    "1.0.4": "2014-04-07T17:01:58.608Z",
+    "1.1.0": "2014-04-24T18:06:17.300Z",
+    "1.2.0": "2014-05-29T17:11:02.362Z",
+    "1.2.1": "2014-06-03T00:43:02.047Z",
+    "1.2.2": "2014-06-09T20:42:02.880Z",
+    "1.2.3": "2014-06-12T01:46:13.711Z",
+    "1.3.0": "2014-06-29T00:35:07.395Z",
+    "1.3.1": "2014-07-09T19:56:13.955Z",
+    "1.3.2": "2014-07-12T02:45:11.917Z",
+    "1.4.0": "2014-07-22T02:36:40.493Z",
+    "1.4.1": "2014-07-26T20:51:44.572Z",
+    "1.4.2": "2014-07-27T19:17:05.102Z",
+    "1.4.3": "2014-07-30T01:57:08.348Z",
+    "1.4.4": "2014-08-04T21:12:30.992Z",
+    "1.5.0": "2014-08-06T05:23:58.966Z",
+    "1.5.1": "2014-08-10T03:49:14.868Z",
+    "1.5.2": "2014-08-15T01:44:34.666Z",
+    "1.5.3": "2014-08-17T17:58:22.850Z",
+    "1.5.4": "2014-09-05T05:06:27.532Z",
+    "1.6.0": "2014-09-08T01:55:54.182Z",
+    "1.6.1": "2014-09-08T02:59:37.793Z",
+    "1.6.2": "2014-09-16T05:51:48.663Z",
+    "1.6.3": "2014-09-24T20:03:28.791Z",
+    "1.6.4": "2014-10-08T17:05:20.120Z",
+    "1.7.0": "2014-10-16T04:15:43.659Z",
+    "1.7.1": "2014-10-23T04:20:01.443Z",
+    "1.7.2": "2015-01-03T04:35:34.564Z",
+    "1.8.0": "2015-01-06T04:17:27.572Z",
+    "1.8.1": "2015-01-21T05:04:38.586Z",
+    "1.6.5": "2015-02-04T22:19:40.440Z",
+    "1.9.0": "2015-02-17T00:46:14.214Z",
+    "1.9.1": "2015-02-17T19:01:22.984Z",
+    "1.9.2": "2015-03-15T02:52:05.823Z",
+    "1.9.3": "2015-05-15T05:12:55.170Z",
+    "1.10.0": "2015-06-18T04:52:56.197Z",
+    "1.10.1": "2016-01-17T04:51:56.747Z",
+    "1.10.2": "2016-01-20T05:56:47.928Z",
+    "1.10.3": "2016-05-31T03:19:43.455Z",
+    "1.11.0": "2016-06-08T06:17:48.440Z",
+    "1.11.1": "2016-06-11T01:30:04.320Z",
+    "1.11.2": "2017-01-23T16:51:02.629Z",
+    "1.12.0": "2017-02-26T00:28:19.390Z",
+    "1.12.1": "2017-03-05T03:59:13.116Z",
+    "1.12.2": "2017-04-27T03:06:26.381Z",
+    "1.12.3": "2017-05-17T05:26:23.671Z",
+    "1.12.4": "2017-08-06T05:54:55.708Z",
+    "1.12.5": "2017-09-21T23:21:20.128Z",
+    "1.12.6": "2017-09-23T00:24:10.593Z",
+    "1.13.0": "2017-09-28T01:11:15.341Z",
+    "1.13.1": "2017-09-29T20:11:08.976Z",
+    "1.13.2": "2018-02-07T18:38:40.596Z",
+    "1.14.0": "2019-05-08T03:33:33.249Z",
+    "1.14.1": "2019-05-11T03:40:40.466Z"
+  },
+  "readmeFilename": "README.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/expressjs/serve-static.git"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/expressjs/serve-static/issues"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/expressjs/serve-static#readme",
+  "users": {
+    "atd": true,
+    "levisl176": true,
+    "illuspas": true,
+    "dgarlitt": true,
+    "h4des": true,
+    "j3kz": true,
+    "mykhael": true,
+    "robermac": true,
+    "vboctor": true,
+    "flockonus": true,
+    "simplyianm": true,
+    "jacktan1991": true,
+    "softwind": true,
+    "damianof": true,
+    "nadimix": true,
+    "sculove": true,
+    "phoenix-xsy": true,
+    "nex": true,
+    "blakecscott": true,
+    "rainstormza": true,
+    "sonhuytran": true,
+    "wkaifang": true,
+    "brentonhouse": true,
+    "mygoare": true,
+    "panlw": true,
+    "kparkov": true,
+    "temoto-kun": true,
+    "kerimdzhanov": true,
+    "danielbankhead": true,
+    "rsp": true,
+    "joshukraine": true,
+    "lwgojustgo": true,
+    "milfromoz": true,
+    "evan2x": true,
+    "jtuesday": true,
+    "wangnan0610": true,
+    "sammok2003": true,
+    "viz": true,
+    "jaqbec": true,
+    "spencermathews": true,
+    "monjer": true,
+    "cptpancake": true,
+    "antixrist": true,
+    "afewinterestingthings": true,
+    "moosecouture": true,
+    "programmer.severson": true,
+    "xiechao06": true,
+    "mobeicaoyuan": true,
+    "scotchulous": true,
+    "kthjm": true,
+    "ghkddbguse": true,
+    "scottfreecode": true,
+    "kistoryg": true,
+    "nickeltobias": true,
+    "mojaray2k": true,
+    "dzhou777": true,
+    "juangotama": true,
+    "itonyyo": true,
+    "jetthiago": true,
+    "usingthesystem": true,
+    "tute": true,
+    "ahmehri": true,
+    "kujisoft": true,
+    "jk6": true,
+    "giussa_dan": true,
+    "isa424": true,
+    "jon_shen": true,
+    "rubiadias": true,
+    "quafoo": true,
+    "rocket0191": true,
+    "jasonwang1888": true,
+    "ridermansb": true,
+    "axelrindle": true,
+    "kankungyip": true,
+    "chaoliu": true,
+    "heartnett": true,
+    "ldq-first": true,
+    "shenyu": true,
+    "drewigg": true,
+    "3ddario": true,
+    "largepuma": true,
+    "wxhthx": true,
+    "asfrom30": true,
+    "mengkzhaoyun": true,
+    "oliverkascha": true,
+    "luffy84217": true,
+    "mayq0422": true,
+    "astesio": true,
+    "fenivana": true,
+    "ubbn": true,
+    "shivayl": true,
+    "71emj1": true,
+    "mrhuangyuhui": true,
+    "codeamancoder": true,
+    "mdedirudianto": true,
+    "sethbergman": true,
+    "eduarte78": true,
+    "endsoul": true,
+    "zuojiang": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/serve-static.min.json
+++ b/test/fixtures/registry-mocks/content/serve-static.min.json
@@ -1,0 +1,1369 @@
+{
+  "name": "serve-static",
+  "dist-tags": {
+    "latest": "1.14.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "serve-static",
+      "version": "1.0.0",
+      "dependencies": {
+        "send": "0.1.4"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "98efa31e6ae767b233bc44c77bd29140b2d31c6f",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.1": {
+      "name": "serve-static",
+      "version": "1.0.1",
+      "dependencies": {
+        "send": "0.1.4"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "10dcbfd44b3e0291a131fc9ab4ab25a9f5a78a42",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.2": {
+      "name": "serve-static",
+      "version": "1.0.2",
+      "dependencies": {
+        "send": "0.2.0"
+      },
+      "devDependencies": {
+        "connect": "^2.13.0",
+        "mocha": "^1.17.0",
+        "should": "^3.0.0",
+        "supertest": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "4129f6727b09fb031134fa6d185683e30bfbef54",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.3": {
+      "name": "serve-static",
+      "version": "1.0.3",
+      "dependencies": {
+        "send": "0.2.0"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.17.1",
+        "should": "~3.1.3",
+        "supertest": "~0.9.0"
+      },
+      "dist": {
+        "shasum": "3443a4002fb50d7fa0a777bb53103301e4d0c38a",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.4": {
+      "name": "serve-static",
+      "version": "1.0.4",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "send": "0.2.0"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.18.2",
+        "should": "~3.3.0",
+        "supertest": "~0.10.0"
+      },
+      "dist": {
+        "shasum": "426fedebe77bad21f373f1efcae09746639fba06",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.1.0": {
+      "name": "serve-static",
+      "version": "1.1.0",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "send": "0.3.0"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.18.2",
+        "should": "~3.3.0",
+        "supertest": "~0.11.0"
+      },
+      "dist": {
+        "shasum": "454dfa05bb3ddd4e701a8915b83a278aa91c5643",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.0": {
+      "name": "serve-static",
+      "version": "1.2.0",
+      "dependencies": {
+        "parseurl": "1.0.1",
+        "send": "0.4.0"
+      },
+      "devDependencies": {
+        "connect": "~2.14.1",
+        "mocha": "~1.18.2",
+        "should": "~3.3.0",
+        "supertest": "~0.11.0"
+      },
+      "dist": {
+        "shasum": "b711bde722cad70686c1add385c6020bcdb7d295",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.1": {
+      "name": "serve-static",
+      "version": "1.2.1",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.4.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "a800a9de23dbd1ffb1258edb986128ee4a4ea03d",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.2": {
+      "name": "serve-static",
+      "version": "1.2.2",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.4.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "6ffc6c23fad03bcd0710eceda844123bd71bc951",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.2.3": {
+      "name": "serve-static",
+      "version": "1.2.3",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.4.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "93cecbc340f079ecb8589281d1dc31c26c0cd158",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.2.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.0": {
+      "name": "serve-static",
+      "version": "1.3.0",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "1.0.1",
+        "send": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.13",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "0aba0b27c1b8264eee1a3f9c615886738d9727cb",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.1": {
+      "name": "serve-static",
+      "version": "1.3.1",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.1.3",
+        "send": "0.5.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "95489d1bcf491d54350d5aeeb2cca53cd3b12d4f",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.3.2": {
+      "name": "serve-static",
+      "version": "1.3.2",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.1.3",
+        "send": "0.6.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "d904a6cbf55f511c78138f6f45ee6e69d9d105ca",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.0": {
+      "name": "serve-static",
+      "version": "1.4.0",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "03c6608035158e3bb999129d9793cddc7e0db772",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.1": {
+      "name": "serve-static",
+      "version": "1.4.1",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "6814dc11c575db0394883af5ec2202ff989491b6",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.2": {
+      "name": "serve-static",
+      "version": "1.4.2",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "0153b12368318402827aad902d0f124e79145092",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.3": {
+      "name": "serve-static",
+      "version": "1.4.3",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "9f08c7dea1b15e2eb1382ae0e12b8a0de295de52",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.4.4": {
+      "name": "serve-static",
+      "version": "1.4.4",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.7.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "9dc99f37a2c5e28cda2fe6045114620a62032f29",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.4.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.0": {
+      "name": "serve-static",
+      "version": "1.5.0",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.2.0",
+        "send": "0.8.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "c0f19e3cb9bef0203258db282a3ddda9cb8e675c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.1": {
+      "name": "serve-static",
+      "version": "1.5.1",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.8.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "86185e202015641a1f962447f5695605cd8aa9c2",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.2": {
+      "name": "serve-static",
+      "version": "1.5.2",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.8.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "565d369193a075edac7fa973550d88df154f7b66",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.3": {
+      "name": "serve-static",
+      "version": "1.5.3",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.8.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "2e28efa5899686fd3ccdb97a80aa464002244581",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.5.4": {
+      "name": "serve-static",
+      "version": "1.5.4",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.8.5",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "819fb37ae46bd02dd520b77fcf7fd8f5112f9782",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.5.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.0": {
+      "name": "serve-static",
+      "version": "1.6.0",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "283f43b9051293691ab4979bf2e09b4482517677",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.1": {
+      "name": "serve-static",
+      "version": "1.6.1",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "2f257563afbe931d28cee4aa3dfeddc975a87193",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.2": {
+      "name": "serve-static",
+      "version": "1.6.2",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "c1390ff43941867250296b091391d25be7c87571",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.3": {
+      "name": "serve-static",
+      "version": "1.6.3",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "b214235d4d4516db050ea9f7b429b46212e79132",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.4": {
+      "name": "serve-static",
+      "version": "1.6.4",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "c512e4188d7a9366672db24e40d294f0c6212367",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.0": {
+      "name": "serve-static",
+      "version": "1.7.0",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.10.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.5",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "af2ad4e619fa2d46dcd19dd59e3b034c92510e4d",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.1": {
+      "name": "serve-static",
+      "version": "1.7.1",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~2.0.0",
+        "should": "~4.1.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "6ea54d5ba7ef563f00e5fad25d0e4f5307e9809b",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.7.2": {
+      "name": "serve-static",
+      "version": "1.7.2",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.10.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "3164ce06d4e6c3459bdcc9d6018fb4fb35e84b39",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.7.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.8.0": {
+      "name": "serve-static",
+      "version": "1.8.0",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.11.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "239e57bbfce030a8933d274e3fe7b55492ea267c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.8.1": {
+      "name": "serve-static",
+      "version": "1.8.1",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.11.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "08fabd39999f050fc311443f46d5888a77ecfc7c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.6.5": {
+      "name": "serve-static",
+      "version": "1.6.5",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.9.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.2",
+        "mocha": "~1.21.0",
+        "should": "~4.0.0",
+        "supertest": "~0.14.0"
+      },
+      "dist": {
+        "shasum": "aca17e0deac4a87729f6078781b7d27f63aa3d9c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.9.0": {
+      "name": "serve-static",
+      "version": "1.9.0",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.12.0",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "d304085813ee0a9b3e1c068c9062a56ad8424b44",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.9.1": {
+      "name": "serve-static",
+      "version": "1.9.1",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.12.1",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~2.1.0",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "a611b2b8a2cfb5f89685f293cb365f3f5eb61451",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.9.2": {
+      "name": "serve-static",
+      "version": "1.9.2",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.12.2",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "~2.2.1",
+        "supertest": "~0.15.0"
+      },
+      "dist": {
+        "shasum": "069fa32453557b218ec2e39140c82d8905d5672c",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.9.3": {
+      "name": "serve-static",
+      "version": "1.9.3",
+      "dependencies": {
+        "escape-html": "1.0.1",
+        "parseurl": "~1.3.0",
+        "send": "0.12.3",
+        "utils-merge": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "5f8da07323ad385ff3dc541f1a7917b2e436eb57",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.10.0": {
+      "name": "serve-static",
+      "version": "1.10.0",
+      "dependencies": {
+        "escape-html": "1.0.2",
+        "parseurl": "~1.3.0",
+        "send": "0.13.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "be632faa685820e4a43ed3df1379135cc4f370d7",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.10.1": {
+      "name": "serve-static",
+      "version": "1.10.1",
+      "dependencies": {
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.0",
+        "send": "0.13.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "7f80024368d7fcd7975d0c38844ec5d9b2c43ac4",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.10.2": {
+      "name": "serve-static",
+      "version": "1.10.2",
+      "dependencies": {
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.13.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "2.3.4",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "feb800d0e722124dd0b00333160c16e9caa8bcb3",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.10.3": {
+      "name": "serve-static",
+      "version": "1.10.3",
+      "dependencies": {
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.13.2"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.1",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "ce5a6ecd3101fed5ec09827dac22a9c29bfb0535",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.11.0": {
+      "name": "serve-static",
+      "version": "1.11.0",
+      "dependencies": {
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.14.0"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "dbe5fb4e4b63d4d11a824b5be3f368907e675bba",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.11.1": {
+      "name": "serve-static",
+      "version": "1.11.1",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.14.1"
+      },
+      "devDependencies": {
+        "eslint": "2.11.1",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.3.2",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "d6cce7693505f733c759de57befc1af76c0f0805",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.11.2": {
+      "name": "serve-static",
+      "version": "1.11.2",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.14.2"
+      },
+      "devDependencies": {
+        "eslint": "3.14.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "2cf9889bd4435a320cc36895c9aa57bd662e6ac7",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.12.0": {
+      "name": "serve-static",
+      "version": "1.12.0",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.0"
+      },
+      "devDependencies": {
+        "eslint": "3.16.1",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-markdown": "1.0.0-beta.3",
+        "eslint-plugin-promise": "3.4.0",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "150eb8aa262c2dd1924e960373145446c069dad6",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.12.1": {
+      "name": "serve-static",
+      "version": "1.12.1",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.1"
+      },
+      "devDependencies": {
+        "eslint": "3.17.0",
+        "eslint-config-standard": "7.0.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "7443a965e3ced647aceb5639fa06bf4d1bbe0039",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.12.2": {
+      "name": "serve-static",
+      "version": "1.12.2",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "e546e2726081b81b4bcec8e90808ebcdd323afba",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.12.3": {
+      "name": "serve-static",
+      "version": "1.12.3",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.3"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.2.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "4.2.2",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "9f4ba19e2f3030c547f8af99107838ec38d5b1e2",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.12.4": {
+      "name": "serve-static",
+      "version": "1.12.4",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
+        "send": "0.15.4"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.6.1",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "9b6aa98eeb7253c4eedc4c1f6fdbca609901a961",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.12.5": {
+      "name": "serve-static",
+      "version": "1.12.5",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.15.5"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "693a54118216f0310105c7180e5fdd6a50f654a5",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.12.6": {
+      "name": "serve-static",
+      "version": "1.12.6",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.15.6"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "b973773f63449934da54e5beba5e31d9f4211577",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.13.0": {
+      "name": "serve-static",
+      "version": "1.13.0",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.0"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "810c91db800e94ba287eae6b4e06caab9fdc16f1",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.13.1": {
+      "name": "serve-static",
+      "version": "1.13.1",
+      "dependencies": {
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.1"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.0",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
+        "shasum": "4c57d53404a761d8f2e7c1e8a18a47dbf278a719",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.13.2": {
+      "name": "serve-static",
+      "version": "1.13.2",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+        "shasum": "095e8472fd5b46237db50ce486a43f4b86c6cec1",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 24364
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.14.0": {
+      "name": "serve-static",
+      "version": "1.14.0",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.0"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "safe-buffer": "5.1.2",
+        "supertest": "4.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-Kg15ayeXWLhAE5T9adD3xGcEHchIZsDUExIIfSTOzg6kgmIa86NP8NpuOAYKLbPEYU1OQ+KCQrtKh8AG3h7KAQ==",
+        "shasum": "fad67e9f36d8c670b93fffd0586afe634f6c88a5",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 24749,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc0k4NCRA9TVsSAnZWagAA7mkQAI7fJzKb8h9eZnXTjYY8\nZTg81cXUpO2bJnIx7ZQkiyL4KQaO62FVuVF/T0l2fAuaqE9MqUWVFGuqyYN7\nu0ZO2vHCf3SZqqNxdBw+xMFD8mIHHyCsAy1se1TyI1yXpo9nbuh5a5aCL4Tm\n0Ly+NazfLOtu/YX7JUj2qwI0BscPJuWB6sUiOZC1pQshiGmOomAbrD/6s7nr\nDkFMFSs5B6/GpiYkh5gHh+JI2NXFxzxciUpHcq2Ef0G5sDbPt3I1p+tuL/EV\noI9lugHSRh6P5hyB9M60a+SeQAS4sRea77VigXNjotHUw7krTUgVA4+pJUdA\no4fEAJg0+rxUK6SEcI4vADXDqRU1CG7FQBgYle+wJdp3IwbEWd47sfZE1ZIW\nVXgK5HWU9+Di8TCTSasM8JSiwqsIJZTL3C3Q2R0Jilsw8JE8EIsgrx/gSlyM\nXnWa/JWRVpj/w64IGf+gH2nl36B9Y938bjaTKMEYxiHpWnu9Yl0yWixsD3kw\nOSyoLv1ZvGLml4u6g+EzCsRup8pZOtT2+TJFI0IHsVYbskdTAE7q5H6R0Ra0\nlwqgdqMdS83Bf80wc/B6XRH5ZJINxWglV6kUfiOMp3Y2dBt83aiePOqsaOKI\nQKHrB1EtbjNjez0YVrqGH0rVsCenXD6pu5YHkO1Hg3YsoTUEeMzyET0AQ6tJ\nHaMq\r\n=44Cy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.14.1": {
+      "name": "serve-static",
+      "version": "1.14.1",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "istanbul": "0.4.5",
+        "mocha": "6.1.4",
+        "safe-buffer": "5.1.2",
+        "supertest": "4.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+        "shasum": "666e636dc4f010f7ef29970a88a674320898b2f9",
+        "tarball": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 24894,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc1kQ5CRA9TVsSAnZWagAATzwP/j3OHYbfRHaSzvx+7R9w\nS65ncOxHfuv8DsFQRCJsWmkq1+px8WBIRCZiPePbZC4U/bH9ZnOSycKOWEn9\nc+YAWpOvR+JGFJjMI2KFn3kQgb//WFnD6Hg2d1wY9CeIGp5wfhyDpf7sl1oZ\n9MByAaTfHBxc46eoZ5w2drm7XlOseA5rk8r12NeN7q5JVVRJuPUS2k3Xu+sM\n4vv95+kKz9K4kNLxKfBxK28DNKk1zbtvfade6fMi24YfWVSJO+eiQZ2pCXXf\nx5I31i7gE6RMM2ijr/mwCsZn4zGMzWhnRgejTxEIQeEGm5skMP8MfeobUNon\nRb/XABMEAhWwYBssPwOccjlBPy+iK5KYxSihx28uIj++yreQIWqjdHaqeq7j\nZPdUitvLTfZ3PNCKwtjYqfbKQXZhGlMoT0fOIHYm7KXT2RRwi8XyZVR607xT\nBZVksFpf3K7uuoRWowRohNTpNRJZI90sUm08IBV3iL6XtJg4Rb/iGZCOUHnJ\nEcPKmQZxPKE/Af//RTqBQAOSfYSCoHrWzI7M07JEuGHsQSXB1eeXtZkVirqd\n9i9kSN/u1j7UMj6ml2OJTcH4mchvkPYTS+I+ailnzEPqyaXVZvYCOGTZ4OAl\ng5lKaWEDeYxdg2FwjWKRQCU39kaV7Ia47fTY0sDGfqXREPyJ3ZyhuMrBKHac\nMTiw\r\n=GE2J\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    }
+  },
+  "modified": "2019-05-11T03:40:43.146Z"
+}

--- a/test/fixtures/registry-mocks/content/setprototypeof.json
+++ b/test/fixtures/registry-mocks/content/setprototypeof.json
@@ -1,0 +1,436 @@
+{
+  "_id": "setprototypeof",
+  "_rev": "14-fe7ed5e208ddd12980055beb47b4e8ec",
+  "name": "setprototypeof",
+  "description": "A small polyfill for Object.setprototypeof",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "setprototypeof",
+      "version": "1.0.0",
+      "description": "A small polyfill for Object.setprototypeof",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/wesleytodd/setprototypeof.git"
+      },
+      "keywords": [
+        "polyfill",
+        "object",
+        "setprototypeof"
+      ],
+      "author": {
+        "name": "Wes Todd"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/wesleytodd/setprototypeof/issues"
+      },
+      "homepage": "https://github.com/wesleytodd/setprototypeof",
+      "gitHead": "737c200fa382c4d10466b48e7426f9c6b38ea358",
+      "_id": "setprototypeof@1.0.0",
+      "_shasum": "d5fafca01e1174d0079bd1bf881f09c8a339794c",
+      "_from": ".",
+      "_npmVersion": "2.1.4",
+      "_nodeVersion": "0.10.29",
+      "_npmUser": {
+        "name": "wesleytodd",
+        "email": "wes@wesleytodd.com"
+      },
+      "maintainers": [
+        {
+          "name": "wesleytodd",
+          "email": "wes@wesleytodd.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d5fafca01e1174d0079bd1bf881f09c8a339794c",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "setprototypeof",
+      "version": "1.0.1",
+      "description": "A small polyfill for Object.setprototypeof",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wesleytodd/setprototypeof.git"
+      },
+      "keywords": [
+        "polyfill",
+        "object",
+        "setprototypeof"
+      ],
+      "author": {
+        "name": "Wes Todd"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/wesleytodd/setprototypeof/issues"
+      },
+      "homepage": "https://github.com/wesleytodd/setprototypeof",
+      "gitHead": "1e3d0cde6b7f4a9fba10cd28e62b200c9d8f899f",
+      "_id": "setprototypeof@1.0.1",
+      "_shasum": "52009b27888c4dc48f591949c0a8275834c1ca7e",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "wesleytodd",
+        "email": "wes@wesleytodd.com"
+      },
+      "dist": {
+        "shasum": "52009b27888c4dc48f591949c0a8275834c1ca7e",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "wesleytodd",
+          "email": "wes@wesleytodd.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/setprototypeof-1.0.1.tgz_1454803015119_0.7522649802267551"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "setprototypeof",
+      "version": "1.0.2",
+      "description": "A small polyfill for Object.setprototypeof",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wesleytodd/setprototypeof.git"
+      },
+      "keywords": [
+        "polyfill",
+        "object",
+        "setprototypeof"
+      ],
+      "author": {
+        "name": "Wes Todd"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/wesleytodd/setprototypeof/issues"
+      },
+      "homepage": "https://github.com/wesleytodd/setprototypeof",
+      "gitHead": "34da239ae7ab69b7b42791d5b928379ce51a0ff2",
+      "_id": "setprototypeof@1.0.2",
+      "_shasum": "81a552141ec104b88e89ce383103ad5c66564d08",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "wesleytodd",
+        "email": "wes@wesleytodd.com"
+      },
+      "dist": {
+        "shasum": "81a552141ec104b88e89ce383103ad5c66564d08",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "wesleytodd",
+          "email": "wes@wesleytodd.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/setprototypeof-1.0.2.tgz_1479056139581_0.43114364007487893"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "setprototypeof",
+      "version": "1.0.3",
+      "description": "A small polyfill for Object.setprototypeof",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wesleytodd/setprototypeof.git"
+      },
+      "keywords": [
+        "polyfill",
+        "object",
+        "setprototypeof"
+      ],
+      "author": {
+        "name": "Wes Todd"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/wesleytodd/setprototypeof/issues"
+      },
+      "homepage": "https://github.com/wesleytodd/setprototypeof",
+      "gitHead": "a8a71aab8118651b9b0ea97ecfc28521ec82b008",
+      "_id": "setprototypeof@1.0.3",
+      "_shasum": "66567e37043eeb4f04d91bd658c0cbefb55b8e04",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "wesleytodd",
+        "email": "wes@wesleytodd.com"
+      },
+      "dist": {
+        "shasum": "66567e37043eeb4f04d91bd658c0cbefb55b8e04",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "wesleytodd",
+          "email": "wes@wesleytodd.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/setprototypeof-1.0.3.tgz_1487607661334_0.977291816379875"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "setprototypeof",
+      "version": "1.1.0",
+      "description": "A small polyfill for Object.setprototypeof",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wesleytodd/setprototypeof.git"
+      },
+      "keywords": [
+        "polyfill",
+        "object",
+        "setprototypeof"
+      ],
+      "author": {
+        "name": "Wes Todd"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/wesleytodd/setprototypeof/issues"
+      },
+      "homepage": "https://github.com/wesleytodd/setprototypeof",
+      "gitHead": "8fc2c260d8b7da91133edefde49a3df461f220c8",
+      "_id": "setprototypeof@1.1.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.4.0",
+      "_npmUser": {
+        "name": "wesleytodd",
+        "email": "wes@wesleytodd.com"
+      },
+      "dist": {
+        "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+        "shasum": "d0bd85536887b6fe7c0d818cb962d9d91c54e656",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "wesleytodd",
+          "email": "wes@wesleytodd.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/setprototypeof-1.1.0.tgz_1505346623089_0.6391460271552205"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "setprototypeof",
+      "version": "1.1.1",
+      "description": "A small polyfill for Object.setprototypeof",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "test": "standard && mocha",
+        "testallversions": "npm run node010 && npm run node4 && npm run node6 && npm run node9 && npm run node11",
+        "testversion": "docker run -it --rm -v $(PWD):/usr/src/app -w /usr/src/app node:${NODE_VER} npm install mocha@${MOCHA_VER:-latest} && npm t",
+        "node010": "NODE_VER=0.10 MOCHA_VER=3 npm run testversion",
+        "node4": "NODE_VER=4 npm run testversion",
+        "node6": "NODE_VER=6 npm run testversion",
+        "node9": "NODE_VER=9 npm run testversion",
+        "node11": "NODE_VER=11 npm run testversion"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wesleytodd/setprototypeof.git"
+      },
+      "keywords": [
+        "polyfill",
+        "object",
+        "setprototypeof"
+      ],
+      "author": {
+        "name": "Wes Todd"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/wesleytodd/setprototypeof/issues"
+      },
+      "homepage": "https://github.com/wesleytodd/setprototypeof",
+      "devDependencies": {
+        "mocha": "^5.2.0",
+        "standard": "^12.0.1"
+      },
+      "gitHead": "ae67afeeed1b9ba8b351674dd9ccf3b9716ad474",
+      "_id": "setprototypeof@1.1.1",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.3.0",
+      "_npmUser": {
+        "name": "wesleytodd",
+        "email": "wes@wesleytodd.com"
+      },
+      "dist": {
+        "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+        "shasum": "7e95acb24aa92f5885e0abef5ba131330d4ae683",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 3913,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcL6RHCRA9TVsSAnZWagAAwAwP/jcFCYLz/VPbvfeDih6A\nVTjvUfj2y2nNpkvBpHAaW5cX6Z44slEj3kRvaT7zcqaff1WAiZC5hFkxHn0X\nrRHcXffC2cSyNJ9AOSkTZG+H8GMUnhm1R/ueyzc5b3KHdLM69wCNRzsgftQJ\ndQV6/xTIdstCfNEySL8/rJcU1NaRXhnxb4TzPX2tVUk5reexYj2oyCD0b3ly\njwFZ1LK6KsrOrrm7pMf85qWtrlxR1AvQUV6VjWzD/ZhsPuyIiNtwtIWta9P/\nioMD5o5aKOF/Z0SBpk4aix9GzYZ6VjXq7RigKq4uKJfcA+RqSYaq+6KvJUFu\nGVQuAxSckvoXefySe240sE78R5aiWoc8xQJ+bU7OQBkTJ9xpljDtynQ+1P5C\nDIxhpslGtxjHB7N2oE6jsKF2X+Gx5a7gjvFsXLPQZETIBct7PKOjGScqFwfp\nD4xzXJFc5ckNXaaDLUymMno5M/61W2hc3wVaI33Dlj/c0N3wxmYOy5w5DcH3\nVRSQVJwHYm2NB565bdoHnnYyHuohrxpw5QMlF4KkL7xIDwEh+YIlsBp/JFpE\nT12NGnemKX++jXYrIjf1sbjcNWpwigjALNkKfP8i06/Ezhlxmc91oZg/ndxL\nfocbF/+cLh/ix2nt6h1J8E9cdSLKyrOqamfKXA5t9qYB17UZAJVCNS5bO2e+\nhE7g\r\n=4XiP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "wesleytodd",
+          "email": "wes@wesleytodd.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/setprototypeof_1.1.1_1546626118682_0.5274603400934563"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.0": {
+      "name": "setprototypeof",
+      "version": "1.2.0",
+      "description": "A small polyfill for Object.setprototypeof",
+      "main": "index.js",
+      "typings": "index.d.ts",
+      "scripts": {
+        "test": "standard && mocha",
+        "testallversions": "npm run node010 && npm run node4 && npm run node6 && npm run node9 && npm run node11",
+        "testversion": "docker run -it --rm -v $(PWD):/usr/src/app -w /usr/src/app node:${NODE_VER} npm install mocha@${MOCHA_VER:-latest} && npm t",
+        "node010": "NODE_VER=0.10 MOCHA_VER=3 npm run testversion",
+        "node4": "NODE_VER=4 npm run testversion",
+        "node6": "NODE_VER=6 npm run testversion",
+        "node9": "NODE_VER=9 npm run testversion",
+        "node11": "NODE_VER=11 npm run testversion",
+        "prepublishOnly": "npm t",
+        "postpublish": "git push origin && git push origin --tags"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wesleytodd/setprototypeof.git"
+      },
+      "keywords": [
+        "polyfill",
+        "object",
+        "setprototypeof"
+      ],
+      "author": {
+        "name": "Wes Todd"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/wesleytodd/setprototypeof/issues"
+      },
+      "homepage": "https://github.com/wesleytodd/setprototypeof",
+      "devDependencies": {
+        "mocha": "^6.1.4",
+        "standard": "^13.0.2"
+      },
+      "gitHead": "52d00b3a6dbd92fbf36c8019a1e36179b4a0f308",
+      "_id": "setprototypeof@1.2.0",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.3.0",
+      "_npmUser": {
+        "name": "wesleytodd",
+        "email": "wes@wesleytodd.com"
+      },
+      "dist": {
+        "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+        "shasum": "66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 4025,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdL/p1CRA9TVsSAnZWagAAKAcQAI46fu9HmRW3DoNhyrCe\nfby3f4I77mNyE8wMYbKk2u++sApIkulCZdYulwGqKsnynjTtYUSSXETjQ1WH\nlbY8o2GO71azqpQcXCiMXAD7ERUTajp8T/5BIvnqxMtJt/czDaRJ3vLJDH/P\nj0i0S5siqfEUxxZsrerc8oHV6BIrBovTi654ZMHaUQ0DRTUiWutxDZGhhqhq\n3qVixd9p1zqHMK8ZLhwGlybWsVVh8yd6BsE6LvbhmnJkisJncOGek1C02Kbl\n8jRh+juAXV9UPWXBFYClmFAXQgI1YLcp35M7iHWRYc8IlvMqKbpa78Mhqr+q\nJgA9dMwNneF+g25tZYSS+HmP8uKaRofHqQqzzG0p6IuWfdykjiJ71/BaIXKf\nNttwxZoPU6K8yAFksT4BVUGVSY+yngTcsCv/ELYCHCiXtQAJTgCBJxNRhK6B\n6PiGLN/uH7YY7u/rjMhtoMC7+xS+R1M8YX3tcz4pdjbuvvSYUjmQ6xcojBDR\nUvoz0AqLUkx+p14s+NHA4uYkDpx4JqXdn2O3ncD2QCGc0rfP9YDyDhRLtDEf\nJkyWUUwX4F9JOfar2maT4J1wr5zPfRoawjI7AnDcjrclc0E6KItycDzw48pk\nGD8qIxdqpiLqGwtnnrzjdkplaccudApC2uK0dEuCvy37KRTl2M9gB3s+5rqo\ntA+9\r\n=jU56\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "wesleytodd",
+          "email": "wes@wesleytodd.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/setprototypeof_1.2.0_1563425396455_0.08155255328700584"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Polyfill for `Object.setPrototypeOf`\n\n[![NPM Version](https://img.shields.io/npm/v/setprototypeof.svg)](https://npmjs.org/package/setprototypeof)\n[![NPM Downloads](https://img.shields.io/npm/dm/setprototypeof.svg)](https://npmjs.org/package/setprototypeof)\n[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](https://github.com/standard/standard)\n\nA simple cross platform implementation to set the prototype of an instianted object.  Supports all modern browsers and at least back to IE8.\n\n## Usage:\n\n```\n$ npm install --save setprototypeof\n```\n\n```javascript\nvar setPrototypeOf = require('setprototypeof')\n\nvar obj = {}\nsetPrototypeOf(obj, {\n  foo: function () {\n    return 'bar'\n  }\n})\nobj.foo() // bar\n```\n\nTypeScript is also supported:\n\n```typescript\nimport setPrototypeOf from 'setprototypeof'\n```\n",
+  "maintainers": [
+    {
+      "name": "wesleytodd",
+      "email": "wes@wesleytodd.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-07-18T04:49:59.167Z",
+    "created": "2015-02-04T13:56:57.705Z",
+    "1.0.0": "2015-02-04T13:56:57.705Z",
+    "1.0.1": "2016-02-06T23:56:57.210Z",
+    "1.0.2": "2016-11-13T16:55:41.672Z",
+    "1.0.3": "2017-02-20T16:21:03.362Z",
+    "1.1.0": "2017-09-13T23:50:24.119Z",
+    "1.1.1": "2019-01-04T18:21:58.834Z",
+    "1.2.0": "2019-07-18T04:49:56.614Z"
+  },
+  "homepage": "https://github.com/wesleytodd/setprototypeof",
+  "keywords": [
+    "polyfill",
+    "object",
+    "setprototypeof"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wesleytodd/setprototypeof.git"
+  },
+  "author": {
+    "name": "Wes Todd"
+  },
+  "bugs": {
+    "url": "https://github.com/wesleytodd/setprototypeof/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "mojaray2k": true,
+    "wangnan0610": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/setprototypeof.min.json
+++ b/test/fixtures/registry-mocks/content/setprototypeof.min.json
@@ -1,0 +1,82 @@
+{
+  "name": "setprototypeof",
+  "dist-tags": {
+    "latest": "1.2.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "setprototypeof",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "d5fafca01e1174d0079bd1bf881f09c8a339794c",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "setprototypeof",
+      "version": "1.0.1",
+      "dist": {
+        "shasum": "52009b27888c4dc48f591949c0a8275834c1ca7e",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "setprototypeof",
+      "version": "1.0.2",
+      "dist": {
+        "shasum": "81a552141ec104b88e89ce383103ad5c66564d08",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "setprototypeof",
+      "version": "1.0.3",
+      "dist": {
+        "shasum": "66567e37043eeb4f04d91bd658c0cbefb55b8e04",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "setprototypeof",
+      "version": "1.1.0",
+      "dist": {
+        "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+        "shasum": "d0bd85536887b6fe7c0d818cb962d9d91c54e656",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "setprototypeof",
+      "version": "1.1.1",
+      "devDependencies": {
+        "mocha": "^5.2.0",
+        "standard": "^12.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+        "shasum": "7e95acb24aa92f5885e0abef5ba131330d4ae683",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 3913,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcL6RHCRA9TVsSAnZWagAAwAwP/jcFCYLz/VPbvfeDih6A\nVTjvUfj2y2nNpkvBpHAaW5cX6Z44slEj3kRvaT7zcqaff1WAiZC5hFkxHn0X\nrRHcXffC2cSyNJ9AOSkTZG+H8GMUnhm1R/ueyzc5b3KHdLM69wCNRzsgftQJ\ndQV6/xTIdstCfNEySL8/rJcU1NaRXhnxb4TzPX2tVUk5reexYj2oyCD0b3ly\njwFZ1LK6KsrOrrm7pMf85qWtrlxR1AvQUV6VjWzD/ZhsPuyIiNtwtIWta9P/\nioMD5o5aKOF/Z0SBpk4aix9GzYZ6VjXq7RigKq4uKJfcA+RqSYaq+6KvJUFu\nGVQuAxSckvoXefySe240sE78R5aiWoc8xQJ+bU7OQBkTJ9xpljDtynQ+1P5C\nDIxhpslGtxjHB7N2oE6jsKF2X+Gx5a7gjvFsXLPQZETIBct7PKOjGScqFwfp\nD4xzXJFc5ckNXaaDLUymMno5M/61W2hc3wVaI33Dlj/c0N3wxmYOy5w5DcH3\nVRSQVJwHYm2NB565bdoHnnYyHuohrxpw5QMlF4KkL7xIDwEh+YIlsBp/JFpE\nT12NGnemKX++jXYrIjf1sbjcNWpwigjALNkKfP8i06/Ezhlxmc91oZg/ndxL\nfocbF/+cLh/ix2nt6h1J8E9cdSLKyrOqamfKXA5t9qYB17UZAJVCNS5bO2e+\nhE7g\r\n=4XiP\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.2.0": {
+      "name": "setprototypeof",
+      "version": "1.2.0",
+      "devDependencies": {
+        "mocha": "^6.1.4",
+        "standard": "^13.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+        "shasum": "66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424",
+        "tarball": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 4025,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdL/p1CRA9TVsSAnZWagAAKAcQAI46fu9HmRW3DoNhyrCe\nfby3f4I77mNyE8wMYbKk2u++sApIkulCZdYulwGqKsnynjTtYUSSXETjQ1WH\nlbY8o2GO71azqpQcXCiMXAD7ERUTajp8T/5BIvnqxMtJt/czDaRJ3vLJDH/P\nj0i0S5siqfEUxxZsrerc8oHV6BIrBovTi654ZMHaUQ0DRTUiWutxDZGhhqhq\n3qVixd9p1zqHMK8ZLhwGlybWsVVh8yd6BsE6LvbhmnJkisJncOGek1C02Kbl\n8jRh+juAXV9UPWXBFYClmFAXQgI1YLcp35M7iHWRYc8IlvMqKbpa78Mhqr+q\nJgA9dMwNneF+g25tZYSS+HmP8uKaRofHqQqzzG0p6IuWfdykjiJ71/BaIXKf\nNttwxZoPU6K8yAFksT4BVUGVSY+yngTcsCv/ELYCHCiXtQAJTgCBJxNRhK6B\n6PiGLN/uH7YY7u/rjMhtoMC7+xS+R1M8YX3tcz4pdjbuvvSYUjmQ6xcojBDR\nUvoz0AqLUkx+p14s+NHA4uYkDpx4JqXdn2O3ncD2QCGc0rfP9YDyDhRLtDEf\nJkyWUUwX4F9JOfar2maT4J1wr5zPfRoawjI7AnDcjrclc0E6KItycDzw48pk\nGD8qIxdqpiLqGwtnnrzjdkplaccudApC2uK0dEuCvy37KRTl2M9gB3s+5rqo\ntA+9\r\n=jU56\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-07-18T04:49:59.167Z"
+}

--- a/test/fixtures/registry-mocks/content/sha.js.json
+++ b/test/fixtures/registry-mocks/content/sha.js.json
@@ -1,0 +1,2686 @@
+{
+  "_id": "sha.js",
+  "_rev": "78-39082194caf493f0bdb43c48469af6db",
+  "name": "sha.js",
+  "description": "Streamable SHA hashes in pure javascript",
+  "dist-tags": {
+    "latest": "2.4.11"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "0.0.0",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@0.0.0",
+      "dist": {
+        "shasum": "0a5f0fa333bedc82fe6dc923254a85d36fd2db0d",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "1.0.0",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@1.0.0",
+      "dist": {
+        "shasum": "8fdf3cb893193f1a563f2bbacadb3b84cde8da16",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "1.1.0",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@1.1.0",
+      "dist": {
+        "shasum": "2bc4a3f868d14419affc5053d4b4f3182c39ae17",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "1.2.0",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@1.2.0",
+      "dist": {
+        "shasum": "9cd782558b6280926e422ae194bd79573163f9e0",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "1.2.1",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@1.2.1",
+      "dist": {
+        "shasum": "2235cdcd49e1b2ede32293f1f7bc6b7fa731af8a",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "1.2.2",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@1.2.2",
+      "dist": {
+        "shasum": "69bdb251b1ba9cc73bceadab306f7ed0fbb5ab83",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "1.3.0",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@1.3.0",
+      "dist": {
+        "shasum": "ae6e0bdd39a9a587274370030fa6ccb93ac23790",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.0.0",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "native-buffer-browserify": "~2.0.8"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.0.0",
+      "dist": {
+        "shasum": "5dfb7678cf0c328ea29a0724d7c58c9bf57125cd",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.1.1",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "native-buffer-browserify": "~2.0.8"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.1.1",
+      "dist": {
+        "shasum": "980fd04b0011f0aa96a0a6ae3e02aea261275f55",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.3": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.1.3",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "native-buffer-browserify": "~2.0.8"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.1.3",
+      "dist": {
+        "shasum": "cf55f22929f57a9cd1c27a8355ba09ac4d8ab0ce",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.4": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.1.4",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.1.4",
+      "_shasum": "c8caee3bdf78f58b5023bf77bae2f2729495acfd",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c8caee3bdf78f58b5023bf77bae2f2729495acfd",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.5": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.1.5",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.1.5",
+      "_shasum": "756b08dcf6df57a4a4c7e791a3a124f5ced18c5f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "756b08dcf6df57a4a4c7e791a3a124f5ced18c5f",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.6": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.1.6",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.1.6",
+      "_shasum": "20e6eb81f3e66f081ddf84dd8f0464bea6c02fd4",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "20e6eb81f3e66f081ddf84dd8f0464bea6c02fd4",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.7": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.1.7",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.1.7",
+      "_shasum": "4ab5d386d5c1a26183e61bcc446a9370a3eb8859",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4ab5d386d5c1a26183e61bcc446a9370a3eb8859",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.7.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.8": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.1.8",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "a8751f6d8a81d49c4f2f0516e037bbc6900d1d8f",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.1.8",
+      "_shasum": "9b89a99b030eed2280b06a2b79383a4ceecd7719",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9b89a99b030eed2280b06a2b79383a4ceecd7719",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.8.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.2": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.2.2",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "eeeb530e69a44ee30fbe9106622ee9741c8043a8",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.2.2",
+      "_shasum": "3067e13b0196d1f88df68a7237c2e1b2c5afa6a9",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3067e13b0196d1f88df68a7237c2e1b2c5afa6a9",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.3": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.2.3",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "68974c360d78cc79f1863727f4a6b97a3a87ea8b",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.2.3",
+      "_shasum": "4df6064880a711f569a0b17e31cd438723ba8c11",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4df6064880a711f569a0b17e31cd438723ba8c11",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.4": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.2.4",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "buffer": "~2.3.2",
+        "global": "^4.2.1",
+        "typedarray": "0.0.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "ba602936b958e19d58c219a4f007d5389c798dc9",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.2.4",
+      "_shasum": "45330cdc5d5fd245decb8f671ed940eb3dab1803",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "45330cdc5d5fd245decb8f671ed940eb3dab1803",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.5": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.2.5",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "global": "^4.2.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "typedarray": "0.0.6",
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "5d6ed4d7116d1e7a0f934b331a303cb4b568c4a3",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.2.5",
+      "_shasum": "bd2cf9763d8b58655c8f7988a4a3f30fada229a3",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bd2cf9763d8b58655c8f7988a4a3f30fada229a3",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.6": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.2.6",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "typedarray": "0.0.6",
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "f867e611f54d4dac371e0b247d72978ba26fca82",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.2.6",
+      "_shasum": "17ddeddc5f722fb66501658895461977867315ba",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "17ddeddc5f722fb66501658895461977867315ba",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+      },
+      "directories": {}
+    },
+    "2.2.7": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.2.7",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "1d3275d844c44f8d93ee7fcbadc6b33c8cb0a1c2",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.2.7",
+      "_shasum": "6c2bf1e6eec8629c44b721899cd62070389fcc28",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6c2bf1e6eec8629c44b721899cd62070389fcc28",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.7.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.3.0",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "ac9d3d4527d4b42566380f28188bc34f5112bf6f",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.3.0",
+      "_shasum": "9fbcbb99583712fd44dedeffebebe5e4617baf71",
+      "_from": ".",
+      "_npmVersion": "1.4.26",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9fbcbb99583712fd44dedeffebebe5e4617baf71",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.1": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.3.1",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "64229ddd3d30073a869a774ef062fa12410602d2",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.3.1",
+      "_shasum": "9568ddab9a50a8b2818164a845e6e288f67b4f07",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9568ddab9a50a8b2818164a845e6e288f67b4f07",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.2": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.3.2",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "69d5974e5edbea59b2027b823c7288259ffd9e6f",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.3.2",
+      "_shasum": "f02f7a0e37de35600218bd78cf749398f4253c65",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f02f7a0e37de35600218bd78cf749398f4253c65",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.3": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.3.3",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "d7c1638cf09c91af5ca4e2a9c5379f40f2ba0953",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.3.3",
+      "_shasum": "7814ac915ea1f328abbec13f55861fd758d44ef1",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7814ac915ea1f328abbec13f55861fd758d44ef1",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.4": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.3.4",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "b044c1019e7a22a5ef7bfa8345eaa2b485ca1220",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.3.4",
+      "_shasum": "dc446f6da31aaf1de1b89417e8d795579f7cfb91",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dc446f6da31aaf1de1b89417e8d795579f7cfb91",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.5": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.3.5",
+      "homepage": "https://github.com/dominictarr/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/dominictarr/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/{vectors,write,hash}.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/17..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "f08a5ea1e030d41f5480247d4c438de04066c91c",
+      "bugs": {
+        "url": "https://github.com/dominictarr/sha.js/issues"
+      },
+      "_id": "sha.js@2.3.5",
+      "_shasum": "e6c0b0f43e29528eb68c0a8251a16c2654d8e331",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e6c0b0f43e29528eb68c0a8251a16c2654d8e331",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.3.6": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.3.6",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "73ae700d77d9be033ddc02820b7bc7958c44e0f8",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.3.6",
+      "_shasum": "10585a3f7fd8f1da715adac6f9d54516da0670cc",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "10585a3f7fd8f1da715adac6f9d54516da0670cc",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+      },
+      "directories": {}
+    },
+    "2.4.0": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.4.0",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "196737d015aee6976b14d4636c2e62bf710e8a53",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.0",
+      "_shasum": "ba7f1a4fe312a88b90dab80f228ab24ef31a7ac3",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ba7f1a4fe312a88b90dab80f228ab24ef31a7ac3",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.4.1": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.4.1",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm test",
+        "test": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "69bca086dad6ae1437f6db782ad0576ae809b566",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.1",
+      "_shasum": "b7daae383cc8deefddbc07780247fafce4328f5b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b7daae383cc8deefddbc07780247fafce4328f5b",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.4.2": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.4.2",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "ee9184bb71cb672167b5f43f580ccb0cf9c22402",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.2",
+      "_shasum": "bc345745589215a7200b5af774e68c3e44d2f188",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bc345745589215a7200b5af774e68c3e44d2f188",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.4.3": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.4.3",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "2047818ca6309f627a2743c28b6b8f83c51e8899",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.3",
+      "_shasum": "5607469fc8544336cd3a987773faf9d55b6daf7b",
+      "_from": ".",
+      "_npmVersion": "3.3.1",
+      "_nodeVersion": "2.3.1",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5607469fc8544336cd3a987773faf9d55b6daf7b",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.4.4": {
+      "name": "sha.js",
+      "description": "streaming sha1 hash in pure javascript",
+      "version": "2.4.4",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "8a30527c7e68d583785e8fd1aeebe004d8541bfc",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.4",
+      "_shasum": "da1b088fde46c9ed4f17e6d29f29f4928e98e251",
+      "_from": ".",
+      "_npmVersion": "2.13.2",
+      "_nodeVersion": "2.5.0",
+      "_npmUser": {
+        "name": "dominictarr",
+        "email": "dominic.tarr@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "dist": {
+        "shasum": "da1b088fde46c9ed4f17e6d29f29f4928e98e251",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.4.5": {
+      "name": "sha.js",
+      "description": "Streamable SHA hashes in pure javascript",
+      "version": "2.4.5",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "9d45c7871b96621ce3c7b9add507e0bcbdeda382",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.5",
+      "_shasum": "27d171efcc82a118b99639ff581660242b506e7c",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "27d171efcc82a118b99639ff581660242b506e7c",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/sha.js-2.4.5.tgz_1456441454357_0.8692891360260546"
+      },
+      "directories": {}
+    },
+    "2.4.7": {
+      "name": "sha.js",
+      "version": "2.4.7",
+      "description": "Streamable SHA hashes in pure javascript",
+      "keywords": [
+        "sha",
+        "sha1",
+        "sha2",
+        "sha224",
+        "sha256",
+        "sha384",
+        "sha512"
+      ],
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "license": "MIT",
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "files": [
+        "lib",
+        "index.js",
+        "bin.js"
+      ],
+      "main": "./index.js",
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/crypto-browserify/sha.js.git"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "tape test/*.js"
+      },
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "gitHead": "e6a0ef616ce221056028921640e0132908b44680",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.7",
+      "_shasum": "06153adfe1112a74a2f448b119a76bf727146099",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "06153adfe1112a74a2f448b119a76bf727146099",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/sha.js-2.4.7.tgz_1478742850867_0.6826028320938349"
+      },
+      "directories": {}
+    },
+    "2.4.8": {
+      "name": "sha.js",
+      "description": "Streamable SHA hashes in pure javascript",
+      "version": "2.4.8",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "c233442bbd5695863d03155511d61bc8dcc63652",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.8",
+      "_shasum": "37068c2c476b6baf402d14a49c67f597921f634f",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.1.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "email@dcousens.com"
+      },
+      "dist": {
+        "shasum": "37068c2c476b6baf402d14a49c67f597921f634f",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/sha.js-2.4.8.tgz_1478821351146_0.4951752780470997"
+      },
+      "directories": {}
+    },
+    "2.4.9": {
+      "name": "sha.js",
+      "description": "Streamable SHA hashes in pure javascript",
+      "version": "2.4.9",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^10.0.2",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "f5906a095ecb3fa70cdad47f3dee93261be872b4",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.9",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+        "shasum": "98f64880474b74f4a38b8da9d3c0f2d104633e7d",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sha.js-2.4.9.tgz_1506347837168_0.3898042682558298"
+      },
+      "directories": {}
+    },
+    "2.4.10": {
+      "name": "sha.js",
+      "description": "Streamable SHA hashes in pure javascript",
+      "version": "2.4.10",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^10.0.2",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "MIT",
+      "gitHead": "7d66b3383d828c3472f5ced4a7c574dbe014180a",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.10",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+        "shasum": "b1fde5cd7d11a5626638a07c604ab909cfa31f9b",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sha.js-2.4.10.tgz_1516592610285_0.07845293125137687"
+      },
+      "directories": {}
+    },
+    "2.4.11": {
+      "name": "sha.js",
+      "description": "Streamable SHA hashes in pure javascript",
+      "version": "2.4.11",
+      "homepage": "https://github.com/crypto-browserify/sha.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/crypto-browserify/sha.js.git"
+      },
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^10.0.2",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "scripts": {
+        "prepublish": "npm ls && npm run unit",
+        "lint": "standard",
+        "test": "npm run lint && npm run unit",
+        "unit": "set -e; for t in test/*.js; do node $t; done;"
+      },
+      "author": {
+        "name": "Dominic Tarr",
+        "email": "dominic.tarr@gmail.com",
+        "url": "dominictarr.com"
+      },
+      "license": "(MIT AND BSD-3-Clause)",
+      "gitHead": "105bfe57c69e13c83fcf7a6ca660dd984cb291bf",
+      "bugs": {
+        "url": "https://github.com/crypto-browserify/sha.js/issues"
+      },
+      "_id": "sha.js@2.4.11",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "dcousens",
+        "email": "npm@dcousens.com"
+      },
+      "dist": {
+        "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+        "shasum": "37a5cf0b81ecbc6943de109ba2960d1b26584ae7",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+        "fileCount": 16,
+        "unpackedSize": 31084
+      },
+      "maintainers": [
+        {
+          "name": "dcousens",
+          "email": "email@dcousens.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sha.js_2.4.11_1521506126147_0.8013128166429841"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# sha.js\n[![NPM Package](https://img.shields.io/npm/v/sha.js.svg?style=flat-square)](https://www.npmjs.org/package/sha.js)\n[![Build Status](https://img.shields.io/travis/crypto-browserify/sha.js.svg?branch=master&style=flat-square)](https://travis-ci.org/crypto-browserify/sha.js)\n[![Dependency status](https://img.shields.io/david/crypto-browserify/sha.js.svg?style=flat-square)](https://david-dm.org/crypto-browserify/sha.js#info=dependencies)\n\n[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)\n\nNode style `SHA` on pure JavaScript.\n\n```js\nvar shajs = require('sha.js')\n\nconsole.log(shajs('sha256').update('42').digest('hex'))\n// => 73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049\nconsole.log(new shajs.sha256().update('42').digest('hex'))\n// => 73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049\n\nvar sha256stream = shajs('sha256')\nsha256stream.end('42')\nconsole.log(sha256stream.read().toString('hex'))\n// => 73475cb40a568e8da8a045ced110137e159f890ac4da883b6b17dc651b3a8049\n```\n\n## supported hashes\n`sha.js` currently implements:\n\n  - SHA (SHA-0) -- **legacy, do not use in new systems**\n  - SHA-1 -- **legacy, do not use in new systems**\n  - SHA-224\n  - SHA-256\n  - SHA-384\n  - SHA-512\n\n\n## Not an actual stream\nNote, this doesn't actually implement a stream, but wrapping this in a stream is trivial.\nIt does update incrementally, so you can hash things larger than RAM, as it uses a constant amount of memory (except when using base64 or utf8 encoding, see code comments).\n\n\n## Acknowledgements\nThis work is derived from Paul Johnston's [A JavaScript implementation of the Secure Hash Algorithm](http://pajhome.org.uk/crypt/md5/sha1.html).\n\n\n## LICENSE [MIT](LICENSE)\n",
+  "maintainers": [
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    }
+  ],
+  "time": {
+    "modified": "2019-07-29T05:28:42.401Z",
+    "created": "2013-12-27T05:28:03.917Z",
+    "0.0.0": "2013-12-27T05:28:03.917Z",
+    "1.0.0": "2013-12-27T07:56:36.540Z",
+    "1.1.0": "2013-12-27T16:31:34.311Z",
+    "1.2.0": "2013-12-31T05:40:57.905Z",
+    "1.2.1": "2013-12-31T11:52:37.277Z",
+    "1.2.2": "2014-01-06T04:03:04.616Z",
+    "1.3.0": "2014-01-06T09:25:05.986Z",
+    "2.0.0": "2014-01-15T09:24:38.093Z",
+    "2.1.1": "2014-01-27T13:30:06.189Z",
+    "2.1.3": "2014-04-27T17:19:21.789Z",
+    "2.1.4": "2014-06-07T01:07:09.546Z",
+    "2.1.5": "2014-06-07T01:10:31.300Z",
+    "2.1.6": "2014-07-19T18:15:47.381Z",
+    "2.1.7": "2014-07-28T07:01:30.817Z",
+    "2.1.8": "2014-08-31T16:55:29.209Z",
+    "2.2.2": "2014-09-16T11:49:33.479Z",
+    "2.2.3": "2014-09-16T12:00:25.991Z",
+    "2.2.4": "2014-09-16T12:28:48.441Z",
+    "2.2.5": "2014-09-16T12:31:34.950Z",
+    "2.2.6": "2014-09-18T09:35:13.144Z",
+    "2.2.7": "2014-11-06T14:27:10.728Z",
+    "2.3.0": "2014-11-18T11:13:36.370Z",
+    "2.3.1": "2015-01-11T11:28:20.352Z",
+    "2.3.2": "2015-01-12T08:43:28.858Z",
+    "2.3.3": "2015-01-12T19:05:09.251Z",
+    "2.3.4": "2015-01-12T19:13:52.346Z",
+    "2.3.5": "2015-01-13T21:36:24.061Z",
+    "2.3.6": "2015-01-14T06:54:46.873Z",
+    "2.4.0": "2015-04-05T05:57:34.534Z",
+    "2.4.1": "2015-05-19T00:43:20.328Z",
+    "2.4.2": "2015-06-05T08:47:52.715Z",
+    "2.4.3": "2015-09-14T12:26:40.015Z",
+    "2.4.4": "2015-09-18T21:28:14.515Z",
+    "2.4.5": "2016-02-25T23:04:16.794Z",
+    "2.4.6": "2016-11-10T01:48:15.798Z",
+    "2.4.7": "2016-11-10T01:54:12.484Z",
+    "2.4.8": "2016-11-10T23:42:33.143Z",
+    "2.4.9": "2017-09-25T13:57:17.311Z",
+    "2.4.10": "2018-01-22T03:43:30.365Z",
+    "2.4.11": "2018-03-20T00:35:26.208Z"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/crypto-browserify/sha.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/crypto-browserify/sha.js.git"
+  },
+  "author": {
+    "name": "Dominic Tarr",
+    "email": "dominic.tarr@gmail.com",
+    "url": "dominictarr.com"
+  },
+  "bugs": {
+    "url": "https://github.com/crypto-browserify/sha.js/issues"
+  },
+  "license": "(MIT AND BSD-3-Clause)",
+  "users": {
+    "miguelprovencio": true,
+    "orkisz": true,
+    "alexlange": true,
+    "hugozap": true,
+    "m0a": true,
+    "4rlekin": true,
+    "scott.m.sarsfield": true,
+    "serge-nikitin": true,
+    "rocket0191": true,
+    "koulmomo": true,
+    "monkeymonk": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/sha.js.min.json
+++ b/test/fixtures/registry-mocks/content/sha.js.min.json
@@ -1,0 +1,730 @@
+{
+  "name": "sha.js",
+  "dist-tags": {
+    "latest": "2.4.11"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "sha.js",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "0a5f0fa333bedc82fe6dc923254a85d36fd2db0d",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-0.0.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "sha.js",
+      "version": "1.0.0",
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "8fdf3cb893193f1a563f2bbacadb3b84cde8da16",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "sha.js",
+      "version": "1.1.0",
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "2bc4a3f868d14419affc5053d4b4f3182c39ae17",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "sha.js",
+      "version": "1.2.0",
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "9cd782558b6280926e422ae194bd79573163f9e0",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "sha.js",
+      "version": "1.2.1",
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "2235cdcd49e1b2ede32293f1f7bc6b7fa731af8a",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "sha.js",
+      "version": "1.2.2",
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "69bdb251b1ba9cc73bceadab306f7ed0fbb5ab83",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.2.2.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "sha.js",
+      "version": "1.3.0",
+      "dependencies": {
+        "bops": "~0.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "ae6e0bdd39a9a587274370030fa6ccb93ac23790",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-1.3.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "sha.js",
+      "version": "2.0.0",
+      "dependencies": {
+        "native-buffer-browserify": "~2.0.8"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "5dfb7678cf0c328ea29a0724d7c58c9bf57125cd",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.0.0.tgz"
+      }
+    },
+    "2.1.1": {
+      "name": "sha.js",
+      "version": "2.1.1",
+      "dependencies": {
+        "native-buffer-browserify": "~2.0.8"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "980fd04b0011f0aa96a0a6ae3e02aea261275f55",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.1.tgz"
+      }
+    },
+    "2.1.3": {
+      "name": "sha.js",
+      "version": "2.1.3",
+      "dependencies": {
+        "native-buffer-browserify": "~2.0.8"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "cf55f22929f57a9cd1c27a8355ba09ac4d8ab0ce",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.3.tgz"
+      }
+    },
+    "2.1.4": {
+      "name": "sha.js",
+      "version": "2.1.4",
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "c8caee3bdf78f58b5023bf77bae2f2729495acfd",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.4.tgz"
+      }
+    },
+    "2.1.5": {
+      "name": "sha.js",
+      "version": "2.1.5",
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "756b08dcf6df57a4a4c7e791a3a124f5ced18c5f",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.5.tgz"
+      }
+    },
+    "2.1.6": {
+      "name": "sha.js",
+      "version": "2.1.6",
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "20e6eb81f3e66f081ddf84dd8f0464bea6c02fd4",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.6.tgz"
+      }
+    },
+    "2.1.7": {
+      "name": "sha.js",
+      "version": "2.1.7",
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "4ab5d386d5c1a26183e61bcc446a9370a3eb8859",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.7.tgz"
+      }
+    },
+    "2.1.8": {
+      "name": "sha.js",
+      "version": "2.1.8",
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "9b89a99b030eed2280b06a2b79383a4ceecd7719",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.1.8.tgz"
+      }
+    },
+    "2.2.2": {
+      "name": "sha.js",
+      "version": "2.2.2",
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "3067e13b0196d1f88df68a7237c2e1b2c5afa6a9",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.2.tgz"
+      }
+    },
+    "2.2.3": {
+      "name": "sha.js",
+      "version": "2.2.3",
+      "dependencies": {
+        "buffer": "~2.3.2"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "4df6064880a711f569a0b17e31cd438723ba8c11",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.3.tgz"
+      }
+    },
+    "2.2.4": {
+      "name": "sha.js",
+      "version": "2.2.4",
+      "dependencies": {
+        "buffer": "~2.3.2",
+        "global": "^4.2.1",
+        "typedarray": "0.0.6"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "45330cdc5d5fd245decb8f671ed940eb3dab1803",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.4.tgz"
+      }
+    },
+    "2.2.5": {
+      "name": "sha.js",
+      "version": "2.2.5",
+      "dependencies": {
+        "global": "^4.2.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "typedarray": "0.0.6",
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "bd2cf9763d8b58655c8f7988a4a3f30fada229a3",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.5.tgz"
+      }
+    },
+    "2.2.6": {
+      "name": "sha.js",
+      "version": "2.2.6",
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "typedarray": "0.0.6",
+        "tape": "~2.3.2"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "17ddeddc5f722fb66501658895461977867315ba",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+      }
+    },
+    "2.2.7": {
+      "name": "sha.js",
+      "version": "2.2.7",
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "6c2bf1e6eec8629c44b721899cd62070389fcc28",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.7.tgz"
+      }
+    },
+    "2.3.0": {
+      "name": "sha.js",
+      "version": "2.3.0",
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "9fbcbb99583712fd44dedeffebebe5e4617baf71",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.0.tgz"
+      }
+    },
+    "2.3.1": {
+      "name": "sha.js",
+      "version": "2.3.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "9568ddab9a50a8b2818164a845e6e288f67b4f07",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.1.tgz"
+      }
+    },
+    "2.3.2": {
+      "name": "sha.js",
+      "version": "2.3.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "f02f7a0e37de35600218bd78cf749398f4253c65",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.2.tgz"
+      }
+    },
+    "2.3.3": {
+      "name": "sha.js",
+      "version": "2.3.3",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "7814ac915ea1f328abbec13f55861fd758d44ef1",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.3.tgz"
+      }
+    },
+    "2.3.4": {
+      "name": "sha.js",
+      "version": "2.3.4",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "dc446f6da31aaf1de1b89417e8d795579f7cfb91",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.4.tgz"
+      }
+    },
+    "2.3.5": {
+      "name": "sha.js",
+      "version": "2.3.5",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "e6c0b0f43e29528eb68c0a8251a16c2654d8e331",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.5.tgz"
+      }
+    },
+    "2.3.6": {
+      "name": "sha.js",
+      "version": "2.3.6",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "10585a3f7fd8f1da715adac6f9d54516da0670cc",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.3.6.tgz"
+      }
+    },
+    "2.4.0": {
+      "name": "sha.js",
+      "version": "2.4.0",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "ba7f1a4fe312a88b90dab80f228ab24ef31a7ac3",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.0.tgz"
+      }
+    },
+    "2.4.1": {
+      "name": "sha.js",
+      "version": "2.4.1",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "b7daae383cc8deefddbc07780247fafce4328f5b",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.1.tgz"
+      }
+    },
+    "2.4.2": {
+      "name": "sha.js",
+      "version": "2.4.2",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "bc345745589215a7200b5af774e68c3e44d2f188",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.2.tgz"
+      }
+    },
+    "2.4.3": {
+      "name": "sha.js",
+      "version": "2.4.3",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "5607469fc8544336cd3a987773faf9d55b6daf7b",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.3.tgz"
+      }
+    },
+    "2.4.4": {
+      "name": "sha.js",
+      "version": "2.4.4",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "da1b088fde46c9ed4f17e6d29f29f4928e98e251",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.4.tgz"
+      }
+    },
+    "2.4.5": {
+      "name": "sha.js",
+      "version": "2.4.5",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "27d171efcc82a118b99639ff581660242b506e7c",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.5.tgz"
+      }
+    },
+    "2.4.7": {
+      "name": "sha.js",
+      "version": "2.4.7",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^6.0.8",
+        "tape": "^4.5.1"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "06153adfe1112a74a2f448b119a76bf727146099",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.7.tgz"
+      }
+    },
+    "2.4.8": {
+      "name": "sha.js",
+      "version": "2.4.8",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^4.0.0",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "shasum": "37068c2c476b6baf402d14a49c67f597921f634f",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+      }
+    },
+    "2.4.9": {
+      "name": "sha.js",
+      "version": "2.4.9",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^10.0.2",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
+        "shasum": "98f64880474b74f4a38b8da9d3c0f2d104633e7d",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.9.tgz"
+      }
+    },
+    "2.4.10": {
+      "name": "sha.js",
+      "version": "2.4.10",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^10.0.2",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+        "shasum": "b1fde5cd7d11a5626638a07c604ab909cfa31f9b",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz"
+      }
+    },
+    "2.4.11": {
+      "name": "sha.js",
+      "version": "2.4.11",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "buffer": "~2.3.2",
+        "hash-test-vectors": "^1.3.1",
+        "standard": "^10.0.2",
+        "tape": "~2.3.2",
+        "typedarray": "0.0.6"
+      },
+      "bin": {
+        "sha.js": "./bin.js"
+      },
+      "dist": {
+        "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+        "shasum": "37a5cf0b81ecbc6943de109ba2960d1b26584ae7",
+        "tarball": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+        "fileCount": 16,
+        "unpackedSize": 31084
+      }
+    }
+  },
+  "modified": "2019-07-29T05:28:42.401Z"
+}

--- a/test/fixtures/registry-mocks/content/snapdragon-node.json
+++ b/test/fixtures/registry-mocks/content/snapdragon-node.json
@@ -1,0 +1,1381 @@
+{
+  "_id": "snapdragon-node",
+  "_rev": "13-1d2f377502526d1bd4fd50463f6ee140",
+  "name": "snapdragon-node",
+  "description": "Class for creating AST nodes.",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.8.1"
+      },
+      "keywords": [
+        "generategenerator",
+        "node",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "snapdragon",
+            "snapdragon-util",
+            "snapdragon-capture"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "05bbed33d061d58c40f4ce15a5d35a61bd403e56",
+      "_id": "snapdragon-node@0.1.0",
+      "_shasum": "2d4e7237df851b93c361a8aab559a918ac4820b2",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2d4e7237df851b93c361a8aab559a918ac4820b2",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-0.1.0.tgz_1484911551650_0.4797430185135454"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.8.1"
+      },
+      "keywords": [
+        "generategenerator",
+        "node",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "snapdragon",
+            "snapdragon-util",
+            "snapdragon-capture"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "8d482a7d939f3467351356eb447eb3e82d5d5dad",
+      "_id": "snapdragon-node@0.2.0",
+      "_shasum": "4d2ee33d72bb1caeb65aa32fdb7c9b9e7fc348e4",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4d2ee33d72bb1caeb65aa32fdb7c9b9e7fc348e4",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-0.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-0.2.0.tgz_1484966199776_0.9185646020341665"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.8.1"
+      },
+      "keywords": [
+        "generategenerator",
+        "node",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "snapdragon",
+            "snapdragon-util",
+            "snapdragon-capture"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "dbc6c32a1ab6d7372b74f74c1160204ba5eac8fd",
+      "_id": "snapdragon-node@1.0.0",
+      "_shasum": "70f06a3e6954bcbb30001c7fabf81a5393eef324",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "70f06a3e6954bcbb30001c7fabf81a5393eef324",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-1.0.0.tgz_1484992379835_0.12347350222989917"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^1.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "snapdragon",
+        "snapdragonplugin",
+        "token"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "e07e4695c05e55b90d983a60a2a0a2b3972cbc2e",
+      "_id": "snapdragon-node@1.0.1",
+      "_shasum": "15e5b89fc84f9d9604657b079606fcbb06cdd0f1",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "15e5b89fc84f9d9604657b079606fcbb06cdd0f1",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-1.0.1.tgz_1484995630258_0.797238051192835"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "1.0.2",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-util": "^1.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "snapdragon",
+        "snapdragonplugin",
+        "token"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "8328f532a2cc7a4ed9ab62caab0602ab34a30863",
+      "_id": "snapdragon-node@1.0.2",
+      "_shasum": "1f29e33d675d5e2d74a052ca798f8fac2c452f04",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1f29e33d675d5e2d74a052ca798f8fac2c452f04",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-1.0.2.tgz_1484998633025_0.20634198607876897"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "1.0.3",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-util": "^1.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "snapdragon",
+        "snapdragonplugin",
+        "token"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "be17d1ef3743fa87e945f68d49a40bd09cfc9bc7",
+      "_id": "snapdragon-node@1.0.3",
+      "_shasum": "54ca3efd8aadedfb015c6af64844d85fe2362b15",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "54ca3efd8aadedfb015c6af64844d85fe2362b15",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-1.0.3.tgz_1484998869720_0.5219865818507969"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "1.0.5",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "snapdragon",
+        "snapdragonplugin",
+        "token"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-util": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.1",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "gitHead": "bea9505d40be74b3c452039e72e857c9ae3c4b5e",
+      "_id": "snapdragon-node@1.0.5",
+      "_shasum": "65f0e1609354f03ab788d462dfad1cdcfc778d42",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "65f0e1609354f03ab788d462dfad1cdcfc778d42",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-1.0.5.tgz_1486278117060_0.4909474002197385"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "1.0.6",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-util": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.1",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "convert",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "token",
+        "transform"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-util",
+            "snapdragon-cheerio",
+            "breakdance"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "bea9505d40be74b3c452039e72e857c9ae3c4b5e",
+      "_id": "snapdragon-node@1.0.6",
+      "_shasum": "2448d5ef6fea7f5e8fd5326a0a114854da271356",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2448d5ef6fea7f5e8fd5326a0a114854da271356",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.6.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-1.0.6.tgz_1487184989101_0.8563321211840957"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": "0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.3.0",
+        "snapdragon": "^0.11.0"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "convert",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "token",
+        "transform"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "breakdance",
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-cheerio",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "3e97da325deaa8a751e0ee20e82495a824229d78",
+      "_id": "snapdragon-node@2.0.0",
+      "_shasum": "2c1fcf7a494da1fea737139f62116bdc7e5ea3ef",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2c1fcf7a494da1fea737139f62116bdc7e5ea3ef",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-2.0.0.tgz_1493640545135_0.04281848669052124"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.3.0",
+        "snapdragon": "^0.11.0"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "convert",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "token",
+        "transform"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "breakdance",
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-cheerio",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "b84e00bde10f9ce5ec40c1a883e323f4fd752506",
+      "_id": "snapdragon-node@2.0.1",
+      "_shasum": "3b485cef2a6d55dfaeb52641a8388c6ea81cbea2",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3b485cef2a6d55dfaeb52641a8388c6ea81cbea2",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-node-2.0.1.tgz_1493641595792_0.8030496526043862"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "2.1.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "object-copy": "^1.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.0",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.2",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.4.2",
+        "snapdragon": "^0.11.0"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "convert",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "token",
+        "transform"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "breakdance",
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-cheerio",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "89723cd26cf2ca5987c127726c94471144a186f6",
+      "_id": "snapdragon-node@2.1.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-ebmlZ8o6BhMUv/mlAnJcFWXcFaa78G8b5vbUqAH7q7aM/++cEb9gdLyG39b+FetOVrXweDjMjm5iqMIZ8BLupA==",
+        "shasum": "09b4ad8c81a6d03216dc85e818b00bc7ff9e504e",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon-node-2.1.0.tgz_1498391683006_0.48273008898831904"
+      },
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "snapdragon-node",
+      "description": "Snapdragon utility for creating a new AST node in custom code, such as plugins.",
+      "version": "2.1.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.0",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.2",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.4.2",
+        "snapdragon": "^0.11.0"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "convert",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "token",
+        "transform"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "breakdance",
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-cheerio",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "d2bc7304fc1b8103d6bb892d9ef099957468ff14",
+      "_id": "snapdragon-node@2.1.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+        "shasum": "6c175f86ff14bdb0724563e8f3c1b021a286853b",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon-node-2.1.1.tgz_1498392256120_0.4632513278629631"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "snapdragon-node",
+      "description": "Class for creating AST nodes.",
+      "version": "3.0.0",
+      "homepage": "https://github.com/here-be/snapdragon-node",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/here-be/snapdragon-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/here-be/snapdragon-node/issues"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha",
+        "cover": "nyc --reporter=text --reporter=html mocha"
+      },
+      "devDependencies": {
+        "define-property": "^2.0.2",
+        "gulp-format-md": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^13.1.0",
+        "snapdragon": "^0.12.0"
+      },
+      "keywords": [
+        "ast",
+        "compile",
+        "compiler",
+        "convert",
+        "node",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "token",
+        "transform"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "breakdance",
+            "snapdragon",
+            "snapdragon-capture",
+            "snapdragon-cheerio",
+            "snapdragon-util"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "7f226faa8c855fb91a4465f50bf16af58ee5826a",
+      "_id": "snapdragon-node@3.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "11.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-8fmjo9AOZXFBWxHS9kOdqA4Mq9x1ldbnPLXjz1voBCmDuQcVBySjlekv4+QnKj0LdNc3hEF19xUrTBQJ2zPyCw==",
+        "shasum": "92f5bc808a7f31be4b50acf489e5c9fc62cf4552",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 35767,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb+RdZCRA9TVsSAnZWagAAXskP/A/+74GxpjNc4nrspuH/\nLk5xauXYoFyDJQcPsn6azQvNxc5qeotX6VlMp1HD131IU6967uy6es1QH5lZ\na/fjlXOUWhH/pISA+uuVzyU+OUIPSuknDeBG0OAg5JWvxcbriFoIQvSNB1Xx\ntBdAeq005OEwq/FSrYpiGxtJ6BGu9XnrbV0kcGze/r2lM2Z24Pfg1sffOFpT\njEAbrm2UMcjeDrWJGs38AqtQvUKO4FL1bvSaBPWDwuLe7eu9fnOomks7O0YU\nbrn/zaBWngMSAX6c8ehaw7aIEwFcgo0+nfo+RmQ41cALkJLF/ZY2AynrumwB\nMkohX/H6hHnx7ye1Qtf5GRbAptY7YOIrRpWv17ZTjApBhI5Y0sL7puEaf0VM\nmP4rC83nZANhH0ArVooZqbIySEzM6QUoPEmw8MnGgUNwPb9uK/VhbT2kajz2\nP+Pp6HqMh72Z19cZmO3sx8QdIINjhqFqT3uDNSiJA4xsaT1Y+KMNrQ2b8PFF\n149Ef6PuLf/Y6Ffiq+mY5YTHaGepPOd/griE7iEIrQjlhuUfkPLsSEO5YRom\nZbFrPfKl+6sTxHTSh1yLdb8Eyt5p3Kl3AcZGb8D3QDB94jZBs7E01dCPCuev\nxzFG1zIdwzOfgxTRrn+REG2VUmdCWblho3jFMeRSEAZ0orDhN4knbiG9N1We\nG42W\r\n=PEEL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "daniel@tschinder.de",
+          "name": "danez"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon-node_3.0.0_1543051096446_0.39484929895287335"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# snapdragon-node [![NPM version](https://img.shields.io/npm/v/snapdragon-node.svg?style=flat)](https://www.npmjs.com/package/snapdragon-node) [![NPM monthly downloads](https://img.shields.io/npm/dm/snapdragon-node.svg?style=flat)](https://npmjs.org/package/snapdragon-node) [![NPM total downloads](https://img.shields.io/npm/dt/snapdragon-node.svg?style=flat)](https://npmjs.org/package/snapdragon-node) [![Linux Build Status](https://img.shields.io/travis/here-be/snapdragon-node.svg?style=flat&label=Travis)](https://travis-ci.org/here-be/snapdragon-node)\n\n> Class for creating AST nodes.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save snapdragon-node\n```\n\n## Usage\n\n```js\nconst Node = require('snapdragon-node');\n// either pass on object with \"type\" and (optional) \"val\"\nconst node1 = new Node({type: 'star', val: '*'});\n// or pass \"val\" (first) and \"type\" (second) as string\nconst node2 = new Node('*', 'star');\n// both result in => Node { type: 'star', val: '*' }\n```\n\n## Snapdragon usage\n\nWith [snapdragon](https://github.com/here-be/snapdragon) v0.9.0 and higher, it's recommended that you use `this.node()` to create a new `Node` inside parser handlers (instead of doing `new Node()`).\n\n### Snapdragon ^1.0.0\n\nExample usage inside a [snapdragon](https://github.com/here-be/snapdragon) parser handler function.\n\n```js\nconst Node = require('snapdragon-node');\nconst Token = require('snapdragon-token');\n\n// create a new AST node\nconst node = new Node({ type: 'star', value: '*' });\n\n// convert a Lexer Token into an AST Node\nconst token = new Token({ type: 'star', value: '*' });\nconst node = new Node(token);\n```\n\n## Node objects\n\nAST Nodes are represented as `Node` objects that implement the following interface:\n\n```js\ninterface Node {\n  type: string;\n  value: string | undefined\n  nodes: array | undefined\n}\n```\n\n* `type` **{string}** - A string representing the node variant type. This property is often used for classifying the purpose or nature of the node, so that parsers or compilers can determine what to do with it.\n* `value` **{string|undefined}** (optional) - In general, value should only be a string when `node.nodes` is undefined. This is not reinforced, but is considered good practice. Use a different property name to store arbitrary strings on the node when `node.nodes` is an array.\n* `nodes` **{array|undefined}** (optional) - array of child nodes\n\nA number of useful methods and non-enumerable properties are also exposed for adding, finding and removing child nodes, etc.\n\nContinue reading the API documentation for more details.\n\n## Node API\n\n### [Node](index.js#L20)\n\nCreate a new AST `Node` with the given `type` and `value`, or an object to initialize with.\n\n**Params**\n\n* `type` **{object|string}**: Either an object to initialize with, or a string to be used as the `node.type`.\n* `value` **{string|boolean}**: If the first argument is a string, the second argument may be a string value to set on `node.value`.\n* `clone` **{boolean}**: When an object is passed as the first argument, pass true as the last argument to deep clone values before assigning them to the new node.\n* `returns` **{Object}**: node instance\n\n**Example**\n\n```js\nconsole.log(new Node({ type: 'star', value: '*' }));\nconsole.log(new Node('star', '*'));\n// both result in => Node { type: 'star', value: '*' }\n```\n\n### [.clone](index.js#L50)\n\nReturn a clone of the node. Values that are arrays or plain objects are deeply cloned.\n\n* `returns` **{Object}**: returns a clone of the node\n\n**Example**\n\n```js\nconst node = new Node({type: 'star', value: '*'});\nconsle.log(node.clone() !== node);\n//=> true\n```\n\n### [.stringify](index.js#L68)\n\nReturn a string created from `node.value` and/or recursively visiting over `node.nodes`.\n\n* `returns` **{String}**\n\n**Example**\n\n```js\nconst node = new Node({type: 'star', value: '*'});\nconsle.log(node.stringify());\n//=> '*'\n```\n\n### [.push](index.js#L88)\n\nPush a child node onto the `node.nodes` array.\n\n**Params**\n\n* `node` **{Object}**\n* `returns` **{Number}**: Returns the length of `node.nodes`, like `Array.push`\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nfoo.push(bar);\n```\n\n### [.unshift](index.js#L117)\n\nUnshift a child node onto `node.nodes`, and set `node` as the parent on `child.parent`.\n\n**Params**\n\n* `node` **{Object}**\n* `returns` **{Number}**: Returns the length of `node.nodes`\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nfoo.unshift(bar);\n```\n\n### [.pop](index.js#L151)\n\nPop a node from `node.nodes`.\n\n* `returns` **{Number}**: Returns the popped `node`\n\n**Example**\n\n```js\nconst node = new Node({type: 'foo'});\nnode.push(new Node({type: 'a'}));\nnode.push(new Node({type: 'b'}));\nnode.push(new Node({type: 'c'}));\nnode.push(new Node({type: 'd'}));\nconsole.log(node.nodes.length);\n//=> 4\nnode.pop();\nconsole.log(node.nodes.length);\n//=> 3\n```\n\n### [.shift](index.js#L178)\n\nShift a node from `node.nodes`.\n\n* `returns` **{Object}**: Returns the shifted `node`\n\n**Example**\n\n```js\nconst node = new Node({type: 'foo'});\nnode.push(new Node({type: 'a'}));\nnode.push(new Node({type: 'b'}));\nnode.push(new Node({type: 'c'}));\nnode.push(new Node({type: 'd'}));\nconsole.log(node.nodes.length);\n//=> 4\nnode.shift();\nconsole.log(node.nodes.length);\n//=> 3\n```\n\n### [.remove](index.js#L197)\n\nRemove `node` from `node.nodes`.\n\n**Params**\n\n* `node` **{Object}**\n* `returns` **{Object}**: Returns the removed node.\n\n**Example**\n\n```js\nnode.remove(childNode);\n```\n\n### [.find](index.js#L228)\n\nGet the first child node from `node.nodes` that matches the given `type`. If `type` is a number, the child node at that index is returned.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Object}**: Returns a child node or undefined.\n\n**Example**\n\n```js\nconst child = node.find(1); //<= index of the node to get\nconst child = node.find('foo'); //<= node.type of a child node\nconst child = node.find(/^(foo|bar)$/); //<= regex to match node.type\nconst child = node.find(['foo', 'bar']); //<= array of node.type(s)\n```\n\n### [.has](index.js#L259)\n\nReturns true if `node.nodes` array contains the given `node`.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\ncosole.log(foo.has(bar)); // false\nfoo.push(bar);\ncosole.log(foo.has(bar)); // true\n```\n\n### [.hasType](index.js#L284)\n\nReturn true if the `node.nodes` has the given `type`.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nfoo.push(bar);\n\ncosole.log(foo.hasType('qux'));          // false\ncosole.log(foo.hasType(/^(qux|bar)$/));  // true\ncosole.log(foo.hasType(['qux', 'bar'])); // true\n```\n\n### [.isType](index.js#L303)\n\nReturn true if the node is the given `type`.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nconst node = new Node({type: 'bar'});\ncosole.log(node.isType('foo'));          // false\ncosole.log(node.isType(/^(foo|bar)$/));  // true\ncosole.log(node.isType(['foo', 'bar'])); // true\n```\n\n### [.isEmpty](index.js#L323)\n\nReturns true if `node.value` is an empty string, or `node.nodes` does not contain any non-empty text nodes.\n\n**Params**\n\n* `fn` **{Function}**: (optional) Filter function that is called on `node` and/or child nodes. `isEmpty` will return false immediately when the filter function returns false on any nodes.\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nconst node = new Node({type: 'text'});\nnode.isEmpty(); //=> true\nnode.value = 'foo';\nnode.isEmpty(); //=> false\n```\n\n### [.isInside](index.js#L342)\n\nReturns true if the node has an ancestor node of the given `type`\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nconst box = new Node({type: 'box'});\nconst marble = new Node({type: 'marble'});\nbox.push(marble);\nmarble.isInside('box'); //=> true\n```\n\n### [.siblings](index.js#L365)\n\nGet the siblings array, or `null` if it doesn't exist.\n\n* `returns` **{Array}**\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nconst baz = new Node({type: 'baz'});\nfoo.push(bar);\nfoo.push(baz);\n\nconsole.log(bar.siblings.length) // 2\nconsole.log(baz.siblings.length) // 2\n```\n\n### [.index](index.js#L393)\n\nCalculate the node's current index on `node.parent.nodes`, or `-1` if the node does not have a parent, or is not on `node.parent.nodes`.\n\n* `returns` **{Number}**\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nconst baz = new Node({type: 'baz'});\nconst qux = new Node({type: 'qux'});\nfoo.push(bar);\nfoo.push(baz);\nfoo.unshift(qux);\n\nconsole.log(bar.index) // 1\nconsole.log(baz.index) // 2\nconsole.log(qux.index) // 0\n```\n\n### [.prev](index.js#L424)\n\nGet the previous node from the [siblings](#siblings) array or `null`.\n\n* `returns` **{Object}**\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nconst baz = new Node({type: 'baz'});\nfoo.push(bar);\nfoo.push(baz);\n\nconsole.log(baz.prev.type) // 'bar'\n```\n\n### [.next](index.js#L453)\n\nGet the next element from the [siblings](#siblings) array, or `null` if a next node does not exist.\n\n* `returns` **{Object}**\n\n**Example**\n\n```js\nconst parent = new Node({type: 'root'});\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nconst baz = new Node({type: 'baz'});\nparent.push(foo);\nparent.push(bar);\nparent.push(baz);\n\nconsole.log(foo.next.type) // 'bar'\nconsole.log(bar.next.type) // 'baz'\n```\n\n### [.first](index.js#L480)\n\nGet the first child node from `node.nodes`.\n\n* `returns` **{Object}**: The first node, or undefiend\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nconst baz = new Node({type: 'baz'});\nconst qux = new Node({type: 'qux'});\nfoo.push(bar);\nfoo.push(baz);\nfoo.push(qux);\n\nconsole.log(foo.first.type) // 'bar'\n```\n\n### [.last](index.js#L504)\n\nGet the last child node from `node.nodes`.\n\n* `returns` **{Object}**: The last node, or undefiend\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\nconst baz = new Node({type: 'baz'});\nconst qux = new Node({type: 'qux'});\nfoo.push(bar);\nfoo.push(baz);\nfoo.push(qux);\n\nconsole.log(foo.last.type) // 'qux'\n```\n\n### [.depth](index.js#L525)\n\nGet the `node.depth`. The root node has a depth of 0. Add 1 to child nodes for each level of nesting.\n\n* `returns` **{Object}**: The last node, or undefiend\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nfoo.push(bar);\n\nconsole.log(foo.depth) // 1\nconsole.log(bar.depth) // 2\n```\n\n### [Node#isNode](index.js#L545)\n\nStatic method that returns true if the given value is a node.\n\n**Params**\n\n* `node` **{Object}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nconst Node = require('snapdragon-node');\nconst node = new Node({type: 'foo'});\nconsole.log(Node.isNode(node)); //=> true\nconsole.log(Node.isNode({})); //=> false\n```\n\n### Non-enumerable properties\n\n* `node.isNode` **{boolean}** - this value is set to `true` when a node is created. This can be useful in situationas as a fast alternative to using `instanceof Node` if you [need to determine](#nodeisnode) if a value is a `node` object.\n* `node.size` **{number}** - the number of child nodes that have been pushed or unshifted onto `node.nodes` using the node's API. This is useful for determining if nodes were added to `node.nodes` without using `node.push()` or `node.unshift()` (for example: `if (node.nodes && node.size !== node.nodes.length)`)\n* `node.parent` **{object}** (instance of Node)\n\n## Release history\n\nSee [the changelog](changelog.md).\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\nPlease read the [contributing guide](.github/contributing.md) for advice on opening issues, pull requests, and coding standards.\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [breakdance](https://www.npmjs.com/package/breakdance): Breakdance is a node.js library for converting HTML to markdown. Highly pluggable, flexible and easy… [more](http://breakdance.io) | [homepage](http://breakdance.io \"Breakdance is a node.js library for converting HTML to markdown. Highly pluggable, flexible and easy to use. It's time for your markup to get down.\")\n* [snapdragon-capture](https://www.npmjs.com/package/snapdragon-capture): Snapdragon plugin that adds a capture method to the parser instance. | [homepage](https://github.com/jonschlinkert/snapdragon-capture \"Snapdragon plugin that adds a capture method to the parser instance.\")\n* [snapdragon-cheerio](https://www.npmjs.com/package/snapdragon-cheerio): Snapdragon plugin for converting a cheerio AST to a snapdragon AST. | [homepage](https://github.com/jonschlinkert/snapdragon-cheerio \"Snapdragon plugin for converting a cheerio AST to a snapdragon AST.\")\n* [snapdragon-util](https://www.npmjs.com/package/snapdragon-util): Utilities for the snapdragon parser/compiler. | [homepage](https://github.com/here-be/snapdragon-util \"Utilities for the snapdragon parser/compiler.\")\n* [snapdragon](https://www.npmjs.com/package/snapdragon): Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map… [more](https://github.com/here-be/snapdragon) | [homepage](https://github.com/here-be/snapdragon \"Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.\")\n\n### Author\n\n**Jon Schlinkert**\n\n* [GitHub Profile](https://github.com/jonschlinkert)\n* [Twitter Profile](https://twitter.com/jonschlinkert)\n* [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.8.0, on November 24, 2018._",
+  "maintainers": [
+    {
+      "email": "daniel@tschinder.de",
+      "name": "danez"
+    },
+    {
+      "email": "github@sellside.com",
+      "name": "jonschlinkert"
+    }
+  ],
+  "time": {
+    "modified": "2018-11-24T09:18:19.222Z",
+    "created": "2017-01-20T11:25:52.299Z",
+    "0.1.0": "2017-01-20T11:25:52.299Z",
+    "0.2.0": "2017-01-21T02:36:41.677Z",
+    "1.0.0": "2017-01-21T09:53:00.497Z",
+    "1.0.1": "2017-01-21T10:47:12.141Z",
+    "1.0.2": "2017-01-21T11:37:13.705Z",
+    "1.0.3": "2017-01-21T11:41:10.411Z",
+    "1.0.5": "2017-02-05T07:01:57.810Z",
+    "1.0.6": "2017-02-15T18:56:31.127Z",
+    "2.0.0": "2017-05-01T12:09:05.870Z",
+    "2.0.1": "2017-05-01T12:26:36.594Z",
+    "2.1.0": "2017-06-25T11:54:44.027Z",
+    "2.1.1": "2017-06-25T12:04:17.139Z",
+    "3.0.0": "2018-11-24T09:18:16.600Z"
+  },
+  "homepage": "https://github.com/here-be/snapdragon-node",
+  "keywords": [
+    "ast",
+    "compile",
+    "compiler",
+    "convert",
+    "node",
+    "parse",
+    "parser",
+    "plugin",
+    "render",
+    "snapdragon",
+    "snapdragonplugin",
+    "token",
+    "transform"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/here-be/snapdragon-node.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/here-be/snapdragon-node/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/snapdragon-node.min.json
+++ b/test/fixtures/registry-mocks/content/snapdragon-node.min.json
@@ -1,0 +1,309 @@
+{
+  "name": "snapdragon-node",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "snapdragon-node",
+      "version": "0.1.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.8.1"
+      },
+      "dist": {
+        "shasum": "2d4e7237df851b93c361a8aab559a918ac4820b2",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "0.2.0": {
+      "name": "snapdragon-node",
+      "version": "0.2.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.8.1"
+      },
+      "dist": {
+        "shasum": "4d2ee33d72bb1caeb65aa32fdb7c9b9e7fc348e4",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.0": {
+      "name": "snapdragon-node",
+      "version": "1.0.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.8.1"
+      },
+      "dist": {
+        "shasum": "70f06a3e6954bcbb30001c7fabf81a5393eef324",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.1": {
+      "name": "snapdragon-node",
+      "version": "1.0.1",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^1.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "15e5b89fc84f9d9604657b079606fcbb06cdd0f1",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.2": {
+      "name": "snapdragon-node",
+      "version": "1.0.2",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-util": "^1.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "1f29e33d675d5e2d74a052ca798f8fac2c452f04",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.3": {
+      "name": "snapdragon-node",
+      "version": "1.0.3",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-util": "^1.0.2"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "54ca3efd8aadedfb015c6af64844d85fe2362b15",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.5": {
+      "name": "snapdragon-node",
+      "version": "1.0.5",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-util": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.1",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "65f0e1609354f03ab788d462dfad1cdcfc778d42",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.6": {
+      "name": "snapdragon-node",
+      "version": "1.0.6",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-util": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.1",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "2448d5ef6fea7f5e8fd5326a0a114854da271356",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.0.0": {
+      "name": "snapdragon-node",
+      "version": "2.0.0",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.3.0",
+        "snapdragon": "^0.11.0"
+      },
+      "dist": {
+        "shasum": "2c1fcf7a494da1fea737139f62116bdc7e5ea3ef",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.0.0.tgz"
+      },
+      "engines": {
+        "node": "0.10.0"
+      }
+    },
+    "2.0.1": {
+      "name": "snapdragon-node",
+      "version": "2.0.1",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "mocha": "^3.3.0",
+        "snapdragon": "^0.11.0"
+      },
+      "dist": {
+        "shasum": "3b485cef2a6d55dfaeb52641a8388c6ea81cbea2",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.1.0": {
+      "name": "snapdragon-node",
+      "version": "2.1.0",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "object-copy": "^1.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.0",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.2",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.4.2",
+        "snapdragon": "^0.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-ebmlZ8o6BhMUv/mlAnJcFWXcFaa78G8b5vbUqAH7q7aM/++cEb9gdLyG39b+FetOVrXweDjMjm5iqMIZ8BLupA==",
+        "shasum": "09b4ad8c81a6d03216dc85e818b00bc7ff9e504e",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.1.1": {
+      "name": "snapdragon-node",
+      "version": "2.1.1",
+      "dependencies": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.0",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.2",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.4.2",
+        "snapdragon": "^0.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+        "shasum": "6c175f86ff14bdb0724563e8f3c1b021a286853b",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "snapdragon-node",
+      "version": "3.0.0",
+      "devDependencies": {
+        "define-property": "^2.0.2",
+        "gulp-format-md": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^13.1.0",
+        "snapdragon": "^0.12.0"
+      },
+      "dist": {
+        "integrity": "sha512-8fmjo9AOZXFBWxHS9kOdqA4Mq9x1ldbnPLXjz1voBCmDuQcVBySjlekv4+QnKj0LdNc3hEF19xUrTBQJ2zPyCw==",
+        "shasum": "92f5bc808a7f31be4b50acf489e5c9fc62cf4552",
+        "tarball": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-3.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 35767,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb+RdZCRA9TVsSAnZWagAAXskP/A/+74GxpjNc4nrspuH/\nLk5xauXYoFyDJQcPsn6azQvNxc5qeotX6VlMp1HD131IU6967uy6es1QH5lZ\na/fjlXOUWhH/pISA+uuVzyU+OUIPSuknDeBG0OAg5JWvxcbriFoIQvSNB1Xx\ntBdAeq005OEwq/FSrYpiGxtJ6BGu9XnrbV0kcGze/r2lM2Z24Pfg1sffOFpT\njEAbrm2UMcjeDrWJGs38AqtQvUKO4FL1bvSaBPWDwuLe7eu9fnOomks7O0YU\nbrn/zaBWngMSAX6c8ehaw7aIEwFcgo0+nfo+RmQ41cALkJLF/ZY2AynrumwB\nMkohX/H6hHnx7ye1Qtf5GRbAptY7YOIrRpWv17ZTjApBhI5Y0sL7puEaf0VM\nmP4rC83nZANhH0ArVooZqbIySEzM6QUoPEmw8MnGgUNwPb9uK/VhbT2kajz2\nP+Pp6HqMh72Z19cZmO3sx8QdIINjhqFqT3uDNSiJA4xsaT1Y+KMNrQ2b8PFF\n149Ef6PuLf/Y6Ffiq+mY5YTHaGepPOd/griE7iEIrQjlhuUfkPLsSEO5YRom\nZbFrPfKl+6sTxHTSh1yLdb8Eyt5p3Kl3AcZGb8D3QDB94jZBs7E01dCPCuev\nxzFG1zIdwzOfgxTRrn+REG2VUmdCWblho3jFMeRSEAZ0orDhN4knbiG9N1We\nG42W\r\n=PEEL\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    }
+  },
+  "modified": "2018-11-24T09:18:19.222Z"
+}

--- a/test/fixtures/registry-mocks/content/snapdragon-util.json
+++ b/test/fixtures/registry-mocks/content/snapdragon-util.json
@@ -1,0 +1,1733 @@
+{
+  "_id": "snapdragon-util",
+  "_rev": "18-32352b269c161e57eb183aca44ab580e",
+  "name": "snapdragon-util",
+  "description": "Utilities for the snapdragon parser/compiler.",
+  "dist-tags": {
+    "latest": "5.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "generategenerator",
+        "snapdragon",
+        "util"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "_id": "snapdragon-util@0.1.0",
+      "_shasum": "a152d283865e73d5638a98edeb5f224f687a80b7",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a152d283865e73d5638a98edeb5f224f687a80b7",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-0.1.0.tgz_1484817267822_0.4896240758243948"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "generategenerator",
+        "snapdragon",
+        "util"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "0cb64c7061d028a1634109685a70c627c31f3eb4",
+      "_id": "snapdragon-util@0.1.1",
+      "_shasum": "2384b8d846f17d8200673d82310ef746cfdb5321",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2384b8d846f17d8200673d82310ef746cfdb5321",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-0.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-0.1.1.tgz_1484963812695_0.42882254370488226"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "generategenerator",
+        "snapdragon",
+        "util"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "a0fa648149d2d0e2a35fbe5eeec039fbf1b9df88",
+      "_id": "snapdragon-util@1.0.0",
+      "_shasum": "4d95397268269edc2a79bfa391dff30d2e548727",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4d95397268269edc2a79bfa391dff30d2e548727",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-1.0.0.tgz_1484992615532_0.5757098200265318"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0"
+      },
+      "keywords": [
+        "generategenerator",
+        "snapdragon",
+        "util"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "e58a940b8cfadf72f64192622521527c91faf3ef",
+      "_id": "snapdragon-util@1.0.1",
+      "_shasum": "446fcc004a587b97193a5243a6f735b5442d33f9",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "446fcc004a587b97193a5243a6f735b5442d33f9",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-1.0.1.tgz_1484993200462_0.14513341896235943"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "1.0.2",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "keywords": [
+        "capture",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "snapdragon",
+        "snapdragonplugin",
+        "util"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "0a6cdd8e93d57a1e8980446b77e7c57e5da3b131",
+      "_id": "snapdragon-util@1.0.2",
+      "_shasum": "f49d083e74b22b519dd7aaf6c92a1c5dd198d781",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f49d083e74b22b519dd7aaf6c92a1c5dd198d781",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-1.0.2.tgz_1484995521243_0.22518426459282637"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "1.0.3",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "255fdddd9a9d670ba97c6cd3eb7e55eb3ca2a772",
+      "_id": "snapdragon-util@1.0.3",
+      "_shasum": "9478f785bdec55e11db0efcc8e735b3bb95ed1e0",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9478f785bdec55e11db0efcc8e735b3bb95ed1e0",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-1.0.3.tgz_1486057670224_0.6658729165792465"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "1.0.4",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "1f168dd0aa036cc8770790b5a0afb31dcf8cb76d",
+      "_id": "snapdragon-util@1.0.4",
+      "_shasum": "343efb9ad160adbf4eec4f2434e0eaae6e245e88",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "343efb9ad160adbf4eec4f2434e0eaae6e245e88",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-1.0.4.tgz_1486278728009_0.7380673007573932"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "1.0.5",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "3c65011218f9aa6d5380d746686dd4b37f593725",
+      "_id": "snapdragon-util@1.0.5",
+      "_shasum": "32398a91f8b12bd031d569ec2e5308355c9abe41",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "32398a91f8b12bd031d569ec2e5308355c9abe41",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-1.0.5.tgz_1486278770461_0.9841277650557458"
+      },
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "1.0.6",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-node": "^1.0.6"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.10.1",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "a8ee4265c9fd7638cadcd5159c023d7b877b83a6",
+      "_id": "snapdragon-util@1.0.6",
+      "_shasum": "8b3d2d6dec8930c90e054ba052e562ca1b3a621e",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8b3d2d6dec8930c90e054ba052e562ca1b3a621e",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.6.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-1.0.6.tgz_1487185217022_0.9143254722002894"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "utils.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.10.1",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-node": "^1.0.6"
+      },
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "b3e30f746b3a6ff746a615129c64827cc75c661d",
+      "_id": "snapdragon-util@2.0.0",
+      "_shasum": "7e43ed71c0c77e4127db46dcb0550d585d25e46e",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e43ed71c0c77e4127db46dcb0550d585d25e46e",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-2.0.0.tgz_1487186734480_0.6906527932733297"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "2.1.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.10.1",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-node": "^1.0.6"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "90d901a935cd98836e5a239f6ea6e7f9be0efce8",
+      "_id": "snapdragon-util@2.1.0",
+      "_shasum": "cabb0e457018eeeaf1182dc42c332bf4a7141d2e",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cabb0e457018eeeaf1182dc42c332bf4a7141d2e",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-2.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-2.1.0.tgz_1488139830058_0.032811991404742"
+      },
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "2.1.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.10.1",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-node": "^1.0.6"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "0ea032c8ea02010338568e82e8510a4054966203",
+      "_id": "snapdragon-util@2.1.1",
+      "_shasum": "552779df8a1493a0e78c06cc80953a262770957a",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "552779df8a1493a0e78c06cc80953a262770957a",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-2.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-2.1.1.tgz_1488660854816_0.24682563240639865"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "3.0.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "devDependencies": {
+        "define-property": "^1.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "isobject": "^3.0.0",
+        "mocha": "^3.3.0",
+        "snapdragon": "^0.11.0",
+        "snapdragon-node": "^1.0.6"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "48b72a87a26736d2a8df22f7294fb1a41ae6a9de",
+      "_id": "snapdragon-util@3.0.0",
+      "_shasum": "0ac6288d8409e45d04fd1034e0bb745701cae9c0",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0ac6288d8409e45d04fd1034e0bb745701cae9c0",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-util-3.0.0.tgz_1493638981660_0.6029416942037642"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "3.0.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "devDependencies": {
+        "define-property": "^1.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "isobject": "^3.0.0",
+        "mocha": "^3.3.0",
+        "snapdragon": "^0.11.0",
+        "snapdragon-node": "^1.0.6"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "1655d7f02f5957ebddc9cc7757a25bf8f221e5a7",
+      "_id": "snapdragon-util@3.0.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+        "shasum": "f956479486f2acd79700693f6f7b805e45ab56e2",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon-util-3.0.1.tgz_1498383999677_0.4173418020363897"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "4.0.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Rouven Weßling",
+          "url": "www.rouvenwessling.de"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "devDependencies": {
+        "define-property": "^1.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.0",
+        "gulp-format-md": "^1.0.0",
+        "gulp-istanbul": "^1.1.2",
+        "gulp-mocha": "^3.0.1",
+        "isobject": "^3.0.1",
+        "mocha": "^3.5.3",
+        "snapdragon": "^0.11.0",
+        "snapdragon-node": "^2.1.1"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "51ebbd9ea96455a075d304ad7fbb9701ba9955a0",
+      "_id": "snapdragon-util@4.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-EthB2f44R7/fdbUrGmlOIJ15k5nkC3/LvWaD6u7wu9fo4Eabk7qq1MTkSGoTWWm1hxb2lxG/r9H3KKhhNOGkgw==",
+        "shasum": "49c858a089174abe7b8d186a367424823167446a",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon-util-4.0.0.tgz_1509518278524_0.9129899861291051"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "5.0.0",
+      "homepage": "https://github.com/here-be/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Rouven Weßling",
+          "url": "www.rouvenwessling.de"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/here-be/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/here-be/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "define-property": "^2.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.1",
+        "gulp-format-md": "^1.0.0",
+        "gulp-istanbul": "^1.1.3",
+        "gulp-mocha": "^5.0.0",
+        "isobject": "^3.0.1",
+        "mocha": "^3.5.3",
+        "snapdragon": "^0.11.0"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "related": {
+          "list": [
+            "snapdragon-node",
+            "snapdragon-position",
+            "snapdragon-token"
+          ]
+        },
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "c17a41eb646e95cf9a53297efa12089adf40febf",
+      "_id": "snapdragon-util@5.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-ke2RjTrbCn1sh2FzoONPnKatBpemhg4XskLz7nBhDREaiEvztFtCrSAb2Kn55h3B5pTvD1q5Pw36nmOIo1Ascw==",
+        "shasum": "630c326a5e021166109dcc23ea6e7ccd60feab08",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon-util-5.0.0.tgz_1515661422107_0.8418538775295019"
+      },
+      "directories": {}
+    },
+    "5.0.1": {
+      "name": "snapdragon-util",
+      "description": "Utilities for the snapdragon parser/compiler.",
+      "version": "5.0.1",
+      "homepage": "https://github.com/here-be/snapdragon-util",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        },
+        {
+          "name": "Rouven Weßling",
+          "url": "www.rouvenwessling.de"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/here-be/snapdragon-util.git"
+      },
+      "bugs": {
+        "url": "https://github.com/here-be/snapdragon-util/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "define-property": "^2.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.1",
+        "gulp-format-md": "^1.0.0",
+        "gulp-istanbul": "^1.1.3",
+        "gulp-mocha": "^5.0.0",
+        "isobject": "^3.0.1",
+        "mocha": "^3.5.3",
+        "snapdragon": "^0.11.0"
+      },
+      "keywords": [
+        "capture",
+        "compile",
+        "compiler",
+        "convert",
+        "match",
+        "parse",
+        "parser",
+        "plugin",
+        "render",
+        "snapdragon",
+        "snapdragonplugin",
+        "transform",
+        "util"
+      ],
+      "verb": {
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "related": {
+          "list": [
+            "snapdragon-node",
+            "snapdragon-position",
+            "snapdragon-token"
+          ]
+        },
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "ca133741eafd65bac5351587da7376c32b15d6c2",
+      "_id": "snapdragon-util@5.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-0F6MbgMMKw37GfnJjrNX4WbNdAacz+I7mzgVLKPa4sB9zQ7XeMVtaqoDrrSv2sHnhX5noL55tZSaHI5FQOLGMQ==",
+        "shasum": "281f1114bdd3c90b46585783a2e4d4eb684fa200",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-5.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon-util-5.0.1.tgz_1515661466032_0.7892721705138683"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# snapdragon-util [![NPM version](https://img.shields.io/npm/v/snapdragon-util.svg?style=flat)](https://www.npmjs.com/package/snapdragon-util) [![NPM monthly downloads](https://img.shields.io/npm/dm/snapdragon-util.svg?style=flat)](https://npmjs.org/package/snapdragon-util) [![NPM total downloads](https://img.shields.io/npm/dt/snapdragon-util.svg?style=flat)](https://npmjs.org/package/snapdragon-util) [![Linux Build Status](https://img.shields.io/travis/here-be/snapdragon-util.svg?style=flat&label=Travis)](https://travis-ci.org/here-be/snapdragon-util)\n\n> Utilities for the snapdragon parser/compiler.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save snapdragon-util\n```\n\n## Usage\n\n```js\nvar util = require('snapdragon-util');\n```\n\n## API\n\n### [.isNode](index.js#L20)\n\nReturns true if the given value is a node.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar node = new Node({type: 'foo'});\nconsole.log(utils.isNode(node)); //=> true\nconsole.log(utils.isNode({})); //=> false\n```\n\n### [.noop](index.js#L36)\n\nEmit an empty string for the given `node`.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{undefined}**\n\n**Example**\n\n```js\n// do nothing for beginning-of-string\nsnapdragon.compiler.set('bos', utils.noop);\n```\n\n### [.value](index.js#L54)\n\nReturns `node.value` or `node.val`.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{String}**: returns\n\n**Example**\n\n```js\nconst star = new Node({type: 'star', value: '*'});\nconst slash = new Node({type: 'slash', val: '/'});\nconsole.log(utils.value(star)) //=> '*'\nconsole.log(utils.value(slash)) //=> '/'\n```\n\n### [.identity](index.js#L72)\n\nAppend `node.value` to `compiler.output`.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{undefined}**\n\n**Example**\n\n```js\nsnapdragon.compiler.set('text', utils.identity);\n```\n\n### [.append](index.js#L95)\n\nPreviously named `.emit`, this method appends the given `value` to `compiler.output` for the given node. Useful when you know what value should be appended advance, regardless of the actual value of `node.value`.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Function}**: Returns a compiler middleware function.\n\n**Example**\n\n```js\nsnapdragon.compiler\n  .set('i', function(node) {\n    this.mapVisit(node);\n  })\n  .set('i.open', utils.append('<i>'))\n  .set('i.close', utils.append('</i>'))\n```\n\n### [.toNoop](index.js#L118)\n\nUsed in compiler middleware, this onverts an AST node into an empty `text` node and deletes `node.nodes` if it exists. The advantage of this method is that, as opposed to completely removing the node, indices will not need to be re-calculated in sibling nodes, and nothing is appended to the output.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `nodes` **{Array}**: Optionally pass a new `nodes` value, to replace the existing `node.nodes` array.\n\n**Example**\n\n```js\nutils.toNoop(node);\n// convert `node.nodes` to the given value instead of deleting it\nutils.toNoop(node, []);\n```\n\n### [.visit](index.js#L147)\n\nVisit `node` with the given `fn`. The built-in `.visit` method in snapdragon automatically calls registered compilers, this allows you to pass a visitor function.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `fn` **{Function}**\n* `returns` **{Object}**: returns the node after recursively visiting all child nodes.\n\n**Example**\n\n```js\nsnapdragon.compiler.set('i', function(node) {\n  utils.visit(node, function(childNode) {\n    // do stuff with \"childNode\"\n    return childNode;\n  });\n});\n```\n\n### [.mapVisit](index.js#L174)\n\nMap [visit](#visit) the given `fn` over `node.nodes`. This is called by [visit](#visit), use this method if you do not want `fn` to be called on the first node.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `options` **{Object}**\n* `fn` **{Function}**\n* `returns` **{Object}**: returns the node\n\n**Example**\n\n```js\nsnapdragon.compiler.set('i', function(node) {\n  utils.mapVisit(node, function(childNode) {\n    // do stuff with \"childNode\"\n    return childNode;\n  });\n});\n```\n\n### [.addOpen](index.js#L213)\n\nUnshift an `*.open` node onto `node.nodes`.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `Node` **{Function}**: (required) Node constructor function from [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node).\n* `filter` **{Function}**: Optionaly specify a filter function to exclude the node.\n* `returns` **{Object}**: Returns the created opening node.\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nsnapdragon.parser.set('brace', function(node) {\n  var match = this.match(/^{/);\n  if (match) {\n    var parent = new Node({type: 'brace'});\n    utils.addOpen(parent, Node);\n    console.log(parent.nodes[0]):\n    // { type: 'brace.open', value: '' };\n\n    // push the parent \"brace\" node onto the stack\n    this.push(parent);\n\n    // return the parent node, so it's also added to the AST\n    return brace;\n  }\n});\n```\n\n### [.addClose](index.js#L263)\n\nPush a `*.close` node onto `node.nodes`.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `Node` **{Function}**: (required) Node constructor function from [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node).\n* `filter` **{Function}**: Optionaly specify a filter function to exclude the node.\n* `returns` **{Object}**: Returns the created closing node.\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nsnapdragon.parser.set('brace', function(node) {\n  var match = this.match(/^}/);\n  if (match) {\n    var parent = this.parent();\n    if (parent.type !== 'brace') {\n      throw new Error('missing opening: ' + '}');\n    }\n\n    utils.addClose(parent, Node);\n    console.log(parent.nodes[parent.nodes.length - 1]):\n    // { type: 'brace.close', value: '' };\n\n    // no need to return a node, since the parent\n    // was already added to the AST\n    return;\n  }\n});\n```\n\n### [.wrapNodes](index.js#L293)\n\nWraps the given `node` with `*.open` and `*.close` nodes.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `Node` **{Function}**: (required) Node constructor function from [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node).\n* `filter` **{Function}**: Optionaly specify a filter function to exclude the node.\n* `returns` **{Object}**: Returns the node\n\n### [.pushNode](index.js#L318)\n\nPush the given `node` onto `parent.nodes`, and set `parent` as `node.parent.\n\n**Params**\n\n* `parent` **{Object}**\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Object}**: Returns the child node\n\n**Example**\n\n```js\nvar parent = new Node({type: 'foo'});\nvar node = new Node({type: 'bar'});\nutils.pushNode(parent, node);\nconsole.log(parent.nodes[0].type) // 'bar'\nconsole.log(node.parent.type) // 'foo'\n```\n\n### [.unshiftNode](index.js#L348)\n\nUnshift `node` onto `parent.nodes`, and set `parent` as `node.parent.\n\n**Params**\n\n* `parent` **{Object}**\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{undefined}**\n\n**Example**\n\n```js\nvar parent = new Node({type: 'foo'});\nvar node = new Node({type: 'bar'});\nutils.unshiftNode(parent, node);\nconsole.log(parent.nodes[0].type) // 'bar'\nconsole.log(node.parent.type) // 'foo'\n```\n\n### [.popNode](index.js#L381)\n\nPop the last `node` off of `parent.nodes`. The advantage of using this method is that it checks for `node.nodes` and works with any version of `snapdragon-node`.\n\n**Params**\n\n* `parent` **{Object}**\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Number|Undefined}**: Returns the length of `node.nodes` or undefined.\n\n**Example**\n\n```js\nvar parent = new Node({type: 'foo'});\nutils.pushNode(parent, new Node({type: 'foo'}));\nutils.pushNode(parent, new Node({type: 'bar'}));\nutils.pushNode(parent, new Node({type: 'baz'}));\nconsole.log(parent.nodes.length); //=> 3\nutils.popNode(parent);\nconsole.log(parent.nodes.length); //=> 2\n```\n\n### [.shiftNode](index.js#L409)\n\nShift the first `node` off of `parent.nodes`. The advantage of using this method is that it checks for `node.nodes` and works with any version of `snapdragon-node`.\n\n**Params**\n\n* `parent` **{Object}**\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Number|Undefined}**: Returns the length of `node.nodes` or undefined.\n\n**Example**\n\n```js\nvar parent = new Node({type: 'foo'});\nutils.pushNode(parent, new Node({type: 'foo'}));\nutils.pushNode(parent, new Node({type: 'bar'}));\nutils.pushNode(parent, new Node({type: 'baz'}));\nconsole.log(parent.nodes.length); //=> 3\nutils.shiftNode(parent);\nconsole.log(parent.nodes.length); //=> 2\n```\n\n### [.removeNode](index.js#L436)\n\nRemove the specified `node` from `parent.nodes`.\n\n**Params**\n\n* `parent` **{Object}**\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Object|undefined}**: Returns the removed node, if successful, or undefined if it does not exist on `parent.nodes`.\n\n**Example**\n\n```js\nvar parent = new Node({type: 'abc'});\nvar foo = new Node({type: 'foo'});\nutils.pushNode(parent, foo);\nutils.pushNode(parent, new Node({type: 'bar'}));\nutils.pushNode(parent, new Node({type: 'baz'}));\nconsole.log(parent.nodes.length); //=> 3\nutils.removeNode(parent, foo);\nconsole.log(parent.nodes.length); //=> 2\n```\n\n### [.isType](index.js#L467)\n\nReturns true if `node.type` matches the given `type`. Throws a `TypeError` if `node` is not an instance of `Node`.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar node = new Node({type: 'foo'});\nconsole.log(utils.isType(node, 'foo')); // false\nconsole.log(utils.isType(node, 'bar')); // true\n```\n\n### [.hasType](index.js#L509)\n\nReturns true if the given `node` has the given `type` in `node.nodes`. Throws a `TypeError` if `node` is not an instance of `Node`.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar node = new Node({\n  type: 'foo',\n  nodes: [\n    new Node({type: 'bar'}),\n    new Node({type: 'baz'})\n  ]\n});\nconsole.log(utils.hasType(node, 'xyz')); // false\nconsole.log(utils.hasType(node, 'baz')); // true\n```\n\n### [.firstOfType](index.js#L542)\n\nReturns the first node from `node.nodes` of the given `type`\n\n**Params**\n\n* `nodes` **{Array}**\n* `type` **{String}**\n* `returns` **{Object|undefined}**: Returns the first matching node or undefined.\n\n**Example**\n\n```js\nvar node = new Node({\n  type: 'foo',\n  nodes: [\n    new Node({type: 'text', value: 'abc'}),\n    new Node({type: 'text', value: 'xyz'})\n  ]\n});\n\nvar textNode = utils.firstOfType(node.nodes, 'text');\nconsole.log(textNode.value);\n//=> 'abc'\n```\n\n### [.findNode](index.js#L578)\n\nReturns the node at the specified index, or the first node of the given `type` from `node.nodes`.\n\n**Params**\n\n* `nodes` **{Array}**\n* `type` **{String|Number}**: Node type or index.\n* `returns` **{Object}**: Returns a node or undefined.\n\n**Example**\n\n```js\nvar node = new Node({\n  type: 'foo',\n  nodes: [\n    new Node({type: 'text', value: 'abc'}),\n    new Node({type: 'text', value: 'xyz'})\n  ]\n});\n\nvar nodeOne = utils.findNode(node.nodes, 'text');\nconsole.log(nodeOne.value);\n//=> 'abc'\n\nvar nodeTwo = utils.findNode(node.nodes, 1);\nconsole.log(nodeTwo.value);\n//=> 'xyz'\n```\n\n### [.isOpen](index.js#L602)\n\nReturns true if the given node is an \"*.open\" node.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar brace = new Node({type: 'brace'});\nvar open = new Node({type: 'brace.open'});\nvar close = new Node({type: 'brace.close'});\n\nconsole.log(utils.isOpen(brace)); // false\nconsole.log(utils.isOpen(open)); // true\nconsole.log(utils.isOpen(close)); // false\n```\n\n### [.isClose](index.js#L631)\n\nReturns true if the given node is a \"*.close\" node.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar brace = new Node({type: 'brace'});\nvar open = new Node({type: 'brace.open'});\nvar close = new Node({type: 'brace.close'});\n\nconsole.log(utils.isClose(brace)); // false\nconsole.log(utils.isClose(open)); // false\nconsole.log(utils.isClose(close)); // true\n```\n\n### [.isBlock](index.js#L662)\n\nReturns true if the given node is an \"*.open\" node.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar brace = new Node({type: 'brace'});\nvar open = new Node({type: 'brace.open', value: '{'});\nvar inner = new Node({type: 'text', value: 'a,b,c'});\nvar close = new Node({type: 'brace.close', value: '}'});\nbrace.push(open);\nbrace.push(inner);\nbrace.push(close);\n\nconsole.log(utils.isBlock(brace)); // true\n```\n\n### [.hasNode](index.js#L691)\n\nReturns true if `parent.nodes` has the given `node`.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nconst foo = new Node({type: 'foo'});\nconst bar = new Node({type: 'bar'});\ncosole.log(util.hasNode(foo, bar)); // false\nfoo.push(bar);\ncosole.log(util.hasNode(foo, bar)); // true\n```\n\n### [.hasOpen](index.js#L723)\n\nReturns true if `node.nodes` **has** an `.open` node\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar brace = new Node({\n  type: 'brace',\n  nodes: []\n});\n\nvar open = new Node({type: 'brace.open'});\nconsole.log(utils.hasOpen(brace)); // false\n\nbrace.pushNode(open);\nconsole.log(utils.hasOpen(brace)); // true\n```\n\n### [.hasClose](index.js#L754)\n\nReturns true if `node.nodes` **has** a `.close` node\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar brace = new Node({\n  type: 'brace',\n  nodes: []\n});\n\nvar close = new Node({type: 'brace.close'});\nconsole.log(utils.hasClose(brace)); // false\n\nbrace.pushNode(close);\nconsole.log(utils.hasClose(brace)); // true\n```\n\n### [.hasOpenAndClose](index.js#L789)\n\nReturns true if `node.nodes` has both `.open` and `.close` nodes\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar Node = require('snapdragon-node');\nvar brace = new Node({\n  type: 'brace',\n  nodes: []\n});\n\nvar open = new Node({type: 'brace.open'});\nvar close = new Node({type: 'brace.close'});\nconsole.log(utils.hasOpen(brace)); // false\nconsole.log(utils.hasClose(brace)); // false\n\nbrace.pushNode(open);\nbrace.pushNode(close);\nconsole.log(utils.hasOpen(brace)); // true\nconsole.log(utils.hasClose(brace)); // true\n```\n\n### [.addType](index.js#L811)\n\nPush the given `node` onto the `state.inside` array for the given type. This array is used as a specialized \"stack\" for only the given `node.type`.\n\n**Params**\n\n* `state` **{Object}**: The `compiler.state` object or custom state object.\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Array}**: Returns the `state.inside` stack for the given type.\n\n**Example**\n\n```js\nvar state = { inside: {}};\nvar node = new Node({type: 'brace'});\nutils.addType(state, node);\nconsole.log(state.inside);\n//=> { brace: [{type: 'brace'}] }\n```\n\n### [.removeType](index.js#L851)\n\nRemove the given `node` from the `state.inside` array for the given type. This array is used as a specialized \"stack\" for only the given `node.type`.\n\n**Params**\n\n* `state` **{Object}**: The `compiler.state` object or custom state object.\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `returns` **{Array}**: Returns the `state.inside` stack for the given type.\n\n**Example**\n\n```js\nvar state = { inside: {}};\nvar node = new Node({type: 'brace'});\nutils.addType(state, node);\nconsole.log(state.inside);\n//=> { brace: [{type: 'brace'}] }\nutils.removeType(state, node);\n//=> { brace: [] }\n```\n\n### [.isEmpty](index.js#L880)\n\nReturns true if `node.value` is an empty string, or `node.nodes` does not contain any non-empty text nodes.\n\n**Params**\n\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `fn` **{Function}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar node = new Node({type: 'text'});\nutils.isEmpty(node); //=> true\nnode.value = 'foo';\nutils.isEmpty(node); //=> false\n```\n\n### [.isInsideType](index.js#L922)\n\nReturns true if the `state.inside` stack for the given type exists and has one or more nodes on it.\n\n**Params**\n\n* `state` **{Object}**\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar state = { inside: {}};\nvar node = new Node({type: 'brace'});\nconsole.log(utils.isInsideType(state, 'brace')); //=> false\nutils.addType(state, node);\nconsole.log(utils.isInsideType(state, 'brace')); //=> true\nutils.removeType(state, node);\nconsole.log(utils.isInsideType(state, 'brace')); //=> false\n```\n\n### [.isInside](index.js#L956)\n\nReturns true if `node` is either a child or grand-child of the given `type`, or `state.inside[type]` is a non-empty array.\n\n**Params**\n\n* `state` **{Object}**: Either the `compiler.state` object, if it exists, or a user-supplied state object.\n* `node` **{Object}**: Instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n* `type` **{String}**: The `node.type` to check for.\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nvar state = { inside: {}};\nvar node = new Node({type: 'brace'});\nvar open = new Node({type: 'brace.open'});\nconsole.log(utils.isInside(state, open, 'brace')); //=> false\nutils.pushNode(node, open);\nconsole.log(utils.isInside(state, open, 'brace')); //=> true\n```\n\n### [.last](index.js#L1004)\n\nGet the last `n` element from the given `array`. Used for getting\na node from `node.nodes.`\n\n**Params**\n\n* `array` **{Array}**\n* `n` **{Number}**\n* `returns` **{undefined}**\n\n### [.arrayify](index.js#L1028)\n\nCast the given `value` to an array.\n\n**Params**\n\n* `value` **{any}**\n* `returns` **{Array}**\n\n**Example**\n\n```js\nconsole.log(utils.arrayify(''));\n//=> []\nconsole.log(utils.arrayify('foo'));\n//=> ['foo']\nconsole.log(utils.arrayify(['foo']));\n//=> ['foo']\n```\n\n### [.stringify](index.js#L1047)\n\nConvert the given `value` to a string by joining with `,`. Useful\nfor creating a cheerio/CSS/DOM-style selector from a list of strings.\n\n**Params**\n\n* `value` **{any}**\n* `returns` **{Array}**\n\n### [.trim](index.js#L1060)\n\nEnsure that the given value is a string and call `.trim()` on it,\nor return an empty string.\n\n**Params**\n\n* `str` **{String}**\n* `returns` **{String}**\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\nPlease read the [contributing guide](.github/contributing.md) for advice on opening issues, pull requests, and coding standards.\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [snapdragon-node](https://www.npmjs.com/package/snapdragon-node): Snapdragon utility for creating a new AST node in custom code, such as plugins. | [homepage](https://github.com/jonschlinkert/snapdragon-node \"Snapdragon utility for creating a new AST node in custom code, such as plugins.\")\n* [snapdragon-position](https://www.npmjs.com/package/snapdragon-position): Snapdragon util and plugin for patching the position on an AST node. | [homepage](https://github.com/here-be/snapdragon-position \"Snapdragon util and plugin for patching the position on an AST node.\")\n* [snapdragon-token](https://www.npmjs.com/package/snapdragon-token): Create a snapdragon token. Used by the snapdragon lexer, but can also be used by… [more](https://github.com/here-be/snapdragon-token) | [homepage](https://github.com/here-be/snapdragon-token \"Create a snapdragon token. Used by the snapdragon lexer, but can also be used by plugins.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 43 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 2 | [realityking](https://github.com/realityking) |\n\n### Author\n\n**Jon Schlinkert**\n\n* [linkedin/in/jonschlinkert](https://linkedin.com/in/jonschlinkert)\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on January 11, 2018._",
+  "maintainers": [
+    {
+      "email": "daniel@tschinder.de",
+      "name": "danez"
+    },
+    {
+      "email": "github@sellside.com",
+      "name": "jonschlinkert"
+    }
+  ],
+  "time": {
+    "modified": "2018-03-26T00:11:07.106Z",
+    "created": "2017-01-19T09:14:29.818Z",
+    "0.1.0": "2017-01-19T09:14:29.818Z",
+    "0.1.1": "2017-01-21T01:56:54.343Z",
+    "1.0.0": "2017-01-21T09:56:57.401Z",
+    "1.0.1": "2017-01-21T10:06:40.989Z",
+    "1.0.2": "2017-01-21T10:45:21.908Z",
+    "1.0.3": "2017-02-02T17:47:50.893Z",
+    "1.0.4": "2017-02-05T07:12:08.783Z",
+    "1.0.5": "2017-02-05T07:12:51.260Z",
+    "1.0.6": "2017-02-15T19:00:17.712Z",
+    "2.0.0": "2017-02-15T19:25:36.208Z",
+    "2.1.0": "2017-02-26T20:10:30.691Z",
+    "2.1.1": "2017-03-04T20:54:16.858Z",
+    "3.0.0": "2017-05-01T11:43:02.481Z",
+    "3.0.1": "2017-06-25T09:46:40.807Z",
+    "4.0.0": "2017-11-01T06:37:59.569Z",
+    "5.0.0": "2018-01-11T09:03:43.283Z",
+    "5.0.1": "2018-01-11T09:04:26.184Z"
+  },
+  "homepage": "https://github.com/here-be/snapdragon-util",
+  "keywords": [
+    "capture",
+    "compile",
+    "compiler",
+    "convert",
+    "match",
+    "parse",
+    "parser",
+    "plugin",
+    "render",
+    "snapdragon",
+    "snapdragonplugin",
+    "transform",
+    "util"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/here-be/snapdragon-util.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/here-be/snapdragon-util/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Jon Schlinkert",
+      "url": "http://twitter.com/jonschlinkert"
+    },
+    {
+      "name": "Rouven Weßling",
+      "url": "www.rouvenwessling.de"
+    }
+  ],
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/snapdragon-util.min.json
+++ b/test/fixtures/registry-mocks/content/snapdragon-util.min.json
@@ -1,0 +1,396 @@
+{
+  "name": "snapdragon-util",
+  "dist-tags": {
+    "latest": "5.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "snapdragon-util",
+      "version": "0.1.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "a152d283865e73d5638a98edeb5f224f687a80b7",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "0.1.1": {
+      "name": "snapdragon-util",
+      "version": "0.1.1",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "2384b8d846f17d8200673d82310ef746cfdb5321",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.0": {
+      "name": "snapdragon-util",
+      "version": "1.0.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "4d95397268269edc2a79bfa391dff30d2e548727",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.1": {
+      "name": "snapdragon-util",
+      "version": "1.0.1",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0"
+      },
+      "dist": {
+        "shasum": "446fcc004a587b97193a5243a6f735b5442d33f9",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.2": {
+      "name": "snapdragon-util",
+      "version": "1.0.2",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "f49d083e74b22b519dd7aaf6c92a1c5dd198d781",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.3": {
+      "name": "snapdragon-util",
+      "version": "1.0.3",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "9478f785bdec55e11db0efcc8e735b3bb95ed1e0",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.4": {
+      "name": "snapdragon-util",
+      "version": "1.0.4",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "343efb9ad160adbf4eec4f2434e0eaae6e245e88",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.5": {
+      "name": "snapdragon-util",
+      "version": "1.0.5",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "snapdragon-node": "^1.0.3"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.9.0",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "32398a91f8b12bd031d569ec2e5308355c9abe41",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.0.6": {
+      "name": "snapdragon-util",
+      "version": "1.0.6",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "snapdragon-node": "^1.0.6"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.10.1",
+        "snapdragon-capture-set": "^1.0.1"
+      },
+      "dist": {
+        "shasum": "8b3d2d6dec8930c90e054ba052e562ca1b3a621e",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.0.0": {
+      "name": "snapdragon-util",
+      "version": "2.0.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.10.1",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-node": "^1.0.6"
+      },
+      "dist": {
+        "shasum": "7e43ed71c0c77e4127db46dcb0550d585d25e46e",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.1.0": {
+      "name": "snapdragon-util",
+      "version": "2.1.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.10.1",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-node": "^1.0.6"
+      },
+      "dist": {
+        "shasum": "cabb0e457018eeeaf1182dc42c332bf4a7141d2e",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.1.1": {
+      "name": "snapdragon-util",
+      "version": "2.1.1",
+      "dependencies": {
+        "kind-of": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "snapdragon": "^0.10.1",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-node": "^1.0.6"
+      },
+      "dist": {
+        "shasum": "552779df8a1493a0e78c06cc80953a262770957a",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-2.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "3.0.0": {
+      "name": "snapdragon-util",
+      "version": "3.0.0",
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "devDependencies": {
+        "define-property": "^1.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "isobject": "^3.0.0",
+        "mocha": "^3.3.0",
+        "snapdragon": "^0.11.0",
+        "snapdragon-node": "^1.0.6"
+      },
+      "dist": {
+        "shasum": "0ac6288d8409e45d04fd1034e0bb745701cae9c0",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.1": {
+      "name": "snapdragon-util",
+      "version": "3.0.1",
+      "dependencies": {
+        "kind-of": "^3.2.0"
+      },
+      "devDependencies": {
+        "define-property": "^1.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.12",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.0",
+        "isobject": "^3.0.0",
+        "mocha": "^3.3.0",
+        "snapdragon": "^0.11.0",
+        "snapdragon-node": "^1.0.6"
+      },
+      "dist": {
+        "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+        "shasum": "f956479486f2acd79700693f6f7b805e45ab56e2",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "4.0.0": {
+      "name": "snapdragon-util",
+      "version": "4.0.0",
+      "dependencies": {
+        "kind-of": "^6.0.0"
+      },
+      "devDependencies": {
+        "define-property": "^1.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.0",
+        "gulp-format-md": "^1.0.0",
+        "gulp-istanbul": "^1.1.2",
+        "gulp-mocha": "^3.0.1",
+        "isobject": "^3.0.1",
+        "mocha": "^3.5.3",
+        "snapdragon": "^0.11.0",
+        "snapdragon-node": "^2.1.1"
+      },
+      "dist": {
+        "integrity": "sha512-EthB2f44R7/fdbUrGmlOIJ15k5nkC3/LvWaD6u7wu9fo4Eabk7qq1MTkSGoTWWm1hxb2lxG/r9H3KKhhNOGkgw==",
+        "shasum": "49c858a089174abe7b8d186a367424823167446a",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-4.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "5.0.0": {
+      "name": "snapdragon-util",
+      "version": "5.0.0",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "define-property": "^2.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.1",
+        "gulp-format-md": "^1.0.0",
+        "gulp-istanbul": "^1.1.3",
+        "gulp-mocha": "^5.0.0",
+        "isobject": "^3.0.1",
+        "mocha": "^3.5.3",
+        "snapdragon": "^0.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-ke2RjTrbCn1sh2FzoONPnKatBpemhg4XskLz7nBhDREaiEvztFtCrSAb2Kn55h3B5pTvD1q5Pw36nmOIo1Ascw==",
+        "shasum": "630c326a5e021166109dcc23ea6e7ccd60feab08",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-5.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "5.0.1": {
+      "name": "snapdragon-util",
+      "version": "5.0.1",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "devDependencies": {
+        "define-property": "^2.0.0",
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^4.0.1",
+        "gulp-format-md": "^1.0.0",
+        "gulp-istanbul": "^1.1.3",
+        "gulp-mocha": "^5.0.0",
+        "isobject": "^3.0.1",
+        "mocha": "^3.5.3",
+        "snapdragon": "^0.11.0"
+      },
+      "dist": {
+        "integrity": "sha512-0F6MbgMMKw37GfnJjrNX4WbNdAacz+I7mzgVLKPa4sB9zQ7XeMVtaqoDrrSv2sHnhX5noL55tZSaHI5FQOLGMQ==",
+        "shasum": "281f1114bdd3c90b46585783a2e4d4eb684fa200",
+        "tarball": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-5.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "modified": "2018-03-26T00:11:07.106Z"
+}

--- a/test/fixtures/registry-mocks/content/snapdragon.json
+++ b/test/fixtures/registry-mocks/content/snapdragon.json
@@ -1,0 +1,3937 @@
+{
+  "_id": "snapdragon",
+  "_rev": "41-bd8d060d9504ae933f53f9edfc7b5156",
+  "name": "snapdragon",
+  "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+  "dist-tags": {
+    "latest": "0.12.0",
+    "patch": "0.8.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/snapdragon/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.2",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [],
+      "gitHead": "5a7b88e509000f5005304d78857d0c2a4c0e14d7",
+      "_id": "snapdragon@0.1.0",
+      "_shasum": "7a87bdcf1c3b9af6df60bb4b06fb479813ccce39",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7a87bdcf1c3b9af6df60bb4b06fb479813ccce39",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://github.com/doowb"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/snapdragon/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.2",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "gitHead": "30f284075a9c2d8edba3e0c839e520ce4d48cfc3",
+      "_id": "snapdragon@0.1.1",
+      "_shasum": "43de7f3fa4940e88ae3bf50f688dc09ee3b7c3f3",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43de7f3fa4940e88ae3bf50f688dc09ee3b7c3f3",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://github.com/doowb"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": {
+        "type": "MIT",
+        "url": "https://github.com/jonschlinkert/snapdragon/blob/master/LICENSE"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.2",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "gitHead": "3523690976f66e6af5720b9c0066b1bdc6be038c",
+      "_id": "snapdragon@0.1.2",
+      "_shasum": "681252dad47147740755d17dad2860fadec9e49b",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "681252dad47147740755d17dad2860fadec9e49b",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://github.com/doowb"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jonschlinkert/snapdragon"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.4",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "gitHead": "f53a7d6a2e3ee124d62aa81afbab5a933d321065",
+      "_id": "snapdragon@0.2.0",
+      "_shasum": "d106b862f5ff1471f6ad3bc9d5afe7a70e2472b3",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d106b862f5ff1471f6ad3bc9d5afe7a70e2472b3",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://github.com/doowb"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "define-property": "^0.2.5",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.4",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "benchmarked": "^0.1.4",
+        "braces": "^1.8.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "gitHead": "4b71abd5efd99480547ffcc97ff3c162db0ee1fb",
+      "_id": "snapdragon@0.2.1",
+      "_shasum": "89d11c845b8260c0ce45c6028dceed93a77d54f5",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "89d11c845b8260c0ce45c6028dceed93a77d54f5",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.2.2",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://github.com/doowb"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "define-property": "^0.2.5",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.4",
+        "minimist": "^1.1.1",
+        "set-value": "^0.2.0",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "benchmarked": "^0.1.4",
+        "braces": "^1.8.1",
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "gitHead": "6857a332e14180653c0d2c0c7a2d7ae83390a45a",
+      "_id": "snapdragon@0.2.2",
+      "_shasum": "932c968208f946df12fc17851ec3938aee5d6a5c",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "932c968208f946df12fc17851ec3938aee5d6a5c",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.2.3",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        "Brian Woodward (https://github.com/doowb)"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "define-property": "^0.2.5",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.1.0",
+        "extend-shallow": "^2.0.1",
+        "minimist": "^1.2.0",
+        "set-value": "^0.3.1",
+        "source-map": "^0.5.3",
+        "source-map-resolve": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "jade",
+            "css"
+          ]
+        },
+        "reflinks": [
+          "jade",
+          "css"
+        ]
+      },
+      "gitHead": "618cfb13c3bc66ef1e31789c1414241bbd7be269",
+      "_id": "snapdragon@0.2.3",
+      "_shasum": "6acf350ceca838b68d6262d20e5ae405c1efa135",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6acf350ceca838b68d6262d20e5ae405c1efa135",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        "Brian Woodward (https://github.com/doowb)"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "base-methods": "^0.6.1",
+        "define-property": "^0.2.5",
+        "export-files": "^2.1.0",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.3",
+        "source-map-resolve": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "benchmarked": "^0.1.4",
+        "braces": "^1.8.2",
+        "export-dirs": "^0.2.4",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "matched": "^0.3.2",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "jade",
+            "css"
+          ],
+          "description": ""
+        },
+        "reflinks": [
+          "jade",
+          "css"
+        ]
+      },
+      "gitHead": "276067d6958ab32f00d757aa21be6ea3662443b8",
+      "_id": "snapdragon@0.3.0",
+      "_shasum": "8a08f768042bc6eaea50c13ba79a4a94a3b1a55d",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8a08f768042bc6eaea50c13ba79a4a94a3b1a55d",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.3.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        "Brian Woodward (https://github.com/doowb)"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "base-methods": "^0.6.1",
+        "define-property": "^0.2.5",
+        "export-files": "^2.1.0",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.3",
+        "source-map-resolve": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "benchmarked": "^0.1.4",
+        "braces": "^1.8.2",
+        "export-dirs": "^0.2.4",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "matched": "^0.3.2",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "jade",
+            "css"
+          ],
+          "description": ""
+        },
+        "reflinks": [
+          "jade",
+          "css"
+        ]
+      },
+      "gitHead": "911004788c2b651d2d8f2722241fa9c00ed217c2",
+      "_id": "snapdragon@0.3.1",
+      "_shasum": "e5719a5cec9a90f624db41ee326c242e8facef50",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e5719a5cec9a90f624db41ee326c242e8facef50",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.4.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        "Brian Woodward (https://github.com/doowb)"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^1.0.3",
+        "source-map": "^0.5.3",
+        "source-map-resolve": "^0.5.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.8",
+        "gulp-istanbul": "^0.10.4",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "verb": {
+        "reflinks": [
+          "css",
+          "pug",
+          "verb"
+        ],
+        "related": {
+          "list": [
+            "css",
+            "pug"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "951aebcf9c3c4de6b973c490f6481b13e53700ab",
+      "_id": "snapdragon@0.4.0",
+      "_shasum": "c73ac0469cb02efff6412866fcb878d55b2d40ec",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c73ac0469cb02efff6412866fcb878d55b2d40ec",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.4.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.4.0.tgz_1461135463059_0.5549712625797838"
+      },
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.4.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        "Brian Woodward (https://github.com/doowb)"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^1.0.4",
+        "source-map": "^0.5.5",
+        "source-map-resolve": "^0.5.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.8",
+        "gulp-istanbul": "^0.10.4",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "verb": {
+        "reflinks": [
+          "css",
+          "pug",
+          "verb"
+        ],
+        "related": {
+          "list": [
+            "css",
+            "pug"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "e12e787d772917146b3dd385a946b1a9a7b87312",
+      "_id": "snapdragon@0.4.1",
+      "_shasum": "94918f22c2e9105693fc6565c41c55eae0866ce7",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "94918f22c2e9105693fc6565c41c55eae0866ce7",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.4.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.4.1.tgz_1461663119754_0.8553889133036137"
+      },
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "snapdragon",
+      "description": "snapdragon is an extremely pluggable, powerful and easy-to-use parser-renderer factory.",
+      "version": "0.4.2",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "collaborators": [
+        "Brian Woodward (https://github.com/doowb)"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^2.0.0",
+        "source-map": "^0.5.5",
+        "source-map-resolve": "^0.5.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.8",
+        "gulp-istanbul": "^0.10.4",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5"
+      },
+      "keywords": [
+        "compile",
+        "compiler",
+        "css",
+        "exec",
+        "match",
+        "parse",
+        "parser",
+        "pattern",
+        "pre",
+        "pre-compile",
+        "regex",
+        "render",
+        "renderer",
+        "stringify"
+      ],
+      "verb": {
+        "reflinks": [
+          "css",
+          "pug",
+          "verb"
+        ],
+        "related": {
+          "list": [
+            "css",
+            "pug"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "705939c3b4c4cdf628cc02e56ba7e5dd0e87d5be",
+      "_id": "snapdragon@0.4.2",
+      "_shasum": "2d568fe7d80de09e2ea52b8944f8b5c3012bb888",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2d568fe7d80de09e2ea52b8944f8b5c3012bb888",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.4.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.4.2.tgz_1461951702152_0.888032752322033"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.5.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib",
+        "LICENSE",
+        "README.md"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        }
+      },
+      "gitHead": "ba675ceb542d92e564f2399507ad6eb5ed886993",
+      "_id": "snapdragon@0.5.0",
+      "_shasum": "558af297c49333c9409640c0cdc03a010441fe37",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "558af297c49333c9409640c0cdc03a010441fe37",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.5.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.5.0.tgz_1473082667855_0.9212112256791443"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.6.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib",
+        "LICENSE",
+        "README.md"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "related": {
+          "list": []
+        }
+      },
+      "gitHead": "a1c72232e18d9d200ede6f01bc6efe0756e57458",
+      "_id": "snapdragon@0.6.0",
+      "_shasum": "a5c514c5a288ea2c882b5cf3109d97aab2b633f2",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a5c514c5a288ea2c882b5cf3109d97aab2b633f2",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.6.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.6.0.tgz_1473393528546_0.36207341169938445"
+      },
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.7.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "These libraries use snapdragon:",
+          "list": [
+            "braces",
+            "micromatch",
+            "expand-brackets",
+            "extglob"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "a0ea3018ca8e3c4b18717d3f7646d3640fc57e29",
+      "_id": "snapdragon@0.7.0",
+      "_shasum": "0db39f7c434d30be2282502baea2df34dc612ed3",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0db39f7c434d30be2282502baea2df34dc612ed3",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.7.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.7.0.tgz_1474949450052_0.13504316518083215"
+      },
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.7.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "These libraries use snapdragon:",
+          "list": [
+            "braces",
+            "micromatch",
+            "expand-brackets",
+            "extglob"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "f368abeadc2b8bee9e38ae9b73a7e791e3e0d4f4",
+      "_id": "snapdragon@0.7.1",
+      "_shasum": "b48f7d6affc00363fa03a7d5751595b3c274eb87",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b48f7d6affc00363fa03a7d5751595b3c274eb87",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.7.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.7.1.tgz_1475919298711_0.48579126223921776"
+      },
+      "directories": {}
+    },
+    "0.7.2": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.7.2",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "These libraries use snapdragon:",
+          "list": [
+            "braces",
+            "micromatch",
+            "expand-brackets",
+            "extglob"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "d9c9e4305de079577f154d8228600db70be45cae",
+      "_id": "snapdragon@0.7.2",
+      "_shasum": "8d68e945e5e14329306eca1a6695dba6d783cc7d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8d68e945e5e14329306eca1a6695dba6d783cc7d",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.7.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.7.2.tgz_1475919404424_0.48797370586544275"
+      },
+      "directories": {}
+    },
+    "0.7.3": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.7.3",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "These libraries use snapdragon:",
+          "list": [
+            "braces",
+            "micromatch",
+            "expand-brackets",
+            "extglob"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "5e164437a31aade2a350abd739d339545fc9c75b",
+      "_id": "snapdragon@0.7.3",
+      "_shasum": "a00c46806af3998b0defb93e9af9d24d93a5e00e",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a00c46806af3998b0defb93e9af9d24d93a5e00e",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.7.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.7.3.tgz_1476092851043_0.8315688958391547"
+      },
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.8.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "These libraries use snapdragon:",
+          "list": [
+            "braces",
+            "micromatch",
+            "expand-brackets",
+            "extglob"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "f88cadf7adc6560616d795d8856ab232a5257901",
+      "_id": "snapdragon@0.8.0",
+      "_shasum": "0d20de020d7c5bba8f8a36617aa096c23708f547",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0d20de020d7c5bba8f8a36617aa096c23708f547",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.8.0.tgz_1476101300007_0.182540244422853"
+      },
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.8.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "These libraries use snapdragon:",
+          "list": [
+            "braces",
+            "micromatch",
+            "expand-brackets",
+            "extglob"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "9ef383bfad2b2fb65fc7b9b23f279e4b072ef7cb",
+      "_id": "snapdragon@0.8.1",
+      "_shasum": "e12b5487faded3e3dea0ac91e9400bf75b401370",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e12b5487faded3e3dea0ac91e9400bf75b401370",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.8.1.tgz_1476101941080_0.05476894066669047"
+      },
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.9.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.0",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2",
+        "snapdragon-capture": "^0.1.0",
+        "snapdragon-capture-set": "^1.0.0",
+        "verb-generate-readme": "^0.4.1"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "expand-brackets",
+            "extglob",
+            "micromatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-node",
+            "snapdragon-util",
+            "snapdragon-capture-set"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node",
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "d9ca57efe04b26002dcaa574cb9338eb3022ff5f",
+      "_id": "snapdragon@0.9.0",
+      "_shasum": "4f4f2828079b6eb12090be6629847b28fa10dacc",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4f4f2828079b6eb12090be6629847b28fa10dacc",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.9.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.9.0.tgz_1484995080251_0.8137559653259814"
+      },
+      "directories": {}
+    },
+    "0.9.1": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.9.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.6.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.3",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.1.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "expand-brackets",
+            "extglob",
+            "micromatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node",
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "9ef07949b4f1ece6077065ad99e76a50259f0a6a",
+      "_id": "snapdragon@0.9.1",
+      "_shasum": "34bfe5308fb697db3ae7d63164cf3f8e2098edef",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "34bfe5308fb697db3ae7d63164cf3f8e2098edef",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.9.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.9.1.tgz_1486060459295_0.09194394061341882"
+      },
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.10.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.5",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.1.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node",
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "aa6616758561ed7ac7d52771125c813c15e03d6c",
+      "_id": "snapdragon@0.10.0",
+      "_shasum": "6f3dc84605b70671165a0221b61d9df948d8478c",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6f3dc84605b70671165a0221b61d9df948d8478c",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.10.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.10.0.tgz_1486465691215_0.07218118431046605"
+      },
+      "directories": {}
+    },
+    "0.10.1": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.10.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.5",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.1.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node",
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "291fd6387db2ac31d4f7d5c3d64cda70c5c375a6",
+      "_id": "snapdragon@0.10.1",
+      "_shasum": "7a5658ddf8406e3c67c5e0f47b489187df132971",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "6.9.2",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7a5658ddf8406e3c67c5e0f47b489187df132971",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.10.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.10.1.tgz_1486605334408_0.540455324575305"
+      },
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.11.0",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib",
+        "verbfile.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.2"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.3"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node",
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "7bf616979baf704687983f197a1a37a80a2d7b39",
+      "_id": "snapdragon@0.11.0",
+      "_shasum": "260ba99290368fcf54b186a33240b635649dca4a",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.6.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        },
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "260ba99290368fcf54b186a33240b635649dca4a",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/snapdragon-0.11.0.tgz_1489297100648_0.9813721152022481"
+      },
+      "directories": {}
+    },
+    "0.11.1": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.11.1",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Daniel Tschinder",
+          "url": "https://github.com/danez"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib",
+        "verbfile.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.3"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node",
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "a9b141354ea3a29aacb01da0ed46894a04acb442",
+      "_id": "snapdragon@0.11.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-+eyewgSDYrMRJFxnr18IsFnoUjhC6NltRRGDf8bLZic64+n90ZqLzwQkNtJ8fLjdkTBnZO4RG+488Dzwqtzb6Q==",
+        "shasum": "d6661e010ae4e15f58154102bc9ef1acffcd5034",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.1.tgz",
+        "fileCount": 10,
+        "unpackedSize": 52670
+      },
+      "maintainers": [
+        {
+          "email": "brian.woodward@gmail.com",
+          "name": "doowb"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon_0.11.1_1519463597615_0.9867283834211398"
+      }
+    },
+    "0.11.2": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.11.2",
+      "homepage": "https://github.com/here-be/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Daniel Tschinder",
+          "url": "https://github.com/danez"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/here-be/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/here-be/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib",
+        "verbfile.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.3"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node",
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "1f31b07a34db5824949513d1dab5e2fd4d0b3edb",
+      "_id": "snapdragon@0.11.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-lWPTXHHgkLXQ4VtYS0WZ4mg8KouXtOC3b1td2MnKSN6rVMwtgj7IXQ4EpXXy08eYHPe2GZ51xy7RZt0hDBJPmg==",
+        "shasum": "08ae8999e0f911870bca6be1bc7e7181e8cc9fc4",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.2.tgz",
+        "fileCount": 10,
+        "unpackedSize": 52640
+      },
+      "maintainers": [
+        {
+          "email": "brian.woodward@gmail.com",
+          "name": "doowb"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon_0.11.2_1519468815665_0.053594923825706076"
+      }
+    },
+    "0.8.2": {
+      "name": "snapdragon",
+      "description": "Fast, pluggable and easy-to-use parser-renderer factory.",
+      "version": "0.8.2",
+      "homepage": "https://github.com/jonschlinkert/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Edward Betts",
+          "url": "http://edwardbetts.com"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "These libraries use snapdragon:",
+          "list": [
+            "braces",
+            "expand-brackets",
+            "extglob",
+            "micromatch"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "readme": "# snapdragon [![NPM version](https://img.shields.io/npm/v/snapdragon.svg?style=flat)](https://www.npmjs.com/package/snapdragon) [![NPM downloads](https://img.shields.io/npm/dm/snapdragon.svg?style=flat)](https://npmjs.org/package/snapdragon) [![Build Status](https://img.shields.io/travis/jonschlinkert/snapdragon.svg?style=flat)](https://travis-ci.org/jonschlinkert/snapdragon)\n\n> Fast, pluggable and easy-to-use parser-renderer factory.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save snapdragon\n```\n\nCreated by [jonschlinkert](https://github.com/jonschlinkert) and [doowb](https://github.com/doowb).\n\n**Features**\n\n* Bootstrap your own parser, get sourcemap support for free\n* All parsing and compiling is handled by simple, reusable middleware functions\n* Inspired by the parsers in [pug](http://jade-lang.com) and [css](https://github.com/reworkcss/css).\n\n## History\n\n### v0.5.0\n\n**Breaking changes**\n\nSubstantial breaking changes were made in v0.5.0! Most of these changes are part of a larger refactor that will be finished in 0.6.0, including the introduction of a `Lexer` class.\n\n* Renderer was renamed to `Compiler`\n* the `.render` method was renamed to `.compile`\n* Many other smaller changes. A more detailed overview will be provided in 0.6.0. If you don't have to time review code, I recommend you wait for the 0.6.0 release.\n\n## Usage examples\n\n```js\nvar Snapdragon = require('snapdragon');\nvar snapdragon = new Snapdragon();\n```\n\n**Parse**\n\n```js\nvar ast = snapdragon.parser('some string', options)\n  // parser middleware that can be called by other middleware\n  .set('foo', function () {})\n  // parser middleware, runs immediately in the order defined\n  .use(bar())\n  .use(baz())\n```\n\n**Render**\n\n```js\n// pass the `ast` from the parse method\nvar res = snapdragon.compiler(ast)\n  // compiler middleware, called when the name of the middleware\n  // matches the `node.type` (defined in a parser middleware)\n  .set('bar', function () {})\n  .set('baz', function () {})\n  .compile()\n```\n\nSee the [examples](./examples/).\n\n## Getting started\n\n**Parsers**\n\nParsers are middleware functions used for parsing a string into an ast node.\n\n```js\nvar ast = snapdragon.parser(str, options)\n  .use(function() {\n    var pos = this.position();\n    var m = this.match(/^\\./);\n    if (!m) return;\n    return pos({\n      // `type` specifies the compiler to use\n      type: 'dot',\n      val: m[0]\n    });\n  })\n```\n\n**AST node**\n\nWhen the parser finds a match, `pos()` is called, pushing a token for that node onto the ast that looks something like:\n\n```js\n{ type: 'dot',\n  val: '.',\n  position:\n   { start: { lineno: 1, column: 1 },\n     end: { lineno: 1, column: 2 } }}\n```\n\n**Renderers**\n\nRenderers are _named_ middleware functions that visit over an array of ast nodes to compile a string.\n\n```js\nvar res = snapdragon.compiler(ast)\n  .set('dot', function (node) {\n    console.log(node.val)\n    //=> '.'\n    return this.emit(node.val);\n  })\n```\n\n**Source maps**\n\nIf you want source map support, make sure to emit the position as well.\n\n```js\nvar res = snapdragon.compiler(ast)\n  .set('dot', function (node) {\n    return this.emit(node.val, node.position);\n  })\n```\n\n## Docs\n\n### Parser middleware\n\nA parser middleware is a function that returns an abject called a `token`. This token is pushed onto the AST as a node.\n\n**Example token**\n\n```js\n{ type: 'dot',\n  val: '.',\n  position:\n   { start: { lineno: 1, column: 1 },\n     end: { lineno: 1, column: 2 } }}\n```\n\n**Example parser middleware**\n\nMatch a single `.` in a string:\n\n1. Get the starting position by calling `this.position()`\n2. pass a regex for matching a single dot to the `.match` method\n3. if **no match** is found, return `undefined`\n4. if a **match** is found, `pos()` is called, which returns a token with:\n  - `type`: the name of the [compiler] to use\n  - `val`: The actual value captured by the regex. In this case, a `.`. Note that you can capture and return whatever will be needed by the corresponding [compiler].\n  - The ending position: automatically calculated by adding the length of the first capture group to the starting position.\n\n## Renderer middleware\n\nRenderers are run when the name of the compiler middleware matches the `type` defined on an ast `node` (which is defined in a parser).\n\n**Example**\n\nExercise: Parse a dot, then compile it as an escaped dot.\n\n```js\nvar ast = snapdragon.parser('.')\n  .use(function () {\n    var pos = this.position();\n    var m = this.match(/^\\./);\n    if (!m) return;\n    return pos({\n      // define the `type` of compiler to use\n      type: 'dot',\n      val: m[0]\n    })\n  })\n\nvar result = snapdragon.compiler(ast)\n  .set('dot', function (node) {\n    return this.emit('\\\\' + node.val);\n  })\n  .compile()\n\nconsole.log(result.output);\n//=> '\\.'\n```\n\n## API\n\n### [Parser](lib/parser.js#L19)\n\nCreate a new `Parser` with the given `input` and `options`.\n\n**Params**\n\n* `input` **{String}**\n* `options` **{Object}**\n\n### [.define](lib/parser.js#L103)\n\nDefine a non-enumberable property on the `Parser` instance.\n\n**Example**\n\n```js\nparser.define('foo', 'bar');\n```\n\n**Params**\n\n* `key` **{String}**: propery name\n* `val` **{any}**: property value\n* `returns` **{Object}**: Returns the Parser instance for chaining.\n\nSet parser `name` with the given `fn`\n\n**Params**\n\n* `name` **{String}**\n* `fn` **{Function}**\n\nGet parser `name`\n\n**Params**\n\n* `name` **{String}**\n\nPush a `token` onto the `type` stack.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Object}** `token`\n\nPop a token off of the `type` stack\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Object}**: Returns a token\n\nReturn true if inside a `stack` node. Types are `braces`, `parens` or `brackets`.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nparser.isType(node, 'brace');\n```\n\n**Params**\n\n* `node` **{Object}**\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n### [.define](lib/compiler.js#L71)\n\nDefine a non-enumberable property on the `Compiler` instance.\n\n**Example**\n\n```js\ncompiler.define('foo', 'bar');\n```\n\n**Params**\n\n* `key` **{String}**: propery name\n* `val` **{any}**: property value\n* `returns` **{Object}**: Returns the Compiler instance for chaining.\n\n## About\n\n### Related projects\n\n* [braces](https://www.npmjs.com/package/braces): Fastest brace expansion for node.js, with the most complete support for the Bash 4.3 braces… [more](https://github.com/jonschlinkert/braces) | [homepage](https://github.com/jonschlinkert/braces \"Fastest brace expansion for node.js, with the most complete support for the Bash 4.3 braces specification.\")\n* [expand-brackets](https://www.npmjs.com/package/expand-brackets): Expand POSIX bracket expressions (character classes) in glob patterns. | [homepage](https://github.com/jonschlinkert/expand-brackets \"Expand POSIX bracket expressions (character classes) in glob patterns.\")\n* [extglob](https://www.npmjs.com/package/extglob): Convert extended globs to regex-compatible strings. Add (almost) the expressive power of regular expressions to… [more](https://github.com/jonschlinkert/extglob) | [homepage](https://github.com/jonschlinkert/extglob \"Convert extended globs to regex-compatible strings. Add (almost) the expressive power of regular expressions to glob patterns.\")\n* [micromatch](https://www.npmjs.com/package/micromatch): Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch. | [homepage](https://github.com/jonschlinkert/micromatch \"Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch.\")\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Contributors\n\n| **Commits** | **Contributor**<br/> | \n| --- | --- |\n| 106 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 2 | [doowb](https://github.com/doowb) |\n\n### Building docs\n\n_(This document was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme) (a [verb](https://github.com/verbose/verb) generator), please don't edit the readme directly. Any changes to the readme must be made in [.verb.md](.verb.md).)_\n\nTo generate the readme and API documentation with [verb](https://github.com/verbose/verb):\n\n```sh\n$ npm install -g verb verb-generate-readme && verb\n```\n\n### Running tests\n\nInstall dev dependencies:\n\n```sh\n$ npm install -d && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](http://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2016, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT license](https://github.com/jonschlinkert/snapdragon/blob/master/LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.1.31, on October 10, 2016._",
+      "readmeFilename": "README.md",
+      "gitHead": "6c952b12cabe896a86d9a4fe378f934bccbe6436",
+      "_id": "snapdragon@0.8.2",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.7.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+        "shasum": "64922e7c565b0e14204ba1aa7d6964278d25182d",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 35228
+      },
+      "maintainers": [
+        {
+          "email": "brian.woodward@gmail.com",
+          "name": "doowb"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon_0.8.2_1520776598430_0.674348590844402"
+      }
+    },
+    "0.11.3": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.11.3",
+      "homepage": "https://github.com/here-be/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Daniel Tschinder",
+          "url": "https://github.com/danez"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/here-be/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/here-be/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-capture": "^0.2.0",
+        "gulp": "^3.9.1",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "gulp-format-md": "^0.1.11",
+        "verb-generate-readme": "^0.6.0"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "a05b1903473174f4492f12cf95dc39e9b5b7e70d",
+      "_id": "snapdragon@0.11.3",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.7.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-x/zK3oUmOuJiF5zuYvtkEgM3gQ5lLTiZsVGCwyPqpGTK3RwllzF01DxfrReuizy68xs5Yx2Yi4r9NTmdZDpA0g==",
+        "shasum": "a1fa5ddb6ee8122edba3b717a8cf6ffe04b9f5da",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.3.tgz",
+        "fileCount": 9,
+        "unpackedSize": 52074
+      },
+      "maintainers": [
+        {
+          "email": "brian.woodward@gmail.com",
+          "name": "doowb"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon_0.11.3_1521590778620_0.4619365623953484"
+      }
+    },
+    "0.11.4": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.11.4",
+      "homepage": "https://github.com/here-be/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Daniel Tschinder",
+          "url": "https://github.com/danez"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/here-be/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/here-be/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^4.0.0",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-capture": "^0.2.0",
+        "gulp": "^3.9.1",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "gulp-format-md": "^0.1.11",
+        "verb-generate-readme": "^0.6.0"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "d1f94bed9abfff862d066a679b4b9888a2cecf1d",
+      "_id": "snapdragon@0.11.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "danez",
+        "email": "daniel@tschinder.de"
+      },
+      "dist": {
+        "integrity": "sha512-p5kB9EVE2VobItKhgrnVWmYsKw2RVV8OrzocrmO3va4fcp9vzJaSYz9CKtL+k6vIQ5gTiiDlxR+VbBMDPkb05w==",
+        "shasum": "2d420e6045c9ea252ba6d096f4f6ccbf27928645",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.4.tgz",
+        "fileCount": 9,
+        "unpackedSize": 51961
+      },
+      "maintainers": [
+        {
+          "email": "daniel@tschinder.de",
+          "name": "danez"
+        },
+        {
+          "email": "brian.woodward@gmail.com",
+          "name": "doowb"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon_0.11.4_1523268385789_0.538461442928829"
+      }
+    },
+    "0.11.5": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.11.5",
+      "homepage": "https://github.com/here-be/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Daniel Tschinder",
+          "url": "https://github.com/danez"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/here-be/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/here-be/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-capture": "^0.2.0",
+        "gulp": "^3.9.1",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "gulp-format-md": "^0.1.11",
+        "verb-generate-readme": "^0.6.0"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "3067f0fe16d5d2771aea793c450f09cb2da533ca",
+      "_id": "snapdragon@0.11.5",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-iC2oF+H+TjiZN4a7I5HNUH8imAFT9z3GydV8X5ZFLcBiDYROWNeqI34BHArXTVO/RGs88STtAtiMP3tCiNdUYg==",
+        "shasum": "522812d175f24f919629fd37406b02e434e645e6",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.5.tgz",
+        "fileCount": 9,
+        "unpackedSize": 52074,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1321CRA9TVsSAnZWagAA7x8QAJ/two9eQzhSn8b8LM8H\nDKBaNZPGXhD/3Vz1QFkZ9jBA9JP4flkUgPDDH4l6QY7wzKCekhCEMvFyQYym\nNBjbAZoJNuJ+iCEhc3lDnCOg1sckTrWLoj0reol7KGUx/F1bbJq0/tozD8ES\niq+iHbAlOUfmGaSzNC4eZdgdD0bLN7EpWP1r1iFCTemxF8ebpV1+ourafMn8\nyYR5bET4YHz9hi5ReOQvxLheVxrl3PNiEjNAaLUFC69RfF2Q2lnMikUv8VQq\nE214m+dF+YAqLJUS7Ym3LqYg8V+vt8dv92JvdJV2KKlmUVlJrKHwgBSwxY+z\nB926haJR36PpfuNVIILzInyiBNb17dE/fAsQS0wdMjzdCK8LJKvRje6TFduT\nzBhFPzDctukh4C8EH/HGOsHNGYNUPBrRSahvOUhAk0L7SvlpCkkQnPv6dzCD\nlPCaSAASzqrL822/fIGEWO7ZTX+imbo1NpKYprPeCIUWbN5pjw3o04IKGaIL\n9N6whFmYY4NLoAC5CUn6sSv9iGpiyTl9DmCxeqDftkB/2zaZZERuAZvLlOyk\nhGwq98X5Jyi4P2Fopdm5N3F87uTqZVqSqPabOqKXw7T7fmQRT77boBcOp3xB\nEWKC/oXO0pTJ2HHW2WGqjbek5dBNqOXPxPUfqeoAlNXRuQPd7kexgW9B/1KS\nAcKT\r\n=fDBm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "daniel@tschinder.de",
+          "name": "danez"
+        },
+        {
+          "email": "brian.woodward@gmail.com",
+          "name": "doowb"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon_0.11.5_1524071860558_0.9206960309060677"
+      }
+    },
+    "0.12.0": {
+      "name": "snapdragon",
+      "description": "Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.",
+      "version": "0.12.0",
+      "homepage": "https://github.com/here-be/snapdragon",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Daniel Tschinder",
+          "url": "https://github.com/danez"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/here-be/snapdragon.git"
+      },
+      "bugs": {
+        "url": "https://github.com/here-be/snapdragon/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js",
+        "lib"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^4.0.0",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-capture": "^0.2.0",
+        "gulp": "^3.9.1",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "gulp-format-md": "^0.1.11",
+        "verb-generate-readme": "^0.6.0"
+      },
+      "keywords": [
+        "lexer",
+        "snapdragon"
+      ],
+      "verb": {
+        "toc": "collapsible",
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "description": "A few of the libraries that use snapdragon:",
+          "implementations": [
+            "braces",
+            "breakdance",
+            "expand-brackets",
+            "extglob",
+            "micromatch",
+            "nanomatch"
+          ],
+          "list": [
+            "snapdragon-capture",
+            "snapdragon-capture-set",
+            "snapdragon-node",
+            "snapdragon-util"
+          ]
+        },
+        "reflinks": [
+          "css",
+          "pug",
+          "snapdragon-capture",
+          "snapdragon-capture-set",
+          "snapdragon-node"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "82fb20dc905ac0e22061ffaabaced311f296d4cd",
+      "_id": "snapdragon@0.12.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-E7epxLolFdELn4LzTfDOImU0gZDk5Y071Pou8+3rEP7980ZbDbBje3xDQAqP5lnPItU1W7QEoqNSJvHtvK8DcQ==",
+        "shasum": "ad7e56891a87eb38012386159bee99a0430e6e06",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.12.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 51961,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa136KCRA9TVsSAnZWagAAZ6wQAJESx5m4d2EumEaKoQxi\nGPLg371uxQS+wGCDK+h+UsAxFJaqMOvdXMxu0ZduNNJtorbksd+Et3wc+iOq\nV/kFflfYwlq+/DBDxwV+qJXLMm/iRSyJD0M9ZYqiv2A/8e5zox5PWChkFva7\nr4XbGYbsB17YP4EQqoRhelzzanPOGEmbudwTNvI+xphR4JzpYZJcV5RLN4vH\ne2qU+ZZZljujFcceAKe4wj8ITLIm0zfzCPE6hqbPQKLEoLMDVojACZKDuAll\n8JB/BKOp8mTPPa/af9dBqc+zHCJP4w7t+Pw7l1g16vwPlmk1/+YINyqPi772\nUzfCX7hBbYQ1kpM78VMildR0G7k4UY4D7hSrEUbsNwa4otqUZH6kIXhoIAQu\no2tEYreePR2BgzwEWPsudtk//5VydAGxUVORmgrvAo040SN4gSYLZRoz/mTI\nOUQpy+Vg1BWR+S5IE+5JgfM/g6ZNpHmsl+xXwcCEJdF1OVcMEAet1CnCuiPv\nZNb6kgov/Tk5q/IJi6DhXHAL8kVlTLm1f2bWUEFAmHSqdcNabQoMDu938tKu\nfvQlGXamH971zd2eMtPCmnfL7SZqftJv5WJHCqktejtIRSep6x1U39xErXSq\nKb1ONqXzFcWwDjLMgdgwd4cvjF1B+vYqPdPnX1QP0YxrYJY+4VpWRiyS+1fa\ncOXO\r\n=xGSM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "daniel@tschinder.de",
+          "name": "danez"
+        },
+        {
+          "email": "brian.woodward@gmail.com",
+          "name": "doowb"
+        },
+        {
+          "email": "github@sellside.com",
+          "name": "jonschlinkert"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/snapdragon_0.12.0_1524072072857_0.6239108463867951"
+      }
+    }
+  },
+  "readme": "# snapdragon [![NPM version](https://img.shields.io/npm/v/snapdragon.svg?style=flat)](https://www.npmjs.com/package/snapdragon) [![NPM monthly downloads](https://img.shields.io/npm/dm/snapdragon.svg?style=flat)](https://npmjs.org/package/snapdragon) [![NPM total downloads](https://img.shields.io/npm/dt/snapdragon.svg?style=flat)](https://npmjs.org/package/snapdragon) [![Linux Build Status](https://img.shields.io/travis/here-be/snapdragon.svg?style=flat&label=Travis)](https://travis-ci.org/here-be/snapdragon)\n\n> Easy-to-use plugin system for creating powerful, fast and versatile parsers and compilers, with built-in source-map support.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Table of Contents\n\n<details>\n<summary><strong>Details</strong></summary>\n\n- [Install](#install)\n- [Quickstart example](#quickstart-example)\n- [Parsing](#parsing)\n- [Compiling](#compiling)\n- [All together](#all-together)\n- [API](#api)\n  * [Parse](#parse)\n  * [Compile](#compile)\n- [Snapdragon in the wild](#snapdragon-in-the-wild)\n- [History](#history)\n  * [v0.9.0](#v090)\n  * [v0.5.0](#v050)\n- [About](#about)\n\n</details>\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save snapdragon\n```\n\nCreated by [jonschlinkert](https://github.com/jonschlinkert) and [doowb](https://github.com/doowb).\n\n**Features**\n\n* Bootstrap your own parser, get sourcemap support for free\n* All parsing and compiling is handled by simple, reusable middleware functions\n* Inspired by the parsers in [pug](https://pugjs.org/) and [css](https://github.com/reworkcss/css).\n\n## Quickstart example\n\nAll of the examples in this document assume the following two lines of setup code exist first:\n\n```js\nvar Snapdragon = require('snapdragon');\nvar snapdragon = new Snapdragon();\n```\n\n**Parse a string**\n\n```js\nvar ast = snapdragon.parser\n  // parser handlers (essentially middleware)\n  // used for parsing substrings to create tokens\n  .set('foo', function () {})\n  .set('bar', function () {})\n  .parse('some string', options);\n```\n\n**Compile an AST returned from `.parse()`**\n\n```js\nvar result = snapdragon.compiler\n  // compiler handlers (essentially middleware), \n  // called on a node when the `node.type` matches\n  // the name of the handler\n  .set('foo', function () {})\n  .set('bar', function () {})\n  // pass the `ast` from the parse method\n  .compile(ast)\n\n// the compiled string\nconsole.log(result.output);\n```\n\nSee the [examples](./examples/).\n\n## Parsing\n\n**Parser handlers**\n\nParser handlers are middleware functions responsible for matching substrings to create tokens:\n\n**Example handler**\n\n```js\nvar ast = snapdragon.parser\n  .set('dot', function() {\n    var pos = this.position();\n    var m = this.match(/^\\./);\n    if (!m) return;\n    return pos({\n      // the \"type\" will be used by the compiler later on,\n      // we'll go over this in the compiler docs\n      type: 'dot',\n      // \"val\" is the string captured by \".match\",\n      // in this case that would be '.'\n      val: m[0]\n    });\n  })\n  .parse('.'[, options])\n```\n\n_As a side node, it's not scrictly required to set the `type` on the token, since the parser will add it to the token if it's undefined, based on the name of the handler. But it's good practice since tokens aren't always returned._\n\n**Example token**\n\nAnd the resulting tokens look something like this:\n\n```js\n{ \n  type: 'dot',\n  val: '.' \n}\n```\n\n**Position**\n\nNext, `pos()` is called on the token as it's returned, which patches the token with the `position` of the string that was captured:\n\n```js\n{ type: 'dot',\n  val: '.',\n  position:\n   { start: { lineno: 1, column: 1 },\n     end: { lineno: 1, column: 2 } }}\n```\n\n**Life as an AST node**\n\nWhen the token is returned, the parser pushes it onto the `nodes` array of the \"previous\" node (since we're in a tree, the \"previous\" node might be literally the last node that was created, or it might be the \"parent\" node inside a nested context, like when parsing brackets or something with an open or close), at which point the token begins its life as an AST node.\n\n**Wrapping up**\n\nIn the parser calls all handlers and cannot find a match for a substring, an error is thrown.\n\nAssuming the parser finished parsing the entire string, an AST is returned.\n\n## Compiling\n\nThe compiler's job is to take the AST created by the [parser](#parsing) and convert it to a new string. It does this by iterating over each node on the AST and calling a function on the node based on its `type`.\n\nThis function is called a \"handler\".\n\n**Compiler handlers**\n\nHandlers are _named_ middleware functions that are called on a node when `node.type` matches the name of a registered handler.\n\n```js\nvar result = snapdragon.compiler\n  .set('dot', function (node) {\n    console.log(node.val)\n    //=> '.'\n    return this.emit(node.val);\n  })\n```\n\nIf `node.type` does not match a registered handler, an error is thrown.\n\n**Source maps**\n\nIf you want source map support, make sure to emit the entire node as the second argument as well (this allows the compiler to get the `node.position`).\n\n```js\nvar res = snapdragon.compiler\n  .set('dot', function (node) {\n    return this.emit(node.val, node);\n  })\n```\n\n## All together\n\nThis is a very basic example, but it shows how to parse a dot, then compile it as an escaped dot.\n\n```js\nvar Snapdragon = require('..');\nvar snapdragon = new Snapdragon();\n\nvar ast = snapdragon.parser\n  .set('dot', function () {\n    var pos = this.position();\n    var m = this.match(/^\\./);\n    if (!m) return;\n    return pos({\n      type: 'dot',\n      val: m[0]\n    })\n  })\n  .parse('.')\n\nvar result = snapdragon.compiler\n  .set('dot', function (node) {\n    return this.emit('\\\\' + node.val);\n  })\n  .compile(ast)\n\nconsole.log(result.output);\n//=> '\\.'\n```\n\n## API\n\n### [Parser](lib/parser.js#L27)\n\nCreate a new `Parser` with the given `input` and `options`.\n\n**Params**\n\n* `input` **{String}**\n* `options` **{Object}**\n\n**Example**\n\n```js\nvar Snapdragon = require('snapdragon');\nvar Parser = Snapdragon.Parser;\nvar parser = new Parser();\n```\n\n### [.error](lib/parser.js#L97)\n\nThrow a formatted error message with details including the cursor position.\n\n**Params**\n\n* `msg` **{String}**: Message to use in the Error.\n* `node` **{Object}**\n* `returns` **{undefined}**\n\n**Example**\n\n```js\nparser.set('foo', function(node) {\n  if (node.val !== 'foo') {\n    throw this.error('expected node.val to be \"foo\"', node);\n  }\n});\n```\n\n### [.define](lib/parser.js#L115)\n\nDefine a non-enumberable property on the `Parser` instance. This is useful in plugins, for exposing methods inside handlers.\n\n**Params**\n\n* `key` **{String}**: propery name\n* `val` **{any}**: property value\n* `returns` **{Object}**: Returns the Parser instance for chaining.\n\n**Example**\n\n```js\nparser.define('foo', 'bar');\n```\n\n### [.node](lib/parser.js#L133)\n\nCreate a new [Node](#node) with the given `val` and `type`.\n\n**Params**\n\n* `val` **{Object}**\n* `type` **{String}**\n* `returns` **{Object}**: returns the [Node](#node) instance.\n\n**Example**\n\n```js\nparser.node('/', 'slash');\n```\n\n### [.position](lib/parser.js#L155)\n\nMark position and patch `node.position`.\n\n* `returns` **{Function}**: Returns a function that takes a `node`\n\n**Example**\n\n```js\nparser.set('foo', function(node) {\n  var pos = this.position();\n  var match = this.match(/foo/);\n  if (match) {\n    // call `pos` with the node\n    return pos(this.node(match[0]));\n  }\n});\n```\n\n### [.set](lib/parser.js#L187)\n\nAdd parser `type` with the given visitor `fn`.\n\n**Params**\n\n* `type` **{String}**\n* `fn` **{Function}**\n\n**Example**\n\n```js\n parser.set('all', function() {\n   var match = this.match(/^./);\n   if (match) {\n     return this.node(match[0]);\n   }\n });\n```\n\n### [.get](lib/parser.js#L206)\n\nGet parser `type`.\n\n**Params**\n\n* `type` **{String}**\n\n**Example**\n\n```js\nvar fn = parser.get('slash');\n```\n\n### [.push](lib/parser.js#L229)\n\nPush a node onto the stack for the given `type`.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Object}** `token`\n\n**Example**\n\n```js\nparser.set('all', function() {\n  var match = this.match(/^./);\n  if (match) {\n    var node = this.node(match[0]);\n    this.push(node);\n    return node;\n  }\n});\n```\n\n### [.pop](lib/parser.js#L261)\n\nPop a token off of the stack of the given `type`.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Object}**: Returns a token\n\n**Example**\n\n```js\nparser.set('close', function() {\n  var match = this.match(/^\\}/);\n  if (match) {\n    var node = this.node({\n      type: 'close',\n      val: match[0]\n    });\n\n    this.pop(node.type);\n    return node;\n  }\n});\n```\n\n### [.isInside](lib/parser.js#L294)\n\nReturn true if inside a \"set\" of the given `type`. Sets are created manually by adding a type to `parser.sets`. A node is \"inside\" a set when an `*.open` node for the given `type` was previously pushed onto the set. The type is removed from the set by popping it off when the `*.close` node for the given type is reached.\n\n**Params**\n\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nparser.set('close', function() {\n  var pos = this.position();\n  var m = this.match(/^\\}/);\n  if (!m) return;\n  if (!this.isInside('bracket')) {\n    throw new Error('missing opening bracket');\n  }\n});\n```\n\n### [.isType](lib/parser.js#L324)\n\nReturn true if `node` is the given `type`.\n\n**Params**\n\n* `node` **{Object}**\n* `type` **{String}**\n* `returns` **{Boolean}**\n\n**Example**\n\n```js\nparser.isType(node, 'brace');\n```\n\n### [.prev](lib/parser.js#L340)\n\nGet the previous AST node from the `parser.stack` (when inside a nested context) or `parser.nodes`.\n\n* `returns` **{Object}**\n\n**Example**\n\n```js\nvar prev = this.prev();\n```\n\n### [.prev](lib/parser.js#L394)\n\nMatch `regex`, return captures, and update the cursor position by `match[0]` length.\n\n**Params**\n\n* `regex` **{RegExp}**\n* `returns` **{Object}**\n\n**Example**\n\n```js\n// make sure to use the starting regex boundary: \"^\"\nvar match = this.match(/^\\./);\n```\n\n**Params**\n\n* `input` **{String}**\n* `returns` **{Object}**: Returns an AST with `ast.nodes`\n\n**Example**\n\n```js\nvar ast = parser.parse('foo/bar');\n```\n\n### [Compiler](lib/compiler.js#L24)\n\nCreate a new `Compiler` with the given `options`.\n\n**Params**\n\n* `options` **{Object}**\n* `state` **{Object}**: Optionally pass a \"state\" object to use inside visitor functions.\n\n**Example**\n\n```js\nvar Snapdragon = require('snapdragon');\nvar Compiler = Snapdragon.Compiler;\nvar compiler = new Compiler();\n```\n\n### [.error](lib/compiler.js#L67)\n\nThrow a formatted error message with details including the cursor position.\n\n**Params**\n\n* `msg` **{String}**: Message to use in the Error.\n* `node` **{Object}**\n* `returns` **{undefined}**\n\n**Example**\n\n```js\ncompiler.set('foo', function(node) {\n  if (node.val !== 'foo') {\n    throw this.error('expected node.val to be \"foo\"', node);\n  }\n});\n```\n\n### [.emit](lib/compiler.js#L86)\n\nConcat the given string to `compiler.output`.\n\n**Params**\n\n* `string` **{String}**\n* `node` **{Object}**: Optionally pass the node to use for position if source maps are enabled.\n* `returns` **{String}**: returns the string\n\n**Example**\n\n```js\ncompiler.set('foo', function(node) {\n  this.emit(node.val, node);\n});\n```\n\n### [.noop](lib/compiler.js#L104)\n\nEmit an empty string to effectively \"skip\" the string for the given `node`, but still emit the position and node type.\n\n**Params**\n\n* **{Object}**: node\n\n**Example**\n\n```js\n// example: do nothing for beginning-of-string\nsnapdragon.compiler.set('bos', compiler.noop);\n```\n\n### [.define](lib/compiler.js#L124)\n\nDefine a non-enumberable property on the `Compiler` instance. This is useful in plugins, for exposing methods inside handlers.\n\n**Params**\n\n* `key` **{String}**: propery name\n* `val` **{any}**: property value\n* `returns` **{Object}**: Returns the Compiler instance for chaining.\n\n**Example**\n\n```js\ncompiler.define('customMethod', function() {\n  // do stuff\n});\n```\n\n### [.set](lib/compiler.js#L152)\n\nAdd a compiler `fn` for the given `type`. Compilers are called when the `.compile` method encounters a node of the given type to generate the output string.\n\n**Params**\n\n* `type` **{String}**\n* `fn` **{Function}**\n\n**Example**\n\n```js\ncompiler\n  .set('comma', function(node) {\n    this.emit(',');\n  })\n  .set('dot', function(node) {\n    this.emit('.');\n  })\n  .set('slash', function(node) {\n    this.emit('/');\n  });\n```\n\n### [.get](lib/compiler.js#L168)\n\nGet the compiler of the given `type`.\n\n**Params**\n\n* `type` **{String}**\n\n**Example**\n\n```js\nvar fn = compiler.get('slash');\n```\n\n### [.visit](lib/compiler.js#L188)\n\nVisit `node` using the registered compiler function associated with the `node.type`.\n\n**Params**\n\n* `node` **{Object}**\n* `returns` **{Object}**: returns the node\n\n**Example**\n\n```js\ncompiler\n  .set('i', function(node) {\n    this.visit(node);\n  })\n```\n\n### [.mapVisit](lib/compiler.js#L226)\n\nIterate over `node.nodes`, calling [visit](#visit) on each node.\n\n**Params**\n\n* `node` **{Object}**\n* `returns` **{Object}**: returns the node\n\n**Example**\n\n```js\ncompiler\n  .set('i', function(node) {\n    utils.mapVisit(node);\n  })\n```\n\n### [.compile](lib/compiler.js#L250)\n\nCompile the given `AST` and return a string. Iterates over `ast.nodes` with [mapVisit](#mapVisit).\n\n**Params**\n\n* `ast` **{Object}**\n* `options` **{Object}**: Compiler options\n* `returns` **{Object}**: returns the node\n\n**Example**\n\n```js\nvar ast = parser.parse('foo');\nvar str = compiler.compile(ast);\n```\n\n## Snapdragon in the wild\n\nA few of the libraries that use snapdragon:\n\n* [braces](https://www.npmjs.com/package/braces): Bash-like brace expansion, implemented in JavaScript. Safer than other brace expansion libs, with complete support… [more](https://github.com/micromatch/braces) | [homepage](https://github.com/micromatch/braces \"Bash-like brace expansion, implemented in JavaScript. Safer than other brace expansion libs, with complete support for the Bash 4.3 braces specification, without sacrificing speed.\")\n* [breakdance](https://www.npmjs.com/package/breakdance): Breakdance is a node.js library for converting HTML to markdown. Highly pluggable, flexible and easy… [more](http://breakdance.io) | [homepage](http://breakdance.io \"Breakdance is a node.js library for converting HTML to markdown. Highly pluggable, flexible and easy to use. It's time for your markup to get down.\")\n* [expand-brackets](https://www.npmjs.com/package/expand-brackets): Expand POSIX bracket expressions (character classes) in glob patterns. | [homepage](https://github.com/jonschlinkert/expand-brackets \"Expand POSIX bracket expressions (character classes) in glob patterns.\")\n* [extglob](https://www.npmjs.com/package/extglob): Extended glob support for JavaScript. Adds (almost) the expressive power of regular expressions to glob… [more](https://github.com/micromatch/extglob) | [homepage](https://github.com/micromatch/extglob \"Extended glob support for JavaScript. Adds (almost) the expressive power of regular expressions to glob patterns.\")\n* [micromatch](https://www.npmjs.com/package/micromatch): Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch. | [homepage](https://github.com/micromatch/micromatch \"Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch.\")\n* [nanomatch](https://www.npmjs.com/package/nanomatch): Fast, minimal glob matcher for node.js. Similar to micromatch, minimatch and multimatch, but complete Bash… [more](https://github.com/micromatch/nanomatch) | [homepage](https://github.com/micromatch/nanomatch \"Fast, minimal glob matcher for node.js. Similar to micromatch, minimatch and multimatch, but complete Bash 4.3 wildcard support only (no support for exglobs, posix brackets or braces)\")\n\n## History\n\n### v0.9.0\n\n**Breaking changes!**\n\nIn an attempt to make snapdragon lighter, more versatile, and more pluggable, some major changes were made in this release.\n\n* `parser.capture` was externalized to [snapdragon-capture](https://github.com/jonschlinkert/snapdragon-capture)\n* `parser.capturePair` was externalized to [snapdragon-capture-set](https://github.com/jonschlinkert/snapdragon-capture-set)\n* Nodes are now an instance of [snapdragon-node](https://github.com/jonschlinkert/snapdragon-node)\n\n### v0.5.0\n\n**Breaking changes!**\n\nSubstantial breaking changes were made in v0.5.0! Most of these changes are part of a larger refactor that will be finished in 0.6.0, including the introduction of a `Lexer` class.\n\n* Renderer was renamed to `Compiler`\n* the `.render` method was renamed to `.compile`\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nA few of the libraries that use snapdragon:\n\n* [snapdragon-capture-set](https://www.npmjs.com/package/snapdragon-capture-set): Plugin that adds a `.captureSet()` method to snapdragon, for matching and capturing substrings that have… [more](https://github.com/jonschlinkert/snapdragon-capture-set) | [homepage](https://github.com/jonschlinkert/snapdragon-capture-set \"Plugin that adds a `.captureSet()` method to snapdragon, for matching and capturing substrings that have an `open` and `close`, like braces, brackets, etc\")\n* [snapdragon-capture](https://www.npmjs.com/package/snapdragon-capture): Snapdragon plugin that adds a capture method to the parser instance. | [homepage](https://github.com/jonschlinkert/snapdragon-capture \"Snapdragon plugin that adds a capture method to the parser instance.\")\n* [snapdragon-node](https://www.npmjs.com/package/snapdragon-node): Snapdragon utility for creating a new AST node in custom code, such as plugins. | [homepage](https://github.com/jonschlinkert/snapdragon-node \"Snapdragon utility for creating a new AST node in custom code, such as plugins.\")\n* [snapdragon-util](https://www.npmjs.com/package/snapdragon-util): Utilities for the snapdragon parser/compiler. | [homepage](https://github.com/here-be/snapdragon-util \"Utilities for the snapdragon parser/compiler.\")\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 156 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 3 | [doowb](https://github.com/doowb) |\n| 2 | [danez](https://github.com/danez) |\n| 1 | [EdwardBetts](https://github.com/EdwardBetts) |\n\n### Author\n\n**Jon Schlinkert**\n\n* [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)\n* [GitHub Profile](https://github.com/jonschlinkert)\n* [Twitter Profile](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on March 20, 2018._",
+  "maintainers": [
+    {
+      "email": "daniel@tschinder.de",
+      "name": "danez"
+    },
+    {
+      "email": "brian.woodward@gmail.com",
+      "name": "doowb"
+    },
+    {
+      "email": "github@sellside.com",
+      "name": "jonschlinkert"
+    }
+  ],
+  "time": {
+    "modified": "2018-04-18T17:21:17.524Z",
+    "created": "2015-05-11T03:18:31.916Z",
+    "0.1.0": "2015-05-11T03:18:31.916Z",
+    "0.1.1": "2015-05-11T17:44:04.852Z",
+    "0.1.2": "2015-05-16T03:07:56.202Z",
+    "0.2.0": "2015-05-30T02:37:47.908Z",
+    "0.2.1": "2015-08-31T06:44:48.670Z",
+    "0.2.2": "2015-09-24T02:26:47.631Z",
+    "0.2.3": "2015-12-09T09:06:03.920Z",
+    "0.3.0": "2015-12-09T11:14:00.934Z",
+    "0.3.1": "2015-12-09T12:01:52.225Z",
+    "0.4.0": "2016-04-20T06:57:43.943Z",
+    "0.4.1": "2016-04-26T09:32:01.708Z",
+    "0.4.2": "2016-04-29T17:41:44.379Z",
+    "0.5.0": "2016-09-05T13:37:49.810Z",
+    "0.6.0": "2016-09-09T03:58:50.112Z",
+    "0.7.0": "2016-09-27T04:10:51.590Z",
+    "0.7.1": "2016-10-08T09:34:59.344Z",
+    "0.7.2": "2016-10-08T09:36:45.146Z",
+    "0.7.3": "2016-10-10T09:47:32.910Z",
+    "0.8.0": "2016-10-10T12:08:21.693Z",
+    "0.8.1": "2016-10-10T12:19:03.060Z",
+    "0.9.0": "2017-01-21T10:38:02.350Z",
+    "0.9.1": "2017-02-02T18:34:21.103Z",
+    "0.10.0": "2017-02-07T11:08:11.899Z",
+    "0.10.1": "2017-02-09T01:55:35.683Z",
+    "0.11.0": "2017-03-12T05:38:21.388Z",
+    "0.11.1": "2018-02-24T09:13:17.667Z",
+    "0.11.2": "2018-02-24T10:40:15.731Z",
+    "0.8.2": "2018-03-11T13:56:38.513Z",
+    "0.11.3": "2018-03-21T00:06:18.675Z",
+    "0.11.4": "2018-04-09T10:06:25.873Z",
+    "0.11.5": "2018-04-18T17:17:40.610Z",
+    "0.12.0": "2018-04-18T17:21:12.939Z"
+  },
+  "homepage": "https://github.com/here-be/snapdragon",
+  "keywords": [
+    "lexer",
+    "snapdragon"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/here-be/snapdragon.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/here-be/snapdragon/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Brian Woodward",
+      "url": "https://twitter.com/doowb"
+    },
+    {
+      "name": "Daniel Tschinder",
+      "url": "https://github.com/danez"
+    },
+    {
+      "name": "Jon Schlinkert",
+      "url": "http://twitter.com/jonschlinkert"
+    }
+  ],
+  "users": {
+    "jonschlinkert": true,
+    "heartnett": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/snapdragon.min.json
+++ b/test/fixtures/registry-mocks/content/snapdragon.min.json
@@ -1,0 +1,1046 @@
+{
+  "name": "snapdragon",
+  "dist-tags": {
+    "latest": "0.12.0",
+    "patch": "0.8.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "snapdragon",
+      "version": "0.1.0",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.2",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "7a87bdcf1c3b9af6df60bb4b06fb479813ccce39",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "snapdragon",
+      "version": "0.1.1",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.2",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "43de7f3fa4940e88ae3bf50f688dc09ee3b7c3f3",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "snapdragon",
+      "version": "0.1.2",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.2",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "681252dad47147740755d17dad2860fadec9e49b",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "snapdragon",
+      "version": "0.2.0",
+      "dependencies": {
+        "chalk": "^1.0.0",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.4",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "d106b862f5ff1471f6ad3bc9d5afe7a70e2472b3",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.1": {
+      "name": "snapdragon",
+      "version": "0.2.1",
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "define-property": "^0.2.5",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.4",
+        "minimist": "^1.1.1",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "benchmarked": "^0.1.4",
+        "braces": "^1.8.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "89d11c845b8260c0ce45c6028dceed93a77d54f5",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.2": {
+      "name": "snapdragon",
+      "version": "0.2.2",
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "define-property": "^0.2.5",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.0.1",
+        "extend-shallow": "^1.1.4",
+        "minimist": "^1.1.1",
+        "set-value": "^0.2.0",
+        "source-map": "^0.4.2",
+        "source-map-resolve": "^0.3.1",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "benchmarked": "^0.1.4",
+        "braces": "^1.8.1",
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "932c968208f946df12fc17851ec3938aee5d6a5c",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.2.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.3": {
+      "name": "snapdragon",
+      "version": "0.2.3",
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "define-property": "^0.2.5",
+        "export-dirs": "^0.2.4",
+        "export-files": "^2.1.0",
+        "extend-shallow": "^2.0.1",
+        "minimist": "^1.2.0",
+        "set-value": "^0.3.1",
+        "source-map": "^0.5.3",
+        "source-map-resolve": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.0",
+        "gulp-istanbul": "^0.10.0",
+        "gulp-jshint": "^1.11.2",
+        "gulp-mocha": "^2.1.3",
+        "jshint-stylish": "^2.0.1",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "6acf350ceca838b68d6262d20e5ae405c1efa135",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.2.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.0": {
+      "name": "snapdragon",
+      "version": "0.3.0",
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "base-methods": "^0.6.1",
+        "define-property": "^0.2.5",
+        "export-files": "^2.1.0",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.3",
+        "source-map-resolve": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "benchmarked": "^0.1.4",
+        "braces": "^1.8.2",
+        "export-dirs": "^0.2.4",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "matched": "^0.3.2",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "8a08f768042bc6eaea50c13ba79a4a94a3b1a55d",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.1": {
+      "name": "snapdragon",
+      "version": "0.3.1",
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-yellow": "^0.1.1",
+        "base-methods": "^0.6.1",
+        "define-property": "^0.2.5",
+        "export-files": "^2.1.0",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.3",
+        "source-map-resolve": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "ansi-bold": "^0.1.1",
+        "benchmarked": "^0.1.4",
+        "braces": "^1.8.2",
+        "export-dirs": "^0.2.4",
+        "gulp": "^3.9.0",
+        "gulp-eslint": "^1.1.1",
+        "gulp-istanbul": "^0.10.3",
+        "gulp-mocha": "^2.2.0",
+        "matched": "^0.3.2",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "e5719a5cec9a90f624db41ee326c242e8facef50",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.4.0": {
+      "name": "snapdragon",
+      "version": "0.4.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^1.0.3",
+        "source-map": "^0.5.3",
+        "source-map-resolve": "^0.5.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.8",
+        "gulp-istanbul": "^0.10.4",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5"
+      },
+      "dist": {
+        "shasum": "c73ac0469cb02efff6412866fcb878d55b2d40ec",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.4.1": {
+      "name": "snapdragon",
+      "version": "0.4.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^1.0.4",
+        "source-map": "^0.5.5",
+        "source-map-resolve": "^0.5.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.8",
+        "gulp-istanbul": "^0.10.4",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5"
+      },
+      "dist": {
+        "shasum": "94918f22c2e9105693fc6565c41c55eae0866ce7",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.4.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.4.2": {
+      "name": "snapdragon",
+      "version": "0.4.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "lazy-cache": "^2.0.0",
+        "source-map": "^0.5.5",
+        "source-map-resolve": "^0.5.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^2.0.0",
+        "gulp-format-md": "^0.1.8",
+        "gulp-istanbul": "^0.10.4",
+        "gulp-mocha": "^2.2.0",
+        "mocha": "^2.4.5"
+      },
+      "dist": {
+        "shasum": "2d568fe7d80de09e2ea52b8944f8b5c3012bb888",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.4.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.5.0": {
+      "name": "snapdragon",
+      "version": "0.5.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "558af297c49333c9409640c0cdc03a010441fe37",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.6.0": {
+      "name": "snapdragon",
+      "version": "0.6.0",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "a5c514c5a288ea2c882b5cf3109d97aab2b633f2",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.7.0": {
+      "name": "snapdragon",
+      "version": "0.7.0",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "0db39f7c434d30be2282502baea2df34dc612ed3",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.7.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.7.1": {
+      "name": "snapdragon",
+      "version": "0.7.1",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "b48f7d6affc00363fa03a7d5751595b3c274eb87",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.7.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.7.2": {
+      "name": "snapdragon",
+      "version": "0.7.2",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "8d68e945e5e14329306eca1a6695dba6d783cc7d",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.7.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.7.3": {
+      "name": "snapdragon",
+      "version": "0.7.3",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "a00c46806af3998b0defb93e9af9d24d93a5e00e",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.7.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.8.0": {
+      "name": "snapdragon",
+      "version": "0.8.0",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "0d20de020d7c5bba8f8a36617aa096c23708f547",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.8.1": {
+      "name": "snapdragon",
+      "version": "0.8.1",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "e12b5487faded3e3dea0ac91e9400bf75b401370",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.9.0": {
+      "name": "snapdragon",
+      "version": "0.9.0",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.0",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2",
+        "snapdragon-capture": "^0.1.0",
+        "snapdragon-capture-set": "^1.0.0",
+        "verb-generate-readme": "^0.4.1"
+      },
+      "dist": {
+        "shasum": "4f4f2828079b6eb12090be6629847b28fa10dacc",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.9.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.9.1": {
+      "name": "snapdragon",
+      "version": "0.9.1",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.6.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.3",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.1.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.2"
+      },
+      "dist": {
+        "shasum": "34bfe5308fb697db3ae7d63164cf3f8e2098edef",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.9.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.10.0": {
+      "name": "snapdragon",
+      "version": "0.10.0",
+      "dependencies": {
+        "base": "^0.11.1",
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.5",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.1.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.2"
+      },
+      "dist": {
+        "shasum": "6f3dc84605b70671165a0221b61d9df948d8478c",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.10.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.10.1": {
+      "name": "snapdragon",
+      "version": "0.10.1",
+      "dependencies": {
+        "base": "^0.11.1",
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.5",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.1.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.2"
+      },
+      "dist": {
+        "shasum": "7a5658ddf8406e3c67c5e0f47b489187df132971",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.10.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.11.0": {
+      "name": "snapdragon",
+      "version": "0.11.0",
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^2.0.2"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.3"
+      },
+      "dist": {
+        "shasum": "260ba99290368fcf54b186a33240b635649dca4a",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.11.1": {
+      "name": "snapdragon",
+      "version": "0.11.1",
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.3"
+      },
+      "dist": {
+        "integrity": "sha512-+eyewgSDYrMRJFxnr18IsFnoUjhC6NltRRGDf8bLZic64+n90ZqLzwQkNtJ8fLjdkTBnZO4RG+488Dzwqtzb6Q==",
+        "shasum": "d6661e010ae4e15f58154102bc9ef1acffcd5034",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.1.tgz",
+        "fileCount": 10,
+        "unpackedSize": 52670
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.11.2": {
+      "name": "snapdragon",
+      "version": "0.11.2",
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.11",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "mocha": "^3.2.0",
+        "snapdragon-capture": "^0.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "verb-generate-readme": "^0.4.3"
+      },
+      "dist": {
+        "integrity": "sha512-lWPTXHHgkLXQ4VtYS0WZ4mg8KouXtOC3b1td2MnKSN6rVMwtgj7IXQ4EpXXy08eYHPe2GZ51xy7RZt0hDBJPmg==",
+        "shasum": "08ae8999e0f911870bca6be1bc7e7181e8cc9fc4",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.2.tgz",
+        "fileCount": 10,
+        "unpackedSize": 52640
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.8.2": {
+      "name": "snapdragon",
+      "version": "0.8.2",
+      "dependencies": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.0",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+        "shasum": "64922e7c565b0e14204ba1aa7d6964278d25182d",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+        "fileCount": 9,
+        "unpackedSize": 35228
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.11.3": {
+      "name": "snapdragon",
+      "version": "0.11.3",
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-capture": "^0.2.0",
+        "gulp": "^3.9.1",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "gulp-format-md": "^0.1.11",
+        "verb-generate-readme": "^0.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-x/zK3oUmOuJiF5zuYvtkEgM3gQ5lLTiZsVGCwyPqpGTK3RwllzF01DxfrReuizy68xs5Yx2Yi4r9NTmdZDpA0g==",
+        "shasum": "a1fa5ddb6ee8122edba3b717a8cf6ffe04b9f5da",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.3.tgz",
+        "fileCount": 9,
+        "unpackedSize": 52074
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.11.4": {
+      "name": "snapdragon",
+      "version": "0.11.4",
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^4.0.0",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-capture": "^0.2.0",
+        "gulp": "^3.9.1",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "gulp-format-md": "^0.1.11",
+        "verb-generate-readme": "^0.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-p5kB9EVE2VobItKhgrnVWmYsKw2RVV8OrzocrmO3va4fcp9vzJaSYz9CKtL+k6vIQ5gTiiDlxR+VbBMDPkb05w==",
+        "shasum": "2d420e6045c9ea252ba6d096f4f6ccbf27928645",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.4.tgz",
+        "fileCount": 9,
+        "unpackedSize": 51961
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.11.5": {
+      "name": "snapdragon",
+      "version": "0.11.5",
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "debug": "^2.6.2",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^2.1.1",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-capture": "^0.2.0",
+        "gulp": "^3.9.1",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "gulp-format-md": "^0.1.11",
+        "verb-generate-readme": "^0.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-iC2oF+H+TjiZN4a7I5HNUH8imAFT9z3GydV8X5ZFLcBiDYROWNeqI34BHArXTVO/RGs88STtAtiMP3tCiNdUYg==",
+        "shasum": "522812d175f24f919629fd37406b02e434e645e6",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.11.5.tgz",
+        "fileCount": 9,
+        "unpackedSize": 52074,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1321CRA9TVsSAnZWagAA7x8QAJ/two9eQzhSn8b8LM8H\nDKBaNZPGXhD/3Vz1QFkZ9jBA9JP4flkUgPDDH4l6QY7wzKCekhCEMvFyQYym\nNBjbAZoJNuJ+iCEhc3lDnCOg1sckTrWLoj0reol7KGUx/F1bbJq0/tozD8ES\niq+iHbAlOUfmGaSzNC4eZdgdD0bLN7EpWP1r1iFCTemxF8ebpV1+ourafMn8\nyYR5bET4YHz9hi5ReOQvxLheVxrl3PNiEjNAaLUFC69RfF2Q2lnMikUv8VQq\nE214m+dF+YAqLJUS7Ym3LqYg8V+vt8dv92JvdJV2KKlmUVlJrKHwgBSwxY+z\nB926haJR36PpfuNVIILzInyiBNb17dE/fAsQS0wdMjzdCK8LJKvRje6TFduT\nzBhFPzDctukh4C8EH/HGOsHNGYNUPBrRSahvOUhAk0L7SvlpCkkQnPv6dzCD\nlPCaSAASzqrL822/fIGEWO7ZTX+imbo1NpKYprPeCIUWbN5pjw3o04IKGaIL\n9N6whFmYY4NLoAC5CUn6sSv9iGpiyTl9DmCxeqDftkB/2zaZZERuAZvLlOyk\nhGwq98X5Jyi4P2Fopdm5N3F87uTqZVqSqPabOqKXw7T7fmQRT77boBcOp3xB\nEWKC/oXO0pTJ2HHW2WGqjbek5dBNqOXPxPUfqeoAlNXRuQPd7kexgW9B/1KS\nAcKT\r\n=fDBm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.12.0": {
+      "name": "snapdragon",
+      "version": "0.12.0",
+      "dependencies": {
+        "component-emitter": "^1.2.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "get-value": "^2.0.6",
+        "isobject": "^3.0.0",
+        "map-cache": "^0.2.2",
+        "snapdragon-node": "^1.0.6",
+        "snapdragon-util": "^4.0.0",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.2.0",
+        "snapdragon-capture-set": "^1.0.1",
+        "snapdragon-capture": "^0.2.0",
+        "gulp": "^3.9.1",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-mocha": "^3.0.1",
+        "gulp-unused": "^0.2.1",
+        "gulp-format-md": "^0.1.11",
+        "verb-generate-readme": "^0.6.0"
+      },
+      "dist": {
+        "integrity": "sha512-E7epxLolFdELn4LzTfDOImU0gZDk5Y071Pou8+3rEP7980ZbDbBje3xDQAqP5lnPItU1W7QEoqNSJvHtvK8DcQ==",
+        "shasum": "ad7e56891a87eb38012386159bee99a0430e6e06",
+        "tarball": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.12.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 51961,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa136KCRA9TVsSAnZWagAAZ6wQAJESx5m4d2EumEaKoQxi\nGPLg371uxQS+wGCDK+h+UsAxFJaqMOvdXMxu0ZduNNJtorbksd+Et3wc+iOq\nV/kFflfYwlq+/DBDxwV+qJXLMm/iRSyJD0M9ZYqiv2A/8e5zox5PWChkFva7\nr4XbGYbsB17YP4EQqoRhelzzanPOGEmbudwTNvI+xphR4JzpYZJcV5RLN4vH\ne2qU+ZZZljujFcceAKe4wj8ITLIm0zfzCPE6hqbPQKLEoLMDVojACZKDuAll\n8JB/BKOp8mTPPa/af9dBqc+zHCJP4w7t+Pw7l1g16vwPlmk1/+YINyqPi772\nUzfCX7hBbYQ1kpM78VMildR0G7k4UY4D7hSrEUbsNwa4otqUZH6kIXhoIAQu\no2tEYreePR2BgzwEWPsudtk//5VydAGxUVORmgrvAo040SN4gSYLZRoz/mTI\nOUQpy+Vg1BWR+S5IE+5JgfM/g6ZNpHmsl+xXwcCEJdF1OVcMEAet1CnCuiPv\nZNb6kgov/Tk5q/IJi6DhXHAL8kVlTLm1f2bWUEFAmHSqdcNabQoMDu938tKu\nfvQlGXamH971zd2eMtPCmnfL7SZqftJv5WJHCqktejtIRSep6x1U39xErXSq\nKb1ONqXzFcWwDjLMgdgwd4cvjF1B+vYqPdPnX1QP0YxrYJY+4VpWRiyS+1fa\ncOXO\r\n=xGSM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2018-04-18T17:21:17.524Z"
+}

--- a/test/fixtures/registry-mocks/content/sockjs-client.json
+++ b/test/fixtures/registry-mocks/content/sockjs-client.json
@@ -1,0 +1,2521 @@
+{
+  "_id": "sockjs-client",
+  "_rev": "57-9e617832a9d7f64cf34ef9b61421b386",
+  "name": "sockjs-client",
+  "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object.",
+  "dist-tags": {
+    "latest": "1.5.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "sockjs-client",
+      "author": {
+        "name": "Matthew Sackman"
+      },
+      "version": "0.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-client-node.git"
+      },
+      "main": "index",
+      "description": "Client library for SockJS",
+      "dependencies": {
+        "node-uuid": "1.3.3"
+      },
+      "_npmUser": {
+        "name": "msackman",
+        "email": "matthew@rabbitmq.com"
+      },
+      "_id": "sockjs-client@0.1.0",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-10",
+      "_nodeVersion": "v0.6.7",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "b9bcf1e5334de90500817e7e12dba724a02de17d",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "sockjs-client",
+      "author": {
+        "name": "Matthew Sackman"
+      },
+      "version": "0.1.1",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-client-node.git"
+      },
+      "main": "index",
+      "description": "Client library for SockJS",
+      "dependencies": {
+        "node-uuid": "1.3.3"
+      },
+      "_npmUser": {
+        "name": "msackman",
+        "email": "matthew@rabbitmq.com"
+      },
+      "_id": "sockjs-client@0.1.1",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-10",
+      "_nodeVersion": "v0.6.7",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "b65d9f24532da2a4e4ec4ca29d1b174d691884a5",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "sockjs-client",
+      "author": {
+        "name": "Matthew Sackman"
+      },
+      "version": "0.1.2",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-client-node.git"
+      },
+      "main": "index",
+      "description": "Client library for SockJS",
+      "dependencies": {
+        "node-uuid": "1.3.3"
+      },
+      "_npmUser": {
+        "name": "msackman",
+        "email": "matthew@rabbitmq.com"
+      },
+      "_id": "sockjs-client@0.1.2",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-10",
+      "_nodeVersion": "v0.6.7",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "6991468810a36a9eff9bb0338091c5ff653a7f06",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-0.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "sockjs-client",
+      "author": {
+        "name": "Matthew Sackman"
+      },
+      "version": "0.1.3",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-client-node.git"
+      },
+      "main": "index",
+      "description": "Client library for SockJS",
+      "dependencies": {
+        "node-uuid": "1.3.3"
+      },
+      "_npmUser": {
+        "name": "msackman",
+        "email": "matthew@rabbitmq.com"
+      },
+      "_id": "sockjs-client@0.1.3",
+      "devDependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.16",
+      "_nodeVersion": "v0.6.15",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "aaaf2f27bf4bf6f101e69f71008c8dbe6e810a81",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-0.1.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0-beta.4": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.4",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.1.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js"
+      },
+      "gitHead": "dbfc219259701a1e8a649f6cdffb81fa59da9168",
+      "_id": "sockjs-client@1.0.0-beta.4",
+      "_shasum": "9bb31d1b2941e018386346541e645bf0f71f367f",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9bb31d1b2941e018386346541e645bf0f71f367f",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.5": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.5",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.1.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js"
+      },
+      "gitHead": "ac3abbd3cfd37e5a138aea5fdd79a81dbb9a9879",
+      "_id": "sockjs-client@1.0.0-beta.5",
+      "_shasum": "79717d8946721257c04dc727ac633c16baa6858a",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "79717d8946721257c04dc727ac633c16baa6858a",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.6": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.6",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.1.3"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js"
+      },
+      "gitHead": "b912ce19a2b0069575848ddfd740a3e0980fc652",
+      "_id": "sockjs-client@1.0.0-beta.6",
+      "_shasum": "b8ea8a86defe5b0b85ae2516ae861a341924369d",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b8ea8a86defe5b0b85ae2516ae861a341924369d",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.7": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.7",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.1.5"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "d5db71471865f686aa5238298a9206749efa8a00",
+      "_id": "sockjs-client@1.0.0-beta.7",
+      "_shasum": "7b11ea76414d2ed237ab90d3f932e5822cee62f8",
+      "_from": ".",
+      "_npmVersion": "2.1.11",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7b11ea76414d2ed237ab90d3f932e5822cee62f8",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.8": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.8",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "c7ec8069fc7b759f6c29536dcd69f399b636dad7",
+      "_id": "sockjs-client@1.0.0-beta.8",
+      "_shasum": "f66c4bb9e62be01e7903437c4cd70497ff5f2a07",
+      "_from": ".",
+      "_npmVersion": "2.1.12",
+      "_nodeVersion": "0.10.28",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f66c4bb9e62be01e7903437c4cd70497ff5f2a07",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.9": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.9",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.2.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "761e66f19da7c188d24c363d4837d624e30b70d8",
+      "_id": "sockjs-client@1.0.0-beta.9",
+      "_shasum": "ad9e533249386efc9119ebaa2026ebf36ed5837d",
+      "_from": ".",
+      "_npmVersion": "2.1.12",
+      "_nodeVersion": "0.10.28",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ad9e533249386efc9119ebaa2026ebf36ed5837d",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.9.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.10": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.10",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.2.3"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "50e58d8c70ebcd2117d51d305d745f6f05424b47",
+      "_id": "sockjs-client@1.0.0-beta.10",
+      "_shasum": "5cd009db31fdd8631ff73ca7b4ae8f3ca3c6f986",
+      "_from": ".",
+      "_npmVersion": "2.1.8",
+      "_nodeVersion": "0.10.28",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5cd009db31fdd8631ff73ca7b4ae8f3ca3c6f986",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.10.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.11": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.11",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "70c186c4ea6549d458db808ab5fe94778ae407ba",
+      "_id": "sockjs-client@1.0.0-beta.11",
+      "_shasum": "4bf090e20087251cc8ef7d2a2688ff3b620358c3",
+      "_from": ".",
+      "_npmVersion": "2.1.8",
+      "_nodeVersion": "0.10.28",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4bf090e20087251cc8ef7d2a2688ff3b620358c3",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.11.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.12": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.12",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "2978ed72b6c41e413d417a6f989914b94e8cb9d7",
+      "_id": "sockjs-client@1.0.0-beta.12",
+      "_shasum": "5e7a4b662447bb92de9bc7613b771b36c4804a6f",
+      "_from": ".",
+      "_npmVersion": "2.1.8",
+      "_nodeVersion": "0.10.28",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5e7a4b662447bb92de9bc7613b771b36c4804a6f",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.12.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-beta.13": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0-beta.13",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "fdf37dac50db90a2f647846e7bec4d2e9f325857",
+      "_id": "sockjs-client@1.0.0-beta.13",
+      "_shasum": "434e3960b80a7c721ca31b010d1a3f098217a973",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "434e3960b80a7c721ca31b010d1a3f098217a973",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.13.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.0",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "d3417e7914124002b7ad212976176e5c0d506efb",
+      "_id": "sockjs-client@1.0.0",
+      "_shasum": "af6d2d340482709bde27890a0ba804dfd765f8f9",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "af6d2d340482709bde27890a0ba804dfd765f8f9",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.1",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "5af2fce8ec2c33be207b95b45b10c3cd14223532",
+      "_id": "sockjs-client@1.0.1",
+      "_shasum": "8943ae05b46547bc2054816c409002cf5e2fe026",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "8943ae05b46547bc2054816c409002cf5e2fe026",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.2",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "6a76e12999b0b1344537a9162f6c50b1eb096660",
+      "_id": "sockjs-client@1.0.2",
+      "_shasum": "7875d75ef31706a0d0213353164de953f3fe30d5",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "7875d75ef31706a0d0213353164de953f3fe30d5",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.0.3",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp"
+      },
+      "gitHead": "c887e34e23e6b4d18e1f1ce4848cf4f8b08f5109",
+      "_id": "sockjs-client@1.0.3",
+      "_shasum": "b0d8280998460eb2564c5d79d7e3d7cfd8a353ad",
+      "_from": ".",
+      "_npmVersion": "2.13.1",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "b0d8280998460eb2564c5d79d7e3d7cfd8a353ad",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.1.0",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp",
+        "lint": "gulp eslint"
+      },
+      "gitHead": "3be0c73f55de9474cf7d81e77cec49f08fa798ae",
+      "_id": "sockjs-client@1.1.0",
+      "_shasum": "1404b670b47ad5f6ae959e319e84ee718523f477",
+      "_from": ".",
+      "_npmVersion": "2.14.6",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "1404b670b47ad5f6ae959e319e84ee718523f477",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/sockjs-client-1.1.0.tgz_1462053674763_0.7162165541667491"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.1.1",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "eventsource": "~0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "make test",
+        "test_local": "zuul --local 9090 -- tests/browser.js",
+        "zuul": "zuul -- tests/browser.js",
+        "gulp": "gulp",
+        "lint": "gulp eslint"
+      },
+      "gitHead": "91e30059cc32c6b41ddd0de05c68681e9b00d503",
+      "_id": "sockjs-client@1.1.1",
+      "_shasum": "284843e9a9784d7c474b1571b3240fca9dda4bb0",
+      "_from": ".",
+      "_npmVersion": "2.14.6",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "284843e9a9784d7c474b1571b3240fca9dda4bb0",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/sockjs-client-1.1.1.tgz_1463768700428_0.4972501073498279"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication channel between the browser and the web se",
+      "version": "1.1.2",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "eventsource": "0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.1"
+      },
+      "devDependencies": {
+        "browserify": "^13.3.0",
+        "envify": "^4.0.0",
+        "eslint": "^3.14.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.9.1",
+        "gulp-header": "^1.8.8",
+        "gulp-rename": "~1.2.0",
+        "gulp-replace": "^0.5.4",
+        "gulp-sourcemaps": "^2.4.0",
+        "gulp-uglify": "^2.0.0",
+        "mocha": "^3.2.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^1.7.10",
+        "pump": "^1.0.2",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "github:brycekahle/zuul#ngrok",
+        "zuul-ngrok": "github:brycekahle/zuul-ngrok#master"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "mocha tests/node.js",
+        "test:bundle": "gulp testbundle",
+        "test:browser_local": "npm run test:bundle && zuul --disable-tunnel --local 9090 -- tests/browser.js",
+        "test:browser_remote": "npm run test:bundle && zuul -- tests/browser.js",
+        "gulp": "gulp",
+        "lint": "eslint .",
+        "version": "gulp release && git add -A dist lib/version.js",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "1d48f43b6effb13c1abb0be3fc2ec00f9c8aeecb",
+      "_id": "sockjs-client@1.1.2",
+      "_shasum": "f0212a8550e4c9468c8cceaeefd2e3493c033ad5",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "6.9.4",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "f0212a8550e4c9468c8cceaeefd2e3493c033ad5",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/sockjs-client-1.1.2.tgz_1485215207434_0.7400715253315866"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object.",
+      "version": "1.1.4",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.6.6",
+        "eventsource": "0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
+      },
+      "devDependencies": {
+        "browserify": "^13.3.0",
+        "envify": "^4.0.0",
+        "eslint": "^3.19.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.9.1",
+        "gulp-header": "^1.8.8",
+        "gulp-rename": "~1.2.0",
+        "gulp-replace": "^0.5.4",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^2.1.2",
+        "mocha": "^3.3.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^1.7.11",
+        "pump": "^1.0.2",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "github:brycekahle/zuul#ngrok",
+        "zuul-ngrok": "github:brycekahle/zuul-ngrok#master"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "mocha tests/node.js",
+        "test:bundle": "gulp testbundle",
+        "test:browser_local": "npm run test:bundle && zuul --disable-tunnel --local 9090 -- tests/browser.js",
+        "test:browser_remote": "npm run test:bundle && zuul -- tests/browser.js",
+        "gulp": "gulp",
+        "lint": "eslint .",
+        "version": "gulp release && git add -A dist lib/version.js",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "f2067b33dccad3b81be5c9b1bdff8cb86dbaf57e",
+      "_id": "sockjs-client@1.1.4",
+      "_shasum": "5babe386b775e4cf14e7520911452654016c8b12",
+      "_from": ".",
+      "_npmVersion": "4.5.0",
+      "_nodeVersion": "6.9.4",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "5babe386b775e4cf14e7520911452654016c8b12",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/sockjs-client-1.1.4.tgz_1493586265626_0.5522258910350502"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object.",
+      "version": "1.1.5",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "jsdelivr": "dist/sockjs.min.js",
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.6.6",
+        "eventsource": "0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
+      },
+      "devDependencies": {
+        "browserify": "^13.3.0",
+        "envify": "^4.0.0",
+        "eslint": "^3.19.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.9.1",
+        "gulp-header": "^1.8.8",
+        "gulp-rename": "~1.2.0",
+        "gulp-replace": "^0.5.4",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^2.1.2",
+        "mocha": "^3.3.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^1.7.11",
+        "pump": "^1.0.2",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "github:brycekahle/zuul#ngrok",
+        "zuul-ngrok": "github:brycekahle/zuul-ngrok#master"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "mocha tests/node.js",
+        "test:bundle": "gulp testbundle",
+        "test:browser_local": "npm run test:bundle && zuul --disable-tunnel --local 9090 -- tests/browser.js",
+        "test:browser_remote": "npm run test:bundle && zuul -- tests/browser.js",
+        "gulp": "gulp",
+        "lint": "eslint .",
+        "version": "gulp release && git add -A dist lib/version.js",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "c58872c92def222bfe5305721e7dfaa8b736c620",
+      "_id": "sockjs-client@1.1.5",
+      "_shasum": "1bb7c0f7222c40f42adf14f4442cbd1269771a83",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.14.2",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "1bb7c0f7222c40f42adf14f4442cbd1269771a83",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+        "fileCount": 68,
+        "unpackedSize": 812165,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbDeQaCRA9TVsSAnZWagAAZyMP/At4L4Hs8abKR624bmh1\nXWhWBL6zCh3J9ZqWFOFsX0NnQ9Pna8TNQwkfv5ai56s+XO1fe5WeFH0F0VuM\nwOOGq8gCujU7RgroHkQJmDwjPuPiptaXQEw6jAc+GdPX5H+TZIFhwK2oZDn6\nDRVGHzlUqm1nfU55iKnCFGA/9b6+iHLdjQj2zbAEHApsIlgvzld92tyCkJIj\nkBazuXaGK9vgrCgznrSJz39neAYFFtXxx5aA01fIXbqlND42Tawtlxt3+To8\n9ff0yooPOWUV7MkaT+XRPtzGDojFLmLMwJEJTihisvGvmorAQAUn9ztkpKn/\n41vEoEAsQeHjJP6mPFhF67QMihYjsKwINhFTdnZtnigrPjtajEqQpx1hytYS\n00Fv1uJOJK4bP4JL+j922bFlVjdDU5PAeq27JvYvsp3R9jyaP3r5rSs8V6zc\n8jWNv+ubrQOY/oOQNsVeFNCHacjx/aP2oFpKwx6aAm260tjUKH2QTA7HOUyI\nLVuUr3MEyBAixCTVhPUlo4Cc9AATD7UGtDzUr7LkyqA1P5RNQya0kTE+JzV/\nfPeNj7AVRtaHJapxOBtuQGw4YYWx0RECQ2Q7v7pKCmnR874byj1tD2gbPGZo\ngTGj2Q2k/7yCjt8/i/dE0cZn+9oG/0eArw906SBaD2V2vMGBcf1rcuvGYkOH\nioOU\r\n=A5hz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sockjs-client_1.1.5_1527637016480_0.10252123034147997"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.0": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object.",
+      "version": "1.2.0",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "jsdelivr": "dist/sockjs.min.js",
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.0.1",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "browserify": "^16.2.2",
+        "envify": "^4.0.0",
+        "eslint": "^5.6.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^4.0.0",
+        "gulp-header": "^2.0.5",
+        "gulp-rename": "^1.4.0",
+        "gulp-replace": "^1.0.0",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^3.0.1",
+        "karma": "^3.0.0",
+        "karma-browserify": "^5.3.0",
+        "karma-browserstack-launcher": "git+https://git@github.com/karma-runner/karma-browserstack-launcher.git#310c22835987b50a908b99d0995fc1655a7e06f5",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-mocha": "^1.3.0",
+        "mocha": "^5.2.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^2.1.0",
+        "pump": "^3.0.0",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^2.0.0"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "mocha tests/node.js",
+        "test:bundle": "gulp testbundle",
+        "test:browser_local": "npm run test:bundle && npx karma start --browsers Chrome",
+        "test:browser_remote": "npm run test:bundle && npx karma start",
+        "gulp": "gulp",
+        "lint": "eslint .",
+        "version": "gulp release && git add -A dist lib/version.js",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "7c158a2b41a5a1b3e2bf6a08e89cf483c835012b",
+      "_id": "sockjs-client@1.2.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-sAibkw+jfBSCBcxsZZqPpw0fPtH4yf1HlGqkmrsB3DisahTsnUXJScX0jqkebW3SHRXTYxZyUVyDbzKDfflYgw==",
+        "shasum": "43a0b6d70c7f07049897b2ec26b9571e4cdab4c6",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.2.0.tgz",
+        "fileCount": 64,
+        "unpackedSize": 824897,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbpTUGCRA9TVsSAnZWagAAHjgP/3YlJM/PPTm3kukBE4s3\nrieR6MQTS8DNyC+QCEAqdUkAv+sEyS1TTkrBwcp4WkJ5obqnSgDfHVgrOmJ3\n/Evrj1BZHIT3a+VZxOePekhvI6cOrZPD83BW2S9iod+u8UQUmRyY0/RtaZ+z\njNKCf2qkiC29YfxBq/GjwGSEghm0k9x2bYFkcCc64L1mSTlZI8UxxgSkzUEi\nzDz+SQUC7q3eGdCyGICbawADgq9uCSjac4MyNOjkAeT55USzCshQRxtQiZsS\nTHcUaTdiqCR5KmGsgROTSzrplYnLOoFhjUOdnv4T6IXBmMY7yOrUB+JxYZ2l\nhaINLCMTQQP4uwmQDrmNmM/FQNAqm1SmVk+1JrIU4/yvkAruuVnVDz4H0Moi\neeY7hyclxKrzVKGqeAljBlwfqM1gDbgRiiaTkwFCxzNl7Q/5MQQ7jLGmR94T\nsI7LEDX4TXvhZHvjD5UWRDKWjeH5VoYKAgbYSYF+b4OybyHSlKzpJD4JWXyo\nv9Pr4adxbVJT08oED7C9c/pUAEfu5Q1q814jN9I7MFOvVyES9NI1RSki+Tsc\nThTpmEVzNDG0mXOrYL8il5uGs5QccNqPpHdGtWJDAdzV+N14WhbARKpv+luk\nFavduDbI6DaKQQSpFyCm6ULo0L07GbMjGgB88EWUsTO8orGqb19+Piy2lakr\nszg3\r\n=2sFQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sockjs-client_1.2.0_1537553669452_0.210169940109739"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.3.0": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object.",
+      "version": "1.3.0",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "jsdelivr": "dist/sockjs.min.js",
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "browserify": "^16.2.2",
+        "envify": "^4.0.0",
+        "eslint": "^5.6.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^4.0.0",
+        "gulp-header": "^2.0.5",
+        "gulp-rename": "^1.4.0",
+        "gulp-replace": "^1.0.0",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^3.0.1",
+        "karma": "^3.0.0",
+        "karma-browserify": "^5.3.0",
+        "karma-browserstack-launcher": "git+https://git@github.com/karma-runner/karma-browserstack-launcher.git#310c22835987b50a908b99d0995fc1655a7e06f5",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-mocha": "^1.3.0",
+        "mocha": "^5.2.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^2.1.0",
+        "pump": "^3.0.0",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^2.0.0"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "mocha tests/node.js",
+        "test:bundle": "gulp testbundle",
+        "test:browser_local": "npm run test:bundle && npx karma start --browsers Chrome",
+        "test:browser_remote": "npm run test:bundle && npx karma start",
+        "gulp": "gulp",
+        "lint": "eslint .",
+        "version": "gulp release && git add -A dist lib/version.js",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "e077df367f73a5f207da2307141528c36778d83d",
+      "_id": "sockjs-client@1.3.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+        "shasum": "12fc9d6cb663da5739d3dc5fb6e8687da95cb177",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+        "fileCount": 64,
+        "unpackedSize": 825834,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqQamCRA9TVsSAnZWagAAOOkP/3+8shVpu1COFdOaczMo\n3KCZ+mxhp5AWVOe4zwJSb7O3cY7k+htExg0eh7RcpHoUH/WJIQABEAA/5m/P\nlsomTD6+b16S/DueJlksRC9xJU/rlZRhQqptTJ0CzPwxZbpNXMJdOA7p/vtO\n4/mram2eYD9/VM81GA0bQdkTN7ZIx03nJp+q0UZh2FpgPn8STfyeoPky2irv\nwRwEAkGisa9p5PY8mgwagtYpTS7hu2KWiuIwNoaEalld3BrPuU165lzWUNex\nbuczYte+saufKkPPfkqVgEji47uaEMXynlKjSRqzVa2HOQPcjRORskt8zERM\n4JebOkRnK07goU7sTzIVIotGAm93LIEuPnnm9X9v+K6fdwmskts88x1OVV+C\nX7rkgAh9vdx9HriBGQf6jzvCTAfB3bf1uniZv4IHn+TDmK8iDHjiJOweIzGs\nb4Ey3OOw2sZAoz62JW+CfuZmIt2eF9k8xos2qoQoo7zKXrGLxBEOivtgTH12\nll6YZ0tQAxm+obwT8VyIrN0Hs3xBJfqmILwixW4UZ3bqIiVxp6gKh6KJ9rvS\nLxBergd6pVWTVv77HG9zWv4EdPtq4IK0qcrCpdxENpzZPiawaPjSncGfj0U5\nsuEyv6MR1ki4WwjHOp9k5T8a/tMa1qQY7xn2juzHjCbS5C0o9YN8Xolu3mV9\nCxFW\r\n=QZF5\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sockjs-client_1.3.0_1537803941847_0.9962823452871308"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.0": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object.",
+      "version": "1.4.0",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "jsdelivr": "dist/sockjs.min.js",
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "browserify": "^16.2.3",
+        "envify": "^4.0.0",
+        "eslint": "^6.2.1",
+        "expect.js": "~0.3.1",
+        "gulp": "^4.0.2",
+        "gulp-header": "^2.0.5",
+        "gulp-rename": "^1.4.0",
+        "gulp-replace": "^1.0.0",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^3.0.2",
+        "karma": "^4.2.0",
+        "karma-browserify": "^6.1.0",
+        "karma-browserstack-launcher": "^1.5.1",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-mocha": "^1.3.0",
+        "mocha": "^5.2.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^2.1.0",
+        "pump": "^3.0.0",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^2.0.0"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "mocha tests/node.js",
+        "test:bundle": "gulp testbundle",
+        "test:browser_local": "npm run test:bundle && npx karma start --browsers Chrome",
+        "test:browser_remote": "npm run test:bundle && npx karma start",
+        "gulp": "gulp",
+        "lint": "eslint .",
+        "version": "gulp release && git add -A dist lib/version.js Changelog.md",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "cffcff536fc2fb7394a43ba70092fffdccaece96",
+      "_id": "sockjs-client@1.4.0",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
+        "shasum": "c9f2568e19c8fd8173b4997ea3420e0bb306c7d5",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
+        "fileCount": 66,
+        "unpackedSize": 827860,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdXvuyCRA9TVsSAnZWagAA/vAP/31wRSOu2OM7bm+ZelqL\nRHrZDzBaLu0DTELYsziQ3UcaaQw2vfnXHJCOOrHZC8atbIjLAitTg5TrFUT/\ndqTijIMajF/aLSlW6fQjSxluZ5rBvDa6ve3iWaH5LjrPtKVx3cZjgF5VGOU/\naM2Hzcqd+ITEOeHiExGJxL4kMkR0PiJf2xWSHxRVip8WS/wTew+6Mn2aiOs0\niNOldL3T0oi7Yy/xVWmkFl6WrYOL+QPosxmQScWvt8FdolOIqUEic0pLBCUU\nisTA4XKv+aMv7yDRfsSalUkkSkpkjdFll0LWI0+riPEtDVah1hiU8wsNDIyl\nqsusyX3ZR+yEblYW/7VgMOKPiIjaf8apbYJ4nua9kMKpeAZBB9SS4kHXgg2u\nDFolDNxfZFDl1B3NOSBjuJYQTh+bqNOKK3ZWyd6a4cCB73DSVuNiZ7KaH4jT\nPwnH9stplOvIROK8MmC2xaBoR260mgXJC9K5d4Lveteo9bzDEAUqPSYkstP1\n0hqHq/jH1boaRolDHP0JUcIRfbkL1AQj1/8YVLqEwBcF8cmLGeG5+l1PsvdM\nOdTgkapr9XAdTYwDax1d3mUL+uoIT3AHIGLnggAIPBiU5VSpmSQyAVdHz3bf\nD89u8tAWFZiobWkcPTAjnaQEep67HymBwCIHiIqjQ40kVOXHJ1pQXCzoLIm5\nAKaM\r\n=kHpw\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sockjs-client_1.4.0_1566505905145_0.09790336547819822"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.0": {
+      "name": "sockjs-client",
+      "description": "SockJS-client is a browser JavaScript library that provides a WebSocket-like object.",
+      "version": "1.5.0",
+      "author": {
+        "name": "Bryce Kahle"
+      },
+      "jsdelivr": "dist/sockjs.min.js",
+      "browser": {
+        "./lib/transport/driver/websocket.js": "./lib/transport/browser/websocket.js",
+        "eventsource": "./lib/transport/browser/eventsource.js",
+        "./lib/transport/driver/xhr.js": "./lib/transport/browser/abstract-xhr.js",
+        "crypto": "./lib/utils/browser-crypto.js",
+        "events": "./lib/event/emitter.js"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-client/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "debug": "^3.2.6",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "^0.11.3",
+        "inherits": "^2.0.4",
+        "json3": "^3.3.3",
+        "url-parse": "^1.4.7"
+      },
+      "devDependencies": {
+        "browserify": "^16.5.1",
+        "envify": "^4.0.0",
+        "eslint": "^7.6.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^4.0.2",
+        "gulp-header": "^2.0.9",
+        "gulp-rename": "^2.0.0",
+        "gulp-replace": "^1.0.0",
+        "gulp-sourcemaps": "^2.6.5",
+        "gulp-uglify": "^3.0.2",
+        "karma": "^5.1.1",
+        "karma-browserify": "^7.0.0",
+        "karma-browserstack-launcher": "^1.6.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-mocha": "^2.0.1",
+        "mocha": "^8.1.0",
+        "proxyquire": "^2.1.3",
+        "pump": "^3.0.0",
+        "serve-static": "^1.14.1",
+        "sockjs": "^0.3.21",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^2.0.0"
+      },
+      "homepage": "http://sockjs.org",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "./lib/entry.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-client.git"
+      },
+      "scripts": {
+        "test": "mocha tests/node.js",
+        "test:bundle": "gulp testbundle",
+        "test:browser_local": "npm run test:bundle && npx karma start --browsers Chrome",
+        "test:browser_remote": "npm run test:bundle && npx karma start",
+        "gulp": "gulp",
+        "lint": "eslint .",
+        "version": "gulp release && git add -A dist lib/version.js Changelog.md",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "d8f5fa86aad9ebc57c6868c8607aa62e5b6e4caa",
+      "_id": "sockjs-client@1.5.0",
+      "_nodeVersion": "12.18.3",
+      "_npmVersion": "6.14.6",
+      "dist": {
+        "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+        "shasum": "2f8ff5d4b659e0d092f7aba0b7c386bd2aa20add",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
+        "fileCount": 66,
+        "unpackedSize": 839190,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfJzkpCRA9TVsSAnZWagAAotcQAI3XZAvKN6oUR4B+keX0\nJ6mC5m50MZ1cJgmVN+sRySA3Ppk87adWEnoVAce4bOqEFY7KUg3AtQoiQGdG\nmLGfoBmC38EjzYa4r/7UV4Gyh1Ng2wwqFeZAktsMOrJj3iLBjTIhMydydlEn\nHT6yhUd2pCL2sqmOKh0EIJwRJcfDwrrmN8IN8nUaTATWP/+S8OxbDa5E7zV+\nXPycNZp3buVhkf+WdK/7S/SMm2kSHfgaa1iCiMTccxt3+uE7+GeBOOkONa1n\nfUXyj1SIJT7zi935mrS1sy5C/hjf827dgsYm5LRJrGDVvQ2iLGjPeOWxeb8A\nTTh53058N8v/xkaB9XlV3kMhgeSG07yysxX61213228mlMSdEQ6UxHJuGj9W\nYMPW1SqBTm4d6YhFlURq/KmbJmkwnolQ8ivbRnhkpIRcOViV94dgMN3nv3x9\n+PwpZDjNxwSgUsveWTsjnAS95lYQYpSnM0KeIjKMUpDo0UnK1pAQBkgbHkPO\nHl9nSYV/DY9+xeNgBpM/6HZqceNN06OSXDuej19QLn4A30qcelk52pXLPHCK\nU9VkPeSMskwN6UB7WSfIhtzNR40J3RiRF/CLFr2amGlDW5jt5Z+U3LZ7m4O5\nhZJTnqIT4jdGAd8hOfvdCiGK9q58RQ3ux49jjUVFOhzoYuXOJBxQtwa2I1zD\nUnOV\r\n=G8cB\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "npm@brycekahle.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sockjs-client_1.5.0_1596406056817_0.1897448217954354"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "\n# SockJS-client\n\n[![npm version](https://img.shields.io/npm/v/sockjs-client.svg?style=flat-square)](https://www.npmjs.com/package/sockjs-client)[![Build Status](https://img.shields.io/travis/sockjs/sockjs-client/master.svg?style=flat-square)](https://travis-ci.org/sockjs/sockjs-client)[![Dependencies](https://img.shields.io/librariesio/release/npm/sockjs-client.svg?style=flat-square)](https://libraries.io/npm/sockjs-client)[![Chat](https://img.shields.io/badge/Chat-gitter.im-blue.svg?style=flat-square)](https://gitter.im/sockjs/sockjs-client)[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg?style=flat-square)](code-of-conduct.md)\n[![BrowserStack Status](https://automate.browserstack.com/badge.svg?badge_key=N3V0cStKM3RtUy9Bb2l2cHFhMVdobTZnUitBZ1lLcUkwYnl2TWgyMHppQT0tLWxncU5UeTdLb0Rqc1VQQTI5SklRelE9PQ==--596ccf9d3cd2f462f1043ee6803a9405e00446ac)](https://automate.browserstack.com/public-build/N3V0cStKM3RtUy9Bb2l2cHFhMVdobTZnUitBZ1lLcUkwYnl2TWgyMHppQT0tLWxncU5UeTdLb0Rqc1VQQTI5SklRelE9PQ==--596ccf9d3cd2f462f1043ee6803a9405e00446ac)\n\n<a href=\"https://www.netlify.com\">\n  <img src=\"https://www.netlify.com/img/global/badges/netlify-color-accent.svg\"/>\n</a>\n\n# SockJS for enterprise\n\nAvailable as part of the Tidelift Subscription.\n\nThe maintainers of SockJS and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/npm-sockjs-client?utm_source=npm-sockjs-client&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)\n\n# Summary\n\nSockJS is a browser JavaScript library that provides a WebSocket-like\nobject. SockJS gives you a coherent, cross-browser, Javascript API\nwhich creates a low latency, full duplex, cross-domain communication\nchannel between the browser and the web server.\n\nUnder the hood SockJS tries to use native WebSockets first. If that\nfails it can use a variety of browser-specific transport protocols and\npresents them through WebSocket-like abstractions.\n\nSockJS is intended to work for all modern browsers and in environments\nwhich don't support the WebSocket protocol -- for example, behind restrictive\ncorporate proxies.\n\nSockJS-client does require a server counterpart:\n\n * [SockJS-node](https://github.com/sockjs/sockjs-node) is a SockJS\n   server for Node.js.\n\n\nPhilosophy:\n\n * The API should follow\n   [HTML5 Websockets API](https://www.w3.org/TR/websockets/) as\n   closely as possible.\n * All the transports must support cross domain connections out of the\n   box. It's possible and recommended to host a SockJS server on a\n   different server than your main web site.\n * There is support for at least one streaming protocol for every\n   major browser.\n * Streaming transports should work cross-domain and\n   should support cookies (for cookie-based sticky sessions).\n * Polling transports are used as a fallback for old browsers and\n   hosts behind restrictive proxies.\n * Connection establishment should be fast and lightweight.\n * No Flash inside (no need to open port 843 - which doesn't work\n   through proxies, no need to host 'crossdomain.xml', no need\n   [to wait for 3 seconds](https://github.com/gimite/web-socket-js/issues/49)\n   in order to detect problems)\n\n\nSubscribe to\n[SockJS mailing list](https://groups.google.com/forum/#!forum/sockjs) for\ndiscussions and support.\n\n# SockJS family\n\n  * [SockJS-client](https://github.com/sockjs/sockjs-client) JavaScript client library\n  * [SockJS-node](https://github.com/sockjs/sockjs-node) Node.js server\n  * [SockJS-erlang](https://github.com/sockjs/sockjs-erlang) Erlang server\n  * [SockJS-cyclone](https://github.com/flaviogrossi/sockjs-cyclone) Python/Cyclone/Twisted server\n  * [SockJS-tornado](https://github.com/MrJoes/sockjs-tornado) Python/Tornado server\n  * [SockJS-twisted](https://github.com/DesertBus/sockjs-twisted/) Python/Twisted server\n  * [SockJS-aiohttp](https://github.com/aio-libs/sockjs/) Python/Aiohttp server\n  * [Spring Framework](https://projects.spring.io/spring-framework) Java [client](https://docs.spring.io/spring-framework/docs/current/spring-framework-reference/web.html#websocket-fallback-sockjs-client) & server\n  * [vert.x](https://github.com/vert-x/vert.x) Java/vert.x server\n  * [Xitrum](https://xitrum-framework.github.io/) Scala server\n  * [Atmosphere Framework](https://github.com/Atmosphere/atmosphere) JavaEE Server, Play Framework, Netty, Vert.x\n  * [Actix SockJS](https://github.com/fafhrd91/actix-sockjs) Rust Server, Actix Framework\n\nWork in progress:\n\n  * [SockJS-ruby](https://github.com/nyarly/sockjs-ruby)\n  * [SockJS-netty](https://github.com/cgbystrom/sockjs-netty)\n  * [SockJS-gevent](https://github.com/ksava/sockjs-gevent) ([SockJS-gevent fork](https://github.com/njoyce/sockjs-gevent))\n  * [pyramid-SockJS](https://github.com/fafhrd91/pyramid_sockjs)\n  * [wildcloud-websockets](https://github.com/wildcloud/wildcloud-websockets)\n  * [wai-SockJS](https://github.com/Palmik/wai-sockjs)\n  * [SockJS-perl](https://github.com/vti/sockjs-perl)\n  * [SockJS-go](https://github.com/igm/sockjs-go/)\n  * [syp.biz.SockJS.NET](https://github.com/sypbiz/SockJS.NET) - .NET port of the SockJS client\n\n# Getting Started\n\nSockJS mimics the [WebSockets API](https://www.w3.org/TR/websockets/),\nbut instead of `WebSocket` there is a `SockJS` Javascript object.\n\nFirst, you need to load the SockJS JavaScript library. For example, you can\nput that in your HTML head:\n\n```html\n<script src=\"https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js\"></script>\n```\n\nAfter the script is loaded you can establish a connection with the\nSockJS server. Here's a simple example:\n\n```javascript\n var sock = new SockJS('https://mydomain.com/my_prefix');\n sock.onopen = function() {\n     console.log('open');\n     sock.send('test');\n };\n\n sock.onmessage = function(e) {\n     console.log('message', e.data);\n     sock.close();\n };\n\n sock.onclose = function() {\n     console.log('close');\n };\n\n```\n\n# SockJS-client API\n\n## SockJS class\n\nSimilar to the 'WebSocket' API, the 'SockJS' constructor takes one, or more arguments:\n\n```javascript\nvar sockjs = new SockJS(url, _reserved, options);\n```\n\n`url` may contain a query string, if one is desired.\n\nWhere `options` is a hash which can contain:\n\n *  **server (string)**\n\n    String to append to url for actual data connection. Defaults to a random 4 digit number.\n\n *  **transports (string OR array of strings)**\n\n    Sometimes it is useful to disable some fallback transports. This\n    option allows you to supply a list transports that may be used by\n    SockJS. By default all available transports will be used.\n\n *  **sessionId (number OR function)**\n\n    Both client and server use session identifiers to distinguish connections.\n    If you specify this option as a number, SockJS will use its random string\n    generator function to generate session ids that are N-character long\n    (where N corresponds to the number specified by **sessionId**).\n    When you specify this option as a function, the function must return a\n    randomly generated string. Every time SockJS needs to generate a session\n    id it will call this function and use the returned string directly.\n    If you don't specify this option, the default is to use the default random\n    string generator to generate 8-character long session ids.\n\n  * **timeout (number)**\n\n    Specify a minimum timeout in milliseconds to use for the transport connections.\n    By default this is dynamically calculated based on the measured RTT and\n    the number of expected round trips. This setting will establish a minimum,\n    but if the calculated timeout is higher, that will be used.\n\nAlthough the 'SockJS' object tries to emulate the 'WebSocket'\nbehaviour, it's impossible to support all of its features. An\nimportant SockJS limitation is the fact that you're not allowed to\nopen more than one SockJS connection to a single domain at a time.\nThis limitation is caused by an in-browser limit of outgoing\nconnections - usually [browsers don't allow opening more than two\noutgoing connections to a single domain](https://stackoverflow.com/questions/985431/max-parallel-http-connections-in-a-browser). A single SockJS session\nrequires those two connections - one for downloading data, the other for\nsending messages.  Opening a second SockJS session at the same time\nwould most likely block, and can result in both sessions timing out.\n\nOpening more than one SockJS connection at a time is generally a\nbad practice. If you absolutely must do it, you can use\nmultiple subdomains, using a different subdomain for every\nSockJS connection.\n\n# Supported transports, by browser (html served from http:// or https://)\n\n_Browser_       | _Websockets_     | _Streaming_ | _Polling_\n----------------|------------------|-------------|-------------------\nIE 6, 7         | no               | no          | jsonp-polling\nIE 8, 9 (cookies=no) |    no       | xdr-streaming &dagger; | xdr-polling &dagger;\nIE 8, 9 (cookies=yes)|    no       | iframe-htmlfile | iframe-xhr-polling\nIE 10           | rfc6455          | xhr-streaming   | xhr-polling\nChrome 6-13     | hixie-76         | xhr-streaming   | xhr-polling\nChrome 14+      | hybi-10 / rfc6455| xhr-streaming   | xhr-polling\nFirefox <10     | no &Dagger;      | xhr-streaming   | xhr-polling\nFirefox 10+     | hybi-10 / rfc6455| xhr-streaming   | xhr-polling\nSafari 5.x      | hixie-76         | xhr-streaming   | xhr-polling\nSafari 6+       | rfc6455          | xhr-streaming   | xhr-polling\nOpera 10.70+    | no &Dagger;      | iframe-eventsource | iframe-xhr-polling\nOpera 12.10+    | rfc6455          | xhr-streaming | xhr-polling\nKonqueror       | no               | no          | jsonp-polling\n\n\n * **&dagger;**: IE 8+ supports [XDomainRequest][^9], which is\n    essentially a modified AJAX/XHR that can do requests across\n    domains. But unfortunately it doesn't send any cookies, which\n    makes it inappropriate for deployments when the load balancer uses\n    JSESSIONID cookie to do sticky sessions.\n\n * **&Dagger;**: Firefox 4.0 and Opera 11.00 and shipped with disabled\n     Websockets \"hixie-76\". They can still be enabled by manually\n     changing a browser setting.\n\n# Supported transports, by browser (html served from file://)\n\nSometimes you may want to serve your html from \"file://\" address - for\ndevelopment or if you're using PhoneGap or similar technologies. But\ndue to the Cross Origin Policy files served from \"file://\" have no\nOrigin, and that means some of SockJS transports won't work. For this\nreason the SockJS transport table is different than usually, major\ndifferences are:\n\n_Browser_       | _Websockets_  | _Streaming_        | _Polling_\n----------------|---------------|--------------------|-------------------\nIE 8, 9         | same as above | iframe-htmlfile    | iframe-xhr-polling\nOther           | same as above | iframe-eventsource | iframe-xhr-polling\n\n# Supported transports, by name\n\n_Transport_          | _References_\n---------------------|---------------\nwebsocket (rfc6455)  | [rfc 6455][^10]\nwebsocket (hixie-76) | [draft-hixie-thewebsocketprotocol-76][^1]\nwebsocket (hybi-10)  | [draft-ietf-hybi-thewebsocketprotocol-10][^2]\nxhr-streaming        | Transport using [Cross domain XHR][^5] [streaming][^7] capability (readyState=3).\nxdr-streaming        | Transport using [XDomainRequest][^9] [streaming][^7] capability (readyState=3).\neventsource          | [EventSource/Server-sent events][^4].\niframe-eventsource   | [EventSource/Server-sent events][^4] used from an [iframe via postMessage][^3].\nhtmlfile             | [HtmlFile][^8].\niframe-htmlfile      | [HtmlFile][^8] used from an [iframe via postMessage][^3].\nxhr-polling          | Long-polling using [cross domain XHR][^5].\nxdr-polling          | Long-polling using [XDomainRequest][^9].\niframe-xhr-polling   | Long-polling using normal AJAX from an [iframe via postMessage][^3].\njsonp-polling        | Slow and old fashioned [JSONP polling][^6]. This transport will show \"busy indicator\" (aka: \"spinning wheel\") when sending data.\n\n\n[^1]: https://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76\n[^2]: https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-10\n[^3]: https://developer.mozilla.org/en/DOM/window.postMessage\n[^4]: https://html.spec.whatwg.org/multipage/comms.html#server-sent-events\n[^5]: https://secure.wikimedia.org/wikipedia/en/wiki/XMLHttpRequest#Cross-domain_requests\n[^6]: https://secure.wikimedia.org/wikipedia/en/wiki/JSONP\n[^7]: http://www.debugtheweb.com/test/teststreaming.aspx\n[^8]: http://cometdaily.com/2007/11/18/ie-activexhtmlfile-transport-part-ii/\n[^9]: https://blogs.msdn.microsoft.com/ieinternals/2010/05/13/xdomainrequest-restrictions-limitations-and-workarounds/\n[^10]: https://www.rfc-editor.org/rfc/rfc6455.txt\n\n\n# Connecting to SockJS without the client\n\nAlthough the main point of SockJS is to enable browser-to-server\nconnectivity, it is possible to connect to SockJS from an external\napplication. Any SockJS server complying with 0.3 protocol does\nsupport a raw WebSocket url. The raw WebSocket url for the test server\nlooks like:\n\n * ws://localhost:8081/echo/websocket\n\nYou can connect any WebSocket RFC 6455 compliant WebSocket client to\nthis url. This can be a command line client, external application,\nthird party code or even a browser (though I don't know why you would\nwant to do so).\n\n\n# Deployment\n\nYou should use a version of sockjs-client\nthat supports the protocol used by your server. For example:\n\n```html\n<script src=\"https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js\"></script>\n```\n\n\nFor server-side deployment tricks, especially about load balancing and\nsession stickiness, take a look at the\n[SockJS-node readme](https://github.com/sockjs/sockjs-node#readme).\n\n\n# Development and testing\n\nSockJS-client needs [node.js](https://nodejs.org/) for running a test\nserver and JavaScript minification. If you want to work on\nSockJS-client source code, checkout the git repo and follow these\nsteps:\n\n    cd sockjs-client\n    npm install\n\nTo generate JavaScript, run:\n\n    gulp browserify\n\nTo generate minified JavaScript, run:\n\n    gulp browserify:min\n\nBoth commands output into the `build` directory.\n\n## Testing\n\nAutomated testing provided by:\n\n<a href=\"https://browserstack.com\"><img src=\"img/Browserstack-logo@2x.png\" height=\"50\"></a>\n\nOnce you've compiled the SockJS-client you may want to check if your changes\npass all the tests.\n\n    npm run test:browser_local\n\nThis will start [karma](https://karma-runner.github.io) and a test support server.\n\n# Browser Quirks\n\nThere are various browser quirks which we don't intend to address:\n\n * Pressing ESC in Firefox, before Firefox 20, closes the SockJS connection. For a workaround\n   and discussion see [#18](https://github.com/sockjs/sockjs-client/issues/18).\n * `jsonp-polling` transport will show a \"spinning wheel\" (aka. \"busy indicator\")\n   when sending data.\n * You can't open more than one SockJS connection to one domain at the\n   same time due to [the browser's limit of concurrent connections](https://stackoverflow.com/questions/985431/max-parallel-http-connections-in-a-browser)\n   (this limit is not counting native WebSocket connections).\n * Although SockJS is trying to escape any strange Unicode characters\n   (even invalid ones - [like surrogates \\xD800-\\xDBFF](https://en.wikipedia.org/wiki/Mapping_of_Unicode_characters#Surrogates) or [\\xFFFE and \\xFFFF](https://en.wikipedia.org/wiki/Unicode#Character_General_Category))\n   it's advisable to use only valid characters. Using invalid\n   characters is a bit slower, and may not work with SockJS servers\n   that have proper Unicode support.\n * Having a global function called `onmessage` or such is probably a\n   bad idea, as it could be called by the built-in `postMessage` API.\n * From SockJS' point of view there is nothing special about\n   SSL/HTTPS. Connecting between unencrypted and encrypted sites\n   should work just fine.\n * Although SockJS does its best to support both prefix and cookie based\n   sticky sessions, the latter may not work well cross-domain with\n   browsers that don't accept third-party cookies by default (Safari).\n   In order to get around this make sure you're connecting to SockJS\n   from the same parent domain as the main site. For example\n   'sockjs.a.com' is able to set cookies if you're connecting from\n   'www.a.com' or 'a.com'.\n * Trying to connect from secure \"https://\" to insecure \"http://\" is\n   not a good idea. The other way around should be fine.\n * Long polling is known to cause problems on Heroku, but a\n   [workaround for SockJS is available](https://github.com/sockjs/sockjs-node/issues/57#issuecomment-5242187).\n * SockJS [websocket transport is more stable over SSL](https://github.com/sockjs/sockjs-client/issues/94). If\n   you're a serious SockJS user then consider using SSL\n   ([more info](https://www.ietf.org/mail-archive/web/hybi/current/msg01605.html)).\n",
+  "maintainers": [
+    {
+      "name": "brycekahle",
+      "email": "bkahle@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-08-02T22:07:39.200Z",
+    "created": "2012-03-23T16:31:29.232Z",
+    "0.1.0": "2012-03-23T16:31:29.992Z",
+    "0.1.1": "2012-03-23T16:35:45.514Z",
+    "0.1.2": "2012-04-02T17:09:29.716Z",
+    "0.1.3": "2012-05-01T13:00:42.080Z",
+    "1.0.0-beta.4": "2014-11-19T19:07:05.656Z",
+    "1.0.0-beta.5": "2014-11-21T21:39:12.408Z",
+    "1.0.0-beta.6": "2014-11-22T19:19:39.508Z",
+    "1.0.0-beta.7": "2014-12-08T18:02:15.212Z",
+    "1.0.0-beta.8": "2014-12-16T21:20:05.596Z",
+    "1.0.0-beta.9": "2014-12-16T23:06:08.991Z",
+    "1.0.0-beta.10": "2014-12-17T21:16:54.798Z",
+    "1.0.0-beta.11": "2015-02-01T16:45:17.128Z",
+    "1.0.0-beta.12": "2015-02-01T16:54:29.746Z",
+    "1.0.0-beta.13": "2015-05-05T19:36:12.780Z",
+    "1.0.0": "2015-05-14T05:33:20.390Z",
+    "1.0.1": "2015-07-20T00:58:26.063Z",
+    "1.0.2": "2015-07-22T06:20:43.424Z",
+    "1.0.3": "2015-07-31T18:14:31.658Z",
+    "1.1.0": "2016-04-30T22:01:16.785Z",
+    "1.1.1": "2016-05-20T18:25:01.576Z",
+    "1.1.2": "2017-01-23T23:46:48.194Z",
+    "1.1.3": "2017-04-30T21:02:02.502Z",
+    "1.1.4": "2017-04-30T21:04:27.746Z",
+    "1.1.5": "2018-05-29T23:36:56.638Z",
+    "1.2.0": "2018-09-21T18:14:29.645Z",
+    "1.3.0": "2018-09-24T15:45:41.966Z",
+    "1.4.0": "2019-08-22T20:31:45.357Z",
+    "1.5.0": "2020-08-02T22:07:36.995Z"
+  },
+  "author": {
+    "name": "Bryce Kahle"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sockjs/sockjs-client.git"
+  },
+  "keywords": [
+    "websockets",
+    "websocket"
+  ],
+  "readmeFilename": "README.md",
+  "homepage": "http://sockjs.org",
+  "contributors": [
+    {
+      "name": "Bryce Kahle",
+      "email": "bkahle@gmail.com"
+    },
+    {
+      "name": "Marek Majkowski",
+      "email": "deadbeef@popcount.org"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/sockjs/sockjs-client/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "famousgarkin": true,
+    "antanst": true,
+    "jackstraw": true,
+    "preco21": true,
+    "segen": true,
+    "staydan": true,
+    "isik": true,
+    "shahyar": true,
+    "shuoshubao": true,
+    "panlw": true,
+    "muzi131313": true,
+    "moueza": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/sockjs-client.min.json
+++ b/test/fixtures/registry-mocks/content/sockjs-client.min.json
@@ -1,0 +1,915 @@
+{
+  "name": "sockjs-client",
+  "dist-tags": {
+    "latest": "1.5.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "sockjs-client",
+      "version": "0.1.0",
+      "dependencies": {
+        "node-uuid": "1.3.3"
+      },
+      "dist": {
+        "shasum": "b9bcf1e5334de90500817e7e12dba724a02de17d",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.1": {
+      "name": "sockjs-client",
+      "version": "0.1.1",
+      "dependencies": {
+        "node-uuid": "1.3.3"
+      },
+      "dist": {
+        "shasum": "b65d9f24532da2a4e4ec4ca29d1b174d691884a5",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-0.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.2": {
+      "name": "sockjs-client",
+      "version": "0.1.2",
+      "dependencies": {
+        "node-uuid": "1.3.3"
+      },
+      "dist": {
+        "shasum": "6991468810a36a9eff9bb0338091c5ff653a7f06",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-0.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.3": {
+      "name": "sockjs-client",
+      "version": "0.1.3",
+      "dependencies": {
+        "node-uuid": "1.3.3"
+      },
+      "dist": {
+        "shasum": "aaaf2f27bf4bf6f101e69f71008c8dbe6e810a81",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-0.1.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "1.0.0-beta.4": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.4",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.1.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "9bb31d1b2941e018386346541e645bf0f71f367f",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.4.tgz"
+      }
+    },
+    "1.0.0-beta.5": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.5",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.1.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "79717d8946721257c04dc727ac633c16baa6858a",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.5.tgz"
+      }
+    },
+    "1.0.0-beta.6": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.6",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.1.3"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "b8ea8a86defe5b0b85ae2516ae861a341924369d",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.6.tgz"
+      }
+    },
+    "1.0.0-beta.7": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.7",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.1.5"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "7b11ea76414d2ed237ab90d3f932e5822cee62f8",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.7.tgz"
+      }
+    },
+    "1.0.0-beta.8": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.8",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.2.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "f66c4bb9e62be01e7903437c4cd70497ff5f2a07",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.8.tgz"
+      }
+    },
+    "1.0.0-beta.9": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.9",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.2.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "ad9e533249386efc9119ebaa2026ebf36ed5837d",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.9.tgz"
+      }
+    },
+    "1.0.0-beta.10": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.10",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^0.2.3"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "5cd009db31fdd8631ff73ca7b4ae8f3ca3c6f986",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.10.tgz"
+      }
+    },
+    "1.0.0-beta.11": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.11",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "4bf090e20087251cc8ef7d2a2688ff3b620358c3",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.11.tgz"
+      }
+    },
+    "1.0.0-beta.12": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.12",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul#ngrok"
+      },
+      "dist": {
+        "shasum": "5e7a4b662447bb92de9bc7613b771b36c4804a6f",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.12.tgz"
+      }
+    },
+    "1.0.0-beta.13": {
+      "name": "sockjs-client",
+      "version": "1.0.0-beta.13",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.0"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "dist": {
+        "shasum": "434e3960b80a7c721ca31b010d1a3f098217a973",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0-beta.13.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "sockjs-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "dist": {
+        "shasum": "af6d2d340482709bde27890a0ba804dfd765f8f9",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "sockjs-client",
+      "version": "1.0.1",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "dist": {
+        "shasum": "8943ae05b46547bc2054816c409002cf5e2fe026",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "sockjs-client",
+      "version": "1.0.2",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "dist": {
+        "shasum": "7875d75ef31706a0d0213353164de953f3fe30d5",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "sockjs-client",
+      "version": "1.0.3",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.7.3",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.11",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "dist": {
+        "shasum": "b0d8280998460eb2564c5d79d7e3d7cfd8a353ad",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "sockjs-client",
+      "version": "1.1.0",
+      "dependencies": {
+        "debug": "^2.1.0",
+        "eventsource": "^0.1.3",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.0.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "dist": {
+        "shasum": "1404b670b47ad5f6ae959e319e84ee718523f477",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "sockjs-client",
+      "version": "1.1.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "eventsource": "~0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.1"
+      },
+      "devDependencies": {
+        "browserify": "^6.1.0",
+        "envify": "~3.0.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.8.8",
+        "gulp-eslint": "~0.1.8",
+        "gulp-header": "^1.2.2",
+        "gulp-mocha": "~1.1.1",
+        "gulp-rename": "~1.2.0",
+        "gulp-sourcemaps": "~1.2.4",
+        "gulp-uglify": "~1.0.1",
+        "mocha": "^1.21.5",
+        "node-static": "^0.7.6",
+        "proxyquire": "~1.0.1",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "git://github.com/brycekahle/zuul.git#ngrok"
+      },
+      "dist": {
+        "shasum": "284843e9a9784d7c474b1571b3240fca9dda4bb0",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "sockjs-client",
+      "version": "1.1.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "eventsource": "0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.1"
+      },
+      "devDependencies": {
+        "browserify": "^13.3.0",
+        "envify": "^4.0.0",
+        "eslint": "^3.14.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.9.1",
+        "gulp-header": "^1.8.8",
+        "gulp-rename": "~1.2.0",
+        "gulp-replace": "^0.5.4",
+        "gulp-sourcemaps": "^2.4.0",
+        "gulp-uglify": "^2.0.0",
+        "mocha": "^3.2.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^1.7.10",
+        "pump": "^1.0.2",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "github:brycekahle/zuul#ngrok",
+        "zuul-ngrok": "github:brycekahle/zuul-ngrok#master"
+      },
+      "dist": {
+        "shasum": "f0212a8550e4c9468c8cceaeefd2e3493c033ad5",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz"
+      }
+    },
+    "1.1.4": {
+      "name": "sockjs-client",
+      "version": "1.1.4",
+      "dependencies": {
+        "debug": "^2.6.6",
+        "eventsource": "0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
+      },
+      "devDependencies": {
+        "browserify": "^13.3.0",
+        "envify": "^4.0.0",
+        "eslint": "^3.19.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.9.1",
+        "gulp-header": "^1.8.8",
+        "gulp-rename": "~1.2.0",
+        "gulp-replace": "^0.5.4",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^2.1.2",
+        "mocha": "^3.3.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^1.7.11",
+        "pump": "^1.0.2",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "github:brycekahle/zuul#ngrok",
+        "zuul-ngrok": "github:brycekahle/zuul-ngrok#master"
+      },
+      "dist": {
+        "shasum": "5babe386b775e4cf14e7520911452654016c8b12",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz"
+      }
+    },
+    "1.1.5": {
+      "name": "sockjs-client",
+      "version": "1.1.5",
+      "dependencies": {
+        "debug": "^2.6.6",
+        "eventsource": "0.1.6",
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
+      },
+      "devDependencies": {
+        "browserify": "^13.3.0",
+        "envify": "^4.0.0",
+        "eslint": "^3.19.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^3.9.1",
+        "gulp-header": "^1.8.8",
+        "gulp-rename": "~1.2.0",
+        "gulp-replace": "^0.5.4",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^2.1.2",
+        "mocha": "^3.3.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^1.7.11",
+        "pump": "^1.0.2",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^1.0.0",
+        "zuul": "github:brycekahle/zuul#ngrok",
+        "zuul-ngrok": "github:brycekahle/zuul-ngrok#master"
+      },
+      "dist": {
+        "shasum": "1bb7c0f7222c40f42adf14f4442cbd1269771a83",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+        "fileCount": 68,
+        "unpackedSize": 812165,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbDeQaCRA9TVsSAnZWagAAZyMP/At4L4Hs8abKR624bmh1\nXWhWBL6zCh3J9ZqWFOFsX0NnQ9Pna8TNQwkfv5ai56s+XO1fe5WeFH0F0VuM\nwOOGq8gCujU7RgroHkQJmDwjPuPiptaXQEw6jAc+GdPX5H+TZIFhwK2oZDn6\nDRVGHzlUqm1nfU55iKnCFGA/9b6+iHLdjQj2zbAEHApsIlgvzld92tyCkJIj\nkBazuXaGK9vgrCgznrSJz39neAYFFtXxx5aA01fIXbqlND42Tawtlxt3+To8\n9ff0yooPOWUV7MkaT+XRPtzGDojFLmLMwJEJTihisvGvmorAQAUn9ztkpKn/\n41vEoEAsQeHjJP6mPFhF67QMihYjsKwINhFTdnZtnigrPjtajEqQpx1hytYS\n00Fv1uJOJK4bP4JL+j922bFlVjdDU5PAeq27JvYvsp3R9jyaP3r5rSs8V6zc\n8jWNv+ubrQOY/oOQNsVeFNCHacjx/aP2oFpKwx6aAm260tjUKH2QTA7HOUyI\nLVuUr3MEyBAixCTVhPUlo4Cc9AATD7UGtDzUr7LkyqA1P5RNQya0kTE+JzV/\nfPeNj7AVRtaHJapxOBtuQGw4YYWx0RECQ2Q7v7pKCmnR874byj1tD2gbPGZo\ngTGj2Q2k/7yCjt8/i/dE0cZn+9oG/0eArw906SBaD2V2vMGBcf1rcuvGYkOH\nioOU\r\n=A5hz\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.2.0": {
+      "name": "sockjs-client",
+      "version": "1.2.0",
+      "dependencies": {
+        "debug": "^4.0.1",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "browserify": "^16.2.2",
+        "envify": "^4.0.0",
+        "eslint": "^5.6.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^4.0.0",
+        "gulp-header": "^2.0.5",
+        "gulp-rename": "^1.4.0",
+        "gulp-replace": "^1.0.0",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^3.0.1",
+        "karma": "^3.0.0",
+        "karma-browserify": "^5.3.0",
+        "karma-browserstack-launcher": "git+https://git@github.com/karma-runner/karma-browserstack-launcher.git#310c22835987b50a908b99d0995fc1655a7e06f5",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-mocha": "^1.3.0",
+        "mocha": "^5.2.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^2.1.0",
+        "pump": "^3.0.0",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-sAibkw+jfBSCBcxsZZqPpw0fPtH4yf1HlGqkmrsB3DisahTsnUXJScX0jqkebW3SHRXTYxZyUVyDbzKDfflYgw==",
+        "shasum": "43a0b6d70c7f07049897b2ec26b9571e4cdab4c6",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.2.0.tgz",
+        "fileCount": 64,
+        "unpackedSize": 824897,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbpTUGCRA9TVsSAnZWagAAHjgP/3YlJM/PPTm3kukBE4s3\nrieR6MQTS8DNyC+QCEAqdUkAv+sEyS1TTkrBwcp4WkJ5obqnSgDfHVgrOmJ3\n/Evrj1BZHIT3a+VZxOePekhvI6cOrZPD83BW2S9iod+u8UQUmRyY0/RtaZ+z\njNKCf2qkiC29YfxBq/GjwGSEghm0k9x2bYFkcCc64L1mSTlZI8UxxgSkzUEi\nzDz+SQUC7q3eGdCyGICbawADgq9uCSjac4MyNOjkAeT55USzCshQRxtQiZsS\nTHcUaTdiqCR5KmGsgROTSzrplYnLOoFhjUOdnv4T6IXBmMY7yOrUB+JxYZ2l\nhaINLCMTQQP4uwmQDrmNmM/FQNAqm1SmVk+1JrIU4/yvkAruuVnVDz4H0Moi\neeY7hyclxKrzVKGqeAljBlwfqM1gDbgRiiaTkwFCxzNl7Q/5MQQ7jLGmR94T\nsI7LEDX4TXvhZHvjD5UWRDKWjeH5VoYKAgbYSYF+b4OybyHSlKzpJD4JWXyo\nv9Pr4adxbVJT08oED7C9c/pUAEfu5Q1q814jN9I7MFOvVyES9NI1RSki+Tsc\nThTpmEVzNDG0mXOrYL8il5uGs5QccNqPpHdGtWJDAdzV+N14WhbARKpv+luk\nFavduDbI6DaKQQSpFyCm6ULo0L07GbMjGgB88EWUsTO8orGqb19+Piy2lakr\nszg3\r\n=2sFQ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.3.0": {
+      "name": "sockjs-client",
+      "version": "1.3.0",
+      "dependencies": {
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "browserify": "^16.2.2",
+        "envify": "^4.0.0",
+        "eslint": "^5.6.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^4.0.0",
+        "gulp-header": "^2.0.5",
+        "gulp-rename": "^1.4.0",
+        "gulp-replace": "^1.0.0",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^3.0.1",
+        "karma": "^3.0.0",
+        "karma-browserify": "^5.3.0",
+        "karma-browserstack-launcher": "git+https://git@github.com/karma-runner/karma-browserstack-launcher.git#310c22835987b50a908b99d0995fc1655a7e06f5",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-mocha": "^1.3.0",
+        "mocha": "^5.2.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^2.1.0",
+        "pump": "^3.0.0",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-R9jxEzhnnrdxLCNln0xg5uGHqMnkhPSTzUZH2eXcR03S/On9Yvoq2wyUZILRUhZCNVu2PmwWVoyuiPz8th8zbg==",
+        "shasum": "12fc9d6cb663da5739d3dc5fb6e8687da95cb177",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.3.0.tgz",
+        "fileCount": 64,
+        "unpackedSize": 825834,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqQamCRA9TVsSAnZWagAAOOkP/3+8shVpu1COFdOaczMo\n3KCZ+mxhp5AWVOe4zwJSb7O3cY7k+htExg0eh7RcpHoUH/WJIQABEAA/5m/P\nlsomTD6+b16S/DueJlksRC9xJU/rlZRhQqptTJ0CzPwxZbpNXMJdOA7p/vtO\n4/mram2eYD9/VM81GA0bQdkTN7ZIx03nJp+q0UZh2FpgPn8STfyeoPky2irv\nwRwEAkGisa9p5PY8mgwagtYpTS7hu2KWiuIwNoaEalld3BrPuU165lzWUNex\nbuczYte+saufKkPPfkqVgEji47uaEMXynlKjSRqzVa2HOQPcjRORskt8zERM\n4JebOkRnK07goU7sTzIVIotGAm93LIEuPnnm9X9v+K6fdwmskts88x1OVV+C\nX7rkgAh9vdx9HriBGQf6jzvCTAfB3bf1uniZv4IHn+TDmK8iDHjiJOweIzGs\nb4Ey3OOw2sZAoz62JW+CfuZmIt2eF9k8xos2qoQoo7zKXrGLxBEOivtgTH12\nll6YZ0tQAxm+obwT8VyIrN0Hs3xBJfqmILwixW4UZ3bqIiVxp6gKh6KJ9rvS\nLxBergd6pVWTVv77HG9zWv4EdPtq4IK0qcrCpdxENpzZPiawaPjSncGfj0U5\nsuEyv6MR1ki4WwjHOp9k5T8a/tMa1qQY7xn2juzHjCbS5C0o9YN8Xolu3mV9\nCxFW\r\n=QZF5\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.4.0": {
+      "name": "sockjs-client",
+      "version": "1.4.0",
+      "dependencies": {
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "devDependencies": {
+        "browserify": "^16.2.3",
+        "envify": "^4.0.0",
+        "eslint": "^6.2.1",
+        "expect.js": "~0.3.1",
+        "gulp": "^4.0.2",
+        "gulp-header": "^2.0.5",
+        "gulp-rename": "^1.4.0",
+        "gulp-replace": "^1.0.0",
+        "gulp-sourcemaps": "^2.6.0",
+        "gulp-uglify": "^3.0.2",
+        "karma": "^4.2.0",
+        "karma-browserify": "^6.1.0",
+        "karma-browserstack-launcher": "^1.5.1",
+        "karma-chrome-launcher": "^2.2.0",
+        "karma-mocha": "^1.3.0",
+        "mocha": "^5.2.0",
+        "node-static": "^0.7.6",
+        "proxyquire": "^2.1.0",
+        "pump": "^3.0.0",
+        "sockjs": "^0.3.17",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
+        "shasum": "c9f2568e19c8fd8173b4997ea3420e0bb306c7d5",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
+        "fileCount": 66,
+        "unpackedSize": 827860,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdXvuyCRA9TVsSAnZWagAA/vAP/31wRSOu2OM7bm+ZelqL\nRHrZDzBaLu0DTELYsziQ3UcaaQw2vfnXHJCOOrHZC8atbIjLAitTg5TrFUT/\ndqTijIMajF/aLSlW6fQjSxluZ5rBvDa6ve3iWaH5LjrPtKVx3cZjgF5VGOU/\naM2Hzcqd+ITEOeHiExGJxL4kMkR0PiJf2xWSHxRVip8WS/wTew+6Mn2aiOs0\niNOldL3T0oi7Yy/xVWmkFl6WrYOL+QPosxmQScWvt8FdolOIqUEic0pLBCUU\nisTA4XKv+aMv7yDRfsSalUkkSkpkjdFll0LWI0+riPEtDVah1hiU8wsNDIyl\nqsusyX3ZR+yEblYW/7VgMOKPiIjaf8apbYJ4nua9kMKpeAZBB9SS4kHXgg2u\nDFolDNxfZFDl1B3NOSBjuJYQTh+bqNOKK3ZWyd6a4cCB73DSVuNiZ7KaH4jT\nPwnH9stplOvIROK8MmC2xaBoR260mgXJC9K5d4Lveteo9bzDEAUqPSYkstP1\n0hqHq/jH1boaRolDHP0JUcIRfbkL1AQj1/8YVLqEwBcF8cmLGeG5+l1PsvdM\nOdTgkapr9XAdTYwDax1d3mUL+uoIT3AHIGLnggAIPBiU5VSpmSQyAVdHz3bf\nD89u8tAWFZiobWkcPTAjnaQEep67HymBwCIHiIqjQ40kVOXHJ1pQXCzoLIm5\nAKaM\r\n=kHpw\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.5.0": {
+      "name": "sockjs-client",
+      "version": "1.5.0",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "^0.11.3",
+        "inherits": "^2.0.4",
+        "json3": "^3.3.3",
+        "url-parse": "^1.4.7"
+      },
+      "devDependencies": {
+        "browserify": "^16.5.1",
+        "envify": "^4.0.0",
+        "eslint": "^7.6.0",
+        "expect.js": "~0.3.1",
+        "gulp": "^4.0.2",
+        "gulp-header": "^2.0.9",
+        "gulp-rename": "^2.0.0",
+        "gulp-replace": "^1.0.0",
+        "gulp-sourcemaps": "^2.6.5",
+        "gulp-uglify": "^3.0.2",
+        "karma": "^5.1.1",
+        "karma-browserify": "^7.0.0",
+        "karma-browserstack-launcher": "^1.6.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-mocha": "^2.0.1",
+        "mocha": "^8.1.0",
+        "proxyquire": "^2.1.3",
+        "pump": "^3.0.0",
+        "serve-static": "^1.14.1",
+        "sockjs": "^0.3.21",
+        "vinyl-buffer": "~1.0.0",
+        "vinyl-source-stream": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+        "shasum": "2f8ff5d4b659e0d092f7aba0b7c386bd2aa20add",
+        "tarball": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
+        "fileCount": 66,
+        "unpackedSize": 839190,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfJzkpCRA9TVsSAnZWagAAotcQAI3XZAvKN6oUR4B+keX0\nJ6mC5m50MZ1cJgmVN+sRySA3Ppk87adWEnoVAce4bOqEFY7KUg3AtQoiQGdG\nmLGfoBmC38EjzYa4r/7UV4Gyh1Ng2wwqFeZAktsMOrJj3iLBjTIhMydydlEn\nHT6yhUd2pCL2sqmOKh0EIJwRJcfDwrrmN8IN8nUaTATWP/+S8OxbDa5E7zV+\nXPycNZp3buVhkf+WdK/7S/SMm2kSHfgaa1iCiMTccxt3+uE7+GeBOOkONa1n\nfUXyj1SIJT7zi935mrS1sy5C/hjf827dgsYm5LRJrGDVvQ2iLGjPeOWxeb8A\nTTh53058N8v/xkaB9XlV3kMhgeSG07yysxX61213228mlMSdEQ6UxHJuGj9W\nYMPW1SqBTm4d6YhFlURq/KmbJmkwnolQ8ivbRnhkpIRcOViV94dgMN3nv3x9\n+PwpZDjNxwSgUsveWTsjnAS95lYQYpSnM0KeIjKMUpDo0UnK1pAQBkgbHkPO\nHl9nSYV/DY9+xeNgBpM/6HZqceNN06OSXDuej19QLn4A30qcelk52pXLPHCK\nU9VkPeSMskwN6UB7WSfIhtzNR40J3RiRF/CLFr2amGlDW5jt5Z+U3LZ7m4O5\nhZJTnqIT4jdGAd8hOfvdCiGK9q58RQ3ux49jjUVFOhzoYuXOJBxQtwa2I1zD\nUnOV\r\n=G8cB\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-08-02T22:07:39.200Z"
+}

--- a/test/fixtures/registry-mocks/content/sockjs.json
+++ b/test/fixtures/registry-mocks/content/sockjs.json
@@ -1,0 +1,2111 @@
+{
+  "_id": "sockjs",
+  "_rev": "111-29ab7122f1e9c63d84f95f03a2a2cc63",
+  "name": "sockjs",
+  "dist-tags": {
+    "latest": "0.3.21"
+  },
+  "versions": {
+    "0.0.0-rc1": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.0.0-rc1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/majek/sockjs-client.git"
+      },
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "main": "index",
+      "_npmJsonOpts": {
+        "file": "/home/marek/.npm/sockjs/0.0.0-rc1/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "sockjs@0.0.0-rc1",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "dd7a107308d7e8b6bec9b4b32d4692cbbbef33ea",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.0-rc1.tgz"
+      },
+      "scripts": {},
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.0-rc2": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.0.0-rc2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/majek/sockjs-client.git"
+      },
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "main": "index",
+      "_npmJsonOpts": {
+        "file": "/home/marek/.npm/sockjs/0.0.0-rc2/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "sockjs@0.0.0-rc2",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "60c9c9947c7800d02e943b0028fba7c18af47d97",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.0-rc2.tgz"
+      },
+      "scripts": {},
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/majek/sockjs-client.git"
+      },
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "main": "index",
+      "_npmJsonOpts": {
+        "file": "/home/marek/.npm/sockjs/0.0.1/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "sockjs@0.0.1",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.14",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "af7966e2290d0279da621e43d1a5da8453c242f7",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.1.tgz"
+      },
+      "scripts": {},
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.0.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/majek/sockjs-client.git"
+      },
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "main": "index",
+      "_npmJsonOpts": {
+        "file": "/home/marek/.npm/sockjs/0.0.2/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "sockjs@0.0.2",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "364f31f416c66abe5e1c619e942439315610584c",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.2.tgz"
+      },
+      "scripts": {},
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.0.3",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/majek/sockjs-client.git"
+      },
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "main": "index",
+      "_npmJsonOpts": {
+        "file": "/home/marek/.npm/sockjs/0.0.3/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "sockjs@0.0.3",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "ad5da88575cb1851d3992271889b4902f91035d1",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.3.tgz"
+      },
+      "scripts": {},
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.0.4",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/majek/sockjs-client.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "main": "index",
+      "_npmJsonOpts": {
+        "file": "/home/marek/.npm/sockjs/0.0.4/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "sockjs@0.0.4",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f3016cccd74e475180467a7c8a026561e8aec38b",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.4.tgz"
+      },
+      "scripts": {},
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.0.5",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "main": "index",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "_id": "sockjs@0.0.5",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.99",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "c903366a8b8ac705a2a4623dd4ee015bf131e5a2",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "main": "index",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "_id": "sockjs@0.1.0",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.99",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e127adf7a3e11395c0b3f8fda1b2b848d6188394",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.1.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "main": "index",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "_id": "sockjs@0.1.1",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.99",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "5e719cc4991010b4d682f05a5aaac8b437d4029d",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.1.2",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "main": "index",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "_id": "sockjs@0.1.2",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.99",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "41c358eec0823fbde79b3515adb568df982f590a",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.2.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.2.0",
+        "faye-websocket": "0.3.x",
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "main": "index",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "_id": "sockjs@0.2.0",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.99",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "e78ad1ec3bafbe850eb8c4f58897c8aba3c39c31",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.2.1",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0",
+        "rbytes": "0.0.2"
+      },
+      "optionalDependencies": {
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "_id": "sockjs@0.2.1",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.6.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "71c125a7e7ade415e92d150009f1e2a436c3b6a5",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.0",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0",
+        "rbytes": "0.0.2"
+      },
+      "optionalDependencies": {
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "_id": "sockjs@0.3.0",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.6.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "bb5cea1a3fe9eb5e29ab41d376088659d087b6f6",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.1",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0",
+        "rbytes": "0.0.2"
+      },
+      "optionalDependencies": {
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "_id": "sockjs@0.3.1",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.6.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "591964e8ca893ca655b67736d08b8ff7cd3ce69b",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.3": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.3",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0",
+        "rbytes": "0.0.2"
+      },
+      "optionalDependencies": {
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "_id": "sockjs@0.3.3",
+      "dist": {
+        "shasum": "1ef4b359c17b8c5b1357c42335fdf05a06d54ba4",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.3.tgz"
+      },
+      "_npmVersion": "1.1.62",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.4": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.4",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "_id": "sockjs@0.3.4",
+      "dist": {
+        "shasum": "58aeb1594c049eb789a603d36d9db106d855ef49",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.4.tgz"
+      },
+      "_npmVersion": "1.1.62",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.5": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.5",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "_id": "sockjs@0.3.5",
+      "dist": {
+        "shasum": "76fc86197de5279e1089c498b15d742f0f10fa35",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.5.tgz"
+      },
+      "_npmVersion": "1.1.62",
+      "_npmUser": {
+        "name": "majek",
+        "email": "majek04@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.6": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.6",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.4"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "_id": "sockjs@0.3.6",
+      "dist": {
+        "shasum": "6173e2cc327dfad98003d40568090e1132fd278d",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.2",
+      "_npmUser": {
+        "name": "glasser",
+        "email": "glasser@meteor.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.7": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.7",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.4"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "_id": "sockjs@0.3.7",
+      "dist": {
+        "shasum": "2950e0586d8a9d3044958a831ade68db197749cb",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.2",
+      "_npmUser": {
+        "name": "glasser",
+        "email": "glasser@meteor.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.8": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.8",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.7.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "_id": "sockjs@0.3.8",
+      "dist": {
+        "shasum": "c083cb0505db1ea1a949d3bd12d8a1ea385a456c",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "glasser",
+        "email": "glasser@meteor.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.9": {
+      "name": "sockjs",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "version": "0.3.9",
+      "license": "MIT",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.7.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "main": "index",
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "_id": "sockjs@0.3.9",
+      "_shasum": "5ae2c732dac07f6d7e9e8a9a60ec86ec4fc3ffc7",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "glasser",
+        "email": "glasser@meteor.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5ae2c732dac07f6d7e9e8a9a60ec86ec4fc3ffc7",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.9.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.10": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.10",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.7.3",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "f80bf1a23ee55e841b418b315b7d5c3a2f5ee419",
+      "_id": "sockjs@0.3.10",
+      "scripts": {},
+      "_shasum": "3910afb2ae8adc82591f2288456319cdf4727e7e",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3910afb2ae8adc82591f2288456319cdf4727e7e",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.10.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.11": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.11",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.7.3 || ^0.8.0",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "06eaad62a968520ea090c44ad7d6a84c0f5e37b3",
+      "_id": "sockjs@0.3.11",
+      "scripts": {},
+      "_shasum": "936d84d00f5bfce82f939aec9a7e1c9b8b39fb17",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "glasser",
+        "email": "glasser@meteor.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "936d84d00f5bfce82f939aec9a7e1c9b8b39fb17",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.11.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.12": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.12",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.7.3 || ^0.8.0 || ^0.9.0",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "c088f3969878f4dc255b66713d63586f62f55c88",
+      "_id": "sockjs@0.3.12",
+      "scripts": {},
+      "_shasum": "99f5686851cf8655706da977f56ccd266dded859",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "glasser",
+        "email": "glasser@meteor.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "99f5686851cf8655706da977f56ccd266dded859",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.12.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.13": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.13",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.9.3",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "1a543cdb98feb69c0c0dc47afaf74989c7a623e1",
+      "_id": "sockjs@0.3.13",
+      "scripts": {},
+      "_shasum": "aec6e096dede8e3ca0a66ec9dc9f32dd8e53bda1",
+      "_from": ".",
+      "_npmVersion": "2.1.8",
+      "_nodeVersion": "0.10.28",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "aec6e096dede8e3ca0a66ec9dc9f32dd8e53bda1",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.13.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.14": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.14",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.9.3",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "dd3497abf30100b4eaa9b4df47ad36973bad2279",
+      "_id": "sockjs@0.3.14",
+      "scripts": {},
+      "_shasum": "7570a730228f647b18e6f380fecc306a00bc0e77",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "glasser",
+        "email": "glasser@meteor.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7570a730228f647b18e6f380fecc306a00bc0e77",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.14.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.15": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.15",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.9.3",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "cb9925c6f135094d8b901d8d4f8d7e2fa54f5058",
+      "_id": "sockjs@0.3.15",
+      "scripts": {},
+      "_shasum": "e19b577e59e0fbdb21a0ae4f46203ca24cad8db8",
+      "_from": ".",
+      "_npmVersion": "2.6.1",
+      "_nodeVersion": "0.10.28",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e19b577e59e0fbdb21a0ae4f46203ca24cad8db8",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.15.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.16": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.16",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "f57cdfcdcb3fc52cad6041efbdfc36004737b2ef",
+      "_id": "sockjs@0.3.16",
+      "scripts": {},
+      "_shasum": "2bf5b90eb681b5216dfb98b8cf3e01a33ca271bc",
+      "_from": ".",
+      "_npmVersion": "2.14.6",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "2bf5b90eb681b5216dfb98b8cf3e01a33ca271bc",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.16.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/sockjs-0.3.16.tgz_1458754491754_0.15781300561502576"
+      },
+      "directories": {}
+    },
+    "0.3.17": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.17",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^2.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "0edbb8915d1816f20ba4de2b7960cc948d459691",
+      "_id": "sockjs@0.3.17",
+      "scripts": {},
+      "_shasum": "ef1b88f5d73e6278fad8e9476ac91064382f3b44",
+      "_from": ".",
+      "_npmVersion": "2.14.6",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "ef1b88f5d73e6278fad8e9476ac91064382f3b44",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.17.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/sockjs-0.3.17.tgz_1461947818760_0.02725877147167921"
+      },
+      "directories": {}
+    },
+    "0.3.18": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.18",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^2.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-node.git"
+      },
+      "gitHead": "a0178fae57d1f70b7d375369e70ce15bd592442e",
+      "_id": "sockjs@0.3.18",
+      "scripts": {},
+      "_shasum": "d9b289316ca7df77595ef299e075f0f937eb4207",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "shasum": "d9b289316ca7df77595ef299e075f0f937eb4207",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/sockjs-0.3.18.tgz_1474904162499_0.951328881084919"
+      },
+      "directories": {}
+    },
+    "0.3.19": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.19",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.0.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-node.git"
+      },
+      "scripts": {
+        "version": "make build && git add Changelog",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "14a5c3cf097126bde74436d001816c53a0593d43",
+      "_id": "sockjs@0.3.19",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+        "shasum": "d976bbe800af7bd20ae08598d582393508993c0d",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sockjs-0.3.19.tgz_1507825437179_0.2547635759692639"
+      },
+      "directories": {}
+    },
+    "0.3.20": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.20",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.4.0",
+        "websocket-driver": "0.6.5"
+      },
+      "devDependencies": {
+        "coffeescript": "^1.12.7"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-node.git"
+      },
+      "scripts": {
+        "version": "make build && git add Changelog",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "a0f6afb109f8a1b0141fa6ac6a7f082af8a689cf",
+      "_id": "sockjs@0.3.20",
+      "_nodeVersion": "12.16.1",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
+        "shasum": "b26a283ec562ef8b2687b44033a4eeceac75d855",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
+        "fileCount": 17,
+        "unpackedSize": 82508,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeZp8OCRA9TVsSAnZWagAAaiMP/1TboNGNwWbk71Rtggr/\nXp3OCYgc7MOU5Fof0iK2iI6Iwof+XX/6wWQsq6TJqgCMzSILZQNIEZJyOLOA\nq4OtqhOm4CBjS6/y/4/bO4pNuSsoRPnCFaablvXQUYzUN5LbyPtixILe6itS\nmDQKiT2A08S/vZnsnjDA16EyPm8wleyPBGWUGGujtNHjuZzrwhV5y7bvWiBl\ncIsU/Isjz/spfwT08aMNSoW5eg1tBN9IqTWvSnMp+V4TYbo2OppA/FAdqUWy\nofGcdq3ekQKejK8urXI1CCTj7HnqO0ZwXDk9/Wn0B2gL25in2cyeaLf0taxc\nLYpMuZtNdZFcX0M+z8XIwT03+y//jN8/dzQoYK2kEkK9FSLS+Ilc/qhBV2Ux\nwvAazcRgU03sxiEaARvbkDb0siz2BNbrNUsReXaKNfO0c3EiCoaWMUuQGSWb\nD7UiCSrHT1kBPgU9yIUr/PZV5c8bWlPZY2AjL1ZAlk1zvoeZnvoJbXDvplae\neJeSw8KapSdTmg4wJYRA5luqzftlVnKdbC1o/R1rrtIo4esYCTPBrdcb4gNh\n/5ky/J8Bo70vlU8I1mYX8EjiyBQ+fupZV9xYdfWYg2sWQGpkOTAXbPqzaYL7\n1K38nJAGu7wK09m77rs3xwtN096NlodVbj3A6gnWbvUmTdc7oRLDyKwgjnXN\n9B52\r\n=cUlo\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        }
+      ],
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "bkahle@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sockjs_0.3.20_1583783693877_0.9537753302050365"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.3.21": {
+      "name": "sockjs",
+      "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+      "version": "0.3.21",
+      "author": {
+        "name": "Marek Majkowski"
+      },
+      "bugs": {
+        "url": "https://github.com/sockjs/sockjs-node/issues"
+      },
+      "contributors": [
+        {
+          "name": "Bryce Kahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "Marek Majkowski",
+          "email": "deadbeef@popcount.org"
+        }
+      ],
+      "dependencies": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^3.4.0",
+        "websocket-driver": "^0.7.4"
+      },
+      "devDependencies": {
+        "coffeescript": "^1.12.7"
+      },
+      "homepage": "https://github.com/sockjs/sockjs-node",
+      "keywords": [
+        "websockets",
+        "websocket"
+      ],
+      "license": "MIT",
+      "main": "index",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sockjs/sockjs-node.git"
+      },
+      "scripts": {
+        "version": "make build && git add Changelog",
+        "postversion": "npm publish",
+        "postpublish": "git push origin --all && git push origin --tags"
+      },
+      "gitHead": "a8fca8e0afaf3906acfc7beafb18789290c2646c",
+      "_id": "sockjs@0.3.21",
+      "_nodeVersion": "12.18.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
+        "shasum": "b34ffb98e796930b60a0cfa11904d6a339a7d417",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+        "fileCount": 17,
+        "unpackedSize": 82610,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfI4wzCRA9TVsSAnZWagAAI8gP/32u68LbJbk2OTYNW939\nLlHOUcmP64gyycdXhldKPe9VUk66u19Fl0sTv6FyR51q4syYFAMYZC/i9dEI\nyO1zwafe8KALmTVMWhkfd4wp1JhCNzaaFf9OhPpnQ5jbojhwmML6cFWSefuS\nWm/21+iFGmHFBy2Cigj03/cIwXQlPUgEosEhiYHATlDR/uvkXTpayzxwvcvk\nG3NZr9iBPathyWEjrCNdHiCvca83jUGLKpd+aMT7rd6ZNVmU4aN/Uft96K+G\nhxVy4FwxNADHmJP1v4AoQ38fO38VuSWbWsjzwrVQOlPny/F5UX/HmTg0fzLe\ngMVAJa7kTXAh24jEpmBprRiZPWkGrRCWGe2ZkMdAGwbVv23nS8j1cKzvHxJl\nky4UYQeyFNLlE0tRNSB10Mp9QlukP1HPSSYBq2Lxbo4yc3kA+03ICa3hBaYe\ng9j+ff7VHdUnycGP6auAR7YWefROsVy9UtuN9ceZRVDAE7c4EzM9Qp9Zfgu9\nwsVcvVlzhH0ABcVtQ9EIJERewkTYAcX7GkfjIziZozruhxd+EW8IRiWhLKOP\nTCtweJCLsbgsmXAViHoxHqRCFHdW231xfwg2myqd7fKd1LZ04H2KTbdH8xJH\nlrQqWfi64mIe+loGYL84oJY9WRs65udmf7E6jS6/kLqwWyp+xiUkrG05pOqs\n9kA8\r\n=ebr9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "brycekahle",
+          "email": "bkahle@gmail.com"
+        },
+        {
+          "name": "glasser",
+          "email": "glasser@meteor.com"
+        },
+        {
+          "name": "majek",
+          "email": "majek04@gmail.com"
+        },
+        {
+          "name": "msackman",
+          "email": "matthew@rabbitmq.com"
+        },
+        {
+          "name": "squaremo",
+          "email": "mikeb@squaremobius.net"
+        }
+      ],
+      "_npmUser": {
+        "name": "brycekahle",
+        "email": "npm@brycekahle.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/sockjs_0.3.21_1596165170622_0.24039822285809453"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "name": "brycekahle",
+      "email": "bkahle@gmail.com"
+    },
+    {
+      "name": "glasser",
+      "email": "glasser@meteor.com"
+    },
+    {
+      "name": "majek",
+      "email": "majek04@gmail.com"
+    },
+    {
+      "name": "msackman",
+      "email": "matthew@rabbitmq.com"
+    },
+    {
+      "name": "squaremo",
+      "email": "mikeb@squaremobius.net"
+    }
+  ],
+  "time": {
+    "modified": "2020-07-31T03:12:53.181Z",
+    "created": "2011-08-11T16:17:37.350Z",
+    "0.0.0-rc1": "2011-08-11T16:17:38.568Z",
+    "0.0.0-rc2": "2011-08-11T16:38:43.935Z",
+    "0.0.1": "2011-08-17T15:45:15.654Z",
+    "0.0.2": "2011-08-19T17:07:50.313Z",
+    "0.0.3": "2011-08-31T14:50:05.360Z",
+    "0.0.4": "2011-09-07T14:28:14.818Z",
+    "0.0.5": "2011-10-17T10:39:38.312Z",
+    "0.1.0": "2011-10-26T10:57:05.699Z",
+    "0.1.1": "2011-11-18T16:31:57.450Z",
+    "0.1.2": "2011-12-06T16:16:37.096Z",
+    "0.2.0": "2012-01-18T16:07:45.260Z",
+    "0.2.1": "2012-02-13T14:23:34.042Z",
+    "0.3.0": "2012-04-02T11:25:14.462Z",
+    "0.3.1": "2012-04-24T15:58:16.476Z",
+    "0.3.3": "2012-09-27T15:18:00.722Z",
+    "0.3.4": "2012-11-15T14:39:50.744Z",
+    "0.3.5": "2012-12-14T12:35:33.146Z",
+    "0.3.6": "2013-04-30T20:19:08.126Z",
+    "0.3.7": "2013-04-30T20:29:47.837Z",
+    "0.3.8": "2013-10-12T17:28:33.380Z",
+    "0.3.9": "2014-05-22T01:47:44.745Z",
+    "0.3.10": "2014-10-24T21:27:32.926Z",
+    "0.3.11": "2014-11-10T23:29:02.596Z",
+    "0.3.12": "2015-01-06T00:46:22.894Z",
+    "0.3.13": "2015-02-26T15:49:28.662Z",
+    "0.3.14": "2015-03-05T22:40:04.635Z",
+    "0.3.15": "2015-03-11T15:59:12.119Z",
+    "0.3.16": "2016-03-23T17:34:52.272Z",
+    "0.3.17": "2016-04-29T16:36:59.151Z",
+    "0.3.18": "2016-09-26T15:36:04.352Z",
+    "0.3.19": "2017-10-12T16:23:58.269Z",
+    "0.3.20": "2020-03-09T19:54:54.000Z",
+    "0.3.21": "2020-07-31T03:12:50.735Z"
+  },
+  "author": {
+    "name": "Marek Majkowski"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sockjs/sockjs-node.git"
+  },
+  "description": "SockJS-node is a server counterpart of SockJS-client a JavaScript library that provides a WebSocket-like object in the browser. SockJS gives you a coherent, cross-browser, Javascript API which creates a low latency, full duplex, cross-domain communication",
+  "users": {
+    "2454": true,
+    "285858315": true,
+    "konklone": true,
+    "tmaximini": true,
+    "leesei": true,
+    "dexteryy": true,
+    "stringparser": true,
+    "genediazjr": true,
+    "nitayneeman": true,
+    "ysk8": true,
+    "farukscan": true,
+    "akiva": true,
+    "programmingpearls": true,
+    "gerst20051": true,
+    "panlw": true,
+    "vwal": true,
+    "stany": true,
+    "antanst": true,
+    "nackjicholson": true,
+    "perrybhandal": true,
+    "preco21": true,
+    "x0000ff": true,
+    "ymk": true,
+    "staydan": true,
+    "isik": true,
+    "myprlab": true,
+    "fenyot": true,
+    "zuojiang": true,
+    "takonyc": true
+  },
+  "homepage": "https://github.com/sockjs/sockjs-node",
+  "keywords": [
+    "websockets",
+    "websocket"
+  ],
+  "bugs": {
+    "url": "https://github.com/sockjs/sockjs-node/issues"
+  },
+  "readme": "[![NPM version](https://badge.fury.io/js/sockjs.svg)](http://badge.fury.io/js/sockjs)\n\nSockJS family:\n\n  * [SockJS-client](https://github.com/sockjs/sockjs-client) JavaScript client library\n  * [SockJS-node](https://github.com/sockjs/sockjs-node) Node.js server\n  * [SockJS-erlang](https://github.com/sockjs/sockjs-erlang) Erlang server\n  * [SockJS-tornado](https://github.com/MrJoes/sockjs-tornado) Python/Tornado server\n  * [vert.x](https://github.com/eclipse/vert.x) Java/vert.x server\n\nWork in progress:\n\n  * [SockJS-ruby](https://github.com/nyarly/sockjs-ruby)\n  * [SockJS-netty](https://github.com/cgbystrom/sockjs-netty)\n  * [SockJS-gevent](https://github.com/sdiehl/sockjs-gevent) ([and a fork](https://github.com/njoyce/sockjs-gevent))\n  * [pyramid-SockJS](https://github.com/fafhrd91/pyramid_sockjs)\n  * [wildcloud-websockets](https://github.com/wildcloud/wildcloud-websockets)\n  * [SockJS-cyclone](https://github.com/flaviogrossi/sockjs-cyclone)\n  * [SockJS-twisted](https://github.com/Fugiman/sockjs-twisted/)\n  * [wai-SockJS](https://github.com/Palmik/wai-sockjs)\n  * [SockJS-perl](https://github.com/vti/sockjs-perl)\n  * [SockJS-go](https://github.com/igm/sockjs-go/)\n\nWhat is SockJS?\n===============\n\nSockJS is a JavaScript library (for browsers) that provides a WebSocket-like\nobject. SockJS gives you a coherent, cross-browser, Javascript API\nwhich creates a low latency, full duplex, cross-domain communication\nchannel between the browser and the web server, with WebSockets or without.\nThis necessitates the use of a server, which this is one version of, for Node.js.\n\n\nSockJS-node server\n==================\n\nSockJS-node is a Node.js server side counterpart of\n[SockJS-client browser library](https://github.com/sockjs/sockjs-client)\nwritten in CoffeeScript.\n\nTo install `sockjs-node` run:\n\n    npm install sockjs\n\nA simplified echo SockJS server could look more or less like:\n\n```javascript\nvar http = require('http');\nvar sockjs = require('sockjs');\n\nvar echo = sockjs.createServer();\necho.on('connection', function(conn) {\n    conn.on('data', function(message) {\n        conn.write(message);\n    });\n    conn.on('close', function() {});\n});\n\nvar server = http.createServer();\necho.installHandlers(server, {prefix:'/echo'});\nserver.listen(9999, '0.0.0.0');\n```\n\n(Take look at\n[examples](https://github.com/sockjs/sockjs-node/tree/master/examples/echo)\ndirectory for a complete version.)\n\nSubscribe to\n[SockJS mailing list](https://groups.google.com/forum/#!forum/sockjs) for\ndiscussions and support.\n\n\nSockJS-node API\n---------------\n\nThe API design is based on common Node APIs like the\n[Streams API](http://nodejs.org/docs/v0.5.8/api/streams.html) or the\n[Http.Server API](http://nodejs.org/docs/v0.5.8/api/http.html#http.Server).\n\n### Server class\n\nSockJS module is generating a `Server` class, similar to\n[Node.js http.createServer](http://nodejs.org/docs/v0.5.8/api/http.html#http.createServer)\nmodule.\n\n```javascript\nvar sockjs_server = sockjs.createServer(options);\n```\n\nWhere `options` is a hash which can contain:\n\n<dl>\n<dt>sockjs_url (string)</dt>\n<dd>Transports which don't support cross-domain communication natively\n   ('eventsource' to name one) use an iframe trick. A simple page is\n   served from the SockJS server (using its foreign domain) and is\n   placed in an invisible iframe. Code run from this iframe doesn't\n   need to worry about cross-domain issues, as it's being run from\n   domain local to the SockJS server. This iframe also does need to\n   load SockJS javascript client library, and this option lets you specify\n   its url (if you're unsure, point it to\n   <a href=\"https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js\">\n   the latest minified SockJS client release</a>, this is the default).\n   You must explicitly specify this url on the server side for security\n   reasons - we don't want the possibility of running any foreign\n   javascript within the SockJS domain (aka cross site scripting attack).\n   Also, sockjs javascript library is probably already cached by the\n   browser - it makes sense to reuse the sockjs url you're using in\n   normally.</dd>\n\n<dt>prefix (string regex)</dt>\n<dd>A url prefix for the server. All http requests which paths begins\n   with selected prefix will be handled by SockJS. All other requests\n   will be passed through, to previously registered handlers.</dd>\n\n<dt>response_limit (integer)</dt>\n<dd>Most streaming transports save responses on the client side and\n   don't free memory used by delivered messages. Such transports need\n   to be garbage-collected once in a while. `response_limit` sets\n   a minimum number of bytes that can be send over a single http streaming\n   request before it will be closed. After that client needs to open\n   new request. Setting this value to one effectively disables\n   streaming and will make streaming transports to behave like polling\n   transports. The default value is 128K.</dd>\n\n<dt>websocket (boolean)</dt>\n<dd>Some load balancers don't support websockets. This option can be used\n   to disable websockets support by the server. By default websockets are\n   enabled.</dd>\n\n<dt>jsessionid (boolean or function)</dt>\n<dd>Some hosting providers enable sticky sessions only to requests that\n  have JSESSIONID cookie set. This setting controls if the server should\n  set this cookie to a dummy value. By default setting JSESSIONID cookie\n  is disabled. More sophisticated behaviour can be achieved by supplying\n  a function.</dd>\n\n<dt>log (function(severity, message))</dt>\n<dd>It's quite useful, especially for debugging, to see some messages\n  printed by a SockJS-node library. This is done using this `log`\n  function, which is by default set to `console.log`. If this\n  behaviour annoys you for some reason, override `log` setting with a\n  custom handler.  The following `severities` are used: `debug`\n  (miscellaneous logs), `info` (requests logs), `error` (serious\n  errors, consider filing an issue).</dd>\n\n<dt>heartbeat_delay (milliseconds)</dt>\n<dd>In order to keep proxies and load balancers from closing long\n  running http requests we need to pretend that the connection is\n  active and send a heartbeat packet once in a while. This setting\n  controls how often this is done. By default a heartbeat packet is\n  sent every 25 seconds.  </dd>\n\n<dt>disconnect_delay (milliseconds)</dt>\n<dd>The server sends a `close` event when a client receiving\n  connection have not been seen for a while. This delay is configured\n  by this setting. By default the `close` event will be emitted when a\n  receiving connection wasn't seen for 5 seconds.  </dd>\n\n<dt>disable_cors (boolean)</dt>\n<dd>Enabling this option will prevent\n  <a href=\"https://en.wikipedia.org/wiki/Cross-origin_resource_sharing\">CORS</a>\n  headers from being included in the HTTP response. Can be used when the\n  sockjs client is known to be connecting from the same origin as the \n  sockjs server.</dd>\n</dl>\n\n\n### Server instance\n\nOnce you have create `Server` instance you can hook it to the\n[http.Server instance](http://nodejs.org/docs/v0.5.8/api/http.html#http.createServer).\n\n```javascript\nvar http_server = http.createServer();\nsockjs_server.installHandlers(http_server, options);\nhttp_server.listen(...);\n```\n\nWhere `options` can overshadow options given when creating `Server`\ninstance.\n\n`Server` instance is an\n[EventEmitter](http://nodejs.org/docs/v0.4.10/api/events.html#events.EventEmitter),\nand emits following event:\n\n<dl>\n<dt>Event: connection (connection)</dt>\n<dd>A new connection has been successfully opened.</dd>\n</dl>\n\nAll http requests that don't go under the path selected by `prefix`\nwill remain unanswered and will be passed to previously registered\nhandlers. You must install your custom http handlers before calling\n`installHandlers`.\n\n### Connection instance\n\nA `Connection` instance supports\n[Node Stream API](http://nodejs.org/docs/v0.5.8/api/streams.html) and\nhas following methods and properties:\n\n<dl>\n<dt>Property: readable (boolean)</dt>\n<dd>Is the stream readable?</dd>\n\n<dt>Property: writable (boolean)</dt>\n<dd>Is the stream writable?</dd>\n\n<dt>Property: remoteAddress (string)</dt>\n<dd>Last known IP address of the client.</dd>\n\n<dt>Property: remotePort (number)</dt>\n<dd>Last known port number of the client.</dd>\n\n<dt>Property: address (object)</dt>\n<dd>Hash with 'address' and 'port' fields.</dd>\n\n<dt>Property: headers (object)</dt>\n<dd>Hash containing various headers copied from last receiving request\n    on that connection. Exposed headers include: `origin`, `referer`\n    and `x-forwarded-for` (and friends). We explicitly do not grant\n    access to `cookie` header, as using it may easily lead to security\n    issues (for details read the section \"Authorisation\").</dd>\n\n<dt>Property: url (string)</dt>\n<dd><a href=\"http://nodejs.org/docs/v0.4.10/api/http.html#request.url\">Url</a>\n    property copied from last request.</dd>\n\n<dt>Property: pathname (string)</dt>\n<dd>`pathname` from parsed url, for convenience.</dd>\n\n<dt>Property: prefix (string)</dt>\n<dd>Prefix of the url on which the request was handled.</dd>\n\n<dt>Property: protocol (string)</dt>\n<dd>Protocol used by the connection. Keep in mind that some protocols\n   are indistinguishable - for example \"xhr-polling\" and \"xdr-polling\".</dd>\n\n<dt>Property: readyState (integer)</dt>\n<dd>Current state of the connection:\n   0-connecting, 1-open, 2-closing, 3-closed.</dd>\n\n<dt>write(message)</dt>\n<dd>Sends a message over opened connection. A message must be a\n  non-empty string. It's illegal to send a message after the connection was\n  closed (either after 'close' or 'end' method or 'close' event).</dd>\n\n<dt>close([code], [reason])</dt>\n<dd>Asks the remote client to disconnect. 'code' and 'reason'\n   parameters are optional and can be used to share the reason of\n   disconnection.</dd>\n\n<dt>end()</dt>\n<dd>Asks the remote client to disconnect with default 'code' and\n   'reason' values.</dd>\n\n</dl>\n\nA `Connection` instance emits the following events:\n\n<dl>\n<dt>Event: data (message)</dt>\n<dd>A message arrived on the connection. Message is a unicode\n  string.</dd>\n\n<dt>Event: close ()</dt>\n<dd>Connection was closed. This event is triggered exactly once for\n   every connection.</dd>\n</dl>\n\nFor example:\n\n```javascript\nsockjs_server.on('connection', function(conn) {\n    console.log('connection' + conn);\n    conn.on('close', function() {\n        console.log('close ' + conn);\n    });\n    conn.on('data', function(message) {\n        console.log('message ' + conn,\n                    message);\n    });\n});\n```\n\n### Footnote\n\nA fully working echo server does need a bit more boilerplate (to\nhandle requests unanswered by SockJS), see the\n[`echo` example](https://github.com/sockjs/sockjs-node/tree/master/examples/echo)\nfor a complete code.\n\n### Examples\n\nIf you want to see samples of running code, take a look at:\n\n * [./examples/echo](https://github.com/sockjs/sockjs-node/tree/master/examples/echo)\n   directory, which contains a full example of a echo server.\n * [./examples/test_server](https://github.com/sockjs/sockjs-node/tree/master/examples/test_server) a standard SockJS test server.\n\n\nConnecting to SockJS-node without the client\n--------------------------------------------\n\nAlthough the main point of SockJS it to enable browser-to-server\nconnectivity, it is possible to connect to SockJS from an external\napplication. Any SockJS server complying with 0.3 protocol does\nsupport a raw WebSocket url. The raw WebSocket url for the test server\nlooks like:\n\n * ws://localhost:8081/echo/websocket\n\nYou can connect any WebSocket RFC 6455 compliant WebSocket client to\nthis url. This can be a command line client, external application,\nthird party code or even a browser (though I don't know why you would\nwant to do so).\n\nNote: This endpoint will *not send any heartbeat packets*.\n\n\nDeployment and load balancing\n-----------------------------\n\nThere are two issues that need to be considered when planning a\nnon-trivial SockJS-node deployment: WebSocket-compatible load balancer\nand sticky sessions (aka session affinity).\n\n### WebSocket compatible load balancer\n\nOften WebSockets don't play nicely with proxies and load balancers.\nDeploying a SockJS server behind Nginx or Apache could be painful.\n\nFortunately recent versions of an excellent load balancer\n[HAProxy](http://haproxy.1wt.eu/) are able to proxy WebSocket\nconnections. We propose to put HAProxy as a front line load balancer\nand use it to split SockJS traffic from normal HTTP data. Take a look\nat the sample\n[SockJS HAProxy configuration](https://github.com/sockjs/sockjs-node/blob/master/examples/haproxy.cfg).\n\nThe config also shows how to use HAproxy balancing to split traffic\nbetween multiple Node.js servers. You can also do balancing using dns\nnames.\n\n### Sticky sessions\n\nIf you plan deploying more than one SockJS server, you must make sure\nthat all HTTP requests for a single session will hit the same server.\nSockJS has two mechanisms that can be useful to achieve that:\n\n * Urls are prefixed with server and session id numbers, like:\n   `/resource/<server_number>/<session_id>/transport`.  This is\n   useful for load balancers that support prefix-based affinity\n   (HAProxy does).\n * `JSESSIONID` cookie is being set by SockJS-node. Many load\n   balancers turn on sticky sessions if that cookie is set. This\n   technique is derived from Java applications, where sticky sessions\n   are often necessary. HAProxy does support this method, as well as\n   some hosting providers, for example CloudFoundry.  In order to\n   enable this method on the client side, please supply a\n   `cookie:true` option to SockJS constructor.\n\n\nDevelopment and testing\n-----------------------\n\nIf you want to work on SockJS-node source code, you need to clone the\ngit repo and follow these steps. First you need to install\ndependencies:\n\n    cd sockjs-node\n    npm install\n    npm install --dev\n    ln -s .. node_modules/sockjs\n\nYou're ready to compile CoffeeScript:\n\n    make build\n\nIf compilation succeeds you may want to test if your changes pass all\nthe tests. Currently, there are two separate test suites. For both of\nthem you need to start a SockJS-node test server (by default listening\non port 8081):\n\n    make test_server\n\n### SockJS-protocol Python tests\n\nTo run it run something like:\n\n    cd sockjs-protocol\n    make test_deps\n    ./venv/bin/python sockjs-protocol.py\n\nFor details see\n[SockJS-protocol README](https://github.com/sockjs/sockjs-protocol#readme).\n\n### SockJS-client QUnit tests\n\nYou need to start a second web server (by default listening on 8080)\nthat is serving various static html and javascript files:\n\n    cd sockjs-client\n    make test\n\nAt that point you should have two web servers running: sockjs-node on\n8081 and sockjs-client on 8080. When you open the browser on\n[http://localhost:8080/](http://localhost:8080/) you should be able\nrun the QUnit tests against your sockjs-node server.\n\nFor details see\n[SockJS-client README](https://github.com/sockjs/sockjs-client#readme).\n\nAdditionally, if you're doing more serious development consider using\n`make serve`, which will automatically the server when you modify the\nsource code.\n\n\nVarious issues and design considerations\n----------------------------------------\n\n### Authorisation\n\nSockJS-node does not expose cookies to the application. This is done\ndeliberately as using cookie-based authorisation with SockJS simply\ndoesn't make sense and will lead to security issues.\n\nCookies are a contract between a browser and an http server, and are\nidentified by a domain name. If a browser has a cookie set for\nparticular domain, it will pass it as a part of all http requests to\nthe host. But to get various transports working, SockJS uses a middleman\n- an iframe hosted from target SockJS domain. That means the server\nwill receive requests from the iframe, and not from the real\ndomain. The domain of an iframe is the same as the SockJS domain. The\nproblem is that any website can embed the iframe and communicate with\nit - and request establishing SockJS connection. Using cookies for\nauthorisation in this scenario will result in granting full access to\nSockJS communication with your website from any website. This is a\nclassic CSRF attack.\n\nBasically - cookies are not suited for SockJS model. If you want to\nauthorise a session - provide a unique token on a page, send it as a\nfirst thing over SockJS connection and validate it on the server\nside. In essence, this is how cookies work.\n\n\n### Deploying SockJS on Heroku\n\nLong polling is known to cause problems on Heroku, but\n[workaround for SockJS is available](https://github.com/sockjs/sockjs-node/issues/57#issuecomment-5242187).\n",
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Bryce Kahle",
+      "email": "bkahle@gmail.com"
+    },
+    {
+      "name": "Marek Majkowski",
+      "email": "deadbeef@popcount.org"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/sockjs.min.json
+++ b/test/fixtures/registry-mocks/content/sockjs.min.json
@@ -1,0 +1,559 @@
+{
+  "name": "sockjs",
+  "dist-tags": {
+    "latest": "0.3.21"
+  },
+  "versions": {
+    "0.0.0-rc1": {
+      "name": "sockjs",
+      "version": "0.0.0-rc1",
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "dist": {
+        "shasum": "dd7a107308d7e8b6bec9b4b32d4692cbbbef33ea",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.0-rc1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.0-rc2": {
+      "name": "sockjs",
+      "version": "0.0.0-rc2",
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "dist": {
+        "shasum": "60c9c9947c7800d02e943b0028fba7c18af47d97",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.0-rc2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.1": {
+      "name": "sockjs",
+      "version": "0.0.1",
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "dist": {
+        "shasum": "af7966e2290d0279da621e43d1a5da8453c242f7",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.2": {
+      "name": "sockjs",
+      "version": "0.0.2",
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "dist": {
+        "shasum": "364f31f416c66abe5e1c619e942439315610584c",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.3": {
+      "name": "sockjs",
+      "version": "0.0.3",
+      "dependencies": {
+        "coffee-script": "1.1.1",
+        "jquery": "1.5.1",
+        "node-uuid": "1.2.0"
+      },
+      "dist": {
+        "shasum": "ad5da88575cb1851d3992271889b4902f91035d1",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.3.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.4": {
+      "name": "sockjs",
+      "version": "0.0.4",
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "dist": {
+        "shasum": "f3016cccd74e475180467a7c8a026561e8aec38b",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.4.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.5": {
+      "name": "sockjs",
+      "version": "0.0.5",
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "dist": {
+        "shasum": "c903366a8b8ac705a2a4623dd4ee015bf131e5a2",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.0.5.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "sockjs",
+      "version": "0.1.0",
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "dist": {
+        "shasum": "e127adf7a3e11395c0b3f8fda1b2b848d6188394",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.1": {
+      "name": "sockjs",
+      "version": "0.1.1",
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "dist": {
+        "shasum": "5e719cc4991010b4d682f05a5aaac8b437d4029d",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.2": {
+      "name": "sockjs",
+      "version": "0.1.2",
+      "dependencies": {
+        "node-uuid": "1.2.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "dist": {
+        "shasum": "41c358eec0823fbde79b3515adb568df982f590a",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.0": {
+      "name": "sockjs",
+      "version": "0.2.0",
+      "dependencies": {
+        "node-uuid": "1.2.0",
+        "faye-websocket": "0.3.x",
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.1.1"
+      },
+      "dist": {
+        "shasum": "e78ad1ec3bafbe850eb8c4f58897c8aba3c39c31",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.2.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.2.1": {
+      "name": "sockjs",
+      "version": "0.2.1",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0",
+        "rbytes": "0.0.2"
+      },
+      "optionalDependencies": {
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "71c125a7e7ade415e92d150009f1e2a436c3b6a5",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.2.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.3.0": {
+      "name": "sockjs",
+      "version": "0.3.0",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0",
+        "rbytes": "0.0.2"
+      },
+      "optionalDependencies": {
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "bb5cea1a3fe9eb5e29ab41d376088659d087b6f6",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.3.1": {
+      "name": "sockjs",
+      "version": "0.3.1",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0",
+        "rbytes": "0.0.2"
+      },
+      "optionalDependencies": {
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "591964e8ca893ca655b67736d08b8ff7cd3ce69b",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.3.3": {
+      "name": "sockjs",
+      "version": "0.3.3",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0",
+        "rbytes": "0.0.2"
+      },
+      "optionalDependencies": {
+        "rbytes": "0.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "1ef4b359c17b8c5b1357c42335fdf05a06d54ba4",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.3.tgz"
+      }
+    },
+    "0.3.4": {
+      "name": "sockjs",
+      "version": "0.3.4",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "58aeb1594c049eb789a603d36d9db106d855ef49",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.4.tgz"
+      }
+    },
+    "0.3.5": {
+      "name": "sockjs",
+      "version": "0.3.5",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "76fc86197de5279e1089c498b15d742f0f10fa35",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.5.tgz"
+      }
+    },
+    "0.3.6": {
+      "name": "sockjs",
+      "version": "0.3.6",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.4"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "6173e2cc327dfad98003d40568090e1132fd278d",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.6.tgz"
+      }
+    },
+    "0.3.7": {
+      "name": "sockjs",
+      "version": "0.3.7",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.4.4"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "2950e0586d8a9d3044958a831ade68db197749cb",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.7.tgz"
+      }
+    },
+    "0.3.8": {
+      "name": "sockjs",
+      "version": "0.3.8",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.7.0"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "c083cb0505db1ea1a949d3bd12d8a1ea385a456c",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.8.tgz"
+      }
+    },
+    "0.3.9": {
+      "name": "sockjs",
+      "version": "0.3.9",
+      "dependencies": {
+        "node-uuid": "1.3.3",
+        "faye-websocket": "0.7.2"
+      },
+      "devDependencies": {
+        "coffee-script": "1.2.x"
+      },
+      "dist": {
+        "shasum": "5ae2c732dac07f6d7e9e8a9a60ec86ec4fc3ffc7",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.9.tgz"
+      }
+    },
+    "0.3.10": {
+      "name": "sockjs",
+      "version": "0.3.10",
+      "dependencies": {
+        "faye-websocket": "^0.7.3",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "3910afb2ae8adc82591f2288456319cdf4727e7e",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.10.tgz"
+      }
+    },
+    "0.3.11": {
+      "name": "sockjs",
+      "version": "0.3.11",
+      "dependencies": {
+        "faye-websocket": "^0.7.3 || ^0.8.0",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "936d84d00f5bfce82f939aec9a7e1c9b8b39fb17",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.11.tgz"
+      }
+    },
+    "0.3.12": {
+      "name": "sockjs",
+      "version": "0.3.12",
+      "dependencies": {
+        "faye-websocket": "^0.7.3 || ^0.8.0 || ^0.9.0",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "99f5686851cf8655706da977f56ccd266dded859",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.12.tgz"
+      }
+    },
+    "0.3.13": {
+      "name": "sockjs",
+      "version": "0.3.13",
+      "dependencies": {
+        "faye-websocket": "^0.9.3",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "aec6e096dede8e3ca0a66ec9dc9f32dd8e53bda1",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.13.tgz"
+      }
+    },
+    "0.3.14": {
+      "name": "sockjs",
+      "version": "0.3.14",
+      "dependencies": {
+        "faye-websocket": "^0.9.3",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "7570a730228f647b18e6f380fecc306a00bc0e77",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.14.tgz"
+      }
+    },
+    "0.3.15": {
+      "name": "sockjs",
+      "version": "0.3.15",
+      "dependencies": {
+        "faye-websocket": "^0.9.3",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "e19b577e59e0fbdb21a0ae4f46203ca24cad8db8",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.15.tgz"
+      }
+    },
+    "0.3.16": {
+      "name": "sockjs",
+      "version": "0.3.16",
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "node-uuid": "^1.4.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "2bf5b90eb681b5216dfb98b8cf3e01a33ca271bc",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.16.tgz"
+      }
+    },
+    "0.3.17": {
+      "name": "sockjs",
+      "version": "0.3.17",
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^2.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "ef1b88f5d73e6278fad8e9476ac91064382f3b44",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.17.tgz"
+      }
+    },
+    "0.3.18": {
+      "name": "sockjs",
+      "version": "0.3.18",
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^2.0.2"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "shasum": "d9b289316ca7df77595ef299e075f0f937eb4207",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz"
+      }
+    },
+    "0.3.19": {
+      "name": "sockjs",
+      "version": "0.3.19",
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.0.1"
+      },
+      "devDependencies": {
+        "coffee-script": "^1.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+        "shasum": "d976bbe800af7bd20ae08598d582393508993c0d",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz"
+      }
+    },
+    "0.3.20": {
+      "name": "sockjs",
+      "version": "0.3.20",
+      "dependencies": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.4.0",
+        "websocket-driver": "0.6.5"
+      },
+      "devDependencies": {
+        "coffeescript": "^1.12.7"
+      },
+      "dist": {
+        "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
+        "shasum": "b26a283ec562ef8b2687b44033a4eeceac75d855",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
+        "fileCount": 17,
+        "unpackedSize": 82508,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeZp8OCRA9TVsSAnZWagAAaiMP/1TboNGNwWbk71Rtggr/\nXp3OCYgc7MOU5Fof0iK2iI6Iwof+XX/6wWQsq6TJqgCMzSILZQNIEZJyOLOA\nq4OtqhOm4CBjS6/y/4/bO4pNuSsoRPnCFaablvXQUYzUN5LbyPtixILe6itS\nmDQKiT2A08S/vZnsnjDA16EyPm8wleyPBGWUGGujtNHjuZzrwhV5y7bvWiBl\ncIsU/Isjz/spfwT08aMNSoW5eg1tBN9IqTWvSnMp+V4TYbo2OppA/FAdqUWy\nofGcdq3ekQKejK8urXI1CCTj7HnqO0ZwXDk9/Wn0B2gL25in2cyeaLf0taxc\nLYpMuZtNdZFcX0M+z8XIwT03+y//jN8/dzQoYK2kEkK9FSLS+Ilc/qhBV2Ux\nwvAazcRgU03sxiEaARvbkDb0siz2BNbrNUsReXaKNfO0c3EiCoaWMUuQGSWb\nD7UiCSrHT1kBPgU9yIUr/PZV5c8bWlPZY2AjL1ZAlk1zvoeZnvoJbXDvplae\neJeSw8KapSdTmg4wJYRA5luqzftlVnKdbC1o/R1rrtIo4esYCTPBrdcb4gNh\n/5ky/J8Bo70vlU8I1mYX8EjiyBQ+fupZV9xYdfWYg2sWQGpkOTAXbPqzaYL7\n1K38nJAGu7wK09m77rs3xwtN096NlodVbj3A6gnWbvUmTdc7oRLDyKwgjnXN\n9B52\r\n=cUlo\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.3.21": {
+      "name": "sockjs",
+      "version": "0.3.21",
+      "dependencies": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^3.4.0",
+        "websocket-driver": "^0.7.4"
+      },
+      "devDependencies": {
+        "coffeescript": "^1.12.7"
+      },
+      "dist": {
+        "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
+        "shasum": "b34ffb98e796930b60a0cfa11904d6a339a7d417",
+        "tarball": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+        "fileCount": 17,
+        "unpackedSize": 82610,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfI4wzCRA9TVsSAnZWagAAI8gP/32u68LbJbk2OTYNW939\nLlHOUcmP64gyycdXhldKPe9VUk66u19Fl0sTv6FyR51q4syYFAMYZC/i9dEI\nyO1zwafe8KALmTVMWhkfd4wp1JhCNzaaFf9OhPpnQ5jbojhwmML6cFWSefuS\nWm/21+iFGmHFBy2Cigj03/cIwXQlPUgEosEhiYHATlDR/uvkXTpayzxwvcvk\nG3NZr9iBPathyWEjrCNdHiCvca83jUGLKpd+aMT7rd6ZNVmU4aN/Uft96K+G\nhxVy4FwxNADHmJP1v4AoQ38fO38VuSWbWsjzwrVQOlPny/F5UX/HmTg0fzLe\ngMVAJa7kTXAh24jEpmBprRiZPWkGrRCWGe2ZkMdAGwbVv23nS8j1cKzvHxJl\nky4UYQeyFNLlE0tRNSB10Mp9QlukP1HPSSYBq2Lxbo4yc3kA+03ICa3hBaYe\ng9j+ff7VHdUnycGP6auAR7YWefROsVy9UtuN9ceZRVDAE7c4EzM9Qp9Zfgu9\nwsVcvVlzhH0ABcVtQ9EIJERewkTYAcX7GkfjIziZozruhxd+EW8IRiWhLKOP\nTCtweJCLsbgsmXAViHoxHqRCFHdW231xfwg2myqd7fKd1LZ04H2KTbdH8xJH\nlrQqWfi64mIe+loGYL84oJY9WRs65udmf7E6jS6/kLqwWyp+xiUkrG05pOqs\n9kA8\r\n=ebr9\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-07-31T03:12:53.181Z"
+}

--- a/test/fixtures/registry-mocks/content/source-map-resolve.json
+++ b/test/fixtures/registry-mocks/content/source-map-resolve.json
@@ -1,0 +1,1183 @@
+{
+  "_id": "source-map-resolve",
+  "_rev": "26-6f6c22133c7648653b00f1b2f8027713",
+  "name": "source-map-resolve",
+  "description": "Resolve the source map and/or sources for a generated file.",
+  "dist-tags": {
+    "latest": "0.6.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "source-map-resolve",
+      "version": "0.1.0",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/source-map-resolve"
+      },
+      "keywords": [
+        "source map",
+        "sourceMappingURL",
+        "resolve"
+      ],
+      "scripts": {
+        "test": "jshint *.js lib/ test/ && node test/source-map-resolve.js && node test/windows.js"
+      },
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "resolve-url": "~0.2.1",
+        "simple-asyncify": "~0.1.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve",
+      "_id": "source-map-resolve@0.1.0",
+      "dist": {
+        "shasum": "6be37734b29bdd2b95592d89d0905dbedbab180b",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "source-map-resolve",
+      "version": "0.1.1",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/source-map-resolve"
+      },
+      "keywords": [
+        "source map",
+        "sourceMappingURL",
+        "resolve"
+      ],
+      "scripts": {
+        "test": "jshint *.js lib/ test/ && node test/source-map-resolve.js && node test/windows.js"
+      },
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "resolve-url": "~0.2.1",
+        "simple-asyncify": "~0.1.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve",
+      "_id": "source-map-resolve@0.1.1",
+      "dist": {
+        "shasum": "8a591216a4f19c8695e8e16711f5fd2d0a986e7f",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "source-map-resolve",
+      "version": "0.1.2",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourceMappingURL",
+        "resolve"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/source-map-resolve"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "test": "jshint *.js lib/ test/ && node test/source-map-resolve.js && node test/windows.js"
+      },
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "resolve-url": "~0.2.1",
+        "simple-asyncify": "~0.1.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve",
+      "_id": "source-map-resolve@0.1.2",
+      "dist": {
+        "shasum": "a1592b6df4ff26e18bc1329a5e47272009ab3d52",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "source-map-resolve",
+      "version": "0.1.3",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/source-map-resolve"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "test": "jshint lib/ test/ && node test/source-map-resolve.js && node test/windows.js"
+      },
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve",
+      "_id": "source-map-resolve@0.1.3",
+      "_shasum": "c6db00fe1220fcd2f8014af9020e20990de3ec38",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c6db00fe1220fcd2f8014af9020e20990de3ec38",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "source-map-resolve",
+      "version": "0.1.4",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/source-map-resolve"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "test": "jshint lib/ test/ && node test/source-map-resolve.js && node test/windows.js"
+      },
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve",
+      "_id": "source-map-resolve@0.1.4",
+      "_shasum": "61b4fdcc2aea74e88f54b20dd2513186fb5378e0",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "61b4fdcc2aea74e88f54b20dd2513186fb5378e0",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "source-map-resolve",
+      "version": "0.2.0",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/source-map-resolve"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "test": "jshint lib/ test/ && node test/source-map-resolve.js && node test/windows.js"
+      },
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve",
+      "_id": "source-map-resolve@0.2.0",
+      "_shasum": "898d41777f5c1e14092a5e0a6d3e9d1e6da16479",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "898d41777f5c1e14092a5e0a6d3e9d1e6da16479",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "source-map-resolve",
+      "version": "0.3.0",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/lydell/source-map-resolve"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "test": "jshint lib/ test/ && node test/source-map-resolve.js && node test/windows.js"
+      },
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "gitHead": "3a23d184a70dcdbc32661812915d0a27f4d16945",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve",
+      "_id": "source-map-resolve@0.3.0",
+      "_shasum": "d298388fbdd17cd10be57e41dea9950a27ab5d2e",
+      "_from": ".",
+      "_npmVersion": "1.4.18",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d298388fbdd17cd10be57e41dea9950a27ab5d2e",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "source-map-resolve",
+      "version": "0.3.1",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/lydell/source-map-resolve"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "lint": "jshint lib/ test/",
+        "unit": "node test/source-map-resolve.js && node test/windows.js",
+        "test": "npm run lint && npm run unit",
+        "build": "node generate-source-map-resolve.js"
+      },
+      "dependencies": {
+        "source-map-url": "~0.3.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "gitHead": "3564509b9b5b3ce6270f6d4170b6d1437bedf2e4",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve",
+      "_id": "source-map-resolve@0.3.1",
+      "_shasum": "610f6122a445b8dd51535a2a71b783dfc1248761",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "610f6122a445b8dd51535a2a71b783dfc1248761",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "source-map-resolve",
+      "version": "0.4.0",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lydell/source-map-resolve.git"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "lint": "jshint lib/ test/",
+        "unit": "node test/source-map-resolve.js && node test/windows.js",
+        "test": "npm run lint && npm run unit",
+        "build": "node generate-source-map-resolve.js"
+      },
+      "dependencies": {
+        "source-map-url": "^0.3.0",
+        "atob": "^1.1.2",
+        "urix": "^0.1.0",
+        "resolve-url": "^0.2.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "^1.0.2",
+        "Base64": "^0.3.0",
+        "simple-asyncify": "^1.0.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "gitHead": "109db6d6a51f406d6ee4d126e7b694b853c3adce",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve#readme",
+      "_id": "source-map-resolve@0.4.0",
+      "_shasum": "5c43d28a2d8f76622f2372890220cdb0c09f09b5",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "1.8.4",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "dist": {
+        "shasum": "5c43d28a2d8f76622f2372890220cdb0c09f09b5",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "source-map-resolve",
+      "version": "0.5.0",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lydell/source-map-resolve.git"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "lint": "jshint lib/ test/",
+        "unit": "node test/source-map-resolve.js && node test/windows.js",
+        "test": "npm run lint && npm run unit",
+        "build": "node generate-source-map-resolve.js"
+      },
+      "dependencies": {
+        "source-map-url": "^0.4.0",
+        "atob": "^2.0.0",
+        "urix": "^0.1.0",
+        "resolve-url": "^0.2.1"
+      },
+      "devDependencies": {
+        "tape": "^4.4.0",
+        "jshint": "~2.9.1",
+        "setimmediate": "^1.0.4",
+        "Base64": "^0.3.0",
+        "simple-asyncify": "^1.0.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "gitHead": "663ad74f07aab1d5ef44942fd9c4df91cee5e687",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve#readme",
+      "_id": "source-map-resolve@0.5.0",
+      "_shasum": "fcad0b64b70afb27699e425950cb5ebcd410bc20",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "dist": {
+        "shasum": "fcad0b64b70afb27699e425950cb5ebcd410bc20",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/source-map-resolve-0.5.0.tgz_1456659131712_0.8686265745200217"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "source-map-resolve",
+      "version": "0.5.1",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lydell/source-map-resolve.git"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "lint": "jshint lib/ test/",
+        "unit": "node test/source-map-resolve.js && node test/windows.js && node test/read.js",
+        "test": "npm run lint && npm run unit",
+        "build": "node generate-source-map-resolve.js"
+      },
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "source-map-url": "^0.4.0",
+        "atob": "^2.0.0",
+        "urix": "^0.1.0",
+        "resolve-url": "^0.2.1"
+      },
+      "devDependencies": {
+        "tape": "^4.4.0",
+        "jshint": "~2.9.1",
+        "setimmediate": "^1.0.4",
+        "Base64": "^0.3.0",
+        "simple-asyncify": "^1.0.0"
+      },
+      "testling": {
+        "files": "test/source-map-resolve.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "gitHead": "61e0c21003c48230dfb4f72adc7720b122d79b91",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve#readme",
+      "_id": "source-map-resolve@0.5.1",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "8.7.0",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+        "shasum": "7ad0f593f2281598e854df80f19aae4b92d7a11a",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/source-map-resolve-0.5.1.tgz_1508580242990_0.501070941099897"
+      },
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "source-map-resolve",
+      "version": "0.5.2",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lydell/source-map-resolve.git"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "lint": "jshint lib/ test/",
+        "unit": "node test/source-map-resolve.js && node test/windows.js",
+        "test": "npm run lint && npm run unit",
+        "build": "node generate-source-map-resolve.js"
+      },
+      "dependencies": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "Base64": "1.0.1",
+        "jshint": "2.9.5",
+        "setimmediate": "1.0.5",
+        "simple-asyncify": "1.0.0",
+        "tape": "4.9.0"
+      },
+      "gitHead": "858cd9e2ecce25427761b8be616cabf704c69316",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve#readme",
+      "_id": "source-map-resolve@0.5.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.1",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+        "shasum": "72e2cc34095543e43b2c62b2c4c10d4a9054f259",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+        "fileCount": 19,
+        "unpackedSize": 84875,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa9H2FCRA9TVsSAnZWagAA05sP/0/U8obKbbexyKl8t/BY\n1180vVJicJpW0CldFggqZrgWG/cnZQkTZjlCn4HRVfTHqRy0jdUHvSeZAyam\nTmYl0tMVfrGgADIR+E/xELC4zgK2lq0p1TCL3k7lK2mSKiG1CaB+0FGlMD/P\nsBmPs8TY2sIvjq3Zfh1/mHYRMrsPJCpWDoqtdK/3d8+pjFKopoDXU+udXj1v\nq5KF0O/7vFKxbFe4Z/USRae0E/6xhBx+j8eKiF1ZcLNMH5u012UE0frFw9aa\nKIcuLugn+cP8h6TPRAmK8EnWGXrjlpcWdTKnD9DVCyrVe6T+DfMJGtFYe6Ku\nuTdZec00LlVG8huC3uWBWxP9DKm+lqH58h1zoZvsKKnMKdIAQDLhvw40XNDs\n1ITF/2rQL7khnhCUh7XPonVcxAwQgSwgso4oQkxVG9JNHht/3BUtSqbHn1Gw\n9Tt9HhDUHkBV7ClZ0KXnbVBfkWA+J//Ao9Pn3onUm9qlwCiNucvz4nlbwqoo\nW6aZgvJJr1L8NpyAgPTj268dO8EeoGRk2oLzvS7tFJYoZDu6gDWZwNMHuHpH\nuuUtt2PM5n95e9H5cSg/t7cKw1GQSXEprOjQd21iaS+mbnBv9ZtAajjNGBL+\nUKuj2XpMVOp+FSEhKtkALic3u8CRXHETmV3zHInEMj+ArAyy/UAI1abGN1gw\n1eGT\r\n=Gvd3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/source-map-resolve_0.5.2_1525972355927_0.09065684340520819"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.5.3": {
+      "name": "source-map-resolve",
+      "version": "0.5.3",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lydell/source-map-resolve.git"
+      },
+      "main": "lib/source-map-resolve-node.js",
+      "browser": "source-map-resolve.js",
+      "scripts": {
+        "lint": "jshint lib/ test/",
+        "unit": "node test/source-map-resolve.js && node test/windows.js",
+        "test": "npm run lint && npm run unit",
+        "build": "node generate-source-map-resolve.js"
+      },
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "Base64": "1.1.0",
+        "jshint": "2.10.3",
+        "setimmediate": "1.0.5",
+        "simple-asyncify": "1.0.0",
+        "tape": "4.12.1"
+      },
+      "gitHead": "b8244f108af0aaf34c32a61e97b66e38db682afc",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve#readme",
+      "_id": "source-map-resolve@0.5.3",
+      "_nodeVersion": "12.8.0",
+      "_npmVersion": "6.10.2",
+      "dist": {
+        "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+        "shasum": "190866bece7553e1f8f267a2ee82c606b5509a1a",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+        "fileCount": 8,
+        "unpackedSize": 34259,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeB67DCRA9TVsSAnZWagAAaVYP/0+WCdbJaSmbnhBU8xBJ\nQmAhI8mO4tkWyjo4UI0/a+EXUopgOqXbLXNE7lnYwiER+XCjZYhVJfVQYQaW\nsW/IriDzH8gvpiZoWZZrMmd5bVJ+2Uxg17/KudaHgb7wTT4Kf0oUcsOQEdTj\n3tth97IH1hB+lO09PjwyXeoi3VqBfqbicjyVSMn0w2DGPkNS35qUoHc65fFT\nSYv00KROhLLctmEkopepb/B5WVDTLLaHkHGtb0MeIVZkX9th4Oapyh8NI2kV\nbl4Bh93l5kv9Ize4kbHL+FMaRl9CLb0RWIe5aaorbE8xluVf7q4AKfSk2n3H\nhNSpuhJcpFYA53n7zw4Pemt2jwlq3COeWkqNTOJofIxbt8x7o0ml8GQmI88j\nTMiDbwhHVY1j5UCKh887EmJNcSle8UCKLriXcvdThqLNQgFYTw6znNSBFXzm\nANNmLH8ELkWn86BmrITZG5dt6/XmkCsFOFn0N2iiTDUIicdMI8HTv0NaWelo\n0lNgc4eD/aJQ5N97EpZ5aRu7kiab4CC/qAh5ohqCpqgcr8F0YNjxDpSVJf8j\nVhD+dtSabIoRSxyN5VWA10STtUyyIacmBwG8KH/zOqmwhbjMJoF2KErKxoVO\nD4BviZFnaPaHN0OegH/ybPdk6r6j6d5aTwPdUMf8Dx8RQehNDoZBS0QNCuhl\n2msY\r\n=gRFQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/source-map-resolve_0.5.3_1577561794888_0.08838750313874422"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.6.0": {
+      "name": "source-map-resolve",
+      "version": "0.6.0",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Resolve the source map and/or sources for a generated file.",
+      "keywords": [
+        "source map",
+        "sourcemap",
+        "source",
+        "map",
+        "sourceMappingURL",
+        "resolve",
+        "resolver",
+        "locate",
+        "locator",
+        "find",
+        "finder"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lydell/source-map-resolve.git"
+      },
+      "scripts": {
+        "lint": "jshint index.js test/",
+        "unit": "node test/index.js && node test/read.js && node test/windows.js",
+        "test": "npm run lint && npm run unit"
+      },
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
+      },
+      "devDependencies": {
+        "Base64": "1.1.0",
+        "jshint": "2.10.3",
+        "setimmediate": "1.0.5",
+        "simple-asyncify": "1.0.0",
+        "tape": "4.12.1"
+      },
+      "gitHead": "eeed61bac2e498ea5239c8162101b021f568b959",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-resolve/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-resolve#readme",
+      "_id": "source-map-resolve@0.6.0",
+      "_nodeVersion": "13.8.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+        "shasum": "3d9df87e236b53f16d01e58150fc7711138e5ed2",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23823,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJedpQECRA9TVsSAnZWagAAQdcQAJIprSf8Fb0ja1LUo5LN\nlNUKPh44FPKO2B2G/XuTNg6oe3hbWL/fxiVwNpMuVzbGY5peTSdG7K4K9x3P\n1Db735iGRiT6iEkJ7fZwXOA453ghBr/+6+Fru2mySbdzDSq/XEz27xWpT1Ob\n/QQaLtpp/Z5bGAbD25xnFTwc/6St/XWvCgU/WZEnVRP9rb38BSDzK+Oi2Der\n7L8IIi1KXuFPmZ9t5UQ+tcrbBIP/SLHCfwspJmZG1XGIcTnY+0tcgBDXl8KY\nipeiI+AsHwyZx9JhF/8AQejqVuItzeqpNlRUNvIQEx82jHa9lutPVoUVaU2r\n9rKo26Cabw6/3deU+U6RyaMlY9xvM/8RZPtq6fd7Yom6sOlp/3ZAXaqFvRqv\nGKUSzYhy2CmQ+gG+uIzQYDhSxvKUXK97wEKWUHCJOWMJzPvvBDrHvZuTKdCK\nvKtHJk6VDJPPeJC9ho4LWMIQa/bP+JmTdSockvFBFBqTccT+aP81mtTSVMRX\nYv+0rfj+ANCyhEKXtLAzq3WTMxK34jCtDxukwxQavvcks580zVD6+D56dBzO\nH2M4QqtZh8ojL3H5ZqnE18OnTjs73i8uA6N4lil6rk/fvUg0Fn3I4RDh79ui\nRkZ16vMkUYQkqwyi1TbhsKqj+cQ873qY5yaHPQgBJlBQ0T4VOhwTTSzhn5jv\nmv5U\r\n=UxXd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/source-map-resolve_0.6.0_1584829444080_0.39315145730358503"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "Overview [![Build Status](https://travis-ci.org/lydell/source-map-resolve.svg?branch=master)](https://travis-ci.org/lydell/source-map-resolve)\n========\n\nResolve the source map and/or sources for a generated file.\n\n```js\nvar sourceMapResolve = require(\"source-map-resolve\")\nvar sourceMap        = require(\"source-map\")\n\nvar code = [\n  \"!function(){...}();\",\n  \"/*# sourceMappingURL=foo.js.map */\"\n].join(\"\\n\")\n\nsourceMapResolve.resolveSourceMap(code, \"/js/foo.js\", fs.readFile, function(error, result) {\n  if (error) {\n    return notifyFailure(error)\n  }\n  result\n  // {\n  //   map: {file: \"foo.js\", mappings: \"...\", sources: [\"/coffee/foo.coffee\"], names: []},\n  //   url: \"/js/foo.js.map\",\n  //   sourcesRelativeTo: \"/js/foo.js.map\",\n  //   sourceMappingURL: \"foo.js.map\"\n  // }\n\n  sourceMapResolve.resolveSources(result.map, result.sourcesRelativeTo, fs.readFile, function(error, result) {\n    if (error) {\n      return notifyFailure(error)\n    }\n    result\n    // {\n    //   sourcesResolved: [\"/coffee/foo.coffee\"],\n    //   sourcesContent: [\"<contents of /coffee/foo.coffee>\"]\n    // }\n  })\n})\n\nsourceMapResolve.resolve(code, \"/js/foo.js\", fs.readFile, function(error, result) {\n  if (error) {\n    return notifyFailure(error)\n  }\n  result\n  // {\n  //   map: {file: \"foo.js\", mappings: \"...\", sources: [\"/coffee/foo.coffee\"], names: []},\n  //   url: \"/js/foo.js.map\",\n  //   sourcesRelativeTo: \"/js/foo.js.map\",\n  //   sourceMappingURL: \"foo.js.map\",\n  //   sourcesResolved: [\"/coffee/foo.coffee\"],\n  //   sourcesContent: [\"<contents of /coffee/foo.coffee>\"]\n  // }\n  result.map.sourcesContent = result.sourcesContent\n  var map = new sourceMap.sourceMapConsumer(result.map)\n  map.sourceContentFor(\"/coffee/foo.coffee\")\n  // \"<contents of /coffee/foo.coffee>\"\n})\n```\n\n\nInstallation\n============\n\n`npm install source-map-resolve`\n\nUsage\n=====\n\n### `sourceMapResolve.resolveSourceMap(code, codeUrl, read, callback)` ###\n\n- `code` is a string of code that may or may not contain a sourceMappingURL\n  comment. Such a comment is used to resolve the source map.\n- `codeUrl` is the url to the file containing `code`. If the sourceMappingURL\n  is relative, it is resolved against `codeUrl`.\n- `read(url, callback)` is a function that reads `url` and responds using\n  `callback(error, content)`. In Node.js you might want to use `fs.readFile`,\n  while in the browser you might want to use an asynchronus `XMLHttpRequest`.\n- `callback(error, result)` is a function that is invoked with either an error\n  or `null` and the result.\n\nThe result is an object with the following properties:\n\n- `map`: The source map for `code`, as an object (not a string).\n- `url`: The url to the source map. If the source map came from a data uri,\n  this property is `null`, since then there is no url to it.\n- `sourcesRelativeTo`: The url that the sources of the source map are relative\n  to. Since the sources are relative to the source map, and the url to the\n  source map is provided as the `url` property, this property might seem\n  superfluos. However, remember that the `url` property can be `null` if the\n  source map came from a data uri. If so, the sources are relative to the file\n  containing the data uri—`codeUrl`. This property will be identical to the\n  `url` property or `codeUrl`, whichever is appropriate. This way you can\n  conveniently resolve the sources without having to think about where the\n  source map came from.\n- `sourceMappingURL`: The url of the sourceMappingURL comment in `code`.\n\nIf `code` contains no sourceMappingURL, the result is `null`.\n\n### `sourceMapResolve.resolveSources(map, mapUrl, read, [options], callback)` ###\n\n- `map` is a source map, as an object (not a string).\n- `mapUrl` is the url to the file containing `map`. Relative sources in the\n  source map, if any, are resolved against `mapUrl`.\n- `read(url, callback)` is a function that reads `url` and responds using\n  `callback(error, content)`. In Node.js you might want to use `fs.readFile`,\n  while in the browser you might want to use an asynchronus `XMLHttpRequest`.\n- `options` is an optional object with any of the following properties:\n  - `sourceRoot`: Override the `sourceRoot` property of the source map, which\n    might only be relevant when resolving sources in the browser. This lets you\n    bypass it when using the module outside of a browser, if needed. Pass a\n    string to replace the `sourceRoot` property with, or `false` to ignore it.\n    Defaults to `undefined`.\n- `callback(error, result)` is a function that is invoked with either an error\n  or `null` and the result.\n\nThe result is an object with the following properties:\n\n- `sourcesResolved`: The same as `map.sources`, except all the sources are\n  fully resolved.\n- `sourcesContent`: An array with the contents of all sources in `map.sources`,\n  in the same order as `map.sources`. If getting the contents of a source fails,\n  an error object is put into the array instead.\n\n### `sourceMapResolve.resolve(code, codeUrl, read, [options], callback)` ###\n\nThe arguments are identical to `sourceMapResolve.resolveSourceMap`, except that\nyou may also provide the same `options` as in `sourceMapResolve.resolveSources`.\n\nThis is a convenience method that first resolves the source map and then its\nsources. You could also do this by first calling\n`sourceMapResolve.resolveSourceMap` and then `sourceMapResolve.resolveSources`.\n\nThe result is identical to `sourceMapResolve.resolveSourceMap`, with the\nproperties from `sourceMapResolve.resolveSources` merged into it.\n\nThere is one extra feature available, though. If `code` is `null`, `codeUrl` is\ntreated as a url to the source map instead of to `code`, and will be read. This\nis handy if you _sometimes_ get the source map url from the `SourceMap: <url>`\nheader (see the [Notes] section). In this case, the `sourceMappingURL` property\nof the result is `null`.\n\n\n[Notes]: #notes\n\n### `sourceMapResolve.*Sync()` ###\n\nThere are also sync versions of the three previous functions. They are identical\nto the async versions, except:\n\n- They expect a sync reading function. In Node.js you might want to use\n  `fs.readFileSync`, while in the browser you might want to use a synchronus\n  `XMLHttpRequest`.\n- They throw errors and return the result instead of using a callback.\n\n`sourceMapResolve.resolveSourcesSync` also accepts `null` as the `read`\nparameter. The result is the same as when passing a function as the `read\nparameter`, except that the `sourcesContent` property of the result will be an\nempty array. In other words, the sources aren’t read. You only get the\n`sourcesResolved` property. (This only supported in the synchronus version, since\nthere is no point doing it asynchronusly.)\n\n### `sourceMapResolve.parseMapToJSON(string, [data])` ###\n\nThe spec says that if a source map (as a string) starts with `)]}'`, it should\nbe stripped off. This is to prevent XSSI attacks. This function does that and\nreturns the result of `JSON.parse`ing what’s left.\n\nIf this function throws `error`, `error.sourceMapData === data`.\n\n### Errors\n\nAll errors passed to callbacks or thrown by this module have a `sourceMapData`\nproperty that contain as much as possible of the intended result of the function\nup until the error occurred.\n\nNote that while the `map` property of result objects always is an object,\n`error.sourceMapData.map` will be a string if parsing that string fails.\n\n\nNote\n====\n\nThis module resolves the source map for a given generated file by looking for a\nsourceMappingURL comment. The spec defines yet a way to provide the URL to the\nsource map: By sending the `SourceMap: <url>` header along with the generated\nfile. Since this module doesn’t retrive the generated code for you (instead\n_you_ give the generated code to the module), it’s up to you to look for such a\nheader when you retrieve the file (should the need arise).\n\n\nLicense\n=======\n\n[MIT](LICENSE).\n",
+  "maintainers": [
+    {
+      "name": "lydell",
+      "email": "simon.lydell@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-03-21T22:24:06.538Z",
+    "created": "2014-03-03T20:08:03.526Z",
+    "0.1.0": "2014-03-03T20:08:03.526Z",
+    "0.1.1": "2014-03-06T18:58:07.968Z",
+    "0.1.2": "2014-03-23T12:41:20.396Z",
+    "0.1.3": "2014-05-06T15:55:04.931Z",
+    "0.1.4": "2014-06-16T18:25:22.382Z",
+    "0.2.0": "2014-06-22T18:22:29.559Z",
+    "0.3.0": "2014-07-02T16:14:43.746Z",
+    "0.3.1": "2014-08-16T13:44:55.386Z",
+    "0.4.0": "2015-08-29T12:22:45.501Z",
+    "0.5.0": "2016-02-28T11:32:14.612Z",
+    "0.5.1": "2017-10-21T10:04:04.572Z",
+    "0.5.2": "2018-05-10T17:12:36.047Z",
+    "0.5.3": "2019-12-28T19:36:35.020Z",
+    "0.6.0": "2020-03-21T22:24:04.207Z"
+  },
+  "homepage": "https://github.com/lydell/source-map-resolve#readme",
+  "keywords": [
+    "source map",
+    "sourcemap",
+    "source",
+    "map",
+    "sourceMappingURL",
+    "resolve",
+    "resolver",
+    "locate",
+    "locator",
+    "find",
+    "finder"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lydell/source-map-resolve.git"
+  },
+  "author": {
+    "name": "Simon Lydell"
+  },
+  "bugs": {
+    "url": "https://github.com/lydell/source-map-resolve/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "users": {
+    "rocman": true,
+    "flozz": true,
+    "miadzadfallah": true,
+    "drewigg": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/source-map-resolve.min.json
+++ b/test/fixtures/registry-mocks/content/source-map-resolve.min.json
@@ -1,0 +1,317 @@
+{
+  "name": "source-map-resolve",
+  "dist-tags": {
+    "latest": "0.6.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "source-map-resolve",
+      "version": "0.1.0",
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "resolve-url": "~0.2.1",
+        "simple-asyncify": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "6be37734b29bdd2b95592d89d0905dbedbab180b",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "source-map-resolve",
+      "version": "0.1.1",
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "resolve-url": "~0.2.1",
+        "simple-asyncify": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "8a591216a4f19c8695e8e16711f5fd2d0a986e7f",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "source-map-resolve",
+      "version": "0.1.2",
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "resolve-url": "~0.2.1",
+        "simple-asyncify": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "a1592b6df4ff26e18bc1329a5e47272009ab3d52",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "source-map-resolve",
+      "version": "0.1.3",
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "c6db00fe1220fcd2f8014af9020e20990de3ec38",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "source-map-resolve",
+      "version": "0.1.4",
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "61b4fdcc2aea74e88f54b20dd2513186fb5378e0",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.1.4.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "source-map-resolve",
+      "version": "0.2.0",
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "898d41777f5c1e14092a5e0a6d3e9d1e6da16479",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "source-map-resolve",
+      "version": "0.3.0",
+      "dependencies": {
+        "source-map-url": "~0.2.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "d298388fbdd17cd10be57e41dea9950a27ab5d2e",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "source-map-resolve",
+      "version": "0.3.1",
+      "dependencies": {
+        "source-map-url": "~0.3.0",
+        "atob": "~1.1.0",
+        "urix": "~0.1.0",
+        "resolve-url": "~0.2.1"
+      },
+      "devDependencies": {
+        "tape": "~2.5.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "~1.0.1",
+        "Base64": "~0.2.0",
+        "simple-asyncify": "~0.1.0"
+      },
+      "dist": {
+        "shasum": "610f6122a445b8dd51535a2a71b783dfc1248761",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "source-map-resolve",
+      "version": "0.4.0",
+      "dependencies": {
+        "source-map-url": "^0.3.0",
+        "atob": "^1.1.2",
+        "urix": "^0.1.0",
+        "resolve-url": "^0.2.1"
+      },
+      "devDependencies": {
+        "tape": "^4.2.0",
+        "jshint": "~2.4.3",
+        "setimmediate": "^1.0.2",
+        "Base64": "^0.3.0",
+        "simple-asyncify": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "5c43d28a2d8f76622f2372890220cdb0c09f09b5",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.4.0.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "source-map-resolve",
+      "version": "0.5.0",
+      "dependencies": {
+        "source-map-url": "^0.4.0",
+        "atob": "^2.0.0",
+        "urix": "^0.1.0",
+        "resolve-url": "^0.2.1"
+      },
+      "devDependencies": {
+        "tape": "^4.4.0",
+        "jshint": "~2.9.1",
+        "setimmediate": "^1.0.4",
+        "Base64": "^0.3.0",
+        "simple-asyncify": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "fcad0b64b70afb27699e425950cb5ebcd410bc20",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.0.tgz"
+      }
+    },
+    "0.5.1": {
+      "name": "source-map-resolve",
+      "version": "0.5.1",
+      "dependencies": {
+        "decode-uri-component": "^0.2.0",
+        "source-map-url": "^0.4.0",
+        "atob": "^2.0.0",
+        "urix": "^0.1.0",
+        "resolve-url": "^0.2.1"
+      },
+      "devDependencies": {
+        "tape": "^4.4.0",
+        "jshint": "~2.9.1",
+        "setimmediate": "^1.0.4",
+        "Base64": "^0.3.0",
+        "simple-asyncify": "^1.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+        "shasum": "7ad0f593f2281598e854df80f19aae4b92d7a11a",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz"
+      }
+    },
+    "0.5.2": {
+      "name": "source-map-resolve",
+      "version": "0.5.2",
+      "dependencies": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "Base64": "1.0.1",
+        "jshint": "2.9.5",
+        "setimmediate": "1.0.5",
+        "simple-asyncify": "1.0.0",
+        "tape": "4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+        "shasum": "72e2cc34095543e43b2c62b2c4c10d4a9054f259",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+        "fileCount": 19,
+        "unpackedSize": 84875,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa9H2FCRA9TVsSAnZWagAA05sP/0/U8obKbbexyKl8t/BY\n1180vVJicJpW0CldFggqZrgWG/cnZQkTZjlCn4HRVfTHqRy0jdUHvSeZAyam\nTmYl0tMVfrGgADIR+E/xELC4zgK2lq0p1TCL3k7lK2mSKiG1CaB+0FGlMD/P\nsBmPs8TY2sIvjq3Zfh1/mHYRMrsPJCpWDoqtdK/3d8+pjFKopoDXU+udXj1v\nq5KF0O/7vFKxbFe4Z/USRae0E/6xhBx+j8eKiF1ZcLNMH5u012UE0frFw9aa\nKIcuLugn+cP8h6TPRAmK8EnWGXrjlpcWdTKnD9DVCyrVe6T+DfMJGtFYe6Ku\nuTdZec00LlVG8huC3uWBWxP9DKm+lqH58h1zoZvsKKnMKdIAQDLhvw40XNDs\n1ITF/2rQL7khnhCUh7XPonVcxAwQgSwgso4oQkxVG9JNHht/3BUtSqbHn1Gw\n9Tt9HhDUHkBV7ClZ0KXnbVBfkWA+J//Ao9Pn3onUm9qlwCiNucvz4nlbwqoo\nW6aZgvJJr1L8NpyAgPTj268dO8EeoGRk2oLzvS7tFJYoZDu6gDWZwNMHuHpH\nuuUtt2PM5n95e9H5cSg/t7cKw1GQSXEprOjQd21iaS+mbnBv9ZtAajjNGBL+\nUKuj2XpMVOp+FSEhKtkALic3u8CRXHETmV3zHInEMj+ArAyy/UAI1abGN1gw\n1eGT\r\n=Gvd3\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.5.3": {
+      "name": "source-map-resolve",
+      "version": "0.5.3",
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      },
+      "devDependencies": {
+        "Base64": "1.1.0",
+        "jshint": "2.10.3",
+        "setimmediate": "1.0.5",
+        "simple-asyncify": "1.0.0",
+        "tape": "4.12.1"
+      },
+      "dist": {
+        "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+        "shasum": "190866bece7553e1f8f267a2ee82c606b5509a1a",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+        "fileCount": 8,
+        "unpackedSize": 34259,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeB67DCRA9TVsSAnZWagAAaVYP/0+WCdbJaSmbnhBU8xBJ\nQmAhI8mO4tkWyjo4UI0/a+EXUopgOqXbLXNE7lnYwiER+XCjZYhVJfVQYQaW\nsW/IriDzH8gvpiZoWZZrMmd5bVJ+2Uxg17/KudaHgb7wTT4Kf0oUcsOQEdTj\n3tth97IH1hB+lO09PjwyXeoi3VqBfqbicjyVSMn0w2DGPkNS35qUoHc65fFT\nSYv00KROhLLctmEkopepb/B5WVDTLLaHkHGtb0MeIVZkX9th4Oapyh8NI2kV\nbl4Bh93l5kv9Ize4kbHL+FMaRl9CLb0RWIe5aaorbE8xluVf7q4AKfSk2n3H\nhNSpuhJcpFYA53n7zw4Pemt2jwlq3COeWkqNTOJofIxbt8x7o0ml8GQmI88j\nTMiDbwhHVY1j5UCKh887EmJNcSle8UCKLriXcvdThqLNQgFYTw6znNSBFXzm\nANNmLH8ELkWn86BmrITZG5dt6/XmkCsFOFn0N2iiTDUIicdMI8HTv0NaWelo\n0lNgc4eD/aJQ5N97EpZ5aRu7kiab4CC/qAh5ohqCpqgcr8F0YNjxDpSVJf8j\nVhD+dtSabIoRSxyN5VWA10STtUyyIacmBwG8KH/zOqmwhbjMJoF2KErKxoVO\nD4BviZFnaPaHN0OegH/ybPdk6r6j6d5aTwPdUMf8Dx8RQehNDoZBS0QNCuhl\n2msY\r\n=gRFQ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.6.0": {
+      "name": "source-map-resolve",
+      "version": "0.6.0",
+      "dependencies": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0"
+      },
+      "devDependencies": {
+        "Base64": "1.1.0",
+        "jshint": "2.10.3",
+        "setimmediate": "1.0.5",
+        "simple-asyncify": "1.0.0",
+        "tape": "4.12.1"
+      },
+      "dist": {
+        "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+        "shasum": "3d9df87e236b53f16d01e58150fc7711138e5ed2",
+        "tarball": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 23823,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJedpQECRA9TVsSAnZWagAAQdcQAJIprSf8Fb0ja1LUo5LN\nlNUKPh44FPKO2B2G/XuTNg6oe3hbWL/fxiVwNpMuVzbGY5peTSdG7K4K9x3P\n1Db735iGRiT6iEkJ7fZwXOA453ghBr/+6+Fru2mySbdzDSq/XEz27xWpT1Ob\n/QQaLtpp/Z5bGAbD25xnFTwc/6St/XWvCgU/WZEnVRP9rb38BSDzK+Oi2Der\n7L8IIi1KXuFPmZ9t5UQ+tcrbBIP/SLHCfwspJmZG1XGIcTnY+0tcgBDXl8KY\nipeiI+AsHwyZx9JhF/8AQejqVuItzeqpNlRUNvIQEx82jHa9lutPVoUVaU2r\n9rKo26Cabw6/3deU+U6RyaMlY9xvM/8RZPtq6fd7Yom6sOlp/3ZAXaqFvRqv\nGKUSzYhy2CmQ+gG+uIzQYDhSxvKUXK97wEKWUHCJOWMJzPvvBDrHvZuTKdCK\nvKtHJk6VDJPPeJC9ho4LWMIQa/bP+JmTdSockvFBFBqTccT+aP81mtTSVMRX\nYv+0rfj+ANCyhEKXtLAzq3WTMxK34jCtDxukwxQavvcks580zVD6+D56dBzO\nH2M4QqtZh8ojL3H5ZqnE18OnTjs73i8uA6N4lil6rk/fvUg0Fn3I4RDh79ui\nRkZ16vMkUYQkqwyi1TbhsKqj+cQ873qY5yaHPQgBJlBQ0T4VOhwTTSzhn5jv\nmv5U\r\n=UxXd\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-03-21T22:24:06.538Z"
+}

--- a/test/fixtures/registry-mocks/content/source-map-url.json
+++ b/test/fixtures/registry-mocks/content/source-map-url.json
@@ -1,0 +1,311 @@
+{
+  "_id": "source-map-url",
+  "_rev": "7-2f032e90f27814b301b77a4275c6b3c0",
+  "name": "source-map-url",
+  "description": "Tools for working with sourceMappingURL comments.",
+  "dist-tags": {
+    "latest": "0.4.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "source-map-url",
+      "version": "0.1.0",
+      "description": "Tools for working with sourceMappingURL comments.",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "main": "source-map-url.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/source-map-url"
+      },
+      "keywords": [
+        "source map",
+        "sourceMappingURL",
+        "comment",
+        "annotation"
+      ],
+      "scripts": {
+        "test": "jshint source-map-url.js test/ && mocha"
+      },
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "chai": "~1.9.0",
+        "jshint": "~2.4.3"
+      },
+      "testling": {
+        "harness": "mocha",
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5..latest",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-url/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-url",
+      "_id": "source-map-url@0.1.0",
+      "dist": {
+        "shasum": "afb634c335ca73c95301594137280f233699ee5b",
+        "tarball": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "source-map-url",
+      "version": "0.2.0",
+      "description": "Tools for working with sourceMappingURL comments.",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "main": "source-map-url.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/source-map-url"
+      },
+      "keywords": [
+        "source map",
+        "sourceMappingURL",
+        "comment",
+        "annotation"
+      ],
+      "scripts": {
+        "test": "jshint source-map-url.js test/ && mocha"
+      },
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "chai": "~1.9.0",
+        "jshint": "~2.4.3"
+      },
+      "testling": {
+        "harness": "mocha",
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-url/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-url",
+      "_id": "source-map-url@0.2.0",
+      "dist": {
+        "shasum": "5c3d205a993c50d443081933718ae4ccac222425",
+        "tarball": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "source-map-url",
+      "version": "0.3.0",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Tools for working with sourceMappingURL comments.",
+      "keywords": [
+        "source map",
+        "sourceMappingURL",
+        "comment",
+        "annotation"
+      ],
+      "main": "source-map-url.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/lydell/source-map-url"
+      },
+      "scripts": {
+        "lint": "jshint source-map-url.js test/ ",
+        "unit": "mocha",
+        "test": "npm run lint && npm run unit"
+      },
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "expect.js": "~0.3.1",
+        "jshint": "~2.4.3"
+      },
+      "testling": {
+        "harness": "mocha",
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "gitHead": "ffa8f4cd7ad1bc582681f3f222095152e6597f10",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-url/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-url",
+      "_id": "source-map-url@0.3.0",
+      "_shasum": "7ecaf13b57bcd09da8a40c5d269db33799d4aaf9",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7ecaf13b57bcd09da8a40c5d269db33799d4aaf9",
+        "tarball": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "source-map-url",
+      "version": "0.4.0",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Tools for working with sourceMappingURL comments.",
+      "keywords": [
+        "source map",
+        "sourceMappingURL",
+        "comment",
+        "annotation"
+      ],
+      "main": "source-map-url.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/lydell/source-map-url.git"
+      },
+      "scripts": {
+        "lint": "jshint source-map-url.js test/ ",
+        "unit": "mocha",
+        "test": "npm run lint && npm run unit"
+      },
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "expect.js": "~0.3.1",
+        "jshint": "~2.4.3"
+      },
+      "testling": {
+        "harness": "mocha",
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "chrome/latest",
+          "firefox/latest",
+          "opera/12",
+          "opera/latest",
+          "safari/5",
+          "iphone/6",
+          "android-browser/4"
+        ]
+      },
+      "gitHead": "f13c43ca675379922f26c87737fdcbbeac07eb09",
+      "bugs": {
+        "url": "https://github.com/lydell/source-map-url/issues"
+      },
+      "homepage": "https://github.com/lydell/source-map-url#readme",
+      "_id": "source-map-url@0.4.0",
+      "_shasum": "3e935d7ddd73631b97659956d55128e87b5084a3",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "dist": {
+        "shasum": "3e935d7ddd73631b97659956d55128e87b5084a3",
+        "tarball": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {}
+    }
+  },
+  "readme": "Overview [![Build Status](https://travis-ci.org/lydell/source-map-url.png?branch=master)](https://travis-ci.org/lydell/source-map-url)\n========\n\n[![browser support](https://ci.testling.com/lydell/source-map-url.png)](https://ci.testling.com/lydell/source-map-url)\n\nTools for working with sourceMappingURL comments.\n\n```js\nvar sourceMappingURL = require(\"source-map-url\")\n\nvar code = [\n  \"!function(){...}();\",\n  \"/*# sourceMappingURL=foo.js.map */\"\n].join(\"\\n\")\n\nsourceMappingURL.existsIn(code)\n// true\n\nsourceMappingURL.getFrom(code)\n// foo.js.map\n\ncode = sourceMappingURL.insertBefore(code, \"// License: MIT\\n\")\n// !function(){...}();\n// // License: MIT\n// /*# sourceMappingURL=foo.js.map */\n\ncode = sourceMappingURL.removeFrom(code)\n// !function(){...}();\n// // License: MIT\n\nsourceMappingURL.existsIn(code)\n// false\n\nsourceMappingURL.getFrom(code)\n// null\n\ncode += \"//# sourceMappingURL=/other/file.js.map\"\n// !function(){...}();\n// // License: MIT\n// //# sourceMappingURL=/other/file.js.map\n```\n\n\nInstallation\n============\n\n- `npm install source-map-url`\n- `bower install source-map-url`\n- `component install lydell/source-map-url`\n\nWorks with CommonJS, AMD and browser globals, through UMD.\n\n\nUsage\n=====\n\n### `sourceMappingURL.getFrom(code)` ###\n\nReturns the url of the sourceMappingURL comment in `code`. Returns `null` if\nthere is no such comment.\n\n### `sourceMappingURL.existsIn(code)` ###\n\nReturns `true` if there is a sourceMappingURL comment in `code`, or `false`\notherwise.\n\n### `sourceMappingURL.removeFrom(code)` ###\n\nRemoves the sourceMappingURL comment in `code`. Does nothing if there is no\nsuch comment. Returns the updated `code`.\n\n### `sourceMappingURL.insertBefore(code, string)` ###\n\nInserts `string` before the sourceMappingURL comment in `code`. Appends\n`string` to `code` if there is no such comment.\n\nLets you append something to a file without worrying about burying the\nsourceMappingURL comment (by keeping it at the end of the file).\n\n### `sourceMappingURL.regex` ###\n\nThe regex that is used to match sourceMappingURL comments. It matches both `//`\nand `/**/` comments, thus supporting both JavaScript and CSS.\n\n\nTests\n=====\n\nStart by running `npm test`, which lints the code and runs the test suite in Node.js.\n\nTo run the tests in a browser, run `testling` (`npm install -g testling`) or `testling -u`.\n\n\nLicense\n=======\n\n[The X11 (“MIT”) License](LICENSE).\n",
+  "maintainers": [
+    {
+      "name": "lydell",
+      "email": "simon.lydell@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2015-11-12T21:03:24.856Z",
+    "created": "2014-02-22T15:41:32.487Z",
+    "0.1.0": "2014-02-22T15:41:32.487Z",
+    "0.2.0": "2014-02-23T09:21:34.645Z",
+    "0.3.0": "2014-08-16T13:34:25.335Z",
+    "0.4.0": "2015-11-12T21:03:24.856Z"
+  },
+  "readmeFilename": "readme.md",
+  "homepage": "https://github.com/lydell/source-map-url#readme",
+  "keywords": [
+    "source map",
+    "sourceMappingURL",
+    "comment",
+    "annotation"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lydell/source-map-url.git"
+  },
+  "author": {
+    "name": "Simon Lydell"
+  },
+  "bugs": {
+    "url": "https://github.com/lydell/source-map-url/issues"
+  },
+  "license": "MIT",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/source-map-url.min.json
+++ b/test/fixtures/registry-mocks/content/source-map-url.min.json
@@ -1,0 +1,61 @@
+{
+  "name": "source-map-url",
+  "dist-tags": {
+    "latest": "0.4.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "source-map-url",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "chai": "~1.9.0",
+        "jshint": "~2.4.3"
+      },
+      "dist": {
+        "shasum": "afb634c335ca73c95301594137280f233699ee5b",
+        "tarball": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "source-map-url",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "chai": "~1.9.0",
+        "jshint": "~2.4.3"
+      },
+      "dist": {
+        "shasum": "5c3d205a993c50d443081933718ae4ccac222425",
+        "tarball": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.2.0.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "source-map-url",
+      "version": "0.3.0",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "expect.js": "~0.3.1",
+        "jshint": "~2.4.3"
+      },
+      "dist": {
+        "shasum": "7ecaf13b57bcd09da8a40c5d269db33799d4aaf9",
+        "tarball": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "source-map-url",
+      "version": "0.4.0",
+      "devDependencies": {
+        "mocha": "~1.17.1",
+        "expect.js": "~0.3.1",
+        "jshint": "~2.4.3"
+      },
+      "dist": {
+        "shasum": "3e935d7ddd73631b97659956d55128e87b5084a3",
+        "tarball": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz"
+      }
+    }
+  },
+  "modified": "2015-11-12T21:03:24.856Z"
+}

--- a/test/fixtures/registry-mocks/content/spdy-transport.json
+++ b/test/fixtures/registry-mocks/content/spdy-transport.json
@@ -1,0 +1,3361 @@
+{
+  "_id": "spdy-transport",
+  "_rev": "56-7673f947c1cd22af6234100b036310d6",
+  "name": "spdy-transport",
+  "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0-dev": {
+      "name": "spdy-transport",
+      "version": "1.0.0-dev",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "0fb448e8fce7758a737e1b9929821a30a6235c14",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-dev",
+      "_shasum": "cce2034f0d47e6ddae2fff441e1315a33fabe05c",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cce2034f0d47e6ddae2fff441e1315a33fabe05c",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-dev.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc1": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc1",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "3b7b803b0bcf709881c0620fdfc3def4e9eb941f",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc1",
+      "_shasum": "d60beba4f7141ee933a017731395ed8cb4ce26f8",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d60beba4f7141ee933a017731395ed8cb4ce26f8",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc2": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc2",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "c7052bf991a65998ce988461cd991cb3c070dca6",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc2",
+      "_shasum": "4cf7ac9ba81e5934e8ce6e415c61b9d08a2bb0d2",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4cf7ac9ba81e5934e8ce6e415c61b9d08a2bb0d2",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc3": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc3",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "76172b88665e737e76568d492f210fd6b090f5fd",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc3",
+      "_shasum": "2e482317be1ddc0cfa26634e87ab3f34e065ad82",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2e482317be1ddc0cfa26634e87ab3f34e065ad82",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc4": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc4",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "5806366d50e3b41d2f258feb9ce7eaa45bdf54d4",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc4",
+      "_shasum": "f77bb02278ba6894bf7d12feeeec08efe68cc652",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f77bb02278ba6894bf7d12feeeec08efe68cc652",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc5": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc5",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "03fd3487b4acb88f4b3b006869da775f2f2edad7",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc5",
+      "_shasum": "cc8b2e6cdbde505361ce0ffaa9e782c11850ee36",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cc8b2e6cdbde505361ce0ffaa9e782c11850ee36",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc5.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc6": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc6",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "1d03b2b7f807d764ffaa35a686a4f9eaafc88033",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc6",
+      "_shasum": "8a95c12d8ff916030d7564c9569a741e4805901d",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8a95c12d8ff916030d7564c9569a741e4805901d",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc6.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc7": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc7",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "a1691b5d67c4777c2de77a73d078bf391cdb1247",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc7",
+      "_shasum": "931671f201b8a348f165df57cd570bac13c462a1",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "931671f201b8a348f165df57cd570bac13c462a1",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc7.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc8": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc8",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "fd4c430cc0e6522415c530042ca8de4d54fa705c",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc8",
+      "_shasum": "f7734257c01bdd04be3803237209d41702775574",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f7734257c01bdd04be3803237209d41702775574",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc8.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0-rc9": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc9",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "fb3f926729a3596c9612442942cc3aafe303f163",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0-rc9",
+      "_shasum": "3cbd15060643a214c3c804e82b9c7cc57f2614aa",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3cbd15060643a214c3c804e82b9c7cc57f2614aa",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc9.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "spdy-transport",
+      "version": "1.0.0",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "ad0dfe573557a766c964eecef1e8b08ea5366042",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.0",
+      "_shasum": "7c703341b92487903257d043b7af35da6733c0da",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7c703341b92487903257d043b7af35da6733c0da",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "spdy-transport",
+      "version": "1.0.1",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "8a907e5e05df0a056152ed52349c5e68a0c70cd8",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.1",
+      "_shasum": "135b7bd6100f680f58af09abb53a5e73d82834f3",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "135b7bd6100f680f58af09abb53a5e73d82834f3",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "spdy-transport",
+      "version": "1.0.2",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "3ef9e423736535ed232bec2555e14170701afab9",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.0.2",
+      "_shasum": "527bde799497c6b5cedcdc1803636ab6d5c8e3ab",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "527bde799497c6b5cedcdc1803636ab6d5c8e3ab",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "spdy-transport",
+      "version": "1.1.0",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "3e270c57feb9795d00e0e122c0ef2c6c7b47fb38",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.0",
+      "_shasum": "7e05a263cd0861171437f6ab0704be693b63bdce",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e05a263cd0861171437f6ab0704be693b63bdce",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "spdy-transport",
+      "version": "1.1.1",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "73b3ec6f2ad623b4248f021c5c159ef1d7566e3d",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.1",
+      "_shasum": "7b9a1e0cd8224330466858443c3e14da8d414ade",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7b9a1e0cd8224330466858443c3e14da8d414ade",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "spdy-transport",
+      "version": "1.1.2",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "12fdddd1e2e4d4dc536507606379cdeb9afa75bc",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.2",
+      "_shasum": "fc107dfaacaec8e74783b2a80aaab0d753032e2c",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fc107dfaacaec8e74783b2a80aaab0d753032e2c",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "spdy-transport",
+      "version": "1.1.3",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "54c191cdbc2cb1c353301c7626d3d26d9721d08a",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.3",
+      "_shasum": "cc44afdcf0ed5589a5bb85f83eca529f410e095a",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cc44afdcf0ed5589a5bb85f83eca529f410e095a",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "spdy-transport",
+      "version": "1.1.4",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "23d1569cefa633660dfa9bb9d9d31bc78d5288b5",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.4",
+      "_shasum": "9eee0c0e481e0d2b3d347919ce09cbcb07eadf70",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9eee0c0e481e0d2b3d347919ce09cbcb07eadf70",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "spdy-transport",
+      "version": "1.1.5",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "54b0a753410ab47f5db4bc7604c2a545e179e6a1",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.5",
+      "_shasum": "169f1ec57aad85d7e70e358cf98d5a1212f6e5dc",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "169f1ec57aad85d7e70e358cf98d5a1212f6e5dc",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.6": {
+      "name": "spdy-transport",
+      "version": "1.1.6",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "cef8bdd943b029deae34a196c3d77e9bcae8b1d8",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.6",
+      "_shasum": "8f9b25fab0cc2d7ae3b3d6bb009f5498540c14d4",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8f9b25fab0cc2d7ae3b3d6bb009f5498540c14d4",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.7": {
+      "name": "spdy-transport",
+      "version": "1.1.7",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "56a6d8804f570646079a02067dba6c683206d476",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.7",
+      "_shasum": "3ea0e27ce5aef40f3ee95a73a9289a37dda29dde",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3ea0e27ce5aef40f3ee95a73a9289a37dda29dde",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.8": {
+      "name": "spdy-transport",
+      "version": "1.1.8",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "5611b813c0826530a798cd9108f2d45dc6d7e72a",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.8",
+      "_shasum": "4378d947ff5aeedd2779f57eeeb1a40fdffb48cb",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4378d947ff5aeedd2779f57eeeb1a40fdffb48cb",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.9": {
+      "name": "spdy-transport",
+      "version": "1.1.9",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "00156fae1d434a815ca1c63f5008bd7624045fcf",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.9",
+      "_shasum": "260e86fbc57e5d89dcc27703388117157e24301d",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "260e86fbc57e5d89dcc27703388117157e24301d",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.9.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.10": {
+      "name": "spdy-transport",
+      "version": "1.1.10",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "b053619262c88844bdeb5c4c7bfe3248fb305b88",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.10",
+      "_shasum": "5432831a822ba24e1251a310f9fa3571b10b51d9",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5432831a822ba24e1251a310f9fa3571b10b51d9",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.10.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.11": {
+      "name": "spdy-transport",
+      "version": "1.1.11",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "2437a9da1bff43f2f022de64908597f4cc44f128",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.1.11",
+      "_shasum": "bd0574bf781079fd77af755582500018199cc331",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "bd0574bf781079fd77af755582500018199cc331",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.11.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "spdy-transport",
+      "version": "1.2.0",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "11decd41edc9930eeb26bb31f2a55e01eeab3f46",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.2.0",
+      "_shasum": "f129a8f8fae3f678e5dbd82e0c76f2365ee5f8c8",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "f129a8f8fae3f678e5dbd82e0c76f2365ee5f8c8",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "spdy-transport",
+      "version": "1.2.1",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "c81973754c2d6a419087f358f3d53b3d0aa39c1f",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@1.2.1",
+      "_shasum": "efefa742b1c7cbe75236b3db0c69b2d5fe40fc07",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "efefa742b1c7cbe75236b3db0c69b2d5fe40fc07",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "spdy-transport",
+      "version": "2.0.0",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "72d5945dd2d2daec75d955a3d7386403acc54b01",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.0",
+      "_shasum": "51c228e51d69af22f25bd79d26d573ade959cbd5",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "51c228e51d69af22f25bd79d26d573ade959cbd5",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "spdy-transport",
+      "version": "2.0.1",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "74020b0fd2e0985d99abcc129f737752a19ee989",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.1",
+      "_shasum": "6640de811ed21b662ef3aaea7edd016c634034c3",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "6640de811ed21b662ef3aaea7edd016c634034c3",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "spdy-transport",
+      "version": "2.0.2",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "5d3628f63c9d7e3f6267876bea1114ccd70829ca",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.2",
+      "_shasum": "f3269021464caa092c9d6947609da5bb344c6ee5",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "f3269021464caa092c9d6947609da5bb344c6ee5",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "spdy-transport",
+      "version": "2.0.3",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "c2a9b676fe88e25b78757d9b01fb5860007c0aa4",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.3",
+      "_shasum": "a7d023aaca1897cf3169cdcb81a05ccd7061917f",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "a7d023aaca1897cf3169cdcb81a05ccd7061917f",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "spdy-transport",
+      "version": "2.0.4",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "014038c9e85c1a1f9fa680cf51cdfd059f40cb4b",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.4",
+      "_shasum": "a67f1469cd75839593ddf61a4c32ba7d6f80c06d",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "a67f1469cd75839593ddf61a4c32ba7d6f80c06d",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.5": {
+      "name": "spdy-transport",
+      "version": "2.0.5",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "134d49f56d283f2857d8750e481de6b7a93c3dd7",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.5",
+      "_shasum": "a63586c4d7ea6f3a1236dc4a21198fb6ce1b7e17",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "a63586c4d7ea6f3a1236dc4a21198fb6ce1b7e17",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.6": {
+      "name": "spdy-transport",
+      "version": "2.0.6",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "f29c595c04d12210583be81c41e93ea2a5070357",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.6",
+      "_shasum": "5b82c4ad17641a9c45c9b25bd0149f8cf5756112",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "5b82c4ad17641a9c45c9b25bd0149f8cf5756112",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.7": {
+      "name": "spdy-transport",
+      "version": "2.0.7",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "d321ee04a6fba4947160563459e601fc57b040a3",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.7",
+      "_shasum": "54c59652ebe16c7de916147603a36ddaefdf990f",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "54c59652ebe16c7de916147603a36ddaefdf990f",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.8": {
+      "name": "spdy-transport",
+      "version": "2.0.8",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "a85dd735e1ddb397cc7238e99b41994ce0858581",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.8",
+      "_shasum": "e39b009acd2054e7d2cf7e619db8632b59b25a02",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "e39b009acd2054e7d2cf7e619db8632b59b25a02",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.9": {
+      "name": "spdy-transport",
+      "version": "2.0.9",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "01084f12dcc8a2b3176c86b40da6abb0a40f9392",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.9",
+      "_shasum": "a379dfcf10a120af0c88d85b7771d8e72905cfc1",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "a379dfcf10a120af0c88d85b7771d8e72905cfc1",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.10": {
+      "name": "spdy-transport",
+      "version": "2.0.10",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "aa2d889f7b49d6f6b52ed6979fcb236f6662eb39",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.10",
+      "_shasum": "b2a15769880c576996263b12a1544097de728027",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "b2a15769880c576996263b12a1544097de728027",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.11": {
+      "name": "spdy-transport",
+      "version": "2.0.11",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "3301030669bc4bc406fc8aa2caca15795f53f660",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.11",
+      "_shasum": "16f844759dcddf39fa37a1ba800b43bedcf8dd1e",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "16f844759dcddf39fa37a1ba800b43bedcf8dd1e",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.11.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-transport-2.0.11.tgz_1463600955672_0.0656150165013969"
+      },
+      "directories": {}
+    },
+    "2.0.12": {
+      "name": "spdy-transport",
+      "version": "2.0.12",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "258bf4b009381233c94cba536ac685d4924b2fbf",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.12",
+      "_shasum": "2553ad0c6b87d4179ebe871b0c443201e4b12139",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "2553ad0c6b87d4179ebe871b0c443201e4b12139",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.12.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-transport-2.0.12.tgz_1470098958150_0.9737411784008145"
+      },
+      "directories": {}
+    },
+    "2.0.13": {
+      "name": "spdy-transport",
+      "version": "2.0.13",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "f82aa7539bb229519eebdf3c7db983ba6f4cc344",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.13",
+      "_shasum": "0bbccfdeb17dd4d088976a1e608e715e03d17ba1",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "0bbccfdeb17dd4d088976a1e608e715e03d17ba1",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.13.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-transport-2.0.13.tgz_1471513527302_0.14695241721346974"
+      },
+      "directories": {}
+    },
+    "2.0.14": {
+      "name": "spdy-transport",
+      "version": "2.0.14",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "8bb0b80dbef87da21a40a88f642259528638daff",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.14",
+      "_shasum": "0cdd8c950888d38efa9bb6a01d305f840cdd4ddb",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "0cdd8c950888d38efa9bb6a01d305f840cdd4ddb",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.14.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-transport-2.0.14.tgz_1471630788750_0.8458907129243016"
+      },
+      "directories": {}
+    },
+    "2.0.15": {
+      "name": "spdy-transport",
+      "version": "2.0.15",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "f6acc88127c9aa0b5fbd827b348c1d9941c4f158",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.15",
+      "_shasum": "10bd739d18973f00e1d1071d0c2bce8020f51207",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "10bd739d18973f00e1d1071d0c2bce8020f51207",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.15.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-transport-2.0.15.tgz_1474223606292_0.9088348380755633"
+      },
+      "directories": {}
+    },
+    "2.0.17": {
+      "name": "spdy-transport",
+      "version": "2.0.17",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "074cb8e134b14d73415375784361f84ae7feae35",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.17",
+      "_shasum": "94376f85a7aaabf9e6edb6bd2f11ee26359be5b5",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "94376f85a7aaabf9e6edb6bd2f11ee26359be5b5",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.17.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-transport-2.0.17.tgz_1477875418010_0.01618213765323162"
+      },
+      "directories": {}
+    },
+    "2.0.18": {
+      "name": "spdy-transport",
+      "version": "2.0.18",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/spdy-transport.git"
+      },
+      "homepage": "https://github.com/indutny/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/**/*.js && jshint lib/**/*.js && mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "main": "./lib/spdy-transport",
+      "gitHead": "0bc70336508388ff5d111fd5027d3c31a56c7875",
+      "bugs": {
+        "url": "https://github.com/indutny/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.18",
+      "_shasum": "43fc9c56be2cccc12bb3e2754aa971154e836ea6",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "7.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "43fc9c56be2cccc12bb3e2754aa971154e836ea6",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.18.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-transport-2.0.18.tgz_1479933280126_0.23772102943621576"
+      },
+      "directories": {}
+    },
+    "2.0.19": {
+      "name": "spdy-transport",
+      "version": "2.0.19",
+      "main": "lib/spdy-transport",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/spdy-http2/spdy-transport.git"
+      },
+      "homepage": "https://github.com/spdy-http2/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.6.8",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "devDependencies": {
+        "async": "^2.4.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2",
+        "stream-pair": "^1.0.3"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "gitHead": "08892e98b6f8dd09a301240c760c4d5a0fc89068",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.19",
+      "_shasum": "f4bb95424296cd52927485ddd88a821682f196eb",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "daviddias.p@gmail.com"
+      },
+      "dist": {
+        "shasum": "f4bb95424296cd52927485ddd88a821682f196eb",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.19.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "daviddias",
+          "email": "daviddias.p@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy-transport-2.0.19.tgz_1495507980719_0.15188046684488654"
+      },
+      "directories": {}
+    },
+    "2.0.20": {
+      "name": "spdy-transport",
+      "version": "2.0.20",
+      "main": "lib/spdy-transport",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/spdy-http2/spdy-transport.git"
+      },
+      "homepage": "https://github.com/spdy-http2/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "devDependencies": {
+        "async": "^2.4.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2",
+        "stream-pair": "^1.0.3"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "gitHead": "0438165a1e08b4b72dd803721698f5b7c4545c21",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.0.20",
+      "_shasum": "735e72054c486b2354fe89e702256004a39ace4d",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "daviddias.p@gmail.com"
+      },
+      "dist": {
+        "shasum": "735e72054c486b2354fe89e702256004a39ace4d",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "daviddias",
+          "email": "daviddias.p@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy-transport-2.0.20.tgz_1495658194853_0.4438294831197709"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "spdy-transport",
+      "version": "2.1.0",
+      "main": "lib/spdy-transport",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/spdy-http2/spdy-transport.git"
+      },
+      "homepage": "https://github.com/spdy-http2/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "devDependencies": {
+        "async": "^2.4.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2",
+        "stream-pair": "^1.0.3"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "gitHead": "db622a5913324f74b11c03dd9ae8769a7964a107",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.1.0",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "daviddias.p@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+        "shasum": "4bbb15aaffed0beefdd56ad61dbdc8ba3e2cb7a1",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
+        "fileCount": 26,
+        "unpackedSize": 139551
+      },
+      "maintainers": [
+        {
+          "email": "daviddias.p@gmail.com",
+          "name": "daviddias"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "rauchg@gmail.com",
+          "name": "rauchg"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy-transport_2.1.0_1521655187928_0.6744279531580166"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.1.1": {
+      "name": "spdy-transport",
+      "version": "2.1.1",
+      "main": "lib/spdy-transport",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/spdy-http2/spdy-transport.git"
+      },
+      "homepage": "https://github.com/spdy-http2/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "devDependencies": {
+        "async": "^2.4.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2",
+        "stream-pair": "^1.0.3"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "gitHead": "c8205a7d583bd5b330ca873cee04ee90bee0fbbb",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@2.1.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "mail@daviddias.me"
+      },
+      "dist": {
+        "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+        "shasum": "c54815d73858aadd06ce63001e7d25fa6441623b",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
+        "fileCount": 26,
+        "unpackedSize": 139571,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb3KvrCRA9TVsSAnZWagAAFdQP/2OjdEGfMHulQmY8dX1T\n2vdKuR9olD1Ut8JhsDcR6zwG9eiR8lq6QRvpcNPIdp58JykPj3zbQ+1xw/wI\nv0/epl+Pj/sqGsc1MdgoZmKMZBPOH0+dND5Wpis7FjmgmCYGKsEiVEkismla\nO7qwZkCZVEgS314/BQg9hVXudRV3PBn6W4BPJL8+MfcBgICxbHMHwKivQG25\n20l7UPAuFwcvEvYu7YPBRitl3U2nmO8B0D0vTslX2NuI7f7Zuvst5VfOJ0QD\nrb2zMdrBd2Sb7J9QWbQqH+psVMZuZ15R7Gk6otZA5Xe/0s9hTCqHUkVnvWDt\nuMOaxt/KKSyQ9tJj1JneYFMh9Fa2Gdh/B/D8VT9ycH4+b1TqDqjSa0l+4zCH\nA4pIiokUaw5jJ4T4e5S7ezCUZd9hUmnsXM5Ww74TSFR0sBjhejkELGN/ZPFk\nbhW+cMYmQi6MKhGBDOdMHf6SFn/pdRfCD2yDYc/P5j9AVSkS4Jr4hzTjNBhO\nn6GO5kY9mHcmnTT68bT6oEw+oYR+6O+8tdlIOWzH8Ln+Zg0l2neemypgft+j\nDxNVAi6vn+pUc8zGcky1fOvKq2zqTMCQIzjkwnycrKXOYAANmZYzYoIJE857\nOeqcZLAjQsYdXcRpFCDbZe+W4VrIM12+ZMdQ+M/duusgJex/wtEKSv0X3lzR\nR3qY\r\n=6qwa\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "daviddias.p@gmail.com",
+          "name": "daviddias"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "rauchg@gmail.com",
+          "name": "rauchg"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy-transport_2.1.1_1541188586648_0.6568124334384773"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "spdy-transport",
+      "version": "3.0.0",
+      "main": "lib/spdy-transport",
+      "description": "SPDY v2, v3, v3.1 and HTTP2 transport",
+      "license": "MIT",
+      "keywords": [
+        "spdy",
+        "http2",
+        "transport"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/spdy-http2/spdy-transport.git"
+      },
+      "homepage": "https://github.com/spdy-http2/spdy-transport",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dependencies": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      },
+      "devDependencies": {
+        "async": "^2.6.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2",
+        "standard": "^12.0.1",
+        "stream-pair": "^1.0.3"
+      },
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/**/*-test.js test/**/**/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js test/**/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "gitHead": "f177937e614db6b53bebb10976e4055ecbfc767f",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/spdy-transport/issues"
+      },
+      "_id": "spdy-transport@3.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "mail@daviddias.me"
+      },
+      "dist": {
+        "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+        "shasum": "00d4863a6400ad75df93361a1608605e5dcdcf31",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+        "fileCount": 26,
+        "unpackedSize": 136272,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4+EFCRA9TVsSAnZWagAAa/wP/2T4Ugd6mJhTwt+4wufd\nlT71gH0+Azxfu9H4SVAZLOCWBuKhQUf3YD1GVyDa2Hni4N3jzVltSMSfxzxS\nbzC5SDjFfRAjsEigdkmgbnZWJCyW30qbFWq+d2+k/6KW2+5ojRqnF+7/Zrpm\nM/idP1vNUAWFF3LSpcCxoEdLHfDb/rqFwjjrvF2iHKPQQyo8jwZlAHE8oRm0\nF0cjxmTAh9Ls8fpywpn7WX2WO0nQgIW/ci8Xv4+emkNWm1PCjSgmjp63bMXy\nTVrUr4AQgLMQQMZHc8iJF3birGy4uWFGBxAuf4HnGXLOU/yQXI7Wd174Kd9f\n9//kVcshlsRkEpDduqfbypFHadhkFSJtFGHfjzRpMA/lQ0OVPi6xSpaTa67d\nWBIzUGpxeX3/2NHYWF33KK3uRYvOpFUfDGkdBsn+p/L/MhiWTRXEPOOIAKoE\nxLCRmlYOFy8Mag0vzNHdPMF6iO4ZHOAJyAUAnDFmDkXgMjqkHQ5p6gGiu3Cq\n5EPStg23KQzgD+WgtdMaU0o6ugrYnH0aWMPEUIjF1+e15wecg1ZE8V4yAKho\nnmE+DnSPdIDmR8S4brn1DcYl/cC6YE2fWoYi715k2vLJ9SA6QZjhroH1G8qq\n3ON3Ctbay6fPoj2BsFYo5TT8m0dcl+gAUixZbKsKRGyObnlXw2icngzkkSLw\nXk3n\r\n=QooX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "daviddias.p@gmail.com",
+          "name": "daviddias"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "rauchg@gmail.com",
+          "name": "rauchg"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy-transport_3.0.0_1541660933221_0.2206460869146074"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# spdy-transport\n\n[![Build Status](https://travis-ci.org/spdy-http2/spdy-transport.svg?branch=master)](http://travis-ci.org/spdy-http2/spdy-transport)\n[![NPM version](https://badge.fury.io/js/spdy-transport.svg)](http://badge.fury.io/js/spdy-transport)\n[![dependencies Status](https://david-dm.org/spdy-http2/spdy-transport/status.svg?style=flat-square)](https://david-dm.org/spdy-http2/spdy-transport)\n[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)\n[![Waffle](https://img.shields.io/badge/track-waffle-blue.svg?style=flat-square)](https://waffle.io/spdy-http2/node-spdy)\n\n> SPDY/HTTP2 generic transport implementation.\n\n## Usage\n\n```javascript\nvar transport = require('spdy-transport');\n\n// NOTE: socket is some stream or net.Socket instance, may be an argument\n// of `net.createServer`'s connection handler.\n\nvar server = transport.connection.create(socket, {\n  protocol: 'http2',\n  isServer: true\n});\n\nserver.on('stream', function(stream) {\n  console.log(stream.method, stream.path, stream.headers);\n  stream.respond(200, {\n    header: 'value'\n  });\n\n  stream.on('readable', function() {\n    var chunk = stream.read();\n    if (!chunk)\n      return;\n\n    console.log(chunk);\n  });\n\n  stream.on('end', function() {\n    console.log('end');\n  });\n\n  // And other node.js Stream APIs\n  // ...\n});\n```\n\n## LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2015.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n\n[0]: http://json.org/\n[1]: http://github.com/indutny/bud-backend\n[2]: https://github.com/nodejs/io.js\n[3]: https://github.com/libuv/libuv\n[4]: http://openssl.org/\n",
+  "maintainers": [
+    {
+      "email": "daviddias.p@gmail.com",
+      "name": "daviddias"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "rauchg@gmail.com",
+      "name": "rauchg"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-05T12:59:46.139Z",
+    "created": "2015-06-21T01:09:26.593Z",
+    "1.0.0-dev": "2015-06-21T01:09:26.593Z",
+    "1.0.0-rc1": "2015-07-01T22:57:38.115Z",
+    "1.0.0-rc2": "2015-07-06T22:24:00.530Z",
+    "1.0.0-rc3": "2015-07-08T04:19:23.207Z",
+    "1.0.0-rc4": "2015-07-10T05:12:43.112Z",
+    "1.0.0-rc5": "2015-07-12T06:44:18.418Z",
+    "1.0.0-rc6": "2015-07-13T03:09:36.571Z",
+    "1.0.0-rc7": "2015-07-13T21:20:30.326Z",
+    "1.0.0-rc8": "2015-07-15T05:56:22.624Z",
+    "1.0.0-rc9": "2015-07-15T20:40:29.091Z",
+    "1.0.0": "2015-07-16T00:52:10.936Z",
+    "1.0.1": "2015-07-16T00:55:42.958Z",
+    "1.0.2": "2015-07-17T02:56:31.827Z",
+    "1.1.0": "2015-07-22T20:01:30.757Z",
+    "1.1.1": "2015-08-11T03:57:13.555Z",
+    "1.1.2": "2015-08-11T08:00:59.465Z",
+    "1.1.3": "2015-08-12T04:14:11.464Z",
+    "1.1.4": "2015-08-13T01:06:11.654Z",
+    "1.1.5": "2015-08-13T04:08:01.975Z",
+    "1.1.6": "2015-08-13T04:27:01.189Z",
+    "1.1.7": "2015-08-13T18:02:46.543Z",
+    "1.1.8": "2015-08-17T17:39:21.011Z",
+    "1.1.9": "2015-10-14T02:40:22.882Z",
+    "1.1.10": "2015-10-14T16:32:49.184Z",
+    "1.1.11": "2015-11-03T00:40:05.262Z",
+    "1.2.0": "2015-11-09T03:45:38.527Z",
+    "1.2.1": "2015-11-09T04:13:27.307Z",
+    "2.0.0": "2015-11-19T04:55:16.357Z",
+    "2.0.1": "2015-12-01T21:31:11.657Z",
+    "2.0.2": "2015-12-01T22:02:13.892Z",
+    "2.0.3": "2015-12-01T22:19:22.755Z",
+    "2.0.4": "2015-12-05T20:53:52.072Z",
+    "2.0.5": "2016-01-14T10:14:32.230Z",
+    "2.0.6": "2016-01-14T21:13:23.461Z",
+    "2.0.7": "2016-01-19T05:15:06.313Z",
+    "2.0.8": "2016-01-20T05:25:44.824Z",
+    "2.0.9": "2016-01-22T19:01:40.579Z",
+    "2.0.10": "2016-01-25T16:16:14.166Z",
+    "2.0.11": "2016-05-18T19:49:18.163Z",
+    "2.0.12": "2016-08-02T00:49:19.000Z",
+    "2.0.13": "2016-08-18T09:45:29.359Z",
+    "2.0.14": "2016-08-19T18:19:51.212Z",
+    "2.0.15": "2016-09-18T18:33:28.211Z",
+    "2.0.17": "2016-10-31T00:56:58.592Z",
+    "2.0.18": "2016-11-23T20:34:42.153Z",
+    "2.0.19": "2017-05-23T02:53:02.038Z",
+    "2.0.20": "2017-05-24T20:36:36.050Z",
+    "2.1.0": "2018-03-21T17:59:47.995Z",
+    "2.1.1": "2018-11-02T19:56:26.742Z",
+    "3.0.0": "2018-11-08T07:08:53.372Z"
+  },
+  "homepage": "https://github.com/spdy-http2/spdy-transport",
+  "keywords": [
+    "spdy",
+    "http2",
+    "transport"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/spdy-http2/spdy-transport.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/spdy-http2/spdy-transport/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "daviddias": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/spdy-transport.min.json
+++ b/test/fixtures/registry-mocks/content/spdy-transport.min.json
@@ -1,0 +1,1125 @@
+{
+  "name": "spdy-transport",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "1.0.0-dev": {
+      "name": "spdy-transport",
+      "version": "1.0.0-dev",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "cce2034f0d47e6ddae2fff441e1315a33fabe05c",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-dev.tgz"
+      }
+    },
+    "1.0.0-rc1": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "d60beba4f7141ee933a017731395ed8cb4ce26f8",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc1.tgz"
+      }
+    },
+    "1.0.0-rc2": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "4cf7ac9ba81e5934e8ce6e415c61b9d08a2bb0d2",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc2.tgz"
+      }
+    },
+    "1.0.0-rc3": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "2e482317be1ddc0cfa26634e87ab3f34e065ad82",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc3.tgz"
+      }
+    },
+    "1.0.0-rc4": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "f77bb02278ba6894bf7d12feeeec08efe68cc652",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc4.tgz"
+      }
+    },
+    "1.0.0-rc5": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc5",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "cc8b2e6cdbde505361ce0ffaa9e782c11850ee36",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc5.tgz"
+      }
+    },
+    "1.0.0-rc6": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc6",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "8a95c12d8ff916030d7564c9569a741e4805901d",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc6.tgz"
+      }
+    },
+    "1.0.0-rc7": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc7",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "931671f201b8a348f165df57cd570bac13c462a1",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc7.tgz"
+      }
+    },
+    "1.0.0-rc8": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc8",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "f7734257c01bdd04be3803237209d41702775574",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc8.tgz"
+      }
+    },
+    "1.0.0-rc9": {
+      "name": "spdy-transport",
+      "version": "1.0.0-rc9",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "3cbd15060643a214c3c804e82b9c7cc57f2614aa",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0-rc9.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "spdy-transport",
+      "version": "1.0.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "7c703341b92487903257d043b7af35da6733c0da",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "spdy-transport",
+      "version": "1.0.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "135b7bd6100f680f58af09abb53a5e73d82834f3",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "spdy-transport",
+      "version": "1.0.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "527bde799497c6b5cedcdc1803636ab6d5c8e3ab",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "spdy-transport",
+      "version": "1.1.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "7e05a263cd0861171437f6ab0704be693b63bdce",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "spdy-transport",
+      "version": "1.1.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.2",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "7b9a1e0cd8224330466858443c3e14da8d414ade",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "spdy-transport",
+      "version": "1.1.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "fc107dfaacaec8e74783b2a80aaab0d753032e2c",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "spdy-transport",
+      "version": "1.1.3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "cc44afdcf0ed5589a5bb85f83eca529f410e095a",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.3.tgz"
+      }
+    },
+    "1.1.4": {
+      "name": "spdy-transport",
+      "version": "1.1.4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "9eee0c0e481e0d2b3d347919ce09cbcb07eadf70",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.4.tgz"
+      }
+    },
+    "1.1.5": {
+      "name": "spdy-transport",
+      "version": "1.1.5",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "169f1ec57aad85d7e70e358cf98d5a1212f6e5dc",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.5.tgz"
+      }
+    },
+    "1.1.6": {
+      "name": "spdy-transport",
+      "version": "1.1.6",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "8f9b25fab0cc2d7ae3b3d6bb009f5498540c14d4",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.6.tgz"
+      }
+    },
+    "1.1.7": {
+      "name": "spdy-transport",
+      "version": "1.1.7",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "3ea0e27ce5aef40f3ee95a73a9289a37dda29dde",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.7.tgz"
+      }
+    },
+    "1.1.8": {
+      "name": "spdy-transport",
+      "version": "1.1.8",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "4378d947ff5aeedd2779f57eeeb1a40fdffb48cb",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.8.tgz"
+      }
+    },
+    "1.1.9": {
+      "name": "spdy-transport",
+      "version": "1.1.9",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "260e86fbc57e5d89dcc27703388117157e24301d",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.9.tgz"
+      }
+    },
+    "1.1.10": {
+      "name": "spdy-transport",
+      "version": "1.1.10",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "5432831a822ba24e1251a310f9fa3571b10b51d9",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.10.tgz"
+      }
+    },
+    "1.1.11": {
+      "name": "spdy-transport",
+      "version": "1.1.11",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "bd0574bf781079fd77af755582500018199cc331",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.1.11.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "spdy-transport",
+      "version": "1.2.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "f129a8f8fae3f678e5dbd82e0c76f2365ee5f8c8",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "spdy-transport",
+      "version": "1.2.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "efefa742b1c7cbe75236b3db0c69b2d5fe40fc07",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-1.2.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "spdy-transport",
+      "version": "2.0.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "51c228e51d69af22f25bd79d26d573ade959cbd5",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "spdy-transport",
+      "version": "2.0.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "6640de811ed21b662ef3aaea7edd016c634034c3",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "spdy-transport",
+      "version": "2.0.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "f3269021464caa092c9d6947609da5bb344c6ee5",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "spdy-transport",
+      "version": "2.0.3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "a7d023aaca1897cf3169cdcb81a05ccd7061917f",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.3.tgz"
+      }
+    },
+    "2.0.4": {
+      "name": "spdy-transport",
+      "version": "2.0.4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "a67f1469cd75839593ddf61a4c32ba7d6f80c06d",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.4.tgz"
+      }
+    },
+    "2.0.5": {
+      "name": "spdy-transport",
+      "version": "2.0.5",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "a63586c4d7ea6f3a1236dc4a21198fb6ce1b7e17",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.5.tgz"
+      }
+    },
+    "2.0.6": {
+      "name": "spdy-transport",
+      "version": "2.0.6",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "5b82c4ad17641a9c45c9b25bd0149f8cf5756112",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.6.tgz"
+      }
+    },
+    "2.0.7": {
+      "name": "spdy-transport",
+      "version": "2.0.7",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "54c59652ebe16c7de916147603a36ddaefdf990f",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.7.tgz"
+      }
+    },
+    "2.0.8": {
+      "name": "spdy-transport",
+      "version": "2.0.8",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "e39b009acd2054e7d2cf7e619db8632b59b25a02",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.8.tgz"
+      }
+    },
+    "2.0.9": {
+      "name": "spdy-transport",
+      "version": "2.0.9",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "a379dfcf10a120af0c88d85b7771d8e72905cfc1",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.9.tgz"
+      }
+    },
+    "2.0.10": {
+      "name": "spdy-transport",
+      "version": "2.0.10",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "b2a15769880c576996263b12a1544097de728027",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.10.tgz"
+      }
+    },
+    "2.0.11": {
+      "name": "spdy-transport",
+      "version": "2.0.11",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "16f844759dcddf39fa37a1ba800b43bedcf8dd1e",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.11.tgz"
+      }
+    },
+    "2.0.12": {
+      "name": "spdy-transport",
+      "version": "2.0.12",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "2553ad0c6b87d4179ebe871b0c443201e4b12139",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.12.tgz"
+      }
+    },
+    "2.0.13": {
+      "name": "spdy-transport",
+      "version": "2.0.13",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "0bbccfdeb17dd4d088976a1e608e715e03d17ba1",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.13.tgz"
+      }
+    },
+    "2.0.14": {
+      "name": "spdy-transport",
+      "version": "2.0.14",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.4",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "0cdd8c950888d38efa9bb6a01d305f840cdd4ddb",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.14.tgz"
+      }
+    },
+    "2.0.15": {
+      "name": "spdy-transport",
+      "version": "2.0.15",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "10bd739d18973f00e1d1071d0c2bce8020f51207",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.15.tgz"
+      }
+    },
+    "2.0.17": {
+      "name": "spdy-transport",
+      "version": "2.0.17",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "94376f85a7aaabf9e6edb6bd2f11ee26359be5b5",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.17.tgz"
+      }
+    },
+    "2.0.18": {
+      "name": "spdy-transport",
+      "version": "2.0.18",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.4.0"
+      },
+      "devDependencies": {
+        "async": "^1.2.1",
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.5",
+        "stream-pair": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "43fc9c56be2cccc12bb3e2754aa971154e836ea6",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.18.tgz"
+      }
+    },
+    "2.0.19": {
+      "name": "spdy-transport",
+      "version": "2.0.19",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "devDependencies": {
+        "async": "^2.4.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "shasum": "f4bb95424296cd52927485ddd88a821682f196eb",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.19.tgz"
+      }
+    },
+    "2.0.20": {
+      "name": "spdy-transport",
+      "version": "2.0.20",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "devDependencies": {
+        "async": "^2.4.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "shasum": "735e72054c486b2354fe89e702256004a39ace4d",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "spdy-transport",
+      "version": "2.1.0",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "devDependencies": {
+        "async": "^2.4.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+        "shasum": "4bbb15aaffed0beefdd56ad61dbdc8ba3e2cb7a1",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
+        "fileCount": 26,
+        "unpackedSize": 139551
+      }
+    },
+    "2.1.1": {
+      "name": "spdy-transport",
+      "version": "2.1.1",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
+      },
+      "devDependencies": {
+        "async": "^2.4.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
+        "shasum": "c54815d73858aadd06ce63001e7d25fa6441623b",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
+        "fileCount": 26,
+        "unpackedSize": 139571,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb3KvrCRA9TVsSAnZWagAAFdQP/2OjdEGfMHulQmY8dX1T\n2vdKuR9olD1Ut8JhsDcR6zwG9eiR8lq6QRvpcNPIdp58JykPj3zbQ+1xw/wI\nv0/epl+Pj/sqGsc1MdgoZmKMZBPOH0+dND5Wpis7FjmgmCYGKsEiVEkismla\nO7qwZkCZVEgS314/BQg9hVXudRV3PBn6W4BPJL8+MfcBgICxbHMHwKivQG25\n20l7UPAuFwcvEvYu7YPBRitl3U2nmO8B0D0vTslX2NuI7f7Zuvst5VfOJ0QD\nrb2zMdrBd2Sb7J9QWbQqH+psVMZuZ15R7Gk6otZA5Xe/0s9hTCqHUkVnvWDt\nuMOaxt/KKSyQ9tJj1JneYFMh9Fa2Gdh/B/D8VT9ycH4+b1TqDqjSa0l+4zCH\nA4pIiokUaw5jJ4T4e5S7ezCUZd9hUmnsXM5Ww74TSFR0sBjhejkELGN/ZPFk\nbhW+cMYmQi6MKhGBDOdMHf6SFn/pdRfCD2yDYc/P5j9AVSkS4Jr4hzTjNBhO\nn6GO5kY9mHcmnTT68bT6oEw+oYR+6O+8tdlIOWzH8Ln+Zg0l2neemypgft+j\nDxNVAi6vn+pUc8zGcky1fOvKq2zqTMCQIzjkwnycrKXOYAANmZYzYoIJE857\nOeqcZLAjQsYdXcRpFCDbZe+W4VrIM12+ZMdQ+M/duusgJex/wtEKSv0X3lzR\nR3qY\r\n=6qwa\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.0.0": {
+      "name": "spdy-transport",
+      "version": "3.0.0",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      },
+      "devDependencies": {
+        "async": "^2.6.1",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2",
+        "standard": "^12.0.1",
+        "stream-pair": "^1.0.3"
+      },
+      "dist": {
+        "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+        "shasum": "00d4863a6400ad75df93361a1608605e5dcdcf31",
+        "tarball": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+        "fileCount": 26,
+        "unpackedSize": 136272,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4+EFCRA9TVsSAnZWagAAa/wP/2T4Ugd6mJhTwt+4wufd\nlT71gH0+Azxfu9H4SVAZLOCWBuKhQUf3YD1GVyDa2Hni4N3jzVltSMSfxzxS\nbzC5SDjFfRAjsEigdkmgbnZWJCyW30qbFWq+d2+k/6KW2+5ojRqnF+7/Zrpm\nM/idP1vNUAWFF3LSpcCxoEdLHfDb/rqFwjjrvF2iHKPQQyo8jwZlAHE8oRm0\nF0cjxmTAh9Ls8fpywpn7WX2WO0nQgIW/ci8Xv4+emkNWm1PCjSgmjp63bMXy\nTVrUr4AQgLMQQMZHc8iJF3birGy4uWFGBxAuf4HnGXLOU/yQXI7Wd174Kd9f\n9//kVcshlsRkEpDduqfbypFHadhkFSJtFGHfjzRpMA/lQ0OVPi6xSpaTa67d\nWBIzUGpxeX3/2NHYWF33KK3uRYvOpFUfDGkdBsn+p/L/MhiWTRXEPOOIAKoE\nxLCRmlYOFy8Mag0vzNHdPMF6iO4ZHOAJyAUAnDFmDkXgMjqkHQ5p6gGiu3Cq\n5EPStg23KQzgD+WgtdMaU0o6ugrYnH0aWMPEUIjF1+e15wecg1ZE8V4yAKho\nnmE+DnSPdIDmR8S4brn1DcYl/cC6YE2fWoYi715k2vLJ9SA6QZjhroH1G8qq\n3ON3Ctbay6fPoj2BsFYo5TT8m0dcl+gAUixZbKsKRGyObnlXw2icngzkkSLw\nXk3n\r\n=QooX\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-01-05T12:59:46.139Z"
+}

--- a/test/fixtures/registry-mocks/content/spdy.json
+++ b/test/fixtures/registry-mocks/content/spdy.json
@@ -1,0 +1,16534 @@
+{
+  "_id": "spdy",
+  "_rev": "521-c0079f1cc473359237c11cd1c18e84eb",
+  "name": "spdy",
+  "description": "Implementation of the SPDY protocol on node.js.",
+  "dist-tags": {
+    "stable": "1.14.9",
+    "unstable": "1.3.0",
+    "latest": "4.0.2"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "spdy",
+      "description": "...",
+      "version": "0.0.1",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "dependencies": {
+        "zlibcontext": ">= 1.0.4"
+      },
+      "engine": [
+        "node >= 0.4.0"
+      ],
+      "main": "./lib/spdy",
+      "_id": "spdy@0.0.1",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "0.3.18",
+      "_nodeVersion": "v0.4.5",
+      "directories": {
+        "lib": "./lib"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "716b9a383fd06b5d1ca8beaecca59a0afde1555c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.0.1.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "spdy",
+      "description": "...",
+      "version": "0.1.0",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "dependencies": {
+        "zlibcontext": ">= 1.0.4"
+      },
+      "engine": [
+        "node >= 0.5.0-pre"
+      ],
+      "main": "./lib/spdy",
+      "_npmJsonOpts": {
+        "file": "/home/donnerjack13589/.npm/spdy/0.1.0/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "spdy@0.1.0",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "933b8c75cd10d7e253737a19fc1277ea4b16bd92",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.1.0.tgz"
+      },
+      "scripts": {},
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "spdy",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "version": "0.1.1",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "dependencies": {
+        "zlibcontext": ">= 1.0.4"
+      },
+      "engine": [
+        "node >= 0.5.0-pre"
+      ],
+      "main": "./lib/spdy",
+      "_npmJsonOpts": {
+        "file": "/home/donnerjack13589/.npm/spdy/0.1.1/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "spdy@0.1.1",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.13",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "644370755e15a420fbaae5bae22f31d780fe37c0",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.1.1.tgz"
+      },
+      "scripts": {},
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "spdy",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "version": "0.1.2",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "dependencies": {
+        "zlibcontext": ">= 1.0.4"
+      },
+      "engine": [
+        "node >= 0.5.x"
+      ],
+      "main": "./lib/spdy",
+      "_npmJsonOpts": {
+        "file": "/home/indutny/.npm/spdy/0.1.2/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "spdy@0.1.2",
+      "devDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.18",
+      "_nodeVersion": "v0.4.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "93bceaa7539b2c1e616d001bb1adb5ee098d4a34",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.1.2.tgz"
+      },
+      "scripts": {},
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "spdy",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "version": "0.1.4",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "dependencies": {
+        "zlibcontext": "~ 1.0.9"
+      },
+      "engines": [
+        "node >= 0.6.0"
+      ],
+      "main": "./lib/spdy",
+      "devDependencies": {},
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "_id": "spdy@0.1.4",
+      "_engineSupported": false,
+      "_npmVersion": "1.0.103",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "4584bfc76f7b2c6189b1e08c003c5a4c64c273cf",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.1.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "spdy",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        }
+      ],
+      "dependencies": {},
+      "engines": [
+        "node ~ 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "devDependencies": {},
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "_id": "spdy@1.0.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.7.0-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "ab243436f363fc6654b668fc3dd7b64d733bee9d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "spdy",
+      "version": "1.1.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "0.8.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node ~ 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "_id": "spdy@1.1.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.7.0-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "55bd0603722198f592948e00739b21c78f59f572",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "spdy",
+      "version": "1.2.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "0.8.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node ~ 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "_id": "spdy@1.2.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-beta-4",
+      "_nodeVersion": "v0.7.0-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "17896d7c8f31720646a0ea3adbdfe22205f78e91",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "spdy",
+      "version": "1.2.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.2.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "_id": "spdy@1.2.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.0-2",
+      "_nodeVersion": "v0.8.0-pre",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "187ae05f4bb8ca2580d13b6d639faeeb2c7be3fd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "spdy",
+      "version": "1.3.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.0",
+      "dist": {
+        "shasum": "270ae4b763cfb0e9878a24c02ba9fbf36b15dc37",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "spdy",
+      "version": "1.3.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.1",
+      "dist": {
+        "shasum": "61208f9220275f6616245a354328ad812287c64c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "spdy",
+      "version": "1.3.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.2",
+      "dist": {
+        "shasum": "7a4511256e6b16a86379e6a02c5d795a518da333",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.3": {
+      "name": "spdy",
+      "version": "1.3.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.3",
+      "dist": {
+        "shasum": "7b46a52baa92d355877dfbf63ccdc845eef19dbf",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.4": {
+      "name": "spdy",
+      "version": "1.3.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.4",
+      "dist": {
+        "shasum": "beb8fbf3b53222e3a450dfd37bbd4d6fafccf7ed",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.4.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.5": {
+      "name": "spdy",
+      "version": "1.3.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.5",
+      "dist": {
+        "shasum": "df99c014c391f13538f7f38bc3f47ca623240b2c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.5.tgz"
+      },
+      "_npmVersion": "1.1.63",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.6": {
+      "name": "spdy",
+      "version": "1.3.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.6",
+      "dist": {
+        "shasum": "760c11a22c4ddbb2abc6061e454eb20c9994dc61",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.6.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.7": {
+      "name": "spdy",
+      "version": "1.3.7",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.7",
+      "dist": {
+        "shasum": "a4d2dbe2866ccc13566eacd8263973e19e8d7bb4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.7.tgz"
+      },
+      "_npmVersion": "1.1.66",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.8": {
+      "name": "spdy",
+      "version": "1.3.8",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.8",
+      "dist": {
+        "shasum": "e112af1e97ff945b239d11df84de0b38fc4ff24c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.8.tgz"
+      },
+      "_npmVersion": "1.1.66",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.9": {
+      "name": "spdy",
+      "version": "1.3.9",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.3.9",
+      "dist": {
+        "shasum": "56b600a297bacb7395f1087dd74454bf72a8781d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.9.tgz"
+      },
+      "_npmVersion": "1.1.66",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "spdy",
+      "version": "1.4.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.4.0",
+      "dist": {
+        "shasum": "99e5a201a09a606eee71d4a97203bae24ef0636c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.0.tgz"
+      },
+      "_npmVersion": "1.1.66",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "spdy",
+      "version": "1.4.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.4.1",
+      "dist": {
+        "shasum": "e31ad69fac0c4bec8efd8ab0c4724cf1932d3fd3",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.2",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.2": {
+      "name": "spdy",
+      "version": "1.4.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.4.2",
+      "dist": {
+        "shasum": "8bc2e4ed23a6ef7fb3c6c5b9ff997b99a8e50f1d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.2.tgz"
+      },
+      "_npmVersion": "1.1.66",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.3": {
+      "name": "spdy",
+      "version": "1.4.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.4.3",
+      "dist": {
+        "shasum": "177123c634158cda84d9151c755e489a2a875a1d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.4": {
+      "name": "spdy",
+      "version": "1.4.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.4.4",
+      "dist": {
+        "shasum": "c3fbf945e86cc8beea08697812664d3fd8b9acf9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.5": {
+      "name": "spdy",
+      "version": "1.4.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.4.5",
+      "dist": {
+        "shasum": "f5a80e5b047021bad2faec7c5d0cf8dd1d84d343",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.6": {
+      "name": "spdy",
+      "version": "1.4.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.4.6",
+      "dist": {
+        "shasum": "e719dd5cd7ff1cd62936e903790cbee052604025",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.12",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "spdy",
+      "version": "1.5.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.5.0",
+      "dist": {
+        "shasum": "732762abe12ca1ce285a413c6a50abb258ce5137",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "spdy",
+      "version": "1.6.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.6.0",
+      "dist": {
+        "shasum": "056dc360fd96ba917e29eea6c756685804398552",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.6.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "spdy",
+      "version": "1.6.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.6.1",
+      "dist": {
+        "shasum": "6f21e1d2fac5c817a42db2966e07aa996d88caa8",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.6.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "spdy",
+      "version": "1.7.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.7.0",
+      "dist": {
+        "shasum": "df32801e7c0c196081cffbc0cc694fce879578cb",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.15",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.7.1": {
+      "name": "spdy",
+      "version": "1.7.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.7.1",
+      "dist": {
+        "shasum": "4fde77e602b20c4ecc39ee8619373dd9bf669152",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.17",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.7.2": {
+      "name": "spdy",
+      "version": "1.7.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.7.2",
+      "dist": {
+        "shasum": "138582a0e01a02445cfd67f842d0f49345e39bc8",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.17",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.7.3": {
+      "name": "spdy",
+      "version": "1.7.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.7.3",
+      "dist": {
+        "shasum": "5502a2641aaf68dc9a6dc1e14533b7018746099d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.3.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.7.4": {
+      "name": "spdy",
+      "version": "1.7.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.7.4",
+      "dist": {
+        "shasum": "1f937bf90c4976b5d33b99db6df5d342e57f39cf",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.4.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.7.5": {
+      "name": "spdy",
+      "version": "1.7.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.7.5",
+      "dist": {
+        "shasum": "b8541fb9824a0e137d3c72fe08bfaad13f172e0a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.5.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.7.6": {
+      "name": "spdy",
+      "version": "1.7.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.7.6",
+      "dist": {
+        "shasum": "3b5e66233f2d396cdd43a662398972faca1bcf0e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "spdy",
+      "version": "1.8.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.0",
+      "dist": {
+        "shasum": "30163b318014b816f3109ad7f3ad6d8bc45f2219",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.1": {
+      "name": "spdy",
+      "version": "1.8.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.1",
+      "dist": {
+        "shasum": "b1791954fdcaf631640b64b4b77973fa91a9486c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.2": {
+      "name": "spdy",
+      "version": "1.8.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.2",
+      "dist": {
+        "shasum": "aa8af98a64bd16e101b5db8cf0af2aeceae01f65",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.3": {
+      "name": "spdy",
+      "version": "1.8.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.3",
+      "dist": {
+        "shasum": "bb90f04a7596e8f024cdf7c8c20c2ca77c12d4ff",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.4": {
+      "name": "spdy",
+      "version": "1.8.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.4",
+      "dist": {
+        "shasum": "6b84c18641953595873f05c8b8aa6fd68e379aed",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.5": {
+      "name": "spdy",
+      "version": "1.8.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.5",
+      "dist": {
+        "shasum": "b6cbeaed9c2ab4c8a3014f164a1ae6dea235bbca",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.6": {
+      "name": "spdy",
+      "version": "1.8.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.6",
+      "dist": {
+        "shasum": "27ab13a32874f6d59fac84aad5175265f1b71c0a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.7": {
+      "name": "spdy",
+      "version": "1.8.7",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.7",
+      "dist": {
+        "shasum": "3ae7314e5634c6ca3ebb426f8ba84fce8801eda9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.8": {
+      "name": "spdy",
+      "version": "1.8.8",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.8",
+      "dist": {
+        "shasum": "024f9bce0ec9a3f5f6895465802fcbbb32506d42",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.9": {
+      "name": "spdy",
+      "version": "1.8.9",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "email": "node-spdy+bugs@indutny.com",
+        "url": "https://github.com/indunty/node-spdy/issues"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.9",
+      "dist": {
+        "shasum": "457ed82c5530cacf04863e3d2cc47e4655453b3d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.10": {
+      "name": "spdy",
+      "version": "1.8.10",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.10",
+      "dist": {
+        "shasum": "7093ba9b6f9689bbcf4472f0e62cda6f8537b511",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.24",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.11": {
+      "name": "spdy",
+      "version": "1.8.11",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.11",
+      "dist": {
+        "shasum": "206a23e2b4b332d6d8b42cfff7ce142e8305b867",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.24",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.12": {
+      "name": "spdy",
+      "version": "1.8.12",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.12",
+      "dist": {
+        "shasum": "76276f60913682a6149adbb52f6caa697249611d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.12.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.25",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.8.13": {
+      "name": "spdy",
+      "version": "1.8.13",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.8.13",
+      "dist": {
+        "shasum": "99b2cbe8b825816eb57b77670835c610ef798aee",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.13.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.25",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.9.0": {
+      "name": "spdy",
+      "version": "1.9.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.9.0",
+      "dist": {
+        "shasum": "b32c6e915eada5c490998769db4154c39c21d4e2",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.9.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.25",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.9.1": {
+      "name": "spdy",
+      "version": "1.9.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.9.1",
+      "dist": {
+        "shasum": "1f9299aff0734bc546a2dd4e6220f9362d7f95be",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.9.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.25",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.0": {
+      "name": "spdy",
+      "version": "1.10.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.0",
+      "dist": {
+        "shasum": "b35f38aa4dfbbf594a40f27edf9d81596bd288e6",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.1": {
+      "name": "spdy",
+      "version": "1.10.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.1",
+      "dist": {
+        "shasum": "f400914dff8b0d6317449d64d734a69d2aca7358",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.2": {
+      "name": "spdy",
+      "version": "1.10.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.2",
+      "dist": {
+        "shasum": "f2cc57195aef2efe8c274703c743e0a910f34343",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.3": {
+      "name": "spdy",
+      "version": "1.10.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.3",
+      "dist": {
+        "shasum": "beef46374311b732588b7f9704521b813bd9aa14",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.4": {
+      "name": "spdy",
+      "version": "1.10.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.4",
+      "dist": {
+        "shasum": "3398a59ea84465f873b39b1b595d2fa8a8047b6d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.5": {
+      "name": "spdy",
+      "version": "1.10.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.5",
+      "dist": {
+        "shasum": "fa8525dbd0a3b09d14562e9fcca980a973e4035c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.6",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.6": {
+      "name": "spdy",
+      "version": "1.10.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.6",
+      "dist": {
+        "shasum": "7ab22b2a81728bca3282315b286f87b32e6fc78c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.7": {
+      "name": "spdy",
+      "version": "1.10.7",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.7",
+      "dist": {
+        "shasum": "aad38fa8eaa8aaae0c5d17bd106150d4ab9aed4c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.8": {
+      "name": "spdy",
+      "version": "1.10.8",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.8",
+      "dist": {
+        "shasum": "c8ab1ddcfd7782c73f438de2958165e485693d59",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.2",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.9": {
+      "name": "spdy",
+      "version": "1.10.9",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.9",
+      "dist": {
+        "shasum": "9b739faf4d786d10e1aec3f45bbc69acd210534c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.10": {
+      "name": "spdy",
+      "version": "1.10.10",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.10",
+      "dist": {
+        "shasum": "66032b9d553de18b3acc0017d5b7ae8efae1a0af",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.11": {
+      "name": "spdy",
+      "version": "1.10.11",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.11",
+      "dist": {
+        "shasum": "0deaf3d1ff94b0f61bf48df656cd186110514501",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.10.12": {
+      "name": "spdy",
+      "version": "1.10.12",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.10.12",
+      "dist": {
+        "shasum": "4e2a0b3765ffe50f163b1552b810e6a2c96f030f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.12.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.11.0": {
+      "name": "spdy",
+      "version": "1.11.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.11.0",
+      "dist": {
+        "shasum": "81c44767a313f1b600b562e693853ac86013cb34",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.11.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.12.0": {
+      "name": "spdy",
+      "version": "1.12.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.12.0",
+      "dist": {
+        "shasum": "ea01aa3740aa9e54628cf37e7bc22f1b57b6fe6b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.12.1": {
+      "name": "spdy",
+      "version": "1.12.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.12.1",
+      "dist": {
+        "shasum": "004905b622c06cb197571ef62394f94cd4a16939",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.12.2": {
+      "name": "spdy",
+      "version": "1.12.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.12.2",
+      "dist": {
+        "shasum": "a6844146408ed5ab049e8b377dbf3fe9c99d9235",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.12.3": {
+      "name": "spdy",
+      "version": "1.12.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.12.3",
+      "dist": {
+        "shasum": "d4795de994f1edad62de53c4e6d2d4020e796bdd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.12.4": {
+      "name": "spdy",
+      "version": "1.12.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.12.4",
+      "dist": {
+        "shasum": "6c6d167c7c6b4af2910a39dad1c91323787ad1b0",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.13.0": {
+      "name": "spdy",
+      "version": "1.13.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.13.0",
+      "dist": {
+        "shasum": "5aef915496a49d3b046da500a128e6c6f1116481",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.13.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.13.1": {
+      "name": "spdy",
+      "version": "1.13.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.13.1",
+      "dist": {
+        "shasum": "734e1ad057eec10016abc6c043148603b1739524",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.13.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.0": {
+      "name": "spdy",
+      "version": "1.14.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.0",
+      "dist": {
+        "shasum": "40f9689030d251c24152813b1c7fd0c2a7c1b522",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.1": {
+      "name": "spdy",
+      "version": "1.14.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.1",
+      "dist": {
+        "shasum": "f6f674882aeae6bf9ae33bd922a4fe49cead9d2c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.2": {
+      "name": "spdy",
+      "version": "1.14.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.2",
+      "dist": {
+        "shasum": "0136db5fa41353c1faf9e4f85164f33edce552dc",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.3": {
+      "name": "spdy",
+      "version": "1.14.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.3",
+      "dist": {
+        "shasum": "09f6b17f503d07b3500b2bb19247d758daec00e3",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.4": {
+      "name": "spdy",
+      "version": "1.14.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.4",
+      "dist": {
+        "shasum": "2d5b20af683fe2d65be75f4781906f7576599f8c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.5": {
+      "name": "spdy",
+      "version": "1.14.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.5",
+      "dist": {
+        "shasum": "d8af683a83bd231703e28d7c20b2907e937b319a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.6": {
+      "name": "spdy",
+      "version": "1.14.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.6",
+      "dist": {
+        "shasum": "18f891bb2f6ea1013b9db9599abafb3f6f331c07",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.7": {
+      "name": "spdy",
+      "version": "1.14.7",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.7",
+      "dist": {
+        "shasum": "d24535747bbe165e7860dcbf6a4878883e6f0503",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.8": {
+      "name": "spdy",
+      "version": "1.14.8",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.8",
+      "dist": {
+        "shasum": "32321ec80017612cbd5a06d1a4e805f4dcf33b73",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.9": {
+      "name": "spdy",
+      "version": "1.14.9",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.9",
+      "dist": {
+        "shasum": "2a0d85defcc42e0088d417e1ac0e4bb3c76987fd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.10": {
+      "name": "spdy",
+      "version": "1.14.10",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.10",
+      "dist": {
+        "shasum": "ab664a28c3561a0ced09343f0c8520447fa9fcfc",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.11": {
+      "name": "spdy",
+      "version": "1.14.11",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.11",
+      "dist": {
+        "shasum": "fd389a5b6a215a0e8e673e81b69fdcdb88ac99c2",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.12": {
+      "name": "spdy",
+      "version": "1.14.12",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.12",
+      "dist": {
+        "shasum": "ac9f54cb126370d919f6bcee8c57c0ae398ae704",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.12.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.13": {
+      "name": "spdy",
+      "version": "1.14.13",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.13",
+      "dist": {
+        "shasum": "5c0242983e2120a82ebd700fb521b59b11b76cd6",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.13.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.14": {
+      "name": "spdy",
+      "version": "1.14.14",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.14",
+      "dist": {
+        "shasum": "d82cfa39bdc6edbfb70f22589d5343c5f57d88c5",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.14.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.14.15": {
+      "name": "spdy",
+      "version": "1.14.15",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.14.15",
+      "dist": {
+        "shasum": "eace16f1f66d0d6c87f2599689bfdbeadac2215c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.15.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.0": {
+      "name": "spdy",
+      "version": "1.15.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.0",
+      "dist": {
+        "shasum": "edf8b9a0a478628b74b67c2b2c95c26eb79991ad",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.1": {
+      "name": "spdy",
+      "version": "1.15.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.1",
+      "dist": {
+        "shasum": "72152f8b2d82d7939c128a384b394ed6e3f48fa5",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.2": {
+      "name": "spdy",
+      "version": "1.15.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.2",
+      "dist": {
+        "shasum": "87ba3b47972067fb5288b6965c8fa6059972decd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.3": {
+      "name": "spdy",
+      "version": "1.15.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.3",
+      "dist": {
+        "shasum": "d18c0c72ebd0a318a2d61478b8f8a49378effeeb",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.4": {
+      "name": "spdy",
+      "version": "1.15.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.4",
+      "dist": {
+        "shasum": "88fd24fd35e1e4583f478c2a7eebdf3a0719d905",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.5": {
+      "name": "spdy",
+      "version": "1.15.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.5",
+      "dist": {
+        "shasum": "f03e9f0c396507325e83f8192e13e3641d6014f9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.6": {
+      "name": "spdy",
+      "version": "1.15.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.6",
+      "dist": {
+        "shasum": "d83b37184ecbce3b14b65252842ce46db7dc3206",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.7": {
+      "name": "spdy",
+      "version": "1.15.7",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.7",
+      "dist": {
+        "shasum": "b635de5932183a7710a738350f90540e36082c96",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.15.8": {
+      "name": "spdy",
+      "version": "1.15.8",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.15.8",
+      "dist": {
+        "shasum": "9c7d3765c04e70f0d570d0fc98a5f0dd13048b6d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.0": {
+      "name": "spdy",
+      "version": "1.16.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.0",
+      "dist": {
+        "shasum": "c58e0b6e0fee07833c57c3a722b2fa0db7be8b21",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.2": {
+      "name": "spdy",
+      "version": "1.16.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.2",
+      "dist": {
+        "shasum": "36249693eae44d829ec12674504a46cd70b0264b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.3": {
+      "name": "spdy",
+      "version": "1.16.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.3",
+      "dist": {
+        "shasum": "c28ea3126e8e4ad93b9bc277e6b8b04273e90da8",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.4": {
+      "name": "spdy",
+      "version": "1.16.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.4",
+      "dist": {
+        "shasum": "596c74e74d20f23f792a9ffc5e187bae0730daec",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.5": {
+      "name": "spdy",
+      "version": "1.16.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.5",
+      "dist": {
+        "shasum": "4cb9d297d18e8b73afb63645c3a07b76f80c49ce",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.6": {
+      "name": "spdy",
+      "version": "1.16.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.6",
+      "dist": {
+        "shasum": "eb40d75c2ccdd90a1f61db7a59b348d34ee00696",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.7": {
+      "name": "spdy",
+      "version": "1.16.7",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.7",
+      "dist": {
+        "shasum": "b5d9f7909d47935edda35d1c4756bc6d71b48394",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.8": {
+      "name": "spdy",
+      "version": "1.16.8",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.8",
+      "dist": {
+        "shasum": "0e4d9b7004e91bf77bd13716e7d1915d97da8aba",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.16.9": {
+      "name": "spdy",
+      "version": "1.16.9",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.16.9",
+      "dist": {
+        "shasum": "77448281a55ac78d7769a0ae93962274babceb6a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.0": {
+      "name": "spdy",
+      "version": "1.17.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.0",
+      "dist": {
+        "shasum": "ef0c0493920dc6cdeaa54652643dcf86b2fd667a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.1": {
+      "name": "spdy",
+      "version": "1.17.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.1",
+      "dist": {
+        "shasum": "4e06400e76d481d1d7514772ae682d90082b1eed",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.5": {
+      "name": "spdy",
+      "version": "1.17.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.5",
+      "dist": {
+        "shasum": "2e195784593b546cee8d7437e32864e5a3ea015f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.6": {
+      "name": "spdy",
+      "version": "1.17.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.6",
+      "dist": {
+        "shasum": "c2fb667216444ffec05d0072777d7df0251cb693",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.7": {
+      "name": "spdy",
+      "version": "1.17.7",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.7",
+      "dist": {
+        "shasum": "29ca90c40248ca894104f447c1dde98dfce39b9e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.8": {
+      "name": "spdy",
+      "version": "1.17.8",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.8",
+      "dist": {
+        "shasum": "71824272d32a0aecd445b5c20f2c199fe5baf3de",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.9": {
+      "name": "spdy",
+      "version": "1.17.9",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.9",
+      "dist": {
+        "shasum": "c935d0fd13eee1c77f086176536a2be1bd25b718",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.10": {
+      "name": "spdy",
+      "version": "1.17.10",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.10",
+      "dist": {
+        "shasum": "1ca4b9adfba8ce28ca21c916ea6e1804720f1db5",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.11": {
+      "name": "spdy",
+      "version": "1.17.11",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.11",
+      "dist": {
+        "shasum": "f241e123c1d1e649fadca990f6a95d924e498d21",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.12": {
+      "name": "spdy",
+      "version": "1.17.12",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.12",
+      "dist": {
+        "shasum": "76f79547cc41cab654dcc1124955dd9d807b623f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.12.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.14": {
+      "name": "spdy",
+      "version": "1.17.14",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.14",
+      "dist": {
+        "shasum": "a76a2ae0874a751d49678aeebddcf914afda0986",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.14.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.15": {
+      "name": "spdy",
+      "version": "1.17.15",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.15",
+      "dist": {
+        "shasum": "cc08c3f3a4db1cf1d93386b6b5ce95a38f89af68",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.15.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.16": {
+      "name": "spdy",
+      "version": "1.17.16",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.16",
+      "dist": {
+        "shasum": "399fad84221302daa3a0151cd70a750c0eae36b6",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.16.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.17": {
+      "name": "spdy",
+      "version": "1.17.17",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.17",
+      "dist": {
+        "shasum": "901e2407de8ceddb216fd64af6cbfa5c56531083",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.17.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.18": {
+      "name": "spdy",
+      "version": "1.17.18",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.18",
+      "dist": {
+        "shasum": "91bcf78bd54ef0e12a7a6ebeda3ca019ec93a80a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.18.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.19": {
+      "name": "spdy",
+      "version": "1.17.19",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.19",
+      "dist": {
+        "shasum": "5d729278a38615611159cb64cd62e734b32f71f4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.19.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.20": {
+      "name": "spdy",
+      "version": "1.17.20",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.20",
+      "dist": {
+        "shasum": "a82dfed068a2f67368452894f107ffc5f328b0a4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.20.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.21": {
+      "name": "spdy",
+      "version": "1.17.21",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.21",
+      "dist": {
+        "shasum": "32724d71464f95c954a0360b7576743cb830cdc4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.21.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.22": {
+      "name": "spdy",
+      "version": "1.17.22",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.22",
+      "dist": {
+        "shasum": "f86af278b530c10de015ea02d3461937ef7829e8",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.22.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.17.23": {
+      "name": "spdy",
+      "version": "1.17.23",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.17.23",
+      "dist": {
+        "shasum": "979fcda1b202c4cf6ccb0e50092ca4106757ea79",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.23.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.18.0": {
+      "name": "spdy",
+      "version": "1.18.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.18.0",
+      "dist": {
+        "shasum": "adb99be7b4bdb202c0aac97dfdc0d29b44d266df",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.18.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.18.1": {
+      "name": "spdy",
+      "version": "1.18.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.18.1",
+      "dist": {
+        "shasum": "a04187d6e4d2a40ea8546bafe58ed2e7ca9ab28b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.18.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.19.0": {
+      "name": "spdy",
+      "version": "1.19.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.19.0",
+      "dist": {
+        "shasum": "7f5d69187244a28840acb851048d41727d3bc4e7",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.19.1": {
+      "name": "spdy",
+      "version": "1.19.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.19.1",
+      "dist": {
+        "shasum": "20606c089dc691635c94a3815775ced2be1ec8d9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.19.2": {
+      "name": "spdy",
+      "version": "1.19.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.19.2",
+      "dist": {
+        "shasum": "e0b5638c333adab4f26b985b7cf06c61df0f3915",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.19.3": {
+      "name": "spdy",
+      "version": "1.19.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.19.3",
+      "dist": {
+        "shasum": "db929da82c9b2649439502dcb18cfd3e5ddef846",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.19.4": {
+      "name": "spdy",
+      "version": "1.19.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.19.4",
+      "dist": {
+        "shasum": "bf68e5cc2ed86d414842976138766a913184a983",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.20.0": {
+      "name": "spdy",
+      "version": "1.20.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.20.0",
+      "dist": {
+        "shasum": "c1b295eacbc4e2266421616634f5550299cf05ab",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.20.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.22.0": {
+      "name": "spdy",
+      "version": "1.22.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.22.0",
+      "dist": {
+        "shasum": "2dbae15c44b8fe465e65b34975d5c5f74685cd6b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.22.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.23.0": {
+      "name": "spdy",
+      "version": "1.23.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.23.0",
+      "dist": {
+        "shasum": "f02c43e88278c89ea8f42882038281cf93e1cd99",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.23.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "fedor.indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.24.0": {
+      "name": "spdy",
+      "version": "1.24.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.24.0",
+      "dist": {
+        "shasum": "c69675c5866cc3c1205428d42eb76669ad19a9de",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.24.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.25.0": {
+      "name": "spdy",
+      "version": "1.25.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.25.0",
+      "dist": {
+        "shasum": "76a748bba5803b8668f2860a67c7edb371e893a3",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.25.1": {
+      "name": "spdy",
+      "version": "1.25.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.25.1",
+      "dist": {
+        "shasum": "e42ba02e84a3f894ec34a792fb0f7ba590f5c067",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.25.2": {
+      "name": "spdy",
+      "version": "1.25.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.25.2",
+      "dist": {
+        "shasum": "514e30234e1b65bf5fd6ab076c9f26daa7ed074e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.25.3": {
+      "name": "spdy",
+      "version": "1.25.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.25.3",
+      "_shasum": "34475121b6127d4edce8aa6381b8181e9a0b13df",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "34475121b6127d4edce8aa6381b8181e9a0b13df",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.25.4": {
+      "name": "spdy",
+      "version": "1.25.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.25.4",
+      "_shasum": "d5716b9bcf1ba3f5f2dbadd9dc23c26e8242d6d0",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d5716b9bcf1ba3f5f2dbadd9dc23c26e8242d6d0",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.25.5": {
+      "name": "spdy",
+      "version": "1.25.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.25.5",
+      "_shasum": "fa2515ac66d6b14cb91decbc4e77e1ad4463b39e",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fa2515ac66d6b14cb91decbc4e77e1ad4463b39e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.25.6": {
+      "name": "spdy",
+      "version": "1.25.6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.25.6",
+      "_shasum": "7bdc5aaf8f64f5a58ef6f5af1fc9841adcd03af7",
+      "_from": ".",
+      "_npmVersion": "1.4.7",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7bdc5aaf8f64f5a58ef6f5af1fc9841adcd03af7",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.26.0": {
+      "name": "spdy",
+      "version": "1.26.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.26.0",
+      "_shasum": "a1a704119e2caa14668061cd8e521d84278c1e8c",
+      "_from": ".",
+      "_npmVersion": "1.4.10",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a1a704119e2caa14668061cd8e521d84278c1e8c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.26.1": {
+      "name": "spdy",
+      "version": "1.26.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.26.1",
+      "_shasum": "d75e06d9e460c70737e32abc05e9d96b3886ac1e",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d75e06d9e460c70737e32abc05e9d96b3886ac1e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.26.2": {
+      "name": "spdy",
+      "version": "1.26.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.26.2",
+      "_shasum": "c2bf7548cbd9672466b371b60f011665b8ac5d67",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c2bf7548cbd9672466b371b60f011665b8ac5d67",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.26.3": {
+      "name": "spdy",
+      "version": "1.26.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.26.3",
+      "_shasum": "db9006eabb152f5974c81bbe1810c0e8460dc75a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "db9006eabb152f5974c81bbe1810c0e8460dc75a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.26.4": {
+      "name": "spdy",
+      "version": "1.26.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.26.4",
+      "_shasum": "7cad1958130320c1acb8bc893b4486af793b8a3c",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7cad1958130320c1acb8bc893b4486af793b8a3c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.26.5": {
+      "name": "spdy",
+      "version": "1.26.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.26.5",
+      "_shasum": "2c43117b378ee7a5197c3d5e9a1aceb825250b60",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2c43117b378ee7a5197c3d5e9a1aceb825250b60",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.27.0": {
+      "name": "spdy",
+      "version": "1.27.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.27.0",
+      "_shasum": "b984bef6ce829ccdd228a6442088bd5f07716c88",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b984bef6ce829ccdd228a6442088bd5f07716c88",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.27.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.28.0": {
+      "name": "spdy",
+      "version": "1.28.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.28.0",
+      "_shasum": "3f0dde663c327ddbd45593996fa12e530afe4720",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3f0dde663c327ddbd45593996fa12e530afe4720",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.28.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.28.1": {
+      "name": "spdy",
+      "version": "1.28.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "_id": "spdy@1.28.1",
+      "_shasum": "5e928bcd8c4a7fc0a08cbedc796ab732c77ecb2a",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5e928bcd8c4a7fc0a08cbedc796ab732c77ecb2a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.28.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.28.2": {
+      "name": "spdy",
+      "version": "1.28.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "eefb97defb702a8b2ab6906f05f2eb79fa7fdd8f",
+      "_id": "spdy@1.28.2",
+      "_shasum": "9823d1ecc3b049d7c4886711342444ac5cb60366",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9823d1ecc3b049d7c4886711342444ac5cb60366",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.28.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.29.0": {
+      "name": "spdy",
+      "version": "1.29.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "0ae9f31be47092050645e755214ac91a329cad3b",
+      "_id": "spdy@1.29.0",
+      "_shasum": "5ef82f456f5c14cac1db741cb903059bea143b62",
+      "_from": ".",
+      "_npmVersion": "2.1.2",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5ef82f456f5c14cac1db741cb903059bea143b62",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.29.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.29.1": {
+      "name": "spdy",
+      "version": "1.29.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indunty/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "dad2b9ac96ce1c3500588c8ec2025174d59a92bd",
+      "_id": "spdy@1.29.1",
+      "_shasum": "322b6d11eb499afb1fbf3d189e3cc1a90f088402",
+      "_from": ".",
+      "_npmVersion": "2.1.2",
+      "_nodeVersion": "0.10.32",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "322b6d11eb499afb1fbf3d189e3cc1a90f088402",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.29.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.29.2": {
+      "name": "spdy",
+      "version": "1.29.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "5fca78a34383d8eb4fb201f921191e2b03b96516",
+      "_id": "spdy@1.29.2",
+      "_shasum": "16aed7de064b92692bd4b7cf52842871f19a0d0f",
+      "_from": ".",
+      "_npmVersion": "2.1.10",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "16aed7de064b92692bd4b7cf52842871f19a0d0f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.29.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.30.0": {
+      "name": "spdy",
+      "version": "1.30.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "f9020f8a45f13e128cdb932ea3df778b459b7498",
+      "_id": "spdy@1.30.0",
+      "_shasum": "cfc71ac4c3816a8418da24fe057c8d575e7ffdef",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "1.0.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cfc71ac4c3816a8418da24fe057c8d575e7ffdef",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.30.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.30.1": {
+      "name": "spdy",
+      "version": "1.30.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "daafa9ab0dea095d335244efab041463e7bf75a7",
+      "_id": "spdy@1.30.1",
+      "_shasum": "9d9a1db5dfb7dbde68196395f28c20a6adac9f90",
+      "_from": ".",
+      "_npmVersion": "2.1.18",
+      "_nodeVersion": "1.0.2",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9d9a1db5dfb7dbde68196395f28c20a6adac9f90",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.30.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.30.2": {
+      "name": "spdy",
+      "version": "1.30.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "c747a36dc01faa5bd649784d763d4aeed7659130",
+      "_id": "spdy@1.30.2",
+      "_shasum": "e97794f90dbb8dd3b9d4bc80d03a42bc69bb3187",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.1-pre",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e97794f90dbb8dd3b9d4bc80d03a42bc69bb3187",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.30.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.31.0": {
+      "name": "spdy",
+      "version": "1.31.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "f42927d2404e41cbff543af85bea8192876b3eb1",
+      "_id": "spdy@1.31.0",
+      "_shasum": "5793582f6ce5866921a6e071beae58c028c5029a",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "1.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5793582f6ce5866921a6e071beae58c028c5029a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.32.0": {
+      "name": "spdy",
+      "version": "1.32.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "30098184f8a94637f1fff2b5c3436c673563fe89",
+      "_id": "spdy@1.32.0",
+      "_shasum": "3cd51f08734d441ef7122456638945a19ef18d3f",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "1.6.5",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3cd51f08734d441ef7122456638945a19ef18d3f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-beta1": {
+      "name": "spdy",
+      "version": "2.0.0-beta1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.0",
+        "http-deceiver": "^1.2.0",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0-rc8"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "3debe5eba82722a7cf6156c592c110290b1d9585",
+      "_id": "spdy@2.0.0-beta1",
+      "_shasum": "3399b63241e385e481d4cdf69e5ca5303c91d671",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3399b63241e385e481d4cdf69e5ca5303c91d671",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-beta2": {
+      "name": "spdy",
+      "version": "2.0.0-beta2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.0",
+        "http-deceiver": "^1.2.0",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0-rc9"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "71bd50a56cfa28a93487d6c3361bc4451cc30945",
+      "_id": "spdy@2.0.0-beta2",
+      "_shasum": "9c5be534148f60792a208acd8840655439cbef82",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9c5be534148f60792a208acd8840655439cbef82",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-beta3": {
+      "name": "spdy",
+      "version": "2.0.0-beta3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.0",
+        "http-deceiver": "^1.2.0",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0-rc9"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "e950662874a8422005e1bc3d45390704afd93289",
+      "_id": "spdy@2.0.0-beta3",
+      "_shasum": "0da95d5ceb72392f9c40fa1f229346a2bf1eccdf",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0da95d5ceb72392f9c40fa1f229346a2bf1eccdf",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-beta4": {
+      "name": "spdy",
+      "version": "2.0.0-beta4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.0",
+        "http-deceiver": "^1.2.0",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0-rc9"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "7e93761cf0fceeb1ea53983dc5f69bd11b607bee",
+      "_id": "spdy@2.0.0-beta4",
+      "_shasum": "c81d0d6b2ccbe61df5bffcf37eaa1093d907db79",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c81d0d6b2ccbe61df5bffcf37eaa1093d907db79",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta4.tgz"
+      },
+      "directories": {}
+    },
+    "1.32.1": {
+      "name": "spdy",
+      "version": "1.32.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "448b3ec37b0393e5b30bc8f2c9ea651a08c103df",
+      "_id": "spdy@1.32.1",
+      "_shasum": "c22ae1322fa9eede39060d73a8613076b383c9ec",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c22ae1322fa9eede39060d73a8613076b383c9ec",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.32.2": {
+      "name": "spdy",
+      "version": "1.32.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "47cd2921369e3bb94c42ff7fcf20dd22c64fa2b1",
+      "_id": "spdy@1.32.2",
+      "_shasum": "d67fea4bec284c44081d65c6778f6dd7db779d4c",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d67fea4bec284c44081d65c6778f6dd7db779d4c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.32.3": {
+      "name": "spdy",
+      "version": "1.32.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "607d22e28265a9c706798fcae5180c43f1eb9c70",
+      "_id": "spdy@1.32.3",
+      "_shasum": "770f4cefe4aa32496d4881aa9b2290077b16745b",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "770f4cefe4aa32496d4881aa9b2290077b16745b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.32.4": {
+      "name": "spdy",
+      "version": "1.32.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "77dc4c57accbcbdd7576b3d61dade097afa8db39",
+      "_id": "spdy@1.32.4",
+      "_shasum": "b7ccf239bfff73a6086bdc85701d68ccfe04af49",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b7ccf239bfff73a6086bdc85701d68ccfe04af49",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-beta5": {
+      "name": "spdy",
+      "version": "2.0.0-beta5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.3",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "b9b95fc13b21a584c55ddeaba58ed71514c1ea04",
+      "_id": "spdy@2.0.0-beta5",
+      "_shasum": "1e7a222bc8dbae8cc43bebc4c5135299a9f1ef35",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1e7a222bc8dbae8cc43bebc4c5135299a9f1ef35",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta5.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-beta6": {
+      "name": "spdy",
+      "version": "2.0.0-beta6",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.3",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "b37f7133f4f02772e0b55dd4697ee9eaee31716d",
+      "_id": "spdy@2.0.0-beta6",
+      "_shasum": "172178d55b7b829815a1802dd8f62391f7cd1979",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "172178d55b7b829815a1802dd8f62391f7cd1979",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta6.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-rc1": {
+      "name": "spdy",
+      "version": "2.0.0-rc1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "2c7be7c341206d80b8d56fd9a6e809cc87580be6",
+      "_id": "spdy@2.0.0-rc1",
+      "_shasum": "b0b2922b5c80774171446d0ea3633d1633ee22a2",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b0b2922b5c80774171446d0ea3633d1633ee22a2",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-rc1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-rc2": {
+      "name": "spdy",
+      "version": "2.0.0-rc2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.1"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "0e20bf55cbd58e34a8519e1806f781699cc10e35",
+      "_id": "spdy@2.0.0-rc2",
+      "_shasum": "d534c3f20129d25ea88dcecda9644934c61cfe98",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d534c3f20129d25ea88dcecda9644934c61cfe98",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-rc2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-rc3": {
+      "name": "spdy",
+      "version": "2.0.0-rc3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.2"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "f3a7e68d37064ada1ff84787a2785c2588c07a31",
+      "_id": "spdy@2.0.0-rc3",
+      "_shasum": "ba203befb01ca7172d56292cce06ac9c976787bd",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ba203befb01ca7172d56292cce06ac9c976787bd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-rc3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-rc4": {
+      "name": "spdy",
+      "version": "2.0.0-rc4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.3"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "8017de33ce89b85f42bc363dd2fd79225f1993b2",
+      "_id": "spdy@2.0.0-rc4",
+      "_shasum": "18d8e61638b9510d644cc1610204e3741895a672",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "18d8e61638b9510d644cc1610204e3741895a672",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-rc4.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "spdy",
+      "version": "2.0.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.4"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "add973de7ee9b47ccbfe2cf9f2bfe3f3174cc645",
+      "_id": "spdy@2.0.0",
+      "_shasum": "f63cb6162a74348930bbca0c61153b44ef8938b1",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f63cb6162a74348930bbca0c61153b44ef8938b1",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "spdy",
+      "version": "2.0.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.5"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "f16815d2a7cbd6d8beb10674ba6a7d2a5ca61f75",
+      "_id": "spdy@2.0.2",
+      "_shasum": "5180f65138ac5d1c2d8a79ebc0ce02ef8a02d672",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5180f65138ac5d1c2d8a79ebc0ce02ef8a02d672",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "spdy",
+      "version": "2.0.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.5"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "22d6024b9da9874fbfba50dcbd183f6b2376993b",
+      "_id": "spdy@2.0.3",
+      "_shasum": "f723e434d0bc67b3648a215923fc674b78151af4",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f723e434d0bc67b3648a215923fc674b78151af4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "spdy",
+      "version": "2.0.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.5"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "eb77331d4b7413be688bee3f31c8e8c9431d4144",
+      "_id": "spdy@2.0.4",
+      "_shasum": "acabd019a721aae851d5f4e7c4730b3f78d63fa4",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "acabd019a721aae851d5f4e7c4730b3f78d63fa4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.5": {
+      "name": "spdy",
+      "version": "2.0.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.5"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "8d837c11c40945806ebba815c964bbbb0febcce6",
+      "_id": "spdy@2.0.5",
+      "_shasum": "91535d93e14fd57913386b14c80139006c140822",
+      "_from": ".",
+      "_npmVersion": "2.13.3",
+      "_nodeVersion": "3.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "91535d93e14fd57913386b14c80139006c140822",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "spdy",
+      "version": "2.1.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.2.1"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "6ce7aa224901faf1382987cabd3f6aead5fa7f0f",
+      "_id": "spdy@2.1.0",
+      "_shasum": "ed372b08e7e107cf8511ce75c389a962e44ff291",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "ed372b08e7e107cf8511ce75c389a962e44ff291",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.32.5": {
+      "name": "spdy",
+      "version": "1.32.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "scripts": {
+        "test": "mocha --ui tdd --growl --reporter spec test/unit/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "3c7e45532a6083e1ae9a4fea26b70e62efa7eda4",
+      "_id": "spdy@1.32.5",
+      "_shasum": "70eff23cde4e97d52a445f65afddcc5695eb5edb",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "70eff23cde4e97d52a445f65afddcc5695eb5edb",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "spdy",
+      "version": "3.0.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "54be1f030c1610c10687229ac22dabb6723c21fd",
+      "_id": "spdy@3.0.0",
+      "_shasum": "329705d79705bed7158e52d30828d237749724db",
+      "_from": ".",
+      "_npmVersion": "3.4.1",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "329705d79705bed7158e52d30828d237749724db",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "spdy",
+      "version": "3.0.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "c75a4b1330b4d50434c905b130906a9ba22e5c7b",
+      "_id": "spdy@3.0.1",
+      "_shasum": "3638a05ea8100fd7380757ad3a98b8014b1d2b5b",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "3638a05ea8100fd7380757ad3a98b8014b1d2b5b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "spdy",
+      "version": "3.1.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "7149f28f15f07ad7134d24b3247b9f52368dcd59",
+      "_id": "spdy@3.1.0",
+      "_shasum": "8088c095fc5ff5ad91ca48c61d3d90c76089ada9",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "8088c095fc5ff5ad91ca48c61d3d90c76089ada9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.0": {
+      "name": "spdy",
+      "version": "3.2.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "eac9b5d87b46e7cb4bc18b62147af197bc8da47c",
+      "_id": "spdy@3.2.0",
+      "_shasum": "a35d37c9ca5c0a9ebe72039dfdd3ed27f555a6d1",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "a35d37c9ca5c0a9ebe72039dfdd3ed27f555a6d1",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {}
+    },
+    "3.2.1": {
+      "name": "spdy",
+      "version": "3.2.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "942a1a71c34be58cb44248c8fa467eab013cd823",
+      "_id": "spdy@3.2.1",
+      "_shasum": "0fd0f81578f15ff648ceee51845cfbbbdf389e74",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "0fd0f81578f15ff648ceee51845cfbbbdf389e74",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.2.1.tgz_1456852692362_0.8371058125048876"
+      },
+      "directories": {}
+    },
+    "3.2.2": {
+      "name": "spdy",
+      "version": "3.2.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "d7c6474b6be6a881105fc82b9a3459a50c8f400f",
+      "_id": "spdy@3.2.2",
+      "_shasum": "fc0e0e1cae002c347137771ce8a0611c413ca345",
+      "_from": ".",
+      "_npmVersion": "3.7.1",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "fc0e0e1cae002c347137771ce8a0611c413ca345",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.2.2.tgz_1456900874714_0.8194197746925056"
+      },
+      "directories": {}
+    },
+    "3.2.3": {
+      "name": "spdy",
+      "version": "3.2.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "0b65c15c843b7999e8cab07482a09fc411cf5754",
+      "_id": "spdy@3.2.3",
+      "_shasum": "4cdb751f93e7d3e2e2fba42c9993e3bd29f35b03",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "4cdb751f93e7d3e2e2fba42c9993e3bd29f35b03",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.2.3.tgz_1456902472310_0.6660306372214109"
+      },
+      "directories": {}
+    },
+    "3.2.4": {
+      "name": "spdy",
+      "version": "3.2.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "10931c013ad21907158a27439e3366d43607f424",
+      "_id": "spdy@3.2.4",
+      "_shasum": "04adfc5cdeae8df0ff21e0b2943d6260de4db6d6",
+      "_from": ".",
+      "_npmVersion": "3.8.5",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "04adfc5cdeae8df0ff21e0b2943d6260de4db6d6",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.2.4.tgz_1461189354019_0.31990460655651987"
+      },
+      "directories": {}
+    },
+    "3.3.1": {
+      "name": "spdy",
+      "version": "3.3.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "89ec3bfe2b49bda38e3240283bd298eb71eae685",
+      "_id": "spdy@3.3.1",
+      "_shasum": "0ff1762b693f5957d68b15a14a2e566e0dfc627b",
+      "_from": ".",
+      "_npmVersion": "3.8.5",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "0ff1762b693f5957d68b15a14a2e566e0dfc627b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.3.1.tgz_1461189404295_0.3681348047684878"
+      },
+      "directories": {}
+    },
+    "3.3.2": {
+      "name": "spdy",
+      "version": "3.3.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "adfb60649788fb8a5a3b737071dd6d06cd2e08ac",
+      "_id": "spdy@3.3.2",
+      "_shasum": "68f90c6e50eb2de32255eaabe4ef14fc97e93c8f",
+      "_from": ".",
+      "_npmVersion": "3.8.5",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "68f90c6e50eb2de32255eaabe4ef14fc97e93c8f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.3.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.3.2.tgz_1461609522841_0.9339162933174521"
+      },
+      "directories": {}
+    },
+    "3.3.3": {
+      "name": "spdy",
+      "version": "3.3.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "49dd7147f3feac423f223ab155f5b3379cc137c1",
+      "_id": "spdy@3.3.3",
+      "_shasum": "e3df452152e23274075b0eb0f90c00676b6e5411",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "e3df452152e23274075b0eb0f90c00676b6e5411",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.3.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.3.3.tgz_1463536844342_0.6056442076805979"
+      },
+      "directories": {}
+    },
+    "3.3.4": {
+      "name": "spdy",
+      "version": "3.3.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "d62cffbb01694cd7be6f0eeb8b28e34484fd54ea",
+      "_id": "spdy@3.3.4",
+      "_shasum": "7f741ad4ca8bbfa86a34d31328af115aeb6a9b94",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "7f741ad4ca8bbfa86a34d31328af115aeb6a9b94",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.3.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.3.4.tgz_1468872867956_0.8033408690243959"
+      },
+      "directories": {}
+    },
+    "3.4.0": {
+      "name": "spdy",
+      "version": "3.4.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "4c69c435fa261993475f79e48bc510ddaa2d56eb",
+      "_id": "spdy@3.4.0",
+      "_shasum": "4a7684e74a8ffbfc11a356d86c71670302cd1727",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "4a7684e74a8ffbfc11a356d86c71670302cd1727",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.4.0.tgz_1470406306212_0.6777773981448263"
+      },
+      "directories": {}
+    },
+    "3.4.1": {
+      "name": "spdy",
+      "version": "3.4.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "5c029a07cf670e7b083f542b70c9e400b341821d",
+      "_id": "spdy@3.4.1",
+      "_shasum": "398e4ca0b1ac7a295fa48332ded389c5050a2640",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "398e4ca0b1ac7a295fa48332ded389c5050a2640",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.4.1.tgz_1474317796892_0.30714909196831286"
+      },
+      "directories": {}
+    },
+    "3.4.2": {
+      "name": "spdy",
+      "version": "3.4.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.15"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "aada41c208e8914cbcd00d7dbc586b1bed6e2fa8",
+      "_id": "spdy@3.4.2",
+      "_shasum": "4326b7fb2e594c74027219f39ddc640ea6684c6b",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "4326b7fb2e594c74027219f39ddc640ea6684c6b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.4.2.tgz_1474545008500_0.16386731108650565"
+      },
+      "directories": {}
+    },
+    "3.4.3": {
+      "name": "spdy",
+      "version": "3.4.3",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.15"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "c4a9c71866f27a1e07aca508b0d080c65c0ddbde",
+      "_id": "spdy@3.4.3",
+      "_shasum": "8a241eab7a1cfee9cf6a0cdb9416cf6cd1e99d17",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "8a241eab7a1cfee9cf6a0cdb9416cf6cd1e99d17",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.4.3.tgz_1475188450821_0.28517948486842215"
+      },
+      "directories": {}
+    },
+    "3.4.4": {
+      "name": "spdy",
+      "version": "3.4.4",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/indutny/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.15"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "scripts": {
+        "test": "jscs lib/**/*.js test/*.js && jshint lib/**/*.js && mocha --reporter=spec test/*-test.js"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "52dc157eef87d7d2bb7b39ab25fdcfee45f88dd9",
+      "_id": "spdy@3.4.4",
+      "_shasum": "e0406407ca90ff01b553eb013505442649f5a819",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "e0406407ca90ff01b553eb013505442649f5a819",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/spdy-3.4.4.tgz_1476304679883_0.6189145103562623"
+      },
+      "directories": {}
+    },
+    "3.4.5": {
+      "name": "spdy",
+      "version": "3.4.5",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.15"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^2.2.x",
+        "pre-commit": "^1.2.2",
+        "standard": "^8.6.0"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "dbb0828dd1f9ba4da846f203ee98f0f79a05c2d8",
+      "_id": "spdy@3.4.5",
+      "_shasum": "4e189ad65818309f5cca978661719328e0e1ef74",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "daviddias.p@gmail.com"
+      },
+      "dist": {
+        "shasum": "4e189ad65818309f5cca978661719328e0e1ef74",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "daviddias",
+          "email": "daviddias.p@gmail.com"
+        },
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy-3.4.5.tgz_1495502293409_0.4167220904491842"
+      },
+      "directories": {}
+    },
+    "3.4.7": {
+      "name": "spdy",
+      "version": "3.4.7",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ],
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "a1d8ce4af3bc4af098e6dc77ffdaf5a79c1aaea2",
+      "_id": "spdy@3.4.7",
+      "_shasum": "42ff41ece5cc0f99a3a6c28aabb73f5c3b03acbc",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "daviddias.p@gmail.com"
+      },
+      "dist": {
+        "shasum": "42ff41ece5cc0f99a3a6c28aabb73f5c3b03acbc",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "daviddias",
+          "email": "daviddias.p@gmail.com"
+        },
+        {
+          "name": "fedor.indutny",
+          "email": "fedor.indutny@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "rauchg",
+          "email": "rauchg@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy-3.4.7.tgz_1495504570791_0.5951773677952588"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "spdy",
+      "version": "4.0.0",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2",
+        "standard": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=6.0.0"
+      },
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "1c1a9ad67efa4c373caedbcdb80a91c96900fdab",
+      "_id": "spdy@4.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "mail@daviddias.me"
+      },
+      "dist": {
+        "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
+        "shasum": "81f222b5a743a329aa12cea6a390e60e9b613c52",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 56998,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb5BeBCRA9TVsSAnZWagAAqpIP/1X//E1qhIkdm31Rdlcu\n+jZ52iKbHkNehopOxTL73MSED9nl4j6e/5qOv/hdIOAyWEze9BtLDH8tYBwe\n4Y5DLPac/xTNkl7O/6Krjtybs8WsLuGUssLV+CVukaXmqCnnDPKzhEwgwa6b\nsXVpl3+fM1L+xpPr/1K0a7gxm+xIdeLTFnN3ey+0tlmI9hFaEpiiFpfTIc9g\n2zcHjv4kzde9/PickBnzVVniW/AfxktZ1KX5Jv+vOB9msLatqWBxD1MEu3yw\n0G4fDOkOpUAbgTX0mGhn3BE3UV+d5jRrlerLICZS7QTCG5HDz2Mt1nd3PKbp\nS9eJwdjQBaF8mwen8YzKl1rnCnPf6CQFt5mPZ9o3RuSJAHo4xtsMgCWR47XL\nWH8WSowyDpI8xnp3T5aQGGUfhieQA6nwXpwPJV1mpCACJ1Eb9i4G2I+pol8G\n440VDCVIbU6q5q+lymHyvXaOnEUnCM1geicCX9vuMxYfsHNvgMfO88xcnoiT\nuqQmb9noZVu4ygy7qzWCh+YulrxikUqDum+7LIFOEsK2EhNKFLJFyWWEp2LW\nK8tvE0seVSg9qwjv7XlzZqt4LzyISDyE4rE5LTO/dftuYiv3uJEGNShWAy7l\n2rN33xVtwZ2kmwEKG+DZITjf1ZfiKc/Nydv0Lv9pssXMn6ZrVHyoYiXAZ1a5\nKnXA\r\n=gYUS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "daviddias.p@gmail.com",
+          "name": "daviddias"
+        },
+        {
+          "email": "fedor.indutny@gmail.com",
+          "name": "fedor.indutny"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "rauchg@gmail.com",
+          "name": "rauchg"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy_4.0.0_1541674881110_0.5458421291015885"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.1": {
+      "name": "spdy",
+      "version": "4.0.1",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^6.2.0",
+        "pre-commit": "^1.2.2",
+        "standard": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "38c72152cd71ccd3b9e4218ef3408af3ec124717",
+      "_id": "spdy@4.0.1",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.10.2",
+      "dist": {
+        "integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
+        "shasum": "6f12ed1c5db7ea4f24ebb8b89ba58c87c08257f2",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 57657,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdPxGUCRA9TVsSAnZWagAAcPEP/ROF0W+AI6V2wLvgJyb6\npXC5odFsPV0n87nRs/xFAvqcyBbE9J1k0MEKl51yKQY+l/RZqDmGJiB/FzXo\nkWva9+v6lKioKkag/i7iLe5M8AwTXss7MHRg7BT2GB2ddjR/9R90evKZLtUa\ne0yazI5+mi6kEmLMIuqx1GlSr5BM4FVsnpCFEwkyet1Cf23PcOMHaQGBJr2A\npuxnpmDWWPcq9OAMnrshigD8jPPhECaKKdnLZ4mb1QH+vHaeFt+/TTxLrUmT\nHVPHhln9jr6HrrjY72SirrHP42TTHFdWSMQGOCnXZz5kTRDUZZ83AZNR6OXT\nORiu6NO+i/u1WX1QQloEp/TyvElqsEDaczYKqbH6ygfWdpA01jM25zn6g0fX\ntU9Ay/rSe/hzZmY350D1DcqW9VhitruW/DetG7gJ0rC19tZY7cnpbe+JPAn7\nwlZr32ojNJ/hx9OX0J2EE77ZMVmfB9f1+1Wg4TwuLacmxdoFKyRy3AkpmWGf\nRA2MhD3Klljm3uHh++uVDcfjZzPmKAjkit2A5l8uKmrXO6cMTOkaOUnetilG\nU05N2scmAop2rvh3bZ7N5T24tbyMvnbDzhqaYmKICUffSI3ZNlo/zQtCUa/U\niRJRHS3KJ6eQe6BG897dAm+HiPzh5hTTksk/xlKmSXc4VnSgsRII1hxj+X7D\n6fXP\r\n=3WYR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "daviddias.p@gmail.com",
+          "name": "daviddias"
+        },
+        {
+          "email": "fedor.indutny@gmail.com",
+          "name": "fedor.indutny"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "rauchg@gmail.com",
+          "name": "rauchg"
+        }
+      ],
+      "_npmUser": {
+        "name": "daviddias",
+        "email": "mail@daviddias.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy_4.0.1_1564414355212_0.4968511048410078"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.2": {
+      "name": "spdy",
+      "version": "4.0.2",
+      "description": "Implementation of the SPDY protocol on node.js.",
+      "license": "MIT",
+      "scripts": {
+        "lint": "standard",
+        "test": "mocha --reporter=spec test/*-test.js",
+        "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter=spec test/**/*-test.js"
+      },
+      "pre-commit": [
+        "lint",
+        "test"
+      ],
+      "keywords": [
+        "spdy"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/indutny/node-spdy.git"
+      },
+      "homepage": "https://github.com/indutny/node-spdy",
+      "bugs": {
+        "url": "https://github.com/spdy-http2/node-spdy/issues",
+        "email": "node-spdy+bugs@indutny.com"
+      },
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor.indutny@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Chris Storm",
+          "email": "github@eeecooks.com"
+        },
+        {
+          "name": "François de Metz",
+          "email": "francois@2metz.fr"
+        },
+        {
+          "name": "Ilya Grigorik",
+          "email": "ilya@igvita.com"
+        },
+        {
+          "name": "Roberto Peon"
+        },
+        {
+          "name": "Tatsuhiro Tsujikawa"
+        },
+        {
+          "name": "Jesse Cravens",
+          "email": "jesse.cravens@gmail.com"
+        }
+      ],
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^6.2.3",
+        "pre-commit": "^1.2.2",
+        "standard": "^13.1.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "main": "./lib/spdy",
+      "optionalDependencies": {},
+      "gitHead": "661b14a8db40a76a9a4842fc12ca8908f989cfd9",
+      "_id": "spdy@4.0.2",
+      "_nodeVersion": "13.9.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+        "shasum": "b74f466203a3eda452c02492b91fb9e84a27677b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 57657,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeh/0HCRA9TVsSAnZWagAAy7oP/3f9HKc1UwFDAnOEDnoj\nj54akC4r3NXoT9eiTEIXG4WxvC2JIqmVKRwaeBC8wiXteYbmY1hw6Hg6SIJp\n1lGwtYIusJ2uvX47kSeX/thp3vxl3HBizpUK/j1SyB1ufy+ItUjPU1Uen9az\n1Ne2DwM58lDUkEyU72aFXIXb/BPsXhnPUOWeWJejE1eGOK1ESFu6y2knGlXP\nwPFhuPmTiGohhSy4Jtpw0cCPL8QAf8RGHmTAuwgeTSUxOac01S8i1MMuSN6k\nc5QKDKVeiDW7AXD/FGEMACMLou07t9kbL057TdEnBBRyHBmCDGVlwoGRkuPu\nx8n6k6UpkdUB4WswTIQg9LplbKgR4Lcg3BFhHh9uG+FtVZ7E5K+dE786CXuv\nUH1NuXx8USR65ROULDKXoFLHJExIWiXCBlz/k0hAuvB2W/Jnrz5xZv+VRwqt\n1x6RBSxFqEvPDMUpMBOFG5ziizAuiNo1FgWJCni7xSRLX9zVA/VNAj952Uja\nUz6fvNxTvoGPSOjeg9xi7UZLiZx1n82SAFmRpMeQIatELZuvRw9ph8xu+OX7\n4VPDWd/PBLzvnQee2ojyrUb8ZmrJ/q8kpeWkDRCT6mKT3RJsTnbyJAikM70t\nCMhN8MTiBcHdqOsYbBkLHrZn7qD8j9VhSfezcvRX0cO4rqYSR/zpRRI0LrnE\nd03D\r\n=yDnl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "daviddias.p@gmail.com",
+          "name": "daviddias"
+        },
+        {
+          "email": "fedor.indutny@gmail.com",
+          "name": "fedor.indutny"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "rauchg@gmail.com",
+          "name": "rauchg"
+        }
+      ],
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/spdy_4.0.2_1585970439037_0.08807651559863072"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "email": "daviddias.p@gmail.com",
+      "name": "daviddias"
+    },
+    {
+      "email": "fedor.indutny@gmail.com",
+      "name": "fedor.indutny"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "rauchg@gmail.com",
+      "name": "rauchg"
+    }
+  ],
+  "time": {
+    "modified": "2020-04-04T03:20:41.611Z",
+    "created": "2011-04-11T08:13:40.819Z",
+    "0.0.1": "2011-04-11T08:13:42.445Z",
+    "0.1.0": "2011-06-24T07:04:13.616Z",
+    "0.1.1": "2011-06-27T04:41:04.034Z",
+    "0.1.2": "2011-08-01T08:24:04.852Z",
+    "1.0.4": "2011-11-06T18:29:38.811Z",
+    "0.1.4": "2011-11-06T18:32:24.777Z",
+    "1.0.0": "2011-12-17T08:16:58.168Z",
+    "1.1.0": "2012-01-06T15:40:32.947Z",
+    "1.2.0": "2012-01-07T17:03:10.026Z",
+    "1.2.1": "2012-06-21T17:17:01.600Z",
+    "1.3.0": "2012-07-19T09:36:13.637Z",
+    "1.3.1": "2012-07-19T16:16:46.728Z",
+    "1.3.2": "2012-08-14T16:37:28.592Z",
+    "1.3.3": "2012-08-14T16:49:37.222Z",
+    "1.3.4": "2012-09-21T07:50:17.609Z",
+    "1.3.5": "2012-10-13T07:37:55.747Z",
+    "1.3.6": "2012-11-27T14:26:29.803Z",
+    "1.3.7": "2012-12-14T15:50:43.821Z",
+    "1.3.8": "2012-12-14T15:56:43.111Z",
+    "1.3.9": "2012-12-15T06:47:46.670Z",
+    "1.4.0": "2013-01-24T13:15:40.556Z",
+    "1.4.1": "2013-01-25T11:48:23.165Z",
+    "1.4.2": "2013-01-26T15:21:01.746Z",
+    "1.4.3": "2013-01-27T18:23:59.311Z",
+    "1.4.4": "2013-02-04T13:14:29.750Z",
+    "1.4.5": "2013-02-18T09:21:54.801Z",
+    "1.4.6": "2013-03-07T22:50:11.989Z",
+    "1.5.0": "2013-03-10T13:18:16.292Z",
+    "1.6.0": "2013-04-05T07:41:09.146Z",
+    "1.6.1": "2013-04-05T07:46:40.086Z",
+    "1.7.0": "2013-04-07T10:15:54.292Z",
+    "1.7.1": "2013-04-08T12:50:15.938Z",
+    "1.7.2": "2013-04-10T14:09:18.268Z",
+    "1.7.3": "2013-04-15T19:00:00.341Z",
+    "1.7.4": "2013-04-15T19:15:49.708Z",
+    "1.7.5": "2013-04-15T21:02:17.570Z",
+    "1.7.6": "2013-04-16T11:59:00.129Z",
+    "1.8.0": "2013-04-17T13:31:22.331Z",
+    "1.8.1": "2013-04-21T03:58:43.839Z",
+    "1.8.2": "2013-04-22T19:16:01.225Z",
+    "1.8.3": "2013-05-08T16:57:55.896Z",
+    "1.8.4": "2013-05-08T17:53:46.466Z",
+    "1.8.5": "2013-05-08T18:02:28.616Z",
+    "1.8.6": "2013-05-08T18:08:43.998Z",
+    "1.8.7": "2013-05-08T18:11:29.670Z",
+    "1.8.8": "2013-05-13T14:29:06.448Z",
+    "1.8.9": "2013-05-28T10:30:47.422Z",
+    "1.8.10": "2013-06-18T09:23:32.553Z",
+    "1.8.11": "2013-06-27T18:05:48.052Z",
+    "1.8.12": "2013-06-27T22:19:24.228Z",
+    "1.8.13": "2013-06-28T07:58:05.006Z",
+    "1.9.0": "2013-07-05T11:54:35.780Z",
+    "1.9.1": "2013-07-05T23:41:09.779Z",
+    "1.10.0": "2013-07-24T15:06:56.601Z",
+    "1.10.1": "2013-08-03T07:33:33.318Z",
+    "1.10.2": "2013-08-11T19:00:28.182Z",
+    "1.10.3": "2013-08-11T21:26:22.824Z",
+    "1.10.4": "2013-08-11T21:36:36.115Z",
+    "1.10.5": "2013-08-12T07:59:14.267Z",
+    "1.10.6": "2013-08-29T08:36:45.873Z",
+    "1.10.7": "2013-08-29T12:37:17.878Z",
+    "1.10.8": "2013-09-04T23:29:59.884Z",
+    "1.10.9": "2013-09-12T16:07:01.331Z",
+    "1.10.10": "2013-09-12T16:12:11.822Z",
+    "1.10.11": "2013-09-12T16:29:46.720Z",
+    "1.10.12": "2013-09-22T09:24:46.063Z",
+    "1.11.0": "2013-09-22T17:21:11.862Z",
+    "1.12.0": "2013-09-25T11:30:33.625Z",
+    "1.12.1": "2013-09-25T15:45:37.574Z",
+    "1.12.2": "2013-09-26T08:45:53.750Z",
+    "1.12.3": "2013-09-26T16:18:35.661Z",
+    "1.12.4": "2013-09-26T17:45:00.338Z",
+    "1.13.0": "2013-09-28T12:23:30.561Z",
+    "1.13.1": "2013-09-29T09:19:00.785Z",
+    "1.14.0": "2013-09-30T21:43:02.194Z",
+    "1.14.1": "2013-10-01T19:26:41.756Z",
+    "1.14.2": "2013-10-01T19:44:10.536Z",
+    "1.14.3": "2013-10-02T08:36:49.272Z",
+    "1.14.4": "2013-10-05T15:28:31.071Z",
+    "1.14.5": "2013-10-07T16:24:57.654Z",
+    "1.14.6": "2013-10-08T11:16:31.461Z",
+    "1.14.7": "2013-10-08T18:40:31.813Z",
+    "1.14.8": "2013-10-15T05:35:12.491Z",
+    "1.14.9": "2013-10-20T20:56:45.133Z",
+    "1.14.10": "2013-10-21T19:54:15.519Z",
+    "1.14.11": "2013-10-21T21:57:03.461Z",
+    "1.14.12": "2013-10-27T17:47:25.999Z",
+    "1.14.13": "2013-11-05T18:40:17.168Z",
+    "1.14.14": "2013-11-07T15:08:00.538Z",
+    "1.14.15": "2013-11-07T20:40:33.538Z",
+    "1.15.0": "2013-11-09T13:48:56.778Z",
+    "1.15.1": "2013-11-09T15:28:05.139Z",
+    "1.15.2": "2013-11-09T18:25:28.786Z",
+    "1.15.3": "2013-11-10T18:57:00.895Z",
+    "1.15.4": "2013-11-10T19:18:29.989Z",
+    "1.15.5": "2013-11-10T22:03:42.693Z",
+    "1.15.6": "2013-11-10T22:08:14.069Z",
+    "1.15.7": "2013-11-12T17:50:16.423Z",
+    "1.15.8": "2013-11-12T19:01:29.818Z",
+    "1.16.0": "2013-11-13T19:39:05.563Z",
+    "1.16.2": "2013-11-15T18:28:57.919Z",
+    "1.16.3": "2013-11-15T18:57:44.870Z",
+    "1.16.4": "2013-11-18T18:23:29.348Z",
+    "1.16.5": "2013-11-19T08:21:50.089Z",
+    "1.16.6": "2013-11-20T17:17:44.067Z",
+    "1.16.7": "2013-11-20T17:25:33.123Z",
+    "1.16.8": "2013-11-20T17:35:56.267Z",
+    "1.16.9": "2013-11-22T10:16:01.214Z",
+    "1.16.10": "2013-11-28T21:40:21.383Z",
+    "1.17.0": "2013-11-29T10:56:30.308Z",
+    "1.17.1": "2013-11-29T13:39:14.803Z",
+    "1.17.2": "2013-11-29T16:36:27.478Z",
+    "1.17.3": "2013-12-04T16:55:36.647Z",
+    "1.17.4": "2013-12-04T17:23:49.839Z",
+    "1.17.5": "2013-12-04T17:26:24.115Z",
+    "1.17.6": "2013-12-04T20:56:25.908Z",
+    "1.17.7": "2013-12-10T16:31:57.517Z",
+    "1.17.8": "2013-12-10T16:34:06.654Z",
+    "1.17.9": "2013-12-12T17:37:31.628Z",
+    "1.17.10": "2013-12-12T18:31:34.716Z",
+    "1.17.11": "2013-12-23T10:57:34.010Z",
+    "1.17.12": "2013-12-24T09:29:49.473Z",
+    "1.17.14": "2013-12-24T18:38:47.332Z",
+    "1.17.15": "2013-12-26T19:49:12.438Z",
+    "1.17.16": "2013-12-26T19:55:52.318Z",
+    "1.17.17": "2013-12-27T09:46:03.112Z",
+    "1.17.18": "2013-12-27T15:38:53.388Z",
+    "1.17.19": "2013-12-27T16:40:22.825Z",
+    "1.17.20": "2013-12-27T17:37:38.430Z",
+    "1.17.21": "2013-12-27T17:48:24.795Z",
+    "1.17.22": "2013-12-29T08:11:21.035Z",
+    "1.17.23": "2014-01-08T08:04:09.650Z",
+    "1.18.0": "2014-01-21T21:24:52.624Z",
+    "1.18.1": "2014-01-21T21:59:27.883Z",
+    "1.19.0": "2014-01-21T22:34:55.510Z",
+    "1.19.1": "2014-01-25T05:32:03.721Z",
+    "1.19.2": "2014-02-13T15:05:15.644Z",
+    "1.19.3": "2014-02-19T21:05:58.610Z",
+    "1.19.4": "2014-03-07T09:13:24.918Z",
+    "1.20.0": "2014-03-12T16:41:07.160Z",
+    "1.21.0": "2014-03-14T07:58:01.657Z",
+    "1.22.0": "2014-03-14T08:08:51.588Z",
+    "1.23.0": "2014-03-17T08:41:20.948Z",
+    "1.24.0": "2014-03-18T18:17:45.476Z",
+    "1.25.0": "2014-04-03T07:21:31.773Z",
+    "1.25.1": "2014-04-14T09:03:00.483Z",
+    "1.25.2": "2014-04-18T08:02:00.543Z",
+    "1.25.3": "2014-04-19T06:11:11.207Z",
+    "1.25.4": "2014-04-19T14:00:48.142Z",
+    "1.25.5": "2014-04-24T06:09:14.332Z",
+    "1.25.6": "2014-04-29T09:39:53.415Z",
+    "1.26.0": "2014-05-13T08:32:03.626Z",
+    "1.26.1": "2014-05-21T19:15:24.801Z",
+    "1.26.2": "2014-05-22T16:15:29.808Z",
+    "1.26.3": "2014-05-29T22:27:48.059Z",
+    "1.26.4": "2014-05-29T22:30:40.796Z",
+    "1.26.5": "2014-06-06T15:58:05.278Z",
+    "1.27.0": "2014-07-02T09:26:51.284Z",
+    "1.28.0": "2014-07-28T20:42:38.922Z",
+    "1.28.1": "2014-08-01T21:55:54.745Z",
+    "1.28.2": "2014-10-01T10:47:36.117Z",
+    "1.29.0": "2014-10-07T18:42:14.589Z",
+    "1.29.1": "2014-10-16T20:01:12.897Z",
+    "1.29.2": "2014-12-10T08:57:36.490Z",
+    "1.30.0": "2015-01-18T20:10:38.539Z",
+    "1.30.1": "2015-01-26T22:49:22.742Z",
+    "1.30.2": "2015-02-24T10:01:55.167Z",
+    "1.31.0": "2015-03-05T20:33:48.635Z",
+    "1.32.0": "2015-04-20T09:30:55.906Z",
+    "2.0.0-beta1": "2015-07-15T06:07:48.696Z",
+    "2.0.0-beta2": "2015-07-15T22:34:36.893Z",
+    "2.0.0-beta3": "2015-07-15T23:13:58.932Z",
+    "2.0.0-beta4": "2015-07-16T00:36:24.516Z",
+    "1.32.1": "2015-07-16T21:37:14.562Z",
+    "1.32.2": "2015-07-16T22:27:27.009Z",
+    "1.32.3": "2015-07-17T02:01:31.001Z",
+    "1.32.4": "2015-07-20T23:37:21.497Z",
+    "2.0.0-beta5": "2015-08-10T05:24:22.272Z",
+    "2.0.0-beta6": "2015-08-10T06:19:10.699Z",
+    "2.0.0-rc1": "2015-08-10T23:48:23.569Z",
+    "2.0.0-rc2": "2015-08-11T03:57:53.133Z",
+    "2.0.0-rc3": "2015-08-11T08:01:26.397Z",
+    "2.0.0-rc4": "2015-08-12T04:14:39.693Z",
+    "2.0.0": "2015-08-13T01:06:36.744Z",
+    "2.0.1": "2015-08-13T04:08:27.252Z",
+    "2.0.2": "2015-08-13T04:09:46.628Z",
+    "2.0.3": "2015-08-13T06:01:43.737Z",
+    "2.0.4": "2015-08-14T04:21:03.219Z",
+    "2.0.5": "2015-09-02T17:52:47.566Z",
+    "2.1.0": "2015-11-09T04:16:25.054Z",
+    "1.32.5": "2015-11-16T21:58:44.446Z",
+    "3.0.0": "2015-11-19T04:58:36.563Z",
+    "3.0.1": "2016-01-11T19:58:18.440Z",
+    "3.1.0": "2016-01-13T20:49:33.753Z",
+    "3.2.0": "2016-01-22T19:04:50.733Z",
+    "3.2.1": "2016-03-01T17:18:16.364Z",
+    "3.2.2": "2016-03-02T06:41:17.301Z",
+    "3.2.3": "2016-03-02T07:07:54.634Z",
+    "3.2.4": "2016-04-20T21:55:56.413Z",
+    "3.3.1": "2016-04-20T21:56:44.732Z",
+    "3.3.2": "2016-04-25T18:38:44.988Z",
+    "3.3.3": "2016-05-18T02:00:46.839Z",
+    "3.3.4": "2016-07-18T20:14:29.035Z",
+    "3.4.0": "2016-08-05T14:11:48.398Z",
+    "3.4.1": "2016-09-19T20:43:19.008Z",
+    "3.4.2": "2016-09-22T11:50:10.209Z",
+    "3.4.3": "2016-09-29T22:34:12.755Z",
+    "3.4.4": "2016-10-12T20:38:00.910Z",
+    "3.4.5": "2017-05-23T01:18:14.525Z",
+    "3.4.7": "2017-05-23T01:56:11.966Z",
+    "4.0.0": "2018-11-08T11:01:21.220Z",
+    "4.0.1": "2019-07-29T15:32:35.386Z",
+    "4.0.2": "2020-04-04T03:20:39.257Z"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor.indutny@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/indutny/node-spdy.git"
+  },
+  "users": {
+    "sjonnet": true,
+    "sjonnet19": true,
+    "dbrockman": true,
+    "paazmaya": true,
+    "darosh": true,
+    "leesei": true,
+    "paintedbicycle": true,
+    "eamsen": true,
+    "mcharytoniuk": true,
+    "tsangint": true,
+    "roryrjb": true,
+    "bbuecherl": true,
+    "baishuiz": true,
+    "brandonpapworth": true,
+    "nadimix": true,
+    "ehaase": true,
+    "mikkoh": true,
+    "xieranmaya": true,
+    "nickdugger": true,
+    "codepile": true,
+    "brettv": true,
+    "mikestaub": true,
+    "insdevmail": true,
+    "rajikaimal": true,
+    "jedateach": true,
+    "hongbo-miao": true,
+    "abarroso": true,
+    "mluberry": true,
+    "seakingii": true,
+    "shanewholloway": true,
+    "wujr5": true,
+    "astesio": true,
+    "xinwangwang": true,
+    "nisimjoseph": true,
+    "xtx1130": true,
+    "hitalos": true,
+    "lplabs": true,
+    "rodrigosdo": true,
+    "kevin-foster": true,
+    "avivharuzi": true
+  },
+  "readme": "# SPDY Server for node.js\n\n[![Build Status](https://travis-ci.org/spdy-http2/node-spdy.svg?branch=master)](http://travis-ci.org/spdy-http2/node-spdy)\n[![NPM version](https://badge.fury.io/js/spdy.svg)](http://badge.fury.io/js/spdy)\n[![dependencies Status](https://david-dm.org/spdy-http2/node-spdy/status.svg?style=flat-square)](https://david-dm.org/spdy-http2/node-spdy)\n[![Standard - JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)\n[![Waffle](https://img.shields.io/badge/track-waffle-blue.svg?style=flat-square)](https://waffle.io/spdy-http2/node-spdy)\n\nWith this module you can create [HTTP2][0] / [SPDY][1] servers\nin node.js with natural http module interface and fallback to regular https\n(for browsers that don't support neither HTTP2, nor SPDY yet).\n\nThis module named `spdy` but it [provides](https://github.com/indutny/node-spdy/issues/269#issuecomment-239014184) support for both http/2 (h2) and spdy (2,3,3.1). Also, `spdy` is compatible with Express.\n\n## Usage\n\n### Examples\n\nServer:\n```javascript\nvar spdy = require('spdy'),\n    fs = require('fs');\n\nvar options = {\n  // Private key\n  key: fs.readFileSync(__dirname + '/keys/spdy-key.pem'),\n\n  // Fullchain file or cert file (prefer the former)\n  cert: fs.readFileSync(__dirname + '/keys/spdy-fullchain.pem'),\n\n  // **optional** SPDY-specific options\n  spdy: {\n    protocols: [ 'h2', 'spdy/3.1', ..., 'http/1.1' ],\n    plain: false,\n\n    // **optional**\n    // Parse first incoming X_FORWARDED_FOR frame and put it to the\n    // headers of every request.\n    // NOTE: Use with care! This should not be used without some proxy that\n    // will *always* send X_FORWARDED_FOR\n    'x-forwarded-for': true,\n\n    connection: {\n      windowSize: 1024 * 1024, // Server's window size\n\n      // **optional** if true - server will send 3.1 frames on 3.0 *plain* spdy\n      autoSpdy31: false\n    }\n  }\n};\n\nvar server = spdy.createServer(options, function(req, res) {\n  res.writeHead(200);\n  res.end('hello world!');\n});\n\nserver.listen(3000);\n```\n\nClient:\n```javascript\nvar spdy = require('spdy');\nvar https = require('https');\n\nvar agent = spdy.createAgent({\n  host: 'www.google.com',\n  port: 443,\n\n  // Optional SPDY options\n  spdy: {\n    plain: false,\n    ssl: true,\n\n    // **optional** send X_FORWARDED_FOR\n    'x-forwarded-for': '127.0.0.1'\n  }\n});\n\nhttps.get({\n  host: 'www.google.com',\n  agent: agent\n}, function(response) {\n  console.log('yikes');\n  // Here it goes like with any other node.js HTTP request\n  // ...\n  // And once we're done - we may close TCP connection to server\n  // NOTE: All non-closed requests will die!\n  agent.close();\n}).end();\n```\n\nPlease note that if you use a custom agent, by default all connection-level\nerrors will result in an uncaught exception. To handle these errors subscribe\nto the `error` event and re-emit the captured error:\n\n```javascript\nvar agent = spdy.createAgent({\n  host: 'www.google.com',\n  port: 443\n}).once('error', function (err) {\n  this.emit(err);\n});\n```\n\n#### Push streams\n\nIt is possible to initiate [PUSH_PROMISE][5] to send content to clients _before_\nthe client requests it.\n\n```javascript\nspdy.createServer(options, function(req, res) {\n  var stream = res.push('/main.js', {\n    status: 200, // optional\n    method: 'GET', // optional\n    request: {\n      accept: '*/*'\n    },\n    response: {\n      'content-type': 'application/javascript'\n    }\n  });\n  stream.on('error', function() {\n  });\n  stream.end('alert(\"hello from push stream!\");');\n\n  res.end('<script src=\"/main.js\"></script>');\n}).listen(3000);\n```\n\n[PUSH_PROMISE][5] may be sent using the `push()` method on the current response\nobject.  The signature of the `push()` method is:\n\n`.push('/some/relative/url', { request: {...}, response: {...} }, callback)`\n\nSecond argument contains headers for both PUSH_PROMISE and emulated response.\n`callback` will receive two arguments: `err` (if any error is happened) and a\n[Duplex][4] stream as the second argument.\n\nClient usage:\n```javascript\nvar agent = spdy.createAgent({ /* ... */ });\nvar req = http.get({\n  host: 'www.google.com',\n  agent: agent\n}, function(response) {\n});\nreq.on('push', function(stream) {\n  stream.on('error', function(err) {\n    // Handle error\n  });\n  // Read data from stream\n});\n```\n\nNOTE: You're responsible for the `stream` object once given it in `.push()`\ncallback or `push` event. Hence ignoring `error` event on it will result in\nuncaught exception and crash your program.\n\n#### Trailing headers\n\nServer usage:\n```javascript\nfunction (req, res) {\n  // Send trailing headers to client\n  res.addTrailers({ header1: 'value1', header2: 'value2' });\n\n  // On client's trailing headers\n  req.on('trailers', function(headers) {\n    // ...\n  });\n}\n```\n\nClient usage:\n```javascript\nvar req = http.request({ agent: spdyAgent, /* ... */ }).function (res) {\n  // On server's trailing headers\n  res.on('trailers', function(headers) {\n    // ...\n  });\n});\nreq.write('stuff');\nreq.addTrailers({ /* ... */ });\nreq.end();\n```\n\n#### Options\n\nAll options supported by [tls][2] work with node-spdy.\n\nAdditional options may be passed via `spdy` sub-object:\n\n* `plain` - if defined, server will ignore NPN and ALPN data and choose whether\n  to use spdy or plain http by looking at first data packet.\n* `ssl` - if `false` and `options.plain` is `true`, `http.Server` will be used\n  as a `base` class for created server.\n* `maxChunk` - if set and non-falsy, limits number of bytes sent in one DATA\n  chunk. Setting it to non-zero value is recommended if you care about\n  interleaving of outgoing data from multiple different streams.\n  (defaults to 8192)\n* `protocols` - list of NPN/ALPN protocols to use (default is:\n  `['h2','spdy/3.1', 'spdy/3', 'spdy/2','http/1.1', 'http/1.0']`)\n* `protocol` - use specific protocol if no NPN/ALPN ex In addition,\n* `maxStreams` - set \"[maximum concurrent streams][3]\" protocol option\n\n### API\n\nAPI is compatible with `http` and `https` module, but you can use another\nfunction as base class for SPDYServer.\n\n```javascript\nspdy.createServer(\n  [base class constructor, i.e. https.Server],\n  { /* keys and options */ }, // <- the only one required argument\n  [request listener]\n).listen([port], [host], [callback]);\n```\n\nRequest listener will receive two arguments: `request` and `response`. They're\nboth instances of `http`'s `IncomingMessage` and `OutgoingMessage`. But three\ncustom properties are added to both of them: `isSpdy`, `spdyVersion`. `isSpdy`\nis `true` when the request was processed using HTTP2/SPDY protocols, it is\n`false` in case of HTTP/1.1 fallback. `spdyVersion` is either of: `2`, `3`,\n`3.1`, or `4` (for HTTP2).\n\n\n#### Contributors\n\n* [Fedor Indutny](https://github.com/indutny)\n* [Chris Strom](https://github.com/eee-c)\n* [François de Metz](https://github.com/francois2metz)\n* [Ilya Grigorik](https://github.com/igrigorik)\n* [Roberto Peon](https://github.com/grmocg)\n* [Tatsuhiro Tsujikawa](https://github.com/tatsuhiro-t)\n* [Jesse Cravens](https://github.com/jessecravens)\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2015.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n\n[0]: https://http2.github.io/\n[1]: http://www.chromium.org/spdy\n[2]: http://nodejs.org/docs/latest/api/tls.html#tls.createServer\n[3]: https://httpwg.github.io/specs/rfc7540.html#SETTINGS_MAX_CONCURRENT_STREAMS\n[4]: https://iojs.org/api/stream.html#stream_class_stream_duplex\n[5]: https://httpwg.github.io/specs/rfc7540.html#PUSH_PROMISE\n",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/indutny/node-spdy",
+  "keywords": [
+    "spdy"
+  ],
+  "contributors": [
+    {
+      "name": "Chris Storm",
+      "email": "github@eeecooks.com"
+    },
+    {
+      "name": "François de Metz",
+      "email": "francois@2metz.fr"
+    },
+    {
+      "name": "Ilya Grigorik",
+      "email": "ilya@igvita.com"
+    },
+    {
+      "name": "Roberto Peon"
+    },
+    {
+      "name": "Tatsuhiro Tsujikawa"
+    },
+    {
+      "name": "Jesse Cravens",
+      "email": "jesse.cravens@gmail.com"
+    }
+  ],
+  "bugs": {
+    "url": "https://github.com/spdy-http2/node-spdy/issues",
+    "email": "node-spdy+bugs@indutny.com"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/spdy.min.json
+++ b/test/fixtures/registry-mocks/content/spdy.min.json
@@ -1,0 +1,3256 @@
+{
+  "name": "spdy",
+  "dist-tags": {
+    "stable": "1.14.9",
+    "unstable": "1.3.0",
+    "latest": "4.0.2"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "spdy",
+      "version": "0.0.1",
+      "dependencies": {
+        "zlibcontext": ">= 1.0.4"
+      },
+      "directories": {
+        "lib": "./lib"
+      },
+      "dist": {
+        "shasum": "716b9a383fd06b5d1ca8beaecca59a0afde1555c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.0": {
+      "name": "spdy",
+      "version": "0.1.0",
+      "dependencies": {
+        "zlibcontext": ">= 1.0.4"
+      },
+      "dist": {
+        "shasum": "933b8c75cd10d7e253737a19fc1277ea4b16bd92",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.1": {
+      "name": "spdy",
+      "version": "0.1.1",
+      "dependencies": {
+        "zlibcontext": ">= 1.0.4"
+      },
+      "dist": {
+        "shasum": "644370755e15a420fbaae5bae22f31d780fe37c0",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.1.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.2": {
+      "name": "spdy",
+      "version": "0.1.2",
+      "dependencies": {
+        "zlibcontext": ">= 1.0.4"
+      },
+      "dist": {
+        "shasum": "93bceaa7539b2c1e616d001bb1adb5ee098d4a34",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.1.2.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.1.4": {
+      "name": "spdy",
+      "version": "0.1.4",
+      "dependencies": {
+        "zlibcontext": "~ 1.0.9"
+      },
+      "dist": {
+        "shasum": "4584bfc76f7b2c6189b1e08c003c5a4c64c273cf",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-0.1.4.tgz"
+      },
+      "engines": [
+        "node >= 0.6.0"
+      ]
+    },
+    "1.0.0": {
+      "name": "spdy",
+      "version": "1.0.0",
+      "dist": {
+        "shasum": "ab243436f363fc6654b668fc3dd7b64d733bee9d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.0.0.tgz"
+      },
+      "engines": [
+        "node ~ 0.7.0"
+      ]
+    },
+    "1.1.0": {
+      "name": "spdy",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "0.8.x"
+      },
+      "dist": {
+        "shasum": "55bd0603722198f592948e00739b21c78f59f572",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.1.0.tgz"
+      },
+      "engines": [
+        "node ~ 0.7.0"
+      ]
+    },
+    "1.2.0": {
+      "name": "spdy",
+      "version": "1.2.0",
+      "devDependencies": {
+        "mocha": "0.8.x"
+      },
+      "dist": {
+        "shasum": "17896d7c8f31720646a0ea3adbdfe22205f78e91",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.2.0.tgz"
+      },
+      "engines": [
+        "node ~ 0.7.0"
+      ]
+    },
+    "1.2.1": {
+      "name": "spdy",
+      "version": "1.2.1",
+      "devDependencies": {
+        "mocha": "1.2.x"
+      },
+      "dist": {
+        "shasum": "187ae05f4bb8ca2580d13b6d639faeeb2c7be3fd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.2.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.0": {
+      "name": "spdy",
+      "version": "1.3.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "270ae4b763cfb0e9878a24c02ba9fbf36b15dc37",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.1": {
+      "name": "spdy",
+      "version": "1.3.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "61208f9220275f6616245a354328ad812287c64c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.2": {
+      "name": "spdy",
+      "version": "1.3.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "7a4511256e6b16a86379e6a02c5d795a518da333",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.3": {
+      "name": "spdy",
+      "version": "1.3.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "7b46a52baa92d355877dfbf63ccdc845eef19dbf",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.4": {
+      "name": "spdy",
+      "version": "1.3.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "beb8fbf3b53222e3a450dfd37bbd4d6fafccf7ed",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.5": {
+      "name": "spdy",
+      "version": "1.3.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "df99c014c391f13538f7f38bc3f47ca623240b2c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.6": {
+      "name": "spdy",
+      "version": "1.3.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "760c11a22c4ddbb2abc6061e454eb20c9994dc61",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.7": {
+      "name": "spdy",
+      "version": "1.3.7",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "a4d2dbe2866ccc13566eacd8263973e19e8d7bb4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.7.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.8": {
+      "name": "spdy",
+      "version": "1.3.8",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "e112af1e97ff945b239d11df84de0b38fc4ff24c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.8.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.3.9": {
+      "name": "spdy",
+      "version": "1.3.9",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "56b600a297bacb7395f1087dd74454bf72a8781d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.3.9.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.4.0": {
+      "name": "spdy",
+      "version": "1.4.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "99e5a201a09a606eee71d4a97203bae24ef0636c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.4.1": {
+      "name": "spdy",
+      "version": "1.4.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "e31ad69fac0c4bec8efd8ab0c4724cf1932d3fd3",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.4.2": {
+      "name": "spdy",
+      "version": "1.4.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "8bc2e4ed23a6ef7fb3c6c5b9ff997b99a8e50f1d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.4.3": {
+      "name": "spdy",
+      "version": "1.4.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "177123c634158cda84d9151c755e489a2a875a1d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.4.4": {
+      "name": "spdy",
+      "version": "1.4.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c3fbf945e86cc8beea08697812664d3fd8b9acf9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.4.5": {
+      "name": "spdy",
+      "version": "1.4.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "f5a80e5b047021bad2faec7c5d0cf8dd1d84d343",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.4.6": {
+      "name": "spdy",
+      "version": "1.4.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "e719dd5cd7ff1cd62936e903790cbee052604025",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.4.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.5.0": {
+      "name": "spdy",
+      "version": "1.5.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "732762abe12ca1ce285a413c6a50abb258ce5137",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.5.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.6.0": {
+      "name": "spdy",
+      "version": "1.6.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "056dc360fd96ba917e29eea6c756685804398552",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.6.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.6.1": {
+      "name": "spdy",
+      "version": "1.6.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "6f21e1d2fac5c817a42db2966e07aa996d88caa8",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.6.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.7.0": {
+      "name": "spdy",
+      "version": "1.7.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "df32801e7c0c196081cffbc0cc694fce879578cb",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.7.1": {
+      "name": "spdy",
+      "version": "1.7.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "4fde77e602b20c4ecc39ee8619373dd9bf669152",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.7.2": {
+      "name": "spdy",
+      "version": "1.7.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "138582a0e01a02445cfd67f842d0f49345e39bc8",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.7.3": {
+      "name": "spdy",
+      "version": "1.7.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "5502a2641aaf68dc9a6dc1e14533b7018746099d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.7.4": {
+      "name": "spdy",
+      "version": "1.7.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "1f937bf90c4976b5d33b99db6df5d342e57f39cf",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.7.5": {
+      "name": "spdy",
+      "version": "1.7.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b8541fb9824a0e137d3c72fe08bfaad13f172e0a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.7.6": {
+      "name": "spdy",
+      "version": "1.7.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "3b5e66233f2d396cdd43a662398972faca1bcf0e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.7.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.0": {
+      "name": "spdy",
+      "version": "1.8.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "30163b318014b816f3109ad7f3ad6d8bc45f2219",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.1": {
+      "name": "spdy",
+      "version": "1.8.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b1791954fdcaf631640b64b4b77973fa91a9486c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.2": {
+      "name": "spdy",
+      "version": "1.8.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "aa8af98a64bd16e101b5db8cf0af2aeceae01f65",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.3": {
+      "name": "spdy",
+      "version": "1.8.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "bb90f04a7596e8f024cdf7c8c20c2ca77c12d4ff",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.4": {
+      "name": "spdy",
+      "version": "1.8.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "6b84c18641953595873f05c8b8aa6fd68e379aed",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.5": {
+      "name": "spdy",
+      "version": "1.8.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b6cbeaed9c2ab4c8a3014f164a1ae6dea235bbca",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.6": {
+      "name": "spdy",
+      "version": "1.8.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "27ab13a32874f6d59fac84aad5175265f1b71c0a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.7": {
+      "name": "spdy",
+      "version": "1.8.7",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "3ae7314e5634c6ca3ebb426f8ba84fce8801eda9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.7.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.8": {
+      "name": "spdy",
+      "version": "1.8.8",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "024f9bce0ec9a3f5f6895465802fcbbb32506d42",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.8.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.9": {
+      "name": "spdy",
+      "version": "1.8.9",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "457ed82c5530cacf04863e3d2cc47e4655453b3d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.9.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.10": {
+      "name": "spdy",
+      "version": "1.8.10",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "7093ba9b6f9689bbcf4472f0e62cda6f8537b511",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.10.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.11": {
+      "name": "spdy",
+      "version": "1.8.11",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "206a23e2b4b332d6d8b42cfff7ce142e8305b867",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.11.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.12": {
+      "name": "spdy",
+      "version": "1.8.12",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "76276f60913682a6149adbb52f6caa697249611d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.12.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.8.13": {
+      "name": "spdy",
+      "version": "1.8.13",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "99b2cbe8b825816eb57b77670835c610ef798aee",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.8.13.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.9.0": {
+      "name": "spdy",
+      "version": "1.9.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b32c6e915eada5c490998769db4154c39c21d4e2",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.9.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.9.1": {
+      "name": "spdy",
+      "version": "1.9.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "1f9299aff0734bc546a2dd4e6220f9362d7f95be",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.9.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.0": {
+      "name": "spdy",
+      "version": "1.10.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b35f38aa4dfbbf594a40f27edf9d81596bd288e6",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.1": {
+      "name": "spdy",
+      "version": "1.10.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "f400914dff8b0d6317449d64d734a69d2aca7358",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.2": {
+      "name": "spdy",
+      "version": "1.10.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "f2cc57195aef2efe8c274703c743e0a910f34343",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.3": {
+      "name": "spdy",
+      "version": "1.10.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "beef46374311b732588b7f9704521b813bd9aa14",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.4": {
+      "name": "spdy",
+      "version": "1.10.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "3398a59ea84465f873b39b1b595d2fa8a8047b6d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.5": {
+      "name": "spdy",
+      "version": "1.10.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "fa8525dbd0a3b09d14562e9fcca980a973e4035c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.6": {
+      "name": "spdy",
+      "version": "1.10.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "7ab22b2a81728bca3282315b286f87b32e6fc78c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.7": {
+      "name": "spdy",
+      "version": "1.10.7",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "aad38fa8eaa8aaae0c5d17bd106150d4ab9aed4c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.7.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.8": {
+      "name": "spdy",
+      "version": "1.10.8",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c8ab1ddcfd7782c73f438de2958165e485693d59",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.8.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.9": {
+      "name": "spdy",
+      "version": "1.10.9",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "9b739faf4d786d10e1aec3f45bbc69acd210534c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.9.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.10": {
+      "name": "spdy",
+      "version": "1.10.10",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "66032b9d553de18b3acc0017d5b7ae8efae1a0af",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.10.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.11": {
+      "name": "spdy",
+      "version": "1.10.11",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "0deaf3d1ff94b0f61bf48df656cd186110514501",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.11.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.10.12": {
+      "name": "spdy",
+      "version": "1.10.12",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "4e2a0b3765ffe50f163b1552b810e6a2c96f030f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.10.12.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.11.0": {
+      "name": "spdy",
+      "version": "1.11.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "81c44767a313f1b600b562e693853ac86013cb34",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.11.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.12.0": {
+      "name": "spdy",
+      "version": "1.12.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "ea01aa3740aa9e54628cf37e7bc22f1b57b6fe6b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.12.1": {
+      "name": "spdy",
+      "version": "1.12.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "004905b622c06cb197571ef62394f94cd4a16939",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.12.2": {
+      "name": "spdy",
+      "version": "1.12.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "a6844146408ed5ab049e8b377dbf3fe9c99d9235",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.12.3": {
+      "name": "spdy",
+      "version": "1.12.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d4795de994f1edad62de53c4e6d2d4020e796bdd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.12.4": {
+      "name": "spdy",
+      "version": "1.12.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "6c6d167c7c6b4af2910a39dad1c91323787ad1b0",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.12.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.13.0": {
+      "name": "spdy",
+      "version": "1.13.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "5aef915496a49d3b046da500a128e6c6f1116481",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.13.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.13.1": {
+      "name": "spdy",
+      "version": "1.13.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "734e1ad057eec10016abc6c043148603b1739524",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.13.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.0": {
+      "name": "spdy",
+      "version": "1.14.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "40f9689030d251c24152813b1c7fd0c2a7c1b522",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.1": {
+      "name": "spdy",
+      "version": "1.14.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "f6f674882aeae6bf9ae33bd922a4fe49cead9d2c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.2": {
+      "name": "spdy",
+      "version": "1.14.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "0136db5fa41353c1faf9e4f85164f33edce552dc",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.3": {
+      "name": "spdy",
+      "version": "1.14.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "09f6b17f503d07b3500b2bb19247d758daec00e3",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.4": {
+      "name": "spdy",
+      "version": "1.14.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "2d5b20af683fe2d65be75f4781906f7576599f8c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.5": {
+      "name": "spdy",
+      "version": "1.14.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d8af683a83bd231703e28d7c20b2907e937b319a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.6": {
+      "name": "spdy",
+      "version": "1.14.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "18f891bb2f6ea1013b9db9599abafb3f6f331c07",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.7": {
+      "name": "spdy",
+      "version": "1.14.7",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d24535747bbe165e7860dcbf6a4878883e6f0503",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.7.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.8": {
+      "name": "spdy",
+      "version": "1.14.8",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "32321ec80017612cbd5a06d1a4e805f4dcf33b73",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.8.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.9": {
+      "name": "spdy",
+      "version": "1.14.9",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "2a0d85defcc42e0088d417e1ac0e4bb3c76987fd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.9.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.10": {
+      "name": "spdy",
+      "version": "1.14.10",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "ab664a28c3561a0ced09343f0c8520447fa9fcfc",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.10.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.11": {
+      "name": "spdy",
+      "version": "1.14.11",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "fd389a5b6a215a0e8e673e81b69fdcdb88ac99c2",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.11.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.12": {
+      "name": "spdy",
+      "version": "1.14.12",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "ac9f54cb126370d919f6bcee8c57c0ae398ae704",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.12.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.13": {
+      "name": "spdy",
+      "version": "1.14.13",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "5c0242983e2120a82ebd700fb521b59b11b76cd6",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.13.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.14": {
+      "name": "spdy",
+      "version": "1.14.14",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d82cfa39bdc6edbfb70f22589d5343c5f57d88c5",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.14.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.14.15": {
+      "name": "spdy",
+      "version": "1.14.15",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "eace16f1f66d0d6c87f2599689bfdbeadac2215c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.14.15.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.0": {
+      "name": "spdy",
+      "version": "1.15.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "edf8b9a0a478628b74b67c2b2c95c26eb79991ad",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.1": {
+      "name": "spdy",
+      "version": "1.15.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "72152f8b2d82d7939c128a384b394ed6e3f48fa5",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.2": {
+      "name": "spdy",
+      "version": "1.15.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "87ba3b47972067fb5288b6965c8fa6059972decd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.3": {
+      "name": "spdy",
+      "version": "1.15.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d18c0c72ebd0a318a2d61478b8f8a49378effeeb",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.4": {
+      "name": "spdy",
+      "version": "1.15.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "88fd24fd35e1e4583f478c2a7eebdf3a0719d905",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.5": {
+      "name": "spdy",
+      "version": "1.15.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "f03e9f0c396507325e83f8192e13e3641d6014f9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.6": {
+      "name": "spdy",
+      "version": "1.15.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d83b37184ecbce3b14b65252842ce46db7dc3206",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.7": {
+      "name": "spdy",
+      "version": "1.15.7",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b635de5932183a7710a738350f90540e36082c96",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.7.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.15.8": {
+      "name": "spdy",
+      "version": "1.15.8",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "9c7d3765c04e70f0d570d0fc98a5f0dd13048b6d",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.15.8.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.0": {
+      "name": "spdy",
+      "version": "1.16.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c58e0b6e0fee07833c57c3a722b2fa0db7be8b21",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.2": {
+      "name": "spdy",
+      "version": "1.16.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "36249693eae44d829ec12674504a46cd70b0264b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.3": {
+      "name": "spdy",
+      "version": "1.16.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c28ea3126e8e4ad93b9bc277e6b8b04273e90da8",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.4": {
+      "name": "spdy",
+      "version": "1.16.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "596c74e74d20f23f792a9ffc5e187bae0730daec",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.5": {
+      "name": "spdy",
+      "version": "1.16.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "4cb9d297d18e8b73afb63645c3a07b76f80c49ce",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.6": {
+      "name": "spdy",
+      "version": "1.16.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "eb40d75c2ccdd90a1f61db7a59b348d34ee00696",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.7": {
+      "name": "spdy",
+      "version": "1.16.7",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b5d9f7909d47935edda35d1c4756bc6d71b48394",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.7.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.8": {
+      "name": "spdy",
+      "version": "1.16.8",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "0e4d9b7004e91bf77bd13716e7d1915d97da8aba",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.8.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.16.9": {
+      "name": "spdy",
+      "version": "1.16.9",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "77448281a55ac78d7769a0ae93962274babceb6a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.16.9.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.0": {
+      "name": "spdy",
+      "version": "1.17.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "ef0c0493920dc6cdeaa54652643dcf86b2fd667a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.1": {
+      "name": "spdy",
+      "version": "1.17.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "4e06400e76d481d1d7514772ae682d90082b1eed",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.5": {
+      "name": "spdy",
+      "version": "1.17.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "2e195784593b546cee8d7437e32864e5a3ea015f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.6": {
+      "name": "spdy",
+      "version": "1.17.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c2fb667216444ffec05d0072777d7df0251cb693",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.7": {
+      "name": "spdy",
+      "version": "1.17.7",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "29ca90c40248ca894104f447c1dde98dfce39b9e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.7.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.8": {
+      "name": "spdy",
+      "version": "1.17.8",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "71824272d32a0aecd445b5c20f2c199fe5baf3de",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.8.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.9": {
+      "name": "spdy",
+      "version": "1.17.9",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c935d0fd13eee1c77f086176536a2be1bd25b718",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.9.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.10": {
+      "name": "spdy",
+      "version": "1.17.10",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "1ca4b9adfba8ce28ca21c916ea6e1804720f1db5",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.10.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.11": {
+      "name": "spdy",
+      "version": "1.17.11",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "f241e123c1d1e649fadca990f6a95d924e498d21",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.11.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.12": {
+      "name": "spdy",
+      "version": "1.17.12",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "76f79547cc41cab654dcc1124955dd9d807b623f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.12.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.14": {
+      "name": "spdy",
+      "version": "1.17.14",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "a76a2ae0874a751d49678aeebddcf914afda0986",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.14.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.15": {
+      "name": "spdy",
+      "version": "1.17.15",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "cc08c3f3a4db1cf1d93386b6b5ce95a38f89af68",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.15.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.16": {
+      "name": "spdy",
+      "version": "1.17.16",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "399fad84221302daa3a0151cd70a750c0eae36b6",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.16.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.17": {
+      "name": "spdy",
+      "version": "1.17.17",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "901e2407de8ceddb216fd64af6cbfa5c56531083",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.17.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.18": {
+      "name": "spdy",
+      "version": "1.17.18",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "91bcf78bd54ef0e12a7a6ebeda3ca019ec93a80a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.18.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.19": {
+      "name": "spdy",
+      "version": "1.17.19",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "5d729278a38615611159cb64cd62e734b32f71f4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.19.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.20": {
+      "name": "spdy",
+      "version": "1.17.20",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "a82dfed068a2f67368452894f107ffc5f328b0a4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.20.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.21": {
+      "name": "spdy",
+      "version": "1.17.21",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "32724d71464f95c954a0360b7576743cb830cdc4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.21.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.22": {
+      "name": "spdy",
+      "version": "1.17.22",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "f86af278b530c10de015ea02d3461937ef7829e8",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.22.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.17.23": {
+      "name": "spdy",
+      "version": "1.17.23",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "979fcda1b202c4cf6ccb0e50092ca4106757ea79",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.17.23.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.18.0": {
+      "name": "spdy",
+      "version": "1.18.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "adb99be7b4bdb202c0aac97dfdc0d29b44d266df",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.18.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.18.1": {
+      "name": "spdy",
+      "version": "1.18.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "a04187d6e4d2a40ea8546bafe58ed2e7ca9ab28b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.18.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.19.0": {
+      "name": "spdy",
+      "version": "1.19.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "7f5d69187244a28840acb851048d41727d3bc4e7",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.19.1": {
+      "name": "spdy",
+      "version": "1.19.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "20606c089dc691635c94a3815775ced2be1ec8d9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.19.2": {
+      "name": "spdy",
+      "version": "1.19.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "e0b5638c333adab4f26b985b7cf06c61df0f3915",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.19.3": {
+      "name": "spdy",
+      "version": "1.19.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "db929da82c9b2649439502dcb18cfd3e5ddef846",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.19.4": {
+      "name": "spdy",
+      "version": "1.19.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "bf68e5cc2ed86d414842976138766a913184a983",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.19.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.20.0": {
+      "name": "spdy",
+      "version": "1.20.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c1b295eacbc4e2266421616634f5550299cf05ab",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.20.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.22.0": {
+      "name": "spdy",
+      "version": "1.22.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "2dbae15c44b8fe465e65b34975d5c5f74685cd6b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.22.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.23.0": {
+      "name": "spdy",
+      "version": "1.23.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "f02c43e88278c89ea8f42882038281cf93e1cd99",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.23.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.24.0": {
+      "name": "spdy",
+      "version": "1.24.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c69675c5866cc3c1205428d42eb76669ad19a9de",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.24.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.25.0": {
+      "name": "spdy",
+      "version": "1.25.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "76a748bba5803b8668f2860a67c7edb371e893a3",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.25.1": {
+      "name": "spdy",
+      "version": "1.25.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "e42ba02e84a3f894ec34a792fb0f7ba590f5c067",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.25.2": {
+      "name": "spdy",
+      "version": "1.25.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "514e30234e1b65bf5fd6ab076c9f26daa7ed074e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.25.3": {
+      "name": "spdy",
+      "version": "1.25.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "34475121b6127d4edce8aa6381b8181e9a0b13df",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.25.4": {
+      "name": "spdy",
+      "version": "1.25.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d5716b9bcf1ba3f5f2dbadd9dc23c26e8242d6d0",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.25.5": {
+      "name": "spdy",
+      "version": "1.25.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "fa2515ac66d6b14cb91decbc4e77e1ad4463b39e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.25.6": {
+      "name": "spdy",
+      "version": "1.25.6",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "7bdc5aaf8f64f5a58ef6f5af1fc9841adcd03af7",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.25.6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.26.0": {
+      "name": "spdy",
+      "version": "1.26.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "a1a704119e2caa14668061cd8e521d84278c1e8c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.26.1": {
+      "name": "spdy",
+      "version": "1.26.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d75e06d9e460c70737e32abc05e9d96b3886ac1e",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.26.2": {
+      "name": "spdy",
+      "version": "1.26.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c2bf7548cbd9672466b371b60f011665b8ac5d67",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.26.3": {
+      "name": "spdy",
+      "version": "1.26.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "db9006eabb152f5974c81bbe1810c0e8460dc75a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.26.4": {
+      "name": "spdy",
+      "version": "1.26.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "7cad1958130320c1acb8bc893b4486af793b8a3c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.26.5": {
+      "name": "spdy",
+      "version": "1.26.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "2c43117b378ee7a5197c3d5e9a1aceb825250b60",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.26.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.27.0": {
+      "name": "spdy",
+      "version": "1.27.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b984bef6ce829ccdd228a6442088bd5f07716c88",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.27.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.28.0": {
+      "name": "spdy",
+      "version": "1.28.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "3f0dde663c327ddbd45593996fa12e530afe4720",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.28.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.28.1": {
+      "name": "spdy",
+      "version": "1.28.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "5e928bcd8c4a7fc0a08cbedc796ab732c77ecb2a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.28.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.28.2": {
+      "name": "spdy",
+      "version": "1.28.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "9823d1ecc3b049d7c4886711342444ac5cb60366",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.28.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.29.0": {
+      "name": "spdy",
+      "version": "1.29.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "5ef82f456f5c14cac1db741cb903059bea143b62",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.29.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.29.1": {
+      "name": "spdy",
+      "version": "1.29.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "322b6d11eb499afb1fbf3d189e3cc1a90f088402",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.29.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.29.2": {
+      "name": "spdy",
+      "version": "1.29.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "16aed7de064b92692bd4b7cf52842871f19a0d0f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.29.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.30.0": {
+      "name": "spdy",
+      "version": "1.30.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "cfc71ac4c3816a8418da24fe057c8d575e7ffdef",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.30.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.30.1": {
+      "name": "spdy",
+      "version": "1.30.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "9d9a1db5dfb7dbde68196395f28c20a6adac9f90",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.30.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.30.2": {
+      "name": "spdy",
+      "version": "1.30.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "e97794f90dbb8dd3b9d4bc80d03a42bc69bb3187",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.30.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.31.0": {
+      "name": "spdy",
+      "version": "1.31.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "5793582f6ce5866921a6e071beae58c028c5029a",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.31.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.32.0": {
+      "name": "spdy",
+      "version": "1.32.0",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "3cd51f08734d441ef7122456638945a19ef18d3f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-beta1": {
+      "name": "spdy",
+      "version": "2.0.0-beta1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.0",
+        "http-deceiver": "^1.2.0",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0-rc8"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "3399b63241e385e481d4cdf69e5ca5303c91d671",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-beta2": {
+      "name": "spdy",
+      "version": "2.0.0-beta2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.0",
+        "http-deceiver": "^1.2.0",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0-rc9"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "9c5be534148f60792a208acd8840655439cbef82",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-beta3": {
+      "name": "spdy",
+      "version": "2.0.0-beta3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.0",
+        "http-deceiver": "^1.2.0",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0-rc9"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "0da95d5ceb72392f9c40fa1f229346a2bf1eccdf",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-beta4": {
+      "name": "spdy",
+      "version": "2.0.0-beta4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.0",
+        "http-deceiver": "^1.2.0",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0-rc9"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "c81d0d6b2ccbe61df5bffcf37eaa1093d907db79",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.32.1": {
+      "name": "spdy",
+      "version": "1.32.1",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "c22ae1322fa9eede39060d73a8613076b383c9ec",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.32.2": {
+      "name": "spdy",
+      "version": "1.32.2",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "d67fea4bec284c44081d65c6778f6dd7db779d4c",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.32.3": {
+      "name": "spdy",
+      "version": "1.32.3",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "770f4cefe4aa32496d4881aa9b2290077b16745b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.32.4": {
+      "name": "spdy",
+      "version": "1.32.4",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "b7ccf239bfff73a6086bdc85701d68ccfe04af49",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-beta5": {
+      "name": "spdy",
+      "version": "2.0.0-beta5",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.3",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "1e7a222bc8dbae8cc43bebc4c5135299a9f1ef35",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-beta6": {
+      "name": "spdy",
+      "version": "2.0.0-beta6",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.3",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "172178d55b7b829815a1802dd8f62391f7cd1979",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-beta6.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-rc1": {
+      "name": "spdy",
+      "version": "2.0.0-rc1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "b0b2922b5c80774171446d0ea3633d1633ee22a2",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-rc1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-rc2": {
+      "name": "spdy",
+      "version": "2.0.0-rc2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.1"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "d534c3f20129d25ea88dcecda9644934c61cfe98",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-rc2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-rc3": {
+      "name": "spdy",
+      "version": "2.0.0-rc3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.2"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "ba203befb01ca7172d56292cce06ac9c976787bd",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-rc3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0-rc4": {
+      "name": "spdy",
+      "version": "2.0.0-rc4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.3"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "18d8e61638b9510d644cc1610204e3741895a672",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0-rc4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.0": {
+      "name": "spdy",
+      "version": "2.0.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.4"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "f63cb6162a74348930bbca0c61153b44ef8938b1",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.2": {
+      "name": "spdy",
+      "version": "2.0.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.5"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "5180f65138ac5d1c2d8a79ebc0ce02ef8a02d672",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.3": {
+      "name": "spdy",
+      "version": "2.0.3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.5"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "f723e434d0bc67b3648a215923fc674b78151af4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.4": {
+      "name": "spdy",
+      "version": "2.0.4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.5"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "acabd019a721aae851d5f4e7c4730b3f78d63fa4",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.0.5": {
+      "name": "spdy",
+      "version": "2.0.5",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.1.5"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "91535d93e14fd57913386b14c80139006c140822",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.0.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "2.1.0": {
+      "name": "spdy",
+      "version": "2.1.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^1.2.1"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "ed372b08e7e107cf8511ce75c389a962e44ff291",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-2.1.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "1.32.5": {
+      "name": "spdy",
+      "version": "1.32.5",
+      "devDependencies": {
+        "mocha": "1.3.x"
+      },
+      "dist": {
+        "shasum": "70eff23cde4e97d52a445f65afddcc5695eb5edb",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-1.32.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.0.0": {
+      "name": "spdy",
+      "version": "3.0.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "329705d79705bed7158e52d30828d237749724db",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.0.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.0.1": {
+      "name": "spdy",
+      "version": "3.0.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "3638a05ea8100fd7380757ad3a98b8014b1d2b5b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.0.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.1.0": {
+      "name": "spdy",
+      "version": "3.1.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "8088c095fc5ff5ad91ca48c61d3d90c76089ada9",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.1.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.2.0": {
+      "name": "spdy",
+      "version": "3.2.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "a35d37c9ca5c0a9ebe72039dfdd3ed27f555a6d1",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.2.1": {
+      "name": "spdy",
+      "version": "3.2.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "0fd0f81578f15ff648ceee51845cfbbbdf389e74",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.2.2": {
+      "name": "spdy",
+      "version": "3.2.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "fc0e0e1cae002c347137771ce8a0611c413ca345",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.2.3": {
+      "name": "spdy",
+      "version": "3.2.3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "4cdb751f93e7d3e2e2fba42c9993e3bd29f35b03",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.2.4": {
+      "name": "spdy",
+      "version": "3.2.4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "04adfc5cdeae8df0ff21e0b2943d6260de4db6d6",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.2.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.3.1": {
+      "name": "spdy",
+      "version": "3.3.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "0ff1762b693f5957d68b15a14a2e566e0dfc627b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.3.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.3.2": {
+      "name": "spdy",
+      "version": "3.3.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "68f90c6e50eb2de32255eaabe4ef14fc97e93c8f",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.3.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.3.3": {
+      "name": "spdy",
+      "version": "3.3.3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "e3df452152e23274075b0eb0f90c00676b6e5411",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.3.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.3.4": {
+      "name": "spdy",
+      "version": "3.3.4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "7f741ad4ca8bbfa86a34d31328af115aeb6a9b94",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.3.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.4.0": {
+      "name": "spdy",
+      "version": "3.4.0",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "4a7684e74a8ffbfc11a356d86c71670302cd1727",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.0.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.4.1": {
+      "name": "spdy",
+      "version": "3.4.1",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.0"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "398e4ca0b1ac7a295fa48332ded389c5050a2640",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.1.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.4.2": {
+      "name": "spdy",
+      "version": "3.4.2",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.15"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "4326b7fb2e594c74027219f39ddc640ea6684c6b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.2.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.4.3": {
+      "name": "spdy",
+      "version": "3.4.3",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.15"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "8a241eab7a1cfee9cf6a0cdb9416cf6cd1e99d17",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.3.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.4.4": {
+      "name": "spdy",
+      "version": "3.4.4",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.15"
+      },
+      "devDependencies": {
+        "jscs": "^1.13.1",
+        "jshint": "^2.8.0",
+        "mocha": "^2.2.x"
+      },
+      "dist": {
+        "shasum": "e0406407ca90ff01b553eb013505442649f5a819",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.4.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.4.5": {
+      "name": "spdy",
+      "version": "3.4.5",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "handle-thing": "^1.2.4",
+        "http-deceiver": "^1.2.4",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.15"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^2.2.x",
+        "pre-commit": "^1.2.2",
+        "standard": "^8.6.0"
+      },
+      "dist": {
+        "shasum": "4e189ad65818309f5cca978661719328e0e1ef74",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.5.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "3.4.7": {
+      "name": "spdy",
+      "version": "3.4.7",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^3.4.1",
+        "pre-commit": "^1.2.2",
+        "standard": "^10.0.2"
+      },
+      "dist": {
+        "shasum": "42ff41ece5cc0f99a3a6c28aabb73f5c3b03acbc",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz"
+      },
+      "engines": [
+        "node >= 0.7.0"
+      ]
+    },
+    "4.0.0": {
+      "name": "spdy",
+      "version": "4.0.0",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^5.2.0",
+        "pre-commit": "^1.2.2",
+        "standard": "^12.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-ot0oEGT/PGUpzf/6uk4AWLqkq+irlqHXkrdbk51oWONh3bxQmBuljxPNl66zlRRcIJStWq0QkLUCPOPjgjvU0Q==",
+        "shasum": "81f222b5a743a329aa12cea6a390e60e9b613c52",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-4.0.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 56998,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb5BeBCRA9TVsSAnZWagAAqpIP/1X//E1qhIkdm31Rdlcu\n+jZ52iKbHkNehopOxTL73MSED9nl4j6e/5qOv/hdIOAyWEze9BtLDH8tYBwe\n4Y5DLPac/xTNkl7O/6Krjtybs8WsLuGUssLV+CVukaXmqCnnDPKzhEwgwa6b\nsXVpl3+fM1L+xpPr/1K0a7gxm+xIdeLTFnN3ey+0tlmI9hFaEpiiFpfTIc9g\n2zcHjv4kzde9/PickBnzVVniW/AfxktZ1KX5Jv+vOB9msLatqWBxD1MEu3yw\n0G4fDOkOpUAbgTX0mGhn3BE3UV+d5jRrlerLICZS7QTCG5HDz2Mt1nd3PKbp\nS9eJwdjQBaF8mwen8YzKl1rnCnPf6CQFt5mPZ9o3RuSJAHo4xtsMgCWR47XL\nWH8WSowyDpI8xnp3T5aQGGUfhieQA6nwXpwPJV1mpCACJ1Eb9i4G2I+pol8G\n440VDCVIbU6q5q+lymHyvXaOnEUnCM1geicCX9vuMxYfsHNvgMfO88xcnoiT\nuqQmb9noZVu4ygy7qzWCh+YulrxikUqDum+7LIFOEsK2EhNKFLJFyWWEp2LW\nK8tvE0seVSg9qwjv7XlzZqt4LzyISDyE4rE5LTO/dftuYiv3uJEGNShWAy7l\n2rN33xVtwZ2kmwEKG+DZITjf1ZfiKc/Nydv0Lv9pssXMn6ZrVHyoYiXAZ1a5\nKnXA\r\n=gYUS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "4.0.1": {
+      "name": "spdy",
+      "version": "4.0.1",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^6.2.0",
+        "pre-commit": "^1.2.2",
+        "standard": "^13.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
+        "shasum": "6f12ed1c5db7ea4f24ebb8b89ba58c87c08257f2",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 57657,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdPxGUCRA9TVsSAnZWagAAcPEP/ROF0W+AI6V2wLvgJyb6\npXC5odFsPV0n87nRs/xFAvqcyBbE9J1k0MEKl51yKQY+l/RZqDmGJiB/FzXo\nkWva9+v6lKioKkag/i7iLe5M8AwTXss7MHRg7BT2GB2ddjR/9R90evKZLtUa\ne0yazI5+mi6kEmLMIuqx1GlSr5BM4FVsnpCFEwkyet1Cf23PcOMHaQGBJr2A\npuxnpmDWWPcq9OAMnrshigD8jPPhECaKKdnLZ4mb1QH+vHaeFt+/TTxLrUmT\nHVPHhln9jr6HrrjY72SirrHP42TTHFdWSMQGOCnXZz5kTRDUZZ83AZNR6OXT\nORiu6NO+i/u1WX1QQloEp/TyvElqsEDaczYKqbH6ygfWdpA01jM25zn6g0fX\ntU9Ay/rSe/hzZmY350D1DcqW9VhitruW/DetG7gJ0rC19tZY7cnpbe+JPAn7\nwlZr32ojNJ/hx9OX0J2EE77ZMVmfB9f1+1Wg4TwuLacmxdoFKyRy3AkpmWGf\nRA2MhD3Klljm3uHh++uVDcfjZzPmKAjkit2A5l8uKmrXO6cMTOkaOUnetilG\nU05N2scmAop2rvh3bZ7N5T24tbyMvnbDzhqaYmKICUffSI3ZNlo/zQtCUa/U\niRJRHS3KJ6eQe6BG897dAm+HiPzh5hTTksk/xlKmSXc4VnSgsRII1hxj+X7D\n6fXP\r\n=3WYR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "4.0.2": {
+      "name": "spdy",
+      "version": "4.0.2",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "^0.4.5",
+        "mocha": "^6.2.3",
+        "pre-commit": "^1.2.2",
+        "standard": "^13.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+        "shasum": "b74f466203a3eda452c02492b91fb9e84a27677b",
+        "tarball": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 57657,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeh/0HCRA9TVsSAnZWagAAy7oP/3f9HKc1UwFDAnOEDnoj\nj54akC4r3NXoT9eiTEIXG4WxvC2JIqmVKRwaeBC8wiXteYbmY1hw6Hg6SIJp\n1lGwtYIusJ2uvX47kSeX/thp3vxl3HBizpUK/j1SyB1ufy+ItUjPU1Uen9az\n1Ne2DwM58lDUkEyU72aFXIXb/BPsXhnPUOWeWJejE1eGOK1ESFu6y2knGlXP\nwPFhuPmTiGohhSy4Jtpw0cCPL8QAf8RGHmTAuwgeTSUxOac01S8i1MMuSN6k\nc5QKDKVeiDW7AXD/FGEMACMLou07t9kbL057TdEnBBRyHBmCDGVlwoGRkuPu\nx8n6k6UpkdUB4WswTIQg9LplbKgR4Lcg3BFhHh9uG+FtVZ7E5K+dE786CXuv\nUH1NuXx8USR65ROULDKXoFLHJExIWiXCBlz/k0hAuvB2W/Jnrz5xZv+VRwqt\n1x6RBSxFqEvPDMUpMBOFG5ziizAuiNo1FgWJCni7xSRLX9zVA/VNAj952Uja\nUz6fvNxTvoGPSOjeg9xi7UZLiZx1n82SAFmRpMeQIatELZuvRw9ph8xu+OX7\n4VPDWd/PBLzvnQee2ojyrUb8ZmrJ/q8kpeWkDRCT6mKT3RJsTnbyJAikM70t\nCMhN8MTiBcHdqOsYbBkLHrZn7qD8j9VhSfezcvRX0cO4rqYSR/zpRRI0LrnE\nd03D\r\n=yDnl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    }
+  },
+  "modified": "2020-04-04T03:20:41.611Z"
+}

--- a/test/fixtures/registry-mocks/content/split-string.json
+++ b/test/fixtures/registry-mocks/content/split-string.json
@@ -1,0 +1,2059 @@
+{
+  "_id": "split-string",
+  "_rev": "20-4e5483c247d952ed9de92dd3b087754a",
+  "name": "split-string",
+  "description": "Easy way to split a string on a given character unless it's quoted or escaped.",
+  "dist-tags": {
+    "latest": "6.1.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "keywords": [],
+      "verb": {
+        "related": {
+          "list": [
+            "repeat-string",
+            "randomatic",
+            "deromanize",
+            "romanize"
+          ]
+        }
+      },
+      "_id": "split-string@0.1.0",
+      "_shasum": "540a945ed982a143a03b137bb2515e4ca60cbfad",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "540a945ed982a143a03b137bb2515e4ca60cbfad",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "repeat-string",
+            "randomatic",
+            "deromanize",
+            "romanize"
+          ]
+        }
+      },
+      "gitHead": "743efbb58b584eaf171af452537915b3c66fa722",
+      "_id": "split-string@0.1.1",
+      "_shasum": "a3d434533335e9dc8054d7418716f3d97bf21acb",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a3d434533335e9dc8054d7418716f3d97bf21acb",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://github.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "d901f60e5dc03fcc00c74129eb3e43f2d2cdf0cd",
+      "_id": "split-string@1.0.0",
+      "_shasum": "2ca23672816b3491a46ecb059c59963c5de95f75",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2ca23672816b3491a46ecb059c59963c5de95f75",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/split-string-1.0.0.tgz_1487737433181_0.45007273531518877"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "e88c24d4ca8453e2d466956f0c73ee9ccd93051d",
+      "_id": "split-string@1.0.1",
+      "_shasum": "bcbab3f4152acee3a0d6ab2479c0d2879c3db3ce",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.10.1",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "shasum": "bcbab3f4152acee3a0d6ab2479c0d2879c3db3ce",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/split-string-1.0.1.tgz_1491952105612_0.6221484744455665"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "eac89bb4485e1e0cee55f6789c241e4a60fd97af",
+      "_id": "split-string@2.0.0",
+      "_shasum": "b0a7f89292009f8525efcf4c1a2e59c674d6dbba",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b0a7f89292009f8525efcf4c1a2e59c674d6dbba",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/split-string-2.0.0.tgz_1491959095511_0.9271026512142271"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "2.1.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "email": "brian.woodward@gmail.com",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "Why use this?",
+          "install"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "67234051a8b9064c49f0b3df36a1a66c8e09083a",
+      "_id": "split-string@2.1.0",
+      "_shasum": "15a5fcbf9aeccf34c1edc884161f3852673e1b73",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "15a5fcbf9aeccf34c1edc884161f3852673e1b73",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-2.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/split-string-2.1.0.tgz_1493269826373_0.8184628051239997"
+      },
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "2.1.1",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "0bcaf1d50c58efc1416c2c5370326940e7e6e4a8",
+      "_id": "split-string@2.1.1",
+      "_shasum": "af4b06d821560426446c3cd931cda618940d37d0",
+      "_from": ".",
+      "_npmVersion": "4.6.1",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "af4b06d821560426446c3cd931cda618940d37d0",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-2.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-2.1.1.tgz_1496189785416_0.6811830659862608"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "3.0.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "3a8714bf6fafddb80b1f8078fc274bbeacf589c3",
+      "_id": "split-string@3.0.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-gDh7KKGFeUyVn2YlOH2XBRfyEGWaCHzE5HVOGqeMUEYmmAhOELMg3Bu9bgME69tRvnfBlxESAwpGzsSZrYpSTg==",
+        "shasum": "9b5e13e27dac3268d61602fea65fb15af7124c31",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-3.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-3.0.0.tgz_1497511984034_0.9825430826749653"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "3.0.1",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "9cca70de458a8080945bae18d5d87c52c55f8302",
+      "_id": "split-string@3.0.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-HsubuzD59ZKW/bglt2ow/GNOlyriQNa68LHfSwwOqIYZzfIlIZdYG1vSnDrhpd7GmswcqgkHmXKojzVi8snORw==",
+        "shasum": "0fb9b50a47469e1207ea091258ba88459e977ca0",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-3.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-3.0.1.tgz_1497553496060_0.9683597080875188"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "3.0.2",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "5000293c78d099b823c3a9c40c1cab43cc48db25",
+      "_id": "split-string@3.0.2",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.7.3",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==",
+        "shasum": "6129bc92731716e5aa1fb73c333078f0b7c114c8",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-3.0.2.tgz_1498022817563_0.23230708576738834"
+      },
+      "directories": {}
+    },
+    "3.1.0": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "3.1.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "2f83feb70267a54ca01e795e6a0558a51b89d6c8",
+      "_id": "split-string@3.1.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+        "shasum": "7cb09dda3a86585705c64b39a6466038682e8fe2",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-3.1.0.tgz_1511106894667_0.3419800808187574"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "4.0.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "1b231bc766c3f823e3b57018cb1a8c54d824f3a6",
+      "_id": "split-string@4.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-ybjKzGBZ6rrcKO3NU99SWUaDWAgV0nMmtJxbFV0g0qxo9JpQTHJzeh4oSqwyGFh8UPBDxRUC3ed2PBECtcGKiw==",
+        "shasum": "9e4899bb5a5ae0d3bf98035ac4b371c284ea6571",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-4.0.0.tgz_1511407057759_0.4824769797269255"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "5.0.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "nyc mocha"
+      },
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.5.3",
+        "gulp-format-md": "^1.0.0",
+        "nyc": "^11.4.1"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "cd378515474ff60744a393c1abd2051c7cb3fc09",
+      "_id": "split-string@5.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-Eyu0eiC0R3XVexCHC8J7kBBqanyfwzprnp2te3EpJNhI1tmzg1Jlko+5lr/68DUgnovuRnXVbQnQSrCjS2Y58A==",
+        "shasum": "0552161cfb5037e36eda06ab69dc8fd40429baab",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-5.0.0.tgz_1515436384056_0.48941135220229626"
+      },
+      "directories": {}
+    },
+    "5.0.1": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "5.0.1",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "nyc mocha"
+      },
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.5.3",
+        "gulp-format-md": "^1.0.0",
+        "nyc": "^11.4.1"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "54d231db1b2a9747aa6254035a9ff8f82a0c6377",
+      "_id": "split-string@5.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-ez4z9+4NrY1NlNaYDK1ng7aRSTtKyM8LqL5QUcTQmRxxVql4zMPJm7cogSDf5xFUsF27+k7Zf7vaLncAZvTz0g==",
+        "shasum": "9bff9926e295cbd3eaa64a5976a2771bca0f244b",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-5.0.1.tgz_1515436423091_0.5416859670076519"
+      },
+      "directories": {}
+    },
+    "5.0.2": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "5.0.2",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "nyc mocha"
+      },
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.5.3",
+        "gulp-format-md": "^1.0.0",
+        "nyc": "^11.4.1"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "527a4bb3300e0a7aa63b407948cc7b993bff6971",
+      "_id": "split-string@5.0.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-5Ilku6nwJwK+dZmCisvIfXch8jmj9qrLRNhVZ8iXflriWlUyZdgMUxoivPk9/qYBAUgxRJGuy6e0hgbBQ01t0w==",
+        "shasum": "b0eb642f71d554c2b99b72f64194bd2759048b14",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-5.0.2.tgz_1515436788286_0.6456026339437813"
+      },
+      "directories": {}
+    },
+    "5.0.3": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "5.0.3",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "test": "nyc mocha"
+      },
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.5.3",
+        "gulp-format-md": "^1.0.0",
+        "nyc": "^11.4.1"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "4e90d62e8b0b51e8f321df0abd0d5a75229fec5a",
+      "_id": "split-string@5.0.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-drSaNER+4vDUqyd1Thuygb3W5dXM+/bDCtDPWHS9Lru5CZxns4sYaXofPdRQc5qIgVQt3lltcOpm/7kuT+RuVg==",
+        "shasum": "d13ede51e296f85436e6cf2ae4fab5d0c65bc394",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string-5.0.3.tgz_1515582368514_0.4988768012262881"
+      },
+      "directories": {}
+    },
+    "5.0.4": {
+      "name": "split-string",
+      "description": "Split a string on a character except when the character is escaped.",
+      "version": "5.0.4",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=8"
+      },
+      "scripts": {
+        "test": "nyc mocha"
+      },
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3",
+        "nyc": "^11.4.1"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "a27de1fcdee10fb9cf2e4e03fe390f2d9eba55c6",
+      "_id": "split-string@5.0.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-EaNnJxhMdwO6cGXgax2TnEjkkcDatQ173A5745soFMRW8qTUxTTjxnWSV6UQjefIJlABgcRnnURos0CJdxmaCQ==",
+        "shasum": "7c9ea7190d90b70e99260c285f4558b5678e01a3",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 20685
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string_5.0.4_1518798015691_0.03419363805845821"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.0": {
+      "name": "split-string",
+      "description": "Easy way to split a string on a given character unless it's quoted or escaped.",
+      "version": "6.0.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "scripts": {
+        "test": "nyc mocha"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "47d6e9092cbc0c22bb05c2b6b4872829dabddb02",
+      "_id": "split-string@6.0.0",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-a+7NZ4oXyH02emLyo1/15L1IkGfM0rJegxl6TsJS9MCDaYBVy+ySnfUW+wKxP8xo1WPmgLo5S45+025IP6FkOw==",
+        "shasum": "6f36e120087ce5d1173eca156c3dd21e97ae534f",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-6.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17992,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbcpMsCRA9TVsSAnZWagAAkgQP/RUOtOqW9gk2eslRvy8X\nbgBSslqxRDrEcmeY9PuWhvDsPdPQ2AvRa+j0J2a/ws3HXl0CtAaAMiN8dkIB\nIkaycU6paMVzemNQ4aN9l9Vx92IYR5yNxXfGnIJPKqG8HRaa2AlDXSgARebe\nz0fq90Fk8Hmn9C9XITNrGEoWPKk1f/cWrTqyeaS/lJTtCgOEbDQdmalwSPsb\nQ88WgyVXjJYKM7wdwg5Ue+ZtpR4XYjPXK2nB4XujuNCW9n6Ii3oRxzTLI2fj\nuFxpCh98bjd7HZslCb1aBq0KHmNvFHd6TJ0m+1MUKyD+P3oBFm4TAJnAtUOE\n+gi3U9lvend+Q5oU2phpUOxd8uuvN7GKU6kMP8wleG1IwWABlNf8cAB4ljfE\nuJ+ZBHA5KNK/6AgcRoZXiS6DBqjuM7DjQScvdaAaB9KCpbWMdXNph7twzABd\nZbIFees+qaVz/Z+akhhU210PIwfKSsGaaWO6pCkWVZ1XeLe6HFH2pFus+jnT\n3m0Wjc1ucQfVlEuvYZu0y7U6GnwSE8KkR9JIdOBr/ax6gsMOjvKuF7N6utYc\n0hUKU3PKeJHXWR10OdFOQPpK9PvshVXKfPlmCHoXxFQV0nBLl5p90r0mg++R\nfu7WvJhKeXMvznhENnYmx1vnBXfBJPeihGq8DHVUggcgo7zLjEO+nQinhBi8\nlzYh\r\n=rDrf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string_6.0.0_1534235436117_0.47715545198758313"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.1.0": {
+      "name": "split-string",
+      "description": "Easy way to split a string on a given character unless it's quoted or escaped.",
+      "version": "6.1.0",
+      "homepage": "https://github.com/jonschlinkert/split-string",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "name": "Brian Woodward",
+          "url": "https://twitter.com/doowb"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/split-string.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/split-string/issues"
+      },
+      "license": "MIT",
+      "main": "index.js",
+      "types": "types/index.d.ts",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "scripts": {
+        "test": "nyc mocha",
+        "test:types": "dtslint types"
+      },
+      "devDependencies": {
+        "dtslint": "^0.7.0",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2"
+      },
+      "keywords": [
+        "character",
+        "escape",
+        "split",
+        "string"
+      ],
+      "nyc": {
+        "reporter": [
+          "lcov",
+          "text-summary"
+        ]
+      },
+      "verb": {
+        "toc": false,
+        "layout": "default",
+        "titles": [
+          ".",
+          "install",
+          "Why use this?"
+        ],
+        "related": {
+          "list": [
+            "deromanize",
+            "randomatic",
+            "repeat-string",
+            "romanize"
+          ]
+        },
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "757bdcb3bd110e8dfb55ae35d2856b6875692aad",
+      "_id": "split-string@6.1.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "doowb",
+        "email": "brian.woodward@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-9UBdnmnvx2NLLd4bMs7CEKK+wSzbujVv3ONyorkP1o8M3pVJQtXDO1cN19xD1JJs6ltOrtPrkUND0HzLSinUcA==",
+        "shasum": "e9cedcf94cdab077d9b5528927894dec4b0f42ab",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-6.1.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19425,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcvkhNCRA9TVsSAnZWagAAwB0P/24jbZb3hUGwREdoNr0S\nBSpYZ+Z6TzTa4cyToDphy2i+38GfVeY7xQrno60egFvvsEvIIWKlMbsYZxGK\nKZeSDPioSJDXiMJQWqhokg96qxWY51ToxjMapRUuEnXU+Nh1rTVVocLoAK1C\nsvu2ARcU6A/af9Gma0E6EHsmipzLXaei8kQBqfGegQajpGK34W61W9chFOkm\nwMcB8YAbsoOSo1vEiR4oxwuulUOflv0S70q5aIBZxqwJYfwgqAiciF2gJD1V\nAHwcP5H9Iw1ZZrprpM5jtGYavlYecjxafFY8+QGJJUeqIqxDYm1Dg5s4V9Ng\nIeAMXS3UaIsS/l1Xvt9UwhuRw4D3sPhW+jolZTWliKTLMnjk4P248RYoTr0s\n14NtID3YFVOdZShl34reflyhkZWkh8Ey9SYBWi7HNFFbB7342xnEZQb0zrwC\nByJNRDdte01PqzS5teafcLgUbFJZMIHPfesy37zj39WFf4y3GI7LuHXZBWUx\nVePbLd9OVOy6HVQ0/Wu4416tuQmcPIPphjxjxvuJWZMbw+DvkwfaEgx6vm4o\nahtPk7039fm9hMkMRpmJZ8Yu1jh/hpSgXJzjQX2hnHQskc4Kzu8G6jHFx6fG\nO4Q4+dpRswADNKMKrBZSSfuI7uHdwQ0SZA6JvWiJ78TJPygYlaIPyPA8LQcF\nfppd\r\n=H3Ma\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "doowb",
+          "email": "brian.woodward@gmail.com"
+        },
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/split-string_6.1.0_1555974220946_0.4783880589392515"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# split-string [![NPM version](https://img.shields.io/npm/v/split-string.svg?style=flat)](https://www.npmjs.com/package/split-string) [![NPM monthly downloads](https://img.shields.io/npm/dm/split-string.svg?style=flat)](https://npmjs.org/package/split-string) [![NPM total downloads](https://img.shields.io/npm/dt/split-string.svg?style=flat)](https://npmjs.org/package/split-string) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/split-string.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/split-string)\n\n> Easy way to split a string on a given character unless it's quoted or escaped.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save split-string\n```\n\n## Usage\n\n```js\nconst split = require('split-string');\n\nconsole.log(split('a.b.c'));\n//=> ['a', 'b', 'c']\n\n// respects escaped characters\nconsole.log(split('a.b.c\\\\.d'));\n//=> ['a', 'b', 'c.d']\n\n// respects double-quoted strings\nconsole.log(split('a.\"b.c.d\".e'));\n//=> ['a', '\"b.c.d\"', 'e']\n```\n\n## Options\n\n### options.quotes\n\n**Type**: `Array|Boolean`\n\n**Default**: `[]`\n\n**Description**\n\nTell split-string not to split inside any of the quote characters specified on the quotes option. Each character signifies both the \"opening\" and \"closing\" character to use.\n\n```js\n// default behavior\nconsole.log(split('a.b.\"c.d.e.f.g\".h.i'));\n//=> [ 'a', 'b', '\"c', 'd', 'e', 'f', 'g\"', 'h', 'i' ]\n\n// with quotes\nconsole.log(split('a.b.\"c.d.e.f.g\".h.i', { quotes: ['\"'] }));\n//=> [ 'a', 'b', '\"c.d.e.f.g\"', 'h', 'i' ]\n\n// escaped quotes will be ignored\nconsole.log(split('a.b.\\\\\"c.d.\"e.f.g\".h.i', { quotes: ['\"'] }));\n//=> [ 'a', 'b', '\"c', 'd', '\"e.f.g\"', 'h', 'i' ]\n\n// example of how to exclude non-escaped quotes from the result\nlet keep = (value, state) => {\n  return value !== '\\\\' && (value !== '\"' || state.prev() === '\\\\');\n};\nconsole.log(split('a.b.\\\\\"c.d.\"e.f.g\".h.i', { quotes: ['\"'], keep }));\n//=> [ 'a', 'b', '\"c', 'd', 'e.f.g', 'h', 'i' ]\n```\n\n## Options\n\n### options.brackets\n\n**Type**: `Object|Boolean`\n\n**Default**: `{}`\n\n**Description**\n\nBy default, no special significance is given to bracket-like characters (such as square brackets, curly braces, angle brackets, and so on).\n\n```js\n// default behavior\nconsole.log(split('a.{b.c}.{d.e}'));\n//=> [ 'a', '{b', 'c}', '{d', 'e}' ]\n```\n\nWhen `options.brackets` is `true`, the following brackets types are supported:\n\n```js\n{\n  '<': '>',\n  '(': ')',\n  '[': ']',\n  '{': '}'\n}\n```\n\nFor example:\n\n```js\nconsole.log(split('a.{b.c}.{d.e}', { brackets: true }));\n//=> [ 'a', '{b.c}', '{d.e}' ]\n```\n\nAlternatively, an object of brackets may be passed, where each key is the _opening bracket_ and each value is the corresponding _closing bracket_. Note that the key and value **must be different characters**. If you want to use the same character for both open and close, use the [quotes option](#optionsquotes).\n\n**Examples**\n\n```js\n// no bracket support by default\nconsole.log(split('a.{b.c}.[d.e].f'));\n//=> [ 'a', '{b', 'c}', '[d', 'e]', 'f' ]\n\n// tell split-string not to split inside curly braces\nconsole.log(split('a.{b.c}.[d.e].f', { brackets: { '{': '}' }}));\n//=> [ 'a', '{b.c}', '[d', 'e]', 'f' ]\n\n// tell split-string not to split inside any of these types: \"<>{}[]()\"\nconsole.log(split('a.{b.c}.[d.e].f', { brackets: true }));\n//=> [ 'a', '{b.c}', '[d.e]', 'f' ]\n\n// ...nested brackets are also supported\nconsole.log(split('a.{b.{c.d}.e}.f', { brackets: true }));\n//=> [ 'a', '{b.{c.d}.e}', 'f' ]\n\n// tell split-string not to split inside the given custom types\nconsole.log(split('«a.b».⟨c.d⟩.[e.f]', { brackets: { '«': '»', '⟨': '⟩' } }));\n//=> [ '«a.b»', '⟨c.d⟩', '[e', 'f]' ]\n```\n\n### options.keep\n\n**Type**: `function`\n\n**Default**: Function that returns true if the character is not `\\\\`.\n\nFunction that returns true when a character should be retained in the result.\n\n**Example**\n\n```js\nconsole.log(split('a.b\\\\.c')); //=> ['a', 'b.c']\n\n// keep all characters\nconsole.log(split('a.b.\\\\c', { keep: () => true })); //=> ['a', 'b\\.c']\n```\n\n### options.separator\n\n**Type**: `string`\n\n**Default**: `.`\n\nThe character to split on.\n\n**Example**\n\n```js\nconsole.log(split('a.b,c', { separator: ',' })); //=> ['a.b', 'c']\n```\n\n## Split function\n\nOptionally pass a function as the last argument to tell split-string whether or not to split when the specified separator is encountered.\n\n**Example**\n\n```js\n// only split on \".\" when the \"previous\" character is \"a\"\nconsole.log(split('a.b.c.a.d.e', state => state.prev() === 'a'));\n//=> [ 'a', 'b.c.a', 'd.e' ]\n```\n\nThe `state` object exposes the following properties:\n\n* `input` - (String) The un-modified, user-defined input string\n* `separator` - (String) the specified separator to split on.\n* `index` - (Number) The current cursor position\n* `value` - (String) The character at the current index\n* `bos` - (Function) Returns true if position is at the beginning-of-string\n* `eos` - (Function) Returns true if position is at the end-of-string\n* `prev` - (Function) Returns the previously scanned character\n* `next` - (Function) Returns the next character after the current position\n* `block` - (Object) The \"current\" AST node.\n* `stack` - (Array) AST nodes\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [deromanize](https://www.npmjs.com/package/deromanize): Convert roman numerals to arabic numbers (useful for books, outlines, documentation, slide decks, etc) | [homepage](https://github.com/jonschlinkert/deromanize \"Convert roman numerals to arabic numbers (useful for books, outlines, documentation, slide decks, etc)\")\n* [randomatic](https://www.npmjs.com/package/randomatic): Generate randomized strings of a specified length using simple character sequences. The original generate-password. | [homepage](https://github.com/jonschlinkert/randomatic \"Generate randomized strings of a specified length using simple character sequences. The original generate-password.\")\n* [repeat-string](https://www.npmjs.com/package/repeat-string): Repeat the given string n times. Fastest implementation for repeating a string. | [homepage](https://github.com/jonschlinkert/repeat-string \"Repeat the given string n times. Fastest implementation for repeating a string.\")\n* [romanize](https://www.npmjs.com/package/romanize): Convert numbers to roman numerals (useful for books, outlines, documentation, slide decks, etc) | [homepage](https://github.com/jonschlinkert/romanize \"Convert numbers to roman numerals (useful for books, outlines, documentation, slide decks, etc)\")\n\n### Contributors\n\n| **Commits** | **Contributor** |  \n| --- | --- |  \n| 56 | [jonschlinkert](https://github.com/jonschlinkert) |  \n| 12 | [doowb](https://github.com/doowb) |  \n| 6  | [Ovyerus](https://github.com/Ovyerus) |  \n| 1  | [silverwind](https://github.com/silverwind) |  \n\n### Author\n\n**Jon Schlinkert**\n\n* [GitHub Profile](https://github.com/jonschlinkert)\n* [Twitter Profile](https://twitter.com/jonschlinkert)\n* [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)\n\n### License\n\nCopyright © 2019, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.8.0, on April 22, 2019._",
+  "maintainers": [
+    {
+      "name": "doowb",
+      "email": "brian.woodward@gmail.com"
+    },
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-22T23:03:43.632Z",
+    "created": "2015-08-27T02:40:57.692Z",
+    "0.1.0": "2015-08-27T02:40:57.692Z",
+    "0.1.1": "2015-08-27T07:51:04.880Z",
+    "1.0.0": "2017-02-22T04:23:53.846Z",
+    "1.0.1": "2017-04-11T23:08:27.582Z",
+    "2.0.0": "2017-04-12T01:04:56.209Z",
+    "2.1.0": "2017-04-27T05:10:28.408Z",
+    "2.1.1": "2017-05-31T00:16:26.595Z",
+    "3.0.0": "2017-06-15T07:33:05.032Z",
+    "3.0.1": "2017-06-15T19:04:57.067Z",
+    "3.0.2": "2017-06-21T05:26:58.600Z",
+    "3.1.0": "2017-11-19T15:54:55.354Z",
+    "4.0.0": "2017-11-23T03:17:37.831Z",
+    "5.0.0": "2018-01-08T18:33:04.187Z",
+    "5.0.1": "2018-01-08T18:33:44.063Z",
+    "5.0.2": "2018-01-08T18:39:49.273Z",
+    "5.0.3": "2018-01-10T11:06:09.541Z",
+    "5.0.4": "2018-02-16T16:20:15.901Z",
+    "6.0.0": "2018-08-14T08:30:36.213Z",
+    "6.1.0": "2019-04-22T23:03:41.133Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/split-string",
+  "keywords": [
+    "character",
+    "escape",
+    "split",
+    "string"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/split-string.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/split-string/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "name": "Brian Woodward",
+      "url": "https://twitter.com/doowb"
+    },
+    {
+      "name": "Jon Schlinkert",
+      "url": "http://twitter.com/jonschlinkert"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/split-string.min.json
+++ b/test/fixtures/registry-mocks/content/split-string.min.json
@@ -1,0 +1,386 @@
+{
+  "name": "split-string",
+  "dist-tags": {
+    "latest": "6.1.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "split-string",
+      "version": "0.1.0",
+      "dependencies": {
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "540a945ed982a143a03b137bb2515e4ca60cbfad",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "split-string",
+      "version": "0.1.1",
+      "dependencies": {
+        "noncharacters": "^1.1.0"
+      },
+      "devDependencies": {
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "a3d434533335e9dc8054d7418716f3d97bf21acb",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "split-string",
+      "version": "1.0.0",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "2ca23672816b3491a46ecb059c59963c5de95f75",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.1": {
+      "name": "split-string",
+      "version": "1.0.1",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "bcbab3f4152acee3a0d6ab2479c0d2879c3db3ce",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "split-string",
+      "version": "2.0.0",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0"
+      },
+      "dist": {
+        "shasum": "b0a7f89292009f8525efcf4c1a2e59c674d6dbba",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.1.0": {
+      "name": "split-string",
+      "version": "2.1.0",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "dist": {
+        "shasum": "15a5fcbf9aeccf34c1edc884161f3852673e1b73",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.1.1": {
+      "name": "split-string",
+      "version": "2.1.1",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "dist": {
+        "shasum": "af4b06d821560426446c3cd931cda618940d37d0",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-2.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "split-string",
+      "version": "3.0.0",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-gDh7KKGFeUyVn2YlOH2XBRfyEGWaCHzE5HVOGqeMUEYmmAhOELMg3Bu9bgME69tRvnfBlxESAwpGzsSZrYpSTg==",
+        "shasum": "9b5e13e27dac3268d61602fea65fb15af7124c31",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.1": {
+      "name": "split-string",
+      "version": "3.0.1",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-HsubuzD59ZKW/bglt2ow/GNOlyriQNa68LHfSwwOqIYZzfIlIZdYG1vSnDrhpd7GmswcqgkHmXKojzVi8snORw==",
+        "shasum": "0fb9b50a47469e1207ea091258ba88459e977ca0",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-3.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.2": {
+      "name": "split-string",
+      "version": "3.0.2",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "^3.2.0",
+        "sections": "^0.1.10",
+        "update-sections": "^0.1.2"
+      },
+      "dist": {
+        "integrity": "sha512-d6myUSfwmBz1izkY4r7r7I0PL41rh21qUDYK1OgclmGHeoqQoujduGxMbzw6BlF3HKmJR4sMpbWVo7/Xzg4YBQ==",
+        "shasum": "6129bc92731716e5aa1fb73c333078f0b7c114c8",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-3.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.1.0": {
+      "name": "split-string",
+      "version": "3.1.0",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+        "shasum": "7cb09dda3a86585705c64b39a6466038682e8fe2",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "4.0.0": {
+      "name": "split-string",
+      "version": "4.0.0",
+      "dependencies": {
+        "extend-shallow": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-ybjKzGBZ6rrcKO3NU99SWUaDWAgV0nMmtJxbFV0g0qxo9JpQTHJzeh4oSqwyGFh8UPBDxRUC3ed2PBECtcGKiw==",
+        "shasum": "9e4899bb5a5ae0d3bf98035ac4b371c284ea6571",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-4.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "5.0.0": {
+      "name": "split-string",
+      "version": "5.0.0",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.5.3",
+        "gulp-format-md": "^1.0.0",
+        "nyc": "^11.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-Eyu0eiC0R3XVexCHC8J7kBBqanyfwzprnp2te3EpJNhI1tmzg1Jlko+5lr/68DUgnovuRnXVbQnQSrCjS2Y58A==",
+        "shasum": "0552161cfb5037e36eda06ab69dc8fd40429baab",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "5.0.1": {
+      "name": "split-string",
+      "version": "5.0.1",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.5.3",
+        "gulp-format-md": "^1.0.0",
+        "nyc": "^11.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-ez4z9+4NrY1NlNaYDK1ng7aRSTtKyM8LqL5QUcTQmRxxVql4zMPJm7cogSDf5xFUsF27+k7Zf7vaLncAZvTz0g==",
+        "shasum": "9bff9926e295cbd3eaa64a5976a2771bca0f244b",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.2": {
+      "name": "split-string",
+      "version": "5.0.2",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.5.3",
+        "gulp-format-md": "^1.0.0",
+        "nyc": "^11.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-5Ilku6nwJwK+dZmCisvIfXch8jmj9qrLRNhVZ8iXflriWlUyZdgMUxoivPk9/qYBAUgxRJGuy6e0hgbBQ01t0w==",
+        "shasum": "b0eb642f71d554c2b99b72f64194bd2759048b14",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.3": {
+      "name": "split-string",
+      "version": "5.0.3",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^3.5.3",
+        "gulp-format-md": "^1.0.0",
+        "nyc": "^11.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-drSaNER+4vDUqyd1Thuygb3W5dXM+/bDCtDPWHS9Lru5CZxns4sYaXofPdRQc5qIgVQt3lltcOpm/7kuT+RuVg==",
+        "shasum": "d13ede51e296f85436e6cf2ae4fab5d0c65bc394",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "5.0.4": {
+      "name": "split-string",
+      "version": "5.0.4",
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "snapdragon-lexer": "^3.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3",
+        "nyc": "^11.4.1"
+      },
+      "dist": {
+        "integrity": "sha512-EaNnJxhMdwO6cGXgax2TnEjkkcDatQ173A5745soFMRW8qTUxTTjxnWSV6UQjefIJlABgcRnnURos0CJdxmaCQ==",
+        "shasum": "7c9ea7190d90b70e99260c285f4558b5678e01a3",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-5.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 20685
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "6.0.0": {
+      "name": "split-string",
+      "version": "6.0.0",
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-a+7NZ4oXyH02emLyo1/15L1IkGfM0rJegxl6TsJS9MCDaYBVy+ySnfUW+wKxP8xo1WPmgLo5S45+025IP6FkOw==",
+        "shasum": "6f36e120087ce5d1173eca156c3dd21e97ae534f",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-6.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17992,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbcpMsCRA9TVsSAnZWagAAkgQP/RUOtOqW9gk2eslRvy8X\nbgBSslqxRDrEcmeY9PuWhvDsPdPQ2AvRa+j0J2a/ws3HXl0CtAaAMiN8dkIB\nIkaycU6paMVzemNQ4aN9l9Vx92IYR5yNxXfGnIJPKqG8HRaa2AlDXSgARebe\nz0fq90Fk8Hmn9C9XITNrGEoWPKk1f/cWrTqyeaS/lJTtCgOEbDQdmalwSPsb\nQ88WgyVXjJYKM7wdwg5Ue+ZtpR4XYjPXK2nB4XujuNCW9n6Ii3oRxzTLI2fj\nuFxpCh98bjd7HZslCb1aBq0KHmNvFHd6TJ0m+1MUKyD+P3oBFm4TAJnAtUOE\n+gi3U9lvend+Q5oU2phpUOxd8uuvN7GKU6kMP8wleG1IwWABlNf8cAB4ljfE\nuJ+ZBHA5KNK/6AgcRoZXiS6DBqjuM7DjQScvdaAaB9KCpbWMdXNph7twzABd\nZbIFees+qaVz/Z+akhhU210PIwfKSsGaaWO6pCkWVZ1XeLe6HFH2pFus+jnT\n3m0Wjc1ucQfVlEuvYZu0y7U6GnwSE8KkR9JIdOBr/ax6gsMOjvKuF7N6utYc\n0hUKU3PKeJHXWR10OdFOQPpK9PvshVXKfPlmCHoXxFQV0nBLl5p90r0mg++R\nfu7WvJhKeXMvznhENnYmx1vnBXfBJPeihGq8DHVUggcgo7zLjEO+nQinhBi8\nlzYh\r\n=rDrf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "6.1.0": {
+      "name": "split-string",
+      "version": "6.1.0",
+      "devDependencies": {
+        "dtslint": "^0.7.0",
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2"
+      },
+      "dist": {
+        "integrity": "sha512-9UBdnmnvx2NLLd4bMs7CEKK+wSzbujVv3ONyorkP1o8M3pVJQtXDO1cN19xD1JJs6ltOrtPrkUND0HzLSinUcA==",
+        "shasum": "e9cedcf94cdab077d9b5528927894dec4b0f42ab",
+        "tarball": "https://registry.npmjs.org/split-string/-/split-string-6.1.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 19425,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcvkhNCRA9TVsSAnZWagAAwB0P/24jbZb3hUGwREdoNr0S\nBSpYZ+Z6TzTa4cyToDphy2i+38GfVeY7xQrno60egFvvsEvIIWKlMbsYZxGK\nKZeSDPioSJDXiMJQWqhokg96qxWY51ToxjMapRUuEnXU+Nh1rTVVocLoAK1C\nsvu2ARcU6A/af9Gma0E6EHsmipzLXaei8kQBqfGegQajpGK34W61W9chFOkm\nwMcB8YAbsoOSo1vEiR4oxwuulUOflv0S70q5aIBZxqwJYfwgqAiciF2gJD1V\nAHwcP5H9Iw1ZZrprpM5jtGYavlYecjxafFY8+QGJJUeqIqxDYm1Dg5s4V9Ng\nIeAMXS3UaIsS/l1Xvt9UwhuRw4D3sPhW+jolZTWliKTLMnjk4P248RYoTr0s\n14NtID3YFVOdZShl34reflyhkZWkh8Ey9SYBWi7HNFFbB7342xnEZQb0zrwC\nByJNRDdte01PqzS5teafcLgUbFJZMIHPfesy37zj39WFf4y3GI7LuHXZBWUx\nVePbLd9OVOy6HVQ0/Wu4416tuQmcPIPphjxjxvuJWZMbw+DvkwfaEgx6vm4o\nahtPk7039fm9hMkMRpmJZ8Yu1jh/hpSgXJzjQX2hnHQskc4Kzu8G6jHFx6fG\nO4Q4+dpRswADNKMKrBZSSfuI7uHdwQ0SZA6JvWiJ78TJPygYlaIPyPA8LQcF\nfppd\r\n=H3Ma\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    }
+  },
+  "modified": "2019-04-22T23:03:43.632Z"
+}

--- a/test/fixtures/registry-mocks/content/ssri.json
+++ b/test/fixtures/registry-mocks/content/ssri.json
@@ -1,0 +1,2606 @@
+{
+  "_id": "ssri",
+  "_rev": "50-51e2799b08816d9275a9fa0b2263a364",
+  "name": "ssri",
+  "description": "Standard Subresource Integrity library -- parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+  "dist-tags": {
+    "latest": "8.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "ssri",
+      "version": "0.0.0",
+      "description": "Simple Subresource Integrity library -- generates, parses, and unparses integrity strings.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "cdb6d7d19ded4d8126c2753b9c15491f8c3f83bb",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@0.0.0",
+      "_shasum": "e67ebd98828741c1055caafb8a3a66cdcea4eb1e",
+      "_from": ".",
+      "_npmVersion": "4.4.4",
+      "_nodeVersion": "4.8.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "e67ebd98828741c1055caafb8a3a66cdcea4eb1e",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-0.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/ssri-0.0.0.tgz_1490244963191_0.1570116642396897"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "ssri",
+      "version": "1.0.0",
+      "description": "Simple Subresource Integrity library -- generates, parses, and unparses integrity strings.",
+      "main": "index.js",
+      "files": [
+        "*.js",
+        "lib"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard lib test *.js",
+        "release": "standard-version -s",
+        "test": "nyc --all -- tap -J test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "2e0a8a6f8035dc785e451ec766849a35cf93aff6",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@1.0.0",
+      "_shasum": "225790b751d5595eabcbdcf8d0d619122640186a",
+      "_from": ".",
+      "_npmVersion": "4.4.4",
+      "_nodeVersion": "4.8.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "225790b751d5595eabcbdcf8d0d619122640186a",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ssri-1.0.0.tgz_1490253746428_0.44512239820323884"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "ssri",
+      "version": "2.0.0",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "a06455fdafa64bcd4ccc03c32e53fe052171f6f4",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@2.0.0",
+      "_shasum": "d5f3de7dfb71fd420a0522c32f3cf30a0ca878bc",
+      "_from": ".",
+      "_npmVersion": "4.4.4",
+      "_nodeVersion": "4.8.1",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "d5f3de7dfb71fd420a0522c32f3cf30a0ca878bc",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/ssri-2.0.0.tgz_1490341841666_0.4269394064322114"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "ssri",
+      "version": "3.0.0",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "91777d050e9be60e94ce7f5d37eb9e8f349ce10f",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@3.0.0",
+      "_shasum": "1d463fee4ab1362a809f1f2fac0e5bcf8bb239ac",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "1d463fee4ab1362a809f1f2fac0e5bcf8bb239ac",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/ssri-3.0.0.tgz_1491194740473_0.8040323832537979"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "ssri",
+      "version": "3.0.1",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "30b2596b769a26630f22230c07f015d77129a1da",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@3.0.1",
+      "_shasum": "6e10bdedae232928769c3d94f79e28693d5f389b",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "6e10bdedae232928769c3d94f79e28693d5f389b",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-3.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/ssri-3.0.1.tgz_1491196618324_0.7827507932670414"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "ssri",
+      "version": "3.0.2",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "74fd52ce7173373dd2617db6763929a447c6553d",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@3.0.2",
+      "_shasum": "116d4afad587889f54ba594b0fafd4c9e28d711f",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "116d4afad587889f54ba594b0fafd4c9e28d711f",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-3.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ssri-3.0.2.tgz_1491196683801_0.7550789609085768"
+      },
+      "directories": {}
+    },
+    "4.0.0": {
+      "name": "ssri",
+      "version": "4.0.0",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "cc54b31994f079b00ccb036a259f74cbcb191d6a",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@4.0.0",
+      "_shasum": "c2df3a5bb877b39bcc426c82888d4198315c4cf6",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "c2df3a5bb877b39bcc426c82888d4198315c4cf6",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ssri-4.0.0.tgz_1491215832165_0.6491898228414357"
+      },
+      "directories": {}
+    },
+    "4.1.0": {
+      "name": "ssri",
+      "version": "4.1.0",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "9c4a4a978b70515e2a71f3e69a116414d23109f5",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@4.1.0",
+      "_shasum": "d88781b15f0eb04d6d1cd0951a2d41b58daeceb4",
+      "_from": ".",
+      "_npmVersion": "4.5.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "d88781b15f0eb04d6d1cd0951a2d41b58daeceb4",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ssri-4.1.0.tgz_1491579758434_0.14692295622080564"
+      },
+      "directories": {}
+    },
+    "4.1.1": {
+      "name": "ssri",
+      "version": "4.1.1",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.2.0",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "b4d40d7ac04630b4bf5f79b674b6052d8ba0bc72",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@4.1.1",
+      "_shasum": "11ccc8dbe39d37ecc6a05b539b073fdda35cf8c1",
+      "_from": ".",
+      "_npmVersion": "4.5.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "11ccc8dbe39d37ecc6a05b539b073fdda35cf8c1",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/ssri-4.1.1.tgz_1491970633037_0.44561820197850466"
+      },
+      "directories": {}
+    },
+    "4.1.2": {
+      "name": "ssri",
+      "version": "4.1.2",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.2.0",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "e0f1a5dccd1583773f98c3cdef088f3c948afab0",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@4.1.2",
+      "_npmVersion": "5.0.0-beta.1",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "shasum": "3d3c69b490d0b107772a9bf81881f38ae071f24b",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/ssri-4.1.2.tgz_1492509214466_0.5280678283888847"
+      },
+      "directories": {}
+    },
+    "4.1.3": {
+      "name": "ssri",
+      "version": "4.1.3",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "76f4a69a573e34a92b16edf540312e8e694b7365",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@4.1.3",
+      "_npmVersion": "5.0.0-beta.61",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-vDXK4C5lxEMlMXyUvsaNAqyYkoMaScW8r6jUTg3uwUOMnvbMmNRSw3Cal0iiWHtMsQxga7NG4GShS0CKt3Pt1w==",
+        "shasum": "ec8b5585cbfc726a5f9aad829efce238de831935",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri-4.1.3.tgz_1495669259707_0.24795893067494035"
+      },
+      "directories": {}
+    },
+    "4.1.4": {
+      "name": "ssri",
+      "version": "4.1.4",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "4789c3a70969df4ea3711931f41b5982ab3f1f18",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@4.1.4",
+      "_npmVersion": "5.0.0",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-CfN7rEZZi9/eLoED+vfKpgEPXdev5D5FV2fCih8j1e+rOSrKwoXzq3HVGy5ybu5mj94lrQ1X2oP+xBjLNtPUQQ==",
+        "shasum": "22be0659c075a612b622158872b585d5fe6b03af",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri-4.1.4.tgz_1496204542507_0.8902380040381104"
+      },
+      "directories": {}
+    },
+    "4.1.5": {
+      "name": "ssri",
+      "version": "4.1.5",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "75be125a348e241edbc1ea5f0e1d40406f002b0b",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@4.1.5",
+      "_npmVersion": "5.0.2-canary.9",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-TaLitc/pZH1UF8LCgZWdbssPiOUcPjBmIJsYJa+YltP77mY2qQ0Y2b+VS4C9RbZRH1GPMt4zckqqBd7GE/61ew==",
+        "shasum": "e3844770b5379ced69b512e70a28d86d86abd43a",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri-4.1.5.tgz_1496697273189_0.7271448955871165"
+      },
+      "directories": {}
+    },
+    "4.1.6": {
+      "name": "ssri",
+      "version": "4.1.6",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "CC0-1.0",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.1.0",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "1bef97d1ba06384b703d438cfb88f1f02d9a8e67",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@4.1.6",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kat@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+        "shasum": "0cb49b6ac84457e7bdd466cb730c3cb623e9a25b",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri-4.1.6.tgz_1496874096398_0.711648159660399"
+      },
+      "directories": {}
+    },
+    "5.0.0": {
+      "name": "ssri",
+      "version": "5.0.0",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.1.0",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "d0343e0bb5d8f8769462fcb8250f4c8ad4ff6d5c",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@5.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.5.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
+        "shasum": "13c19390b606c821f2a10d02b351c1729b94d8cf",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri-5.0.0.tgz_1508783055152_0.24902067962102592"
+      },
+      "directories": {}
+    },
+    "5.1.0": {
+      "name": "ssri",
+      "version": "5.1.0",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.1.0",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "381c619042dcc4ff49172fcd89e0b84d67077f65",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@5.1.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-TevC8fgxQKTfQ1nWtM9GNzr3q5rrHNntG9CDMH1k3QhSZI6Kb+NbjLRs8oPFZa2Hgo7zoekL+UTvoEk7tsbjQg==",
+        "shasum": "2cbf1df36b74d0fc91fcf89640a4b3e1d10b1899",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri-5.1.0.tgz_1516319806538_0.5181513263378292"
+      },
+      "directories": {}
+    },
+    "5.2.1": {
+      "name": "ssri",
+      "version": "5.2.1",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "050324c2341b0b60d42df47f51116dedbab47942",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@5.2.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-y4PjOWlAuxt+yAcXitQYOnOzZpKaH3+f/qGV3OWxbyC2noC9FA9GNC9uILnVdV7jruA1aDKr4OKz3ZDBcVZwFQ==",
+        "shasum": "8b6eb873688759bd3c75a88dee74593d179bb73c",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.2.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 38327
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_5.2.1_1517962077706_0.09262833893093503"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.2": {
+      "name": "ssri",
+      "version": "5.2.2",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "0fb45e7e0eba615bf0080bf350c95e19412ff9a9",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@5.2.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-hm46mN8YSzjGuJtVocXPjwo0yTRXobXqYuK/tV6gr557/tRck4yWXKPRW8OxyJgRvcL3QgX+5ng/kMHBMco7KA==",
+        "shasum": "797be390aefe03996e4d961657a946121e2feacf",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.2.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 38591
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_5.2.2_1518640685016_0.7166281342929599"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.3": {
+      "name": "ssri",
+      "version": "5.2.3",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "5e6fcee066a60e2a7dc505dc1912c0502844e39d",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@5.2.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-28QiVvVENYcfxZmohuG6ZHFJ3jYxPExjVL53GAYk0dgx76NHE7MhBn2NPR2N3vThQyECN8ZHkD0FPcEks3rwLQ==",
+        "shasum": "71e142c51c7cc411b525b4ee9b872233334f8a4f",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.2.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 39070
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_5.2.3_1518820760191_0.22073895365245244"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.2.4": {
+      "name": "ssri",
+      "version": "5.2.4",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "d0f7429cb8d5c38a3aab1dde24a725c61fe2d69d",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@5.2.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
+        "shasum": "9985e14041e65fc397af96542be35724ac11da52",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 39173
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_5.2.4_1518821193016_0.9095896129879257"
+      },
+      "_hasShrinkwrap": false
+    },
+    "5.3.0": {
+      "name": "ssri",
+      "version": "5.3.0",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "0ae0c237690d0b33613524a318ec617b8a61f8b0",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@5.3.0",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "kzm@sykosomatic.org"
+      },
+      "dist": {
+        "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+        "shasum": "ba3872c9c6d33a0704a7d71ff045e5ec48999d06",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 40500
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_5.3.0_1520907920511_0.21070726641763593"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.0": {
+      "name": "ssri",
+      "version": "6.0.0",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {},
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "d1aa2f789a8cbfe8592d63a87cee4127864fdcad",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@6.0.0",
+      "_npmVersion": "6.0.0-next.0",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA==",
+        "shasum": "fc21bfc90e03275ac3e23d5a42e38b8a1cbc130d",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-6.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 40772
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_6.0.0_1523297982126_0.21106611482724236"
+      },
+      "_hasShrinkwrap": false
+    },
+    "6.0.1": {
+      "name": "ssri",
+      "version": "6.0.1",
+      "description": "Standard Subresource Integrity library --  parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "files": [
+        "*.js"
+      ],
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/zkat/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "config": {
+        "nyc": {
+          "exclude": [
+            "node_modules/**",
+            "test/**"
+          ]
+        }
+      },
+      "gitHead": "a4337cd672f341deee2b52699b6720d82e4d0ddf",
+      "bugs": {
+        "url": "https://github.com/zkat/ssri/issues"
+      },
+      "homepage": "https://github.com/zkat/ssri#readme",
+      "_id": "ssri@6.0.1",
+      "_npmVersion": "6.4.1-next.0",
+      "_nodeVersion": "10.6.0",
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "dist": {
+        "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+        "shasum": "2a3c41b28dd45b62b63676ecb74001265ae9edd8",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 41465,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbhFapCRA9TVsSAnZWagAA0zsQAIa6FjZWfFf5yjI5p3aQ\nl/WNuIIw1AkISDYmwyytl2VWkFAU1nU2d4AcMwwR1sUCWt9OLFv7gkoV9aHq\nranYy0FaqdOS/Q8c9JVBDy/lrvbztbJXC7g+Dr6LmbZ8fSi9Qrp4I7FZbck4\nq2tCqf6H2h80rhc1aZCcVucjIAzoSEoc/8iZfbuQRth174slJzb6QK8DaQhC\nEBre8Ne57iRARPEqZHsqLC3G93V8gcWi02Vatzv4LtVbLzI4Kmqft0Kd5Mn0\ndMI2XqhWbL1e/5TvcszeN4YNK7WcF5Kvl1I44scDX0NGENfYF8EX+E7HyIjt\n3M8KmH6tjUrgr995Utw6Abqe2coHnnSqEpDWYhxF1wIxCt17IQbkOl49aDKz\n3FSGLDfepMxLbCYDpIe411pgHj8qLrTh6lsTHwqU9L+jRG/aC1ivRdyG+Mib\nRn6+tOOfLcDjlh4z3YXTHzCvSJ4QJjptmMeifjwWgyE0SByERiGIPpdSK1/5\n63O9ZUW8rfnuW9n1pbveq8GcrAyKzYgGEywqpiQuiBx5b6tEIuH3GfYasORI\naPiQfFkzzXiWrtS+TK2Tz8AAW41quykZ3x2F/S34TwvzTUXSZoxgwORpKXOn\nO7/M0VfpfF7ksB6TsN8TKlZI7CLCJmJVfPUELi7xBqXQWlb5hYEovD274qjv\nhUGF\r\n=M3jW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "zkat",
+          "email": "kat@sykosomatic.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_6.0.1_1535399592913_0.13364523738291578"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.0.0": {
+      "name": "ssri",
+      "version": "7.0.0",
+      "description": "Standard Subresource Integrity library -- parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "minipass": "^2.5.1"
+      },
+      "devDependencies": {
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tap": "^14.6.4",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "tap": {
+        "check-coverage": true
+      },
+      "gitHead": "9c76e0cf1079a314880078ddfa1dd2b241ba4133",
+      "bugs": {
+        "url": "https://github.com/npm/ssri/issues"
+      },
+      "homepage": "https://github.com/npm/ssri#readme",
+      "_id": "ssri@7.0.0",
+      "_nodeVersion": "12.8.1",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-cvBRrMQrBppFp7QQqh2zME8/Fek9akLhpAq6C78Q5npH8vonxkInB/nLIslb3NRCOKoM/PgUvKHd/zojlFCHlQ==",
+        "shasum": "5c2229910a91b6c161312a8d2608d3e83e82c431",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-7.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 42951,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdgnjcCRA9TVsSAnZWagAAfDQP/3KdtQJG08/tj+MiOFz9\nSSBQBUQ1QajvRW45h9o2WoL8cLwedGRS959QBd3NH8T1FP793GJLMmOv4uBM\n3ItAOKudtcWeFlZMpEoFWrzGhasxFfvujFfllszAzR8rj7t+Ccxe4a2WQ1x6\nzj8Vbr0L5sUQsFuUmROhlnWc6Ay5HyzYz0TCnnlrrioSQiOonnd1oFthz6Zn\n0cBdmb0TfhqsQT3uh/rmzxkGSYZx+mXzaSzqusSck33q9Xo5F2ZPvZQsPgC+\n83MJBZEThIR+hMkNTSjt4he5JnDFku9wLuM8cpwjVj6pEYTmmqawgs6jKHwf\nLGYDz5fPUJhwTExu3axLqJauUEqmSwSB6x8EGgf9qOHyYwc0rF795SJKV44l\nIG9dRSpl4+gK87o8ffa8mT53R+0E+jDbTGfUE+9Nc46944lKM1RX68pQlOcm\nAHCsSdYj4+O+1Ig/lym7zTDXU8TkuhawFplVeeYNXUrE7AcSG4Bj8u/m/TDu\nytblL1Jj1tS/QXMD6sBL7Y26suiejg+zo1bpw9oVVjUM8Ciu/wLVSlkDLRTO\nfEXrBjeDbH0Fr/z/cKZRku0ZJjTiyqHORiIF5QHEZShqpBHg6HdtmDaSZ+tG\n3cGAJTxmpVAJbleJR04aqtWbanUbix8U98pJSsfsdAhjICCHYDPOFT2tsoBr\nJ/gF\r\n=xoUi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "anne@npmjs.com",
+          "name": "annekimsey"
+        },
+        {
+          "email": "billatnpm@gmail.com",
+          "name": "billatnpm"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "mike@mikecorp.ca",
+          "name": "mikemimik"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_7.0.0_1568831707859_0.3783619915532417"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.0.1": {
+      "name": "ssri",
+      "version": "7.0.1",
+      "description": "Standard Subresource Integrity library -- parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "minipass": "^3.0.0"
+      },
+      "devDependencies": {
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tap": "^14.6.9",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "tap": {
+        "check-coverage": true
+      },
+      "engines": {
+        "node": ">= 8"
+      },
+      "gitHead": "cea474f30a1b52e1bc199c64033ca34a717e40f5",
+      "bugs": {
+        "url": "https://github.com/npm/ssri/issues"
+      },
+      "homepage": "https://github.com/npm/ssri#readme",
+      "_id": "ssri@7.0.1",
+      "_nodeVersion": "12.8.1",
+      "_npmVersion": "6.12.0-next.0",
+      "dist": {
+        "integrity": "sha512-FfndBvkXL9AHyGLNzU3r9AvYIBBZ7gm+m+kd0p8cT3/v4OliMAyipZAhLVEv1Zi/k4QFq9CstRGVd9pW/zcHFQ==",
+        "shasum": "b0cab7bbb11ac9ea07f003453e2011f8cbed9f34",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-7.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 43069,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdkm3jCRA9TVsSAnZWagAAHnQP/1Q/EhJN3fDnNf7vX/Jb\nQUNUDD0i1ukzFbXKJ1bpvbgkN2i9OJqWEESJt4U7wLsOem+zmGPKiLRKks1L\nkmb/0WgoU53Q/UW4E/dCXCpp39JkobTxVOo2oCmQx+vxF6r/4U6mQ6Oh7QQw\nuBfKfKsFmlCqirXu1MGYX4ivyv2HRrKijvctImo47bijp+QgkS2X7dsQskyy\nvDOMR+C/mKd62iM41ZIM8KTqSrMggT2ANi58ULurRXfXAWg8AiV9ZZKWuN+O\n/lvJJUTfP0P6b1MODkag4dSrk4g8kmPDKLofYS8fshLwFv96l9P8gcx+QbT5\nmq87HeLx+FDtqkwengxGE0yTNjb2RRuVhp1RHUBTYgZ2njX/LH5t3yukTE2r\nix5Zi4TqUReZbm+xgvzvB9CQmqxaaNLzMEwOZZyCSdl4yMuwVvkd/3K3NR7W\nJ3kJMurtI3MRQGCnTeBI6iaRr9zpC6IXayC9/p4lo4PMDUaS2F++GE1I+cA1\nxGAQ8WGQUhJaTe7xSIySxmbG61MUI2zhnxEmHANrnnGfJm8918aQviXILPHF\n6kA3ybNW7Kt8QnJc/oiOOwmKRh68LHKx9RKtoRzvAl2VEuUi5oTPWdAlpb/r\nVbliZ4GhLj620Sh33DqcVHOVL05nNBz1nGWTzsSdu39ps/DHlzoRO6NHKWfH\npTBn\r\n=EK+K\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "anne@npmjs.com",
+          "name": "annekimsey"
+        },
+        {
+          "email": "billatnpm@gmail.com",
+          "name": "billatnpm"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "mike@mikecorp.ca",
+          "name": "mikemimik"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_7.0.1_1569877474656_0.3829581462204419"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.1.0": {
+      "name": "ssri",
+      "version": "7.1.0",
+      "description": "Standard Subresource Integrity library -- parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish && git push --follow-tags",
+        "pretest": "standard",
+        "release": "standard-version -s",
+        "test": "tap -J --coverage test/*.js",
+        "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
+        "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "minipass": "^3.1.1"
+      },
+      "devDependencies": {
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tap": "^14.8.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "tap": {
+        "check-coverage": true
+      },
+      "engines": {
+        "node": ">= 8"
+      },
+      "gitHead": "79ba4ec4b2af9f82538c6917494d5cc1c24bc724",
+      "bugs": {
+        "url": "https://github.com/npm/ssri/issues"
+      },
+      "homepage": "https://github.com/npm/ssri#readme",
+      "_id": "ssri@7.1.0",
+      "_nodeVersion": "12.12.0",
+      "_npmVersion": "6.12.0",
+      "dist": {
+        "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+        "shasum": "92c241bf6de82365b5c7fb4bd76e975522e1294d",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 45632,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdsjqCCRA9TVsSAnZWagAAcjQP/RE6YZbgP3tsEzHe5Gkb\nFK3Hs53FKSmvH8ziKY7mjSEiwNE0WXFFVXG28wBtpWX6lyNSrQtNMOropOME\n7eFuvF/SXj7/9rib4qy3CIygTf1Y9TwY5OVwk9yJrSD+wSO1AJEW4FWTgR/W\nNcK2V2kvQRL874D0Tn/JzRumROMhdiizJowSRgzhzJeytDVRlo1p6ZyjMnIu\nknFtLk/d8ZJoq2IwCYfi5N+4RZt+UGuSdEyN+wb3TGfvMSmq75UjXyqEphiO\nLw8XENxjJE+/idVSpmxlB89XcaankqzrkChSgqXOK0JekIFY0g0DKG0MlMyz\nlcgHzWxrbR5P7Ds1DQ1tVeyfRWwjwKXxrYE5nAEBln0uX+0YuycwZumPCtf8\ndwzZ9i9uhokFbd5/FW8YjggpeWNZnyqeKuLMveTP/vKHZLIGRFw+DQ7kExa9\nME4AITC+bdezbyXDzOShVeoxiqBK+0vKl/zrwubsrev/4e2NQ7GACVrpIW9r\ngHFGt/kjAKuIIMOaW/VWH232i8wk/npkUMFFMZkD0OiKFYdN9oF12/4Q6Ls/\nA5bCQXcgM86v0N0rAsoULwUIwpx5oo5G+9rOA0db62oDWfY9IIfDFiXw+Dep\n6N3CcTRC7Hg514vlMXuKuaElj9QYWM6MqJy6Hb1Knce6HNamFnxLbjCK7OC0\ntMZ5\r\n=3xoh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "anne@npmjs.com",
+          "name": "annekimsey"
+        },
+        {
+          "email": "billatnpm@gmail.com",
+          "name": "billatnpm"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "mike@mikecorp.ca",
+          "name": "mikemimik"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_7.1.0_1571961474062_0.9411436124365424"
+      },
+      "_hasShrinkwrap": false
+    },
+    "8.0.0": {
+      "name": "ssri",
+      "version": "8.0.0",
+      "description": "Standard Subresource Integrity library -- parses, serializes, generates, and verifies integrity metadata according to the SRI spec.",
+      "main": "index.js",
+      "scripts": {
+        "prerelease": "npm t",
+        "postrelease": "npm publish",
+        "prepublishOnly": "git push --follow-tags",
+        "posttest": "npm run lint",
+        "release": "standard-version -s",
+        "test": "tap",
+        "coverage": "tap",
+        "lint": "standard"
+      },
+      "tap": {
+        "check-coverage": true
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/npm/ssri.git"
+      },
+      "keywords": [
+        "w3c",
+        "web",
+        "security",
+        "integrity",
+        "checksum",
+        "hashing",
+        "subresource integrity",
+        "sri",
+        "sri hash",
+        "sri string",
+        "sri generator",
+        "html"
+      ],
+      "author": {
+        "name": "Kat Marchán",
+        "email": "kzm@sykosomatic.org"
+      },
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "devDependencies": {
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tap": "^14.10.6"
+      },
+      "engines": {
+        "node": ">= 8"
+      },
+      "gitHead": "41b764f91eda13867745f8d97c624c316e9c162e",
+      "bugs": {
+        "url": "https://github.com/npm/ssri/issues"
+      },
+      "homepage": "https://github.com/npm/ssri#readme",
+      "_id": "ssri@8.0.0",
+      "_nodeVersion": "13.7.0",
+      "_npmVersion": "6.13.6",
+      "dist": {
+        "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+        "shasum": "79ca74e21f8ceaeddfcb4b90143c458b8d988808",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 46677,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeSz1MCRA9TVsSAnZWagAADNYP/iXjxTytPkB/Mh+Io7y5\n4NcRLmd4Jo5AyMrYPlsHnGa6LonW8Ix2iQwXhqbOJjP1AX3dfE4E5LTsUhxY\ncyBsRcSmOqQClCxRhdd8zjnW4BXhSbPU3HbgiG3WfGkfOpxG/KAEgkgPZnVo\nctNvVue+1axYRGNzFlnMYzg1+L49inSHD+ApPY1raynAeJ/5+KWceNgC5kfk\nqJfyLPOozkwu4/6DeZBDYhP/QSDu8FrnqsItDW8LEI6yyNYsxVWZ+ThK7iFm\nCQfIbDGY6cbf6ycs1u/bD/SqKSgQynQPObwKWYB9iKEuwDqxF036DbBqM0rb\nSk8Mc7nH0TqGk9lAN27E1AmZLGteRJSrOPu6AP9qRmFpLSnZ0Um1nUoTts2n\nRUEKtZ7x8Mq5d5r1wTRIFVDI69q/eIYO+YzjkMBSr/Q+HWQt2EAEMOhFjQXs\n2Kf7zP4dUmxNIP4puRPmm4S+btfreIdrONg5CpNPVViG8xfyy8sn42gBvzU8\nsqcOYOgqVFOMKIO4UHaK5afMPnJX1WGW48vXhVgV14yJLAcqWWeJoOpR3l7r\nXA1EPZ3UOJbf7OeeDPURsPbSr4rIR8lskNr96bDBnMfG5s4eEq2GipdIeJd/\nuYlxG+k1g5W7xSfDAk6DHhfy/rCVRnLZHK+HuC36mbwAVa42Rn9huxbgV4m3\nAdJ9\r\n=2jxg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "evilpacket@gmail.com",
+          "name": "adam_baldwin"
+        },
+        {
+          "email": "ahmad@ahmadnassri.com",
+          "name": "ahmadnassri"
+        },
+        {
+          "email": "cghr1990@gmail.com",
+          "name": "claudiahdz"
+        },
+        {
+          "email": "darcy@darcyclarke.me",
+          "name": "darcyclarke"
+        },
+        {
+          "email": "i@izs.me",
+          "name": "isaacs"
+        },
+        {
+          "email": "mike@mikecorp.ca",
+          "name": "mikemimik"
+        },
+        {
+          "email": "ruyadorno@hotmail.com",
+          "name": "ruyadorno"
+        }
+      ],
+      "_npmUser": {
+        "name": "isaacs",
+        "email": "i@izs.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/ssri_8.0.0_1581989196356_0.45702091932187017"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# ssri [![npm version](https://img.shields.io/npm/v/ssri.svg)](https://npm.im/ssri) [![license](https://img.shields.io/npm/l/ssri.svg)](https://npm.im/ssri) [![Travis](https://img.shields.io/travis/npm/ssri.svg)](https://travis-ci.org/npm/ssri) [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/npm/ssri?svg=true)](https://ci.appveyor.com/project/npm/ssri) [![Coverage Status](https://coveralls.io/repos/github/npm/ssri/badge.svg?branch=latest)](https://coveralls.io/github/npm/ssri?branch=latest)\n\n[`ssri`](https://github.com/npm/ssri), short for Standard Subresource\nIntegrity, is a Node.js utility for parsing, manipulating, serializing,\ngenerating, and verifying [Subresource\nIntegrity](https://w3c.github.io/webappsec/specs/subresourceintegrity/) hashes.\n\n## Install\n\n`$ npm install --save ssri`\n\n## Table of Contents\n\n* [Example](#example)\n* [Features](#features)\n* [Contributing](#contributing)\n* [API](#api)\n  * Parsing & Serializing\n    * [`parse`](#parse)\n    * [`stringify`](#stringify)\n    * [`Integrity#concat`](#integrity-concat)\n    * [`Integrity#merge`](#integrity-merge)\n    * [`Integrity#toString`](#integrity-to-string)\n    * [`Integrity#toJSON`](#integrity-to-json)\n    * [`Integrity#match`](#integrity-match)\n    * [`Integrity#pickAlgorithm`](#integrity-pick-algorithm)\n    * [`Integrity#hexDigest`](#integrity-hex-digest)\n  * Integrity Generation\n    * [`fromHex`](#from-hex)\n    * [`fromData`](#from-data)\n    * [`fromStream`](#from-stream)\n    * [`create`](#create)\n  * Integrity Verification\n    * [`checkData`](#check-data)\n    * [`checkStream`](#check-stream)\n    * [`integrityStream`](#integrity-stream)\n\n### Example\n\n```javascript\nconst ssri = require('ssri')\n\nconst integrity = 'sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==?foo'\n\n// Parsing and serializing\nconst parsed = ssri.parse(integrity)\nssri.stringify(parsed) // === integrity (works on non-Integrity objects)\nparsed.toString() // === integrity\n\n// Async stream functions\nssri.checkStream(fs.createReadStream('./my-file'), integrity).then(...)\nssri.fromStream(fs.createReadStream('./my-file')).then(sri => {\n  sri.toString() === integrity\n})\nfs.createReadStream('./my-file').pipe(ssri.createCheckerStream(sri))\n\n// Sync data functions\nssri.fromData(fs.readFileSync('./my-file')) // === parsed\nssri.checkData(fs.readFileSync('./my-file'), integrity) // => 'sha512'\n```\n\n### Features\n\n* Parses and stringifies SRI strings.\n* Generates SRI strings from raw data or Streams.\n* Strict standard compliance.\n* `?foo` metadata option support.\n* Multiple entries for the same algorithm.\n* Object-based integrity hash manipulation.\n* Small footprint: no dependencies, concise implementation.\n* Full test coverage.\n* Customizable algorithm picker.\n\n### Contributing\n\nThe ssri team enthusiastically welcomes contributions and project participation!\nThere's a bunch of things you can do if you want to contribute! The [Contributor\nGuide](CONTRIBUTING.md) has all the information you need for everything from\nreporting bugs to contributing entire new features. Please don't hesitate to\njump in if you'd like to, or even ask us questions if something isn't clear.\n\n### API\n\n#### <a name=\"parse\"></a> `> ssri.parse(sri, [opts]) -> Integrity`\n\nParses `sri` into an `Integrity` data structure. `sri` can be an integrity\nstring, an `Hash`-like with `digest` and `algorithm` fields and an optional\n`options` field, or an `Integrity`-like object. The resulting object will be an\n`Integrity` instance that has this shape:\n\n```javascript\n{\n  'sha1': [{algorithm: 'sha1', digest: 'deadbeef', options: []}],\n  'sha512': [\n    {algorithm: 'sha512', digest: 'c0ffee', options: []},\n    {algorithm: 'sha512', digest: 'bad1dea', options: ['foo']}\n  ],\n}\n```\n\nIf `opts.single` is truthy, a single `Hash` object will be returned. That is, a\nsingle object that looks like `{algorithm, digest, options}`, as opposed to a\nlarger object with multiple of these.\n\nIf `opts.strict` is truthy, the resulting object will be filtered such that\nit strictly follows the Subresource Integrity spec, throwing away any entries\nwith any invalid components. This also means a restricted set of algorithms\nwill be used -- the spec limits them to `sha256`, `sha384`, and `sha512`.\n\nStrict mode is recommended if the integrity strings are intended for use in\nbrowsers, or in other situations where strict adherence to the spec is needed.\n\n##### Example\n\n```javascript\nssri.parse('sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==?foo') // -> Integrity object\n```\n\n#### <a name=\"stringify\"></a> `> ssri.stringify(sri, [opts]) -> String`\n\nThis function is identical to [`Integrity#toString()`](#integrity-to-string),\nexcept it can be used on _any_ object that [`parse`](#parse) can handle -- that\nis, a string, an `Hash`-like, or an `Integrity`-like.\n\nThe `opts.sep` option defines the string to use when joining multiple entries\ntogether. To be spec-compliant, this _must_ be whitespace. The default is a\nsingle space (`' '`).\n\nIf `opts.strict` is true, the integrity string will be created using strict\nparsing rules. See [`ssri.parse`](#parse).\n\n##### Example\n\n```javascript\n// Useful for cleaning up input SRI strings:\nssri.stringify('\\n\\rsha512-foo\\n\\t\\tsha384-bar')\n// -> 'sha512-foo sha384-bar'\n\n// Hash-like: only a single entry.\nssri.stringify({\n  algorithm: 'sha512',\n  digest:'9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==',\n  options: ['foo']\n})\n// ->\n// 'sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==?foo'\n\n// Integrity-like: full multi-entry syntax. Similar to output of `ssri.parse`\nssri.stringify({\n  'sha512': [\n    {\n      algorithm: 'sha512',\n      digest:'9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==',\n      options: ['foo']\n    }\n  ]\n})\n// ->\n// 'sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==?foo'\n```\n\n#### <a name=\"integrity-concat\"></a> `> Integrity#concat(otherIntegrity, [opts]) -> Integrity`\n\nConcatenates an `Integrity` object with another IntegrityLike, or an integrity\nstring.\n\nThis is functionally equivalent to concatenating the string format of both\nintegrity arguments, and calling [`ssri.parse`](#ssri-parse) on the new string.\n\nIf `opts.strict` is true, the new `Integrity` will be created using strict\nparsing rules. See [`ssri.parse`](#parse).\n\n##### Example\n\n```javascript\n// This will combine the integrity checks for two different versions of\n// your index.js file so you can use a single integrity string and serve\n// either of these to clients, from a single `<script>` tag.\nconst desktopIntegrity = ssri.fromData(fs.readFileSync('./index.desktop.js'))\nconst mobileIntegrity = ssri.fromData(fs.readFileSync('./index.mobile.js'))\n\n// Note that browsers (and ssri) will succeed as long as ONE of the entries\n// for the *prioritized* algorithm succeeds. That is, in order for this fallback\n// to work, both desktop and mobile *must* use the same `algorithm` values.\ndesktopIntegrity.concat(mobileIntegrity)\n```\n\n#### <a name=\"integrity-merge\"></a> `> Integrity#merge(otherIntegrity, [opts])`\n\nSafely merges another IntegrityLike or integrity string into an `Integrity`\nobject.\n\nIf the other integrity value has any algorithms in common with the current\nobject, then the hash digests must match, or an error is thrown.\n\nAny new hashes will be added to the current object's set.\n\nThis is useful when an integrity value may be upgraded with a stronger\nalgorithm, you wish to prevent accidentally supressing integrity errors by\noverwriting the expected integrity value.\n\n##### Example\n\n```javascript\nconst data = fs.readFileSync('data.txt')\n\n// integrity.txt contains 'sha1-X1UT+IIv2+UUWvM7ZNjZcNz5XG4='\n// because we were young, and didn't realize sha1 would not last\nconst expectedIntegrity = ssri.parse(fs.readFileSync('integrity.txt', 'utf8'))\nconst match = ssri.checkData(data, expectedIntegrity, {\n  algorithms: ['sha512', 'sha1']\n})\nif (!match) {\n  throw new Error('data corrupted or something!')\n}\n\n// get a stronger algo!\nif (match && match.algorithm !== 'sha512') {\n  const updatedIntegrity = ssri.fromData(data, { algorithms: ['sha512'] })\n  expectedIntegrity.merge(updatedIntegrity)\n  fs.writeFileSync('integrity.txt', expectedIntegrity.toString())\n  // file now contains\n  // 'sha1-X1UT+IIv2+UUWvM7ZNjZcNz5XG4= sha512-yzd8ELD1piyANiWnmdnpCL5F52f10UfUdEkHywVZeqTt0ymgrxR63Qz0GB7TKPoeeZQmWCaz7T1+9vBnypkYWg=='\n}\n```\n\n#### <a name=\"integrity-to-string\"></a> `> Integrity#toString([opts]) -> String`\n\nReturns the string representation of an `Integrity` object. All hash entries\nwill be concatenated in the string by `opts.sep`, which defaults to `' '`.\n\nIf you want to serialize an object that didn't come from an `ssri` function,\nuse [`ssri.stringify()`](#stringify).\n\nIf `opts.strict` is true, the integrity string will be created using strict\nparsing rules. See [`ssri.parse`](#parse).\n\n##### Example\n\n```javascript\nconst integrity = 'sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==?foo'\n\nssri.parse(integrity).toString() === integrity\n```\n\n#### <a name=\"integrity-to-json\"></a> `> Integrity#toJSON() -> String`\n\nReturns the string representation of an `Integrity` object. All hash entries\nwill be concatenated in the string by `' '`.\n\nThis is a convenience method so you can pass an `Integrity` object directly to `JSON.stringify`.\nFor more info check out [toJSON() behavior on mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON%28%29_behavior).\n\n##### Example\n\n```javascript\nconst integrity = '\"sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A==?foo\"'\n\nJSON.stringify(ssri.parse(integrity)) === integrity\n```\n\n#### <a name=\"integrity-match\"></a> `> Integrity#match(sri, [opts]) -> Hash | false`\n\nReturns the matching (truthy) hash if `Integrity` matches the argument passed as\n`sri`, which can be anything that [`parse`](#parse) will accept. `opts` will be\npassed through to `parse` and [`pickAlgorithm()`](#integrity-pick-algorithm).\n\n##### Example\n\n```javascript\nconst integrity = 'sha512-9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A=='\n\nssri.parse(integrity).match(integrity)\n// Hash {\n//   digest: '9KhgCRIx/AmzC8xqYJTZRrnO8OW2Pxyl2DIMZSBOr0oDvtEFyht3xpp71j/r/pAe1DM+JI/A+line3jUBgzQ7A=='\n//   algorithm: 'sha512'\n// }\n\nssri.parse(integrity).match('sha1-deadbeef')\n// false\n```\n\n#### <a name=\"integrity-pick-algorithm\"></a> `> Integrity#pickAlgorithm([opts]) -> String`\n\nReturns the \"best\" algorithm from those available in the integrity object.\n\nIf `opts.pickAlgorithm` is provided, it will be passed two algorithms as\narguments. ssri will prioritize whichever of the two algorithms is returned by\nthis function. Note that the function may be called multiple times, and it\n**must** return one of the two algorithms provided. By default, ssri will make\na best-effort to pick the strongest/most reliable of the given algorithms. It\nmay intentionally deprioritize algorithms with known vulnerabilities.\n\n##### Example\n\n```javascript\nssri.parse('sha1-WEakDigEST sha512-yzd8ELD1piyANiWnmdnpCL5F52f10UfUdEkHywVZeqTt0ymgrxR63Qz0GB7TKPoeeZQmWCaz7T1').pickAlgorithm() // sha512\n```\n\n#### <a name=\"integrity-hex-digest\"></a> `> Integrity#hexDigest() -> String`\n\n`Integrity` is assumed to be either a single-hash `Integrity` instance, or a\n`Hash` instance. Returns its `digest`, converted to a hex representation of the\nbase64 data.\n\n##### Example\n\n```javascript\nssri.parse('sha1-deadbeef').hexDigest() // '75e69d6de79f'\n```\n\n#### <a name=\"from-hex\"></a> `> ssri.fromHex(hexDigest, algorithm, [opts]) -> Integrity`\n\nCreates an `Integrity` object with a single entry, based on a hex-formatted\nhash. This is a utility function to help convert existing shasums to the\nIntegrity format, and is roughly equivalent to something like:\n\n```javascript\nalgorithm + '-' + Buffer.from(hexDigest, 'hex').toString('base64')\n```\n\n`opts.options` may optionally be passed in: it must be an array of option\nstrings that will be added to all generated integrity hashes generated by\n`fromData`. This is a loosely-specified feature of SRIs, and currently has no\nspecified semantics besides being `?`-separated. Use at your own risk, and\nprobably avoid if your integrity strings are meant to be used with browsers.\n\nIf `opts.strict` is true, the integrity object will be created using strict\nparsing rules. See [`ssri.parse`](#parse).\n\nIf `opts.single` is true, a single `Hash` object will be returned.\n\n##### Example\n\n```javascript\nssri.fromHex('75e69d6de79f', 'sha1').toString() // 'sha1-deadbeef'\n```\n\n#### <a name=\"from-data\"></a> `> ssri.fromData(data, [opts]) -> Integrity`\n\nCreates an `Integrity` object from either string or `Buffer` data, calculating\nall the requested hashes and adding any specified options to the object.\n\n`opts.algorithms` determines which algorithms to generate hashes for. All\nresults will be included in a single `Integrity` object. The default value for\n`opts.algorithms` is `['sha512']`. All algorithm strings must be hashes listed\nin `crypto.getHashes()` for the host Node.js platform.\n\n`opts.options` may optionally be passed in: it must be an array of option\nstrings that will be added to all generated integrity hashes generated by\n`fromData`. This is a loosely-specified feature of SRIs, and currently has no\nspecified semantics besides being `?`-separated. Use at your own risk, and\nprobably avoid if your integrity strings are meant to be used with browsers.\n\nIf `opts.strict` is true, the integrity object will be created using strict\nparsing rules. See [`ssri.parse`](#parse).\n\n##### Example\n\n```javascript\nconst integrityObj = ssri.fromData('foobarbaz', {\n  algorithms: ['sha256', 'sha384', 'sha512']\n})\nintegrity.toString('\\n')\n// ->\n// sha256-l981iLWj8kurw4UbNy8Lpxqdzd7UOxS50Glhv8FwfZ0=\n// sha384-irnCxQ0CfQhYGlVAUdwTPC9bF3+YWLxlaDGM4xbYminxpbXEq+D+2GCEBTxcjES9\n// sha512-yzd8ELD1piyANiWnmdnpCL5F52f10UfUdEkHywVZeqTt0ymgrxR63Qz0GB7TKPoeeZQmWCaz7T1+9vBnypkYWg==\n```\n\n#### <a name=\"from-stream\"></a> `> ssri.fromStream(stream, [opts]) -> Promise<Integrity>`\n\nReturns a Promise of an Integrity object calculated by reading data from\na given `stream`.\n\nIt accepts both `opts.algorithms` and `opts.options`, which are documented as\npart of [`ssri.fromData`](#from-data).\n\nAdditionally, `opts.Promise` may be passed in to inject a Promise library of\nchoice. By default, ssri will use Node's built-in Promises.\n\nIf `opts.strict` is true, the integrity object will be created using strict\nparsing rules. See [`ssri.parse`](#parse).\n\n##### Example\n\n```javascript\nssri.fromStream(fs.createReadStream('index.js'), {\n  algorithms: ['sha1', 'sha512']\n}).then(integrity => {\n  return ssri.checkStream(fs.createReadStream('index.js'), integrity)\n}) // succeeds\n```\n\n#### <a name=\"create\"></a> `> ssri.create([opts]) -> <Hash>`\n\nReturns a Hash object with `update(<Buffer or string>[,enc])` and `digest()` methods.\n\n\nThe Hash object provides the same methods as [crypto class Hash](https://nodejs.org/dist/latest-v6.x/docs/api/crypto.html#crypto_class_hash).\n`digest()` accepts no arguments and returns an Integrity object calculated by reading data from\ncalls to update.\n\nIt accepts both `opts.algorithms` and `opts.options`, which are documented as\npart of [`ssri.fromData`](#from-data).\n\nIf `opts.strict` is true, the integrity object will be created using strict\nparsing rules. See [`ssri.parse`](#parse).\n\n##### Example\n\n```javascript\nconst integrity = ssri.create().update('foobarbaz').digest()\nintegrity.toString()\n// ->\n// sha512-yzd8ELD1piyANiWnmdnpCL5F52f10UfUdEkHywVZeqTt0ymgrxR63Qz0GB7TKPoeeZQmWCaz7T1+9vBnypkYWg==\n```\n\n#### <a name=\"check-data\"></a> `> ssri.checkData(data, sri, [opts]) -> Hash|false`\n\nVerifies `data` integrity against an `sri` argument. `data` may be either a\n`String` or a `Buffer`, and `sri` can be any subresource integrity\nrepresentation that [`ssri.parse`](#parse) can handle.\n\nIf verification succeeds, `checkData` will return the name of the algorithm that\nwas used for verification (a truthy value). Otherwise, it will return `false`.\n\nIf `opts.pickAlgorithm` is provided, it will be used by\n[`Integrity#pickAlgorithm`](#integrity-pick-algorithm) when deciding which of\nthe available digests to match against.\n\nIf `opts.error` is true, and verification fails, `checkData` will throw either\nan `EBADSIZE` or an `EINTEGRITY` error, instead of just returning false.\n\n##### Example\n\n```javascript\nconst data = fs.readFileSync('index.js')\nssri.checkData(data, ssri.fromData(data)) // -> 'sha512'\nssri.checkData(data, 'sha256-l981iLWj8kurw4UbNy8Lpxqdzd7UOxS50Glhv8FwfZ0')\nssri.checkData(data, 'sha1-BaDDigEST') // -> false\nssri.checkData(data, 'sha1-BaDDigEST', {error: true}) // -> Error! EINTEGRITY\n```\n\n#### <a name=\"check-stream\"></a> `> ssri.checkStream(stream, sri, [opts]) -> Promise<Hash>`\n\nVerifies the contents of `stream` against an `sri` argument. `stream` will be\nconsumed in its entirety by this process. `sri` can be any subresource integrity\nrepresentation that [`ssri.parse`](#parse) can handle.\n\n`checkStream` will return a Promise that either resolves to the\n`Hash` that succeeded verification, or, if the verification fails\nor an error happens with `stream`, the Promise will be rejected.\n\nIf the Promise is rejected because verification failed, the returned error will\nhave `err.code` as `EINTEGRITY`.\n\nIf `opts.size` is given, it will be matched against the stream size. An error\nwith `err.code` `EBADSIZE` will be returned by a rejection if the expected size\nand actual size fail to match.\n\nIf `opts.pickAlgorithm` is provided, it will be used by\n[`Integrity#pickAlgorithm`](#integrity-pick-algorithm) when deciding which of\nthe available digests to match against.\n\n##### Example\n\n```javascript\nconst integrity = ssri.fromData(fs.readFileSync('index.js'))\n\nssri.checkStream(\n  fs.createReadStream('index.js'),\n  integrity\n)\n// ->\n// Promise<{\n//   algorithm: 'sha512',\n//   digest: 'sha512-yzd8ELD1piyANiWnmdnpCL5F52f10UfUdEkHywVZeqTt0ymgrxR63Qz0GB7TKPoeeZQmWCaz7T1'\n// }>\n\nssri.checkStream(\n  fs.createReadStream('index.js'),\n  'sha256-l981iLWj8kurw4UbNy8Lpxqdzd7UOxS50Glhv8FwfZ0'\n) // -> Promise<Hash>\n\nssri.checkStream(\n  fs.createReadStream('index.js'),\n  'sha1-BaDDigEST'\n) // -> Promise<Error<{code: 'EINTEGRITY'}>>\n```\n\n#### <a name=\"integrity-stream\"></a> `> integrityStream([opts]) -> IntegrityStream`\n\nReturns a `Transform` stream that data can be piped through in order to generate\nand optionally check data integrity for piped data. When the stream completes\nsuccessfully, it emits `size` and `integrity` events, containing the total\nnumber of bytes processed and a calculated `Integrity` instance based on stream\ndata, respectively.\n\nIf `opts.algorithms` is passed in, the listed algorithms will be calculated when\ngenerating the final `Integrity` instance. The default is `['sha512']`.\n\nIf `opts.single` is passed in, a single `Hash` instance will be returned.\n\nIf `opts.integrity` is passed in, it should be an `integrity` value understood\nby [`parse`](#parse) that the stream will check the data against. If\nverification succeeds, the integrity stream will emit a `verified` event whose\nvalue is a single `Hash` object that is the one that succeeded verification. If\nverification fails, the stream will error with an `EINTEGRITY` error code.\n\nIf `opts.size` is given, it will be matched against the stream size. An error\nwith `err.code` `EBADSIZE` will be emitted by the stream if the expected size\nand actual size fail to match.\n\nIf `opts.pickAlgorithm` is provided, it will be passed two algorithms as\narguments. ssri will prioritize whichever of the two algorithms is returned by\nthis function. Note that the function may be called multiple times, and it\n**must** return one of the two algorithms provided. By default, ssri will make\na best-effort to pick the strongest/most reliable of the given algorithms. It\nmay intentionally deprioritize algorithms with known vulnerabilities.\n\n##### Example\n\n```javascript\nconst integrity = ssri.fromData(fs.readFileSync('index.js'))\nfs.createReadStream('index.js')\n.pipe(ssri.integrityStream({integrity}))\n```\n",
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-19T13:51:06.347Z",
+    "created": "2017-03-23T04:56:05.227Z",
+    "0.0.0": "2017-03-23T04:56:05.227Z",
+    "1.0.0": "2017-03-23T07:22:26.655Z",
+    "2.0.0": "2017-03-24T07:50:43.283Z",
+    "3.0.0": "2017-04-03T04:45:42.387Z",
+    "3.0.1": "2017-04-03T05:17:00.322Z",
+    "3.0.2": "2017-04-03T05:18:04.043Z",
+    "4.0.0": "2017-04-03T10:37:12.533Z",
+    "4.1.0": "2017-04-07T15:42:38.682Z",
+    "4.1.1": "2017-04-12T04:17:14.799Z",
+    "4.1.2": "2017-04-18T09:53:34.701Z",
+    "4.1.3": "2017-05-24T23:40:59.795Z",
+    "4.1.4": "2017-05-31T04:22:22.616Z",
+    "4.1.5": "2017-06-05T21:14:33.392Z",
+    "4.1.6": "2017-06-07T22:21:36.482Z",
+    "5.0.0": "2017-10-23T18:24:16.172Z",
+    "5.1.0": "2018-01-18T23:56:46.704Z",
+    "5.2.1": "2018-02-07T00:07:57.813Z",
+    "5.2.2": "2018-02-14T20:38:05.178Z",
+    "5.2.3": "2018-02-16T22:39:20.241Z",
+    "5.2.4": "2018-02-16T22:46:33.141Z",
+    "5.3.0": "2018-03-13T02:25:20.598Z",
+    "6.0.0": "2018-04-09T18:19:42.225Z",
+    "6.0.1": "2018-08-27T19:53:12.980Z",
+    "7.0.0": "2019-09-18T18:35:08.044Z",
+    "7.0.1": "2019-09-30T21:04:34.791Z",
+    "7.1.0": "2019-10-24T23:57:54.273Z",
+    "8.0.0": "2020-02-18T01:26:36.565Z"
+  },
+  "homepage": "https://github.com/npm/ssri#readme",
+  "keywords": [
+    "w3c",
+    "web",
+    "security",
+    "integrity",
+    "checksum",
+    "hashing",
+    "subresource integrity",
+    "sri",
+    "sri hash",
+    "sri string",
+    "sri generator",
+    "html"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/ssri.git"
+  },
+  "author": {
+    "name": "Kat Marchán",
+    "email": "kzm@sykosomatic.org"
+  },
+  "bugs": {
+    "url": "https://github.com/npm/ssri/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "losymear": true,
+    "yowainwright": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/ssri.min.json
+++ b/test/fixtures/registry-mocks/content/ssri.min.json
@@ -1,0 +1,540 @@
+{
+  "name": "ssri",
+  "dist-tags": {
+    "latest": "8.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "ssri",
+      "version": "0.0.0",
+      "dependencies": {
+        "bluebird": "^3.4.7",
+        "checksum-stream": "^1.0.2"
+      },
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "e67ebd98828741c1055caafb8a3a66cdcea4eb1e",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-0.0.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "ssri",
+      "version": "1.0.0",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "225790b751d5595eabcbdcf8d0d619122640186a",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "ssri",
+      "version": "2.0.0",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "d5f3de7dfb71fd420a0522c32f3cf30a0ca878bc",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-2.0.0.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "ssri",
+      "version": "3.0.0",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "1d463fee4ab1362a809f1f2fac0e5bcf8bb239ac",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "ssri",
+      "version": "3.0.1",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "6e10bdedae232928769c3d94f79e28693d5f389b",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-3.0.1.tgz"
+      }
+    },
+    "3.0.2": {
+      "name": "ssri",
+      "version": "3.0.2",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "116d4afad587889f54ba594b0fafd4c9e28d711f",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-3.0.2.tgz"
+      }
+    },
+    "4.0.0": {
+      "name": "ssri",
+      "version": "4.0.0",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "c2df3a5bb877b39bcc426c82888d4198315c4cf6",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.0.0.tgz"
+      }
+    },
+    "4.1.0": {
+      "name": "ssri",
+      "version": "4.1.0",
+      "devDependencies": {
+        "nyc": "^10.0.0",
+        "standard": "^9.0.1",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.0",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "d88781b15f0eb04d6d1cd0951a2d41b58daeceb4",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.0.tgz"
+      }
+    },
+    "4.1.1": {
+      "name": "ssri",
+      "version": "4.1.1",
+      "devDependencies": {
+        "nyc": "^10.2.0",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "11ccc8dbe39d37ecc6a05b539b073fdda35cf8c1",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.1.tgz"
+      }
+    },
+    "4.1.2": {
+      "name": "ssri",
+      "version": "4.1.2",
+      "devDependencies": {
+        "nyc": "^10.2.0",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.0.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "shasum": "3d3c69b490d0b107772a9bf81881f38ae071f24b",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.2.tgz"
+      }
+    },
+    "4.1.3": {
+      "name": "ssri",
+      "version": "4.1.3",
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-vDXK4C5lxEMlMXyUvsaNAqyYkoMaScW8r6jUTg3uwUOMnvbMmNRSw3Cal0iiWHtMsQxga7NG4GShS0CKt3Pt1w==",
+        "shasum": "ec8b5585cbfc726a5f9aad829efce238de831935",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.3.tgz"
+      }
+    },
+    "4.1.4": {
+      "name": "ssri",
+      "version": "4.1.4",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-CfN7rEZZi9/eLoED+vfKpgEPXdev5D5FV2fCih8j1e+rOSrKwoXzq3HVGy5ybu5mj94lrQ1X2oP+xBjLNtPUQQ==",
+        "shasum": "22be0659c075a612b622158872b585d5fe6b03af",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.4.tgz"
+      }
+    },
+    "4.1.5": {
+      "name": "ssri",
+      "version": "4.1.5",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.0.0",
+        "tap": "^10.3.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-TaLitc/pZH1UF8LCgZWdbssPiOUcPjBmIJsYJa+YltP77mY2qQ0Y2b+VS4C9RbZRH1GPMt4zckqqBd7GE/61ew==",
+        "shasum": "e3844770b5379ced69b512e70a28d86d86abd43a",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.5.tgz"
+      }
+    },
+    "4.1.6": {
+      "name": "ssri",
+      "version": "4.1.6",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.1.0",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
+        "shasum": "0cb49b6ac84457e7bdd466cb730c3cb623e9a25b",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz"
+      }
+    },
+    "5.0.0": {
+      "name": "ssri",
+      "version": "5.0.0",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.1.0",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
+        "shasum": "13c19390b606c821f2a10d02b351c1729b94d8cf",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz"
+      }
+    },
+    "5.1.0": {
+      "name": "ssri",
+      "version": "5.1.0",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      },
+      "devDependencies": {
+        "nyc": "^10.3.2",
+        "standard": "^9.0.2",
+        "standard-version": "^4.1.0",
+        "tap": "^10.3.3",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-TevC8fgxQKTfQ1nWtM9GNzr3q5rrHNntG9CDMH1k3QhSZI6Kb+NbjLRs8oPFZa2Hgo7zoekL+UTvoEk7tsbjQg==",
+        "shasum": "2cbf1df36b74d0fc91fcf89640a4b3e1d10b1899",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.1.0.tgz"
+      }
+    },
+    "5.2.1": {
+      "name": "ssri",
+      "version": "5.2.1",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-y4PjOWlAuxt+yAcXitQYOnOzZpKaH3+f/qGV3OWxbyC2noC9FA9GNC9uILnVdV7jruA1aDKr4OKz3ZDBcVZwFQ==",
+        "shasum": "8b6eb873688759bd3c75a88dee74593d179bb73c",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.2.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 38327
+      }
+    },
+    "5.2.2": {
+      "name": "ssri",
+      "version": "5.2.2",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-hm46mN8YSzjGuJtVocXPjwo0yTRXobXqYuK/tV6gr557/tRck4yWXKPRW8OxyJgRvcL3QgX+5ng/kMHBMco7KA==",
+        "shasum": "797be390aefe03996e4d961657a946121e2feacf",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.2.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 38591
+      }
+    },
+    "5.2.3": {
+      "name": "ssri",
+      "version": "5.2.3",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-28QiVvVENYcfxZmohuG6ZHFJ3jYxPExjVL53GAYk0dgx76NHE7MhBn2NPR2N3vThQyECN8ZHkD0FPcEks3rwLQ==",
+        "shasum": "71e142c51c7cc411b525b4ee9b872233334f8a4f",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.2.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 39070
+      }
+    },
+    "5.2.4": {
+      "name": "ssri",
+      "version": "5.2.4",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
+        "shasum": "9985e14041e65fc397af96542be35724ac11da52",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.2.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 39173
+      }
+    },
+    "5.3.0": {
+      "name": "ssri",
+      "version": "5.3.0",
+      "dependencies": {
+        "safe-buffer": "^5.1.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+        "shasum": "ba3872c9c6d33a0704a7d71ff045e5ec48999d06",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 40500
+      }
+    },
+    "6.0.0": {
+      "name": "ssri",
+      "version": "6.0.0",
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA==",
+        "shasum": "fc21bfc90e03275ac3e23d5a42e38b8a1cbc130d",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-6.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 40772
+      }
+    },
+    "6.0.1": {
+      "name": "ssri",
+      "version": "6.0.1",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1"
+      },
+      "devDependencies": {
+        "nyc": "^11.4.1",
+        "standard": "^10.0.3",
+        "standard-version": "^4.3.0",
+        "tap": "^11.1.0",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+        "shasum": "2a3c41b28dd45b62b63676ecb74001265ae9edd8",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 41465,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbhFapCRA9TVsSAnZWagAA0zsQAIa6FjZWfFf5yjI5p3aQ\nl/WNuIIw1AkISDYmwyytl2VWkFAU1nU2d4AcMwwR1sUCWt9OLFv7gkoV9aHq\nranYy0FaqdOS/Q8c9JVBDy/lrvbztbJXC7g+Dr6LmbZ8fSi9Qrp4I7FZbck4\nq2tCqf6H2h80rhc1aZCcVucjIAzoSEoc/8iZfbuQRth174slJzb6QK8DaQhC\nEBre8Ne57iRARPEqZHsqLC3G93V8gcWi02Vatzv4LtVbLzI4Kmqft0Kd5Mn0\ndMI2XqhWbL1e/5TvcszeN4YNK7WcF5Kvl1I44scDX0NGENfYF8EX+E7HyIjt\n3M8KmH6tjUrgr995Utw6Abqe2coHnnSqEpDWYhxF1wIxCt17IQbkOl49aDKz\n3FSGLDfepMxLbCYDpIe411pgHj8qLrTh6lsTHwqU9L+jRG/aC1ivRdyG+Mib\nRn6+tOOfLcDjlh4z3YXTHzCvSJ4QJjptmMeifjwWgyE0SByERiGIPpdSK1/5\n63O9ZUW8rfnuW9n1pbveq8GcrAyKzYgGEywqpiQuiBx5b6tEIuH3GfYasORI\naPiQfFkzzXiWrtS+TK2Tz8AAW41quykZ3x2F/S34TwvzTUXSZoxgwORpKXOn\nO7/M0VfpfF7ksB6TsN8TKlZI7CLCJmJVfPUELi7xBqXQWlb5hYEovD274qjv\nhUGF\r\n=M3jW\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.0.0": {
+      "name": "ssri",
+      "version": "7.0.0",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "minipass": "^2.5.1"
+      },
+      "devDependencies": {
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tap": "^14.6.4",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-cvBRrMQrBppFp7QQqh2zME8/Fek9akLhpAq6C78Q5npH8vonxkInB/nLIslb3NRCOKoM/PgUvKHd/zojlFCHlQ==",
+        "shasum": "5c2229910a91b6c161312a8d2608d3e83e82c431",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-7.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 42951,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdgnjcCRA9TVsSAnZWagAAfDQP/3KdtQJG08/tj+MiOFz9\nSSBQBUQ1QajvRW45h9o2WoL8cLwedGRS959QBd3NH8T1FP793GJLMmOv4uBM\n3ItAOKudtcWeFlZMpEoFWrzGhasxFfvujFfllszAzR8rj7t+Ccxe4a2WQ1x6\nzj8Vbr0L5sUQsFuUmROhlnWc6Ay5HyzYz0TCnnlrrioSQiOonnd1oFthz6Zn\n0cBdmb0TfhqsQT3uh/rmzxkGSYZx+mXzaSzqusSck33q9Xo5F2ZPvZQsPgC+\n83MJBZEThIR+hMkNTSjt4he5JnDFku9wLuM8cpwjVj6pEYTmmqawgs6jKHwf\nLGYDz5fPUJhwTExu3axLqJauUEqmSwSB6x8EGgf9qOHyYwc0rF795SJKV44l\nIG9dRSpl4+gK87o8ffa8mT53R+0E+jDbTGfUE+9Nc46944lKM1RX68pQlOcm\nAHCsSdYj4+O+1Ig/lym7zTDXU8TkuhawFplVeeYNXUrE7AcSG4Bj8u/m/TDu\nytblL1Jj1tS/QXMD6sBL7Y26suiejg+zo1bpw9oVVjUM8Ciu/wLVSlkDLRTO\nfEXrBjeDbH0Fr/z/cKZRku0ZJjTiyqHORiIF5QHEZShqpBHg6HdtmDaSZ+tG\n3cGAJTxmpVAJbleJR04aqtWbanUbix8U98pJSsfsdAhjICCHYDPOFT2tsoBr\nJ/gF\r\n=xoUi\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.0.1": {
+      "name": "ssri",
+      "version": "7.0.1",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "minipass": "^3.0.0"
+      },
+      "devDependencies": {
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tap": "^14.6.9",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-FfndBvkXL9AHyGLNzU3r9AvYIBBZ7gm+m+kd0p8cT3/v4OliMAyipZAhLVEv1Zi/k4QFq9CstRGVd9pW/zcHFQ==",
+        "shasum": "b0cab7bbb11ac9ea07f003453e2011f8cbed9f34",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-7.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 43069,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdkm3jCRA9TVsSAnZWagAAHnQP/1Q/EhJN3fDnNf7vX/Jb\nQUNUDD0i1ukzFbXKJ1bpvbgkN2i9OJqWEESJt4U7wLsOem+zmGPKiLRKks1L\nkmb/0WgoU53Q/UW4E/dCXCpp39JkobTxVOo2oCmQx+vxF6r/4U6mQ6Oh7QQw\nuBfKfKsFmlCqirXu1MGYX4ivyv2HRrKijvctImo47bijp+QgkS2X7dsQskyy\nvDOMR+C/mKd62iM41ZIM8KTqSrMggT2ANi58ULurRXfXAWg8AiV9ZZKWuN+O\n/lvJJUTfP0P6b1MODkag4dSrk4g8kmPDKLofYS8fshLwFv96l9P8gcx+QbT5\nmq87HeLx+FDtqkwengxGE0yTNjb2RRuVhp1RHUBTYgZ2njX/LH5t3yukTE2r\nix5Zi4TqUReZbm+xgvzvB9CQmqxaaNLzMEwOZZyCSdl4yMuwVvkd/3K3NR7W\nJ3kJMurtI3MRQGCnTeBI6iaRr9zpC6IXayC9/p4lo4PMDUaS2F++GE1I+cA1\nxGAQ8WGQUhJaTe7xSIySxmbG61MUI2zhnxEmHANrnnGfJm8918aQviXILPHF\n6kA3ybNW7Kt8QnJc/oiOOwmKRh68LHKx9RKtoRzvAl2VEuUi5oTPWdAlpb/r\nVbliZ4GhLj620Sh33DqcVHOVL05nNBz1nGWTzsSdu39ps/DHlzoRO6NHKWfH\npTBn\r\n=EK+K\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "7.1.0": {
+      "name": "ssri",
+      "version": "7.1.0",
+      "dependencies": {
+        "figgy-pudding": "^3.5.1",
+        "minipass": "^3.1.1"
+      },
+      "devDependencies": {
+        "standard": "^14.3.0",
+        "standard-version": "^7.0.0",
+        "tap": "^14.8.2",
+        "weallbehave": "^1.2.0",
+        "weallcontribute": "^1.0.8"
+      },
+      "dist": {
+        "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+        "shasum": "92c241bf6de82365b5c7fb4bd76e975522e1294d",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 45632,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdsjqCCRA9TVsSAnZWagAAcjQP/RE6YZbgP3tsEzHe5Gkb\nFK3Hs53FKSmvH8ziKY7mjSEiwNE0WXFFVXG28wBtpWX6lyNSrQtNMOropOME\n7eFuvF/SXj7/9rib4qy3CIygTf1Y9TwY5OVwk9yJrSD+wSO1AJEW4FWTgR/W\nNcK2V2kvQRL874D0Tn/JzRumROMhdiizJowSRgzhzJeytDVRlo1p6ZyjMnIu\nknFtLk/d8ZJoq2IwCYfi5N+4RZt+UGuSdEyN+wb3TGfvMSmq75UjXyqEphiO\nLw8XENxjJE+/idVSpmxlB89XcaankqzrkChSgqXOK0JekIFY0g0DKG0MlMyz\nlcgHzWxrbR5P7Ds1DQ1tVeyfRWwjwKXxrYE5nAEBln0uX+0YuycwZumPCtf8\ndwzZ9i9uhokFbd5/FW8YjggpeWNZnyqeKuLMveTP/vKHZLIGRFw+DQ7kExa9\nME4AITC+bdezbyXDzOShVeoxiqBK+0vKl/zrwubsrev/4e2NQ7GACVrpIW9r\ngHFGt/kjAKuIIMOaW/VWH232i8wk/npkUMFFMZkD0OiKFYdN9oF12/4Q6Ls/\nA5bCQXcgM86v0N0rAsoULwUIwpx5oo5G+9rOA0db62oDWfY9IIfDFiXw+Dep\n6N3CcTRC7Hg514vlMXuKuaElj9QYWM6MqJy6Hb1Knce6HNamFnxLbjCK7OC0\ntMZ5\r\n=3xoh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "8.0.0": {
+      "name": "ssri",
+      "version": "8.0.0",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "devDependencies": {
+        "standard": "^14.3.1",
+        "standard-version": "^7.1.0",
+        "tap": "^14.10.6"
+      },
+      "dist": {
+        "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
+        "shasum": "79ca74e21f8ceaeddfcb4b90143c458b8d988808",
+        "tarball": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 46677,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeSz1MCRA9TVsSAnZWagAADNYP/iXjxTytPkB/Mh+Io7y5\n4NcRLmd4Jo5AyMrYPlsHnGa6LonW8Ix2iQwXhqbOJjP1AX3dfE4E5LTsUhxY\ncyBsRcSmOqQClCxRhdd8zjnW4BXhSbPU3HbgiG3WfGkfOpxG/KAEgkgPZnVo\nctNvVue+1axYRGNzFlnMYzg1+L49inSHD+ApPY1raynAeJ/5+KWceNgC5kfk\nqJfyLPOozkwu4/6DeZBDYhP/QSDu8FrnqsItDW8LEI6yyNYsxVWZ+ThK7iFm\nCQfIbDGY6cbf6ycs1u/bD/SqKSgQynQPObwKWYB9iKEuwDqxF036DbBqM0rb\nSk8Mc7nH0TqGk9lAN27E1AmZLGteRJSrOPu6AP9qRmFpLSnZ0Um1nUoTts2n\nRUEKtZ7x8Mq5d5r1wTRIFVDI69q/eIYO+YzjkMBSr/Q+HWQt2EAEMOhFjQXs\n2Kf7zP4dUmxNIP4puRPmm4S+btfreIdrONg5CpNPVViG8xfyy8sn42gBvzU8\nsqcOYOgqVFOMKIO4UHaK5afMPnJX1WGW48vXhVgV14yJLAcqWWeJoOpR3l7r\nXA1EPZ3UOJbf7OeeDPURsPbSr4rIR8lskNr96bDBnMfG5s4eEq2GipdIeJd/\nuYlxG+k1g5W7xSfDAk6DHhfy/rCVRnLZHK+HuC36mbwAVa42Rn9huxbgV4m3\nAdJ9\r\n=2jxg\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:51:06.347Z"
+}

--- a/test/fixtures/registry-mocks/content/static-extend.json
+++ b/test/fixtures/registry-mocks/content/static-extend.json
@@ -1,0 +1,333 @@
+{
+  "_id": "static-extend",
+  "_rev": "3-d927c2a1b5a4df7679c6ee94c0d0b4a9",
+  "name": "static-extend",
+  "description": "Adds a static `extend` method to a class, to simplify inheritance. Extends the static properties, prototype properties, and descriptors from a `Parent` constructor onto `Child` constructors.",
+  "dist-tags": {
+    "latest": "0.1.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "static-extend",
+      "description": "Adds a static `extend` method to a class, to simplify inheritance. Extends the static properties, prototype properties, and descriptors from a `Parent` constructor onto `Child` constructors.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/static-extend",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/static-extend.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/static-extend/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5"
+      },
+      "keywords": [
+        "class",
+        "ctor",
+        "descriptor",
+        "extend",
+        "extends",
+        "inherit",
+        "inheritance",
+        "merge",
+        "method",
+        "prop",
+        "properties",
+        "property",
+        "prototype"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "b370e8f6e4e7fddba23916faa8bdb446516baad6",
+      "_id": "static-extend@0.1.0",
+      "_shasum": "cddd8ec54d4c52ba631c79871275cfad85744ad8",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cddd8ec54d4c52ba631c79871275cfad85744ad8",
+        "tarball": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/static-extend-0.1.0.tgz_1457684127303_0.9251366925891489"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "static-extend",
+      "description": "Adds a static `extend` method to a class, to simplify inheritance. Extends the static properties, prototype properties, and descriptors from a `Parent` constructor onto `Child` constructors.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/static-extend",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/static-extend.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/static-extend/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5"
+      },
+      "keywords": [
+        "class",
+        "ctor",
+        "descriptor",
+        "extend",
+        "extends",
+        "inherit",
+        "inheritance",
+        "merge",
+        "method",
+        "prop",
+        "properties",
+        "property",
+        "prototype"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "reflinks": [
+          "verb"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "615e9a3c88bdc93cf7d71793d76a77cf54eb996a",
+      "_id": "static-extend@0.1.1",
+      "_shasum": "7f2fb0d42a1020c2f5919dabc493b42912380060",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7f2fb0d42a1020c2f5919dabc493b42912380060",
+        "tarball": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/static-extend-0.1.1.tgz_1457684793966_0.13632435514591634"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "static-extend",
+      "description": "Adds a static `extend` method to a class, to simplify inheritance. Extends the static properties, prototype properties, and descriptors from a `Parent` constructor onto `Child` constructors.",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/static-extend",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/static-extend.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/static-extend/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.9",
+        "mocha": "^2.5.3"
+      },
+      "keywords": [
+        "class",
+        "ctor",
+        "descriptor",
+        "extend",
+        "extends",
+        "inherit",
+        "inheritance",
+        "merge",
+        "method",
+        "prop",
+        "properties",
+        "property",
+        "prototype"
+      ],
+      "verb": {
+        "run": true,
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "reflinks": [
+          "verb",
+          "verb-readme-generator"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "ce41369391163eb9403848a1b4daf00be981c56b",
+      "_id": "static-extend@0.1.2",
+      "_shasum": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
+      "_from": ".",
+      "_npmVersion": "3.8.9",
+      "_nodeVersion": "6.2.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
+        "tarball": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/static-extend-0.1.2.tgz_1465497934772_0.6460855521727353"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# static-extend [![NPM version](https://img.shields.io/npm/v/static-extend.svg?style=flat)](https://www.npmjs.com/package/static-extend) [![NPM downloads](https://img.shields.io/npm/dm/static-extend.svg?style=flat)](https://npmjs.org/package/static-extend) [![Build Status](https://img.shields.io/travis/jonschlinkert/static-extend.svg?style=flat)](https://travis-ci.org/jonschlinkert/static-extend)\n\nAdds a static `extend` method to a class, to simplify inheritance. Extends the static properties, prototype properties, and descriptors from a `Parent` constructor onto `Child` constructors.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install static-extend --save\n```\n\n## Usage\n\n```js\nvar extend = require('static-extend');\n```\n\n## API\n\n### [extend](index.js#L47)\n\nReturns a function for extending the static properties, prototype properties, and descriptors from the `Parent` constructor onto `Child` constructors.\n\n**Params**\n\n* `Parent` **{Function}**: Parent ctor\n* `extendFn` **{Function}**: Optional extend function for handling any necessary custom merging. Useful when updating methods that require a specific prototype.\n* `Child` **{Function}**: Child ctor\n* `proto` **{Object}**: Optionally pass additional prototype properties to inherit.\n* `returns` **{Object}**\n\n**Example**\n\n```js\nvar extend = require('static-extend');\nParent.extend = extend(Parent);\n\n// optionally pass a custom merge function as the second arg\nParent.extend = extend(Parent, function(Child) {\n  Child.prototype.mixin = function(key, val) {\n    Child.prototype[key] = val;\n  };\n});\n\n// extend \"child\" constructors\nParent.extend(Child);\n\n// optionally define prototype methods as the second arg\nParent.extend(Child, {\n  foo: function() {},\n  bar: function() {}\n});\n```\n\n## Contributing\n\nThis document was generated by [verb-readme-generator](https://github.com/verbose/verb-readme-generator) (a [verb](https://github.com/verbose/verb) generator), please don't edit directly. Any changes to the readme must be made in [.verb.md](.verb.md). See [Building Docs](#building-docs).\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new). Or visit the [verb-readme-generator](https://github.com/verbose/verb-readme-generator) project to submit bug reports or pull requests for the readme layout template.\n\n## Building docs\n\nGenerate readme and API documentation with [verb](https://github.com/verbose/verb):\n\n```sh\n$ npm install -g verb verb-readme-generator && verb\n```\n\n## Running tests\n\nInstall dev dependencies:\n\n```sh\n$ npm install -d && npm test\n```\n\n## Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](http://twitter.com/jonschlinkert)\n\n## License\n\nCopyright © 2016, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT license](https://github.com/jonschlinkert/static-extend/blob/master/LICENSE).\n\n***\n\n_This file was generated by [verb](https://github.com/verbose/verb), v0.9.0, on June 09, 2016._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2016-06-09T18:45:37.095Z",
+    "created": "2016-03-11T08:15:29.541Z",
+    "0.1.0": "2016-03-11T08:15:29.541Z",
+    "0.1.1": "2016-03-11T08:26:36.140Z",
+    "0.1.2": "2016-06-09T18:45:37.095Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/static-extend",
+  "keywords": [
+    "class",
+    "ctor",
+    "descriptor",
+    "extend",
+    "extends",
+    "inherit",
+    "inheritance",
+    "merge",
+    "method",
+    "prop",
+    "properties",
+    "property",
+    "prototype"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/static-extend.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/static-extend/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/static-extend.min.json
+++ b/test/fixtures/registry-mocks/content/static-extend.min.json
@@ -1,0 +1,64 @@
+{
+  "name": "static-extend",
+  "dist-tags": {
+    "latest": "0.1.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "static-extend",
+      "version": "0.1.0",
+      "dependencies": {
+        "define-property": "^0.2.5"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5"
+      },
+      "dist": {
+        "shasum": "cddd8ec54d4c52ba631c79871275cfad85744ad8",
+        "tarball": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "static-extend",
+      "version": "0.1.1",
+      "dependencies": {
+        "define-property": "^0.2.5"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.7",
+        "mocha": "^2.4.5"
+      },
+      "dist": {
+        "shasum": "7f2fb0d42a1020c2f5919dabc493b42912380060",
+        "tarball": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "static-extend",
+      "version": "0.1.2",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.9",
+        "mocha": "^2.5.3"
+      },
+      "dist": {
+        "shasum": "60809c39cbff55337226fd5e0b520f341f1fb5c6",
+        "tarball": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2016-06-09T18:45:37.095Z"
+}

--- a/test/fixtures/registry-mocks/content/statuses.json
+++ b/test/fixtures/registry-mocks/content/statuses.json
@@ -1,0 +1,1131 @@
+{
+  "_id": "statuses",
+  "_rev": "64-bba177e63128f3968f712ce70a79bd14",
+  "name": "statuses",
+  "description": "HTTP status utility",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/statuses.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/statuses/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/statuses",
+      "_id": "statuses@1.0.1",
+      "dist": {
+        "shasum": "e6e059e1bc769dfccd80fe7e9901a20a48b8ce9a",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.0.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/statuses.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/statuses/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/statuses",
+      "_id": "statuses@1.0.2",
+      "dist": {
+        "shasum": "6e8a73c2fb0886f5eecf78e0aa2a1b9ae92ab73b",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.0.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/statuses.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/statuses/issues",
+        "email": "me@jongleberry.com"
+      },
+      "license": "MIT",
+      "homepage": "https://github.com/expressjs/statuses",
+      "_id": "statuses@1.0.3",
+      "_shasum": "a7d9bfb30bce92281bdba717ceb9db10d8640afb",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a7d9bfb30bce92281bdba717ceb9db10d8640afb",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.0.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/statuses"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "index.js"
+      ],
+      "gitHead": "0315a85435546839b4bcafaf5c1e6ac2acab660a",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses",
+      "_id": "statuses@1.0.4",
+      "scripts": {},
+      "_shasum": "a8b203f645cf475a66426f6be690205c85f3ebdd",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a8b203f645cf475a66426f6be690205c85f3ebdd",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/statuses"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "index.js",
+        "codes.json",
+        "LICENSE"
+      ],
+      "devDependencies": {
+        "mocha": "1",
+        "istanbul": "0"
+      },
+      "scripts": {
+        "update": "node update.js",
+        "test": "mocha --reporter spec --bail --check-leaks",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks"
+      },
+      "gitHead": "4d540d3e25368b97d1410bf8bd5637a5c9e20ce8",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses",
+      "_id": "statuses@1.1.0",
+      "_shasum": "937882caad053f8d808d845b333cfab9def03222",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.11.13",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "937882caad053f8d808d845b333cfab9def03222",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.1.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/statuses"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "index.js",
+        "codes.json",
+        "LICENSE"
+      ],
+      "devDependencies": {
+        "mocha": "1",
+        "istanbul": "0"
+      },
+      "scripts": {
+        "update": "node update.js",
+        "test": "mocha --reporter spec --bail --check-leaks",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks"
+      },
+      "gitHead": "9b775578df2b528c377f53f3ed3cfa03da4d1274",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses",
+      "_id": "statuses@1.1.1",
+      "_shasum": "10d1811e1bd3182ea3f566bf6b4745cf8edee6cc",
+      "_from": ".",
+      "_npmVersion": "2.0.0",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "10d1811e1bd3182ea3f566bf6b4745cf8edee6cc",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/statuses"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "index.js",
+        "codes.json",
+        "LICENSE"
+      ],
+      "devDependencies": {
+        "csv-parse": "0.0.6",
+        "istanbul": "0",
+        "mocha": "1",
+        "request": "^2.44.0",
+        "stream-to-array": "^2.0.2"
+      },
+      "scripts": {
+        "build": "node scripts/build.js",
+        "update": "node scripts/update.js",
+        "test": "mocha --reporter spec --bail --check-leaks",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks"
+      },
+      "gitHead": "64dc7753f28f0302e4140602e36f0e270ddbb1bd",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses",
+      "_id": "statuses@1.2.0",
+      "_shasum": "4445790d65bec29184f50d54810f67e290c1679e",
+      "_from": ".",
+      "_npmVersion": "2.0.2",
+      "_nodeVersion": "0.11.14",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4445790d65bec29184f50d54810f67e290c1679e",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.2.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/statuses"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "index.js",
+        "codes.json",
+        "LICENSE"
+      ],
+      "devDependencies": {
+        "csv-parse": "0.0.6",
+        "istanbul": "0",
+        "mocha": "1",
+        "stream-to-array": "2"
+      },
+      "scripts": {
+        "build": "node scripts/build.js",
+        "update": "node scripts/update.js",
+        "test": "mocha --reporter spec --bail --check-leaks",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks"
+      },
+      "gitHead": "49e6ac7ae4c63ee8186f56cb52112a7eeda28ed7",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses",
+      "_id": "statuses@1.2.1",
+      "_shasum": "dded45cc18256d51ed40aec142489d5c61026d28",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dded45cc18256d51ed40aec142489d5c61026d28",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.3.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/statuses"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "HISTORY.md",
+        "index.js",
+        "codes.json",
+        "LICENSE"
+      ],
+      "devDependencies": {
+        "csv-parse": "1.0.1",
+        "eslint": "2.10.2",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5",
+        "stream-to-array": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "build": "node scripts/build.js",
+        "fetch": "node scripts/fetch.js",
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "update": "npm run fetch && npm run build"
+      },
+      "gitHead": "b3e31e8c32dd8107e898b44b8c0b2dfff3cba495",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses",
+      "_id": "statuses@1.3.0",
+      "_shasum": "8e55758cb20e7682c1f4fce8dcab30bf01d1e07a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "8e55758cb20e7682c1f4fce8dcab30bf01d1e07a",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/statuses-1.3.0.tgz_1463517875633_0.19560232176445425"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.3.1",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/statuses"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "HISTORY.md",
+        "index.js",
+        "codes.json",
+        "LICENSE"
+      ],
+      "devDependencies": {
+        "csv-parse": "1.1.7",
+        "eslint": "3.10.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "stream-to-array": "2.3.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "build": "node scripts/build.js",
+        "fetch": "node scripts/fetch.js",
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "update": "npm run fetch && npm run build"
+      },
+      "gitHead": "28a619be77f5b4741e6578a5764c5b06ec6d4aea",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses",
+      "_id": "statuses@1.3.1",
+      "_shasum": "faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "dist": {
+        "shasum": "faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/statuses-1.3.1.tgz_1478923281491_0.5574048184789717"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.4.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/statuses.git"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "HISTORY.md",
+        "index.js",
+        "codes.json",
+        "LICENSE"
+      ],
+      "devDependencies": {
+        "csv-parse": "1.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "raw-body": "2.3.2",
+        "stream-to-array": "2.3.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "build": "node scripts/build.js",
+        "fetch": "node scripts/fetch-apache.js && node scripts/fetch-iana.js && node scripts/fetch-nginx.js && node scripts/fetch-node.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "update": "npm run fetch && npm run build"
+      },
+      "gitHead": "f76682144d9f0ed2c726bf0a8c868a33e393a8e5",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses#readme",
+      "_id": "statuses@1.4.0",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "6.11.4",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+        "shasum": "bb73d446da2796106efcc1b601a253d6c46bd087",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "tj@vision-media.ca",
+          "name": "tjholowaychuk"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "mscdex@mscdex.net",
+          "name": "mscdex"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/statuses-1.4.0.tgz_1508525480889_0.6966120798606426"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "1.5.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/statuses.git"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "files": [
+        "HISTORY.md",
+        "index.js",
+        "codes.json",
+        "LICENSE"
+      ],
+      "devDependencies": {
+        "csv-parse": "1.2.4",
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.9.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.7.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "raw-body": "2.3.2",
+        "stream-to-array": "2.3.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "build": "node scripts/build.js",
+        "fetch": "node scripts/fetch-apache.js && node scripts/fetch-iana.js && node scripts/fetch-nginx.js && node scripts/fetch-node.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "update": "npm run fetch && npm run build"
+      },
+      "gitHead": "4fcf6fb80ef50e8f0603b87946b0fa7868c815e7",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses#readme",
+      "_id": "statuses@1.5.0",
+      "_shasum": "161c7dac177659fd9811f43771fa99381478628c",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.13.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "161c7dac177659fd9811f43771fa99381478628c",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 11034
+      },
+      "maintainers": [
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "fishrock123@rocketmail.com",
+          "name": "fishrock123"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "mscdex@mscdex.net",
+          "name": "mscdex"
+        },
+        {
+          "email": "tj@vision-media.ca",
+          "name": "tjholowaychuk"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/statuses_1.5.0_1522201397898_0.27375877363523005"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "statuses",
+      "description": "HTTP status utility",
+      "version": "2.0.0",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/statuses.git"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "status",
+        "code"
+      ],
+      "devDependencies": {
+        "csv-parse": "4.8.8",
+        "eslint": "6.8.0",
+        "eslint-config-standard": "14.1.1",
+        "eslint-plugin-import": "2.20.2",
+        "eslint-plugin-markdown": "1.0.2",
+        "eslint-plugin-node": "11.1.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.1",
+        "mocha": "7.1.1",
+        "nyc": "15.0.1",
+        "raw-body": "2.4.1",
+        "stream-to-array": "2.3.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "build": "node scripts/build.js",
+        "fetch": "node scripts/fetch-apache.js && node scripts/fetch-iana.js && node scripts/fetch-nginx.js && node scripts/fetch-node.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-ci": "nyc --reporter=text npm test",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "update": "npm run fetch && npm run build",
+        "version": "node scripts/version-history.js && git add HISTORY.md"
+      },
+      "gitHead": "3bf877301beccf9a4dd0814ff8e2e0e260a7e7c6",
+      "bugs": {
+        "url": "https://github.com/jshttp/statuses/issues"
+      },
+      "homepage": "https://github.com/jshttp/statuses#readme",
+      "_id": "statuses@2.0.0",
+      "_nodeVersion": "13.12.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-w9jNUUQdpuVoYqXxnyOakhckBbOxRaoYqJscyIBYCS5ixyCnO7nQn7zBZvP9zf5QOPZcz2DLUpE3KsNPbJBOFA==",
+        "shasum": "aa7b107e018eb33e08e8aee2e7337e762dda1028",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 11666,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJenLN9CRA9TVsSAnZWagAATRcQAJUaqCVG9040tRrUxUdA\nIw3zgdZE2bFqllS/qFdwrho8dnxFhvVTZH9ufDQKFrnD52j7Zq/aF3j0UGEF\nW+1dSPzmleON/wagvwsi61GqsyNZWUOYYXsQtfJw6UtLrgcmAeNkXvcWyqvY\n9gWW8/27sMqpcECZLdXX9CaH9ZnBdJr8hIx/qUCAVKBhKLXTVN23/vrlguUM\nXPavbi0uuWy4qFYx1Pejs1BBgizSvD1/8oNf9IldtEX0vtIvE8JHBxCc1nFE\noQiTH+G8PUHUDvW14pxvMge+sXiLIYYfUipxBjzUVimv3QkeBUq9kLDjuwUO\nhegOeaxCqti73VlNHS+Xrgyqsr6nxcyDAiQcfVA4Kq8D3DEOUsBQK1BaDX3D\nuWNRi7mxDxP0I9IE6waj1kH8W4aaPY5q7rN4FDkeM5Cqd0BIQmlzOh1KrRsq\npgAAh+Jke6fDvegcPhNFXUsikAxbggbkBZtbana6lIcevuufOGQTmvktmcuw\nUHKixZEnuuhxR1OuGLU+PPGGugJcckRY56Xe37RriVXUZmWgPcBfb4mMKC2L\n52zMuRvy8j87j+uMN79TYdrZQw9DH+A428o22kKamIGBkGquXRIQu8sK1Is9\n6jOnhoilhjBZ7bgEa4snAlL1s2VeRpqdKWkwIVlGMYUWR73E0khTqgJ8Oblv\n9n90\r\n=DsWi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/statuses_2.0.0_1587327868540_0.816822952129105"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# statuses\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nHTTP status utility for node.\n\nThis module provides a list of status codes and messages sourced from\na few different projects:\n\n  * The [IANA Status Code Registry](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)\n  * The [Node.js project](https://nodejs.org/)\n  * The [NGINX project](https://www.nginx.com/)\n  * The [Apache HTTP Server project](https://httpd.apache.org/)\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install statuses\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar status = require('statuses')\n```\n\n### status(code)\n\nReturns the status message string for a known HTTP status code. The code\nmay be a number or a string. An error is thrown for an unknown status code.\n\n<!-- eslint-disable no-undef -->\n\n```js\nstatus(403) // => 'Forbidden'\nstatus('403') // => 'Forbidden'\nstatus(306) // throws\n```\n\n### status(msg)\n\nReturns the numeric status code for a known HTTP status message. The message\nis case-insensitive. An error is thrown for an unknown status message.\n\n<!-- eslint-disable no-undef -->\n\n```js\nstatus('forbidden') // => 403\nstatus('Forbidden') // => 403\nstatus('foo') // throws\n```\n\n### status.codes\n\nReturns an array of all the status codes as `Integer`s.\n\n### status.code[msg]\n\nReturns the numeric status code for a known status message (in lower-case),\notherwise `undefined`.\n\n<!-- eslint-disable no-undef, no-unused-expressions -->\n\n```js\nstatus['not found'] // => 404\n```\n\n### status.empty[code]\n\nReturns `true` if a status code expects an empty body.\n\n<!-- eslint-disable no-undef, no-unused-expressions -->\n\n```js\nstatus.empty[200] // => undefined\nstatus.empty[204] // => true\nstatus.empty[304] // => true\n```\n\n### status.message[code]\n\nReturns the string message for a known numeric status code, otherwise\n`undefined`. This object is the same format as the\n[Node.js http module `http.STATUS_CODES`](https://nodejs.org/dist/latest/docs/api/http.html#http_http_status_codes).\n\n<!-- eslint-disable no-undef, no-unused-expressions -->\n\n```js\nstatus.message[404] // => 'Not Found'\n```\n\n### status.redirect[code]\n\nReturns `true` if a status code is a valid redirect status.\n\n<!-- eslint-disable no-undef, no-unused-expressions -->\n\n```js\nstatus.redirect[200] // => undefined\nstatus.redirect[301] // => true\n```\n\n### status.retry[code]\n\nReturns `true` if you should retry the rest.\n\n<!-- eslint-disable no-undef, no-unused-expressions -->\n\n```js\nstatus.retry[501] // => undefined\nstatus.retry[503] // => true\n```\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/statuses/master\n[coveralls-url]: https://coveralls.io/r/jshttp/statuses?branch=master\n[node-version-image]: https://badgen.net/npm/node/statuses\n[node-version-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/statuses\n[npm-url]: https://npmjs.org/package/statuses\n[npm-version-image]: https://badgen.net/npm/v/statuses\n[travis-image]: https://badgen.net/travis/jshttp/statuses/master\n[travis-url]: https://travis-ci.org/jshttp/statuses\n",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    }
+  ],
+  "time": {
+    "modified": "2020-04-19T20:24:31.140Z",
+    "created": "2014-03-13T01:21:33.978Z",
+    "1.0.1": "2014-03-13T01:21:33.978Z",
+    "1.0.2": "2014-03-14T19:13:18.390Z",
+    "1.0.3": "2014-06-09T07:25:34.449Z",
+    "1.0.4": "2014-08-21T08:55:36.731Z",
+    "1.1.0": "2014-09-22T00:42:03.183Z",
+    "1.1.1": "2014-09-25T00:25:01.485Z",
+    "1.2.0": "2014-09-29T04:11:14.857Z",
+    "1.2.1": "2015-02-01T23:52:50.008Z",
+    "1.3.0": "2016-05-17T20:44:38.170Z",
+    "1.3.1": "2016-11-12T04:01:23.592Z",
+    "1.4.0": "2017-10-20T18:51:21.858Z",
+    "1.5.0": "2018-03-28T01:43:17.941Z",
+    "2.0.0": "2020-04-19T20:24:28.697Z"
+  },
+  "homepage": "https://github.com/jshttp/statuses#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/statuses.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/statuses/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "tunnckocore": true,
+    "mimmo1": true,
+    "darkowlzz": true,
+    "docksteaderluke": true,
+    "goodseller": true,
+    "maximilianschmitt": true,
+    "j3kz": true,
+    "h0ward": true,
+    "unboundev": true,
+    "igorissen": true,
+    "cwagner": true,
+    "mojaray2k": true,
+    "kodekracker": true,
+    "nickeltobias": true,
+    "ziflex": true,
+    "jota": true,
+    "wangnan0610": true,
+    "quafoo": true,
+    "bengi": true,
+    "daizch": true,
+    "456wyc": true,
+    "snowdream": true,
+    "xueboren": true,
+    "eyson": true,
+    "tedyhy": true,
+    "zhenguo.zhao": true,
+    "hualei": true
+  },
+  "keywords": [
+    "http",
+    "status",
+    "code"
+  ],
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/statuses.min.json
+++ b/test/fixtures/registry-mocks/content/statuses.min.json
@@ -1,0 +1,218 @@
+{
+  "name": "statuses",
+  "dist-tags": {
+    "latest": "2.0.0"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "statuses",
+      "version": "1.0.1",
+      "dist": {
+        "shasum": "e6e059e1bc769dfccd80fe7e9901a20a48b8ce9a",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "statuses",
+      "version": "1.0.2",
+      "dist": {
+        "shasum": "6e8a73c2fb0886f5eecf78e0aa2a1b9ae92ab73b",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "statuses",
+      "version": "1.0.3",
+      "dist": {
+        "shasum": "a7d9bfb30bce92281bdba717ceb9db10d8640afb",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "statuses",
+      "version": "1.0.4",
+      "dist": {
+        "shasum": "a8b203f645cf475a66426f6be690205c85f3ebdd",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.0.4.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "statuses",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "1",
+        "istanbul": "0"
+      },
+      "dist": {
+        "shasum": "937882caad053f8d808d845b333cfab9def03222",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "statuses",
+      "version": "1.1.1",
+      "devDependencies": {
+        "mocha": "1",
+        "istanbul": "0"
+      },
+      "dist": {
+        "shasum": "10d1811e1bd3182ea3f566bf6b4745cf8edee6cc",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "statuses",
+      "version": "1.2.0",
+      "devDependencies": {
+        "csv-parse": "0.0.6",
+        "istanbul": "0",
+        "mocha": "1",
+        "request": "^2.44.0",
+        "stream-to-array": "^2.0.2"
+      },
+      "dist": {
+        "shasum": "4445790d65bec29184f50d54810f67e290c1679e",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "statuses",
+      "version": "1.2.1",
+      "devDependencies": {
+        "csv-parse": "0.0.6",
+        "istanbul": "0",
+        "mocha": "1",
+        "stream-to-array": "2"
+      },
+      "dist": {
+        "shasum": "dded45cc18256d51ed40aec142489d5c61026d28",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "statuses",
+      "version": "1.3.0",
+      "devDependencies": {
+        "csv-parse": "1.0.1",
+        "eslint": "2.10.2",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5",
+        "stream-to-array": "2.2.0"
+      },
+      "dist": {
+        "shasum": "8e55758cb20e7682c1f4fce8dcab30bf01d1e07a",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.3.1": {
+      "name": "statuses",
+      "version": "1.3.1",
+      "devDependencies": {
+        "csv-parse": "1.1.7",
+        "eslint": "3.10.0",
+        "eslint-config-standard": "6.2.1",
+        "eslint-plugin-promise": "3.3.2",
+        "eslint-plugin-standard": "2.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "stream-to-array": "2.3.0"
+      },
+      "dist": {
+        "shasum": "faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.4.0": {
+      "name": "statuses",
+      "version": "1.4.0",
+      "devDependencies": {
+        "csv-parse": "1.2.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.0",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "raw-body": "2.3.2",
+        "stream-to-array": "2.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+        "shasum": "bb73d446da2796106efcc1b601a253d6c46bd087",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.0": {
+      "name": "statuses",
+      "version": "1.5.0",
+      "devDependencies": {
+        "csv-parse": "1.2.4",
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.9.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.7.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5",
+        "raw-body": "2.3.2",
+        "stream-to-array": "2.3.0"
+      },
+      "dist": {
+        "shasum": "161c7dac177659fd9811f43771fa99381478628c",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 11034
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "2.0.0": {
+      "name": "statuses",
+      "version": "2.0.0",
+      "devDependencies": {
+        "csv-parse": "4.8.8",
+        "eslint": "6.8.0",
+        "eslint-config-standard": "14.1.1",
+        "eslint-plugin-import": "2.20.2",
+        "eslint-plugin-markdown": "1.0.2",
+        "eslint-plugin-node": "11.1.0",
+        "eslint-plugin-promise": "4.2.1",
+        "eslint-plugin-standard": "4.0.1",
+        "mocha": "7.1.1",
+        "nyc": "15.0.1",
+        "raw-body": "2.4.1",
+        "stream-to-array": "2.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-w9jNUUQdpuVoYqXxnyOakhckBbOxRaoYqJscyIBYCS5ixyCnO7nQn7zBZvP9zf5QOPZcz2DLUpE3KsNPbJBOFA==",
+        "shasum": "aa7b107e018eb33e08e8aee2e7337e762dda1028",
+        "tarball": "https://registry.npmjs.org/statuses/-/statuses-2.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 11666,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJenLN9CRA9TVsSAnZWagAATRcQAJUaqCVG9040tRrUxUdA\nIw3zgdZE2bFqllS/qFdwrho8dnxFhvVTZH9ufDQKFrnD52j7Zq/aF3j0UGEF\nW+1dSPzmleON/wagvwsi61GqsyNZWUOYYXsQtfJw6UtLrgcmAeNkXvcWyqvY\n9gWW8/27sMqpcECZLdXX9CaH9ZnBdJr8hIx/qUCAVKBhKLXTVN23/vrlguUM\nXPavbi0uuWy4qFYx1Pejs1BBgizSvD1/8oNf9IldtEX0vtIvE8JHBxCc1nFE\noQiTH+G8PUHUDvW14pxvMge+sXiLIYYfUipxBjzUVimv3QkeBUq9kLDjuwUO\nhegOeaxCqti73VlNHS+Xrgyqsr6nxcyDAiQcfVA4Kq8D3DEOUsBQK1BaDX3D\nuWNRi7mxDxP0I9IE6waj1kH8W4aaPY5q7rN4FDkeM5Cqd0BIQmlzOh1KrRsq\npgAAh+Jke6fDvegcPhNFXUsikAxbggbkBZtbana6lIcevuufOGQTmvktmcuw\nUHKixZEnuuhxR1OuGLU+PPGGugJcckRY56Xe37RriVXUZmWgPcBfb4mMKC2L\n52zMuRvy8j87j+uMN79TYdrZQw9DH+A428o22kKamIGBkGquXRIQu8sK1Is9\n6jOnhoilhjBZ7bgEa4snAlL1s2VeRpqdKWkwIVlGMYUWR73E0khTqgJ8Oblv\n9n90\r\n=DsWi\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2020-04-19T20:24:31.140Z"
+}

--- a/test/fixtures/registry-mocks/content/stream-browserify.json
+++ b/test/fixtures/registry-mocks/content/stream-browserify.json
@@ -1,0 +1,1442 @@
+{
+  "_id": "stream-browserify",
+  "_rev": "47-51113491caacc28e0d9bb906a9a8cdfc",
+  "name": "stream-browserify",
+  "description": "the stream module from node core for browsers",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "stream-browserify",
+      "version": "0.0.0",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.0.0",
+      "dist": {
+        "shasum": "b995683428f68f4be8bc86ecfaf505f1921a7ff5",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "stream-browserify",
+      "version": "0.0.1",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "setimmediate": "~1.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.0.1",
+      "dist": {
+        "shasum": "a101560b924c4a75e61c8e5f463aeafbd56abd6a",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "stream-browserify",
+      "version": "0.0.2",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "setimmediate": "~1.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.0.2",
+      "dist": {
+        "shasum": "5b2613a4c4596dae269db3c4f8bf2e44d2bdd166",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "stream-browserify",
+      "version": "0.0.3",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "setimmediate": "~1.0.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.0.3",
+      "dist": {
+        "shasum": "e890f0e73269b3db1045f71b2ccffe56d419fd24",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "stream-browserify",
+      "version": "0.0.4",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.0.4",
+      "dist": {
+        "shasum": "72c5cd044088ca576d5f98691463ee24ad60b14c",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "stream-browserify",
+      "version": "0.1.0",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/16..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.1.0",
+      "dist": {
+        "shasum": "c4a0d007f8aa35a6a2b15a067d178d1f114628a8",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "stream-browserify",
+      "version": "0.1.1",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/16..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.1.1",
+      "dist": {
+        "shasum": "4da6ab4a8cea101866488844eee61ea43c6560d9",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "stream-browserify",
+      "version": "0.1.2",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/3.5",
+          "firefox/10",
+          "firefox/nightly",
+          "chrome/10",
+          "chrome/latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.1.2",
+      "dist": {
+        "shasum": "4365df832595675ff66248238a34fa6055cb5625",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "stream-browserify",
+      "version": "0.1.3",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/3.5",
+          "firefox/10",
+          "firefox/nightly",
+          "chrome/10",
+          "chrome/latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@0.1.3",
+      "dist": {
+        "shasum": "95cf1b369772e27adaf46352265152689c6c4be9",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "stream-browserify",
+      "version": "1.0.0",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^1.0.27-1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/3.5",
+          "firefox/10",
+          "firefox/nightly",
+          "chrome/10",
+          "chrome/latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@1.0.0",
+      "dist": {
+        "shasum": "bf9b4abfb42b274d751479e44e0ff2656b6f1193",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "stream-browserify",
+      "version": "2.0.0",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/3.5",
+          "firefox/10",
+          "firefox/nightly",
+          "chrome/10",
+          "chrome/latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "cb007b8ff699ed51417494502c6d2d3a192bbe34",
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@2.0.0",
+      "_shasum": "6e71aaf53548303f7bc45885b1dbcffedef36715",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "substack",
+        "email": "substack@gmail.com"
+      },
+      "dist": {
+        "shasum": "6e71aaf53548303f7bc45885b1dbcffedef36715",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "stream-browserify",
+      "version": "2.0.1",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.6",
+        "tape": "^4.2.0"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/stream-browserify.git"
+      },
+      "homepage": "https://github.com/substack/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/3.5",
+          "firefox/10",
+          "firefox/nightly",
+          "chrome/10",
+          "chrome/latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "4a0cda308582b8d9dda7261b63d0437298414849",
+      "bugs": {
+        "url": "https://github.com/substack/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@2.0.1",
+      "_shasum": "66266ee5f9bdb9940a4e4514cafb43bb71e5c9db",
+      "_from": ".",
+      "_npmVersion": "2.13.5",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "stevemao",
+        "email": "steve.mao@healthinteract.com.au"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "stevemao",
+          "email": "steve.mao@healthinteract.com.au"
+        }
+      ],
+      "dist": {
+        "shasum": "66266ee5f9bdb9940a4e4514cafb43bb71e5c9db",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "stream-browserify",
+      "version": "2.0.2",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "devDependencies": {
+        "safe-buffer": "^5.1.2",
+        "tape": "^4.2.0",
+        "typedarray": "~0.0.6"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/stream-browserify.git"
+      },
+      "homepage": "https://github.com/browserify/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/3.5",
+          "firefox/10",
+          "firefox/nightly",
+          "chrome/10",
+          "chrome/latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "1d006a94cac968a4347e0dafaecc9aeb2263f4d8",
+      "bugs": {
+        "url": "https://github.com/browserify/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@2.0.2",
+      "_nodeVersion": "11.6.0",
+      "_npmVersion": "6.6.0",
+      "dist": {
+        "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+        "shasum": "87521d38a44aa7ee91ce1cd2a47df0cb49dd660b",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 7536,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcRzC4CRA9TVsSAnZWagAAlp8P/i1A0T6m5KdfftG3JTcx\nuqsj1YYtBSAlm8BTdOvR6kc7c8oR3fcMAUncnrER7celxrfOgPGxMaDlZGNA\nakIqanvA9dum43xdyb/4GfOyYtnG2m0kwDCTLdhB757fJArxlVyTqFnrGOyK\nRBeqcXisO8MhBoyGrpIgwiPawNdoAjrb2uIm5gQel+9oElG8rIHsVDqQH9sS\n8jx4JV+YCpjFo4cUBlHfbEOxyTyw3j5yGN9bjUkVk468D3pdcdREPeoZrkhi\nSwBUC0rfzbywQ9xthFq5rug4rsiS1PU60OUuYI01dIkKht6kxX6XNwb9Xob1\nOHANldgugScyt7EKFFIO/RhigWIlubUhlfg7s/WJAnbUNivb1Cuq3vU8fnAj\nCItKO5PJnd98SI3JDeisVUlAj1c+a9yRj6NBRMDZwMPLU5Pq9iKmGNx8GJxr\ncWTmv9TZE1M/ChBTpa1CTc3ztUhePDdgRV2FHMRKSkEHmIQFAiohV0SRMW2m\nmGG6pl8KNwY8c2Vi9eGzFQybb/CIv8xTLZH/1OMRUE713ti/l/nzx0ceANpO\nZgepCFdSeOl43MSkAdj4wHxRiSH4FQg8xclgIwj1sicJVTNdiQsdQsfC9hWh\nDnDRhiN3vbLM7Sm4gpdqz40MDSZOxDz4XRxqjwUni1X7pnGNgZkfq9s4v0m5\ntRQl\r\n=A68Q\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-browserify_2.0.2_1548169399782_0.24670381755226978"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "stream-browserify",
+      "version": "3.0.0",
+      "description": "the stream module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      },
+      "devDependencies": {
+        "airtap": "^1.0.2",
+        "safe-buffer": "^5.1.2",
+        "tape": "^4.13.0",
+        "through": "^2.3.8"
+      },
+      "scripts": {
+        "test": "node test",
+        "test:browsers": "airtap -- test/index.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/stream-browserify.git"
+      },
+      "homepage": "https://github.com/browserify/stream-browserify",
+      "keywords": [
+        "stream",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/8..latest",
+          "firefox/3.5",
+          "firefox/10",
+          "firefox/nightly",
+          "chrome/10",
+          "chrome/latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "gitHead": "a3625cb4181c4bcdf09884e677d4320c641b8724",
+      "bugs": {
+        "url": "https://github.com/browserify/stream-browserify/issues"
+      },
+      "_id": "stream-browserify@3.0.0",
+      "_nodeVersion": "13.13.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+        "shasum": "22b0a2850cdf6503e73085da1fc7b7d0c2122f2f",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 11567,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJemFSuCRA9TVsSAnZWagAApaEP/0b1fe2df2VpBO+q9DT0\nKBe3Xp13MvkcNMXhUfTHu8BG3V/lVY6D2skfJ1PjAb8JncDZeWHpjKbT+cN9\nkvEbwndbpVhyluerNedTCkkPpY051X9NlTgCP0jU5GjjO+mgugHlltkZlknV\nOO+DNs7SfJz1lrVMosQ7St2nr2Wms9ZQ4BeKBuYdCuo876eBXMWjYfouaw8H\nU3wMkGjpTikPh10xENQ0dXqJpLKr94sFHF4FCq6LEELm0YmFOohM3ubs7cCq\nNl1Yllq3jpW3Ft/OkWr8fD0t9oo8M0/zuGlqo7tJdihrlC7349knoIYmeJdG\nVqYjVpTBhcB7yBvwFGaejldoifrNCdgie96dFtospewMRg0Yri3t0s87eH3H\nXBewfsH9igovLN2TMZQPPUa9IYmNbNwQsQ3JnS+RfaTGdEb1DO4XVAR7s8lQ\nOFObEtRY2Mon71sDwOZkhnpAZcXiDRUC2jvwUPQqPonfk03mnfR/wi9/tfPV\nqLZ6iSBuwlKeXZ+xgIBMmwVWQG0J5/zn2gyyrzm/d0KEN/6FRAq59pcvN75a\nSE/dYamPK5St0vFHSryC8dmlFdNFBDXgbSEUJGjNhWgtm9NhfjAlEkBf/5MI\nJBLj8bI+w4hVP3Oap1LwTwa4/69bBccFLYeDp0zE8TsGPVQAy6v4Sxp6EUjF\nso0W\r\n=Qb9X\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-browserify_3.0.0_1587041454255_0.5621312962881677"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# stream-browserify\n\nthe stream module from node core, for browsers!\n\nThis module uses [`readable-stream`](https://github.com/nodejs/readable-stream), with additions for compatibility with npm packages that use old Node.js stream APIs.\n\n[![build status](https://secure.travis-ci.org/browserify/stream-browserify.svg?branch=master)](http://travis-ci.org/browserify/stream-browserify)\n\n## Install\n\nYou usually do not have to install `stream-browserify` yourself! If your code runs in Node.js, `stream` is built in, or `readable-stream` can be used. If your code runs in the browser, bundlers like [browserify](https://github.com/browserify/browserify) also include the `stream-browserify` module.\n\nBut if none of those apply, with [npm](https://npmjs.org) do:\n\n```bash\nnpm install stream-browserify\n```\n\n## API\n\nConsult the node core\n[documentation on streams](http://nodejs.org/docs/latest/api/stream.html).\n\n## Browser Support\n\nCross-browser testing generously provided by [Sauce Labs](https://saucelabs.com).\n\n[![Sauce Test Status](https://saucelabs.com/browser-matrix/stream-browserify.svg)](https://saucelabs.com/u/stream-browserify)\n\n## License\n\n[MIT](./LICENSE)\n",
+  "maintainers": [
+    {
+      "email": "raynos2@gmail.com",
+      "name": "raynos"
+    },
+    {
+      "email": "lukechilds123@gmail.com",
+      "name": "lukechilds"
+    },
+    {
+      "email": "shtylman@gmail.com",
+      "name": "defunctzombie"
+    },
+    {
+      "email": "substack@gmail.com",
+      "name": "substack"
+    },
+    {
+      "email": "feross@feross.org",
+      "name": "feross"
+    },
+    {
+      "email": "me@gkatsev.com",
+      "name": "gkatsev"
+    },
+    {
+      "email": "zertosh@gmail.com",
+      "name": "zertosh"
+    },
+    {
+      "email": "mathiasbuus@gmail.com",
+      "name": "mafintosh"
+    },
+    {
+      "email": "max@maxogden.com",
+      "name": "maxogden"
+    },
+    {
+      "email": "dominic.tarr@gmail.com",
+      "name": "dominictarr"
+    },
+    {
+      "email": "thlorenz10@gmail.com",
+      "name": "thlorenz"
+    },
+    {
+      "email": "terinjokes@gmail.com",
+      "name": "terinjokes"
+    },
+    {
+      "email": "npm-public@jessemccarthy.net",
+      "name": "jmm"
+    },
+    {
+      "email": "palmermebane@gmail.com",
+      "name": "mellowmelon"
+    },
+    {
+      "email": "darawk@gmail.com",
+      "name": "ashaffer88"
+    },
+    {
+      "email": "b@lupton.cc",
+      "name": "balupton"
+    },
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jryans@gmail.com",
+      "name": "jryans"
+    },
+    {
+      "email": "sethvincent@gmail.com",
+      "name": "sethvincent"
+    },
+    {
+      "email": "yoshuawuyts@gmail.com",
+      "name": "yoshuawuyts"
+    },
+    {
+      "email": "ungoldman@gmail.com",
+      "name": "ungoldman"
+    },
+    {
+      "email": "michael.williams@enspiral.com",
+      "name": "ahdinosaur"
+    },
+    {
+      "email": "contact@elnounch.net",
+      "name": "elnounch"
+    },
+    {
+      "email": "parshap+npm@gmail.com",
+      "name": "parshap"
+    },
+    {
+      "email": "yerko.palma@usach.cl",
+      "name": "yerkopalma"
+    },
+    {
+      "email": "forbes@lindesay.co.uk",
+      "name": "forbeslindesay"
+    },
+    {
+      "email": "martin.heidegger@gmail.com",
+      "name": "leichtgewicht"
+    },
+    {
+      "email": "garann@gmail.com",
+      "name": "garann"
+    },
+    {
+      "email": "bcomnes@gmail.com",
+      "name": "bret"
+    },
+    {
+      "email": "vestibule@anandthakker.net",
+      "name": "anandthakker"
+    },
+    {
+      "email": "dave.des@gmail.com",
+      "name": "mattdesl"
+    },
+    {
+      "email": "hughskennedy@gmail.com",
+      "name": "hughsk"
+    },
+    {
+      "email": "pereira.filype@gmail.com",
+      "name": "fpereira1"
+    },
+    {
+      "email": "renee@kooi.me",
+      "name": "goto-bus-stop"
+    },
+    {
+      "email": "post.ben.here@gmail.com",
+      "name": "bpostlethwaite"
+    },
+    {
+      "email": "github@tixz.dk",
+      "name": "emilbayes"
+    },
+    {
+      "email": "maochenyan@gmail.com",
+      "name": "stevemao"
+    },
+    {
+      "email": "peteris.krumins@gmail.com",
+      "name": "pkrumins"
+    },
+    {
+      "email": "me@JoshDuff.com",
+      "name": "tehshrike"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-09T12:54:37.005Z",
+    "created": "2013-12-03T20:09:52.968Z",
+    "0.0.0": "2013-12-03T20:09:54.660Z",
+    "0.0.1": "2013-12-08T06:32:04.039Z",
+    "0.0.2": "2013-12-08T06:48:59.824Z",
+    "0.0.3": "2013-12-12T02:41:00.204Z",
+    "0.0.4": "2013-12-12T06:59:34.105Z",
+    "0.1.0": "2013-12-20T08:43:31.762Z",
+    "0.1.1": "2013-12-20T08:53:43.481Z",
+    "0.1.2": "2013-12-22T19:15:32.003Z",
+    "0.1.3": "2014-01-25T08:13:36.457Z",
+    "1.0.0": "2014-05-10T05:48:14.652Z",
+    "2.0.0": "2015-06-25T19:16:29.161Z",
+    "2.0.1": "2015-08-27T00:15:57.850Z",
+    "2.0.2": "2019-01-22T15:03:19.918Z",
+    "3.0.0": "2020-04-16T12:50:54.368Z"
+  },
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/browserify/stream-browserify.git"
+  },
+  "readmeFilename": "readme.markdown",
+  "homepage": "https://github.com/browserify/stream-browserify",
+  "keywords": [
+    "stream",
+    "browser",
+    "browserify"
+  ],
+  "bugs": {
+    "url": "https://github.com/browserify/stream-browserify/issues"
+  },
+  "license": "MIT",
+  "users": {
+    "wenbing": true,
+    "ryanj": true,
+    "simplyianm": true,
+    "bigdoods": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/stream-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/stream-browserify.min.json
@@ -1,0 +1,223 @@
+{
+  "name": "stream-browserify",
+  "dist-tags": {
+    "latest": "3.0.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "stream-browserify",
+      "version": "0.0.0",
+      "dependencies": {
+        "inherits": "~2.0.1"
+      },
+      "dist": {
+        "shasum": "b995683428f68f4be8bc86ecfaf505f1921a7ff5",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "stream-browserify",
+      "version": "0.0.1",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "setimmediate": "~1.0.1"
+      },
+      "dist": {
+        "shasum": "a101560b924c4a75e61c8e5f463aeafbd56abd6a",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "stream-browserify",
+      "version": "0.0.2",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "setimmediate": "~1.0.1"
+      },
+      "dist": {
+        "shasum": "5b2613a4c4596dae269db3c4f8bf2e44d2bdd166",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "stream-browserify",
+      "version": "0.0.3",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "setimmediate": "~1.0.1"
+      },
+      "dist": {
+        "shasum": "e890f0e73269b3db1045f71b2ccffe56d419fd24",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "stream-browserify",
+      "version": "0.0.4",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "dist": {
+        "shasum": "72c5cd044088ca576d5f98691463ee24ad60b14c",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.0.4.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "stream-browserify",
+      "version": "0.1.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "c4a0d007f8aa35a6a2b15a067d178d1f114628a8",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "stream-browserify",
+      "version": "0.1.1",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "4da6ab4a8cea101866488844eee61ea43c6560d9",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "stream-browserify",
+      "version": "0.1.2",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "4365df832595675ff66248238a34fa6055cb5625",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "stream-browserify",
+      "version": "0.1.3",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "95cf1b369772e27adaf46352265152689c6c4be9",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.3.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "stream-browserify",
+      "version": "1.0.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^1.0.27-1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "bf9b4abfb42b274d751479e44e0ff2656b6f1193",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "stream-browserify",
+      "version": "2.0.0",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.1"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.5",
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "6e71aaf53548303f7bc45885b1dbcffedef36715",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "stream-browserify",
+      "version": "2.0.1",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "devDependencies": {
+        "typedarray": "~0.0.6",
+        "tape": "^4.2.0"
+      },
+      "dist": {
+        "shasum": "66266ee5f9bdb9940a4e4514cafb43bb71e5c9db",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "stream-browserify",
+      "version": "2.0.2",
+      "dependencies": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "devDependencies": {
+        "safe-buffer": "^5.1.2",
+        "tape": "^4.2.0",
+        "typedarray": "~0.0.6"
+      },
+      "dist": {
+        "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+        "shasum": "87521d38a44aa7ee91ce1cd2a47df0cb49dd660b",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 7536,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcRzC4CRA9TVsSAnZWagAAlp8P/i1A0T6m5KdfftG3JTcx\nuqsj1YYtBSAlm8BTdOvR6kc7c8oR3fcMAUncnrER7celxrfOgPGxMaDlZGNA\nakIqanvA9dum43xdyb/4GfOyYtnG2m0kwDCTLdhB757fJArxlVyTqFnrGOyK\nRBeqcXisO8MhBoyGrpIgwiPawNdoAjrb2uIm5gQel+9oElG8rIHsVDqQH9sS\n8jx4JV+YCpjFo4cUBlHfbEOxyTyw3j5yGN9bjUkVk468D3pdcdREPeoZrkhi\nSwBUC0rfzbywQ9xthFq5rug4rsiS1PU60OUuYI01dIkKht6kxX6XNwb9Xob1\nOHANldgugScyt7EKFFIO/RhigWIlubUhlfg7s/WJAnbUNivb1Cuq3vU8fnAj\nCItKO5PJnd98SI3JDeisVUlAj1c+a9yRj6NBRMDZwMPLU5Pq9iKmGNx8GJxr\ncWTmv9TZE1M/ChBTpa1CTc3ztUhePDdgRV2FHMRKSkEHmIQFAiohV0SRMW2m\nmGG6pl8KNwY8c2Vi9eGzFQybb/CIv8xTLZH/1OMRUE713ti/l/nzx0ceANpO\nZgepCFdSeOl43MSkAdj4wHxRiSH4FQg8xclgIwj1sicJVTNdiQsdQsfC9hWh\nDnDRhiN3vbLM7Sm4gpdqz40MDSZOxDz4XRxqjwUni1X7pnGNgZkfq9s4v0m5\ntRQl\r\n=A68Q\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.0.0": {
+      "name": "stream-browserify",
+      "version": "3.0.0",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      },
+      "devDependencies": {
+        "airtap": "^1.0.2",
+        "safe-buffer": "^5.1.2",
+        "tape": "^4.13.0",
+        "through": "^2.3.8"
+      },
+      "dist": {
+        "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+        "shasum": "22b0a2850cdf6503e73085da1fc7b7d0c2122f2f",
+        "tarball": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+        "fileCount": 13,
+        "unpackedSize": 11567,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJemFSuCRA9TVsSAnZWagAApaEP/0b1fe2df2VpBO+q9DT0\nKBe3Xp13MvkcNMXhUfTHu8BG3V/lVY6D2skfJ1PjAb8JncDZeWHpjKbT+cN9\nkvEbwndbpVhyluerNedTCkkPpY051X9NlTgCP0jU5GjjO+mgugHlltkZlknV\nOO+DNs7SfJz1lrVMosQ7St2nr2Wms9ZQ4BeKBuYdCuo876eBXMWjYfouaw8H\nU3wMkGjpTikPh10xENQ0dXqJpLKr94sFHF4FCq6LEELm0YmFOohM3ubs7cCq\nNl1Yllq3jpW3Ft/OkWr8fD0t9oo8M0/zuGlqo7tJdihrlC7349knoIYmeJdG\nVqYjVpTBhcB7yBvwFGaejldoifrNCdgie96dFtospewMRg0Yri3t0s87eH3H\nXBewfsH9igovLN2TMZQPPUa9IYmNbNwQsQ3JnS+RfaTGdEb1DO4XVAR7s8lQ\nOFObEtRY2Mon71sDwOZkhnpAZcXiDRUC2jvwUPQqPonfk03mnfR/wi9/tfPV\nqLZ6iSBuwlKeXZ+xgIBMmwVWQG0J5/zn2gyyrzm/d0KEN/6FRAq59pcvN75a\nSE/dYamPK5St0vFHSryC8dmlFdNFBDXgbSEUJGjNhWgtm9NhfjAlEkBf/5MI\nJBLj8bI+w4hVP3Oap1LwTwa4/69bBccFLYeDp0zE8TsGPVQAy6v4Sxp6EUjF\nso0W\r\n=Qb9X\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-09T12:54:37.005Z"
+}

--- a/test/fixtures/registry-mocks/content/stream-each.json
+++ b/test/fixtures/registry-mocks/content/stream-each.json
@@ -1,0 +1,639 @@
+{
+  "_id": "stream-each",
+  "_rev": "16-065d8db5e2ce3417b646051f412d87a0",
+  "name": "stream-each",
+  "description": "Iterate all the data in a stream",
+  "dist-tags": {
+    "latest": "1.2.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "stream-each",
+      "version": "1.0.0",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "04c1ed8cc3f6bbfcf1f0833bbe7381042f333cc5",
+      "_id": "stream-each@1.0.0",
+      "_shasum": "d229d2290a636c2a959fcb2ef526a3cd41145e9a",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "d229d2290a636c2a959fcb2ef526a3cd41145e9a",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "stream-each",
+      "version": "1.0.1",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "72cb2f7e21d3667a37fade7a54d0160a99dad0f6",
+      "_id": "stream-each@1.0.1",
+      "_shasum": "c94d4c222159b44090335232cd9efc93d6af8ed1",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "c94d4c222159b44090335232cd9efc93d6af8ed1",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "stream-each",
+      "version": "1.0.2",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "60f494b053d05447c3d8e114f640df06d8c71da6",
+      "_id": "stream-each@1.0.2",
+      "_shasum": "c0bf4b73cc42ef6ae859b1e9c9f8bc6a2c3ad813",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "c0bf4b73cc42ef6ae859b1e9c9f8bc6a2c3ad813",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "stream-each",
+      "version": "1.1.0",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "f24f5d7211e9d1f84ce84f02352e7190ccf2fa45",
+      "_id": "stream-each@1.1.0",
+      "_shasum": "362b5901fb29ea58caafe7d37b2e7e087f5efa45",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "362b5901fb29ea58caafe7d37b2e7e087f5efa45",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "stream-each",
+      "version": "1.1.1",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "39ca9db549e6d7d3c7dfe06c58712f9a574a20c9",
+      "_id": "stream-each@1.1.1",
+      "_shasum": "10d758d732ed133130f1950ec067154b4cd7c455",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "10d758d732ed133130f1950ec067154b4cd7c455",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "karissa",
+          "email": "krmckelv@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "stream-each",
+      "version": "1.1.2",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "f0ef91ddbe95688e376598b9959cab463c733b57",
+      "_id": "stream-each@1.1.2",
+      "_shasum": "7d4f887f24c721ab0155b12a34263d8732ad8d39",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "7d4f887f24c721ab0155b12a34263d8732ad8d39",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "karissa",
+          "email": "krmckelv@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/stream-each-1.1.2.tgz_1454600601831_0.7560806761030108"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "stream-each",
+      "version": "1.2.0",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "2968bf4f195641f5eda594c781a0b590776bc702",
+      "_id": "stream-each@1.2.0",
+      "_shasum": "1e95d47573f580d814dc0ff8cd0f66f1ce53c991",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.6.1",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "1e95d47573f580d814dc0ff8cd0f66f1ce53c991",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "karissa",
+          "email": "krmckelv@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/stream-each-1.2.0.tgz_1478427484733_0.5437065886799246"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "stream-each",
+      "version": "1.2.1",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "3722076dad239f119edd86cc467695fca0edf77c",
+      "_id": "stream-each@1.2.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-fpzgLVZwOHz42oMMvpHwrd8q5xEILMU6FKY38CVgHH4y9PPD/YRKIJ341xLIrzHXhdh7kPPoJ+S/EGHNRIdA1g==",
+        "shasum": "79a894888f35b580ef0462232bfd25fa06274e3e",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "karissa",
+          "email": "krmckelv@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-each-1.2.1.tgz_1507660752392_0.9997272100299597"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "stream-each",
+      "version": "1.2.2",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "f2fdc9b58913253325f449b25201489e98003066",
+      "_id": "stream-each@1.2.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+        "shasum": "8e8c463f91da8991778765873fe4d960d8f616bd",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "karissa",
+          "email": "krmckelv@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-each-1.2.2.tgz_1507662242567_0.13970780046656728"
+      },
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "stream-each",
+      "version": "1.2.3",
+      "description": "Iterate all the data in a stream",
+      "main": "index.js",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "ndjson": "^1.5.0",
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/stream-each.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-each/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-each",
+      "gitHead": "ccc17f5e2c444cb9f0befee545f326eb2ad69b5a",
+      "_id": "stream-each@1.2.3",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.7.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+        "shasum": "ebe27a0c389b04fbcc233642952e10731afa9bae",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6744,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbX1HoCRA9TVsSAnZWagAATYYP/iS0a/FmTrGwQ7/RkbGQ\nadDMVU7EsiLkaI7uQjshLfCHLTttcoTL0E2OTjNMHyPAcMN8w5UTr4zMXw9V\nkNXnFepcIU0kMtf2HAEecyzQREGEVBEtsfpxLI3Ct2OToXkyOpH6/iu10NyT\nEuF/0kMchPHZLPjSogSExDcSErXS14mi2pnkmh+cADDe+Mw9Ck8+Kr7AMIwR\nga3nTHfrcRJ1TkSQ6bBmXGFHulRa5YOnt6YpicunCXLFbjIuj2kaqYWtYPSH\nlGWKyq3ouE/S+6101yDi5vrZL1xudAiXa1z1sMKTPX+Cfu/C8kk8noKBMScH\niTbruY8KtsKzcTROE5hZSN19OiobQChk5tH9z5VitZKugrGFZDsJ1eL+6l+6\n2pq0+vNgeVxFmHf0CyzmyDxvMzq+GZsF0Y8rPp1WH4nJ5nlu/B+DCBO2yOzJ\nJWZXWfmIzTTfVdPemc5ksvm/MXBg3KOHrlizGnjUC3I1yj1oiOsabgXSqf0B\nqlaVdCc6a/dOLTWWtns/DBaWCsmykRnfWoSHExg4U9bpkdJrvf+i0k5quRAo\nsEEbwqOn6jjfIlnMhNIsTg0EkPW/5MUAJ3xcfjxjKW/tlW4n4+NifFmxdtno\nPGxAB3EmVeRPq6KcSoJfMMfkbg7hcPawFVjSJFn7WVDAXPwIYnHVn/Mdq6xw\n1Kbh\r\n=OLss\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "karissa",
+          "email": "krmckelv@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-each_1.2.3_1532973544684_0.4037271324645715"
+      }
+    }
+  },
+  "readme": "# stream-each\n\nIterate all the data in a stream\n\n```\nnpm install stream-each\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/stream-each.svg?style=flat)](http://travis-ci.org/mafintosh/stream-each)\n\n## Usage\n\n``` js\nvar each = require('stream-each')\n\neach(stream, function (data, next) {\n  console.log('data from stream', data)\n  // when ready to consume next chunk\n  next()\n}, function (err) {\n  console.log('no more data')\n})\n```\n\n## API\n\n#### `each(stream, iterator, cb)`\n\nIterate the data in the stream by calling the iterator function with `(data, next)`\nwhere data is a data chunk and next is a callback. Call next when you are ready to\nconsume the next chunk. Optionally you can call next with an error to destroy the stream\n\nWhen the stream ends/errors the callback is called if provided\n\n## License\n\nMIT\n\n## Related\n\n`stream-each` is part of the [mississippi stream utility collection](https://github.com/maxogden/mississippi) which includes more useful stream modules similar to this one.\n",
+  "maintainers": [
+    {
+      "name": "karissa",
+      "email": "krmckelv@gmail.com"
+    },
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    },
+    {
+      "name": "maxogden",
+      "email": "max@maxogden.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-07-30T17:59:07.233Z",
+    "created": "2015-10-18T20:41:57.778Z",
+    "1.0.0": "2015-10-18T20:41:57.778Z",
+    "1.0.1": "2015-10-18T20:45:34.438Z",
+    "1.0.2": "2015-10-18T20:48:08.056Z",
+    "1.1.0": "2015-10-18T21:15:26.755Z",
+    "1.1.1": "2016-01-26T00:58:43.986Z",
+    "1.1.2": "2016-02-04T15:43:23.065Z",
+    "1.2.0": "2016-11-06T10:18:04.958Z",
+    "1.2.1": "2017-10-10T18:39:13.414Z",
+    "1.2.2": "2017-10-10T19:04:03.593Z",
+    "1.2.3": "2018-07-30T17:59:04.760Z"
+  },
+  "homepage": "https://github.com/mafintosh/stream-each",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mafintosh/stream-each.git"
+  },
+  "author": {
+    "name": "Mathias Buus",
+    "url": "@mafintosh"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/stream-each/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "coalesce": true,
+    "morewry": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/stream-each.min.json
+++ b/test/fixtures/registry-mocks/content/stream-each.min.json
@@ -1,0 +1,170 @@
+{
+  "name": "stream-each",
+  "dist-tags": {
+    "latest": "1.2.3"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "stream-each",
+      "version": "1.0.0",
+      "devDependencies": {
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "d229d2290a636c2a959fcb2ef526a3cd41145e9a",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "stream-each",
+      "version": "1.0.1",
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "c94d4c222159b44090335232cd9efc93d6af8ed1",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "stream-each",
+      "version": "1.0.2",
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "c0bf4b73cc42ef6ae859b1e9c9f8bc6a2c3ad813",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "stream-each",
+      "version": "1.1.0",
+      "dependencies": {
+        "end-of-stream": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "362b5901fb29ea58caafe7d37b2e7e087f5efa45",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "stream-each",
+      "version": "1.1.1",
+      "dependencies": {
+        "end-of-stream": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "10d758d732ed133130f1950ec067154b4cd7c455",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "stream-each",
+      "version": "1.1.2",
+      "dependencies": {
+        "end-of-stream": "^1.1.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "7d4f887f24c721ab0155b12a34263d8732ad8d39",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.1.2.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "stream-each",
+      "version": "1.2.0",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "shasum": "1e95d47573f580d814dc0ff8cd0f66f1ce53c991",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "stream-each",
+      "version": "1.2.1",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-fpzgLVZwOHz42oMMvpHwrd8q5xEILMU6FKY38CVgHH4y9PPD/YRKIJ341xLIrzHXhdh7kPPoJ+S/EGHNRIdA1g==",
+        "shasum": "79a894888f35b580ef0462232bfd25fa06274e3e",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "stream-each",
+      "version": "1.2.2",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+        "shasum": "8e8c463f91da8991778765873fe4d960d8f616bd",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz"
+      }
+    },
+    "1.2.3": {
+      "name": "stream-each",
+      "version": "1.2.3",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      },
+      "devDependencies": {
+        "ndjson": "^1.5.0",
+        "standard": "^5.3.1",
+        "tape": "^4.2.1",
+        "through2": "^2.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
+        "shasum": "ebe27a0c389b04fbcc233642952e10731afa9bae",
+        "tarball": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 6744,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbX1HoCRA9TVsSAnZWagAATYYP/iS0a/FmTrGwQ7/RkbGQ\nadDMVU7EsiLkaI7uQjshLfCHLTttcoTL0E2OTjNMHyPAcMN8w5UTr4zMXw9V\nkNXnFepcIU0kMtf2HAEecyzQREGEVBEtsfpxLI3Ct2OToXkyOpH6/iu10NyT\nEuF/0kMchPHZLPjSogSExDcSErXS14mi2pnkmh+cADDe+Mw9Ck8+Kr7AMIwR\nga3nTHfrcRJ1TkSQ6bBmXGFHulRa5YOnt6YpicunCXLFbjIuj2kaqYWtYPSH\nlGWKyq3ouE/S+6101yDi5vrZL1xudAiXa1z1sMKTPX+Cfu/C8kk8noKBMScH\niTbruY8KtsKzcTROE5hZSN19OiobQChk5tH9z5VitZKugrGFZDsJ1eL+6l+6\n2pq0+vNgeVxFmHf0CyzmyDxvMzq+GZsF0Y8rPp1WH4nJ5nlu/B+DCBO2yOzJ\nJWZXWfmIzTTfVdPemc5ksvm/MXBg3KOHrlizGnjUC3I1yj1oiOsabgXSqf0B\nqlaVdCc6a/dOLTWWtns/DBaWCsmykRnfWoSHExg4U9bpkdJrvf+i0k5quRAo\nsEEbwqOn6jjfIlnMhNIsTg0EkPW/5MUAJ3xcfjxjKW/tlW4n4+NifFmxdtno\nPGxAB3EmVeRPq6KcSoJfMMfkbg7hcPawFVjSJFn7WVDAXPwIYnHVn/Mdq6xw\n1Kbh\r\n=OLss\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2018-07-30T17:59:07.233Z"
+}

--- a/test/fixtures/registry-mocks/content/stream-http.json
+++ b/test/fixtures/registry-mocks/content/stream-http.json
@@ -1,0 +1,3111 @@
+{
+  "_id": "stream-http",
+  "_rev": "49-da32fd2df164adea027f7db8109c816f",
+  "name": "stream-http",
+  "description": "Streaming http in the browser",
+  "dist-tags": {
+    "latest": "3.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "stream-http",
+      "version": "1.0.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "ab5e2afce81949115c0a151d30fbaf03cf540d7f",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.0.0",
+      "_shasum": "a6464f871bc9478d631e71f4b42795719f1a8473",
+      "_from": ".",
+      "_npmVersion": "2.12.0",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a6464f871bc9478d631e71f4b42795719f1a8473",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "stream-http",
+      "version": "1.0.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "4a383c74d204f58129f29535638df0208bf99fc2",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.0.1",
+      "_shasum": "c75770f4ba95672bcd9ed5d17ca98360e2241840",
+      "_from": ".",
+      "_npmVersion": "2.12.0",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c75770f4ba95672bcd9ed5d17ca98360e2241840",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "stream-http",
+      "version": "1.0.2",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "7cb4e22c9fadcfebb08b0d3d8d2ec1e3c681e03b",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.0.2",
+      "_shasum": "536a142743699a84ed06e8ee5efe1767e3397d1f",
+      "_from": ".",
+      "_npmVersion": "2.12.0",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "536a142743699a84ed06e8ee5efe1767e3397d1f",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "stream-http",
+      "version": "1.1.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "15181f558696d8f3e016d0fcebc09a7bf85af3c0",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.1.1",
+      "_shasum": "ed1fe3464b4ed81186af5c0c8062835d3c79ca38",
+      "_from": ".",
+      "_npmVersion": "2.12.0",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ed1fe3464b4ed81186af5c0c8062835d3c79ca38",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "stream-http",
+      "version": "1.2.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "cc74bc83c8c3ee65425ddeecf394ed99738b2931",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.2.0",
+      "_shasum": "ed26a476b26dc277552e87b60dd52c219d7ca643",
+      "_from": ".",
+      "_npmVersion": "2.12.0",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ed26a476b26dc277552e87b60dd52c219d7ca643",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "stream-http",
+      "version": "1.2.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "22b3cc7acbdd44002a795f971255b4288654777c",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.2.1",
+      "_shasum": "57cf86692bd97a9bf1f323a04dcc3a4de65cce62",
+      "_from": ".",
+      "_npmVersion": "2.12.0",
+      "_nodeVersion": "0.12.5",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "57cf86692bd97a9bf1f323a04dcc3a4de65cce62",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "stream-http",
+      "version": "1.3.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "c8c0966c639368e4173d0c47bff9564f8d65bb02",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.3.0",
+      "_shasum": "945c98298afafff5eb7c14e66224ac23136e9ed5",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "945c98298afafff5eb7c14e66224ac23136e9ed5",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "stream-http",
+      "version": "1.4.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "f70ac39bf4de9c1dd16f33ee31c07e555076102d",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.4.0",
+      "_shasum": "eb83899e45af41e5843d76f6730c72ec8e75684b",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "eb83899e45af41e5843d76f6730c72ec8e75684b",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "stream-http",
+      "version": "1.4.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "6d17b406a90a7973a3e2756f5c20470d2dfec2b2",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.4.1",
+      "_shasum": "3854d0fc2df61c191c89e98b8c62b93de9c13f8b",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3854d0fc2df61c191c89e98b8c62b93de9c13f8b",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "stream-http",
+      "version": "1.5.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "168dbac90c4bf9ea1d6ea240ffd2e4fbc6dabf91",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.5.0",
+      "_shasum": "bf94d2c6738c2f4c574e757df9719b09614c6a9e",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bf94d2c6738c2f4c574e757df9719b09614c6a9e",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "stream-http",
+      "version": "1.7.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "^1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "43d1322dd619c20d249862f99cf73420c3cdd7ed",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.7.0",
+      "_shasum": "d482c32866e8e6772dd5b48770436d76410d3593",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d482c32866e8e6772dd5b48770436d76410d3593",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "stream-http",
+      "version": "1.6.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "^1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "166795fc0528fe1d8637e1c4a98cb5f8c53548d5",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.6.0",
+      "_shasum": "b67b889b2c1b5ff4493d318ace9f6c298e953ccc",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b67b889b2c1b5ff4493d318ace9f6c298e953ccc",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.1": {
+      "name": "stream-http",
+      "version": "1.7.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "^1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "a169930a20c1f504b46aec93842a40b52be50b30",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@1.7.1",
+      "_shasum": "d3d2a6e14c36a38b9dafb199aee7bbc570519978",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d3d2a6e14c36a38b9dafb199aee7bbc570519978",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.7.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "stream-http",
+      "version": "2.0.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "dc421eb355c0e6607e3e4ef136e1a59e7d62a7cf",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@2.0.0",
+      "_shasum": "c39a77eece75ee7fcc9385d212c96ea528581fa5",
+      "_from": ".",
+      "_npmVersion": "2.14.2",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c39a77eece75ee7fcc9385d212c96ea528581fa5",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "stream-http",
+      "version": "2.0.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "016f4be96f82c59b906e744cd18e7013f21ec750",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@2.0.1",
+      "_shasum": "c2d02702317f5e4b9664805952b1fd62138d82a0",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c2d02702317f5e4b9664805952b1fd62138d82a0",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "stream-http",
+      "version": "2.0.2",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "85381f0e3db76bbad28dd26334e08e802a07325f",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@2.0.2",
+      "_shasum": "5acdcd05c6fe78dfeace92a81a73ebf3e8f82913",
+      "_from": ".",
+      "_npmVersion": "2.14.4",
+      "_nodeVersion": "4.1.1",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5acdcd05c6fe78dfeace92a81a73ebf3e8f82913",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "stream-http",
+      "version": "2.0.3",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && npm run test-browser",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "ae48c2c71c833d39e0e327e5ace45f3e8efe2c6c",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@2.0.3",
+      "_shasum": "f70e7ff5c7269fefe1c63112e918b8bb24407a9a",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "f70e7ff5c7269fefe1c63112e918b8bb24407a9a",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "stream-http",
+      "version": "2.0.4",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "cbc0bd803ce42ec5f3f10c6d887496fac79990cb",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@2.0.4",
+      "_shasum": "5a4c0bc3313272b26acfb68fd4059df642c48b8b",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "5a4c0bc3313272b26acfb68fd4059df642c48b8b",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.5": {
+      "name": "stream-http",
+      "version": "2.0.5",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "3c8b44379c230e4b3f2f9be4d8ffe6ed3b2ccf94",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "_id": "stream-http@2.0.5",
+      "_shasum": "080d22687ed4f237a584848ab3d6fbd8729d8f8d",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "080d22687ed4f237a584848ab3d6fbd8729d8f8d",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "stream-http",
+      "version": "2.1.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "9d24d5510ab8bd70d56d08ee13835e738d28fd94",
+      "_id": "stream-http@2.1.0",
+      "_shasum": "2eff54aaeb0cfa99e69eed0f250bad6a75a88cab",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "2eff54aaeb0cfa99e69eed0f250bad6a75a88cab",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.1": {
+      "name": "stream-http",
+      "version": "2.1.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "945083bd1df2a2dbf9c9d648d00c15201002d6be",
+      "_id": "stream-http@2.1.1",
+      "_shasum": "3b880303babe036d6f6b43127d4dcd6f8893e1db",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "3b880303babe036d6f6b43127d4dcd6f8893e1db",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.1.1.tgz_1455601262267_0.5608040874358267"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "stream-http",
+      "version": "2.2.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "4b1419cff75d4ce2ab17f57a5b3d0f5caa90459e",
+      "_id": "stream-http@2.2.0",
+      "_shasum": "0dd210200b68a22fbc991105181156b230076c3c",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.7.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "0dd210200b68a22fbc991105181156b230076c3c",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-11-east.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.2.0.tgz_1456881311859_0.8881466328166425"
+      },
+      "directories": {}
+    },
+    "2.2.1": {
+      "name": "stream-http",
+      "version": "2.2.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "5e25ed2f65abd9065dbb140deabce5a13b8668dd",
+      "_id": "stream-http@2.2.1",
+      "_shasum": "c0d29dd8546341c66a4880a78272cd4661a956a6",
+      "_from": ".",
+      "_npmVersion": "3.7.3",
+      "_nodeVersion": "5.9.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "c0d29dd8546341c66a4880a78272cd4661a956a6",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.2.1.tgz_1458969127191_0.3222543275915086"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "stream-http",
+      "version": "2.3.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "gitHead": "ff601a9eff4182d3ecd0593cad6effbb3035963b",
+      "_id": "stream-http@2.3.0",
+      "_shasum": "d77de76f6211072119f8d2a49a118717b8feeaa3",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "5.11.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "d77de76f6211072119f8d2a49a118717b8feeaa3",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.3.0.tgz_1461832335352_0.8560710966121405"
+      },
+      "directories": {}
+    },
+    "2.3.1": {
+      "name": "stream-http",
+      "version": "2.3.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "ac250a9b04689f616ce09b93c29804cb5e63c200",
+      "_id": "stream-http@2.3.1",
+      "_shasum": "7e1dc87102c3e31b32e660f04ca31f23ddbd1d52",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "7e1dc87102c3e31b32e660f04ca31f23ddbd1d52",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.3.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.3.1.tgz_1469687955984_0.9986460644286126"
+      },
+      "directories": {}
+    },
+    "2.4.0": {
+      "name": "stream-http",
+      "version": "2.4.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "92500c71be74bc1c4c2d27dabfc9ed2a1d3bb252",
+      "_id": "stream-http@2.4.0",
+      "_shasum": "9599aa8e263667ce4190e0dc04a1d065d3595a7e",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.4.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "9599aa8e263667ce4190e0dc04a1d065d3595a7e",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.4.0.tgz_1473377936887_0.6653944130521268"
+      },
+      "directories": {}
+    },
+    "2.4.1": {
+      "name": "stream-http",
+      "version": "2.4.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "525957277adb1b05bb7e27ff4b5438ca7a9f8ac0",
+      "_id": "stream-http@2.4.1",
+      "_shasum": "8ee5689ae69169e8eb8edd6aeb2ca08ab47e8f59",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "8ee5689ae69169e8eb8edd6aeb2ca08ab47e8f59",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.4.1.tgz_1477642944716_0.22453267988748848"
+      },
+      "directories": {}
+    },
+    "2.5.0": {
+      "name": "stream-http",
+      "version": "2.5.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "8c07b21b8258e651b6859444f5ad77b4a37d2616",
+      "_id": "stream-http@2.5.0",
+      "_shasum": "585eee513217ed98fe199817e7313b6f772a6802",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "585eee513217ed98fe199817e7313b6f772a6802",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.5.0.tgz_1478239364925_0.0796565196942538"
+      },
+      "directories": {}
+    },
+    "2.6.0": {
+      "name": "stream-http",
+      "version": "2.6.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "70f8c7d0b7f9b9bc5b6998ad60c9dab503f9983f",
+      "_id": "stream-http@2.6.0",
+      "_shasum": "adf3309ced17624ebfb7ef13e6ac4cfe405a8b12",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "7.3.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "adf3309ced17624ebfb7ef13e6ac4cfe405a8b12",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.6.0.tgz_1483703989207_0.5768014823552221"
+      },
+      "directories": {}
+    },
+    "2.6.1": {
+      "name": "stream-http",
+      "version": "2.6.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "9321e56abd34615f799e18f11ae330749bfcd88c",
+      "_id": "stream-http@2.6.1",
+      "_shasum": "7d20fcdfebc16b16e4174e31dd94cd9c70f10e89",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "7d20fcdfebc16b16e4174e31dd94cd9c70f10e89",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.6.1.tgz_1484207093219_0.7791753446217626"
+      },
+      "directories": {}
+    },
+    "2.6.2": {
+      "name": "stream-http",
+      "version": "2.6.2",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "c1417c5dfad2e21b7c0cab28b184bff0292d9d3f",
+      "_id": "stream-http@2.6.2",
+      "_shasum": "bdfe40d2ee9262eb6bf2255bb3ad0ec0cdd6526d",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "bdfe40d2ee9262eb6bf2255bb3ad0ec0cdd6526d",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.6.2.tgz_1484560814312_0.4340973813086748"
+      },
+      "directories": {}
+    },
+    "2.6.3": {
+      "name": "stream-http",
+      "version": "2.6.3",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "b63537f11de8b49676536a7ceff3eeaad01fd327",
+      "_id": "stream-http@2.6.3",
+      "_shasum": "4c3ddbf9635968ea2cfd4e48d43de5def2625ac3",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "4c3ddbf9635968ea2cfd4e48d43de5def2625ac3",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.6.3.tgz_1484825188032_0.5002113955561072"
+      },
+      "directories": {}
+    },
+    "2.7.0": {
+      "name": "stream-http",
+      "version": "2.7.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.15.2",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "1dc9ea32f593bec599ed4aa1456ad450a70f6ba2",
+      "_id": "stream-http@2.7.0",
+      "_shasum": "cec1f4e3b494bc4a81b451808970f8b20b4ed5f6",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "cec1f4e3b494bc4a81b451808970f8b20b4ed5f6",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.7.0.tgz_1491288399049_0.7861161674372852"
+      },
+      "directories": {}
+    },
+    "2.7.1": {
+      "name": "stream-http",
+      "version": "2.7.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.15.2",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "8eab4b3e5f0502ec6a2d7babc60b7b2ae8ebb17a",
+      "_id": "stream-http@2.7.1",
+      "_shasum": "546a51741ad5a6b07e9e31b0b10441a917df528a",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.10.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "546a51741ad5a6b07e9e31b0b10441a917df528a",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/stream-http-2.7.1.tgz_1494290695377_0.7630164551082999"
+      },
+      "directories": {}
+    },
+    "2.7.2": {
+      "name": "stream-http",
+      "version": "2.7.2",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.15.2",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "c09a87154359d8f25b81a9083ba654bc6fe1f4de",
+      "_id": "stream-http@2.7.2",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.0.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+        "shasum": "40a050ec8dc3b53b33d9909415c02c0bf1abfbad",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-http-2.7.2.tgz_1497298914196_0.3043717509135604"
+      },
+      "directories": {}
+    },
+    "2.8.0": {
+      "name": "stream-http",
+      "version": "2.8.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "zuul --no-coverage -- test/browser/*.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^2.0.0",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.2",
+        "tape": "^4.8.0",
+        "ua-parser-js": "^0.7.17",
+        "webworkify": "^1.5.0",
+        "zuul": "^3.10.3"
+      },
+      "gitHead": "38ffb3866008da8fa7cb7651a902123b86c1a27a",
+      "_id": "stream-http@2.8.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+        "shasum": "fd86546dac9b1c91aff8fc5d287b98fafb41bc10",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-http-2.8.0.tgz_1516013425528_0.8700386332347989"
+      },
+      "directories": {}
+    },
+    "2.8.1": {
+      "name": "stream-http",
+      "version": "2.8.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "airtap --loopback airtap.local -- test/browser/*.js",
+        "test-browser-local": "airtap --no-instrument --local 8080 -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^0.0.3",
+        "basic-auth": "^2.0.0",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.2",
+        "tape": "^4.8.0",
+        "ua-parser-js": "^0.7.17",
+        "webworkify": "^1.5.0"
+      },
+      "gitHead": "8cf284cd4bbd51330ed9abcf545bb99ffbcaa036",
+      "_id": "stream-http@2.8.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.8.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+        "shasum": "d0441be1a457a73a733a8a7b53570bebd9ef66a4",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
+        "fileCount": 32,
+        "unpackedSize": 90383
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-http_2.8.1_1521059318676_0.711878010816418"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.8.2": {
+      "name": "stream-http",
+      "version": "2.8.2",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "airtap --loopback airtap.local -- test/browser/*.js",
+        "test-browser-local": "airtap --no-instrument --local 8080 -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^0.0.5",
+        "basic-auth": "^2.0.0",
+        "brfs": "^1.6.1",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.3",
+        "tape": "^4.9.0",
+        "ua-parser-js": "^0.7.18",
+        "webworkify": "^1.5.0"
+      },
+      "gitHead": "663f88323cafd81bb06a82d595bae65d9a7ba523",
+      "_id": "stream-http@2.8.2",
+      "_npmVersion": "6.0.0",
+      "_nodeVersion": "10.1.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
+        "shasum": "4126e8c6b107004465918aa2fc35549e77402c87",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+        "fileCount": 32,
+        "unpackedSize": 91297,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa87RcCRA9TVsSAnZWagAAQSsQAJvqBfREk9yfV6w5tKGP\nI8uyzNlFeVj8/qJ3CwNcwC12JAybpdKULYBT4GoNWZmnnQ6b8YyRODsVovBr\nmKd6oDhj+Ifm2QdKYZ/iLJCUHM/gaHjvq21Zh7rgmJ2ka5Nqy2/K3pWSU25d\nEEZXqB/fRBackiXjToldBzs1MY/Iq3lHZnsUuDTPoV8LmedODuR7hxJRu7EO\nMBjXSy4fMy6/ag72+JjzSK9lkOiIeNG22FkEXBqBIl3oo4ccovTPm7W3lPi3\ngbdngHBqIGqriSR4UyxZ8DqODylD6QlVH0T2/FQcuvQ8uvsb85TzE39tP/SU\n8fo2YjoeDYpGHzXiSpu/ccnHR9/HlDBTj1HOTQ3NEjfYBf9Pnvb64zj2B3wy\n2CwF5YwaQjIQCLG++qJ6PpTCRM6fdg4KGUVsgPJ4rF92C8w3Y54tcxj8taeQ\nPCbndeWzirhOOmdZ8AmB5O/O4lq4b/KORBI7DOWtoq1GLN4xhYhhwqyUJX0I\n9mAEb35IOy50laOFt3/vgFRi9GX11ANdgGA5A+CihJexTndAc0F5NhRAG+CZ\nRF+bDlhTnrGai1aXN5aPLksO/vQCwgIQrdQ1f9Pp/DBT05pVyzSlBf1I2qM6\naMf3Cj6oBPUYEZXrZC0+4JD5u8fKp1mKgReYfHmtvhs1hRwT4GEHKIpt/OL1\n6LuN\r\n=UnNh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-http_2.8.2_1525920859334_0.9968750489638951"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.8.3": {
+      "name": "stream-http",
+      "version": "2.8.3",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "airtap --loopback airtap.local -- test/browser/*.js",
+        "test-browser-local": "airtap --no-instrument --local 8080 -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^0.0.5",
+        "basic-auth": "^2.0.0",
+        "brfs": "^1.6.1",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.3",
+        "tape": "^4.9.0",
+        "ua-parser-js": "^0.7.18",
+        "webworkify": "^1.5.0"
+      },
+      "gitHead": "65aed45b2d4b56de0c84f918bfa3a0e7c07504b1",
+      "_id": "stream-http@2.8.3",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.3.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+        "shasum": "b2d242469288a5a27ec4fe8933acf623de6514fc",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+        "fileCount": 32,
+        "unpackedSize": 91282,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbEfBFCRA9TVsSAnZWagAAeQQP/i3lQHavJDzBNP091CX+\nVdZJGyVOno0lpfxZ44FkC6a+r81xgy3+vT1lDB1kTzYyg+6Gb3IP423ChYqg\nE5WU0y+ITs01WPOfkfTenasVIDvGvNbvPwc0zEIRQkiRGVmZNL8ZC/d7Te8f\np32M6hCYsIX73QbIEA1ZuFhor6fKLtBczVhk3iI5oUmd8AgGpn0CtuemG8be\nswZfsgJksp11hq6KcPtXwqTfZcO9pkfnKRHIfZ+8R+QVID6r2+vNSXGYrn9a\nXINYWc5dtI81K+OTWg6V8JbYwS5vnGwKxkQ977GNgDZ1bwYTQZqm7vXBi98i\nc+ttGu04X7dLxc2cp4SNQ9KdipD3uRCONXfh0X34h3Ua8gKn8+e+vpDdnM21\nEt7Fy3ClQLTfo15hQa0xjWlZ4uTCIT/6E3gG4046L4I8/75ShPp6IjEhaiWf\nOTz0zsk9Q9gocIXfNRNyTTgMBKYQ6jOCX2sypKFK34bKOP4IYxpwmsadpk7W\nwsnmKhuwJU7j88RzQs41VUmB4YnxW8qEENRU7Z0HI7o8Jg1bZurFlS9vf2HY\ngonB5/wBdXGZv2ib9+tpvVEyiuMPFQPwgan2//b2idcaTR3qBZn008n1muAI\nlYkuRbbJ6wYLV3PnunAqEGO6gWNILSDixE7zf90fQrVoSuhhiQmsdV2djxWq\nYRbo\r\n=8Knn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-http_2.8.3_1527902276026_0.009094757000913667"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "stream-http",
+      "version": "3.0.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "airtap --loopback airtap.local -- test/browser/*.js",
+        "test-browser-local": "airtap --no-instrument --local 8080 -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^0.1.0",
+        "basic-auth": "^2.0.1",
+        "brfs": "^2.0.1",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.3",
+        "tape": "^4.9.0",
+        "ua-parser-js": "^0.7.18",
+        "webworkify": "^1.5.0"
+      },
+      "gitHead": "e60ce5fb99d1c74e96120aa1086197c43fc100a8",
+      "_id": "stream-http@3.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.11.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "integrity": "sha512-JELJfd+btL9GHtxU3+XXhg9NLYrKFnhybfvRuDghtyVkOFydz3PKNT1df07AMr88qW03WHF+FSV0PySpXignCA==",
+        "shasum": "bd6d3c52610098699e25eb2dfcd188e30e0d12e4",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-3.0.0.tgz",
+        "fileCount": 31,
+        "unpackedSize": 82284,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbtGVnCRA9TVsSAnZWagAArpsP/3s7KzRWNuYXjrdu7c1b\nYzsh5++siHMK+R97JPNnh6EhE/sGOvr+lekslEjYL2P/XY+gVjloRH5vNrXE\nDh8fYC7Fgcbnb6KBK30hUqYn5s3icyLX2DuI1xjd8qjlqWPMQNLJxasV/VcR\neNmnXSuRrM7FWhpYfZXqsK760v3fM6DtYYLkx8nIPNggp8HJeP7mMrgXg5BB\n8S63WQQoG3fqgiXmmIdQGqR1/efPJyCF++hvI+RB92DiB9pCDXMhyT37/6w9\nvnohhE7x+ibtsuhj92X26TzdBveOvP5oIQe1LL+5VH0f3rptKwYXpHal+RJn\ngGdTnRR6yDKcBf8doAdKNLZCCXbW/7LkinsPnzPArlWG0kbOOABAFFj7jJ+r\nhU81VmEFZapX/yrrwJLQesFSwQ+BjO/KV4B+/UkaeAMcyLFyALUW2BI2z/cE\nChWAsgNy5IHM1hZSU3vDG+xe8THAjMqCTnFAS3g7oHRmI50Cs57aYcadndMy\nYQoIZf7US7DeXKjYqVYn7krPQNdikqQgnMKPMDUg2UgKeN6LRCPO12KqdeBa\nkgNVRgl7TwoIj89KI4zi1QNQwsvWIk/L943WqITOXF99CcNOo4owWUHDwmFQ\nNmq01JpY+LmESEiAuWhdAe50Wsf8Veuw2N0xZv0NVxtpAJnrJBtFnzzaHFJe\ns6RC\r\n=fGwA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-http_3.0.0_1538549094595_0.13804367842771348"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "stream-http",
+      "version": "3.1.0",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "airtap --loopback airtap.local -- test/browser/*.js",
+        "test-browser-local": "airtap --no-instrument --local 8080 -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "basic-auth": "^2.0.1",
+        "brfs": "^2.0.1",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.3",
+        "tape": "^4.9.0",
+        "ua-parser-js": "^0.7.18",
+        "webworkify": "^1.5.0"
+      },
+      "gitHead": "a38d9ab491a78ac2fd4907a864613c934e388b08",
+      "_id": "stream-http@3.1.0",
+      "_nodeVersion": "10.16.0",
+      "_npmVersion": "6.10.2",
+      "dist": {
+        "integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
+        "shasum": "22fb33fe9b4056b4eccf58bd8f400c4b993ffe57",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 26073,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdSjUTCRA9TVsSAnZWagAAZdQP/1HrhCcsYwMYB7rTOZPF\ncDs4LLG17YaVGvfnU0meN65nKPi5pUAfpcsuGo30n5iv3XF+T9DxCh7olDfD\neC/9ZWWhty0+r+Q0l/PrxcFD4dX1Puw5R6O23LaSQ7QoLxroi50XI111gCxp\nEqTX8QKwOkIJZ6HJYysaLFYDakkUA1XF5mbQe6qQ9KPcaG83+0xMO6wgIZhM\nBUM09wlfekORdZMKVzAFXquvP5rwozk7TXFJ5GCfYTotnUKbvxmPdZ5qtFq1\nEYQC6OJ7ZwPUtujxbPRurrqmDHDHYS2+fJPXeG2t/kh4+jyS7DUsKEat4Vqw\nv2fgDwjYsfDVXrZqukTbz30iCYIGq7+qxAT8YLjkBypx0zdMebtSI3YgICet\nVKgYyJv7wtqEXcPE2JqXs2XWw/Yfr2r7rC/BFPomhe/kXpmiVvEijkY7oSHv\n6ij4udvZWsP9OJZtRd7mX7wt6DzH9ePmx+/wESnn48LmrOjRgJCMF03pBG8M\nAmAJ8wWr4p0a5qpcP0IQLBye0eY/s301WRjGg3hcHZdJYUaM2nvUwjkjkq+h\nqE4pyTKNABjTiEpfYo7EVJQCJiu5e2G971LjoYUdt6Wevkzdq3ohbenf6rLu\nmYkFCZZGuck/7oxlQphtU40Q/x28GUJ5EO6gAIfQtOpmP32qyiD1PfQaeGLo\nYgve\r\n=bD+g\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-http_3.1.0_1565144339086_0.8410578903356953"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.1": {
+      "name": "stream-http",
+      "version": "3.1.1",
+      "description": "Streaming http in the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/stream-http.git"
+      },
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test/node/*.js",
+        "test-browser": "airtap --loopback airtap.local -- test/browser/*.js",
+        "test-browser-local": "airtap --no-instrument --local 8080 -- test/browser/*.js"
+      },
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/stream-http/issues"
+      },
+      "homepage": "https://github.com/jhiesey/stream-http#readme",
+      "keywords": [
+        "http",
+        "stream",
+        "streaming",
+        "xhr",
+        "http-browserify"
+      ],
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "basic-auth": "^2.0.1",
+        "brfs": "^2.0.2",
+        "cookie-parser": "^1.4.5",
+        "express": "^4.17.1",
+        "tape": "^5.0.0",
+        "ua-parser-js": "^0.7.21",
+        "webworkify": "^1.5.0"
+      },
+      "gitHead": "e84db22d084903bb937763f3118ea0341f872361",
+      "_id": "stream-http@3.1.1",
+      "_nodeVersion": "12.16.2",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-S7OqaYu0EkFpgeGFb/NPOoPLxFko7TPqtEeFg5DXPB4v/KETHG0Ln6fRFrNezoelpaDKmycEmmZ81cC9DAwgYg==",
+        "shasum": "0370a8017cf8d050b9a8554afe608f043eaff564",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 26052,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJesadYCRA9TVsSAnZWagAAtq0P/3qvEO6itmL1l/bgULbn\np4tLL7uYq4meEjBmgFDQG/a2+FEoqStqAjds+sz/6hV/JbFYr4xIAOyWCLno\nA65jlYix/Pne/o0sYaQucCkiN9cDhPpfS0I8SSJr6OFkNDz/ps/0QVTYB0B0\nAZ6Sjk12cbF+D71xxFkZUb2lcP4Uevf9H4qMegTpHyRAvhQkHJvIfG4TvLAH\nAcvryE1RtLfUacKA8mswGg8chHDV0pUDfrJv3nispczEhEe60F35Bbet7miy\ngdZAvqQeTVGgx2/s1aTQWY4ZqrBpM7ewK41ckrB8I3jBQlLjU2IfzKPSZUU3\nQribY1KevLIW55amtNWX1KYvOAE77VGSf7YfZE0cRxK8u1/X21y61rqTBmkg\n4kSgSJ2JkBwIc49Iv9t0TZdmirS1me2iAQMtE10fEG75LJ8SbTzflqXH6VbY\nlh4R/6M/pG5S6c3tKCJCKZYJrGa/eWHbqHYHT/TClKsH62glCkMlOxrQjKeR\n9M0YQzQ6yGH6F/GWENibxmrUG5HL6dM/d5Rj/bRR8Swp/N4ohfNUw+aknReJ\nb+GCY3Ekr8b8PUfdApdaEVlVgTMjAsXHG+tNW+z1E0Q48npOgfu/3nuZf2rw\ngnvtrK900ePO0yJZrw7j/jBCQA7tsGjhf2FsbF7fqWoda/9mfLBdFBOiwORQ\nzyA9\r\n=Pxzb\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "feross",
+        "email": "feross@feross.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-http_3.1.1_1588701016395_0.9821888715971026"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# stream-http [![Build Status](https://travis-ci.org/jhiesey/stream-http.svg?branch=master)](https://travis-ci.org/jhiesey/stream-http)\n\n[![Sauce Test Status](https://saucelabs.com/browser-matrix/stream-http.svg)](https://saucelabs.com/u/stream-http)\n\nThis module is an implementation of Node's native `http` module for the browser.\nIt tries to match Node's API and behavior as closely as possible, but some features\naren't available, since browsers don't give nearly as much control over requests.\n\nThis is heavily inspired by, and intended to replace, [http-browserify](https://github.com/substack/http-browserify).\n\n## What does it do?\n\nIn accordance with its name, `stream-http` tries to provide data to its caller before\nthe request has completed whenever possible.\n\nBackpressure, allowing the browser to only pull data from the server as fast as it is\nconsumed, is supported in:\n* Chrome >= 58 (using `fetch` and `WritableStream`)\n\nThe following browsers support true streaming, where only a small amount of the request\nhas to be held in memory at once:\n* Chrome >= 43 (using the `fetch` API)\n* Firefox >= 9 (using `moz-chunked-arraybuffer` responseType with xhr)\n\nAll other supported browsers support pseudo-streaming, where the data is available before\nthe request finishes, but the entire response must be held in memory. This works for both\ntext and binary data.\n\n### IE note:\nAs of version 3.0.0, IE10 and below are no longer supported. IE11 support will remain for\nnow.\n\n## How do you use it?\n\nThe intent is to have the same API as the client part of the\n[Node HTTP module](https://nodejs.org/api/http.html). The interfaces are the same wherever\npractical, although limitations in browsers make an exact clone of the Node API impossible.\n\nThis module implements `http.request`, `http.get`, and most of `http.ClientRequest`\nand `http.IncomingMessage` in addition to `http.METHODS` and `http.STATUS_CODES`. See the\nNode docs for how these work.\n\n### Extra features compared to Node\n\n* The `message.url` property provides access to the final URL after all redirects. This\nis useful since the browser follows all redirects silently, unlike Node. It is available\nin Chrome 37 and newer, Firefox 32 and newer, and Safari 9 and newer.\n\n* The `options.withCredentials` boolean flag, used to indicate if the browser should send\ncookies or authentication information with a CORS request. Default false.\n\nThis module has to make some tradeoffs to support binary data and/or streaming. Generally,\nthe module can make a fairly good decision about which underlying browser features to use,\nbut sometimes it helps to get a little input from the developer.\n\n* The `options.mode` field passed into `http.request` or `http.get` can take on one of the\nfollowing values:\n  * 'default' (or any falsy value, including `undefined`): Try to provide partial data before\nthe request completes, but not at the cost of correctness for binary data or correctness of\nthe 'content-type' response header. This mode will also avoid slower code paths whenever\npossible, which is particularly useful when making large requests in a browser like Safari\nthat has a weaker JavaScript engine.\n  * 'allow-wrong-content-type': Provides partial data in more cases than 'default', but\nat the expense of causing the 'content-type' response header to be incorrectly reported\n(as 'text/plain; charset=x-user-defined') in some browsers, notably Safari and Chrome 42\nand older. Preserves binary data whenever possible. In some cases the implementation may\nalso be a bit slow. This was the default in versions of this module before 1.5.\n  * 'prefer-streaming': Provide data before the request completes even if binary data (anything\nthat isn't a single-byte ASCII or UTF8 character) will be corrupted. Of course, this option\nis only safe for text data. May also cause the 'content-type' response header to be\nincorrectly reported (as 'text/plain; charset=x-user-defined').\n  * 'disable-fetch': Force the use of plain XHR regardless of the browser declaring a fetch\ncapability. Preserves the correctness of binary data and the 'content-type' response header.\n  * 'prefer-fast': Deprecated; now a synonym for 'default', which has the same performance\ncharacteristics as this mode did in versions before 1.5.\n\n* `options.requestTimeout` allows setting a timeout in millisecionds for XHR and fetch (if\nsupported by the browser). This is a limit on how long the entire process takes from\nbeginning to end. Note that this is not the same as the node `setTimeout` functions,\nwhich apply to pauses in data transfer over the underlying socket, or the node `timeout`\noption, which applies to opening the connection.\n\n### Features missing compared to Node\n\n* `http.Agent` is only a stub\n* The 'socket', 'connect', 'upgrade', and 'continue' events on `http.ClientRequest`.\n* Any operations, including `request.setTimeout`, that operate directly on the underlying\nsocket.\n* Any options that are disallowed for security reasons. This includes setting or getting\ncertain headers.\n* `message.httpVersion`\n* `message.rawHeaders` is modified by the browser, and may not quite match what is sent by\nthe server.\n* `message.trailers` and `message.rawTrailers` will remain empty.\n* Redirects are followed silently by the browser, so it isn't possible to access the 301/302\nredirect pages.\n* The `timeout` event/option and `setTimeout` functions, which operate on the underlying\nsocket, are not available. However, see `options.requestTimeout` above.\n\n## Example\n\n``` js\nhttp.get('/bundle.js', function (res) {\n\tvar div = document.getElementById('result');\n\tdiv.innerHTML += 'GET /beep<br>';\n\n\tres.on('data', function (buf) {\n\t\tdiv.innerHTML += buf;\n\t});\n\n\tres.on('end', function () {\n\t\tdiv.innerHTML += '<br>__END__';\n\t});\n})\n```\n\n## Running tests\n\nThere are two sets of tests: the tests that run in Node (found in `test/node`) and the tests\nthat run in the browser (found in `test/browser`). Normally the browser tests run on\n[Sauce Labs](http://saucelabs.com/).\n\nRunning `npm test` will run both sets of tests, but in order for the Sauce Labs tests to run\nyou will need to sign up for an account (free for open source projects) and put the\ncredentials in a [`.airtaprc` file](https://github.com/airtap/airtap/blob/master/doc/airtaprc.md).\nYou will also need to run a [Sauce Connect Proxy](https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy)\nwith the same credentials.\n\nTo run just the Node tests, run `npm run test-node`.\n\nTo run the browser tests locally, run `npm run test-browser-local` and point your browser to\nthe link shown in your terminal.\n\n## License\n\nMIT. Copyright (C) John Hiesey and other contributors.\n",
+  "maintainers": [
+    {
+      "name": "feross",
+      "email": "feross@feross.org"
+    },
+    {
+      "name": "jhiesey",
+      "email": "john@hiesey.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-05-05T17:50:18.969Z",
+    "created": "2015-07-12T22:32:06.069Z",
+    "1.0.0": "2015-07-12T22:32:06.069Z",
+    "1.0.1": "2015-07-13T01:43:57.627Z",
+    "1.0.2": "2015-07-13T01:47:34.388Z",
+    "1.1.1": "2015-07-13T04:32:10.882Z",
+    "1.2.0": "2015-07-14T02:13:14.221Z",
+    "1.2.1": "2015-07-17T07:51:22.481Z",
+    "1.3.0": "2015-07-20T23:27:17.676Z",
+    "1.4.0": "2015-08-07T06:23:39.145Z",
+    "1.4.1": "2015-08-08T01:26:27.198Z",
+    "1.5.0": "2015-08-20T08:50:12.730Z",
+    "1.7.0": "2015-09-15T21:35:05.706Z",
+    "1.6.0": "2015-09-15T21:36:26.741Z",
+    "1.7.1": "2015-09-15T21:48:29.548Z",
+    "2.0.0": "2015-09-16T00:26:01.429Z",
+    "2.0.1": "2015-09-30T20:23:35.202Z",
+    "2.0.2": "2015-10-02T06:09:45.890Z",
+    "2.0.3": "2016-01-08T22:08:27.822Z",
+    "2.0.4": "2016-01-08T23:47:21.175Z",
+    "2.0.5": "2016-01-09T11:32:23.826Z",
+    "2.1.0": "2016-01-13T04:46:30.453Z",
+    "2.1.1": "2016-02-16T05:41:04.175Z",
+    "2.2.0": "2016-03-02T01:15:14.222Z",
+    "2.2.1": "2016-03-26T05:12:07.609Z",
+    "2.3.0": "2016-04-28T08:32:15.764Z",
+    "2.3.1": "2016-07-28T06:39:16.236Z",
+    "2.4.0": "2016-09-08T23:38:57.127Z",
+    "2.4.1": "2016-10-28T08:22:28.773Z",
+    "2.5.0": "2016-11-04T06:02:47.115Z",
+    "2.6.0": "2017-01-06T11:59:49.456Z",
+    "2.6.1": "2017-01-12T07:44:55.289Z",
+    "2.6.2": "2017-01-16T10:00:16.115Z",
+    "2.6.3": "2017-01-19T11:26:30.176Z",
+    "2.7.0": "2017-04-04T06:46:39.792Z",
+    "2.7.1": "2017-05-09T00:44:58.350Z",
+    "2.7.2": "2017-06-12T20:21:54.314Z",
+    "2.8.0": "2018-01-15T10:50:25.609Z",
+    "2.8.1": "2018-03-14T20:28:38.770Z",
+    "2.8.2": "2018-05-10T02:54:19.419Z",
+    "2.8.3": "2018-06-02T01:17:56.106Z",
+    "3.0.0": "2018-10-03T06:44:54.757Z",
+    "3.1.0": "2019-08-07T02:18:59.210Z",
+    "3.1.1": "2020-05-05T17:50:16.507Z"
+  },
+  "homepage": "https://github.com/jhiesey/stream-http#readme",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jhiesey/stream-http.git"
+  },
+  "author": {
+    "name": "John Hiesey"
+  },
+  "bugs": {
+    "url": "https://github.com/jhiesey/stream-http/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "keywords": [
+    "http",
+    "stream",
+    "streaming",
+    "xhr",
+    "http-browserify"
+  ],
+  "users": {
+    "arulkumar": true,
+    "wenbing": true,
+    "yatsu": true,
+    "filipve": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/stream-http.min.json
+++ b/test/fixtures/registry-mocks/content/stream-http.min.json
@@ -1,0 +1,1058 @@
+{
+  "name": "stream-http",
+  "dist-tags": {
+    "latest": "3.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "stream-http",
+      "version": "1.0.0",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "a6464f871bc9478d631e71f4b42795719f1a8473",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "stream-http",
+      "version": "1.0.1",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "c75770f4ba95672bcd9ed5d17ca98360e2241840",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "stream-http",
+      "version": "1.0.2",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "536a142743699a84ed06e8ee5efe1767e3397d1f",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.0.2.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "stream-http",
+      "version": "1.1.1",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "ed1fe3464b4ed81186af5c0c8062835d3c79ca38",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.1.1.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "stream-http",
+      "version": "1.2.0",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "ed26a476b26dc277552e87b60dd52c219d7ca643",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "stream-http",
+      "version": "1.2.1",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "57cf86692bd97a9bf1f323a04dcc3a4de65cce62",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.2.1.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "stream-http",
+      "version": "1.3.0",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "945c98298afafff5eb7c14e66224ac23136e9ed5",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.3.0.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "stream-http",
+      "version": "1.4.0",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "eb83899e45af41e5843d76f6730c72ec8e75684b",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.4.0.tgz"
+      }
+    },
+    "1.4.1": {
+      "name": "stream-http",
+      "version": "1.4.1",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "3854d0fc2df61c191c89e98b8c62b93de9c13f8b",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.4.1.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "stream-http",
+      "version": "1.5.0",
+      "dependencies": {
+        "builtin-status-codes": "~1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "bf94d2c6738c2f4c574e757df9719b09614c6a9e",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.5.0.tgz"
+      }
+    },
+    "1.7.0": {
+      "name": "stream-http",
+      "version": "1.7.0",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "^1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "d482c32866e8e6772dd5b48770436d76410d3593",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.7.0.tgz"
+      }
+    },
+    "1.6.0": {
+      "name": "stream-http",
+      "version": "1.6.0",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "^1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "b67b889b2c1b5ff4493d318ace9f6c298e953ccc",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.6.0.tgz"
+      }
+    },
+    "1.7.1": {
+      "name": "stream-http",
+      "version": "1.7.1",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "foreach": "^2.0.5",
+        "indexof": "0.0.1",
+        "inherits": "^2.0.1",
+        "object-keys": "^1.0.4",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "d3d2a6e14c36a38b9dafb199aee7bbc570519978",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-1.7.1.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "stream-http",
+      "version": "2.0.0",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "c39a77eece75ee7fcc9385d212c96ea528581fa5",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "stream-http",
+      "version": "2.0.1",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "c2d02702317f5e4b9664805952b1fd62138d82a0",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "stream-http",
+      "version": "2.0.2",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "5acdcd05c6fe78dfeace92a81a73ebf3e8f82913",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "stream-http",
+      "version": "2.0.3",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "f70e7ff5c7269fefe1c63112e918b8bb24407a9a",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.3.tgz"
+      }
+    },
+    "2.0.4": {
+      "name": "stream-http",
+      "version": "2.0.4",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "5a4c0bc3313272b26acfb68fd4059df642c48b8b",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.4.tgz"
+      }
+    },
+    "2.0.5": {
+      "name": "stream-http",
+      "version": "2.0.5",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "080d22687ed4f237a584848ab3d6fbd8729d8f8d",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.0.5.tgz"
+      }
+    },
+    "2.1.0": {
+      "name": "stream-http",
+      "version": "2.1.0",
+      "dependencies": {
+        "builtin-status-codes": "^1.0.0",
+        "inherits": "^2.0.1",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "2eff54aaeb0cfa99e69eed0f250bad6a75a88cab",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.1.0.tgz"
+      }
+    },
+    "2.1.1": {
+      "name": "stream-http",
+      "version": "2.1.1",
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "3b880303babe036d6f6b43127d4dcd6f8893e1db",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.1.1.tgz"
+      }
+    },
+    "2.2.0": {
+      "name": "stream-http",
+      "version": "2.2.0",
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "0dd210200b68a22fbc991105181156b230076c3c",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.2.0.tgz"
+      }
+    },
+    "2.2.1": {
+      "name": "stream-http",
+      "version": "2.2.1",
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "c0d29dd8546341c66a4880a78272cd4661a956a6",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.2.1.tgz"
+      }
+    },
+    "2.3.0": {
+      "name": "stream-http",
+      "version": "2.3.0",
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.1.0"
+      },
+      "dist": {
+        "shasum": "d77de76f6211072119f8d2a49a118717b8feeaa3",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.3.0.tgz"
+      }
+    },
+    "2.3.1": {
+      "name": "stream-http",
+      "version": "2.3.1",
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "7e1dc87102c3e31b32e660f04ca31f23ddbd1d52",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.3.1.tgz"
+      }
+    },
+    "2.4.0": {
+      "name": "stream-http",
+      "version": "2.4.0",
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "9599aa8e263667ce4190e0dc04a1d065d3595a7e",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.4.0.tgz"
+      }
+    },
+    "2.4.1": {
+      "name": "stream-http",
+      "version": "2.4.1",
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "8ee5689ae69169e8eb8edd6aeb2ca08ab47e8f59",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.4.1.tgz"
+      }
+    },
+    "2.5.0": {
+      "name": "stream-http",
+      "version": "2.5.0",
+      "dependencies": {
+        "builtin-status-codes": "^2.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "585eee513217ed98fe199817e7313b6f772a6802",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.5.0.tgz"
+      }
+    },
+    "2.6.0": {
+      "name": "stream-http",
+      "version": "2.6.0",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "adf3309ced17624ebfb7ef13e6ac4cfe405a8b12",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.0.tgz"
+      }
+    },
+    "2.6.1": {
+      "name": "stream-http",
+      "version": "2.6.1",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "7d20fcdfebc16b16e4174e31dd94cd9c70f10e89",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.1.tgz"
+      }
+    },
+    "2.6.2": {
+      "name": "stream-http",
+      "version": "2.6.2",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "bdfe40d2ee9262eb6bf2255bb3ad0ec0cdd6526d",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.2.tgz"
+      }
+    },
+    "2.6.3": {
+      "name": "stream-http",
+      "version": "2.6.3",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.1.0",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.13.0",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "4c3ddbf9635968ea2cfd4e48d43de5def2625ac3",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.3.tgz"
+      }
+    },
+    "2.7.0": {
+      "name": "stream-http",
+      "version": "2.7.0",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.15.2",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "cec1f4e3b494bc4a81b451808970f8b20b4ed5f6",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz"
+      }
+    },
+    "2.7.1": {
+      "name": "stream-http",
+      "version": "2.7.1",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.3.5",
+        "express": "^4.15.2",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "shasum": "546a51741ad5a6b07e9e31b0b10441a917df528a",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz"
+      }
+    },
+    "2.7.2": {
+      "name": "stream-http",
+      "version": "2.7.2",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^1.0.3",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.15.2",
+        "tape": "^4.0.0",
+        "ua-parser-js": "^0.7.7",
+        "webworkify": "^1.0.2",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+        "shasum": "40a050ec8dc3b53b33d9909415c02c0bf1abfbad",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz"
+      }
+    },
+    "2.8.0": {
+      "name": "stream-http",
+      "version": "2.8.0",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "basic-auth": "^2.0.0",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.2",
+        "tape": "^4.8.0",
+        "ua-parser-js": "^0.7.17",
+        "webworkify": "^1.5.0",
+        "zuul": "^3.10.3"
+      },
+      "dist": {
+        "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+        "shasum": "fd86546dac9b1c91aff8fc5d287b98fafb41bc10",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz"
+      }
+    },
+    "2.8.1": {
+      "name": "stream-http",
+      "version": "2.8.1",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^0.0.3",
+        "basic-auth": "^2.0.0",
+        "brfs": "^1.4.0",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.2",
+        "tape": "^4.8.0",
+        "ua-parser-js": "^0.7.17",
+        "webworkify": "^1.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+        "shasum": "d0441be1a457a73a733a8a7b53570bebd9ef66a4",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
+        "fileCount": 32,
+        "unpackedSize": 90383
+      }
+    },
+    "2.8.2": {
+      "name": "stream-http",
+      "version": "2.8.2",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^0.0.5",
+        "basic-auth": "^2.0.0",
+        "brfs": "^1.6.1",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.3",
+        "tape": "^4.9.0",
+        "ua-parser-js": "^0.7.18",
+        "webworkify": "^1.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
+        "shasum": "4126e8c6b107004465918aa2fc35549e77402c87",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+        "fileCount": 32,
+        "unpackedSize": 91297,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa87RcCRA9TVsSAnZWagAAQSsQAJvqBfREk9yfV6w5tKGP\nI8uyzNlFeVj8/qJ3CwNcwC12JAybpdKULYBT4GoNWZmnnQ6b8YyRODsVovBr\nmKd6oDhj+Ifm2QdKYZ/iLJCUHM/gaHjvq21Zh7rgmJ2ka5Nqy2/K3pWSU25d\nEEZXqB/fRBackiXjToldBzs1MY/Iq3lHZnsUuDTPoV8LmedODuR7hxJRu7EO\nMBjXSy4fMy6/ag72+JjzSK9lkOiIeNG22FkEXBqBIl3oo4ccovTPm7W3lPi3\ngbdngHBqIGqriSR4UyxZ8DqODylD6QlVH0T2/FQcuvQ8uvsb85TzE39tP/SU\n8fo2YjoeDYpGHzXiSpu/ccnHR9/HlDBTj1HOTQ3NEjfYBf9Pnvb64zj2B3wy\n2CwF5YwaQjIQCLG++qJ6PpTCRM6fdg4KGUVsgPJ4rF92C8w3Y54tcxj8taeQ\nPCbndeWzirhOOmdZ8AmB5O/O4lq4b/KORBI7DOWtoq1GLN4xhYhhwqyUJX0I\n9mAEb35IOy50laOFt3/vgFRi9GX11ANdgGA5A+CihJexTndAc0F5NhRAG+CZ\nRF+bDlhTnrGai1aXN5aPLksO/vQCwgIQrdQ1f9Pp/DBT05pVyzSlBf1I2qM6\naMf3Cj6oBPUYEZXrZC0+4JD5u8fKp1mKgReYfHmtvhs1hRwT4GEHKIpt/OL1\n6LuN\r\n=UnNh\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.8.3": {
+      "name": "stream-http",
+      "version": "2.8.3",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^0.0.5",
+        "basic-auth": "^2.0.0",
+        "brfs": "^1.6.1",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.3",
+        "tape": "^4.9.0",
+        "ua-parser-js": "^0.7.18",
+        "webworkify": "^1.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+        "shasum": "b2d242469288a5a27ec4fe8933acf623de6514fc",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+        "fileCount": 32,
+        "unpackedSize": 91282,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbEfBFCRA9TVsSAnZWagAAeQQP/i3lQHavJDzBNP091CX+\nVdZJGyVOno0lpfxZ44FkC6a+r81xgy3+vT1lDB1kTzYyg+6Gb3IP423ChYqg\nE5WU0y+ITs01WPOfkfTenasVIDvGvNbvPwc0zEIRQkiRGVmZNL8ZC/d7Te8f\np32M6hCYsIX73QbIEA1ZuFhor6fKLtBczVhk3iI5oUmd8AgGpn0CtuemG8be\nswZfsgJksp11hq6KcPtXwqTfZcO9pkfnKRHIfZ+8R+QVID6r2+vNSXGYrn9a\nXINYWc5dtI81K+OTWg6V8JbYwS5vnGwKxkQ977GNgDZ1bwYTQZqm7vXBi98i\nc+ttGu04X7dLxc2cp4SNQ9KdipD3uRCONXfh0X34h3Ua8gKn8+e+vpDdnM21\nEt7Fy3ClQLTfo15hQa0xjWlZ4uTCIT/6E3gG4046L4I8/75ShPp6IjEhaiWf\nOTz0zsk9Q9gocIXfNRNyTTgMBKYQ6jOCX2sypKFK34bKOP4IYxpwmsadpk7W\nwsnmKhuwJU7j88RzQs41VUmB4YnxW8qEENRU7Z0HI7o8Jg1bZurFlS9vf2HY\ngonB5/wBdXGZv2ib9+tpvVEyiuMPFQPwgan2//b2idcaTR3qBZn008n1muAI\nlYkuRbbJ6wYLV3PnunAqEGO6gWNILSDixE7zf90fQrVoSuhhiQmsdV2djxWq\nYRbo\r\n=8Knn\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.0.0": {
+      "name": "stream-http",
+      "version": "3.0.0",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^0.1.0",
+        "basic-auth": "^2.0.1",
+        "brfs": "^2.0.1",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.3",
+        "tape": "^4.9.0",
+        "ua-parser-js": "^0.7.18",
+        "webworkify": "^1.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-JELJfd+btL9GHtxU3+XXhg9NLYrKFnhybfvRuDghtyVkOFydz3PKNT1df07AMr88qW03WHF+FSV0PySpXignCA==",
+        "shasum": "bd6d3c52610098699e25eb2dfcd188e30e0d12e4",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-3.0.0.tgz",
+        "fileCount": 31,
+        "unpackedSize": 82284,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbtGVnCRA9TVsSAnZWagAArpsP/3s7KzRWNuYXjrdu7c1b\nYzsh5++siHMK+R97JPNnh6EhE/sGOvr+lekslEjYL2P/XY+gVjloRH5vNrXE\nDh8fYC7Fgcbnb6KBK30hUqYn5s3icyLX2DuI1xjd8qjlqWPMQNLJxasV/VcR\neNmnXSuRrM7FWhpYfZXqsK760v3fM6DtYYLkx8nIPNggp8HJeP7mMrgXg5BB\n8S63WQQoG3fqgiXmmIdQGqR1/efPJyCF++hvI+RB92DiB9pCDXMhyT37/6w9\nvnohhE7x+ibtsuhj92X26TzdBveOvP5oIQe1LL+5VH0f3rptKwYXpHal+RJn\ngGdTnRR6yDKcBf8doAdKNLZCCXbW/7LkinsPnzPArlWG0kbOOABAFFj7jJ+r\nhU81VmEFZapX/yrrwJLQesFSwQ+BjO/KV4B+/UkaeAMcyLFyALUW2BI2z/cE\nChWAsgNy5IHM1hZSU3vDG+xe8THAjMqCTnFAS3g7oHRmI50Cs57aYcadndMy\nYQoIZf7US7DeXKjYqVYn7krPQNdikqQgnMKPMDUg2UgKeN6LRCPO12KqdeBa\nkgNVRgl7TwoIj89KI4zi1QNQwsvWIk/L943WqITOXF99CcNOo4owWUHDwmFQ\nNmq01JpY+LmESEiAuWhdAe50Wsf8Veuw2N0xZv0NVxtpAJnrJBtFnzzaHFJe\ns6RC\r\n=fGwA\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.1.0": {
+      "name": "stream-http",
+      "version": "3.1.0",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.0.6",
+        "xtend": "^4.0.0"
+      },
+      "devDependencies": {
+        "airtap": "^2.0.3",
+        "basic-auth": "^2.0.1",
+        "brfs": "^2.0.1",
+        "cookie-parser": "^1.4.3",
+        "express": "^4.16.3",
+        "tape": "^4.9.0",
+        "ua-parser-js": "^0.7.18",
+        "webworkify": "^1.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
+        "shasum": "22fb33fe9b4056b4eccf58bd8f400c4b993ffe57",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 26073,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdSjUTCRA9TVsSAnZWagAAZdQP/1HrhCcsYwMYB7rTOZPF\ncDs4LLG17YaVGvfnU0meN65nKPi5pUAfpcsuGo30n5iv3XF+T9DxCh7olDfD\neC/9ZWWhty0+r+Q0l/PrxcFD4dX1Puw5R6O23LaSQ7QoLxroi50XI111gCxp\nEqTX8QKwOkIJZ6HJYysaLFYDakkUA1XF5mbQe6qQ9KPcaG83+0xMO6wgIZhM\nBUM09wlfekORdZMKVzAFXquvP5rwozk7TXFJ5GCfYTotnUKbvxmPdZ5qtFq1\nEYQC6OJ7ZwPUtujxbPRurrqmDHDHYS2+fJPXeG2t/kh4+jyS7DUsKEat4Vqw\nv2fgDwjYsfDVXrZqukTbz30iCYIGq7+qxAT8YLjkBypx0zdMebtSI3YgICet\nVKgYyJv7wtqEXcPE2JqXs2XWw/Yfr2r7rC/BFPomhe/kXpmiVvEijkY7oSHv\n6ij4udvZWsP9OJZtRd7mX7wt6DzH9ePmx+/wESnn48LmrOjRgJCMF03pBG8M\nAmAJ8wWr4p0a5qpcP0IQLBye0eY/s301WRjGg3hcHZdJYUaM2nvUwjkjkq+h\nqE4pyTKNABjTiEpfYo7EVJQCJiu5e2G971LjoYUdt6Wevkzdq3ohbenf6rLu\nmYkFCZZGuck/7oxlQphtU40Q/x28GUJ5EO6gAIfQtOpmP32qyiD1PfQaeGLo\nYgve\r\n=bD+g\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.1.1": {
+      "name": "stream-http",
+      "version": "3.1.1",
+      "dependencies": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
+      },
+      "devDependencies": {
+        "airtap": "^3.0.0",
+        "basic-auth": "^2.0.1",
+        "brfs": "^2.0.2",
+        "cookie-parser": "^1.4.5",
+        "express": "^4.17.1",
+        "tape": "^5.0.0",
+        "ua-parser-js": "^0.7.21",
+        "webworkify": "^1.5.0"
+      },
+      "dist": {
+        "integrity": "sha512-S7OqaYu0EkFpgeGFb/NPOoPLxFko7TPqtEeFg5DXPB4v/KETHG0Ln6fRFrNezoelpaDKmycEmmZ81cC9DAwgYg==",
+        "shasum": "0370a8017cf8d050b9a8554afe608f043eaff564",
+        "tarball": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 26052,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJesadYCRA9TVsSAnZWagAAtq0P/3qvEO6itmL1l/bgULbn\np4tLL7uYq4meEjBmgFDQG/a2+FEoqStqAjds+sz/6hV/JbFYr4xIAOyWCLno\nA65jlYix/Pne/o0sYaQucCkiN9cDhPpfS0I8SSJr6OFkNDz/ps/0QVTYB0B0\nAZ6Sjk12cbF+D71xxFkZUb2lcP4Uevf9H4qMegTpHyRAvhQkHJvIfG4TvLAH\nAcvryE1RtLfUacKA8mswGg8chHDV0pUDfrJv3nispczEhEe60F35Bbet7miy\ngdZAvqQeTVGgx2/s1aTQWY4ZqrBpM7ewK41ckrB8I3jBQlLjU2IfzKPSZUU3\nQribY1KevLIW55amtNWX1KYvOAE77VGSf7YfZE0cRxK8u1/X21y61rqTBmkg\n4kSgSJ2JkBwIc49Iv9t0TZdmirS1me2iAQMtE10fEG75LJ8SbTzflqXH6VbY\nlh4R/6M/pG5S6c3tKCJCKZYJrGa/eWHbqHYHT/TClKsH62glCkMlOxrQjKeR\n9M0YQzQ6yGH6F/GWENibxmrUG5HL6dM/d5Rj/bRR8Swp/N4ohfNUw+aknReJ\nb+GCY3Ekr8b8PUfdApdaEVlVgTMjAsXHG+tNW+z1E0Q48npOgfu/3nuZf2rw\ngnvtrK900ePO0yJZrw7j/jBCQA7tsGjhf2FsbF7fqWoda/9mfLBdFBOiwORQ\nzyA9\r\n=Pxzb\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-05-05T17:50:18.969Z"
+}

--- a/test/fixtures/registry-mocks/content/stream-shift.json
+++ b/test/fixtures/registry-mocks/content/stream-shift.json
@@ -1,0 +1,147 @@
+{
+  "_id": "stream-shift",
+  "_rev": "2-886011da101a53e40ab9c460543e475e",
+  "name": "stream-shift",
+  "description": "Returns the next buffer/object in a stream's readable queue",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "stream-shift",
+      "version": "1.0.0",
+      "description": "Returns the next buffer/object in a stream's readable queue",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0",
+        "through2": "^2.0.1"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/stream-shift.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-shift/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-shift",
+      "gitHead": "2ea5f7dcd8ac6babb08324e6e603a3269252a2c4",
+      "_id": "stream-shift@1.0.0",
+      "_shasum": "d5c752825e5367e786f78e18e445ea223a155952",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "d5c752825e5367e786f78e18e445ea223a155952",
+        "tarball": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/stream-shift-1.0.0.tgz_1468011662152_0.6510484367609024"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "stream-shift",
+      "version": "1.0.1",
+      "description": "Returns the next buffer/object in a stream's readable queue",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0",
+        "through2": "^2.0.1"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/mafintosh/stream-shift.git"
+      },
+      "author": {
+        "name": "Mathias Buus",
+        "url": "@mafintosh"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/mafintosh/stream-shift/issues"
+      },
+      "homepage": "https://github.com/mafintosh/stream-shift",
+      "gitHead": "c189b6185a25517593bce28a9c74c8b87b83a11a",
+      "_id": "stream-shift@1.0.1",
+      "_nodeVersion": "12.13.0",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+        "shasum": "d7088281559ab2778424279b0877da3c392d5a3d",
+        "tarball": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 3903,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd8haYCRA9TVsSAnZWagAAnpkP/1JP3jQu4Ea+Z8z5xXTr\nNQGV4BWe2VmGX4keAH8TDve8hELddJHGUykQEmiebMw164u6jH4rjM8En9pU\niQf7wXBre4n8rz+mTR4Z5/3wRDEjB/ckf7T7cq+t6kmhvsAtX0S28LdNithK\nbBxyKOF6+fTYHrXdSnb4F0dU7wPvv+lOE9QhrB59wOhLpOvM7CkHWnKDt4va\nQzKb9BNgcwDWOAdYFIMbGONzCWgc3oV8X0CzXPWWPiz5OVNpuMdLYlHkFLBB\npnAB6fTDuulIJsbwr+dO9tPHsq1Y1vUMNIeI8GjDjcir4lmneJU0SA8gCC1L\nVvH9OR1TMu58Rc81HYmwZ2n6uG4fmdnVoAncz3gjkJNu1QHZFdDIXzv5Fl9o\nNFsH2tDn2bQXmjy58Z2+iJ/bIve8aEjnn6HUvvkbZl/rNrQDb5CiA7HKj2Fi\nT/G2SXDCAsfcpFdPmtzrvpg48omAh/CYRmCxkqtqocE2iLzcl0ILYuR1pF9J\nRT2yQuFsba6b4c7tiuQZsLy5amPV6KovOF4fnNQ9h+h1eEB0JG8WUX7YuKvd\nKed/ELh8+bCAUdgjZQDKuUjgHICb5dxhIUeazeoBtZ8YgmPobKw/pblkAljm\nXIt7Ze89xL7EoTY13bSrNHrdv3jCugz7DGHJ8XDrI87r1A4+QdKQcDZamyMm\nebCR\r\n=5RuT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/stream-shift_1.0.1_1576146584161_0.9963042958088779"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# stream-shift\n\nReturns the next buffer/object in a stream's readable queue\n\n```\nnpm install stream-shift\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/stream-shift.svg?style=flat)](http://travis-ci.org/mafintosh/stream-shift)\n\n## Usage\n\n``` js\nvar shift = require('stream-shift')\n\nconsole.log(shift(someStream)) // first item in its buffer\n```\n\n## Credit\n\nThanks [@dignifiedquire](https://github.com/dignifiedquire) for making this work on node 6\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-12-12T10:29:46.489Z",
+    "created": "2016-07-08T21:01:04.886Z",
+    "1.0.0": "2016-07-08T21:01:04.886Z",
+    "1.0.1": "2019-12-12T10:29:44.264Z"
+  },
+  "homepage": "https://github.com/mafintosh/stream-shift",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mafintosh/stream-shift.git"
+  },
+  "author": {
+    "name": "Mathias Buus",
+    "url": "@mafintosh"
+  },
+  "bugs": {
+    "url": "https://github.com/mafintosh/stream-shift/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/stream-shift.min.json
+++ b/test/fixtures/registry-mocks/content/stream-shift.min.json
@@ -1,0 +1,39 @@
+{
+  "name": "stream-shift",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "stream-shift",
+      "version": "1.0.0",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0",
+        "through2": "^2.0.1"
+      },
+      "dist": {
+        "shasum": "d5c752825e5367e786f78e18e445ea223a155952",
+        "tarball": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "stream-shift",
+      "version": "1.0.1",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0",
+        "through2": "^2.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+        "shasum": "d7088281559ab2778424279b0877da3c392d5a3d",
+        "tarball": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 3903,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd8haYCRA9TVsSAnZWagAAnpkP/1JP3jQu4Ea+Z8z5xXTr\nNQGV4BWe2VmGX4keAH8TDve8hELddJHGUykQEmiebMw164u6jH4rjM8En9pU\niQf7wXBre4n8rz+mTR4Z5/3wRDEjB/ckf7T7cq+t6kmhvsAtX0S28LdNithK\nbBxyKOF6+fTYHrXdSnb4F0dU7wPvv+lOE9QhrB59wOhLpOvM7CkHWnKDt4va\nQzKb9BNgcwDWOAdYFIMbGONzCWgc3oV8X0CzXPWWPiz5OVNpuMdLYlHkFLBB\npnAB6fTDuulIJsbwr+dO9tPHsq1Y1vUMNIeI8GjDjcir4lmneJU0SA8gCC1L\nVvH9OR1TMu58Rc81HYmwZ2n6uG4fmdnVoAncz3gjkJNu1QHZFdDIXzv5Fl9o\nNFsH2tDn2bQXmjy58Z2+iJ/bIve8aEjnn6HUvvkbZl/rNrQDb5CiA7HKj2Fi\nT/G2SXDCAsfcpFdPmtzrvpg48omAh/CYRmCxkqtqocE2iLzcl0ILYuR1pF9J\nRT2yQuFsba6b4c7tiuQZsLy5amPV6KovOF4fnNQ9h+h1eEB0JG8WUX7YuKvd\nKed/ELh8+bCAUdgjZQDKuUjgHICb5dxhIUeazeoBtZ8YgmPobKw/pblkAljm\nXIt7Ze89xL7EoTY13bSrNHrdv3jCugz7DGHJ8XDrI87r1A4+QdKQcDZamyMm\nebCR\r\n=5RuT\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-12-12T10:29:46.489Z"
+}

--- a/test/fixtures/registry-mocks/content/through2.json
+++ b/test/fixtures/registry-mocks/content/through2.json
@@ -1,0 +1,2690 @@
+{
+  "_id": "through2",
+  "_rev": "308-cd65928ccff7dfe8976bb1bab999f58f",
+  "name": "through2",
+  "description": "A tiny wrapper around Node.js streams.Transform (Streams2/3) to avoid explicit subclassing noise",
+  "dist-tags": {
+    "latest": "4.0.2",
+    "1.0": "1.1.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "through2",
+      "version": "0.0.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "_id": "through2@0.0.0",
+      "dist": {
+        "shasum": "418434b88c4b59d1b8583f8e26b31a398e332b25",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "through2",
+      "version": "0.0.1",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "_id": "through2@0.0.1",
+      "dist": {
+        "shasum": "ecfdbb4005ee1c3843d14db1e959f9738374af81",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "through2",
+      "version": "0.0.2",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "_id": "through2@0.0.2",
+      "dist": {
+        "shasum": "bbdf39882f3bca1e0a04a64ad3eb1de010e98534",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "through2",
+      "version": "0.0.3",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise: #polyhack -- OK I FIXED THE REPO! HAPPY?",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "_id": "through2@0.0.3",
+      "dist": {
+        "shasum": "24749c99581289e6ae2a0d69121e8cb17088a108",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "through2",
+      "version": "0.0.4",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "_id": "through2@0.0.4",
+      "dist": {
+        "shasum": "b134b520bbe5078bbd143424fb91481c25a54e80",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.5": {
+      "name": "through2",
+      "version": "0.0.5",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "_id": "through2@0.0.5",
+      "dist": {
+        "shasum": "6a4210686015e82a1ecbf891e3e35c0d96905a99",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "through2",
+      "version": "0.1.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2",
+        "xtend": "~2.0.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0",
+        "stream-spigot": "~2.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "_id": "through2@0.1.0",
+      "dist": {
+        "shasum": "54e756cc6a543c72bb5adf55e8a248686b84c9cc",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.5",
+      "_npmUser": {
+        "name": "bryce",
+        "email": "bryce@ravenwall.com"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "through2",
+      "version": "0.2.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2",
+        "xtend": "~2.0.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0",
+        "stream-spigot": "~2.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "_id": "through2@0.2.0",
+      "dist": {
+        "shasum": "6702afc24836e35e42950aad98010be632987777",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "through2",
+      "version": "0.2.1",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2",
+        "xtend": "~2.0.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0",
+        "stream-spigot": "~2.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "_id": "through2@0.2.1",
+      "dist": {
+        "shasum": "fa2def7230dd218add7b216a06594b15a4104395",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "through2",
+      "version": "0.2.2",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.2",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0",
+        "stream-spigot": "~2.0.0"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "_id": "through2@0.2.2",
+      "dist": {
+        "shasum": "d5e70d6a42cb5ba003bbdbc975f5772434dbe513",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "through2",
+      "version": "0.2.3",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.1.9",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~1.1.1",
+        "bl": "~0.4.1",
+        "stream-spigot": "~2.1.2"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "_id": "through2@0.2.3",
+      "dist": {
+        "shasum": "eb3284da4ea311b6cc8ace3653748a52abf25a3f",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "bryce",
+        "email": "bryce@ravenwall.com"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "through2",
+      "version": "0.3.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.3.0",
+      "dist": {
+        "shasum": "2d1d28c8d1daf8d9c5cb78f0a69343c6b8642d97",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "through2",
+      "version": "0.4.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.4.0",
+      "dist": {
+        "shasum": "4c9a96e385ef082a86cce5b915ef512119bc5225",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.4.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.1": {
+      "name": "through2",
+      "version": "0.4.1",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.4.1",
+      "dist": {
+        "shasum": "afd849c65af513c2541a98a7cfbcfec3a15a9686",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.4.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.25",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "through2",
+      "version": "1.0.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.1.10",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "publishConfig": {
+        "tag": "1.0"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@1.0.0",
+      "dist": {
+        "shasum": "2445cd8dfe74285dee5dada055e0571d01ff17ac",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.4.2": {
+      "name": "through2",
+      "version": "0.4.2",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.4.2",
+      "dist": {
+        "shasum": "dbf5866031151ec8352bb6c4db64a2292a840b9b",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "through2",
+      "version": "0.5.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.5.0",
+      "dist": {
+        "shasum": "28957b997cb86034b3520c943c2140d9436b30ac",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "through2",
+      "version": "0.5.1",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~3.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.5.1",
+      "dist": {
+        "shasum": "dfdd012eb9c700e2323fd334f38ac622ab372da7",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "through2",
+      "version": "0.6.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.0.27-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "gitHead": "bebb0a7854a864d8dedaa87ee0dcec0f2af68360",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.6.0",
+      "_shasum": "423484bebaaad0cc65bb205fea8248c9e1de4e57",
+      "_from": ".",
+      "_npmVersion": "2.0.0-alpha.6.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "423484bebaaad0cc65bb205fea8248c9e1de4e57",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "through2",
+      "version": "1.1.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "publishConfig": {
+        "tag": "1.0"
+      },
+      "gitHead": "f50fdd02857e19d0f04b15625adf94569eff5a1d",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@1.1.0",
+      "_shasum": "373c6c0b0158891eeb3d2d524c9c0a140c5b911a",
+      "_from": ".",
+      "_npmVersion": "2.0.0-alpha.6.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "373c6c0b0158891eeb3d2d524c9c0a140c5b911a",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "through2",
+      "version": "0.6.1",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.0.27-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "gitHead": "f66daaa2cb5d37b56c401f3b5a4962f709893267",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.6.1",
+      "_shasum": "f742b32893e8bd26146e789e4fd2ccb2c07a717e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f742b32893e8bd26146e789e4fd2ccb2c07a717e",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "through2",
+      "version": "1.1.1",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "publishConfig": {
+        "tag": "1.0"
+      },
+      "gitHead": "05618510052dcb4ec970c47c1234e0fcad8566de",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@1.1.1",
+      "_shasum": "0847cbc4449f3405574dbdccd9bb841b83ac3545",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0847cbc4449f3405574dbdccd9bb841b83ac3545",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.2": {
+      "name": "through2",
+      "version": "0.6.2",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.0.28 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "gitHead": "0aa8da988475cd6265bd2942c4097d92260e1785",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.6.2",
+      "_shasum": "53265824c555e7fcdc4111dcdc52c7de64636c75",
+      "_from": ".",
+      "_npmVersion": "2.0.1",
+      "_nodeVersion": "0.10.31",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "53265824c555e7fcdc4111dcdc52c7de64636c75",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.3": {
+      "name": "through2",
+      "version": "0.6.3",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "gitHead": "af9b735f360a4edef6e0ba601644457a82374fe7",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.6.3",
+      "_shasum": "795292fde9f254c2a368b38f9cc5d1bd4663afb6",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "795292fde9f254c2a368b38f9cc5d1bd4663afb6",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.4": {
+      "name": "through2",
+      "version": "0.6.4",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "gitHead": "d2817900c47df613d2c90f317500f97e7a0b68bf",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.6.4",
+      "_shasum": "cfb59dfb313217ea35bd0749c410455d90099d3a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "bryce",
+        "email": "bryce@ravenwall.com"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cfb59dfb313217ea35bd0749c410455d90099d3a",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.5": {
+      "name": "through2",
+      "version": "0.6.5",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "gitHead": "ba4a87875f2c82323c10023e36f4ae4b386c1bf8",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2",
+      "_id": "through2@0.6.5",
+      "_shasum": "41ab9c67b29d57209071410e1d7a7a968cd3ad48",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "bryce",
+        "email": "bryce@ravenwall.com"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "41ab9c67b29d57209071410e1d7a7a968cd3ad48",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "through2",
+      "version": "2.0.0",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js | faucet",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.0.0",
+        "xtend": "~4.0.0"
+      },
+      "devDependencies": {
+        "bl": "~0.9.4",
+        "faucet": "0.0.1",
+        "stream-spigot": "~3.0.5",
+        "tape": "~4.0.0"
+      },
+      "gitHead": "6424ae6178834bb978ce3c3c033fa2d0398b0e14",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@2.0.0",
+      "_shasum": "f41a1c31df5e129e4314446f66eca05cd6a30480",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.2-next-nightly201506103ea7e90fce",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f41a1c31df5e129e4314446f66eca05cd6a30480",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "through2",
+      "version": "2.0.1",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js | faucet",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.0.0",
+        "xtend": "~4.0.0"
+      },
+      "devDependencies": {
+        "bl": "~0.9.4",
+        "faucet": "0.0.1",
+        "stream-spigot": "~3.0.5",
+        "tape": "~4.0.0"
+      },
+      "gitHead": "6d52a1b77db13a741f2708cd5854a198e4ae3072",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@2.0.1",
+      "_shasum": "384e75314d49f32de12eebb8136b8eb6b5d59da9",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "dist": {
+        "shasum": "384e75314d49f32de12eebb8136b8eb6b5d59da9",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-6-west.internal.npmjs.com",
+        "tmp": "tmp/through2-2.0.1.tgz_1454928418348_0.7339043114334345"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "through2",
+      "version": "2.0.2",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js | faucet",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~1.1.2",
+        "faucet": "0.0.1",
+        "stream-spigot": "~3.0.5",
+        "tape": "~4.6.2"
+      },
+      "gitHead": "29af30ddf5223793a1c10cf6f42334bfac1336ec",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@2.0.2",
+      "_shasum": "316d3a4f444af641496aa7f45a713be72576baf4",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.2.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "dist": {
+        "shasum": "316d3a4f444af641496aa7f45a713be72576baf4",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/through2-2.0.2.tgz_1480308388398_0.9965543132275343"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "through2",
+      "version": "2.0.3",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js | faucet",
+        "test-local": "brtapsauce-local test/basic-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~1.1.2",
+        "faucet": "0.0.1",
+        "stream-spigot": "~3.0.5",
+        "tape": "~4.6.2"
+      },
+      "gitHead": "4383b10b2cb6a32ae215760715b317513abe609f",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@2.0.3",
+      "_shasum": "0004569b37c7c74ba39c43f3ced78d1ad94140be",
+      "_from": ".",
+      "_npmVersion": "3.10.9",
+      "_nodeVersion": "7.2.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "dist": {
+        "shasum": "0004569b37c7c74ba39c43f3ced78d1ad94140be",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/through2-2.0.3.tgz_1480373529377_0.264686161885038"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "through2",
+      "version": "2.0.4",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "nyc node test/test.js | faucet && nyc report"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "2 || 3",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "gitHead": "e839de7cc95401797cf7af0533f1d5144dc3d9df",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@2.0.4",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.12.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
+        "shasum": "e8362dec238b7590f5743b060342f27b452f4450",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17579,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4WL5CRA9TVsSAnZWagAAdwAP/irs3Ec8bhFhH+U5Rpqi\nNNGhR4jCdBQ05bW8+QMUrbX/6Tb3N24o6hyupnUkOEFnP7G0vPWl9XmSmKVg\nuPIoMbm8twWaMFP/NXA7kDOX0/pQerHecKAF7vNwz3iw6cJpkEwAH5JkgOhp\nqGdBRJRx4Lcv7F7lINZ3J39tOlA9mxioNeVVm4dXPh5pfcsdcg0lUVbQhmTH\nvJTNk9hR0Tfw35VZ1xlXCi9pQhWMPEuEJ5Yhanw9t9Xo8URO3ke/i027fadQ\nm1l8l3I3yUDXvIxA+yXw0n+L7+t+mDorq67TIGkNPDCxxGNCqekD63tDeJ3T\n2dezxSe09aU1Kmok7J0RpLhqvqzWYPfpixJkxnKgV0NjEC3cJjvIpgU9FPu/\nxDXDhd0gtUTF9EPklSZpIJSu+DbIZTx82en/+Ve1jQmi9b5yG6GzEPwvPy4T\nuwJuIYNeyVVsG/7p17rSdZHGOuvAxLnMcTfQGmVrkfA0BLmTiqjqMUDFJEPY\ni4iB935MJhb+WFeSJZ7jKzsDMI/L7z2eVMh6dxNzzPPw6ZJFqHID/Itnz486\nsj57hytuFU9p4ZfuQtYNj/pZdr4ULeARfjFwF66c/XgQiyybB/b5hX2JIwA5\n4s4ANK/573N/MfI6UkHhVx/GBHVr2izGuGV1VdnymH2iTcq2xg6mims7pnu1\nesHr\r\n=ZPOs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/through2_2.0.4_1541497593289_0.44144648728813407"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.5": {
+      "name": "through2",
+      "version": "2.0.5",
+      "description": "A tiny wrapper around Node streams2 Transform to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "node test/test.js | faucet"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "safe-buffer": "~5.1.2",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "gitHead": "72a3cefc0ff1ad5cc178be04eb927f40166226f1",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@2.0.5",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+        "shasum": "01c1e39eb31d07cb7d03a96a70823260b23132cd",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9649,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4g+gCRA9TVsSAnZWagAAozIQAJ9G33BOIVzbaoS4KejZ\nPTu12HkLyxVwCU0iCwR2+BMFw8y0JcNr2eZPNWqSV3beHDPDHY+WRgJesCjP\nzJ5Jv+8hwFLSXG4Kc407ZWV3ten0AV1xlHJjGsY6WjVD6D2KLZiq4mAHQY8m\nWgUSoHSeEvkcgqYLKhFJLfASHlzhwIVbK0P8PfhSulzVBKXKqy229IRTiIY7\nHQXDM0VtBEqnV2rv6+UqvBjY0yTdFWwB4P8x/glNiCBaCMKtzdMMoQvFeIcI\ndbge0qZt2jRZ0ZbRrCF/RBACWomZRpTpGMB7O314GwFPhU3oJwrAyiHcnn4I\n0XXu/56Y8Tw6UqX8LmW2ABr2Ysovxozk9SS0tYeNcPniSWGrTkMlV5UbzSw8\ntPMl1Ph1oQcNYC/jYzetTthA5NNTmuIg0z7QsF9lkGle4Qjg1gWkmVpVEdHH\n0VkDrSM0LZTv+24S1+hwolAtx5NuYT8yImDvOAlaPY1FBTsXEgO6QBjskaOt\neMfvKCB94TLR0IBoJ4Ckr4XDivnNjcSVUwkURj4LTDxY0aKYbnEXmpDqVQZ4\n2iTRR19d33Nkmz6I3VmEGWdYoRpkN7CX3FJ2x1cBgTtNVGftqsJGN92XAWVO\n+/4j+zc2nz6uaWnCWYqiaqXiik1CCITvXMwCi13DWPkVa2azbBrAU3hqshb0\n4rd6\r\n=rL4g\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/through2_2.0.5_1541541791587_0.6666046444978868"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "through2",
+      "version": "3.0.0",
+      "description": "A tiny wrapper around Node.js streams.Transform (Streams2/3) to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "nyc node test/test.js | faucet && nyc report"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "2 || 3",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "gitHead": "f8346bbef3ac9f730ff71d03aaf342d6d2e812bb",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@3.0.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.13.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
+        "shasum": "468b461df9cd9fcc170f22ebf6852e467e578ff2",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-3.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9459,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4hEiCRA9TVsSAnZWagAAVTcP/iGlVD0RaPav2Mhl2OlF\n00cDq0qdYiiTbMWutmwl73ldJ6Y64KH0l3jMnfQZ7G0aserqBrq6//3Ndx4u\npSvNgF7ruCisNNOspWp8oBhfDLt4GFjhW2Q9w4NPWrDxVR9B5uuwRjkq3gpD\ndzzCVfg2JygDBkZpOyogHGs2w/8JjXUANxPxPERLv/ZT/sQyd3dZFViT+Zf6\nNsFHgelEE31VbZ1HW/AYeCB/LwHdOxCyTCLqD+P98VzV26wyBWYQH8iDc2pn\nA0Arc2aIzPnnOVySXv99otN+wuN4S8iW8ssnTaDwQl54b35MiXBejbdkaPTu\n4ZWRiCai7yDDciSHwOrEz3OC7Y7oyJWVIl00qe3S1XmE4KzgeiBw1PF6/2xj\nN0sc29A2IaFlFNtZ+dyvlrcMZnPkXrEFOn//zWlkw7pYjPGQ3+p41E6pc7ms\nOFCQpNt/+8qh8GK6qsRalsMRxI3q+wcA/5y49KI4pP3xnehFzA9hVqzBvFWs\ni2hZq39vQgQ0oV6b588CpSf4kXBSVDAAIrrWDgTbTG36Eb20s4ybTHJeT/N5\nBT1b3kwGZbcwxTKqcmqKpKta2eLQt1rHeI2tkG/8oVrvNrfTOl0cZc4Xhssk\ngVPc0P6Cf8UTEP+CR1n0akIUq/008q07Zs5ZamtvOomVV06igKLCsS8xGE2Q\nzMdO\r\n=JIpQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/through2_3.0.0_1541542177835_0.20023645405245172"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1": {
+      "name": "through2",
+      "version": "3.0.1",
+      "description": "A tiny wrapper around Node.js streams.Transform (Streams2/3) to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "nyc node test/test.js | faucet && nyc report"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "2 || 3"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "gitHead": "d0696e4be57337c5742ac6fe9d20892a2ab78b2e",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@3.0.1",
+      "_nodeVersion": "11.10.1",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+        "shasum": "39276e713c3302edf9e388dd9c812dd3b825bd5a",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17355,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJceIJ5CRA9TVsSAnZWagAAoTcP/RtBJJJnx1t2euwGtGbv\nDYKZIfRxmWsH8VI3RmyYKcHGKOefsMgCfCkM38OLkOxl8bKPJHBv2p7Z+YWO\n+4RX9bWbsS9QbIj6MPguMNPaU1uzBoJoXiR0U1YyTDbQkCheH/dZ/Tkc6Idh\n4D/Ul+bN2kIQsQwzrrC1y18RtXxM0hlA0WolWbdhvjn90xdQHsrG2uxe7/qY\nxhgLHyCc5cWsVwV3HfD9IiHj0/JEifo4++Fb/5vI/VgBsfGdqjg9pN7NbCwu\nOTh1azuCcsB+t91AuK+ZPc6s3ptot1Do8T2MX3QoLQwEtQpO4P/YZCB+LmtL\n6+C0K0bT+jhFmpQoI5YvsSAm14fEYFUDXe9eGBIbyBjG9ImqGBRFjeLFHX4t\nlMsWxI4LoPr+k/t+M65ZxplXbV6B860iEkDhyUPbP6CpexiNei1iLAnPuhUQ\ntFxtskYtJwnOqsfjMCWzfDFu/gb/MBcjBIqczUVwlvh64QPTH5P0P81Nm683\n3bvhgHQ/BYcm2WNWGMXFDOsEIl4/bC68qlGbJNxKvIDnnRwUo9XyzDoumc0Y\nczaa1/oQbPhDixW73R9a59J+DRDJ7ZAa0bh7nUGORUC/P5XdVkD+Xg9hjb2q\nfyrP0+tUh7oR1qPyABAEHMaPXhCwe9RUKGQZ6Q3cALhj/BNZzNxlet0SNp50\nDwQ8\r\n=fkMy\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/through2_3.0.1_1551401592406_0.31603558673929033"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.2": {
+      "name": "through2",
+      "version": "3.0.2",
+      "description": "A tiny wrapper around Node.js streams.Transform (Streams2/3) to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test": "nyc node test/test.js | faucet && nyc report"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "gitHead": "af96bc751822e79e61d6734c603816881752e6b2",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@3.0.2",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+        "shasum": "99f88931cfc761ec7678b41d5d7336b5b6a07bf4",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9512,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe8rmZCRA9TVsSAnZWagAAcmwP/iqYRX0tI/5ERTjZ2/Xj\nvDbPH0nEyze6uGp3nh6uuX3qe/Uxj+vhxmAIwe4ld0sZ/OQxxZIWo2skUvSi\nN+FCx8jK1MbD65mc1NDwsRAmiodKPj61KQEfn5X/+tIc16DA1Z84xsUQ+TMx\nL0BkaSz2F0pI3YYeJlnvovW2ysm0xnAYhorWNuGhJ1eDAjohvaTjLNIadnIi\nDd14POfxnq5QOX2BXIq5jqFuo5ge+jHOVRsgp9gJG74ga/GBuq+ToOrQN9ZM\nbPjLZ5DHWsgXxOBpgbJQpHx+l6Q2tcov+T6fBh33izg/25rW9V0na3BnG41Z\nTqh2H0R8mJcL/tq4WdTMIt3IXyqb509SmgH/4CxGBAdsBYB0Bt6dr+A174RM\ntEJjVH4xwzlxa9wYgyGmhgwuAVA20coCiyE9MqHGTNIqgWITs4PetlDeFNNh\nWL83wxnVsT6KGBwjj42rHwaOn+wqFKP1p8qPLn9K93gu9anrjf1fCYAJqNSm\nKvrDtNDLJE4RAWyfsMhEwLMzqbwVuUDxU7HP5j/LRHKhGaASsHAroBeTCF5q\n8hljs94hnFirj38I34k70IBz+smfDZZ3nMBg4hKPpp8OOIJQPyZvCdEF3oNe\nQDY8mR26u3H60S18bMtb+pg6Bx6TlKgGuSIQrhE6L2hCFVTS+WfsFhdJsxGV\nf1oj\r\n=ZkHt\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/through2_3.0.2_1592965529113_0.4402035709601104"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "through2",
+      "version": "4.0.0",
+      "description": "A tiny wrapper around Node.js streams.Transform (Streams2/3) to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test:node": "hundreds mocha test/test.js",
+        "test:browser": "node -e 'process.exit(process.version.startsWith(\"v8.\") ? 0 : 1)' || polendina --cleanup --runner=mocha test/test.js",
+        "test": "npm run lint && npm run test:node && npm run test:browser",
+        "lint": "standard",
+        "coverage": "c8 --reporter=text --reporter=html mocha test/test.js && npx st -d coverage -p 8888"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "3"
+      },
+      "devDependencies": {
+        "bl": "^4.0.2",
+        "buffer": "^5.6.0",
+        "chai": "^4.2.0",
+        "hundreds": "~0.0.7",
+        "mocha": "^7.2.0",
+        "polendina": "^1.0.0",
+        "standard": "^14.3.4",
+        "stream-spigot": "^3.0.6"
+      },
+      "gitHead": "de7735241f8ba2382a8b0c00db0d6dac141a34ee",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@4.0.0",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-6RB1WIvpLaNJJyFOduxF/bYpbIe5w+kwO5Zq2XdAQ/ZiYw87kdHRAi/HEG3wwX5uO17v9uMK3UyKHuYosJqdFw==",
+        "shasum": "f6df6cd07aa0141ff12faa77514d32df03e34438",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-4.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 829739,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9xrYCRA9TVsSAnZWagAAL94P/0KC/2RetFIyTAzIScQW\nGphU7Wuod4QdSzPpVOwIR5I31268LqADOadKI4ctAmJ+2o06B7tx/1NkPFYq\nJlaC6dhHsQqtEZo6J4YbG8szJpTklTiUbT9bAfiTFUTLs3g/AJb+Ye0Wq0By\nctR3uoYzygFM3Y/JeK6qyzPzY8wu8D7ewAXtRCyDz5mUYVVdXSw3NznfnO5x\nGT/Z0zT/J3bxKx/8K+iIWIXYZN/b5ncqDsr4Tr1Z7/9ulnS4uAC3uYXX4fQt\nQ0cKNGoG5SCL6yeL5ADXtBbKr73RGU2ULK2QyjyuSl5Vp0HmS5PuFCPsSpf7\nw9I7RbohpgxbWw0koAwAq0uv4TMscemKqDcnk5c2RQiugKb44zicHXTwDNyp\nSybdJF4inkh8PfnDzdwaoxyw8ZUQ4qdAmuq4GMRkyS3aiXYrf/trnSN0hVTi\nfiPWmuGpBt6XQU89NufWUBXuYpig8uWuuPDcKuaVB/ekqbAi8nXmFY28bgiF\nudRASzTIFbll64BosQ8E5T0K3Z6t2VQyHPevmz6/CDRKFsHCQKZqnbZf+LwT\nxQMsIH+WPFMareBHEKW/aVbkwfe87oDPWdOLeSQ3XD+2K9npu689a3sFvge5\nO7rUubSsBuxWOXfKDiZ2Yr576lDH617IUIflGXMg52i8nfn8fNnjJhUIkjp0\nsex9\r\n=FQyQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/through2_4.0.0_1593252568366_0.21273259543184575"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.1": {
+      "name": "through2",
+      "version": "4.0.1",
+      "description": "A tiny wrapper around Node.js streams.Transform (Streams2/3) to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test:node": "hundreds mocha test/test.js",
+        "test:browser": "node -e 'process.exit(process.version.startsWith(\"v8.\") ? 0 : 1)' || polendina --cleanup --runner=mocha test/test.js",
+        "test": "npm run lint && npm run test:node && npm run test:browser",
+        "lint": "standard",
+        "coverage": "c8 --reporter=text --reporter=html mocha test/test.js && npx st -d coverage -p 8888"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "3"
+      },
+      "devDependencies": {
+        "bl": "^4.0.2",
+        "buffer": "^5.6.0",
+        "chai": "^4.2.0",
+        "hundreds": "~0.0.7",
+        "mocha": "^7.2.0",
+        "polendina": "^1.0.0",
+        "standard": "^14.3.4",
+        "stream-spigot": "^3.0.6"
+      },
+      "gitHead": "9c0cf1257c3a769884f5f19c1bd2fb25222f4f9e",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@4.0.1",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-G04e2YDcXGlUPGbPKpqcPgcw+CmIWbHAy9ifmGrjfoeColNJ93CsA2qpSOoGvFylskm22ItBIg7L3Wv/eLiVaw==",
+        "shasum": "ef2964e95a055bef1ec06f45688f6e5245da699b",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-4.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9372,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9xtJCRA9TVsSAnZWagAAVhUP/RZ0EKwMF/FDmetYieMF\n+EAWBlT1KEbF4ds3VFb/WHNZAintTKzmnC1PKGAROCB1ZBgpUuR7rMhCyfSg\nR1+KiFWjGcHH9uuEEkPxk6ToVw7i1RZ0Ls0ah8rCKXdGd0ko8wsHl7HCCm1G\nk0IMs7+g6XtHMaQt0m/qBLJtZcBR0bGZo7rKfnjJ3P9Hr7R16FZbiakw2DaP\neJJYYPvS+QkHJOyAGjrx4VmfYih2uiAJOBX+S6dEhhuimvkHa3idciVN0WSN\nGnTQi+pDeZzxZG/zHEjuh1Efye1SMkeC8jiigQfreAgvjAZMBK7g0Jbq/IN4\nryb597nQwS98iDA8UeRSUiqpThwzNMB0Zh7ciQLAXXXE+lE0PYYy3toYrLAJ\nEt8/TEmMqNjdAEbl1U3E0BqipDLfyHEqraROJ6B9f3W3OlvfjT+CmYNSef2s\nX/CL9GMxx0Dq/78e2Pbhfl53vaWlxWMo57+/iycX0d54ccVcrlHNfSnFyL0a\npdE+K4ZqUHHrn5WPi14T3PkF9Fe+O0zZ9WpH53/Y9RS0xtrN2ABsk73203Eh\nJ/3V8bOiH0aDK2ecZNUMhe90+r69eXE3FyKphlt5FEL6Y4he13kNqXxQ5CjT\nOSlRAztw5DMTjWYhvedOxOXBL4b4wiLM3wE5iKnuPT/xjShU9zp4iiKrxTMT\nXaks\r\n=Lx1W\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/through2_4.0.1_1593252681273_0.502396389448263"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.2": {
+      "name": "through2",
+      "version": "4.0.2",
+      "description": "A tiny wrapper around Node.js streams.Transform (Streams2/3) to avoid explicit subclassing noise",
+      "main": "through2.js",
+      "scripts": {
+        "test:node": "hundreds mocha test/test.js",
+        "test:browser": "node -e 'process.exit(process.version.startsWith(\"v8.\") ? 0 : 1)' || polendina --cleanup --runner=mocha test/test.js",
+        "test": "npm run lint && npm run test:node && npm run test:browser",
+        "lint": "standard",
+        "coverage": "c8 --reporter=text --reporter=html mocha test/test.js && npx st -d coverage -p 8888"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/through2.git"
+      },
+      "keywords": [
+        "stream",
+        "streams2",
+        "through",
+        "transform"
+      ],
+      "author": {
+        "name": "Rod Vagg",
+        "email": "r@va.gg",
+        "url": "https://github.com/rvagg"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "3"
+      },
+      "devDependencies": {
+        "bl": "^4.0.2",
+        "buffer": "^5.6.0",
+        "chai": "^4.2.0",
+        "hundreds": "~0.0.7",
+        "mocha": "^7.2.0",
+        "polendina": "^1.0.0",
+        "standard": "^14.3.4",
+        "stream-spigot": "^3.0.6"
+      },
+      "gitHead": "ebe3d0b736115ffca785336301119979df70a708",
+      "bugs": {
+        "url": "https://github.com/rvagg/through2/issues"
+      },
+      "homepage": "https://github.com/rvagg/through2#readme",
+      "_id": "through2@4.0.2",
+      "_nodeVersion": "14.4.0",
+      "_npmVersion": "6.14.5",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+        "shasum": "a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9346,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe+pRoCRA9TVsSAnZWagAAOToP/RtrDJh3hKhs1FI13nN3\nCf2cX0Q3mJZE6BAkI1hrTiJLsbnpjI20KollM0cL0bWCp3Q0JIxJJbmcjOiN\ngR14Skv9A1GxDEmkHptCKpDvtSQHbUW9QS1Xok/VlRPEI2d1z5w3LjlCSYGZ\nDaQVFIJfM023+aRhWSQ1N4+rloGLGCFCqDLko6dfteT4RfWrqBYhvWvY+plf\nQF014OoT9V+BxfRndJhfZA37ud3t0XkqmVdNj/fdpWQZpUMEgjacTKve7waQ\nEJ/E6J+vT72oMRrWcbrjAhULFuDOqnl2bnPrVAS/D10dD8Z2Lh+KdwYZONPV\nxKCp1CSBBP8yd6G2MtL9f8Nrhse4egqVICcv1CWrPXdMAExFC1700+czloEI\nUeHtuWtdOd1MtjAsKv53Wm5m3p3di3tz9k0CewVIqJOw814x06ajIBBKuTDu\nKu6eJqhnXFNdnhRuJMnUDMKWwEI2Pmeu6XWDpVyTqWgpWTHn3rEotO4waN/z\ndE/O+zhD+oKGtLwOCHfJ7YplW//IfSEiLHSDhto/TCZegFn6UC10hO4O5MxR\nEyUq21LfVX4lUYfWVKNULMCVtlt+rMBXWfkvH/UNOexKf+a5sEvwyLasZGep\niEeYva4kKXBpBsPSj6TvKn4OLW70G7fDBRW0RegMAdvwSWjdd5DVpfbkvI0+\na3mH\r\n=5hsR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bryce",
+          "email": "bryce@ravenwall.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/through2_4.0.2_1593480295626_0.011245994121877656"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# through2\n\n![Build & Test](https://github.com/rvagg/through2/workflows/Build%20&%20Test/badge.svg)\n\n[![NPM](https://nodei.co/npm/through2.png?downloads&downloadRank)](https://nodei.co/npm/through2/)\n\n**A tiny wrapper around Node.js streams.Transform (Streams2/3) to avoid explicit subclassing noise**\n\nInspired by [Dominic Tarr](https://github.com/dominictarr)'s [through](https://github.com/dominictarr/through) in that it's so much easier to make a stream out of a function than it is to set up the prototype chain properly: `through(function (chunk) { ... })`.\n\n```js\nfs.createReadStream('ex.txt')\n  .pipe(through2(function (chunk, enc, callback) {\n    for (let i = 0; i < chunk.length; i++)\n      if (chunk[i] == 97)\n        chunk[i] = 122 // swap 'a' for 'z'\n\n    this.push(chunk)\n\n    callback()\n   }))\n  .pipe(fs.createWriteStream('out.txt'))\n  .on('finish', () => doSomethingSpecial())\n```\n\nOr object streams:\n\n```js\nconst all = []\n\nfs.createReadStream('data.csv')\n  .pipe(csv2())\n  .pipe(through2.obj(function (chunk, enc, callback) {\n    const data = {\n        name    : chunk[0]\n      , address : chunk[3]\n      , phone   : chunk[10]\n    }\n    this.push(data)\n\n    callback()\n  }))\n  .on('data', (data) => {\n    all.push(data)\n  })\n  .on('end', () => {\n    doSomethingSpecial(all)\n  })\n```\n\nNote that `through2.obj(fn)` is a convenience wrapper around `through2({ objectMode: true }, fn)`.\n\n## Do you need this?\n\nSince Node.js introduced [Simplified Stream Construction](https://nodejs.org/api/stream.html#stream_simplified_construction), many uses of **through2** have become redundant. Consider whether you really need to use **through2** or just want to use the `'readable-stream'` package, or the core `'stream'` package (which is derived from `'readable-stream'`):\n\n```js\nconst { Transform } = require('readable-stream')\n\nconst transformer = new Transform({\n  transform(chunk, enc, callback) {\n    // ...\n  }\n})\n```\n\n## API\n\n<b><code>through2([ options, ] [ transformFunction ] [, flushFunction ])</code></b>\n\nConsult the **[stream.Transform](https://nodejs.org/docs/latest/api/stream.html#stream_class_stream_transform)** documentation for the exact rules of the `transformFunction` (i.e. `this._transform`) and the optional `flushFunction` (i.e. `this._flush`).\n\n### options\n\nThe options argument is optional and is passed straight through to `stream.Transform`. So you can use `objectMode:true` if you are processing non-binary streams (or just use `through2.obj()`).\n\nThe `options` argument is first, unlike standard convention, because if I'm passing in an anonymous function then I'd prefer for the options argument to not get lost at the end of the call:\n\n```js\nfs.createReadStream('/tmp/important.dat')\n  .pipe(through2({ objectMode: true, allowHalfOpen: false },\n    (chunk, enc, cb) => {\n      cb(null, 'wut?') // note we can use the second argument on the callback\n                       // to provide data as an alternative to this.push('wut?')\n    }\n  ))\n  .pipe(fs.createWriteStream('/tmp/wut.txt'))\n```\n\n### transformFunction\n\nThe `transformFunction` must have the following signature: `function (chunk, encoding, callback) {}`. A minimal implementation should call the `callback` function to indicate that the transformation is done, even if that transformation means discarding the chunk.\n\nTo queue a new chunk, call `this.push(chunk)`&mdash;this can be called as many times as required before the `callback()` if you have multiple pieces to send on.\n\nAlternatively, you may use `callback(err, chunk)` as shorthand for emitting a single chunk or an error.\n\nIf you **do not provide a `transformFunction`** then you will get a simple pass-through stream.\n\n### flushFunction\n\nThe optional `flushFunction` is provided as the last argument (2nd or 3rd, depending on whether you've supplied options) is called just prior to the stream ending. Can be used to finish up any processing that may be in progress.\n\n```js\nfs.createReadStream('/tmp/important.dat')\n  .pipe(through2(\n    (chunk, enc, cb) => cb(null, chunk), // transform is a noop\n    function (cb) { // flush function\n      this.push('tacking on an extra buffer to the end');\n      cb();\n    }\n  ))\n  .pipe(fs.createWriteStream('/tmp/wut.txt'));\n```\n\n<b><code>through2.ctor([ options, ] transformFunction[, flushFunction ])</code></b>\n\nInstead of returning a `stream.Transform` instance, `through2.ctor()` returns a **constructor** for a custom Transform. This is useful when you want to use the same transform logic in multiple instances.\n\n```js\nconst FToC = through2.ctor({objectMode: true}, function (record, encoding, callback) {\n  if (record.temp != null && record.unit == \"F\") {\n    record.temp = ( ( record.temp - 32 ) * 5 ) / 9\n    record.unit = \"C\"\n  }\n  this.push(record)\n  callback()\n})\n\n// Create instances of FToC like so:\nconst converter = new FToC()\n// Or:\nconst converter = FToC()\n// Or specify/override options when you instantiate, if you prefer:\nconst converter = FToC({objectMode: true})\n```\n\n## License\n\n**through2** is Copyright &copy; Rod Vagg and additional contributors and licensed under the MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE file for more details.\n",
+  "maintainers": [
+    {
+      "name": "bryce",
+      "email": "bryce@ravenwall.com"
+    },
+    {
+      "name": "rvagg",
+      "email": "rod@vagg.org"
+    }
+  ],
+  "time": {
+    "modified": "2020-06-30T01:24:58.097Z",
+    "created": "2013-08-01T03:52:14.750Z",
+    "0.0.0": "2013-08-01T03:52:19.254Z",
+    "0.0.1": "2013-08-01T04:23:18.725Z",
+    "0.0.2": "2013-08-01T04:24:34.840Z",
+    "0.0.3": "2013-08-01T04:45:33.254Z",
+    "0.0.4": "2013-08-01T07:07:13.452Z",
+    "0.0.5": "2013-08-02T04:13:35.437Z",
+    "0.1.0": "2013-08-05T02:02:17.284Z",
+    "0.2.0": "2013-08-24T06:06:28.730Z",
+    "0.2.1": "2013-08-25T10:04:50.167Z",
+    "0.2.2": "2013-09-19T06:04:57.568Z",
+    "0.2.3": "2013-09-26T17:04:36.262Z",
+    "0.3.0": "2014-01-03T00:20:50.627Z",
+    "0.4.0": "2014-01-13T11:57:44.964Z",
+    "0.4.1": "2014-01-24T01:17:36.976Z",
+    "1.0.0": "2014-02-18T04:07:39.794Z",
+    "0.4.2": "2014-05-22T09:49:03.138Z",
+    "0.5.0": "2014-06-04T06:14:46.165Z",
+    "0.5.1": "2014-06-04T06:17:06.736Z",
+    "1.0.1": "2014-08-08T09:42:29.558Z",
+    "0.6.0": "2014-08-08T09:47:32.115Z",
+    "1.1.0": "2014-08-08T09:49:57.473Z",
+    "0.6.1": "2014-08-11T22:48:05.884Z",
+    "1.1.1": "2014-08-11T22:48:47.974Z",
+    "0.6.2": "2014-09-21T08:48:24.147Z",
+    "0.6.3": "2014-10-10T01:03:21.598Z",
+    "0.6.4": "2015-04-09T17:21:43.539Z",
+    "0.6.5": "2015-04-09T17:42:07.435Z",
+    "2.0.0": "2015-06-11T10:04:48.524Z",
+    "2.0.1": "2016-02-08T10:46:59.251Z",
+    "2.0.2": "2016-11-28T04:46:28.925Z",
+    "2.0.3": "2016-11-28T22:52:09.981Z",
+    "2.0.4": "2018-11-06T09:46:33.393Z",
+    "2.0.5": "2018-11-06T22:03:11.711Z",
+    "3.0.0": "2018-11-06T22:09:37.970Z",
+    "3.0.1": "2019-03-01T00:53:12.565Z",
+    "3.0.2": "2020-06-24T02:25:29.319Z",
+    "4.0.0": "2020-06-27T10:09:28.551Z",
+    "4.0.1": "2020-06-27T10:11:21.372Z",
+    "4.0.2": "2020-06-30T01:24:55.820Z"
+  },
+  "author": {
+    "name": "Rod Vagg",
+    "email": "r@va.gg",
+    "url": "https://github.com/rvagg"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rvagg/through2.git"
+  },
+  "users": {
+    "306766053": true,
+    "chilts": true,
+    "hughsk": true,
+    "stdarg": true,
+    "jonkemp": true,
+    "alanshaw": true,
+    "delapouite": true,
+    "zckrs": true,
+    "timhudson": true,
+    "joakin": true,
+    "kahboom": true,
+    "bmpvieira": true,
+    "tunnckocore": true,
+    "afc163": true,
+    "levisl176": true,
+    "kmck": true,
+    "zhangyaochun": true,
+    "pingjiang": true,
+    "lewisbrown": true,
+    "ryanj": true,
+    "ziink": true,
+    "wenbing": true,
+    "tclay": true,
+    "akiva": true,
+    "ghostbar": true,
+    "artskydj": true,
+    "joeybaker": true,
+    "seanjh": true,
+    "bezoerb": true,
+    "simplyianm": true,
+    "yashprit": true,
+    "nickleefly": true,
+    "alexkval": true,
+    "lensi": true,
+    "makediff": true,
+    "markthethomas": true,
+    "dudley": true,
+    "chriscalo": true,
+    "jmorris": true,
+    "ggorczynski": true,
+    "davidchubbs": true,
+    "evan2x": true,
+    "plitat": true,
+    "leodutra": true,
+    "awen1983": true,
+    "nex": true,
+    "thecodeparadox": true,
+    "vladan": true,
+    "adiachenko": true,
+    "bret": true,
+    "samhou1988": true,
+    "axelav": true,
+    "greelgorke": true,
+    "jueb": true,
+    "incendiary": true,
+    "ddffx": true,
+    "x4devs": true,
+    "zwxajh": true,
+    "preflight": true,
+    "jessaustin": true,
+    "santihbc": true,
+    "seerdomin": true,
+    "ifeature": true,
+    "ex.zach.ly": true,
+    "0x4c3p": true,
+    "jyounce": true,
+    "barenko": true,
+    "nketchum": true,
+    "smerik": true,
+    "nixon.q": true,
+    "parkerproject": true,
+    "buya": true,
+    "travm": true,
+    "fotooo": true,
+    "nalindak": true,
+    "tomekf": true,
+    "wangnan0610": true,
+    "leahcimic": true,
+    "yuxin": true,
+    "klimnikita": true,
+    "a3.ivanenko": true,
+    "abdihaikal": true,
+    "arttse": true,
+    "sirrah": true,
+    "smedegaard": true,
+    "shipengyan": true,
+    "xiaobao": true,
+    "davidbraun": true,
+    "ezodude": true,
+    "kontrax": true,
+    "cassln": true,
+    "easimonenko": true,
+    "spywhere": true,
+    "brend": true,
+    "dannycoates": true,
+    "nhz.io": true,
+    "aliem": true,
+    "dralc": true,
+    "doruk": true,
+    "samlaudev": true,
+    "illuminator": true,
+    "sasquatch": true,
+    "nahuelhds": true,
+    "tongjieme": true,
+    "lijinghust": true,
+    "sebastian1118": true,
+    "panger": true,
+    "iori20091101": true,
+    "fassetar": true,
+    "farskipper": true,
+    "rplittle": true,
+    "ywc6688": true,
+    "rochejul": true,
+    "epezhman": true,
+    "lgh06": true,
+    "kkk123321": true,
+    "kaapex": true,
+    "volebonet": true,
+    "maxkoryukov": true,
+    "volebo": true,
+    "akarem": true,
+    "octetstream": true,
+    "craigpatten": true,
+    "dvl": true,
+    "jun-oka": true,
+    "monjer": true,
+    "nuer": true,
+    "ikobe": true,
+    "tdmalone": true,
+    "caijf": true,
+    "leidottw": true,
+    "qddegtya": true,
+    "mojaray2k": true,
+    "fahadjadoon": true,
+    "dzhou777": true,
+    "mattms": true,
+    "fanyegong": true,
+    "jkrusinski": true,
+    "slang": true,
+    "magicxiao": true,
+    "eklem": true,
+    "joaquin.briceno": true,
+    "rylan_yan": true,
+    "smokinhuzi": true,
+    "jian263994241": true,
+    "soenkekluth": true,
+    "raojs": true,
+    "chirag8642": true,
+    "simoyw": true,
+    "zixinliango": true,
+    "joris-van-der-wel": true,
+    "caikan": true,
+    "rbecheras": true,
+    "frankl83": true,
+    "coolhanddev": true,
+    "xueboren": true,
+    "mrzmmr": true,
+    "yikuo": true,
+    "stone-jin": true,
+    "jondotsoy": true,
+    "vitorluizc": true,
+    "1two3code": true,
+    "chinawolf_wyp": true,
+    "roccomuso": true,
+    "unixzii": true,
+    "wvlvik": true,
+    "pasturn": true,
+    "dpjayasekara": true,
+    "kodekracker": true,
+    "ahmedfarooki": true,
+    "usex": true,
+    "robmcguinness": true,
+    "tmurngon": true,
+    "majkel": true,
+    "simonja": true,
+    "chaowei.luo": true,
+    "stanlous": true,
+    "h4lll": true,
+    "awhmandan": true,
+    "edosrecki": true,
+    "sheikhsajid": true,
+    "highgravity": true,
+    "ziflex": true,
+    "froguard": true,
+    "tzq1011": true,
+    "kiinlam": true,
+    "shipfi": true,
+    "jns": true,
+    "marcobiedermann": true,
+    "drewigg": true,
+    "jota": true,
+    "dinggewennuan": true,
+    "kamirdjanian": true,
+    "lqweb": true,
+    "zhenguo.zhao": true,
+    "morewry": true,
+    "xieranmaya": true,
+    "hearsid": true,
+    "rubiadias": true,
+    "jmsherry": true,
+    "rossdavis": true,
+    "allanwxm": true,
+    "pftom": true,
+    "johniexu": true,
+    "tcrowe": true
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/rvagg/through2#readme",
+  "keywords": [
+    "stream",
+    "streams2",
+    "through",
+    "transform"
+  ],
+  "bugs": {
+    "url": "https://github.com/rvagg/through2/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/through2.min.json
+++ b/test/fixtures/registry-mocks/content/through2.min.json
@@ -1,0 +1,695 @@
+{
+  "name": "through2",
+  "dist-tags": {
+    "latest": "4.0.2",
+    "1.0": "1.1.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "through2",
+      "version": "0.0.0",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "dist": {
+        "shasum": "418434b88c4b59d1b8583f8e26b31a398e332b25",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "through2",
+      "version": "0.0.1",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "dist": {
+        "shasum": "ecfdbb4005ee1c3843d14db1e959f9738374af81",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "through2",
+      "version": "0.0.2",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "dist": {
+        "shasum": "bbdf39882f3bca1e0a04a64ad3eb1de010e98534",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "through2",
+      "version": "0.0.3",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "dist": {
+        "shasum": "24749c99581289e6ae2a0d69121e8cb17088a108",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "through2",
+      "version": "0.0.4",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0"
+      },
+      "dist": {
+        "shasum": "b134b520bbe5078bbd143424fb91481c25a54e80",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.4.tgz"
+      }
+    },
+    "0.0.5": {
+      "name": "through2",
+      "version": "0.0.5",
+      "dependencies": {
+        "readable-stream": "~1.0.2"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0"
+      },
+      "dist": {
+        "shasum": "6a4210686015e82a1ecbf891e3e35c0d96905a99",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.0.5.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "through2",
+      "version": "0.1.0",
+      "dependencies": {
+        "readable-stream": "~1.0.2",
+        "xtend": "~2.0.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0",
+        "stream-spigot": "~2.0.0"
+      },
+      "dist": {
+        "shasum": "54e756cc6a543c72bb5adf55e8a248686b84c9cc",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "through2",
+      "version": "0.2.0",
+      "dependencies": {
+        "readable-stream": "~1.0.2",
+        "xtend": "~2.0.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0",
+        "stream-spigot": "~2.0.0"
+      },
+      "dist": {
+        "shasum": "6702afc24836e35e42950aad98010be632987777",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "through2",
+      "version": "0.2.1",
+      "dependencies": {
+        "readable-stream": "~1.0.2",
+        "xtend": "~2.0.6"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0",
+        "stream-spigot": "~2.0.0"
+      },
+      "dist": {
+        "shasum": "fa2def7230dd218add7b216a06594b15a4104395",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "through2",
+      "version": "0.2.2",
+      "dependencies": {
+        "readable-stream": "~1.0.2",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~1.0.4",
+        "bl": "~0.2.0",
+        "stream-spigot": "~2.0.0"
+      },
+      "dist": {
+        "shasum": "d5e70d6a42cb5ba003bbdbc975f5772434dbe513",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.2.2.tgz"
+      }
+    },
+    "0.2.3": {
+      "name": "through2",
+      "version": "0.2.3",
+      "dependencies": {
+        "readable-stream": "~1.1.9",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~1.1.1",
+        "bl": "~0.4.1",
+        "stream-spigot": "~2.1.2"
+      },
+      "dist": {
+        "shasum": "eb3284da4ea311b6cc8ace3653748a52abf25a3f",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "through2",
+      "version": "0.3.0",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "2d1d28c8d1daf8d9c5cb78f0a69343c6b8642d97",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.3.0.tgz"
+      }
+    },
+    "0.4.0": {
+      "name": "through2",
+      "version": "0.4.0",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "4c9a96e385ef082a86cce5b915ef512119bc5225",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.4.0.tgz"
+      }
+    },
+    "0.4.1": {
+      "name": "through2",
+      "version": "0.4.1",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "afd849c65af513c2541a98a7cfbcfec3a15a9686",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.4.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "through2",
+      "version": "1.0.0",
+      "dependencies": {
+        "readable-stream": "~1.1.10",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "2445cd8dfe74285dee5dada055e0571d01ff17ac",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-1.0.0.tgz"
+      }
+    },
+    "0.4.2": {
+      "name": "through2",
+      "version": "0.4.2",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "dbf5866031151ec8352bb6c4db64a2292a840b9b",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
+      }
+    },
+    "0.5.0": {
+      "name": "through2",
+      "version": "0.5.0",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "28957b997cb86034b3520c943c2140d9436b30ac",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.5.0.tgz"
+      }
+    },
+    "0.5.1": {
+      "name": "through2",
+      "version": "0.5.1",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~3.0.0"
+      },
+      "devDependencies": {
+        "tape": "~2.3.0",
+        "bl": "~0.6.0",
+        "stream-spigot": "~3.0.1",
+        "brtapsauce": "~0.2.2"
+      },
+      "dist": {
+        "shasum": "dfdd012eb9c700e2323fd334f38ac622ab372da7",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
+      }
+    },
+    "0.6.0": {
+      "name": "through2",
+      "version": "0.6.0",
+      "dependencies": {
+        "readable-stream": ">=1.0.27-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "423484bebaaad0cc65bb205fea8248c9e1de4e57",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "through2",
+      "version": "1.1.0",
+      "dependencies": {
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "373c6c0b0158891eeb3d2d524c9c0a140c5b911a",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-1.1.0.tgz"
+      }
+    },
+    "0.6.1": {
+      "name": "through2",
+      "version": "0.6.1",
+      "dependencies": {
+        "readable-stream": ">=1.0.27-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "f742b32893e8bd26146e789e4fd2ccb2c07a717e",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.1.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "through2",
+      "version": "1.1.1",
+      "dependencies": {
+        "readable-stream": ">=1.1.13-1 <1.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "0847cbc4449f3405574dbdccd9bb841b83ac3545",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz"
+      }
+    },
+    "0.6.2": {
+      "name": "through2",
+      "version": "0.6.2",
+      "dependencies": {
+        "readable-stream": ">=1.0.28 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "53265824c555e7fcdc4111dcdc52c7de64636c75",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.2.tgz"
+      }
+    },
+    "0.6.3": {
+      "name": "through2",
+      "version": "0.6.3",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "795292fde9f254c2a368b38f9cc5d1bd4663afb6",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz"
+      }
+    },
+    "0.6.4": {
+      "name": "through2",
+      "version": "0.6.4",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "cfb59dfb313217ea35bd0749c410455d90099d3a",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.4.tgz"
+      }
+    },
+    "0.6.5": {
+      "name": "through2",
+      "version": "0.6.5",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "bl": ">=0.9.0 <0.10.0-0",
+        "stream-spigot": ">=3.0.4 <3.1.0-0",
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "41ab9c67b29d57209071410e1d7a7a968cd3ad48",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "through2",
+      "version": "2.0.0",
+      "dependencies": {
+        "readable-stream": "~2.0.0",
+        "xtend": "~4.0.0"
+      },
+      "devDependencies": {
+        "bl": "~0.9.4",
+        "faucet": "0.0.1",
+        "stream-spigot": "~3.0.5",
+        "tape": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "f41a1c31df5e129e4314446f66eca05cd6a30480",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "through2",
+      "version": "2.0.1",
+      "dependencies": {
+        "readable-stream": "~2.0.0",
+        "xtend": "~4.0.0"
+      },
+      "devDependencies": {
+        "bl": "~0.9.4",
+        "faucet": "0.0.1",
+        "stream-spigot": "~3.0.5",
+        "tape": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "384e75314d49f32de12eebb8136b8eb6b5d59da9",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
+      }
+    },
+    "2.0.2": {
+      "name": "through2",
+      "version": "2.0.2",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~1.1.2",
+        "faucet": "0.0.1",
+        "stream-spigot": "~3.0.5",
+        "tape": "~4.6.2"
+      },
+      "dist": {
+        "shasum": "316d3a4f444af641496aa7f45a713be72576baf4",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.2.tgz"
+      }
+    },
+    "2.0.3": {
+      "name": "through2",
+      "version": "2.0.3",
+      "dependencies": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~1.1.2",
+        "faucet": "0.0.1",
+        "stream-spigot": "~3.0.5",
+        "tape": "~4.6.2"
+      },
+      "dist": {
+        "shasum": "0004569b37c7c74ba39c43f3ced78d1ad94140be",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      }
+    },
+    "2.0.4": {
+      "name": "through2",
+      "version": "2.0.4",
+      "dependencies": {
+        "readable-stream": "2 || 3",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
+        "shasum": "e8362dec238b7590f5743b060342f27b452f4450",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17579,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4WL5CRA9TVsSAnZWagAAdwAP/irs3Ec8bhFhH+U5Rpqi\nNNGhR4jCdBQ05bW8+QMUrbX/6Tb3N24o6hyupnUkOEFnP7G0vPWl9XmSmKVg\nuPIoMbm8twWaMFP/NXA7kDOX0/pQerHecKAF7vNwz3iw6cJpkEwAH5JkgOhp\nqGdBRJRx4Lcv7F7lINZ3J39tOlA9mxioNeVVm4dXPh5pfcsdcg0lUVbQhmTH\nvJTNk9hR0Tfw35VZ1xlXCi9pQhWMPEuEJ5Yhanw9t9Xo8URO3ke/i027fadQ\nm1l8l3I3yUDXvIxA+yXw0n+L7+t+mDorq67TIGkNPDCxxGNCqekD63tDeJ3T\n2dezxSe09aU1Kmok7J0RpLhqvqzWYPfpixJkxnKgV0NjEC3cJjvIpgU9FPu/\nxDXDhd0gtUTF9EPklSZpIJSu+DbIZTx82en/+Ve1jQmi9b5yG6GzEPwvPy4T\nuwJuIYNeyVVsG/7p17rSdZHGOuvAxLnMcTfQGmVrkfA0BLmTiqjqMUDFJEPY\ni4iB935MJhb+WFeSJZ7jKzsDMI/L7z2eVMh6dxNzzPPw6ZJFqHID/Itnz486\nsj57hytuFU9p4ZfuQtYNj/pZdr4ULeARfjFwF66c/XgQiyybB/b5hX2JIwA5\n4s4ANK/573N/MfI6UkHhVx/GBHVr2izGuGV1VdnymH2iTcq2xg6mims7pnu1\nesHr\r\n=ZPOs\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.5": {
+      "name": "through2",
+      "version": "2.0.5",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "safe-buffer": "~5.1.2",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+        "shasum": "01c1e39eb31d07cb7d03a96a70823260b23132cd",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9649,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4g+gCRA9TVsSAnZWagAAozIQAJ9G33BOIVzbaoS4KejZ\nPTu12HkLyxVwCU0iCwR2+BMFw8y0JcNr2eZPNWqSV3beHDPDHY+WRgJesCjP\nzJ5Jv+8hwFLSXG4Kc407ZWV3ten0AV1xlHJjGsY6WjVD6D2KLZiq4mAHQY8m\nWgUSoHSeEvkcgqYLKhFJLfASHlzhwIVbK0P8PfhSulzVBKXKqy229IRTiIY7\nHQXDM0VtBEqnV2rv6+UqvBjY0yTdFWwB4P8x/glNiCBaCMKtzdMMoQvFeIcI\ndbge0qZt2jRZ0ZbRrCF/RBACWomZRpTpGMB7O314GwFPhU3oJwrAyiHcnn4I\n0XXu/56Y8Tw6UqX8LmW2ABr2Ysovxozk9SS0tYeNcPniSWGrTkMlV5UbzSw8\ntPMl1Ph1oQcNYC/jYzetTthA5NNTmuIg0z7QsF9lkGle4Qjg1gWkmVpVEdHH\n0VkDrSM0LZTv+24S1+hwolAtx5NuYT8yImDvOAlaPY1FBTsXEgO6QBjskaOt\neMfvKCB94TLR0IBoJ4Ckr4XDivnNjcSVUwkURj4LTDxY0aKYbnEXmpDqVQZ4\n2iTRR19d33Nkmz6I3VmEGWdYoRpkN7CX3FJ2x1cBgTtNVGftqsJGN92XAWVO\n+/4j+zc2nz6uaWnCWYqiaqXiik1CCITvXMwCi13DWPkVa2azbBrAU3hqshb0\n4rd6\r\n=rL4g\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.0.0": {
+      "name": "through2",
+      "version": "3.0.0",
+      "dependencies": {
+        "readable-stream": "2 || 3",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
+        "shasum": "468b461df9cd9fcc170f22ebf6852e467e578ff2",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-3.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9459,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4hEiCRA9TVsSAnZWagAAVTcP/iGlVD0RaPav2Mhl2OlF\n00cDq0qdYiiTbMWutmwl73ldJ6Y64KH0l3jMnfQZ7G0aserqBrq6//3Ndx4u\npSvNgF7ruCisNNOspWp8oBhfDLt4GFjhW2Q9w4NPWrDxVR9B5uuwRjkq3gpD\ndzzCVfg2JygDBkZpOyogHGs2w/8JjXUANxPxPERLv/ZT/sQyd3dZFViT+Zf6\nNsFHgelEE31VbZ1HW/AYeCB/LwHdOxCyTCLqD+P98VzV26wyBWYQH8iDc2pn\nA0Arc2aIzPnnOVySXv99otN+wuN4S8iW8ssnTaDwQl54b35MiXBejbdkaPTu\n4ZWRiCai7yDDciSHwOrEz3OC7Y7oyJWVIl00qe3S1XmE4KzgeiBw1PF6/2xj\nN0sc29A2IaFlFNtZ+dyvlrcMZnPkXrEFOn//zWlkw7pYjPGQ3+p41E6pc7ms\nOFCQpNt/+8qh8GK6qsRalsMRxI3q+wcA/5y49KI4pP3xnehFzA9hVqzBvFWs\ni2hZq39vQgQ0oV6b588CpSf4kXBSVDAAIrrWDgTbTG36Eb20s4ybTHJeT/N5\nBT1b3kwGZbcwxTKqcmqKpKta2eLQt1rHeI2tkG/8oVrvNrfTOl0cZc4Xhssk\ngVPc0P6Cf8UTEP+CR1n0akIUq/008q07Zs5ZamtvOomVV06igKLCsS8xGE2Q\nzMdO\r\n=JIpQ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.0.1": {
+      "name": "through2",
+      "version": "3.0.1",
+      "dependencies": {
+        "readable-stream": "2 || 3"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+        "shasum": "39276e713c3302edf9e388dd9c812dd3b825bd5a",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17355,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJceIJ5CRA9TVsSAnZWagAAoTcP/RtBJJJnx1t2euwGtGbv\nDYKZIfRxmWsH8VI3RmyYKcHGKOefsMgCfCkM38OLkOxl8bKPJHBv2p7Z+YWO\n+4RX9bWbsS9QbIj6MPguMNPaU1uzBoJoXiR0U1YyTDbQkCheH/dZ/Tkc6Idh\n4D/Ul+bN2kIQsQwzrrC1y18RtXxM0hlA0WolWbdhvjn90xdQHsrG2uxe7/qY\nxhgLHyCc5cWsVwV3HfD9IiHj0/JEifo4++Fb/5vI/VgBsfGdqjg9pN7NbCwu\nOTh1azuCcsB+t91AuK+ZPc6s3ptot1Do8T2MX3QoLQwEtQpO4P/YZCB+LmtL\n6+C0K0bT+jhFmpQoI5YvsSAm14fEYFUDXe9eGBIbyBjG9ImqGBRFjeLFHX4t\nlMsWxI4LoPr+k/t+M65ZxplXbV6B860iEkDhyUPbP6CpexiNei1iLAnPuhUQ\ntFxtskYtJwnOqsfjMCWzfDFu/gb/MBcjBIqczUVwlvh64QPTH5P0P81Nm683\n3bvhgHQ/BYcm2WNWGMXFDOsEIl4/bC68qlGbJNxKvIDnnRwUo9XyzDoumc0Y\nczaa1/oQbPhDixW73R9a59J+DRDJ7ZAa0bh7nUGORUC/P5XdVkD+Xg9hjb2q\nfyrP0+tUh7oR1qPyABAEHMaPXhCwe9RUKGQZ6Q3cALhj/BNZzNxlet0SNp50\nDwQ8\r\n=fkMy\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "3.0.2": {
+      "name": "through2",
+      "version": "3.0.2",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      },
+      "devDependencies": {
+        "bl": "~2.0.1",
+        "faucet": "0.0.1",
+        "nyc": "~13.1.0",
+        "stream-spigot": "~3.0.6",
+        "tape": "~4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+        "shasum": "99f88931cfc761ec7678b41d5d7336b5b6a07bf4",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9512,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe8rmZCRA9TVsSAnZWagAAcmwP/iqYRX0tI/5ERTjZ2/Xj\nvDbPH0nEyze6uGp3nh6uuX3qe/Uxj+vhxmAIwe4ld0sZ/OQxxZIWo2skUvSi\nN+FCx8jK1MbD65mc1NDwsRAmiodKPj61KQEfn5X/+tIc16DA1Z84xsUQ+TMx\nL0BkaSz2F0pI3YYeJlnvovW2ysm0xnAYhorWNuGhJ1eDAjohvaTjLNIadnIi\nDd14POfxnq5QOX2BXIq5jqFuo5ge+jHOVRsgp9gJG74ga/GBuq+ToOrQN9ZM\nbPjLZ5DHWsgXxOBpgbJQpHx+l6Q2tcov+T6fBh33izg/25rW9V0na3BnG41Z\nTqh2H0R8mJcL/tq4WdTMIt3IXyqb509SmgH/4CxGBAdsBYB0Bt6dr+A174RM\ntEJjVH4xwzlxa9wYgyGmhgwuAVA20coCiyE9MqHGTNIqgWITs4PetlDeFNNh\nWL83wxnVsT6KGBwjj42rHwaOn+wqFKP1p8qPLn9K93gu9anrjf1fCYAJqNSm\nKvrDtNDLJE4RAWyfsMhEwLMzqbwVuUDxU7HP5j/LRHKhGaASsHAroBeTCF5q\n8hljs94hnFirj38I34k70IBz+smfDZZ3nMBg4hKPpp8OOIJQPyZvCdEF3oNe\nQDY8mR26u3H60S18bMtb+pg6Bx6TlKgGuSIQrhE6L2hCFVTS+WfsFhdJsxGV\nf1oj\r\n=ZkHt\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.0": {
+      "name": "through2",
+      "version": "4.0.0",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "3"
+      },
+      "devDependencies": {
+        "bl": "^4.0.2",
+        "buffer": "^5.6.0",
+        "chai": "^4.2.0",
+        "hundreds": "~0.0.7",
+        "mocha": "^7.2.0",
+        "polendina": "^1.0.0",
+        "standard": "^14.3.4",
+        "stream-spigot": "^3.0.6"
+      },
+      "dist": {
+        "integrity": "sha512-6RB1WIvpLaNJJyFOduxF/bYpbIe5w+kwO5Zq2XdAQ/ZiYw87kdHRAi/HEG3wwX5uO17v9uMK3UyKHuYosJqdFw==",
+        "shasum": "f6df6cd07aa0141ff12faa77514d32df03e34438",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-4.0.0.tgz",
+        "fileCount": 6,
+        "unpackedSize": 829739,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9xrYCRA9TVsSAnZWagAAL94P/0KC/2RetFIyTAzIScQW\nGphU7Wuod4QdSzPpVOwIR5I31268LqADOadKI4ctAmJ+2o06B7tx/1NkPFYq\nJlaC6dhHsQqtEZo6J4YbG8szJpTklTiUbT9bAfiTFUTLs3g/AJb+Ye0Wq0By\nctR3uoYzygFM3Y/JeK6qyzPzY8wu8D7ewAXtRCyDz5mUYVVdXSw3NznfnO5x\nGT/Z0zT/J3bxKx/8K+iIWIXYZN/b5ncqDsr4Tr1Z7/9ulnS4uAC3uYXX4fQt\nQ0cKNGoG5SCL6yeL5ADXtBbKr73RGU2ULK2QyjyuSl5Vp0HmS5PuFCPsSpf7\nw9I7RbohpgxbWw0koAwAq0uv4TMscemKqDcnk5c2RQiugKb44zicHXTwDNyp\nSybdJF4inkh8PfnDzdwaoxyw8ZUQ4qdAmuq4GMRkyS3aiXYrf/trnSN0hVTi\nfiPWmuGpBt6XQU89NufWUBXuYpig8uWuuPDcKuaVB/ekqbAi8nXmFY28bgiF\nudRASzTIFbll64BosQ8E5T0K3Z6t2VQyHPevmz6/CDRKFsHCQKZqnbZf+LwT\nxQMsIH+WPFMareBHEKW/aVbkwfe87oDPWdOLeSQ3XD+2K9npu689a3sFvge5\nO7rUubSsBuxWOXfKDiZ2Yr576lDH617IUIflGXMg52i8nfn8fNnjJhUIkjp0\nsex9\r\n=FQyQ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.1": {
+      "name": "through2",
+      "version": "4.0.1",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "3"
+      },
+      "devDependencies": {
+        "bl": "^4.0.2",
+        "buffer": "^5.6.0",
+        "chai": "^4.2.0",
+        "hundreds": "~0.0.7",
+        "mocha": "^7.2.0",
+        "polendina": "^1.0.0",
+        "standard": "^14.3.4",
+        "stream-spigot": "^3.0.6"
+      },
+      "dist": {
+        "integrity": "sha512-G04e2YDcXGlUPGbPKpqcPgcw+CmIWbHAy9ifmGrjfoeColNJ93CsA2qpSOoGvFylskm22ItBIg7L3Wv/eLiVaw==",
+        "shasum": "ef2964e95a055bef1ec06f45688f6e5245da699b",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-4.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9372,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe9xtJCRA9TVsSAnZWagAAVhUP/RZ0EKwMF/FDmetYieMF\n+EAWBlT1KEbF4ds3VFb/WHNZAintTKzmnC1PKGAROCB1ZBgpUuR7rMhCyfSg\nR1+KiFWjGcHH9uuEEkPxk6ToVw7i1RZ0Ls0ah8rCKXdGd0ko8wsHl7HCCm1G\nk0IMs7+g6XtHMaQt0m/qBLJtZcBR0bGZo7rKfnjJ3P9Hr7R16FZbiakw2DaP\neJJYYPvS+QkHJOyAGjrx4VmfYih2uiAJOBX+S6dEhhuimvkHa3idciVN0WSN\nGnTQi+pDeZzxZG/zHEjuh1Efye1SMkeC8jiigQfreAgvjAZMBK7g0Jbq/IN4\nryb597nQwS98iDA8UeRSUiqpThwzNMB0Zh7ciQLAXXXE+lE0PYYy3toYrLAJ\nEt8/TEmMqNjdAEbl1U3E0BqipDLfyHEqraROJ6B9f3W3OlvfjT+CmYNSef2s\nX/CL9GMxx0Dq/78e2Pbhfl53vaWlxWMo57+/iycX0d54ccVcrlHNfSnFyL0a\npdE+K4ZqUHHrn5WPi14T3PkF9Fe+O0zZ9WpH53/Y9RS0xtrN2ABsk73203Eh\nJ/3V8bOiH0aDK2ecZNUMhe90+r69eXE3FyKphlt5FEL6Y4he13kNqXxQ5CjT\nOSlRAztw5DMTjWYhvedOxOXBL4b4wiLM3wE5iKnuPT/xjShU9zp4iiKrxTMT\nXaks\r\n=Lx1W\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "4.0.2": {
+      "name": "through2",
+      "version": "4.0.2",
+      "dependencies": {
+        "readable-stream": "3"
+      },
+      "devDependencies": {
+        "bl": "^4.0.2",
+        "buffer": "^5.6.0",
+        "chai": "^4.2.0",
+        "hundreds": "~0.0.7",
+        "mocha": "^7.2.0",
+        "polendina": "^1.0.0",
+        "standard": "^14.3.4",
+        "stream-spigot": "^3.0.6"
+      },
+      "dist": {
+        "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+        "shasum": "a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764",
+        "tarball": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 9346,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe+pRoCRA9TVsSAnZWagAAOToP/RtrDJh3hKhs1FI13nN3\nCf2cX0Q3mJZE6BAkI1hrTiJLsbnpjI20KollM0cL0bWCp3Q0JIxJJbmcjOiN\ngR14Skv9A1GxDEmkHptCKpDvtSQHbUW9QS1Xok/VlRPEI2d1z5w3LjlCSYGZ\nDaQVFIJfM023+aRhWSQ1N4+rloGLGCFCqDLko6dfteT4RfWrqBYhvWvY+plf\nQF014OoT9V+BxfRndJhfZA37ud3t0XkqmVdNj/fdpWQZpUMEgjacTKve7waQ\nEJ/E6J+vT72oMRrWcbrjAhULFuDOqnl2bnPrVAS/D10dD8Z2Lh+KdwYZONPV\nxKCp1CSBBP8yd6G2MtL9f8Nrhse4egqVICcv1CWrPXdMAExFC1700+czloEI\nUeHtuWtdOd1MtjAsKv53Wm5m3p3di3tz9k0CewVIqJOw814x06ajIBBKuTDu\nKu6eJqhnXFNdnhRuJMnUDMKWwEI2Pmeu6XWDpVyTqWgpWTHn3rEotO4waN/z\ndE/O+zhD+oKGtLwOCHfJ7YplW//IfSEiLHSDhto/TCZegFn6UC10hO4O5MxR\nEyUq21LfVX4lUYfWVKNULMCVtlt+rMBXWfkvH/UNOexKf+a5sEvwyLasZGep\niEeYva4kKXBpBsPSj6TvKn4OLW70G7fDBRW0RegMAdvwSWjdd5DVpfbkvI0+\na3mH\r\n=5hsR\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-06-30T01:24:58.097Z"
+}

--- a/test/fixtures/registry-mocks/content/thunky.json
+++ b/test/fixtures/registry-mocks/content/thunky.json
@@ -1,0 +1,426 @@
+{
+  "_id": "thunky",
+  "_rev": "12-b2bc51f5548cc548109f42a0fd2f059d",
+  "name": "thunky",
+  "description": "delay the evaluation of a paramless async function and cache the result",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "thunky",
+      "version": "0.1.0",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/thunky"
+      },
+      "description": "delay the evaluation of a paramless async function and cache the result",
+      "keywords": [
+        "memo",
+        "thunk",
+        "async",
+        "lazy",
+        "control",
+        "flow",
+        "cache"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "_id": "thunky@0.1.0",
+      "dist": {
+        "shasum": "bf30146824e2b6e67b0f2d7a4ac8beb26908684e",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "thunky",
+      "version": "1.0.0",
+      "description": "delay the evaluation of a paramless async function and cache the result",
+      "main": "index.js",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/thunky.git"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "keywords": [
+        "memo",
+        "thunk",
+        "async",
+        "lazy",
+        "control",
+        "flow",
+        "cache"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/thunky/issues"
+      },
+      "homepage": "https://github.com/mafintosh/thunky#readme",
+      "license": "MIT",
+      "gitHead": "40d0e72ccfea1b2fb11a4706d16d7dc52cdfc9bf",
+      "_id": "thunky@1.0.0",
+      "_shasum": "48c898447cdbf9686d65f3473bc1489e7cc97184",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "48c898447cdbf9686d65f3473bc1489e7cc97184",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/thunky-1.0.0.tgz_1468578380300_0.8760475649032742"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "thunky",
+      "version": "1.0.1",
+      "description": "delay the evaluation of a paramless async function and cache the result",
+      "main": "index.js",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/thunky.git"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "keywords": [
+        "memo",
+        "thunk",
+        "async",
+        "lazy",
+        "control",
+        "flow",
+        "cache"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/thunky/issues"
+      },
+      "homepage": "https://github.com/mafintosh/thunky#readme",
+      "license": "MIT",
+      "gitHead": "02328e063e740e1b2c6edf8d540bd82577ae87fc",
+      "_id": "thunky@1.0.1",
+      "_shasum": "3db1525aac0367b67bd2e532d2773e7c40be2e68",
+      "_from": ".",
+      "_npmVersion": "2.15.9",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "3db1525aac0367b67bd2e532d2773e7c40be2e68",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/thunky-1.0.1.tgz_1468578438552_0.737917662365362"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "thunky",
+      "version": "1.0.2",
+      "description": "delay the evaluation of a paramless async function and cache the result",
+      "main": "index.js",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/thunky.git"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "keywords": [
+        "memo",
+        "thunk",
+        "async",
+        "lazy",
+        "control",
+        "flow",
+        "cache"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/thunky/issues"
+      },
+      "homepage": "https://github.com/mafintosh/thunky#readme",
+      "license": "MIT",
+      "gitHead": "7ad8bbfdfbd62b51ea0e34c5235ba0de0db12223",
+      "_id": "thunky@1.0.2",
+      "_shasum": "a862e018e3fb1ea2ec3fce5d55605cf57f247371",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.5",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "shasum": "a862e018e3fb1ea2ec3fce5d55605cf57f247371",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/thunky-1.0.2.tgz_1486860508065_0.44560420024208724"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "thunky",
+      "version": "1.0.3",
+      "description": "delay the evaluation of a paramless async function and cache the result",
+      "main": "index.js",
+      "devDependencies": {
+        "standard": "^12.0.1",
+        "tape": "^4.9.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/thunky.git"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "keywords": [
+        "memo",
+        "thunk",
+        "async",
+        "lazy",
+        "control",
+        "flow",
+        "cache"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/thunky/issues"
+      },
+      "homepage": "https://github.com/mafintosh/thunky#readme",
+      "license": "MIT",
+      "gitHead": "ce46d4fb455af79369cf14b7bf3eb0911bc01500",
+      "_id": "thunky@1.0.3",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.11.0",
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
+        "shasum": "f5df732453407b09191dae73e2a8cc73f381a826",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 7165,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbxiS9CRA9TVsSAnZWagAA8DsQAKIU9+suySLueSdVZcn1\n/OMQQPWU6PyfDjI6vZq2ECE7PYB9kaOTj45bsVoUZOts9cI0YAqzYFEJK2Qn\n0ZTT+X1bOsmNaNsg3Llv2VWqwBl0uLQcWordK+HsgdUW/Pj7to2D2gfOeIDK\n6CdhGYxD7WLBcS6eJ/KqBGZvMgfToX/w+9GfTjPzU0IxU+1XNCugs8QSrS+z\nYObEgpn1DYjlIarubypRSPd5la+hx/yGQlfpq9barM1Y4V9p87Yt8UL5qw7p\n7ZZIMiR/B78G7s8lrrmzgYSXTui740yjmC5SAXRzHuuGN3WjnFLQSv2G1uKY\n8ZPsUuqo2a7Fj6LFjZjlEcoPS0Lwft0HYRrJ3r1hCpEgDuLoOxjm9z6adstu\nqlvw5LDTWyanE4jM8bndZvf+ay08+kbFUdRmXbeIriHpZD8YdeL+IQ3pl5t/\n4mfA+tDVSGf/FF5tLY5JBSPAelRlJhUUqWGKQ/G/qNhIN+JdioqBTzy3XtZo\nFx3k/VlXmIYlaYvYdvNeAJIGEkyk+g8TXaupbzwLMuh5P7X+jCTsaa3yb4FJ\nmRFrwXfATuQeHMDKrtUHMjlecxF9M91bCRxCJ2AdP9Msq08zF8qHhOiz8bH0\n9f+o0W8zXuLNuWD4Zb8HjbnnOptZzh8m6s3nhCu5xbHT259LZ8gV9ogbpwp5\nG2s6\r\n=VdWZ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/thunky_1.0.3_1539712188066_0.0018386345014538286"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.0": {
+      "name": "thunky",
+      "version": "1.1.0",
+      "description": "delay the evaluation of a paramless async function and cache the result",
+      "main": "index.js",
+      "devDependencies": {
+        "standard": "^12.0.1",
+        "tape": "^4.9.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/mafintosh/thunky.git"
+      },
+      "scripts": {
+        "test": "standard && tape test.js"
+      },
+      "keywords": [
+        "memo",
+        "thunk",
+        "async",
+        "lazy",
+        "control",
+        "flow",
+        "cache"
+      ],
+      "author": {
+        "name": "Mathias Buus Madsen",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "bugs": {
+        "url": "https://github.com/mafintosh/thunky/issues"
+      },
+      "homepage": "https://github.com/mafintosh/thunky#readme",
+      "license": "MIT",
+      "gitHead": "4f24392fd09949e3785598d99b087e8256599989",
+      "_id": "thunky@1.1.0",
+      "_nodeVersion": "10.16.3",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+        "shasum": "5abaf714a9405db0504732bbccd2cedd9ef9537d",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 7758,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdpDfGCRA9TVsSAnZWagAA9Q4P/i1u8AdasQuoaM+NXEOs\nLGhjqM30PR/nuzdLDJhNsYNl/sLOwFZmAnwzVuxG+4t2OeES+a70gGXL2FLV\ndpQJHL+KDnVq2ANoQcJtYRRMDCOM3P5zvTS2DaXtdbBOAX/WPdgvR7FcCXeD\nPOBVpKFmo2A7+0eUpmxSMgVXVmHjkQkx7zmvGjsx+zm+a9a/3jKdI1eywWkG\nLmnW1y+BqxieMestDhrmSPisKBCYiAf3lyu1lrx+I2yMCA+KWUMau8Nq+Qft\nqritsC7qT00T61rRycR6vjLiFOXSd6n22SM32z1yAbeZOK80wYUNrE2nA4Yo\n7RL0c15PFoCDHiUwPAzIjTjCqM+mkGO1PRvtNtn3OyihhBAB7QMEUBOWeRXZ\nuJE3GOhySWGMGwP4K2YhwtOK+q8AK4RVLX4/QW4hc4+BlP0qySVixbK8+KJm\nIflU2vlzopa+m6cmfuWB54rDN0xi+OXotuTnJy8Vhy6uRDhUWX9wGuXK3+Av\nNTlM9wGXbTe88LFzHpZeSqxrmFtLFOEi5G0BSbZdn+qJ8HTatEATml33I2lP\nGU+Rp56Wp1CTgfVw5/Ug0jZiHJtX4uC6vTyDXn9T9OcL2tFkcJeI6foFB/uF\ngRzm4ypBy1Sq/PoGqrdEiLB2/fZb+geRuH3KknnkfOM5ckbO9O24RHD2bRbd\n2ila\r\n=4xXc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "mafintosh",
+        "email": "mathiasbuus@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/thunky_1.1.0_1571043270184_0.776382449698759"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# thunky\n\nDelay the evaluation of a paramless async function and cache the result (see [thunk](http://en.wikipedia.org/wiki/Thunk_%28functional_programming%29)).\n\n```\nnpm install thunky\n```\n\n[![build status](http://img.shields.io/travis/mafintosh/thunky.svg?style=flat)](http://travis-ci.org/mafintosh/thunky)\n\n## Example\n\nLet's make a simple function that returns a random number 1 second after it is called for the first time\n\n``` js\nvar thunky = require('thunky')\n\nvar test = thunky(function (callback) { // the inner function should only accept a callback\n  console.log('waiting 1s and returning random number')\n  setTimeout(function () {\n    callback(Math.random())\n  }, 1000)\n})\n\ntest(function (num) {  // inner function is called the first time we call test\n  console.log(num) // prints random number\n})\n\ntest(function (num) {  // subsequent calls waits for the first call to finish and return the same value\n  console.log(num) // prints the same random number as above\n})\n```\n\n## Lazy evaluation\n\nThunky makes it easy to implement a lazy evaluation pattern.\n\n``` js\nvar getDb = thunky(function (callback) {\n  db.open(myConnectionString, callback)\n})\n\nvar queryDb = function (query, callback) {\n  getDb(function (err, db) {\n    if (err) return callback(err)\n    db.query(query, callback)\n  })\n}\n\nqueryDb('some query', function (err, result) { ... } )\n\nqueryDb('some other query', function (err, result) { ... } )\n```\n\nThe first time `getDb` is called it will try do open a connection to the database.\nAny subsequent calls will just wait for the first call to complete and then call your callback.\n\nA nice property of this pattern is that it *easily* allows us to pass any error caused by `getDb` to the `queryDb` callback.\n\n## Error → No caching\n\nIf the thunk callback is called with an `Error` object as the first argument it will not cache the result\n\n``` js\nvar fails = thunky(function (callback) {\n  console.log('returning an error')\n  callback(new Error('bad stuff'))\n})\n\nfails(function (err) { // inner function is called\n  console.log(err)\n});\n\nfails(function (err) { // inner function is called again as it returned an error before\n  console.log(err)\n})\n```\n\n## Promise version\n\nA promise version is available as well\n\n``` js\nvar thunkyp = require('thunky/promise')\n\nvar ready = thunkyp(async function () {\n  // ... do async stuff\n  return 42\n})\n\n// same semantics as the callback version\nawait ready()\n```\n\n## License\n\nMIT\n",
+  "maintainers": [
+    {
+      "name": "feross",
+      "email": "feross@feross.org"
+    },
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-10-14T08:54:32.960Z",
+    "created": "2013-03-06T18:30:51.672Z",
+    "0.1.0": "2013-03-06T18:30:54.142Z",
+    "1.0.0": "2016-07-15T10:26:22.935Z",
+    "1.0.1": "2016-07-15T10:27:21.115Z",
+    "1.0.2": "2017-02-12T00:48:28.724Z",
+    "1.0.3": "2018-10-16T17:49:48.229Z",
+    "1.1.0": "2019-10-14T08:54:30.361Z"
+  },
+  "author": {
+    "name": "Mathias Buus Madsen",
+    "email": "mathiasbuus@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mafintosh/thunky.git"
+  },
+  "users": {
+    "bret": true,
+    "ziflex": true,
+    "quocnguyen": true
+  },
+  "keywords": [
+    "memo",
+    "thunk",
+    "async",
+    "lazy",
+    "control",
+    "flow",
+    "cache"
+  ],
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/mafintosh/thunky#readme",
+  "bugs": {
+    "url": "https://github.com/mafintosh/thunky/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/thunky.min.json
+++ b/test/fixtures/registry-mocks/content/thunky.min.json
@@ -1,0 +1,85 @@
+{
+  "name": "thunky",
+  "dist-tags": {
+    "latest": "1.1.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "thunky",
+      "version": "0.1.0",
+      "dist": {
+        "shasum": "bf30146824e2b6e67b0f2d7a4ac8beb26908684e",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "thunky",
+      "version": "1.0.0",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0"
+      },
+      "dist": {
+        "shasum": "48c898447cdbf9686d65f3473bc1489e7cc97184",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "thunky",
+      "version": "1.0.1",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0"
+      },
+      "dist": {
+        "shasum": "3db1525aac0367b67bd2e532d2773e7c40be2e68",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "thunky",
+      "version": "1.0.2",
+      "devDependencies": {
+        "standard": "^7.1.2",
+        "tape": "^4.6.0"
+      },
+      "dist": {
+        "shasum": "a862e018e3fb1ea2ec3fce5d55605cf57f247371",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "thunky",
+      "version": "1.0.3",
+      "devDependencies": {
+        "standard": "^12.0.1",
+        "tape": "^4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-YwT8pjmNcAXBZqrubu22P4FYsh2D4dxRmnWBOL8Jk8bUcRUtc5326kx32tuTmFDAZtLOGEVNl8POAR8j896Iow==",
+        "shasum": "f5df732453407b09191dae73e2a8cc73f381a826",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.0.3.tgz",
+        "fileCount": 6,
+        "unpackedSize": 7165,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbxiS9CRA9TVsSAnZWagAA8DsQAKIU9+suySLueSdVZcn1\n/OMQQPWU6PyfDjI6vZq2ECE7PYB9kaOTj45bsVoUZOts9cI0YAqzYFEJK2Qn\n0ZTT+X1bOsmNaNsg3Llv2VWqwBl0uLQcWordK+HsgdUW/Pj7to2D2gfOeIDK\n6CdhGYxD7WLBcS6eJ/KqBGZvMgfToX/w+9GfTjPzU0IxU+1XNCugs8QSrS+z\nYObEgpn1DYjlIarubypRSPd5la+hx/yGQlfpq9barM1Y4V9p87Yt8UL5qw7p\n7ZZIMiR/B78G7s8lrrmzgYSXTui740yjmC5SAXRzHuuGN3WjnFLQSv2G1uKY\n8ZPsUuqo2a7Fj6LFjZjlEcoPS0Lwft0HYRrJ3r1hCpEgDuLoOxjm9z6adstu\nqlvw5LDTWyanE4jM8bndZvf+ay08+kbFUdRmXbeIriHpZD8YdeL+IQ3pl5t/\n4mfA+tDVSGf/FF5tLY5JBSPAelRlJhUUqWGKQ/G/qNhIN+JdioqBTzy3XtZo\nFx3k/VlXmIYlaYvYdvNeAJIGEkyk+g8TXaupbzwLMuh5P7X+jCTsaa3yb4FJ\nmRFrwXfATuQeHMDKrtUHMjlecxF9M91bCRxCJ2AdP9Msq08zF8qHhOiz8bH0\n9f+o0W8zXuLNuWD4Zb8HjbnnOptZzh8m6s3nhCu5xbHT259LZ8gV9ogbpwp5\nG2s6\r\n=VdWZ\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.0": {
+      "name": "thunky",
+      "version": "1.1.0",
+      "devDependencies": {
+        "standard": "^12.0.1",
+        "tape": "^4.9.1"
+      },
+      "dist": {
+        "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+        "shasum": "5abaf714a9405db0504732bbccd2cedd9ef9537d",
+        "tarball": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 7758,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdpDfGCRA9TVsSAnZWagAA9Q4P/i1u8AdasQuoaM+NXEOs\nLGhjqM30PR/nuzdLDJhNsYNl/sLOwFZmAnwzVuxG+4t2OeES+a70gGXL2FLV\ndpQJHL+KDnVq2ANoQcJtYRRMDCOM3P5zvTS2DaXtdbBOAX/WPdgvR7FcCXeD\nPOBVpKFmo2A7+0eUpmxSMgVXVmHjkQkx7zmvGjsx+zm+a9a/3jKdI1eywWkG\nLmnW1y+BqxieMestDhrmSPisKBCYiAf3lyu1lrx+I2yMCA+KWUMau8Nq+Qft\nqritsC7qT00T61rRycR6vjLiFOXSd6n22SM32z1yAbeZOK80wYUNrE2nA4Yo\n7RL0c15PFoCDHiUwPAzIjTjCqM+mkGO1PRvtNtn3OyihhBAB7QMEUBOWeRXZ\nuJE3GOhySWGMGwP4K2YhwtOK+q8AK4RVLX4/QW4hc4+BlP0qySVixbK8+KJm\nIflU2vlzopa+m6cmfuWB54rDN0xi+OXotuTnJy8Vhy6uRDhUWX9wGuXK3+Av\nNTlM9wGXbTe88LFzHpZeSqxrmFtLFOEi5G0BSbZdn+qJ8HTatEATml33I2lP\nGU+Rp56Wp1CTgfVw5/Ug0jZiHJtX4uC6vTyDXn9T9OcL2tFkcJeI6foFB/uF\ngRzm4ypBy1Sq/PoGqrdEiLB2/fZb+geRuH3KknnkfOM5ckbO9O24RHD2bRbd\n2ila\r\n=4xXc\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-10-14T08:54:32.960Z"
+}

--- a/test/fixtures/registry-mocks/content/timers-browserify.json
+++ b/test/fixtures/registry-mocks/content/timers-browserify.json
@@ -1,0 +1,3893 @@
+{
+  "_id": "timers-browserify",
+  "_rev": "53-540300fa6caf5dfb51daf2e654006bc4",
+  "name": "timers-browserify",
+  "description": "timers module for browserify",
+  "dist-tags": {
+    "latest": "2.0.12"
+  },
+  "versions": {
+    "0.0.0": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "0.0.0",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "name": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "main": "main.js",
+      "dependencies": {},
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "_id": "timers-browserify@0.0.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.21",
+      "_nodeVersion": "v0.6.18",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "9deb3bf70e1155b7e608d9c0c552c5a55bd650f9",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-0.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "~1.0.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "_id": "timers-browserify@1.0.0",
+      "dist": {
+        "shasum": "6cff54619a7af3e0feb99dc60b85a883ee192fea",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.0.1",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "_id": "timers-browserify@1.0.1",
+      "dist": {
+        "shasum": "7c93257b543cb1e3003d3663b57d560ee1d27057",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.0.2",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "gitHead": "c67e388b2adf6d8df2de113d48dbbb1a323b0928",
+      "_id": "timers-browserify@1.0.2",
+      "scripts": {},
+      "_shasum": "33935e5d08a02a132cee6bfa45228a7d33ae8466",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "33935e5d08a02a132cee6bfa45228a7d33ae8466",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.0.3",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "gitHead": "26a6b9e81cc0f65d68678592c72d63636795fc93",
+      "_id": "timers-browserify@1.0.3",
+      "scripts": {},
+      "_shasum": "ffba70c9c12eed916fd67318e629ac6f32295551",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ffba70c9c12eed916fd67318e629ac6f32295551",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.1.0",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "gitHead": "0416ec07a897d7e2a5d1b9374b2fb90a36ceaf7e",
+      "_id": "timers-browserify@1.1.0",
+      "scripts": {},
+      "_shasum": "bffd11af00fe82b089b015e8de4dc6a911b7ec3e",
+      "_from": ".",
+      "_npmVersion": "1.4.14",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bffd11af00fe82b089b015e8de4dc6a911b7ec3e",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.2.0",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.10.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "gitHead": "657d34d6d974b6b96e2615250792ff6a2455a7b4",
+      "_id": "timers-browserify@1.2.0",
+      "scripts": {},
+      "_shasum": "411865ceba9e2c0fafc1d2f3b7a6a87bca44194b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "411865ceba9e2c0fafc1d2f3b7a6a87bca44194b",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.3.0",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.10.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "gitHead": "e3a7e858b3b2100303874e2ef0071d1c61e5b489",
+      "_id": "timers-browserify@1.3.0",
+      "scripts": {},
+      "_shasum": "c518e6ba39f19619e6ae464e447b1511e172e96f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c518e6ba39f19619e6ae464e447b1511e172e96f",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.4.0",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.10.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "gitHead": "b8b35bcf4c95305db48a030d0f08b9bafdd6660d",
+      "_id": "timers-browserify@1.4.0",
+      "scripts": {},
+      "_shasum": "6b424b07688cd1978c2a3333ee618c46036d6ddb",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6b424b07688cd1978c2a3333ee618c46036d6ddb",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.4.1",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "gitHead": "e95b087592e08052d773efeec9412d480eb1c22b",
+      "_id": "timers-browserify@1.4.1",
+      "scripts": {},
+      "_shasum": "bf8afeb7b50d6c500e2b3e0a5d759c4005e985d7",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bf8afeb7b50d6c500e2b3e0a5d759c4005e985d7",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.2": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "1.4.2",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "762af88b6ed1d9b2ac97110649b723391ddd6bdd",
+      "_id": "timers-browserify@1.4.2",
+      "scripts": {},
+      "_shasum": "c9c58b575be8407375cb5e2462dacee74359f41d",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c9c58b575be8407375cb5e2462dacee74359f41d",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "6adac285092eaecbb38b74bf9d017c175219b1ff",
+      "_id": "timers-browserify@2.0.0",
+      "scripts": {},
+      "_shasum": "0cae1d5e8ce45f605590bb64331d0b1102eb265b",
+      "_from": ".",
+      "_npmVersion": "3.6.0",
+      "_nodeVersion": "5.6.0",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0cae1d5e8ce45f605590bb64331d0b1102eb265b",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/timers-browserify-2.0.0.tgz_1459186350606_0.3618208144325763"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.1",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "60328740a05aa1bdf6783780fcff2943d54eee8f",
+      "_id": "timers-browserify@2.0.1",
+      "scripts": {},
+      "_shasum": "199291a9fb720ee19f58a611a699083396af1622",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "199291a9fb720ee19f58a611a699083396af1622",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/timers-browserify-2.0.1.tgz_1466555669433_0.2476723336149007"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.2",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "2b4f7e6f3eda4109e06f90b50ee3ec24fc386506",
+      "_id": "timers-browserify@2.0.2",
+      "scripts": {},
+      "_shasum": "ab4883cf597dcd50af211349a00fbca56ac86b86",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ab4883cf597dcd50af211349a00fbca56ac86b86",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/timers-browserify-2.0.2.tgz_1476882406189_0.28604227397590876"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.3",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "global": "^4.3.2",
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "f1b0bf3b6f1472cc5dc4f10f760ea37f6ecdddda",
+      "_id": "timers-browserify@2.0.3",
+      "_npmVersion": "5.1.0",
+      "_nodeVersion": "8.1.3",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-+JAqyNgg+M8+gXIrq2EeUr4kZqRz47Ysco7X5QKRGScRE9HIHckyHD1asozSFGeqx2nmPCgA8T5tIGVO0ML7/w==",
+        "shasum": "41fd0bdc926a5feedc33a17a8e1f7d491925f7fc",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify-2.0.3.tgz_1501523397061_0.9377144535537809"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.4",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "5529f60de812beb769be7c9afffa388184506072",
+      "_id": "timers-browserify@2.0.4",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+        "shasum": "96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify-2.0.4.tgz_1502722044314_0.054807583102956414"
+      },
+      "directories": {}
+    },
+    "2.0.5": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.5",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Dario Segura",
+          "email": "dario.seco@gmail.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "92b9d23ee5bdc783f52315933bac80216a3449c6",
+      "_id": "timers-browserify@2.0.5",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-BMeI1W6E2/mSaPVLUnH9rjEY1Ys2FEC/GKmE/101wusU3byZO5g68BJ5hpJEP8iD1qAJ6SzYAShGA+urHMxOzQ==",
+        "shasum": "04878fb12a155a159c9d1e59faa1f77bf4ecc44c",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.5.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify-2.0.5.tgz_1516764979767_0.6405671837273985"
+      },
+      "directories": {}
+    },
+    "2.0.6": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.6",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Dario Segura",
+          "email": "dario.seco@gmail.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "106b52352aad119298c1fcdde36848969458cee4",
+      "_id": "timers-browserify@2.0.6",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+        "shasum": "241e76927d9ca05f4d959819022f5b3664b64bae",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify-2.0.6.tgz_1516832790650_0.10070195351727307"
+      },
+      "directories": {}
+    },
+    "2.0.7": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.7",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Dario Segura",
+          "email": "dario.seco@gmail.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "Thiago Felix",
+          "email": "thiago@thiagofelix.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "fc37ad35365a6bcbaa0b499d99e9c76619180f4e",
+      "_id": "timers-browserify@2.0.7",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.9.0",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-U7DtjfsHeYjNAyEz4MdCLGZMY3ySyHIgZZp6ba9uxZlMRMiK5yTHUYc2XfGQHKFgxGcmvBF2jafoNtQYvlDpOw==",
+        "shasum": "e74093629cb62c20332af587ddc0c86b4ba97a05",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.7.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9728,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1RGjCRA9TVsSAnZWagAAP9IP/iAxaKHyKzzDwiW9jaZy\nDjK+FiB/X7ajwyqgJd/R33iYAc6o1BzIEzQAkCLSTcBydVER17GYNKkbPZJt\n15s8fPh6wjBloVFL1TcrfzFUZKWCxbf0nZN5t8HZ0oaABCrRC8qls7LXzurt\niuiSXZ+B25C6uBcRcouA47CFma4qS9w+LqfgSkY59AgBkmCsM6JRpYyJw3eV\nCwltlLSGNR4VswWAtNlWKqKXKwapB5+N4ZVFHH01hwEfrXIQp44Nnr+AqtOr\nT8U9ymqZnZmCxc0ZRoeKbpN+hliPwNk84D9ptPkSyYTnmgAAzGA0YzVSkGtR\nBfQ8RhpHriI5zx9RE0fVCNfGRY9JXLp38+CUkn0tZSB3lnweom/+QIvwxGrU\nnOT2j1tkrmbR3epUL96wr8yGhDVY2WfVkFgGPZmGDx6+t0CdzLNvfJ4h1JiN\ndFRxxeuSD/VP3GTy7qXVn70XJgFQqFcDxNFL5W0AldioJa4zULWXCPwQhjJF\n+otUPCU17sTqwc/qQVp62CsQZdTlqXEk/zPfHjlI+YdbPc646zH8dVoXsooB\nGDMuhMcwqHmjOQD6ljApJruCpstP3A0+CPw0fUVEnHuEjQpcHxwHfzG719ci\nZlalCHKm3zieDJPnLh7MJlKLqnEsd6kILIaRkWvx3PpKJcozuyDuGhC/BGpr\ncR0m\r\n=RAUX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify_2.0.7_1523913121856_0.997974360028153"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.8": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.8",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Dario Segura",
+          "email": "dario.seco@gmail.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "Thiago Felix",
+          "email": "thiago@thiagofelix.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "e32c7c44187f2058e172eca0c3ca9cb3e2ecd43a",
+      "_id": "timers-browserify@2.0.8",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.9.0",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-a+QofyerK/mw3zl0nOlU33TP0vnbaF8pDKevVI5hT5LMUFEUQPtbhSohuvRZWB8UW1bP9Bhfqqw6KA3gsbP4Uw==",
+        "shasum": "ad5ecbc2d081e038f8732406aeb723628b482494",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.8.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9907,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1hhYCRA9TVsSAnZWagAA+8cP/j91nMh9uGa+LNfHN60r\nEDpHG8pWLilVYIi6dISM810NNHdwyT5ll9HXXfvDAcoxNcDmYPjwhKGPt/hN\nj8reAQVfNACgQjXFYS/JTVR82Oz+MvbMvviWuIqbImVd342e5hzNcH28OLt7\njNtwvyCXYNUZ9BV1++W4P2kq8hgSa6G0sxbywyYLR4y1HmeRtcHFSkkvbe43\nFffDl5o4X2GxmiTEjrh+a8syzB9OigUqtqf4ypEFZu83g9SbjbbNwlysUPVS\nTjsy5gxxwImdeBDvOJCS+fmap8xxgvO+fmVYMS2IlTHLhJ5a8lJglANaGdqq\nYig0TsEATITP4MZVBoSZ0iXDzT2/+InktVEeTkZn5YYySry3snbvDVNcznLe\nxA7MqcJqKUC3wix46EtySmaS2R+YOJTU4rdN/TJUCPIbkYZaYd5P1xTVdu8o\nIYSO7K+Tz+S6BRBQqzW6nSKCDzHvCrO2l+u2ZwQIBg6Vf0iSHZmLovrYXrJB\nKD2AoQGHSWBkM0ldd0IibjjBpSBM+6x9s8PckUFKZOogmZOjnEjCVREOvvih\n67oKR8/phNyLESFBRMETsj0A2I5E4HFO1/LtmyjECf6DU0S0pIWvn2QZ5/cK\n2/I16ADvbUHPyQgRDph2J9bD9eG+AX2nMp2guy1JwbQ8lPxfPnA3zON0v3MD\nQBRZ\r\n=bzWn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify_2.0.8_1523980375790_0.020820278042240625"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.9": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.9",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Dario Segura",
+          "email": "dario.seco@gmail.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "Thiago Felix",
+          "email": "thiago@thiagofelix.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "47a0b2dcd4a9a860ba8b397f84668418d80ca228",
+      "_id": "timers-browserify@2.0.9",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "9.9.0",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-2DhyvVpCWwY7gk8UmKhYvgHQl9XTlO0Dg0/2UZcLgPnpulhdm2aGIlFy5rU5igmOCA51w6jPHqLRA4UH1YmhcA==",
+        "shasum": "3dea6faaab8038589dc6d0c4ccbc08b02698bab3",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.9.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10039,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1nSGCRA9TVsSAnZWagAAENYP/1QvfKlPD0pn/pHfiICD\ny0cfoZxHdEdBMJl8xmyePBHDQvBJACs7DXyAtW0Exx3hHQcBvRFXlckcZqon\nnw7yuV6V9iC9325XFRBbUBzxcdyxn4CI6uytC1CdiO04/Zu1cBwfGOcbMKYC\nehJYUj+HFSwn4PSKu++AQsQ73SCYH/LGrbGeDjurrrL/628yK24AvJ0G/2Ut\njocYB5xcAHO9wLSinRov3forqKPv92glPQSxWTVgs/J7Cn4+/AiY/vrL2PUo\nFkjBow8N7s5GUzWImB+ZVY2XwSTwOI61WCMhXmOOzBa0BPWA79QgZXrwVKzq\nTMsofCjwqDURvE3lxgkB6oZZUwOCrlBUCxdLjXdLLWv+pu5HVW0dQ7yVyX/A\n0XkB7UW/Wo4Dip4TfyopPOB8vWf0I91GCaV4T0KPAVjwC5U3aXZrPlIYM+je\n4GRw98QjyiQFsmox7JWq1CpAptT/TUM92GVWVx/XfvAPLpY0tZqPsw1toP9X\nxhGFjfyZwbviU8GUkQPCTZ6obFF9xhttEPiAUVcslX9AeZuL+py197G2vO/s\nzPr0FPNMqp1aQi7de9Wz1s22RU97l3+XQY8OVRvzbqmlr8VJZ+5pKeCojlfZ\n1rGHd+chtqDEiMVa7uoG8tQQkK1AW7GVu87kPsbjSrWcD0QSswAhLn7o/rPJ\nW5PV\r\n=6noq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify_2.0.9_1524003973284_0.7885091002376405"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.10": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.10",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Dario Segura",
+          "email": "dario.seco@gmail.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "Thiago Felix",
+          "email": "thiago@thiagofelix.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "https://github.com/jryans/timers-browserify/blob/master/LICENSE.md"
+        }
+      ],
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "bedb5290e1d2366e61b7882d25f44287a94f5cc1",
+      "_id": "timers-browserify@2.0.10",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "9.9.0",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+        "shasum": "1d28e3d2aadf1d5a5996c4e9f95601cd053480ae",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10203,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa13j2CRA9TVsSAnZWagAA6esP/jQtaJd3p6crEf1eKBG/\nQd+W8uVDhzZBM8SNkQmsqkV31HT8yQS3eQKw3cYUg9ey+Cc5+69vlxOxdLum\nDOE/7I2fOEA4Tff32kFtJDjuMGXGHPYEKmp+vWLi69wujL1PEBSfAKPGt+6d\n9R1Y9DlN1D7QGC9FvvP7nsRd/5hm6nI6MuVir/jYqcDZbp2/aWLsRrRQMah6\nZsjidznsPswovA2fVBaPBYZQ4yIZ3eE6IDnrXGzDT+U4G5YvFvAqvnW1pwbI\nkLoWFXro6jzsu+/cQ/n6zlmGGl6d2mcO4UzyTTeMa0y2MkshZR7HcGMGyL8B\nwbX4r1+szgKGQAylFcphZhzjOWYHIqHOKhIZp6aP2NHgfNmK8U/McIPQiqdK\n/MZCdNfhyZCvkK13BvtudRC/v3J+gOWY1QHvmljxxoKVhnS17XgO3Db2zV6U\nnYNwlJswUeiMvM/MdDoTuCezrd0jQSw2e2zCdSqLQBbKn1AOw3STsAX6WLRH\nCuUelloaACWQNV6NRAKH7YW2u9KljSBdwEILibk4OJnayGXNMkKdIbcmSEr/\naoExtCU8w/IkpmXkebTbp3KALO8bo5LfnzG1AyGR74VMLbPZRtaYARMmht00\nFyB9+WDk88zLbbA1uvOmS4xir75ToqLr3PNj053tXwQc5pOHhnplmSHXjK5D\nqYv+\r\n=xkle\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify_2.0.10_1524070645357_0.9856718108700573"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.11": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "http://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.11",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Dario Segura",
+          "email": "dario.seco@gmail.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "Simon Meusel",
+          "email": "info@simonmeusel.de"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "Thiago Felix",
+          "email": "thiago@thiagofelix.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "license": "MIT",
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "31f5ad216b9174a7c0210d4184dc0df6fc3c14d5",
+      "_id": "timers-browserify@2.0.11",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+        "shasum": "800b1f3eee272e5bc53ee465a04d0e804c31211f",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+        "fileCount": 6,
+        "unpackedSize": 16378,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdTticCRA9TVsSAnZWagAAcTkP+wekHljR1vyy8wvG8tsD\n0+rWSAeFwQ5mJeopsQ2A1PNKJnu7wrT6xkGiqGxObU2nWxchltr7+RUYoS3J\nits5J7wZUYcgXvMg+rosnC29ywE9EixEnMjDOnCAyDvvkHFm4cbNiYMHWXFI\nmXBHeGbfK72tKSBMj0DcoJM/9bEdXcyTmG3oqj3pSBpNF8/YqlFo5DxjDisD\nHmmHzHEmdx+Gah/QJ6yv+o5u5tvKHm3hMH+qEoQVq5j3HxFxTnoZHcaolwoj\nUazehC7tdUHnZxgNlTg7yQ1l3YOp7OwLCqelIqHK0DvU400vxgekmcFSIUPA\nl9sX+yAUkWtpispCRZvuBfzWZqGps8KJGY3YYI6uDGi24jLcg8jC+D3E7pNS\nmqFR06aE2lrgbqn2Pb1WQRUNtVB/g3HzFwJ5KaERVUuNifJdDA6aLcLcOn1A\nFxZFJCPBhjZDYtx9xGsskpJ8ACy0aG5MkHM5cracQrTv8gQ3KfbOuZVhpTkV\nXl6c4aw8uAOSgr5LEFVJNCnbaDs/NawEApzylxN5HTODZZ4MOg4T0vyaF0Zt\nYRH40lNgIH+iQ1f07YM5pGxV7iBR+JRT8nQGzkqfCpSAtrdRULvwc4Z1TbqF\n5EN4YpQaJBUsS9uHzApKS1owApM+ad4dEAGfFHM/Yar45nYjeiENqh/sLjEn\nEc9J\r\n=HE7n\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify_2.0.11_1565448348034_0.8638810868930824"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.12": {
+      "author": {
+        "name": "J. Ryan Stinnett",
+        "email": "jryans@gmail.com",
+        "url": "https://convolv.es/"
+      },
+      "name": "timers-browserify",
+      "description": "timers module for browserify",
+      "version": "2.0.12",
+      "homepage": "https://github.com/jryans/timers-browserify",
+      "bugs": {
+        "url": "https://github.com/jryans/timers-browserify/issues"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jryans/timers-browserify.git"
+      },
+      "contributors": [
+        {
+          "name": "Colton Brown",
+          "email": "coltonTB@me.com"
+        },
+        {
+          "name": "Dario Segura",
+          "email": "dario.seco@gmail.com"
+        },
+        {
+          "name": "Guy Bedford",
+          "email": "guybedford@gmail.com"
+        },
+        {
+          "name": "Ionut-Cristian Florescu",
+          "email": "ionut.florescu@gmail.com"
+        },
+        {
+          "name": "James Halliday",
+          "email": "mail@substack.net"
+        },
+        {
+          "name": "Jan Schär",
+          "email": "jscissr@gmail.com"
+        },
+        {
+          "name": "Johannes Ewald",
+          "email": "johannes.ewald@peerigon.com"
+        },
+        {
+          "name": "Jonathan Prins",
+          "email": "jon@blip.tv"
+        },
+        {
+          "name": "Matt Esch",
+          "email": "matt@mattesch.info"
+        },
+        {
+          "name": "Renée Kooi",
+          "email": "renee@kooi.me"
+        },
+        {
+          "name": "Simon Meusel",
+          "email": "info@simonmeusel.de"
+        },
+        {
+          "name": "taoqf",
+          "email": "tao_qiufeng@126.com"
+        },
+        {
+          "name": "Thiago Felix",
+          "email": "thiago@thiagofelix.com"
+        },
+        {
+          "name": "wtgtybhertgeghgtwtg",
+          "email": "wtgtybhertgeghgtwtg@gmail.com"
+        }
+      ],
+      "main": "main.js",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "browserify": "~1.10.16",
+        "connect": "~2.30.2"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "keywords": [
+        "timers",
+        "browserify",
+        "browser"
+      ],
+      "license": "MIT",
+      "jspm": {
+        "map": {
+          "./main.js": {
+            "node": "@node/timers"
+          }
+        }
+      },
+      "gitHead": "dd631db8b93df460e668d03406d35a53525253e6",
+      "_id": "timers-browserify@2.0.12",
+      "_nodeVersion": "14.14.0",
+      "_npmVersion": "6.14.8",
+      "_npmUser": {
+        "name": "jryans",
+        "email": "jryans@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+        "shasum": "44a45c11fbf407f34f97bccd1577c652361b00ee",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10382,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfl/oFCRA9TVsSAnZWagAAF/cP/0MqIr+rvm+iIxYiHcYl\nhx0mCia+fswcTLrUeUmI1xVvGgxHGc4SBi8MbDJtA+IzSK6uNBLkmdplEgqa\n7QaryKjR59mO+BLdf634WVXTkhjpF6F+NLobP61Jjb50Yp0V+JOboYxoLIKd\nozUPJCShOJqJ5p65/zhAO+C4edgkVcULYE1iWPmqwNtQyCeT97DqzT7u0U7e\nCsmbWWr5LltMoj5T0QfRNF4cSqNgP9J2icJbYCaK9i+c7Bk2uQpkDYn1n5kQ\nshMih2nECrUy8vFWp3ZBIcNtQEVx+3DB0I5ISPivnLREN5UAf64HXspo95VD\n2w1J9cRaSgFQ654E1M4u7/PmA4/P2O/8UVQMd5cI9clDKZMrOJrRhwvHWem5\nQiZ6b9zeBmbOBJqDrK4yuj/Hs58qcQ2fWG5AqsWqKgVIpvY8Sp9xjkYK8hk4\nhsJXyjcAVTgebbnqh9VZOiJuhy4mVizmVXhSi9dlMCpznyBJCcekZ59tKeAi\nPupMi9GQP+I+Wy8umOoDZf8ACgb+6GcZwOXjzTDO3tTkDA6rL+H0iWS1t9YV\nq534Qy8uGaw9K6GDhu3B2cWPd/ANQUhiRPGy6GkFF1QDSj6dTFkmis4pEUvS\nrMS996Ods/lgkK4YBA47GcMLUgPx7xp9kzAo4GjJmisQqNEgJe8294+9pz+o\n4erA\r\n=NhPz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "raynos",
+          "email": "raynos2@gmail.com"
+        },
+        {
+          "name": "lukechilds",
+          "email": "lukechilds123@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "substack",
+          "email": "substack@gmail.com"
+        },
+        {
+          "name": "feross",
+          "email": "feross@feross.org"
+        },
+        {
+          "name": "gkatsev",
+          "email": "me@gkatsev.com"
+        },
+        {
+          "name": "zertosh",
+          "email": "zertosh@gmail.com"
+        },
+        {
+          "name": "mafintosh",
+          "email": "mathiasbuus@gmail.com"
+        },
+        {
+          "name": "maxogden",
+          "email": "max@maxogden.com"
+        },
+        {
+          "name": "dominictarr",
+          "email": "dominic.tarr@gmail.com"
+        },
+        {
+          "name": "thlorenz",
+          "email": "thlorenz10@gmail.com"
+        },
+        {
+          "name": "terinjokes",
+          "email": "terinjokes@gmail.com"
+        },
+        {
+          "name": "jmm",
+          "email": "npm-public@jessemccarthy.net"
+        },
+        {
+          "name": "mellowmelon",
+          "email": "palmermebane@gmail.com"
+        },
+        {
+          "name": "ashaffer88",
+          "email": "darawk@gmail.com"
+        },
+        {
+          "name": "balupton",
+          "email": "b@lupton.cc"
+        },
+        {
+          "name": "cwmma",
+          "email": "calvin.metcalf@gmail.com"
+        },
+        {
+          "name": "jprichardson",
+          "email": "jprichardson@gmail.com"
+        },
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        },
+        {
+          "name": "jryans",
+          "email": "jryans@gmail.com"
+        },
+        {
+          "name": "sethvincent",
+          "email": "sethvincent@gmail.com"
+        },
+        {
+          "name": "yoshuawuyts",
+          "email": "yoshuawuyts@gmail.com"
+        },
+        {
+          "name": "ungoldman",
+          "email": "ungoldman@gmail.com"
+        },
+        {
+          "name": "ahdinosaur",
+          "email": "michael.williams@enspiral.com"
+        },
+        {
+          "name": "elnounch",
+          "email": "contact@elnounch.net"
+        },
+        {
+          "name": "parshap",
+          "email": "parshap+npm@gmail.com"
+        },
+        {
+          "name": "yerkopalma",
+          "email": "yerko.palma@usach.cl"
+        },
+        {
+          "name": "forbeslindesay",
+          "email": "forbes@lindesay.co.uk"
+        },
+        {
+          "name": "leichtgewicht",
+          "email": "martin.heidegger@gmail.com"
+        },
+        {
+          "name": "garann",
+          "email": "garann@gmail.com"
+        },
+        {
+          "name": "bret",
+          "email": "bcomnes@gmail.com"
+        },
+        {
+          "name": "anandthakker",
+          "email": "vestibule@anandthakker.net"
+        },
+        {
+          "name": "mattdesl",
+          "email": "dave.des@gmail.com"
+        },
+        {
+          "name": "hughsk",
+          "email": "hughskennedy@gmail.com"
+        },
+        {
+          "name": "fpereira1",
+          "email": "pereira.filype@gmail.com"
+        },
+        {
+          "name": "goto-bus-stop",
+          "email": "renee@kooi.me"
+        },
+        {
+          "name": "bpostlethwaite",
+          "email": "post.ben.here@gmail.com"
+        },
+        {
+          "name": "emilbayes",
+          "email": "github@tixz.dk"
+        },
+        {
+          "name": "stevemao",
+          "email": "maochenyan@gmail.com"
+        },
+        {
+          "name": "pkrumins",
+          "email": "peteris.krumins@gmail.com"
+        },
+        {
+          "name": "tehshrike",
+          "email": "me@JoshDuff.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/timers-browserify_2.0.12_1603795460887_0.9157150168321269"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Overview\n\nAdds support for the `timers` module to browserify.\n\n## Wait, isn't it already supported in the browser?\n\nThe public methods of the `timers` module are:\n\n* `setTimeout(callback, delay, [arg], [...])`\n* `clearTimeout(timeoutId)`\n* `setInterval(callback, delay, [arg], [...])`\n* `clearInterval(intervalId)`\n\nand indeed, browsers support these already.\n\n## So, why does this exist?\n\nThe `timers` module also includes some private methods used in other built-in\nNode.js modules:\n\n* `enroll(item, delay)`\n* `unenroll(item)`\n* `active(item)`\n\nThese are used to efficiently support a large quantity of timers with the same\ntimeouts by creating only a few timers under the covers.\n\nNode.js also offers the `immediate` APIs, which aren't yet available cross-browser, so we polyfill those:\n\n* `setImmediate(callback, [arg], [...])`\n* `clearImmediate(immediateId)`\n\n## I need lots of timers and want to use linked list timers as Node.js does.\n\nLinked lists are efficient when you have thousands (millions?) of timers with the same delay.\nTake a look at [timers-browserify-full](https://www.npmjs.com/package/timers-browserify-full) in this case.\n\n# License\n\n[MIT](http://jryans.mit-license.org/)\n",
+  "maintainers": [
+    {
+      "name": "raynos",
+      "email": "raynos2@gmail.com"
+    },
+    {
+      "name": "lukechilds",
+      "email": "lukechilds123@gmail.com"
+    },
+    {
+      "name": "defunctzombie",
+      "email": "shtylman@gmail.com"
+    },
+    {
+      "name": "substack",
+      "email": "substack@gmail.com"
+    },
+    {
+      "name": "feross",
+      "email": "feross@feross.org"
+    },
+    {
+      "name": "gkatsev",
+      "email": "me@gkatsev.com"
+    },
+    {
+      "name": "zertosh",
+      "email": "zertosh@gmail.com"
+    },
+    {
+      "name": "mafintosh",
+      "email": "mathiasbuus@gmail.com"
+    },
+    {
+      "name": "maxogden",
+      "email": "max@maxogden.com"
+    },
+    {
+      "name": "dominictarr",
+      "email": "dominic.tarr@gmail.com"
+    },
+    {
+      "name": "thlorenz",
+      "email": "thlorenz10@gmail.com"
+    },
+    {
+      "name": "terinjokes",
+      "email": "terinjokes@gmail.com"
+    },
+    {
+      "name": "jmm",
+      "email": "npm-public@jessemccarthy.net"
+    },
+    {
+      "name": "mellowmelon",
+      "email": "palmermebane@gmail.com"
+    },
+    {
+      "name": "ashaffer88",
+      "email": "darawk@gmail.com"
+    },
+    {
+      "name": "balupton",
+      "email": "b@lupton.cc"
+    },
+    {
+      "name": "cwmma",
+      "email": "calvin.metcalf@gmail.com"
+    },
+    {
+      "name": "jprichardson",
+      "email": "jprichardson@gmail.com"
+    },
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    },
+    {
+      "name": "jryans",
+      "email": "jryans@gmail.com"
+    },
+    {
+      "name": "sethvincent",
+      "email": "sethvincent@gmail.com"
+    },
+    {
+      "name": "yoshuawuyts",
+      "email": "yoshuawuyts@gmail.com"
+    },
+    {
+      "name": "ungoldman",
+      "email": "ungoldman@gmail.com"
+    },
+    {
+      "name": "ahdinosaur",
+      "email": "michael.williams@enspiral.com"
+    },
+    {
+      "name": "elnounch",
+      "email": "contact@elnounch.net"
+    },
+    {
+      "name": "parshap",
+      "email": "parshap+npm@gmail.com"
+    },
+    {
+      "name": "yerkopalma",
+      "email": "yerko.palma@usach.cl"
+    },
+    {
+      "name": "forbeslindesay",
+      "email": "forbes@lindesay.co.uk"
+    },
+    {
+      "name": "leichtgewicht",
+      "email": "martin.heidegger@gmail.com"
+    },
+    {
+      "name": "garann",
+      "email": "garann@gmail.com"
+    },
+    {
+      "name": "bret",
+      "email": "bcomnes@gmail.com"
+    },
+    {
+      "name": "anandthakker",
+      "email": "vestibule@anandthakker.net"
+    },
+    {
+      "name": "mattdesl",
+      "email": "dave.des@gmail.com"
+    },
+    {
+      "name": "hughsk",
+      "email": "hughskennedy@gmail.com"
+    },
+    {
+      "name": "fpereira1",
+      "email": "pereira.filype@gmail.com"
+    },
+    {
+      "name": "goto-bus-stop",
+      "email": "renee@kooi.me"
+    },
+    {
+      "name": "bpostlethwaite",
+      "email": "post.ben.here@gmail.com"
+    },
+    {
+      "name": "emilbayes",
+      "email": "github@tixz.dk"
+    },
+    {
+      "name": "stevemao",
+      "email": "maochenyan@gmail.com"
+    },
+    {
+      "name": "pkrumins",
+      "email": "peteris.krumins@gmail.com"
+    },
+    {
+      "name": "tehshrike",
+      "email": "me@JoshDuff.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-27T10:44:23.582Z",
+    "created": "2012-05-30T16:21:55.692Z",
+    "0.0.0": "2012-05-30T16:21:56.381Z",
+    "1.0.0": "2013-12-10T01:59:05.673Z",
+    "1.0.1": "2013-12-28T20:54:37.200Z",
+    "1.0.2": "2014-06-30T17:45:08.033Z",
+    "1.0.3": "2014-06-30T18:03:52.438Z",
+    "1.1.0": "2014-08-26T15:52:06.802Z",
+    "1.2.0": "2015-01-02T17:34:42.474Z",
+    "1.3.0": "2015-02-04T00:03:53.680Z",
+    "1.4.0": "2015-02-23T16:17:35.719Z",
+    "1.4.1": "2015-05-11T03:55:50.849Z",
+    "1.4.2": "2015-12-08T11:40:38.866Z",
+    "2.0.0": "2016-03-28T17:32:31.554Z",
+    "2.0.1": "2016-06-22T00:34:31.197Z",
+    "2.0.2": "2016-10-19T13:06:47.914Z",
+    "2.0.3": "2017-07-31T17:49:57.980Z",
+    "2.0.4": "2017-08-14T14:47:25.244Z",
+    "2.0.5": "2018-01-24T03:36:19.858Z",
+    "2.0.6": "2018-01-24T22:26:31.552Z",
+    "2.0.7": "2018-04-16T21:12:02.841Z",
+    "2.0.8": "2018-04-17T15:52:55.852Z",
+    "2.0.9": "2018-04-17T22:26:13.348Z",
+    "2.0.10": "2018-04-18T16:57:25.459Z",
+    "2.0.11": "2019-08-10T14:45:48.154Z",
+    "2.0.12": "2020-10-27T10:44:21.049Z"
+  },
+  "author": {
+    "name": "J. Ryan Stinnett",
+    "email": "jryans@gmail.com",
+    "url": "https://convolv.es/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jryans/timers-browserify.git"
+  },
+  "homepage": "https://github.com/jryans/timers-browserify",
+  "keywords": [
+    "timers",
+    "browserify",
+    "browser"
+  ],
+  "bugs": {
+    "url": "https://github.com/jryans/timers-browserify/issues"
+  },
+  "readmeFilename": "README.md",
+  "users": {
+    "wenbing": true,
+    "simplyianm": true,
+    "monjer": true
+  },
+  "contributors": [
+    {
+      "name": "Colton Brown",
+      "email": "coltonTB@me.com"
+    },
+    {
+      "name": "Dario Segura",
+      "email": "dario.seco@gmail.com"
+    },
+    {
+      "name": "Guy Bedford",
+      "email": "guybedford@gmail.com"
+    },
+    {
+      "name": "Ionut-Cristian Florescu",
+      "email": "ionut.florescu@gmail.com"
+    },
+    {
+      "name": "James Halliday",
+      "email": "mail@substack.net"
+    },
+    {
+      "name": "Jan Schär",
+      "email": "jscissr@gmail.com"
+    },
+    {
+      "name": "Johannes Ewald",
+      "email": "johannes.ewald@peerigon.com"
+    },
+    {
+      "name": "Jonathan Prins",
+      "email": "jon@blip.tv"
+    },
+    {
+      "name": "Matt Esch",
+      "email": "matt@mattesch.info"
+    },
+    {
+      "name": "Renée Kooi",
+      "email": "renee@kooi.me"
+    },
+    {
+      "name": "Simon Meusel",
+      "email": "info@simonmeusel.de"
+    },
+    {
+      "name": "taoqf",
+      "email": "tao_qiufeng@126.com"
+    },
+    {
+      "name": "Thiago Felix",
+      "email": "thiago@thiagofelix.com"
+    },
+    {
+      "name": "wtgtybhertgeghgtwtg",
+      "email": "wtgtybhertgeghgtwtg@gmail.com"
+    }
+  ],
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/timers-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/timers-browserify.min.json
@@ -1,0 +1,467 @@
+{
+  "name": "timers-browserify",
+  "dist-tags": {
+    "latest": "2.0.12"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "timers-browserify",
+      "version": "0.0.0",
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "9deb3bf70e1155b7e608d9c0c552c5a55bd650f9",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.0.0": {
+      "name": "timers-browserify",
+      "version": "1.0.0",
+      "dependencies": {
+        "setimmediate": "~1.0.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "6cff54619a7af3e0feb99dc60b85a883ee192fea",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.0.1": {
+      "name": "timers-browserify",
+      "version": "1.0.1",
+      "dependencies": {
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "7c93257b543cb1e3003d3663b57d560ee1d27057",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.0.2": {
+      "name": "timers-browserify",
+      "version": "1.0.2",
+      "dependencies": {
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "33935e5d08a02a132cee6bfa45228a7d33ae8466",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.0.3": {
+      "name": "timers-browserify",
+      "version": "1.0.3",
+      "dependencies": {
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "ffba70c9c12eed916fd67318e629ac6f32295551",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.1.0": {
+      "name": "timers-browserify",
+      "version": "1.1.0",
+      "dependencies": {
+        "process": "~0.5.1"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "bffd11af00fe82b089b015e8de4dc6a911b7ec3e",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.2.0": {
+      "name": "timers-browserify",
+      "version": "1.2.0",
+      "dependencies": {
+        "process": "~0.10.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "411865ceba9e2c0fafc1d2f3b7a6a87bca44194b",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.3.0": {
+      "name": "timers-browserify",
+      "version": "1.3.0",
+      "dependencies": {
+        "process": "~0.10.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "c518e6ba39f19619e6ae464e447b1511e172e96f",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.4.0": {
+      "name": "timers-browserify",
+      "version": "1.4.0",
+      "dependencies": {
+        "process": "~0.10.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "6b424b07688cd1978c2a3333ee618c46036d6ddb",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.4.1": {
+      "name": "timers-browserify",
+      "version": "1.4.1",
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "bf8afeb7b50d6c500e2b3e0a5d759c4005e985d7",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "1.4.2": {
+      "name": "timers-browserify",
+      "version": "1.4.2",
+      "dependencies": {
+        "process": "~0.11.0"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "c9c58b575be8407375cb5e2462dacee74359f41d",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.0": {
+      "name": "timers-browserify",
+      "version": "2.0.0",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "0cae1d5e8ce45f605590bb64331d0b1102eb265b",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.1": {
+      "name": "timers-browserify",
+      "version": "2.0.1",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "199291a9fb720ee19f58a611a699083396af1622",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.2": {
+      "name": "timers-browserify",
+      "version": "2.0.2",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "shasum": "ab4883cf597dcd50af211349a00fbca56ac86b86",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.3": {
+      "name": "timers-browserify",
+      "version": "2.0.3",
+      "dependencies": {
+        "global": "^4.3.2",
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-+JAqyNgg+M8+gXIrq2EeUr4kZqRz47Ysco7X5QKRGScRE9HIHckyHD1asozSFGeqx2nmPCgA8T5tIGVO0ML7/w==",
+        "shasum": "41fd0bdc926a5feedc33a17a8e1f7d491925f7fc",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.4": {
+      "name": "timers-browserify",
+      "version": "2.0.4",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+        "shasum": "96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.5": {
+      "name": "timers-browserify",
+      "version": "2.0.5",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-BMeI1W6E2/mSaPVLUnH9rjEY1Ys2FEC/GKmE/101wusU3byZO5g68BJ5hpJEP8iD1qAJ6SzYAShGA+urHMxOzQ==",
+        "shasum": "04878fb12a155a159c9d1e59faa1f77bf4ecc44c",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.6": {
+      "name": "timers-browserify",
+      "version": "2.0.6",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
+        "shasum": "241e76927d9ca05f4d959819022f5b3664b64bae",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.7": {
+      "name": "timers-browserify",
+      "version": "2.0.7",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-U7DtjfsHeYjNAyEz4MdCLGZMY3ySyHIgZZp6ba9uxZlMRMiK5yTHUYc2XfGQHKFgxGcmvBF2jafoNtQYvlDpOw==",
+        "shasum": "e74093629cb62c20332af587ddc0c86b4ba97a05",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.7.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9728,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1RGjCRA9TVsSAnZWagAAP9IP/iAxaKHyKzzDwiW9jaZy\nDjK+FiB/X7ajwyqgJd/R33iYAc6o1BzIEzQAkCLSTcBydVER17GYNKkbPZJt\n15s8fPh6wjBloVFL1TcrfzFUZKWCxbf0nZN5t8HZ0oaABCrRC8qls7LXzurt\niuiSXZ+B25C6uBcRcouA47CFma4qS9w+LqfgSkY59AgBkmCsM6JRpYyJw3eV\nCwltlLSGNR4VswWAtNlWKqKXKwapB5+N4ZVFHH01hwEfrXIQp44Nnr+AqtOr\nT8U9ymqZnZmCxc0ZRoeKbpN+hliPwNk84D9ptPkSyYTnmgAAzGA0YzVSkGtR\nBfQ8RhpHriI5zx9RE0fVCNfGRY9JXLp38+CUkn0tZSB3lnweom/+QIvwxGrU\nnOT2j1tkrmbR3epUL96wr8yGhDVY2WfVkFgGPZmGDx6+t0CdzLNvfJ4h1JiN\ndFRxxeuSD/VP3GTy7qXVn70XJgFQqFcDxNFL5W0AldioJa4zULWXCPwQhjJF\n+otUPCU17sTqwc/qQVp62CsQZdTlqXEk/zPfHjlI+YdbPc646zH8dVoXsooB\nGDMuhMcwqHmjOQD6ljApJruCpstP3A0+CPw0fUVEnHuEjQpcHxwHfzG719ci\nZlalCHKm3zieDJPnLh7MJlKLqnEsd6kILIaRkWvx3PpKJcozuyDuGhC/BGpr\ncR0m\r\n=RAUX\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.8": {
+      "name": "timers-browserify",
+      "version": "2.0.8",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-a+QofyerK/mw3zl0nOlU33TP0vnbaF8pDKevVI5hT5LMUFEUQPtbhSohuvRZWB8UW1bP9Bhfqqw6KA3gsbP4Uw==",
+        "shasum": "ad5ecbc2d081e038f8732406aeb723628b482494",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.8.tgz",
+        "fileCount": 5,
+        "unpackedSize": 9907,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1hhYCRA9TVsSAnZWagAA+8cP/j91nMh9uGa+LNfHN60r\nEDpHG8pWLilVYIi6dISM810NNHdwyT5ll9HXXfvDAcoxNcDmYPjwhKGPt/hN\nj8reAQVfNACgQjXFYS/JTVR82Oz+MvbMvviWuIqbImVd342e5hzNcH28OLt7\njNtwvyCXYNUZ9BV1++W4P2kq8hgSa6G0sxbywyYLR4y1HmeRtcHFSkkvbe43\nFffDl5o4X2GxmiTEjrh+a8syzB9OigUqtqf4ypEFZu83g9SbjbbNwlysUPVS\nTjsy5gxxwImdeBDvOJCS+fmap8xxgvO+fmVYMS2IlTHLhJ5a8lJglANaGdqq\nYig0TsEATITP4MZVBoSZ0iXDzT2/+InktVEeTkZn5YYySry3snbvDVNcznLe\nxA7MqcJqKUC3wix46EtySmaS2R+YOJTU4rdN/TJUCPIbkYZaYd5P1xTVdu8o\nIYSO7K+Tz+S6BRBQqzW6nSKCDzHvCrO2l+u2ZwQIBg6Vf0iSHZmLovrYXrJB\nKD2AoQGHSWBkM0ldd0IibjjBpSBM+6x9s8PckUFKZOogmZOjnEjCVREOvvih\n67oKR8/phNyLESFBRMETsj0A2I5E4HFO1/LtmyjECf6DU0S0pIWvn2QZ5/cK\n2/I16ADvbUHPyQgRDph2J9bD9eG+AX2nMp2guy1JwbQ8lPxfPnA3zON0v3MD\nQBRZ\r\n=bzWn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.9": {
+      "name": "timers-browserify",
+      "version": "2.0.9",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-2DhyvVpCWwY7gk8UmKhYvgHQl9XTlO0Dg0/2UZcLgPnpulhdm2aGIlFy5rU5igmOCA51w6jPHqLRA4UH1YmhcA==",
+        "shasum": "3dea6faaab8038589dc6d0c4ccbc08b02698bab3",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.9.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10039,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa1nSGCRA9TVsSAnZWagAAENYP/1QvfKlPD0pn/pHfiICD\ny0cfoZxHdEdBMJl8xmyePBHDQvBJACs7DXyAtW0Exx3hHQcBvRFXlckcZqon\nnw7yuV6V9iC9325XFRBbUBzxcdyxn4CI6uytC1CdiO04/Zu1cBwfGOcbMKYC\nehJYUj+HFSwn4PSKu++AQsQ73SCYH/LGrbGeDjurrrL/628yK24AvJ0G/2Ut\njocYB5xcAHO9wLSinRov3forqKPv92glPQSxWTVgs/J7Cn4+/AiY/vrL2PUo\nFkjBow8N7s5GUzWImB+ZVY2XwSTwOI61WCMhXmOOzBa0BPWA79QgZXrwVKzq\nTMsofCjwqDURvE3lxgkB6oZZUwOCrlBUCxdLjXdLLWv+pu5HVW0dQ7yVyX/A\n0XkB7UW/Wo4Dip4TfyopPOB8vWf0I91GCaV4T0KPAVjwC5U3aXZrPlIYM+je\n4GRw98QjyiQFsmox7JWq1CpAptT/TUM92GVWVx/XfvAPLpY0tZqPsw1toP9X\nxhGFjfyZwbviU8GUkQPCTZ6obFF9xhttEPiAUVcslX9AeZuL+py197G2vO/s\nzPr0FPNMqp1aQi7de9Wz1s22RU97l3+XQY8OVRvzbqmlr8VJZ+5pKeCojlfZ\n1rGHd+chtqDEiMVa7uoG8tQQkK1AW7GVu87kPsbjSrWcD0QSswAhLn7o/rPJ\nW5PV\r\n=6noq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.10": {
+      "name": "timers-browserify",
+      "version": "2.0.10",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+        "shasum": "1d28e3d2aadf1d5a5996c4e9f95601cd053480ae",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10203,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa13j2CRA9TVsSAnZWagAA6esP/jQtaJd3p6crEf1eKBG/\nQd+W8uVDhzZBM8SNkQmsqkV31HT8yQS3eQKw3cYUg9ey+Cc5+69vlxOxdLum\nDOE/7I2fOEA4Tff32kFtJDjuMGXGHPYEKmp+vWLi69wujL1PEBSfAKPGt+6d\n9R1Y9DlN1D7QGC9FvvP7nsRd/5hm6nI6MuVir/jYqcDZbp2/aWLsRrRQMah6\nZsjidznsPswovA2fVBaPBYZQ4yIZ3eE6IDnrXGzDT+U4G5YvFvAqvnW1pwbI\nkLoWFXro6jzsu+/cQ/n6zlmGGl6d2mcO4UzyTTeMa0y2MkshZR7HcGMGyL8B\nwbX4r1+szgKGQAylFcphZhzjOWYHIqHOKhIZp6aP2NHgfNmK8U/McIPQiqdK\n/MZCdNfhyZCvkK13BvtudRC/v3J+gOWY1QHvmljxxoKVhnS17XgO3Db2zV6U\nnYNwlJswUeiMvM/MdDoTuCezrd0jQSw2e2zCdSqLQBbKn1AOw3STsAX6WLRH\nCuUelloaACWQNV6NRAKH7YW2u9KljSBdwEILibk4OJnayGXNMkKdIbcmSEr/\naoExtCU8w/IkpmXkebTbp3KALO8bo5LfnzG1AyGR74VMLbPZRtaYARMmht00\nFyB9+WDk88zLbbA1uvOmS4xir75ToqLr3PNj053tXwQc5pOHhnplmSHXjK5D\nqYv+\r\n=xkle\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.11": {
+      "name": "timers-browserify",
+      "version": "2.0.11",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "connect": "~2.3.0",
+        "browserify": "~1.10.16"
+      },
+      "dist": {
+        "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+        "shasum": "800b1f3eee272e5bc53ee465a04d0e804c31211f",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+        "fileCount": 6,
+        "unpackedSize": 16378,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdTticCRA9TVsSAnZWagAAcTkP+wekHljR1vyy8wvG8tsD\n0+rWSAeFwQ5mJeopsQ2A1PNKJnu7wrT6xkGiqGxObU2nWxchltr7+RUYoS3J\nits5J7wZUYcgXvMg+rosnC29ywE9EixEnMjDOnCAyDvvkHFm4cbNiYMHWXFI\nmXBHeGbfK72tKSBMj0DcoJM/9bEdXcyTmG3oqj3pSBpNF8/YqlFo5DxjDisD\nHmmHzHEmdx+Gah/QJ6yv+o5u5tvKHm3hMH+qEoQVq5j3HxFxTnoZHcaolwoj\nUazehC7tdUHnZxgNlTg7yQ1l3YOp7OwLCqelIqHK0DvU400vxgekmcFSIUPA\nl9sX+yAUkWtpispCRZvuBfzWZqGps8KJGY3YYI6uDGi24jLcg8jC+D3E7pNS\nmqFR06aE2lrgbqn2Pb1WQRUNtVB/g3HzFwJ5KaERVUuNifJdDA6aLcLcOn1A\nFxZFJCPBhjZDYtx9xGsskpJ8ACy0aG5MkHM5cracQrTv8gQ3KfbOuZVhpTkV\nXl6c4aw8uAOSgr5LEFVJNCnbaDs/NawEApzylxN5HTODZZ4MOg4T0vyaF0Zt\nYRH40lNgIH+iQ1f07YM5pGxV7iBR+JRT8nQGzkqfCpSAtrdRULvwc4Z1TbqF\n5EN4YpQaJBUsS9uHzApKS1owApM+ad4dEAGfFHM/Yar45nYjeiENqh/sLjEn\nEc9J\r\n=HE7n\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "2.0.12": {
+      "name": "timers-browserify",
+      "version": "2.0.12",
+      "dependencies": {
+        "setimmediate": "^1.0.4"
+      },
+      "devDependencies": {
+        "browserify": "~1.10.16",
+        "connect": "~2.30.2"
+      },
+      "dist": {
+        "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
+        "shasum": "44a45c11fbf407f34f97bccd1577c652361b00ee",
+        "tarball": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+        "fileCount": 5,
+        "unpackedSize": 10382,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfl/oFCRA9TVsSAnZWagAAF/cP/0MqIr+rvm+iIxYiHcYl\nhx0mCia+fswcTLrUeUmI1xVvGgxHGc4SBi8MbDJtA+IzSK6uNBLkmdplEgqa\n7QaryKjR59mO+BLdf634WVXTkhjpF6F+NLobP61Jjb50Yp0V+JOboYxoLIKd\nozUPJCShOJqJ5p65/zhAO+C4edgkVcULYE1iWPmqwNtQyCeT97DqzT7u0U7e\nCsmbWWr5LltMoj5T0QfRNF4cSqNgP9J2icJbYCaK9i+c7Bk2uQpkDYn1n5kQ\nshMih2nECrUy8vFWp3ZBIcNtQEVx+3DB0I5ISPivnLREN5UAf64HXspo95VD\n2w1J9cRaSgFQ654E1M4u7/PmA4/P2O/8UVQMd5cI9clDKZMrOJrRhwvHWem5\nQiZ6b9zeBmbOBJqDrK4yuj/Hs58qcQ2fWG5AqsWqKgVIpvY8Sp9xjkYK8hk4\nhsJXyjcAVTgebbnqh9VZOiJuhy4mVizmVXhSi9dlMCpznyBJCcekZ59tKeAi\nPupMi9GQP+I+Wy8umOoDZf8ACgb+6GcZwOXjzTDO3tTkDA6rL+H0iWS1t9YV\nq534Qy8uGaw9K6GDhu3B2cWPd/ANQUhiRPGy6GkFF1QDSj6dTFkmis4pEUvS\nrMS996Ods/lgkK4YBA47GcMLUgPx7xp9kzAo4GjJmisQqNEgJe8294+9pz+o\n4erA\r\n=NhPz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    }
+  },
+  "modified": "2020-10-27T10:44:23.582Z"
+}

--- a/test/fixtures/registry-mocks/content/to-arraybuffer.json
+++ b/test/fixtures/registry-mocks/content/to-arraybuffer.json
@@ -1,0 +1,102 @@
+{
+  "_id": "to-arraybuffer",
+  "_rev": "1-f7aba78f216e07c4b06dfdb364e2c136",
+  "name": "to-arraybuffer",
+  "description": "Get an ArrayBuffer from a Buffer as fast as possible",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "to-arraybuffer",
+      "version": "1.0.1",
+      "description": "Get an ArrayBuffer from a Buffer as fast as possible",
+      "main": "index.js",
+      "scripts": {
+        "test": "npm run test-node && ([ -n \"${TRAVIS_PULL_REQUEST}\" -a \"${TRAVIS_PULL_REQUEST}\" != 'false' ] || npm run test-browser)",
+        "test-node": "tape test.js",
+        "test-browser": "zuul --no-coverage -- test.js",
+        "test-browser-local": "zuul --local 8080 --no-coverage -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jhiesey/to-arraybuffer.git"
+      },
+      "keywords": [
+        "buffer",
+        "to",
+        "arraybuffer",
+        "fast",
+        "read",
+        "only"
+      ],
+      "author": {
+        "name": "John Hiesey"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/jhiesey/to-arraybuffer/issues"
+      },
+      "homepage": "https://github.com/jhiesey/to-arraybuffer#readme",
+      "devDependencies": {
+        "tape": "^4.4.0",
+        "zuul": "^3.9.0"
+      },
+      "gitHead": "6502d9850e70ba7935a7df4ad86b358fc216f9f0",
+      "_id": "to-arraybuffer@1.0.1",
+      "_shasum": "7d229b1fcc637e466ca081180836a7aabff83f43",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jhiesey",
+        "email": "john@hiesey.com"
+      },
+      "dist": {
+        "shasum": "7d229b1fcc637e466ca081180836a7aabff83f43",
+        "tarball": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhiesey",
+          "email": "john@hiesey.com"
+        }
+      ],
+      "directories": {}
+    }
+  },
+  "readme": "# to-arraybuffer [![Build Status](https://travis-ci.org/jhiesey/to-arraybuffer.svg?branch=master)](https://travis-ci.org/jhiesey/to-arraybuffer)\n\n[![Sauce Test Status](https://saucelabs.com/browser-matrix/to-arraybuffer.svg)](https://saucelabs.com/u/to-arraybuffer)\n\nConvert from a Buffer to an ArrayBuffer as fast as possible.\n\nNote that in some cases the returned ArrayBuffer is backed by the same memory as the original\nBuffer (but in other cases it is a copy), so **modifying the ArrayBuffer is not recommended**.\n\nThis module is designed to work both in node.js and in all browsers with ArrayBuffer support\nwhen using [the Buffer implementation provided by Browserify](https://www.npmjs.com/package/buffer).\n\n## Usage\n\n``` js\nvar toArrayBuffer = require('to-arraybuffer')\n\nvar buffer = new Buffer(100)\n// Fill the buffer with some data\n\nvar ab = toArrayBuffer(buffer)\n// `ab` now contains the same data as `buffer`\n```\n\n## License\n\nMIT",
+  "maintainers": [
+    {
+      "name": "jhiesey",
+      "email": "john@hiesey.com"
+    }
+  ],
+  "time": {
+    "modified": "2016-01-13T04:35:30.645Z",
+    "created": "2016-01-13T04:35:30.645Z",
+    "1.0.1": "2016-01-13T04:35:30.645Z"
+  },
+  "homepage": "https://github.com/jhiesey/to-arraybuffer#readme",
+  "keywords": [
+    "buffer",
+    "to",
+    "arraybuffer",
+    "fast",
+    "read",
+    "only"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jhiesey/to-arraybuffer.git"
+  },
+  "author": {
+    "name": "John Hiesey"
+  },
+  "bugs": {
+    "url": "https://github.com/jhiesey/to-arraybuffer/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/to-arraybuffer.min.json
+++ b/test/fixtures/registry-mocks/content/to-arraybuffer.min.json
@@ -1,0 +1,21 @@
+{
+  "name": "to-arraybuffer",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.1": {
+      "name": "to-arraybuffer",
+      "version": "1.0.1",
+      "devDependencies": {
+        "tape": "^4.4.0",
+        "zuul": "^3.9.0"
+      },
+      "dist": {
+        "shasum": "7d229b1fcc637e466ca081180836a7aabff83f43",
+        "tarball": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2016-01-13T04:35:30.645Z"
+}

--- a/test/fixtures/registry-mocks/content/to-object-path.json
+++ b/test/fixtures/registry-mocks/content/to-object-path.json
@@ -1,0 +1,263 @@
+{
+  "_id": "to-object-path",
+  "_rev": "3-1c2620f06d374b88d7df2d378759a174",
+  "name": "to-object-path",
+  "description": "Create an object path from a list or array of strings.",
+  "dist-tags": {
+    "latest": "0.3.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "to-object-path",
+      "description": "Create an object path from a list or array of strings.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/to-object-path",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-object-path.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-object-path/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "base-methods": "^0.2.1",
+        "mocha": "*"
+      },
+      "keywords": [],
+      "verb": {
+        "related": {
+          "list": [
+            "get-value",
+            "set-value",
+            "has-value",
+            "unset-value"
+          ]
+        }
+      },
+      "_id": "to-object-path@0.1.0",
+      "_shasum": "27746389db4eb874a02baae0286d3e91ffafae95",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "27746389db4eb874a02baae0286d3e91ffafae95",
+        "tarball": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "to-object-path",
+      "description": "Create an object path from a list or array of strings.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/jonschlinkert/to-object-path",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-object-path.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-object-path/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "arr-flatten": "^1.0.1",
+        "is-arguments": "^1.0.2"
+      },
+      "devDependencies": {
+        "base-methods": "^0.3.1",
+        "mocha": "*"
+      },
+      "keywords": [
+        "dot",
+        "nested",
+        "notation",
+        "object",
+        "path",
+        "stringify"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "get-value",
+            "set-value",
+            "has-value",
+            "omit-value",
+            "unset-value"
+          ]
+        }
+      },
+      "gitHead": "e627f22b57e55ab0073927bb16bed27aa20ab6a5",
+      "_id": "to-object-path@0.2.0",
+      "_shasum": "1634e1b52a88ba00e3949619fc0081dc9a3b07ca",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1634e1b52a88ba00e3949619fc0081dc9a3b07ca",
+        "tarball": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "to-object-path",
+      "description": "Create an object path from a list or array of strings.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/jonschlinkert/to-object-path",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-object-path.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-object-path/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "devDependencies": {
+        "base": "^0.6.7",
+        "mocha": "*"
+      },
+      "keywords": [
+        "dot",
+        "nested",
+        "notation",
+        "object",
+        "path",
+        "stringify"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "get-value",
+            "set-value",
+            "has-value",
+            "omit-value",
+            "unset-value"
+          ]
+        }
+      },
+      "gitHead": "56f6627285b7f5b7563e6f3ffe3766d966368c17",
+      "_id": "to-object-path@0.3.0",
+      "_shasum": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+        "tarball": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# to-object-path [![NPM version](https://badge.fury.io/js/to-object-path.svg)](http://badge.fury.io/js/to-object-path)\n\n> Create an object path from a list or array of strings.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/)\n\n```sh\n$ npm i to-object-path --save\n```\n\n## Usage\n\n```js\nvar toPath = require('to-object-path');\n\ntoPath('foo', 'bar', 'baz');\ntoPath('foo', ['bar', 'baz']);\n//=> 'foo.bar.baz'\n```\n\nAlso supports passing an arguments object (without having to slice args):\n\n```js\nfunction foo()\n  return toPath(arguments);\n}\n\nfoo('foo', 'bar', 'baz');\nfoo('foo', ['bar', 'baz']);\n//=> 'foo.bar.baz'\n```\n\nVisit the [example](./example.js) to see how this could be used in an application.\n\n## Related projects\n\n* [get-value](https://www.npmjs.com/package/get-value): Use property paths (`  a.b.c`) to get a nested value from an object. | [homepage](https://github.com/jonschlinkert/get-value)\n* [has-value](https://www.npmjs.com/package/has-value): Returns true if a value exists, false if empty. Works with deeply nested values using… [more](https://www.npmjs.com/package/has-value) | [homepage](https://github.com/jonschlinkert/has-value)\n* [omit-value](https://www.npmjs.com/package/omit-value): Omit properties from an object or deeply nested property of an object using object path… [more](https://www.npmjs.com/package/omit-value) | [homepage](https://github.com/jonschlinkert/omit-value)\n* [set-value](https://www.npmjs.com/package/set-value): Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths. | [homepage](https://github.com/jonschlinkert/set-value)\n* [unset-value](https://www.npmjs.com/package/unset-value): Delete nested properties from an object using dot notation. | [homepage](https://github.com/jonschlinkert/unset-value)\n\n## Running tests\n\nInstall dev dependencies:\n\n```sh\n$ npm i -d && npm test\n```\n\n## Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](https://github.com/jonschlinkert/to-object-path/issues/new).\n\n## Author\n\n**Jon Schlinkert**\n\n+ [github/jonschlinkert](https://github.com/jonschlinkert)\n+ [twitter/jonschlinkert](http://twitter.com/jonschlinkert)\n\n## License\n\nCopyright © 2015 Jon Schlinkert\nReleased under the MIT license.\n\n***\n\n_This file was generated by [verb-cli](https://github.com/assemble/verb-cli) on October 28, 2015._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2016-01-31T16:59:38.115Z",
+    "created": "2015-09-02T10:31:54.697Z",
+    "0.1.0": "2015-09-02T10:31:54.697Z",
+    "0.2.0": "2015-10-29T03:52:29.811Z",
+    "0.3.0": "2016-01-31T16:59:38.115Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/to-object-path",
+  "keywords": [
+    "dot",
+    "nested",
+    "notation",
+    "object",
+    "path",
+    "stringify"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/to-object-path.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/to-object-path/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/to-object-path.min.json
+++ b/test/fixtures/registry-mocks/content/to-object-path.min.json
@@ -1,0 +1,61 @@
+{
+  "name": "to-object-path",
+  "dist-tags": {
+    "latest": "0.3.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "to-object-path",
+      "version": "0.1.0",
+      "devDependencies": {
+        "base-methods": "^0.2.1",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "27746389db4eb874a02baae0286d3e91ffafae95",
+        "tarball": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.2.0": {
+      "name": "to-object-path",
+      "version": "0.2.0",
+      "dependencies": {
+        "arr-flatten": "^1.0.1",
+        "is-arguments": "^1.0.2"
+      },
+      "devDependencies": {
+        "base-methods": "^0.3.1",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "1634e1b52a88ba00e3949619fc0081dc9a3b07ca",
+        "tarball": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.3.0": {
+      "name": "to-object-path",
+      "version": "0.3.0",
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "devDependencies": {
+        "base": "^0.6.7",
+        "mocha": "*"
+      },
+      "dist": {
+        "shasum": "297588b7b0e7e0ac08e04e672f85c1f4999e17af",
+        "tarball": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2016-01-31T16:59:38.115Z"
+}

--- a/test/fixtures/registry-mocks/content/to-regex.json
+++ b/test/fixtures/registry-mocks/content/to-regex.json
@@ -1,0 +1,842 @@
+{
+  "_id": "to-regex",
+  "_rev": "11-f6e80be7fab65b5444a2c2bd5021f122",
+  "name": "to-regex",
+  "description": "Generate a regex from a string or array of strings.",
+  "dist-tags": {
+    "latest": "3.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "to-regex",
+      "description": "Generate a regex from a string or array of strings.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/to-regex",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-regex.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-regex/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "match",
+        "regex",
+        "regular expression",
+        "test",
+        "to"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "to-regex-range",
+            "is-glob",
+            "has-glob",
+            "path-regex"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "0bb5d805462e5e54a9d58f39489f308e2234b621",
+      "_id": "to-regex@0.1.0",
+      "_shasum": "338de9c6694ac3d19f73bf4bc94e91a3ddbfe277",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "338de9c6694ac3d19f73bf4bc94e91a3ddbfe277",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-0.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/to-regex-0.1.0.tgz_1474943905872_0.9498569068964571"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "to-regex",
+      "description": "Generate a regex from a string or array of strings.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/to-regex",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-regex.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-regex/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "match",
+        "regex",
+        "regular expression",
+        "test",
+        "to"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "to-regex-range",
+            "is-glob",
+            "has-glob",
+            "path-regex"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ]
+      },
+      "gitHead": "6a28a49cbd109869bb36b9a3be29cb3020a5a398",
+      "_id": "to-regex@0.1.1",
+      "_shasum": "5634b4796f17a796097036357a97064fb70c3125",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5634b4796f17a796097036357a97064fb70c3125",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-0.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/to-regex-0.1.1.tgz_1474948578388_0.5745572135783732"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "to-regex",
+      "description": "Generate a regex from a string or array of strings.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/to-regex",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-regex.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-regex/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "match",
+        "regex",
+        "regular expression",
+        "test",
+        "to"
+      ],
+      "verb": {
+        "toc": {
+          "method": "preWrite"
+        },
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-glob",
+            "is-glob",
+            "path-regex",
+            "to-regex-range"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "a99d68cfcc448013620d9caad3957779342168b2",
+      "_id": "to-regex@1.0.0",
+      "_shasum": "49f5efcaa9d642bce03296d4580f29f9060d89ac",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "49f5efcaa9d642bce03296d4580f29f9060d89ac",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/to-regex-1.0.0.tgz_1475562670912_0.5451310218777508"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "to-regex",
+      "description": "Generate a regex from a string or array of strings.",
+      "version": "2.0.0",
+      "homepage": "https://github.com/jonschlinkert/to-regex",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-regex.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-regex/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "match",
+        "regex",
+        "regular expression",
+        "test",
+        "to"
+      ],
+      "verb": {
+        "toc": {
+          "method": "preWrite"
+        },
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-glob",
+            "is-glob",
+            "path-regex",
+            "to-regex-range"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "a99d68cfcc448013620d9caad3957779342168b2",
+      "_id": "to-regex@2.0.0",
+      "_shasum": "67ea7e4ed2f889b25734da311328bd04fe1f73de",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "67ea7e4ed2f889b25734da311328bd04fe1f73de",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/to-regex-2.0.0.tgz_1475749448404_0.9963046805933118"
+      },
+      "directories": {}
+    },
+    "2.1.0": {
+      "name": "to-regex",
+      "description": "Generate a regex from a string or array of strings.",
+      "version": "2.1.0",
+      "homepage": "https://github.com/jonschlinkert/to-regex",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-regex.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-regex/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "match",
+        "regex",
+        "regular expression",
+        "test",
+        "to"
+      ],
+      "verb": {
+        "toc": {
+          "method": "preWrite"
+        },
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-glob",
+            "is-glob",
+            "path-regex",
+            "to-regex-range"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "62554d3bd1c23cf6d325dbcd7ae7443cac95e8cf",
+      "_id": "to-regex@2.1.0",
+      "_shasum": "e3ad3a40cfe119559a05aea43e4caefacc5e901d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e3ad3a40cfe119559a05aea43e4caefacc5e901d",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-2.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/to-regex-2.1.0.tgz_1475754721640_0.2784986891783774"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "to-regex",
+      "description": "Generate a regex from a string or array of strings.",
+      "version": "3.0.0",
+      "homepage": "https://github.com/jonschlinkert/to-regex",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-regex.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-regex/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "match",
+        "regex",
+        "regular expression",
+        "test",
+        "to"
+      ],
+      "verb": {
+        "toc": {
+          "method": "preWrite"
+        },
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-glob",
+            "is-glob",
+            "path-regex",
+            "to-regex-range"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "a9ae04d5826bca65ea72474682959a31f5186904",
+      "_id": "to-regex@3.0.0",
+      "_shasum": "58183da5021d397828892fc7ed04923664aa06db",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "58183da5021d397828892fc7ed04923664aa06db",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/to-regex-3.0.0.tgz_1476670141173_0.00005844538100063801"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "to-regex",
+      "description": "Generate a regex from a string or array of strings.",
+      "version": "3.0.1",
+      "homepage": "https://github.com/jonschlinkert/to-regex",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-regex.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-regex/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "keywords": [
+        "match",
+        "regex",
+        "regular expression",
+        "test",
+        "to"
+      ],
+      "verb": {
+        "toc": {
+          "method": "preWrite"
+        },
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-glob",
+            "is-glob",
+            "path-regex",
+            "to-regex-range"
+          ]
+        },
+        "reflinks": [
+          "verb",
+          "verb-generate-readme"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "5dda7b0b4b66902426b80055a4b39a9cd46efb70",
+      "_id": "to-regex@3.0.1",
+      "_shasum": "15358bee4a2c83bd76377ba1dc049d0f18837aae",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "15358bee4a2c83bd76377ba1dc049d0f18837aae",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/to-regex-3.0.1.tgz_1476670515755_0.6239306144416332"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "to-regex",
+      "description": "Generate a regex from a string or array of strings.",
+      "version": "3.0.2",
+      "homepage": "https://github.com/jonschlinkert/to-regex",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/to-regex.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/to-regex/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "keywords": [
+        "match",
+        "regex",
+        "regular expression",
+        "test",
+        "to"
+      ],
+      "verb": {
+        "toc": {
+          "method": "preWrite"
+        },
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "related": {
+          "list": [
+            "has-glob",
+            "is-glob",
+            "path-regex",
+            "to-regex-range"
+          ]
+        },
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "cc5735f98f62c8e9cfb98ae5b309abea1c8a2432",
+      "_id": "to-regex@3.0.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "dist": {
+        "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+        "shasum": "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 12626
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/to-regex_3.0.2_1519460972133_0.47922488575382616"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# to-regex [![NPM version](https://img.shields.io/npm/v/to-regex.svg?style=flat)](https://www.npmjs.com/package/to-regex) [![NPM monthly downloads](https://img.shields.io/npm/dm/to-regex.svg?style=flat)](https://npmjs.org/package/to-regex) [![NPM total downloads](https://img.shields.io/npm/dt/to-regex.svg?style=flat)](https://npmjs.org/package/to-regex) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/to-regex.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/to-regex)\n\n> Generate a regex from a string or array of strings.\n\nPlease consider following this project's author, [Jon Schlinkert](https://github.com/jonschlinkert), and consider starring the project to show your :heart: and support.\n\n- [Install](#install)\n- [Usage](#usage)\n- [Options](#options)\n  * [options.contains](#optionscontains)\n  * [options.negate](#optionsnegate)\n  * [options.nocase](#optionsnocase)\n  * [options.flags](#optionsflags)\n  * [options.cache](#optionscache)\n  * [options.safe](#optionssafe)\n- [About](#about)\n  * [Related projects](#related-projects)\n  * [Author](#author)\n  * [License](#license)\n\n_(TOC generated by [verb](https://github.com/verbose/verb) using [markdown-toc](https://github.com/jonschlinkert/markdown-toc))_\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save to-regex\n```\n\n## Usage\n\n```js\nvar toRegex = require('to-regex');\n\nconsole.log(toRegex('foo'));\n//=> /^(?:foo)$/\n\nconsole.log(toRegex('foo', {negate: true}));\n//=> /^(?:(?:(?!^(?:foo)$).)*)$/\n\nconsole.log(toRegex('foo', {contains: true}));\n//=> /(?:foo)/\n\nconsole.log(toRegex(['foo', 'bar'], {negate: true}));\n//=> /^(?:(?:(?!^(?:(?:foo)|(?:bar))$).)*)$/\n\nconsole.log(toRegex(['foo', 'bar'], {negate: true, contains: true}));\n//=> /^(?:(?:(?!(?:(?:foo)|(?:bar))).)*)$/\n```\n\n## Options\n\n### options.contains\n\n**Type**: `Boolean`\n\n**Default**: `undefined`\n\nGenerate a regex that will match any string that _contains_ the given pattern. By default, regex is strict will only return true for exact matches.\n\n```js\nvar toRegex = require('to-regex');\nconsole.log(toRegex('foo', {contains: true}));\n//=> /(?:foo)/\n```\n\n### options.negate\n\n**Type**: `Boolean`\n\n**Default**: `undefined`\n\nCreate a regex that will match everything except the given pattern.\n\n```js\nvar toRegex = require('to-regex');\nconsole.log(toRegex('foo', {negate: true}));\n//=> /^(?:(?:(?!^(?:foo)$).)*)$/\n```\n\n### options.nocase\n\n**Type**: `Boolean`\n\n**Default**: `undefined`\n\nAdds the `i` flag, to enable case-insensitive matching.\n\n```js\nvar toRegex = require('to-regex');\nconsole.log(toRegex('foo', {nocase: true}));\n//=> /^(?:foo)$/i\n```\n\nAlternatively you can pass the flags you want directly on [options.flags](#options.flags).\n\n### options.flags\n\n**Type**: `String`\n\n**Default**: `undefined`\n\nDefine the flags you want to use on the generated regex.\n\n```js\nvar toRegex = require('to-regex');\nconsole.log(toRegex('foo', {flags: 'gm'}));\n//=> /^(?:foo)$/gm\nconsole.log(toRegex('foo', {flags: 'gmi', nocase: true})); //<= handles redundancy\n//=> /^(?:foo)$/gmi\n```\n\n### options.cache\n\n**Type**: `Boolean`\n\n**Default**: `true`\n\nGenerated regex is cached based on the provided string and options. As a result, runtime compilation only happens once per pattern (as long as options are also the same), which can result in dramatic speed improvements.\n\nThis also helps with debugging, since adding options and pattern are added to the generated regex.\n\n**Disable caching**\n\n```js\ntoRegex('foo', {cache: false});\n```\n\n### options.safe\n\n**Type**: `Boolean`\n\n**Default**: `undefined`\n\nCheck the generated regular expression with [safe-regex](https://github.com/substack/safe-regex) and throw an error if the regex is potentially unsafe.\n\n**Examples**\n\n```js\nconsole.log(toRegex('(x+x+)+y'));\n//=> /^(?:(x+x+)+y)$/\n\n// The following would throw an error\ntoRegex('(x+x+)+y', {safe: true});\n```\n\n## About\n\n<details>\n<summary><strong>Contributing</strong></summary>\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n</details>\n\n<details>\n<summary><strong>Running Tests</strong></summary>\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n</details>\n\n<details>\n<summary><strong>Building docs</strong></summary>\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n</details>\n\n### Related projects\n\nYou might also be interested in these projects:\n\n* [has-glob](https://www.npmjs.com/package/has-glob): Returns `true` if an array has a glob pattern. | [homepage](https://github.com/jonschlinkert/has-glob \"Returns `true` if an array has a glob pattern.\")\n* [is-glob](https://www.npmjs.com/package/is-glob): Returns `true` if the given string looks like a glob pattern or an extglob pattern… [more](https://github.com/jonschlinkert/is-glob) | [homepage](https://github.com/jonschlinkert/is-glob \"Returns `true` if the given string looks like a glob pattern or an extglob pattern. This makes it easy to create code that only uses external modules like node-glob when necessary, resulting in much faster code execution and initialization time, and a bet\")\n* [path-regex](https://www.npmjs.com/package/path-regex): Regular expression for matching the parts of a file path. | [homepage](https://github.com/regexps/path-regex \"Regular expression for matching the parts of a file path.\")\n* [to-regex-range](https://www.npmjs.com/package/to-regex-range): Pass two numbers, get a regex-compatible source string for matching ranges. Validated against more than… [more](https://github.com/micromatch/to-regex-range) | [homepage](https://github.com/micromatch/to-regex-range \"Pass two numbers, get a regex-compatible source string for matching ranges. Validated against more than 2.78 million test assertions.\")\n\n### Author\n\n**Jon Schlinkert**\n\n* [linkedin/in/jonschlinkert](https://linkedin.com/in/jonschlinkert)\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2018, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.6.0, on February 24, 2018._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2019-01-08T05:34:04.374Z",
+    "created": "2016-09-27T02:38:27.317Z",
+    "0.1.0": "2016-09-27T02:38:27.317Z",
+    "0.1.1": "2016-09-27T03:56:19.847Z",
+    "1.0.0": "2016-10-04T06:31:13.081Z",
+    "2.0.0": "2016-10-06T10:24:10.761Z",
+    "2.1.0": "2016-10-06T11:52:03.929Z",
+    "3.0.0": "2016-10-17T02:09:03.115Z",
+    "3.0.1": "2016-10-17T02:15:17.419Z",
+    "3.0.2": "2018-02-24T08:29:32.189Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/to-regex",
+  "keywords": [
+    "match",
+    "regex",
+    "regular expression",
+    "test",
+    "to"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/to-regex.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/to-regex/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "arteffeckt": true,
+    "rocket0191": true,
+    "hualei": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/to-regex.min.json
+++ b/test/fixtures/registry-mocks/content/to-regex.min.json
@@ -1,0 +1,196 @@
+{
+  "name": "to-regex",
+  "dist-tags": {
+    "latest": "3.0.2"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "to-regex",
+      "version": "0.1.0",
+      "dependencies": {
+        "extend-shallow": "^2.0.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "338de9c6694ac3d19f73bf4bc94e91a3ddbfe277",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "to-regex",
+      "version": "0.1.1",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "5634b4796f17a796097036357a97064fb70c3125",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "to-regex",
+      "version": "1.0.0",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "49f5efcaa9d642bce03296d4580f29f9060d89ac",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.0.0": {
+      "name": "to-regex",
+      "version": "2.0.0",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "67ea7e4ed2f889b25734da311328bd04fe1f73de",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "2.1.0": {
+      "name": "to-regex",
+      "version": "2.1.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^0.1.1"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "e3ad3a40cfe119559a05aea43e4caefacc5e901d",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-2.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.0": {
+      "name": "to-regex",
+      "version": "3.0.0",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "58183da5021d397828892fc7ed04923664aa06db",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.1": {
+      "name": "to-regex",
+      "version": "3.0.1",
+      "dependencies": {
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "regex-not": "^1.0.0"
+      },
+      "devDependencies": {
+        "gulp": "^3.9.1",
+        "gulp-eslint": "^3.0.1",
+        "gulp-format-md": "^0.1.10",
+        "gulp-istanbul": "^1.1.1",
+        "gulp-mocha": "^3.0.1",
+        "mocha": "^3.0.2"
+      },
+      "dist": {
+        "shasum": "15358bee4a2c83bd76377ba1dc049d0f18837aae",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "3.0.2": {
+      "name": "to-regex",
+      "version": "3.0.2",
+      "dependencies": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^1.0.0",
+        "mocha": "^3.5.3"
+      },
+      "dist": {
+        "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+        "shasum": "13cfdd9b336552f30b51f33a8ae1b42a7a7599ce",
+        "tarball": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 12626
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2019-01-08T05:34:04.374Z"
+}

--- a/test/fixtures/registry-mocks/content/toidentifier.json
+++ b/test/fixtures/registry-mocks/content/toidentifier.json
@@ -1,0 +1,285 @@
+{
+  "_id": "toidentifier",
+  "_rev": "4-4b288931e281a49f77fadf7e59b8a4f7",
+  "name": "toidentifier",
+  "description": "Convert a string of words to a JavaScript identifier",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "toidentifier",
+      "description": "Convert a string of words to a JavaScript identifier",
+      "version": "0.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "bugs": {
+        "url": "https://github.com/koajs/toidentifier/issues",
+        "email": "niftylettuce@gmail.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Nick Baugh",
+          "email": "niftylettuce@gmail.com",
+          "url": "http://niftylettuce.com/"
+        }
+      ],
+      "dependencies": {},
+      "ava": {
+        "failFast": true,
+        "verbose": true
+      },
+      "devDependencies": {
+        "ava": "^0.22.0",
+        "babel-cli": "^6.26.0",
+        "babel-preset-env": "^1.6.1",
+        "codecov": "^2.3.0",
+        "cross-env": "^5.0.5",
+        "eslint": "^4.5.0",
+        "eslint-config-prettier": "^2.3.0",
+        "eslint-plugin-prettier": "^2.2.0",
+        "husky": "^0.14.3",
+        "lint-staged": "^4.0.4",
+        "nyc": "^11.1.0",
+        "prettier": "^1.6.1",
+        "remark-cli": "^4.0.0",
+        "remark-preset-github": "^0.0.6",
+        "xo": "^0.19.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "https://github.com/koajs/toidentifier",
+      "keywords": [
+        "to",
+        "identifier"
+      ],
+      "license": "MIT",
+      "lint-staged": {
+        "*.{js,jsx,mjs,ts,tsx,css,less,scss,json,graphql}": [
+          "prettier --write --single-quote --trailing-comma none",
+          "git add"
+        ],
+        "*.md": [
+          "remark . -qfo",
+          "git add"
+        ]
+      },
+      "main": "lib/index.js",
+      "remarkConfig": {
+        "plugins": [
+          "preset-github"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/koajs/toidentifier.git"
+      },
+      "files": [
+        "lib"
+      ],
+      "scripts": {
+        "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
+        "lint": "xo && remark . -qfo",
+        "precommit": "lint-staged && npm test",
+        "test": "npm run build && npm run lint && npm run test-coverage",
+        "test-coverage": "cross-env NODE_ENV=test nyc ava",
+        "build": "babel src --out-dir lib",
+        "watch": "babel src --watch --out-dir lib"
+      },
+      "xo": {
+        "extends": "prettier",
+        "plugins": [
+          "prettier"
+        ],
+        "parserOptions": {
+          "sourceType": "script"
+        },
+        "rules": {
+          "prettier/prettier": [
+            "error",
+            {
+              "singleQuote": true,
+              "bracketSpacing": true,
+              "trailingComma": "none"
+            }
+          ],
+          "max-len": [
+            "error",
+            {
+              "code": 80,
+              "ignoreUrls": true
+            }
+          ],
+          "capitalized-comments": "off",
+          "camelcase": "off",
+          "no-warning-comments": "off"
+        },
+        "space": true
+      },
+      "gitHead": "6bf014ae81988f80eed392f2d47cda032efdaccf",
+      "_id": "toidentifier@0.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.0",
+      "_npmUser": {
+        "name": "niftylettuce",
+        "email": "niftylettuce@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-rbnQkrIivqT1LG6lv4zIbjXG43nmtQvugnEK6E5tA0OlDJcK6e0O6DkxYmaV/zcB4Sd7Hb2uB0892I7CMYJdww==",
+        "shasum": "32fe700072972c0689f67fdb0e1eb92b2d18d413",
+        "tarball": "https://registry.npmjs.org/toidentifier/-/toidentifier-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "niftylettuce",
+          "email": "niftylettuce@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/toidentifier-0.0.1.tgz_1513674524835_0.4889004931319505"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "toidentifier",
+      "description": "Convert a string of words to a JavaScript identifier",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Nick Baugh",
+          "email": "niftylettuce@gmail.com",
+          "url": "http://niftylettuce.com/"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/component/toidentifier.git"
+      },
+      "devDependencies": {
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.11.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.7.0",
+        "eslint-plugin-standard": "3.1.0",
+        "mocha": "1.21.5",
+        "nyc": "11.8.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test"
+      },
+      "gitHead": "8c09cba5e530de7d74b087ea66740c0e4a5af02b",
+      "bugs": {
+        "url": "https://github.com/component/toidentifier/issues"
+      },
+      "homepage": "https://github.com/component/toidentifier#readme",
+      "_id": "toidentifier@1.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+        "shasum": "7e1be3470f1e77948bc43d94a3c8f4d7752ba553",
+        "tarball": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4327,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbQ4XTCRA9TVsSAnZWagAA7DoP/j60iZmXQNybYW88ghH2\nb0/OM4HaSAJFZaPLs/QWHAG+1njmk4Inxr0YPeqAcU8bkh8UvUBAsf/qnNOV\nVx8R5MQspibif04/f/nB+ZZyoFvv45270S5M+hb22colM3BK0FnfImVZHqI6\n0n+fbicoYYCg3KxEpLC4GdXbJ2R6iSJ+kCnvTFX7/EzDoDjZJjzSMn96HpH+\nakvIo0kEXsTMVmjWwQSo++7JzsfBJs7Z2X+ixOdhf1HHYU5yiDS/8blXY5hN\nG5tcXbsBsFMPSRwKzArB8SqTejls6uRY21DmzvXnNCfS5k5FyftGLtBTpmwk\n2mHLENZ+79t+HP4tXmF/2scY/XjIWCtxjmOPBHg9eMoCe7uiEf/MkNoPQ29a\nKYMYz3gePkHG6NH+IN69e0KYmdzyowxtQy0Oel3L71nnguFD0DzJuhODahvl\nWdrzkyKWYHkrByIQmsYhLei67I+fgiAEURFhXHwRQ6TfW+i7I+0vx6qVZ7Uz\n8kCo7SELv6Suo62QXxB3O9u0qZyISXWfxbV48+T5KDayWmBVNEo9yktzPMF6\nIv49uczFdrGI5rAI2/zW5Ss7I00OnbY1I4va36JkEcoxqriiYGhLK+a7/061\nRKoB8fSKWCaiXEYcNkjiEIhI+5n57xOA4PuEUnfpqizo8yvxVLvOLUmNCtm3\nBVOV\r\n=Yk0D\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        },
+        {
+          "email": "niftylettuce@gmail.com",
+          "name": "niftylettuce"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/toidentifier_1.0.0_1531151827437_0.3834790263753669"
+      }
+    }
+  },
+  "readme": "# toidentifier\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][codecov-image]][codecov-url]\n\n> Convert a string of words to a JavaScript identifier\n\n## Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```bash\n$ npm install toidentifier\n```\n\n## Example\n\n```js\nvar toIdentifier = require('toidentifier')\n\nconsole.log(toIdentifier('Bad Request'))\n// => \"BadRequest\"\n```\n\n## API\n\nThis CommonJS module exports a single default function: `toIdentifier`.\n\n### toIdentifier(string)\n\nGiven a string as the argument, it will be transformed according to\nthe following rules and the new string will be returned:\n\n1. Split into words separated by space characters (`0x20`).\n2. Upper case the first character of each word.\n3. Join the words together with no separator.\n4. Remove all non-word (`[0-9a-z_]`) characters.\n\n## License\n\n[MIT](LICENSE)\n\n[codecov-image]: https://img.shields.io/codecov/c/github/component/toidentifier.svg\n[codecov-url]: https://codecov.io/gh/component/toidentifier\n[downloads-image]: https://img.shields.io/npm/dm/toidentifier.svg\n[downloads-url]: https://npmjs.org/package/toidentifier\n[npm-image]: https://img.shields.io/npm/v/toidentifier.svg\n[npm-url]: https://npmjs.org/package/toidentifier\n[travis-image]: https://img.shields.io/travis/component/toidentifier/master.svg\n[travis-url]: https://travis-ci.org/component/toidentifier\n\n\n##\n\n[npm]: https://www.npmjs.com/\n\n[yarn]: https://yarnpkg.com/\n",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    },
+    {
+      "email": "niftylettuce@gmail.com",
+      "name": "niftylettuce"
+    }
+  ],
+  "time": {
+    "modified": "2018-07-09T15:57:10.194Z",
+    "created": "2017-12-19T09:08:44.919Z",
+    "0.0.1": "2017-12-19T09:08:44.919Z",
+    "1.0.0": "2018-07-09T15:57:07.703Z"
+  },
+  "homepage": "https://github.com/component/toidentifier#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/component/toidentifier.git"
+  },
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Nick Baugh",
+      "email": "niftylettuce@gmail.com",
+      "url": "http://niftylettuce.com/"
+    }
+  ],
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/component/toidentifier/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/toidentifier.min.json
+++ b/test/fixtures/registry-mocks/content/toidentifier.min.json
@@ -1,0 +1,64 @@
+{
+  "name": "toidentifier",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "toidentifier",
+      "version": "0.0.1",
+      "devDependencies": {
+        "ava": "^0.22.0",
+        "babel-cli": "^6.26.0",
+        "babel-preset-env": "^1.6.1",
+        "codecov": "^2.3.0",
+        "cross-env": "^5.0.5",
+        "eslint": "^4.5.0",
+        "eslint-config-prettier": "^2.3.0",
+        "eslint-plugin-prettier": "^2.2.0",
+        "husky": "^0.14.3",
+        "lint-staged": "^4.0.4",
+        "nyc": "^11.1.0",
+        "prettier": "^1.6.1",
+        "remark-cli": "^4.0.0",
+        "remark-preset-github": "^0.0.6",
+        "xo": "^0.19.0"
+      },
+      "dist": {
+        "integrity": "sha512-rbnQkrIivqT1LG6lv4zIbjXG43nmtQvugnEK6E5tA0OlDJcK6e0O6DkxYmaV/zcB4Sd7Hb2uB0892I7CMYJdww==",
+        "shasum": "32fe700072972c0689f67fdb0e1eb92b2d18d413",
+        "tarball": "https://registry.npmjs.org/toidentifier/-/toidentifier-0.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.0": {
+      "name": "toidentifier",
+      "version": "1.0.0",
+      "devDependencies": {
+        "eslint": "4.19.1",
+        "eslint-config-standard": "11.0.0",
+        "eslint-plugin-import": "2.11.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "6.0.1",
+        "eslint-plugin-promise": "3.7.0",
+        "eslint-plugin-standard": "3.1.0",
+        "mocha": "1.21.5",
+        "nyc": "11.8.0"
+      },
+      "dist": {
+        "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+        "shasum": "7e1be3470f1e77948bc43d94a3c8f4d7752ba553",
+        "tarball": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 4327,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbQ4XTCRA9TVsSAnZWagAA7DoP/j60iZmXQNybYW88ghH2\nb0/OM4HaSAJFZaPLs/QWHAG+1njmk4Inxr0YPeqAcU8bkh8UvUBAsf/qnNOV\nVx8R5MQspibif04/f/nB+ZZyoFvv45270S5M+hb22colM3BK0FnfImVZHqI6\n0n+fbicoYYCg3KxEpLC4GdXbJ2R6iSJ+kCnvTFX7/EzDoDjZJjzSMn96HpH+\nakvIo0kEXsTMVmjWwQSo++7JzsfBJs7Z2X+ixOdhf1HHYU5yiDS/8blXY5hN\nG5tcXbsBsFMPSRwKzArB8SqTejls6uRY21DmzvXnNCfS5k5FyftGLtBTpmwk\n2mHLENZ+79t+HP4tXmF/2scY/XjIWCtxjmOPBHg9eMoCe7uiEf/MkNoPQ29a\nKYMYz3gePkHG6NH+IN69e0KYmdzyowxtQy0Oel3L71nnguFD0DzJuhODahvl\nWdrzkyKWYHkrByIQmsYhLei67I+fgiAEURFhXHwRQ6TfW+i7I+0vx6qVZ7Uz\n8kCo7SELv6Suo62QXxB3O9u0qZyISXWfxbV48+T5KDayWmBVNEo9yktzPMF6\nIv49uczFdrGI5rAI2/zW5Ss7I00OnbY1I4va36JkEcoxqriiYGhLK+a7/061\nRKoB8fSKWCaiXEYcNkjiEIhI+5n57xOA4PuEUnfpqizo8yvxVLvOLUmNCtm3\nBVOV\r\n=Yk0D\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    }
+  },
+  "modified": "2018-07-09T15:57:10.194Z"
+}

--- a/test/fixtures/registry-mocks/content/tty-browserify.json
+++ b/test/fixtures/registry-mocks/content/tty-browserify.json
@@ -1,0 +1,466 @@
+{
+  "_id": "tty-browserify",
+  "_rev": "42-6ae0d585570680a9bcf968329aa23839",
+  "name": "tty-browserify",
+  "description": "the tty module from node core for browsers",
+  "dist-tags": {
+    "latest": "0.0.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "tty-browserify",
+      "version": "0.0.0",
+      "description": "the tty module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/tty-browserify.git"
+      },
+      "homepage": "https://github.com/substack/tty-browserify",
+      "keywords": [
+        "tty",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/substack/tty-browserify/issues"
+      },
+      "_id": "tty-browserify@0.0.0",
+      "dist": {
+        "shasum": "a157ba402da24e9bf957f9aa69d524eed42901a6",
+        "tarball": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "tty-browserify",
+      "version": "0.0.1",
+      "description": "the tty module from node core for browsers",
+      "main": "index.js",
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "scripts": {
+        "test": "tape test/*.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/tty-browserify.git"
+      },
+      "homepage": "https://github.com/browserify/tty-browserify",
+      "keywords": [
+        "tty",
+        "browser",
+        "browserify"
+      ],
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "license": "MIT",
+      "gitHead": "7e46e4796eeb123b05b9637b5a3e68e96252632b",
+      "bugs": {
+        "url": "https://github.com/browserify/tty-browserify/issues"
+      },
+      "_id": "tty-browserify@0.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "rene@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+        "shasum": "3f05251ee17904dfd0677546670db9651682b811",
+        "tarball": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/tty-browserify-0.0.1.tgz_1517066741307_0.8590068933553994"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# tty-browserify\n",
+  "maintainers": [
+    {
+      "email": "raynos2@gmail.com",
+      "name": "raynos"
+    },
+    {
+      "email": "lukechilds123@gmail.com",
+      "name": "lukechilds"
+    },
+    {
+      "email": "shtylman@gmail.com",
+      "name": "defunctzombie"
+    },
+    {
+      "email": "substack@gmail.com",
+      "name": "substack"
+    },
+    {
+      "email": "feross@feross.org",
+      "name": "feross"
+    },
+    {
+      "email": "me@gkatsev.com",
+      "name": "gkatsev"
+    },
+    {
+      "email": "zertosh@gmail.com",
+      "name": "zertosh"
+    },
+    {
+      "email": "mathiasbuus@gmail.com",
+      "name": "mafintosh"
+    },
+    {
+      "email": "max@maxogden.com",
+      "name": "maxogden"
+    },
+    {
+      "email": "dominic.tarr@gmail.com",
+      "name": "dominictarr"
+    },
+    {
+      "email": "thlorenz10@gmail.com",
+      "name": "thlorenz"
+    },
+    {
+      "email": "terinjokes@gmail.com",
+      "name": "terinjokes"
+    },
+    {
+      "email": "npm-public@jessemccarthy.net",
+      "name": "jmm"
+    },
+    {
+      "email": "palmermebane@gmail.com",
+      "name": "mellowmelon"
+    },
+    {
+      "email": "darawk@gmail.com",
+      "name": "ashaffer88"
+    },
+    {
+      "email": "b@lupton.cc",
+      "name": "balupton"
+    },
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jryans@gmail.com",
+      "name": "jryans"
+    },
+    {
+      "email": "sethvincent@gmail.com",
+      "name": "sethvincent"
+    },
+    {
+      "email": "yoshuawuyts@gmail.com",
+      "name": "yoshuawuyts"
+    },
+    {
+      "email": "ungoldman@gmail.com",
+      "name": "ungoldman"
+    },
+    {
+      "email": "michael.williams@enspiral.com",
+      "name": "ahdinosaur"
+    },
+    {
+      "email": "contact@elnounch.net",
+      "name": "elnounch"
+    },
+    {
+      "email": "parshap+npm@gmail.com",
+      "name": "parshap"
+    },
+    {
+      "email": "yerko.palma@usach.cl",
+      "name": "yerkopalma"
+    },
+    {
+      "email": "forbes@lindesay.co.uk",
+      "name": "forbeslindesay"
+    },
+    {
+      "email": "martin.heidegger@gmail.com",
+      "name": "leichtgewicht"
+    },
+    {
+      "email": "garann@gmail.com",
+      "name": "garann"
+    },
+    {
+      "email": "bcomnes@gmail.com",
+      "name": "bret"
+    },
+    {
+      "email": "vestibule@anandthakker.net",
+      "name": "anandthakker"
+    },
+    {
+      "email": "dave.des@gmail.com",
+      "name": "mattdesl"
+    },
+    {
+      "email": "hughskennedy@gmail.com",
+      "name": "hughsk"
+    },
+    {
+      "email": "pereira.filype@gmail.com",
+      "name": "fpereira1"
+    },
+    {
+      "email": "renee@kooi.me",
+      "name": "goto-bus-stop"
+    },
+    {
+      "email": "post.ben.here@gmail.com",
+      "name": "bpostlethwaite"
+    },
+    {
+      "email": "github@tixz.dk",
+      "name": "emilbayes"
+    },
+    {
+      "email": "maochenyan@gmail.com",
+      "name": "stevemao"
+    },
+    {
+      "email": "peteris.krumins@gmail.com",
+      "name": "pkrumins"
+    },
+    {
+      "email": "me@JoshDuff.com",
+      "name": "tehshrike"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-09T12:54:39.968Z",
+    "created": "2013-12-03T20:18:53.995Z",
+    "0.0.0": "2013-12-03T20:18:55.544Z",
+    "0.0.1": "2018-01-27T15:25:42.162Z"
+  },
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/browserify/tty-browserify.git"
+  },
+  "users": {
+    "wenbing": true,
+    "simplyianm": true
+  },
+  "homepage": "https://github.com/browserify/tty-browserify",
+  "keywords": [
+    "tty",
+    "browser",
+    "browserify"
+  ],
+  "bugs": {
+    "url": "https://github.com/browserify/tty-browserify/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.markdown"
+}

--- a/test/fixtures/registry-mocks/content/tty-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/tty-browserify.min.json
@@ -1,0 +1,32 @@
+{
+  "name": "tty-browserify",
+  "dist-tags": {
+    "latest": "0.0.1"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "tty-browserify",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "shasum": "a157ba402da24e9bf957f9aa69d524eed42901a6",
+        "tarball": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "tty-browserify",
+      "version": "0.0.1",
+      "devDependencies": {
+        "tape": "~1.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+        "shasum": "3f05251ee17904dfd0677546670db9651682b811",
+        "tarball": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz"
+      }
+    }
+  },
+  "modified": "2020-10-09T12:54:39.968Z"
+}

--- a/test/fixtures/registry-mocks/content/type-is.json
+++ b/test/fixtures/registry-mocks/content/type-is.json
@@ -1,0 +1,3247 @@
+{
+  "_id": "type-is",
+  "_rev": "102-89ebc836b7a802429f3bf5f44fc8069a",
+  "name": "type-is",
+  "description": "Infer the content-type of a request.",
+  "dist-tags": {
+    "latest": "1.6.18"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "type-is",
+      "description": "Infer the content type if a request",
+      "version": "1.0.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/type-is.git"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "dependencies": {
+        "mime": "~1.2.11"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "make test"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.0.0",
+      "dist": {
+        "shasum": "4ff424e97349a1ee1910b4bfc488595ecdc443fc",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "type-is",
+      "description": "Infer the content type if a request",
+      "version": "1.0.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "mime": "~1.2.11"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.0.1",
+      "dist": {
+        "shasum": "ae09d93953c7846f5c083192837575ab363408f1",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "type-is",
+      "description": "Infer the content type if a request",
+      "version": "1.1.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "mime": "~1.2.11"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.1.0",
+      "dist": {
+        "shasum": "d0245ec8b2676668d59dd0cf3255060676a57db6",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "type-is",
+      "description": "Infer the content type if a request",
+      "version": "1.2.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "mime": "1.2.11"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.2.0",
+      "dist": {
+        "shasum": "a9aaa3f2014850d4813663f6c714cf6318195138",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.2.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "mime-types": "1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.2.1",
+      "_shasum": "73d448080a4f1dd18acb1eefff62968c5b5d54a2",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "73d448080a4f1dd18acb1eefff62968c5b5d54a2",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.2.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "mime-types": "1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.2.2",
+      "dist": {
+        "shasum": "dfdbf7cffa57cea0f9b1b55b96f629454e0eee97",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.3.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.3.0",
+      "dist": {
+        "shasum": "131df06aca1476419f95de3e38f2efef8b249c20",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.3.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.3.1",
+      "dist": {
+        "shasum": "a6789b5a52138289ade1ef8f6d9f2874ffd70b6b",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.3.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "~1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d76790909638d4cf1785e09858db5576f91f710f",
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.3.2",
+      "_shasum": "4f2a5dc58775ca1630250afc7186f8b36309d1bb",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4f2a5dc58775ca1630250afc7186f8b36309d1bb",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.4.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/expressjs/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "~2.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1",
+        "should": "4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --require should --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "files": [
+        "index.js"
+      ],
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "f0483c28a704eaef3da9c0f8d9a2fc9dc6d50d3f",
+      "bugs": {
+        "url": "https://github.com/expressjs/type-is/issues"
+      },
+      "homepage": "https://github.com/expressjs/type-is",
+      "_id": "type-is@1.4.0",
+      "_shasum": "de51d78a2ccb19a8fa2e137b06784f6b39a88059",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "jongleberry",
+        "email": "jonathanrichardong@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "de51d78a2ccb19a8fa2e137b06784f6b39a88059",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.5.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "~2.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1",
+        "should": "4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --require should --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "1cff718285478905d97bbf6cf666e0ce1c0284e3",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.5.0",
+      "_shasum": "e3539711529c5ee4e7cd9f5bed27487cb819f823",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e3539711529c5ee4e7cd9f5bed27487cb819f823",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.5.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "74d33287453bf7c166f6410fc608c1c7588070ae",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.5.1",
+      "_shasum": "5c1e62d874f79199fb16b34d16972dba376ccbed",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5c1e62d874f79199fb16b34d16972dba376ccbed",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.5.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "53b2d3f2c0177ac89576055d327d543291d36879",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.5.2",
+      "_shasum": "8291bbe845a904acfaffd05a41fdeb234bfa9e5f",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8291bbe845a904acfaffd05a41fdeb234bfa9e5f",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.3": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.5.3",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.3"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "202b4823bcc0aeda3595c14a03fdcb2c60cb0ebf",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.5.3",
+      "_shasum": "b7fb92d0abc628393f10dd260932cca65fe9ff68",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b7fb92d0abc628393f10dd260932cca65fe9ff68",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.4": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.5.4",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.2",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "d604e7a69ce986692e9f241e21b9abe6d4f77eb0",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.5.4",
+      "_shasum": "f2afe8635dcf2d159096202be6e120423fa19837",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f2afe8635dcf2d159096202be6e120423fa19837",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.5": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.5.5",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "b13dc3fa142ad60bea775181ba5f50364042691f",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.5.5",
+      "_shasum": "45248af57f96366d0326ea0868f6bc8607dc4b21",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "45248af57f96366d0326ea0868f6bc8607dc4b21",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.6": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.5.6",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.8"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "18f74f0f51c066c1485344c2e8d88c86c00d3bea",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.5.6",
+      "_shasum": "5be39670ac699b4d0f59df84264cb05be1c9998b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5be39670ac699b4d0f59df84264cb05be1c9998b",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.7": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.5.7",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.9"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "f4335cc563a98ee80366f04f67c50cef089ae803",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.5.7",
+      "_shasum": "b9368a593cc6ef7d0645e78b2f4c64cbecd05e90",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b9368a593cc6ef7d0645e78b2f4c64cbecd05e90",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.0",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.9"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "8386837f91cfbf9f21f02758dee36655a901e1c4",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.0",
+      "_shasum": "efcb9223fafad5a03be14d8f6c9e1785f2c0e7c3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "efcb9223fafad5a03be14d8f6c9e1785f2c0e7c3",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.1",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.10"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "339a7df4d8fed268b0f12d0fdab91d39f88d6f4e",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.1",
+      "_shasum": "49addecb0f6831cbc1d34ba929f0f3a4f21b0f2e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "49addecb0f6831cbc1d34ba929f0f3a4f21b0f2e",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.2",
+      "author": {
+        "name": "Jonathan Ong",
+        "email": "me@jongleberry.com",
+        "url": "http://jongleberry.com"
+      },
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.11"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "4e33e2fbb1f0daa6ec8c5444dbb60e44292ae314",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.2",
+      "_shasum": "694e83e5d110417e681cea278227f264ae406e33",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "694e83e5d110417e681cea278227f264ae406e33",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.3": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.3",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "294dff1c93d2ccb9a56191d37e390a8d2ad02e6f",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.3",
+      "_shasum": "d87d201777f76dfc526ac202679715d41a28c580",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d87d201777f76dfc526ac202679715d41a28c580",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.4": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.4",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "0edac23cef38f02ded0e072af65a078865af5b66",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.4",
+      "_shasum": "d76fe92f0bcf7b0cf16b64d095e248f71079c318",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d76fe92f0bcf7b0cf16b64d095e248f71079c318",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.5": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.5",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "b5fd0918ecc05113d32dbb97b02bb18cb635b059",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.5",
+      "_shasum": "92129495c7b7563eaf923b447382c6c471f95de4",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "92129495c7b7563eaf923b447382c6c471f95de4",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.6": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.6",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "f2b12fce6172bf91f771d8898055d6efa0e30422",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.6",
+      "_shasum": "398799519b62360f55c3cd6c486294531975926c",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "398799519b62360f55c3cd6c486294531975926c",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.7": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.7",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.18",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "f162e9e971c19d28c348bb9b9ef660d17fcf1ba0",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.7",
+      "_shasum": "5ec2bc7c7debc37f586d518c0747ab901f76bcec",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5ec2bc7c7debc37f586d518c0747ab901f76bcec",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.8": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.8",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.19",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "6c93143cead7c596072133491b84f03a05403d3e",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.8",
+      "_shasum": "3bac8c0c852754c855143e206d4a16e908bf0315",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3bac8c0c852754c855143e206d4a16e908bf0315",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.8.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.9": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.9",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "2f5999d6f2d88f2f36eeb1e8db78c2ec43fdbf13",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.9",
+      "_shasum": "87f3e88b92ff5ac30fbc1acf9a9d00cbc38b3d7a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "87f3e88b92ff5ac30fbc1acf9a9d00cbc38b3d7a",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.10": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.10",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.8"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "mocha": "~1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "072de04e5c6bd4a3dd089dbd70ec2b1d505625a9",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.10",
+      "_shasum": "d27e995b20d8c2a543f3420573f690a3929fd75a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        },
+        {
+          "name": "mscdex",
+          "email": "mscdex@mscdex.net"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d27e995b20d8c2a543f3420573f690a3929fd75a",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.11": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.11",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.9"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "8e60e3e78aef84928e0e6c09da950f6950adcdd2",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.11",
+      "_shasum": "42ecde7970f2363738b986c0351efba5aa531648",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "ritch",
+          "email": "skawful@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "42ecde7970f2363738b986c0351efba5aa531648",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.12": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.12",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.10"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "7ba49c0ccc8e34f4321768c0b13c2ebcccaae28c",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.12",
+      "_shasum": "0352a9dfbfff040fe668cc153cc95829c354173e",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0352a9dfbfff040fe668cc153cc95829c354173e",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-9-west.internal.npmjs.com",
+        "tmp": "tmp/type-is-1.6.12.tgz_1456726142464_0.8247741810046136"
+      },
+      "directories": {}
+    },
+    "1.6.13": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.13",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/type-is.git"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.11"
+      },
+      "devDependencies": {
+        "eslint": "2.10.2",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint **/*.js",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "88c47523fff910343b3ca7d4928dad40f21ea6cd",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is#readme",
+      "_id": "type-is@1.6.13",
+      "_shasum": "6e83ba7bc30cd33a7bb0b7fb00737a2085bf9d08",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "6e83ba7bc30cd33a7bb0b7fb00737a2085bf9d08",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/type-is-1.6.13.tgz_1463622049206_0.9134831207338721"
+      },
+      "directories": {}
+    },
+    "1.6.14": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.14",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/type-is"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.13"
+      },
+      "devDependencies": {
+        "eslint": "2.10.2",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "f88151e69d91c5ed42e29dea78f5566403a5a7ad",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is",
+      "_id": "type-is@1.6.14",
+      "_shasum": "e219639c17ded1ca0789092dd54a03826b817cb2",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e219639c17ded1ca0789092dd54a03826b817cb2",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/type-is-1.6.14.tgz_1479517858770_0.4908413903322071"
+      },
+      "directories": {}
+    },
+    "1.6.15": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.15",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/type-is.git"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "9e88be851cc628364ad8842433dce32437ea4e73",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is#readme",
+      "_id": "type-is@1.6.15",
+      "_shasum": "cab10fb4909e441c82842eafe1ad646c81804410",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "cab10fb4909e441c82842eafe1ad646c81804410",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/type-is-1.6.15.tgz_1491016789014_0.6958203655667603"
+      },
+      "directories": {}
+    },
+    "1.6.16": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.16",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/type-is.git"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "files": [
+        "LICENSE",
+        "HISTORY.md",
+        "index.js"
+      ],
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "dc723b95e2c52c689cf9d4cefbc5d91e74f7524a",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is#readme",
+      "_id": "type-is@1.6.16",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "6.13.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+        "shasum": "f89ce341541c672b25ee7ae3c73dee3b2be50194",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16739
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/type-is_1.6.16_1518812522921_0.03331830182177953"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.17": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.17",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/type-is.git"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "c22b4afcd251c5205d1bb49e6d6835b16233121a",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is#readme",
+      "_id": "type-is@1.6.17",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-jYZzkOoAPVyQ9vlZ4xEJ4BBbHC4a7hbY1xqyCPe6AiQVVqfbZEulJm0VpqK4B+096O1VQi0l6OBGH210ejx/bA==",
+        "shasum": "9ef72233f08ffbe83b8fa3c93f4f93ecbc330bc2",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.17.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17324,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwduDCRA9TVsSAnZWagAAjUMP/AlxKf7FVSUFr1IeznKR\nUIrZtUn1zbEIksxVqt68ZC2Ktj7nvcriZP6UkWPskaL8gQ5u/MRWOKZ3loVU\nzZoskOp+WXZdcLr8+HG6FRytmfRPj2wm04+D0YiRAfdBQJKXI7U3U9EWAkw6\niBWG0mFTQNfrgoArRKfqFbCJrkBy25Z3ouOo6L5MbmRCVpYFmS17Vv+HxlBe\nLB2cpnA4fnJCs6XvrxcyTLBPR/8jL8KeBLLpatLDJeqE3L5M9b/yvpjyPYXc\nBnfPIWGCu5vQjAtVRpLx54C3I7QFK+wbturRwyTbEu+S6MTNy9IboHlg6a0p\nBpds8UpJ83EgQ9oh+GAklzNNJyXwf/ygZ8L7hkL1fTjvLp78+r9k1ojcvEbn\nH8oNRpgkFau77MaPVWznVV4qgQKF2wRx9bDcTnRspJ8Jemgjk7nwwhZe8L42\nB5ZEUwVPGAPWPMXRsvkF0VSVFerGGgUluleBqsGe2xE9kk24vPv/4cAZFZnu\nwCsN7xtyLs8m6/YkOe5U5PJMW0RHt76gfghMwDzZIcZBNZECCC4PA3hqbGve\n1wsdSnzR+ELRi9GYLyab+5NO3OK78WTWw8MrnFYtwMS8uscc4cAl1WGnhkvu\nR2zjksu035ojjFOaGN7QxVdx4ZOP0Y0hnRhKVmEUHZ0Z0Yqo1Q0OHR5Egmlm\nhg/k\r\n=EGkU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/type-is_1.6.17_1556208514463_0.06453249157999785"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.18": {
+      "name": "type-is",
+      "description": "Infer the content-type of a request.",
+      "version": "1.6.18",
+      "contributors": [
+        {
+          "name": "Douglas Christopher Wilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "Jonathan Ong",
+          "email": "me@jongleberry.com",
+          "url": "http://jongleberry.com"
+        }
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/type-is.git"
+      },
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --check-leaks --bail test/",
+        "test-cov": "nyc --reporter=html --reporter=text npm test",
+        "test-travis": "nyc --reporter=text npm test"
+      },
+      "keywords": [
+        "content",
+        "type",
+        "checking"
+      ],
+      "gitHead": "bfebe3d4ac312debccb7dbbc79242e2581dea5f0",
+      "bugs": {
+        "url": "https://github.com/jshttp/type-is/issues"
+      },
+      "homepage": "https://github.com/jshttp/type-is#readme",
+      "_id": "type-is@1.6.18",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "8.16.0",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+        "shasum": "4e552cd05df09467dcbc4ef739de89f2cf37c131",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18497,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcww7VCRA9TVsSAnZWagAADo4P/isJIJ9PaSvaRKD2jXlI\nfnZaodUUUdgiQfzG0uL2nvb7F4iHg6ddCEG5ofw4MzDQAXpsmv2r7F/3CVE7\n6KvUo5mVJ/KngeH95DxUcef/bTTAbCFdht7gbTFpZ0UKM4Ow3iuvgyvz/3aI\nJgkxqw8WgY/IdFk5NVZ3g5x8kGWXD1Llf44LLptYZ3R9J2u73CDP3ft9nE1Y\np9NAu3X0NH11U6IFNS+T62hehOfdsJUjY1XZc6142m7KsXjiDxISiX2tj0kg\n1DsW7oOJeWnbOJSxxfiI4Np1T0gRupjYfFBg/Fsfl6p+qcOAgQYMZTqv2iR+\nWSD9QuL/QYiYKqfAiumnC3uxPkT6AUqohIzk5HUSXrJcuyCmFWNDIO3MllC7\nW+9Ac6+qkN+dMGRx9hWS632uyb6AxbbulXNPbv//JwGzSyu+gLSkOQgk0vto\ngMYi7HUbQQquVBftMs7OqZ3HiP4q1gMr1H4PuoUUQw1FzxgSi6gY8hJriqM/\nPSKVym4y0Umict5DJnirgtSIAArTLVHAmEcY1XRFJB43HLrkNdcCpVH6FfRh\nvZ3dQsN5HQA0ioRyCstwsjDAbEzYStPIXmBOdBFmNnRIMoBe/16HbNZbO208\nKODasC9g3GHFn/IGgr3h8gW+WD76ISD5zUFshm0w4eJGx9XKtzhhjicnm6PO\nO1q0\r\n=WOqY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "doug@somethingdoug.com",
+          "name": "dougwilson"
+        },
+        {
+          "email": "jonathanrichardong@gmail.com",
+          "name": "jongleberry"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/type-is_1.6.18_1556287189103_0.20416863530873397"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# type-is\n\n[![NPM Version][npm-version-image]][npm-url]\n[![NPM Downloads][npm-downloads-image]][npm-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nInfer the content-type of a request.\n\n### Install\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):\n\n```sh\n$ npm install type-is\n```\n\n## API\n\n```js\nvar http = require('http')\nvar typeis = require('type-is')\n\nhttp.createServer(function (req, res) {\n  var istext = typeis(req, ['text/*'])\n  res.end('you ' + (istext ? 'sent' : 'did not send') + ' me text')\n})\n```\n\n### typeis(request, types)\n\nChecks if the `request` is one of the `types`. If the request has no body,\neven if there is a `Content-Type` header, then `null` is returned. If the\n`Content-Type` header is invalid or does not matches any of the `types`, then\n`false` is returned. Otherwise, a string of the type that matched is returned.\n\nThe `request` argument is expected to be a Node.js HTTP request. The `types`\nargument is an array of type strings.\n\nEach type in the `types` array can be one of the following:\n\n- A file extension name such as `json`. This name will be returned if matched.\n- A mime type such as `application/json`.\n- A mime type with a wildcard such as `*/*` or `*/json` or `application/*`.\n  The full mime type will be returned if matched.\n- A suffix such as `+json`. This can be combined with a wildcard such as\n  `*/vnd+json` or `application/*+json`. The full mime type will be returned\n  if matched.\n\nSome examples to illustrate the inputs and returned value:\n\n<!-- eslint-disable no-undef -->\n\n```js\n// req.headers.content-type = 'application/json'\n\ntypeis(req, ['json']) // => 'json'\ntypeis(req, ['html', 'json']) // => 'json'\ntypeis(req, ['application/*']) // => 'application/json'\ntypeis(req, ['application/json']) // => 'application/json'\n\ntypeis(req, ['html']) // => false\n```\n\n### typeis.hasBody(request)\n\nReturns a Boolean if the given `request` has a body, regardless of the\n`Content-Type` header.\n\nHaving a body has no relation to how large the body is (it may be 0 bytes).\nThis is similar to how file existence works. If a body does exist, then this\nindicates that there is data to read from the Node.js request stream.\n\n<!-- eslint-disable no-undef -->\n\n```js\nif (typeis.hasBody(req)) {\n  // read the body, since there is one\n\n  req.on('data', function (chunk) {\n    // ...\n  })\n}\n```\n\n### typeis.is(mediaType, types)\n\nChecks if the `mediaType` is one of the `types`. If the `mediaType` is invalid\nor does not matches any of the `types`, then `false` is returned. Otherwise, a\nstring of the type that matched is returned.\n\nThe `mediaType` argument is expected to be a\n[media type](https://tools.ietf.org/html/rfc6838) string. The `types` argument\nis an array of type strings.\n\nEach type in the `types` array can be one of the following:\n\n- A file extension name such as `json`. This name will be returned if matched.\n- A mime type such as `application/json`.\n- A mime type with a wildcard such as `*/*` or `*/json` or `application/*`.\n  The full mime type will be returned if matched.\n- A suffix such as `+json`. This can be combined with a wildcard such as\n  `*/vnd+json` or `application/*+json`. The full mime type will be returned\n  if matched.\n\nSome examples to illustrate the inputs and returned value:\n\n<!-- eslint-disable no-undef -->\n\n```js\nvar mediaType = 'application/json'\n\ntypeis.is(mediaType, ['json']) // => 'json'\ntypeis.is(mediaType, ['html', 'json']) // => 'json'\ntypeis.is(mediaType, ['application/*']) // => 'application/json'\ntypeis.is(mediaType, ['application/json']) // => 'application/json'\n\ntypeis.is(mediaType, ['html']) // => false\n```\n\n## Examples\n\n### Example body parser\n\n```js\nvar express = require('express')\nvar typeis = require('type-is')\n\nvar app = express()\n\napp.use(function bodyParser (req, res, next) {\n  if (!typeis.hasBody(req)) {\n    return next()\n  }\n\n  switch (typeis(req, ['urlencoded', 'json', 'multipart'])) {\n    case 'urlencoded':\n      // parse urlencoded body\n      throw new Error('implement urlencoded body parsing')\n    case 'json':\n      // parse json body\n      throw new Error('implement json body parsing')\n    case 'multipart':\n      // parse multipart body\n      throw new Error('implement multipart body parsing')\n    default:\n      // 415 error code\n      res.statusCode = 415\n      res.end()\n      break\n  }\n})\n```\n\n## License\n\n[MIT](LICENSE)\n\n[coveralls-image]: https://badgen.net/coveralls/c/github/jshttp/type-is/master\n[coveralls-url]: https://coveralls.io/r/jshttp/type-is?branch=master\n[node-version-image]: https://badgen.net/npm/node/type-is\n[node-version-url]: https://nodejs.org/en/download\n[npm-downloads-image]: https://badgen.net/npm/dm/type-is\n[npm-url]: https://npmjs.org/package/type-is\n[npm-version-image]: https://badgen.net/npm/v/type-is\n[travis-image]: https://badgen.net/travis/jshttp/type-is/master\n[travis-url]: https://travis-ci.org/jshttp/type-is\n",
+  "maintainers": [
+    {
+      "email": "doug@somethingdoug.com",
+      "name": "dougwilson"
+    },
+    {
+      "email": "jonathanrichardong@gmail.com",
+      "name": "jongleberry"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-26T13:59:51.822Z",
+    "created": "2013-12-28T00:06:19.362Z",
+    "1.0.0": "2013-12-28T00:06:19.362Z",
+    "1.0.1": "2014-03-30T07:59:36.618Z",
+    "1.1.0": "2014-04-13T00:23:29.651Z",
+    "1.2.0": "2014-05-12T03:30:58.338Z",
+    "1.2.1": "2014-06-04T04:37:46.796Z",
+    "1.2.2": "2014-06-20T01:21:35.783Z",
+    "1.3.0": "2014-06-20T02:04:10.178Z",
+    "1.3.1": "2014-06-20T03:04:57.712Z",
+    "1.3.2": "2014-06-25T01:04:21.979Z",
+    "1.4.0": "2014-09-02T08:46:55.515Z",
+    "1.5.0": "2014-09-05T19:49:01.787Z",
+    "1.5.1": "2014-09-08T06:33:30.713Z",
+    "1.5.2": "2014-09-29T05:30:21.355Z",
+    "1.5.3": "2014-11-09T22:46:49.093Z",
+    "1.5.4": "2014-12-11T02:42:44.888Z",
+    "1.5.5": "2014-12-31T05:26:13.133Z",
+    "1.5.6": "2015-01-30T05:31:55.125Z",
+    "1.5.7": "2015-02-10T05:35:50.380Z",
+    "1.6.0": "2015-02-13T03:55:36.313Z",
+    "1.6.1": "2015-03-14T04:20:19.211Z",
+    "1.6.2": "2015-05-11T05:52:18.626Z",
+    "1.6.3": "2015-06-08T18:58:33.938Z",
+    "1.6.4": "2015-07-02T01:22:52.689Z",
+    "1.6.5": "2015-07-17T03:36:46.181Z",
+    "1.6.6": "2015-07-31T17:12:11.577Z",
+    "1.6.7": "2015-08-20T18:16:35.954Z",
+    "1.6.8": "2015-09-04T14:57:13.431Z",
+    "1.6.9": "2015-09-28T04:16:01.110Z",
+    "1.6.10": "2015-12-01T19:07:05.618Z",
+    "1.6.11": "2016-01-30T05:09:52.834Z",
+    "1.6.12": "2016-02-29T06:09:05.369Z",
+    "1.6.13": "2016-05-19T01:40:52.083Z",
+    "1.6.14": "2016-11-19T01:11:00.743Z",
+    "1.6.15": "2017-04-01T03:19:49.693Z",
+    "1.6.16": "2018-02-16T20:22:03.004Z",
+    "1.6.17": "2019-04-25T16:08:34.582Z",
+    "1.6.18": "2019-04-26T13:59:49.224Z"
+  },
+  "users": {
+    "parroit": true,
+    "iwill": true,
+    "goodseller": true,
+    "simplyianm": true,
+    "flyslow": true,
+    "jamescostian": true,
+    "kparkov": true,
+    "yash3492": true,
+    "moimikey": true,
+    "thiagoh": true,
+    "konamgil": true,
+    "ubi": true,
+    "x4devs": true,
+    "snowdream": true,
+    "mojaray2k": true,
+    "makediff": true,
+    "shanewholloway": true,
+    "rbecheras": true,
+    "shuoshubao": true,
+    "raycharles": true,
+    "eyson": true,
+    "ganeshkbhat": true,
+    "semir2": true,
+    "mansoorulhaq": true,
+    "xgheaven": true
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jshttp/type-is#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/type-is.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/type-is/issues"
+  },
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "Douglas Christopher Wilson",
+      "email": "doug@somethingdoug.com"
+    },
+    {
+      "name": "Jonathan Ong",
+      "email": "me@jongleberry.com",
+      "url": "http://jongleberry.com"
+    }
+  ],
+  "keywords": [
+    "content",
+    "type",
+    "checking"
+  ]
+}

--- a/test/fixtures/registry-mocks/content/type-is.min.json
+++ b/test/fixtures/registry-mocks/content/type-is.min.json
@@ -1,0 +1,747 @@
+{
+  "name": "type-is",
+  "dist-tags": {
+    "latest": "1.6.18"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "type-is",
+      "version": "1.0.0",
+      "dependencies": {
+        "mime": "~1.2.11"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "4ff424e97349a1ee1910b4bfc488595ecdc443fc",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "type-is",
+      "version": "1.0.1",
+      "dependencies": {
+        "mime": "~1.2.11"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "ae09d93953c7846f5c083192837575ab363408f1",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "type-is",
+      "version": "1.1.0",
+      "dependencies": {
+        "mime": "~1.2.11"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "d0245ec8b2676668d59dd0cf3255060676a57db6",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "type-is",
+      "version": "1.2.0",
+      "dependencies": {
+        "mime": "1.2.11"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "a9aaa3f2014850d4813663f6c714cf6318195138",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.1": {
+      "name": "type-is",
+      "version": "1.2.1",
+      "dependencies": {
+        "mime-types": "1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "73d448080a4f1dd18acb1eefff62968c5b5d54a2",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.2.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.2.2": {
+      "name": "type-is",
+      "version": "1.2.2",
+      "dependencies": {
+        "mime-types": "1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "dfdbf7cffa57cea0f9b1b55b96f629454e0eee97",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.2.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.3.0": {
+      "name": "type-is",
+      "version": "1.3.0",
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "131df06aca1476419f95de3e38f2efef8b249c20",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.3.1": {
+      "name": "type-is",
+      "version": "1.3.1",
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "1.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "a6789b5a52138289ade1ef8f6d9f2874ffd70b6b",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.3.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.3.2": {
+      "name": "type-is",
+      "version": "1.3.2",
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "~1.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "4f2a5dc58775ca1630250afc7186f8b36309d1bb",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.3.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.4.0": {
+      "name": "type-is",
+      "version": "1.4.0",
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "~2.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1",
+        "should": "4"
+      },
+      "dist": {
+        "shasum": "de51d78a2ccb19a8fa2e137b06784f6b39a88059",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.5.0": {
+      "name": "type-is",
+      "version": "1.5.0",
+      "dependencies": {
+        "media-typer": "0.2.0",
+        "mime-types": "~2.0.0"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1",
+        "should": "4"
+      },
+      "dist": {
+        "shasum": "e3539711529c5ee4e7cd9f5bed27487cb819f823",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.5.1": {
+      "name": "type-is",
+      "version": "1.5.1",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.1"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "5c1e62d874f79199fb16b34d16972dba376ccbed",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.2": {
+      "name": "type-is",
+      "version": "1.5.2",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.2"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "1"
+      },
+      "dist": {
+        "shasum": "8291bbe845a904acfaffd05a41fdeb234bfa9e5f",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.3": {
+      "name": "type-is",
+      "version": "1.5.3",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.3"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.0",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "b7fb92d0abc628393f10dd260932cca65fe9ff68",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.4": {
+      "name": "type-is",
+      "version": "1.5.4",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.4"
+      },
+      "devDependencies": {
+        "istanbul": "~0.3.2",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "f2afe8635dcf2d159096202be6e120423fa19837",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.5": {
+      "name": "type-is",
+      "version": "1.5.5",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "45248af57f96366d0326ea0868f6bc8607dc4b21",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.6": {
+      "name": "type-is",
+      "version": "1.5.6",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.8"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "5be39670ac699b4d0f59df84264cb05be1c9998b",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.5.7": {
+      "name": "type-is",
+      "version": "1.5.7",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.9"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "b9368a593cc6ef7d0645e78b2f4c64cbecd05e90",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.0": {
+      "name": "type-is",
+      "version": "1.6.0",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.9"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.5",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "efcb9223fafad5a03be14d8f6c9e1785f2c0e7c3",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.1": {
+      "name": "type-is",
+      "version": "1.6.1",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.10"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.7",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "49addecb0f6831cbc1d34ba929f0f3a4f21b0f2e",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.2": {
+      "name": "type-is",
+      "version": "1.6.2",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.0.11"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.9",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "694e83e5d110417e681cea278227f264ae406e33",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.3": {
+      "name": "type-is",
+      "version": "1.6.3",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.1"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.14",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "d87d201777f76dfc526ac202679715d41a28c580",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.3.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.4": {
+      "name": "type-is",
+      "version": "1.6.4",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.2"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "d76fe92f0bcf7b0cf16b64d095e248f71079c318",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.4.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.5": {
+      "name": "type-is",
+      "version": "1.6.5",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.3"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "92129495c7b7563eaf923b447382c6c471f95de4",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.5.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.6": {
+      "name": "type-is",
+      "version": "1.6.6",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.4"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "398799519b62360f55c3cd6c486294531975926c",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.6.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.7": {
+      "name": "type-is",
+      "version": "1.6.7",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.5"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.18",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "5ec2bc7c7debc37f586d518c0747ab901f76bcec",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.7.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.8": {
+      "name": "type-is",
+      "version": "1.6.8",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.6"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.19",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "3bac8c0c852754c855143e206d4a16e908bf0315",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.8.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.9": {
+      "name": "type-is",
+      "version": "1.6.9",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.7"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "87f3e88b92ff5ac30fbc1acf9a9d00cbc38b3d7a",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.10": {
+      "name": "type-is",
+      "version": "1.6.10",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.8"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.1",
+        "mocha": "~1.21.5"
+      },
+      "dist": {
+        "shasum": "d27e995b20d8c2a543f3420573f690a3929fd75a",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.10.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.11": {
+      "name": "type-is",
+      "version": "1.6.11",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.9"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "42ecde7970f2363738b986c0351efba5aa531648",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.11.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.12": {
+      "name": "type-is",
+      "version": "1.6.12",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.10"
+      },
+      "devDependencies": {
+        "istanbul": "0.4.2",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "0352a9dfbfff040fe668cc153cc95829c354173e",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.12.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.13": {
+      "name": "type-is",
+      "version": "1.6.13",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.11"
+      },
+      "devDependencies": {
+        "eslint": "2.10.2",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.3",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "6e83ba7bc30cd33a7bb0b7fb00737a2085bf9d08",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.14": {
+      "name": "type-is",
+      "version": "1.6.14",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.13"
+      },
+      "devDependencies": {
+        "eslint": "2.10.2",
+        "eslint-config-standard": "5.3.1",
+        "eslint-plugin-promise": "1.1.0",
+        "eslint-plugin-standard": "1.3.2",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "e219639c17ded1ca0789092dd54a03826b817cb2",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.15": {
+      "name": "type-is",
+      "version": "1.6.15",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.15"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "shasum": "cab10fb4909e441c82842eafe1ad646c81804410",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.16": {
+      "name": "type-is",
+      "version": "1.6.16",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      },
+      "devDependencies": {
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.2.1",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "1.21.5"
+      },
+      "dist": {
+        "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+        "shasum": "f89ce341541c672b25ee7ae3c73dee3b2be50194",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+        "fileCount": 5,
+        "unpackedSize": 16739
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.17": {
+      "name": "type-is",
+      "version": "1.6.17",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-jYZzkOoAPVyQ9vlZ4xEJ4BBbHC4a7hbY1xqyCPe6AiQVVqfbZEulJm0VpqK4B+096O1VQi0l6OBGH210ejx/bA==",
+        "shasum": "9ef72233f08ffbe83b8fa3c93f4f93ecbc330bc2",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.17.tgz",
+        "fileCount": 5,
+        "unpackedSize": 17324,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwduDCRA9TVsSAnZWagAAjUMP/AlxKf7FVSUFr1IeznKR\nUIrZtUn1zbEIksxVqt68ZC2Ktj7nvcriZP6UkWPskaL8gQ5u/MRWOKZ3loVU\nzZoskOp+WXZdcLr8+HG6FRytmfRPj2wm04+D0YiRAfdBQJKXI7U3U9EWAkw6\niBWG0mFTQNfrgoArRKfqFbCJrkBy25Z3ouOo6L5MbmRCVpYFmS17Vv+HxlBe\nLB2cpnA4fnJCs6XvrxcyTLBPR/8jL8KeBLLpatLDJeqE3L5M9b/yvpjyPYXc\nBnfPIWGCu5vQjAtVRpLx54C3I7QFK+wbturRwyTbEu+S6MTNy9IboHlg6a0p\nBpds8UpJ83EgQ9oh+GAklzNNJyXwf/ygZ8L7hkL1fTjvLp78+r9k1ojcvEbn\nH8oNRpgkFau77MaPVWznVV4qgQKF2wRx9bDcTnRspJ8Jemgjk7nwwhZe8L42\nB5ZEUwVPGAPWPMXRsvkF0VSVFerGGgUluleBqsGe2xE9kk24vPv/4cAZFZnu\nwCsN7xtyLs8m6/YkOe5U5PJMW0RHt76gfghMwDzZIcZBNZECCC4PA3hqbGve\n1wsdSnzR+ELRi9GYLyab+5NO3OK78WTWw8MrnFYtwMS8uscc4cAl1WGnhkvu\nR2zjksu035ojjFOaGN7QxVdx4ZOP0Y0hnRhKVmEUHZ0Z0Yqo1Q0OHR5Egmlm\nhg/k\r\n=EGkU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "1.6.18": {
+      "name": "type-is",
+      "version": "1.6.18",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "devDependencies": {
+        "eslint": "5.16.0",
+        "eslint-config-standard": "12.0.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-markdown": "1.0.0",
+        "eslint-plugin-node": "8.0.1",
+        "eslint-plugin-promise": "4.1.1",
+        "eslint-plugin-standard": "4.0.0",
+        "mocha": "6.1.4",
+        "nyc": "14.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+        "shasum": "4e552cd05df09467dcbc4ef739de89f2cf37c131",
+        "tarball": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+        "fileCount": 5,
+        "unpackedSize": 18497,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcww7VCRA9TVsSAnZWagAADo4P/isJIJ9PaSvaRKD2jXlI\nfnZaodUUUdgiQfzG0uL2nvb7F4iHg6ddCEG5ofw4MzDQAXpsmv2r7F/3CVE7\n6KvUo5mVJ/KngeH95DxUcef/bTTAbCFdht7gbTFpZ0UKM4Ow3iuvgyvz/3aI\nJgkxqw8WgY/IdFk5NVZ3g5x8kGWXD1Llf44LLptYZ3R9J2u73CDP3ft9nE1Y\np9NAu3X0NH11U6IFNS+T62hehOfdsJUjY1XZc6142m7KsXjiDxISiX2tj0kg\n1DsW7oOJeWnbOJSxxfiI4Np1T0gRupjYfFBg/Fsfl6p+qcOAgQYMZTqv2iR+\nWSD9QuL/QYiYKqfAiumnC3uxPkT6AUqohIzk5HUSXrJcuyCmFWNDIO3MllC7\nW+9Ac6+qkN+dMGRx9hWS632uyb6AxbbulXNPbv//JwGzSyu+gLSkOQgk0vto\ngMYi7HUbQQquVBftMs7OqZ3HiP4q1gMr1H4PuoUUQw1FzxgSi6gY8hJriqM/\nPSKVym4y0Umict5DJnirgtSIAArTLVHAmEcY1XRFJB43HLrkNdcCpVH6FfRh\nvZ3dQsN5HQA0ioRyCstwsjDAbEzYStPIXmBOdBFmNnRIMoBe/16HbNZbO208\nKODasC9g3GHFn/IGgr3h8gW+WD76ISD5zUFshm0w4eJGx9XKtzhhjicnm6PO\nO1q0\r\n=WOqY\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    }
+  },
+  "modified": "2019-04-26T13:59:51.822Z"
+}

--- a/test/fixtures/registry-mocks/content/types/glob.json
+++ b/test/fixtures/registry-mocks/content/types/glob.json
@@ -1,0 +1,1141 @@
+{
+  "_id": "@types/glob",
+  "_rev": "540-cdf6d14e699fbc03cfb840f7b69e2b55",
+  "name": "@types/glob",
+  "description": "TypeScript definitions for Glob",
+  "dist-tags": {
+    "latest": "7.1.3",
+    "ts2.0": "7.1.1",
+    "ts2.1": "7.1.1",
+    "ts2.2": "7.1.1",
+    "ts2.3": "7.1.1",
+    "ts2.4": "7.1.1",
+    "ts2.5": "7.1.1",
+    "ts2.6": "7.1.1",
+    "ts2.7": "7.1.1",
+    "ts2.8": "7.1.1",
+    "ts2.9": "7.1.1",
+    "ts3.0": "7.1.3",
+    "ts3.1": "7.1.3",
+    "ts3.2": "7.1.3",
+    "ts3.3": "7.1.3",
+    "ts3.4": "7.1.3",
+    "ts3.5": "7.1.3",
+    "ts3.6": "7.1.3",
+    "ts3.7": "7.1.3",
+    "ts3.8": "7.1.3",
+    "ts3.9": "7.1.3",
+    "ts4.0": "7.1.3",
+    "ts4.1": "7.1.3",
+    "ts4.2": "7.1.3"
+  },
+  "versions": {
+    "5.0.15-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.15-alpha",
+      "description": "Type definitions for Glob 5.0.10 from https://www.github.com/DefinitelyTyped/DefinitelyTyped",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "equire(\"events\"": "*",
+        "equire('fs'": "*",
+        "equire(\"../minimatch\"": "*"
+      },
+      "_id": "@types/glob@5.0.15-alpha",
+      "_shasum": "ab78a059faef97381a7bcb55e33e5488bd3d7915",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "ab78a059faef97381a7bcb55e33e5488bd3d7915",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.15-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.15-alpha.tgz_1463461309064_0.8073523284401745"
+      },
+      "directories": {}
+    },
+    "5.0.16-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.16-alpha",
+      "description": "Type definitions for Glob 5.0.10 from https://www.github.com/DefinitelyTyped/DefinitelyTyped",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "equire(\"events\"": "*",
+        "equire('fs'": "*",
+        "equire(\"../minimatch\"": "*",
+        "@types/node": "*"
+      },
+      "_id": "@types/glob@5.0.16-alpha",
+      "_shasum": "e759041f67b0e500a91fa10a1516230323d2a23c",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "e759041f67b0e500a91fa10a1516230323d2a23c",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.16-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.16-alpha.tgz_1463691569370_0.8603634051978588"
+      },
+      "directories": {}
+    },
+    "5.0.21-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.21-alpha",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "_id": "@types/glob@5.0.21-alpha",
+      "_shasum": "fbdfd766c739d804f76fa54a4dee8fef3ab8588a",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "fbdfd766c739d804f76fa54a4dee8fef3ab8588a",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.21-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.21-alpha.tgz_1463773229175_0.4415250865276903"
+      },
+      "directories": {}
+    },
+    "5.0.22-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.22-alpha",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "_id": "@types/glob@5.0.22-alpha",
+      "_shasum": "0c275df676c4ba7a1c92a9df440f1a9d43e32c78",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "0c275df676c4ba7a1c92a9df440f1a9d43e32c78",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.22-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.22-alpha.tgz_1464152316741_0.8522203208412975"
+      },
+      "directories": {}
+    },
+    "5.0.23-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.23-alpha",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "@types/node": "4.0.*"
+      },
+      "_id": "@types/glob@5.0.23-alpha",
+      "_shasum": "a772ff78f6d087563830752b578b89877863d7c1",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "a772ff78f6d087563830752b578b89877863d7c1",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.23-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.23-alpha.tgz_1467401152251_0.9246603916399181"
+      },
+      "directories": {}
+    },
+    "5.0.24-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.24-alpha",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "@types/node": "4.0.23-alpha"
+      },
+      "_id": "@types/glob@5.0.24-alpha",
+      "_shasum": "dff53edbc3f0946e28be64fed8144e6081354cbd",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.7.2",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "dff53edbc3f0946e28be64fed8144e6081354cbd",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.24-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.24-alpha.tgz_1467413234463_0.21665450395084918"
+      },
+      "directories": {}
+    },
+    "5.0.25-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.25-alpha",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "@types/node": "4.0.24-alpha"
+      },
+      "_id": "@types/glob@5.0.25-alpha",
+      "_shasum": "a539932beb2d1d0d75287846c43e7ec7eaeddb89",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.7.2",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "a539932beb2d1d0d75287846c43e7ec7eaeddb89",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.25-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.25-alpha.tgz_1467426577295_0.7639074916951358"
+      },
+      "directories": {}
+    },
+    "5.0.26-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.26-alpha",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "@types/node": "4.0.26-alpha"
+      },
+      "_id": "@types/glob@5.0.26-alpha",
+      "_shasum": "b2f5dc078fe88a7f7c5728c0230c80cff6540841",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.7.2",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "b2f5dc078fe88a7f7c5728c0230c80cff6540841",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.26-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.26-alpha.tgz_1467591429355_0.9813095876015723"
+      },
+      "directories": {}
+    },
+    "5.0.28-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.28-alpha",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "@types/minimatch": "2.0.27-alpha",
+        "@types/node": "4.0.27-alpha"
+      },
+      "_id": "@types/glob@5.0.28-alpha",
+      "_shasum": "d46f326ee3e9207e5b426f2dbd27436bda82fd13",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "d46f326ee3e9207e5b426f2dbd27436bda82fd13",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.28-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.28-alpha.tgz_1468008722502_0.4580145035870373"
+      },
+      "directories": {}
+    },
+    "5.0.29": {
+      "name": "@types/glob",
+      "version": "5.0.29",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {
+        "@types/minimatch": "2.0.*",
+        "@types/node": "4.0.*"
+      },
+      "_id": "@types/glob@5.0.29",
+      "_shasum": "2a7940179f1e066d575579dc6e8309eb5cfe2d1a",
+      "_from": "output\\glob",
+      "_resolved": "file:output\\glob",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "dist": {
+        "shasum": "2a7940179f1e066d575579dc6e8309eb5cfe2d1a",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.29.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.29.tgz_1468507312972_0.6603656003717333"
+      },
+      "directories": {}
+    },
+    "5.0.30": {
+      "name": "@types/glob",
+      "version": "5.0.30",
+      "description": "TypeScript definitions for Glob 5.0.10",
+      "license": "MIT",
+      "author": "vvakame <https://github.com/vvakame/>",
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typings": "index.d.ts",
+      "typesPublisherContentHash": "8c143641642f0e205786502b11aa75903aa26780b026607ed34de6e0836fe815",
+      "_id": "@types/glob@5.0.30",
+      "dist": {
+        "shasum": "1026409c5625a8689074602808d082b2867b8a51",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.30.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/glob-5.0.30.tgz_1474306440344_0.5621657641604543"
+      },
+      "directories": {}
+    },
+    "5.0.31": {
+      "name": "@types/glob",
+      "version": "5.0.31",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame/"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy/"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "peerDependencies": {},
+      "typesPublisherContentHash": "d5132bcab580a95ec4db422c769a8e515e43a4ddd79f86cea96a1c6d951df220",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/glob@5.0.31",
+      "dist": {
+        "integrity": "sha512-O6uyCgmMT58nQCdkxvDlil19iYodPTpWPtJc4tWAyjMTZUHjJyXaTJpxDfnuNyzTsLGba+AXIeYwFu3Y8lo+Jw==",
+        "shasum": "6cb8500bd170750c1948f785cc5828e9cff0c36a",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.31.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob-5.0.31.tgz_1502820706548_0.05811617011204362"
+      },
+      "directories": {}
+    },
+    "5.0.32": {
+      "name": "@types/glob",
+      "version": "5.0.32",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "4645ba54f571f547180f74d880c42c4f0a06839f5d0b19dc9a1e5027aa1f8947",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/glob@5.0.32",
+      "dist": {
+        "integrity": "sha512-DMcj5b67Alb/e4KhpzyvphC5nVDHn1oCOGZao3oBddZVMH5vgI/cvdp+O/kcxZGZaPqs0ZLAsK4YrjbtZHO05g==",
+        "shasum": "aec5cfe987c72f099fdb1184452986aa506d5e8f",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.32.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob-5.0.32.tgz_1503352356175_0.2661672660615295"
+      },
+      "directories": {}
+    },
+    "5.0.33": {
+      "name": "@types/glob",
+      "version": "5.0.33",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy",
+          "githubUsername": "voy"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "3b61088a270ca9ff3767ea76660338bea395245f257ab39701a3b645852c80aa",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/glob@5.0.33",
+      "dist": {
+        "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+        "shasum": "3dff7c6ce09d65abe919c7961dc3dee016f36ad7",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob-5.0.33.tgz_1507124261575_0.537655736785382"
+      },
+      "directories": {}
+    },
+    "5.0.34": {
+      "name": "@types/glob",
+      "version": "5.0.34",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy",
+          "githubUsername": "voy"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "56900e2c5f1f06dd0be7553516efaec9abb4262e91ee787e2a3a1f71a6b437a4",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/glob@5.0.34",
+      "dist": {
+        "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
+        "shasum": "ee626c9be3da877d717911c6101eee0a9871bbf4",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob-5.0.34.tgz_1513098894690_0.3784917686134577"
+      },
+      "directories": {}
+    },
+    "5.0.35": {
+      "name": "@types/glob",
+      "version": "5.0.35",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy",
+          "githubUsername": "voy"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "42323e062a8446e6944dca28db363f8464acd6d2b04408df8173b4697a413e85",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/glob@5.0.35",
+      "dist": {
+        "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+        "shasum": "1ae151c802cece940443b5ac246925c85189f32a",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob-5.0.35.tgz_1516737973043_0.20321329892612994"
+      },
+      "directories": {}
+    },
+    "5.0.36": {
+      "name": "@types/glob",
+      "version": "5.0.36",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy",
+          "githubUsername": "voy"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "be647ff0f41782a60bcc1124f52138f4550638a512860e925c1aefc40942a201",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/glob@5.0.36",
+      "dist": {
+        "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
+        "shasum": "0c80a9c8664fc7d19781de229f287077fd622cb2",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6024,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbomvKCRA9TVsSAnZWagAAj38P/RUvfZja7qOv44l/NqTU\nPPE8ftV8mcGjV8adviRU6N/YnAu4+UEvNW9Zpa00aYsC6gg2m8oEJlk+kl01\niaJd709d9urluFgiXOC3ZPjjAEf38JlCd7FNnwKj48OnD6EtY9SzZ0aHq2Zj\nNCf9mbMaBpyLyg3XQlY27GiEIm8GLvmagmc4kfGwObMUHZW07bdBeoBapI0h\nEONikG4qL2KeYgMXPWnf9vyelLcvixU/EzarKlgpKF5RYGZi+Ay32t9c4n5m\nIvi1tR5qiFQVuPN7AvJLwrWgsGQlCDTtfSPh6uncwPuVSeb1XNzADMOgPS8/\n1eMfcXltTAeSxTj30BaSE1c8A0v1mKb6JfbXqx9VojrBlB/ZvMp9HVL3cujN\nsjSxlf2Jau/F6zKd2nhZnZZKPhXY7XfPgF4Y40bfuVFY4rzVLYSUAwX7R6RL\nTTtC0Rxz84itN/WL9bd+JGtYwiUD488dha+AR+tGd0hKzNcZQQbXb65fL6Qa\nb7f8AE93/TK3+MFLrdcCZI+yVwSsP/9b5ywBxseSLwsoZtvmpi9gj7rKDBkL\nsaK7VLZRbzDK6MjGWONZWf0kepe6w2bWJMYcXH5bGs41KaHOeqvKn12rWjgi\nkOT9gmhR/sZA2akIRjO/fYaATvwKwvSRzIOLTlUKvVlrsDf+0wErRLuezGWl\nU4SN\r\n=IbaC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob_5.0.36_1537371081339_0.1376341826648253"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.1.0": {
+      "name": "@types/glob",
+      "version": "7.1.0",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy",
+          "githubUsername": "voy"
+        },
+        {
+          "name": "Klaus Meinhardt",
+          "url": "https://github.com/ajafff",
+          "githubUsername": "ajafff"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "78d17496a0474ac16e1a7cea259c6ae5ba276f2f354ca1d09a7164612ac64835",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/glob@7.1.0",
+      "dist": {
+        "integrity": "sha512-k1M3Y8Ge0bOkG7U5IZObIhkrzZHMpuFpd5RJK9Gh8ekq0EhiezLLqv2ow14ylTKqXTHSqM6AMySbWEHRo+7qdQ==",
+        "shasum": "55ff6b216e9100b22eccec2cfe2e251ccb09a6ab",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-7.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5743,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbomvSCRA9TVsSAnZWagAAOKgQAI8RiEJEXdkWHXFbi19h\naARaygp1fK/VNHopeW68QkHb/S5TxVpkQbnK/x4uo9awA0jnOdXa2Z3PI0fI\n3pXupcC9rF7IvgO3XnD02v84HQffIBKnL+lfYbblgpfJlfcS7PXpKV651Gcj\nxDz6B02udybm/H0QFtBQnqtHc40t1wMALVqC4vgAAt70PRuD9Q5KzEx8KRYy\nKIfIcgDBnBYBf5ngNJqiOJI/1QGRJdAvSdrmBSZscg/Xol61wRBqyBsWgly5\n2KuJvnJQm37txr+WVUxrXTuFhXdrNZHOdvHoOgzrtjDfDMWxc5WCRgd1YfjA\nBfDAX5ivuOQbsrxl3MKwBDMfSkMDZEYfTW4FxRTZUfq6/I7kIgzYDEM7r6ji\n+fZSkx6UfTthebzGqoU7aVaxWIo9GmPEb2nEBIVMFt7+BZAsQT8oWL8lV1wB\nFoWWzNMyVXkSBOKvPq1tHiELteeEVMxU8a14mYpIem9LvSBPTz0EXY2qc2Jj\nUN5WMbdLx4yc2J0+oLpbdTGuwfVfBOA/87XlxkSttUf+BOfqlyQ3tZPoLcsi\nrotfZVsIKc52xVVL/aE7L9nKSeOFL6IMW4/uENK6w1yiEDv3CdTx8hmADKVx\njNmT1qUPeHyB6pE+jLvv0/LcmiJWVIqJTFXnXzV9bTRKZd4bKl4H5sFNuE3u\n8MYp\r\n=o9lz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob_7.1.0_1537371090326_0.519892322086219"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.1.1": {
+      "name": "@types/glob",
+      "version": "7.1.1",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy",
+          "githubUsername": "voy"
+        },
+        {
+          "name": "Klaus Meinhardt",
+          "url": "https://github.com/ajafff",
+          "githubUsername": "ajafff"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "43019f2af91c7a4ca3453c4b806a01c521ca3008ffe1bfefd37c5f9d6135660e",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/glob@7.1.1",
+      "dist": {
+        "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+        "shasum": "aa59a1c6e3fbc421e07ccd31a944c30eba521575",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5782,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbrNCZCRA9TVsSAnZWagAAeXwP/3VI0PE/NZlUx0ENknx+\nwyK5BlhAYCGBPBkdXj5+VTMBHUhPs7I+Dlh21teoLrf5CSregwHs4hO05W14\ny4fK8rNO2/dt9cM0kN7VPySeB1+Wu4u0SfYbTQEORSOokBvxYGUHZOGYR0oN\nK/gMa9aLSunfRZfHwME3lWQAGKzMnXM2KjqM0nEXYNnpvuQ6QjoAbkSCcqJ1\nUEJek81bK+0VBUhlzPfxVqzBX5UjUl6yIIsQv9HcGyKURXoJ46pnZ26+Cf2u\naPu+IFDzcBBAHXOxn6iV5krJrwDmXe2KrHVPxES6XzpPK3OxOFZmOm0odere\nTJ6f9CKLAI8SIa7R1lngarRepo2O8+5g7hDJ01z/KvC2n6WHXoq9kC1BtyuL\nQ9Xoxj7QymwmpIa0g6FSDp56k8yj+7RMgTqBEwgtnUMS2Qg3oHdyv6qLslbo\naM39vQJct0gBjr0kdMAoBBUAuR6nmcuXsFu1IZXxCYsmLjWrEOW5pEOv2Txe\nyqySSJSCoiP9tZvDdhgmtUmI+V/hu08KVdwX4kLGTuts358qkMeWKj9NCXBg\nPE0FyUsd4AiG4L45UzjxFM1TDBlJ7mG+SYMzv9CJOO3fWzzvqUp+03OBsUvn\nBmb/PhMpkrnKozpSBZB9+VMXuO61KN5iETV5nS550CX0FBs4GbTQp6Q4Rz/9\nszf2\r\n=MFu9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob_7.1.1_1538052249169_0.21540510590741557"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.1.2": {
+      "name": "@types/glob",
+      "version": "7.1.2",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy",
+          "githubUsername": "voy"
+        },
+        {
+          "name": "Klaus Meinhardt",
+          "url": "https://github.com/ajafff",
+          "githubUsername": "ajafff"
+        },
+        {
+          "name": "Piotr Błażejewicz",
+          "url": "https://github.com/peterblazejewicz",
+          "githubUsername": "peterblazejewicz"
+        }
+      ],
+      "main": "",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/glob"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "a3c6d67583df2dafd612ed7524e4871a09904af1d71d500436bca5e9047e25d4",
+      "typeScriptVersion": "3.0",
+      "_id": "@types/glob@7.1.2",
+      "dist": {
+        "integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
+        "shasum": "06ca26521353a545d94a0adc74f38a59d232c987",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6104,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe2YauCRA9TVsSAnZWagAA3d4P/2Ff4+sXK6zpz+94sdu8\nE/BHIr8WYe1dC16oeDQNCqxGK1RokLO4pwB+vR8o1OyZ1rYXiJNYkiU73PxF\nrIGvo+341lKN2PzjYwzZVLmSfV6rcx5DSfgM9raGpCQsUM4htkhgk8Ay6W+S\nBI9HMSAd9azB0bpigju1S2fFGHaVp2cDZzexAgT3TB6hpMN21C8EdS+iuTQP\nXAjooCaM4x/aIjsh0chXZdhzlF4JVGnacOUK2F1uzjx+metv+aKCOj24hKiE\niHHy0LKMENeAJvmuJvMsjmp14DN3qO0pM02cMdr2okBIQ+yKvTbF3s2jReFL\noACaM99F5QX40nLaXmtDFTnk+8StzZcnC6xjfa+kLk6RFUaZPzTIcMNfgknX\nx6xEuDBALXm7zERkSa+v1vIJ7t7+qW7PRrLW1us/vqbTCkarenKjMbim3/yz\neTwOIi1PJsjdGcaM2BkrTRLud66ETNMcNXti6ZiFRy3TLaH7CAzOlUXK/nWU\nk/HT5ss+g6Tm43hL9Fvjz5Tk4bw6XMZzARz/T4Z/b/dj57yyNMptGzqGOinG\nA+rfE+Y5TNT5xb0Kqz168RvtjXFfINaT+dJuO8UfRne2sFvYBjl6pqv+VQ2H\nhpvMLszBlnbHHApUn42CFCrcJQd2LhXzp6WUyvF3pzlVxZK85/t/CvYVOtVt\n5HpN\r\n=Ggx4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob_7.1.2_1591314091180_0.9988084229898508"
+      },
+      "_hasShrinkwrap": false
+    },
+    "7.1.3": {
+      "name": "@types/glob",
+      "version": "7.1.3",
+      "description": "TypeScript definitions for Glob",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "voy",
+          "url": "https://github.com/voy",
+          "githubUsername": "voy"
+        },
+        {
+          "name": "Klaus Meinhardt",
+          "url": "https://github.com/ajafff",
+          "githubUsername": "ajafff"
+        },
+        {
+          "name": "Piotr Błażejewicz",
+          "url": "https://github.com/peterblazejewicz",
+          "githubUsername": "peterblazejewicz"
+        }
+      ],
+      "main": "",
+      "types": "index.d.ts",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+        "directory": "types/glob"
+      },
+      "scripts": {},
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "typesPublisherContentHash": "7749df2e489409fe93fbc5902be2e14db351a40c53d972c3b2fd802ed2b175e1",
+      "typeScriptVersion": "3.0",
+      "_id": "@types/glob@7.1.3",
+      "dist": {
+        "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+        "shasum": "e6ba80f36b7daad2c685acd9266382e68985c183",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6128,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfA7jnCRA9TVsSAnZWagAAckQP/jXoz0ANdqPAIsZ0FbEU\noogAjBpPXv+DItUtwTCeRfr4WM1pLorZW6MvLmHtO5CAc5f4IGUiRuc8suJH\nim+304lE58kU2PlzV/U5mDRcHe50z+Kz9w2oIGYzH9i9GDxvsf0d31b9SOTB\n7oHcTeAnpMLKn2dfe/1g5NHd88t3rNW/x5u+Av49ucwaPSTFx/7y7Te3lSlX\n5A3pi2Le9Uns7C+2Tyz8696qP2f85JsL/Bzfw+U85Y7W786yOe1HPhMTWU7E\nVKAJ5AEfAsCxPteSyueCD1/4eciTzr6Uksr3uCpsGNkaAgSCFqaNeVXGIK2+\niaFjym0cUHtJ6TJ9sz2apuI2NQcc2agDlskVZtvPWF0VS4ZR1oPLJ/eyPRjf\nKiE2pmf6K1SBgUidWRTT/6RbWTeBJ0Mmsk6d8LdqIVXeAXkcbS1dnQ/vjdIj\nDfK/buC7l6znPdxM97Q0MTlfpFHQAgm/5O60Ueu2Ct8SajNDDHka0hNZ75cm\nEvJWo+VECTEc92ATWXbou+xTN97HqjFYHvbXuvzpG0bXgLeCtc8QkrTTN1pF\nKrssW9j0BeZ89TLC+T1Abv+P3EMdMlDhZcay7t/UpMzYq8KqiXfM9j4zed4n\nQ/uzlCKy+/4Uy2J7KBy/cemTShPbtrB5QZM0W4QMjL4tinX1cD4cJJtXONsi\nCQQ7\r\n=Cj1T\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/glob_7.1.3_1594079462669_0.34577343693169005"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Installation\r\n> `npm install --save @types/glob`\r\n\r\n# Summary\r\nThis package contains type definitions for Glob (https://github.com/isaacs/node-glob).\r\n\r\n# Details\r\nFiles were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/glob.\r\n\r\n### Additional Details\r\n * Last updated: Mon, 06 Jul 2020 23:50:37 GMT\r\n * Dependencies: [@types/minimatch](https://npmjs.com/package/@types/minimatch), [@types/node](https://npmjs.com/package/@types/node)\r\n * Global values: none\r\n\r\n# Credits\r\nThese definitions were written by [vvakame](https://github.com/vvakame), [voy](https://github.com/voy), [Klaus Meinhardt](https://github.com/ajafff), and [Piotr Błażejewicz](https://github.com/peterblazejewicz).\r\n",
+  "maintainers": [
+    {
+      "email": "ts-npm-types@microsoft.com",
+      "name": "types"
+    }
+  ],
+  "time": {
+    "modified": "2020-11-11T17:25:54.251Z",
+    "created": "2016-05-17T05:01:49.638Z",
+    "5.0.15-alpha": "2016-05-17T05:01:49.638Z",
+    "5.0.16-alpha": "2016-05-19T20:59:29.954Z",
+    "5.0.21-alpha": "2016-05-20T19:40:31.262Z",
+    "5.0.22-alpha": "2016-05-25T04:58:39.192Z",
+    "5.0.23-alpha": "2016-07-01T19:25:54.297Z",
+    "5.0.24-alpha": "2016-07-01T22:47:15.047Z",
+    "5.0.25-alpha": "2016-07-02T02:29:37.779Z",
+    "5.0.26-alpha": "2016-07-04T00:17:12.891Z",
+    "5.0.28-alpha": "2016-07-08T20:12:02.968Z",
+    "5.0.29": "2016-07-14T14:41:55.064Z",
+    "5.0.30": "2016-09-19T17:34:00.587Z",
+    "5.0.31": "2017-08-15T18:11:46.616Z",
+    "5.0.32": "2017-08-21T21:52:36.265Z",
+    "5.0.33": "2017-10-04T13:37:41.661Z",
+    "5.0.34": "2017-12-12T17:14:54.741Z",
+    "5.0.35": "2018-01-23T20:06:13.149Z",
+    "5.0.36": "2018-09-19T15:31:21.510Z",
+    "7.1.0": "2018-09-19T15:31:30.446Z",
+    "7.1.1": "2018-09-27T12:44:09.250Z",
+    "7.1.2": "2020-06-04T23:41:31.295Z",
+    "7.1.3": "2020-07-06T23:51:02.774Z"
+  },
+  "license": "MIT",
+  "readmeFilename": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+    "directory": "types/glob"
+  },
+  "contributors": [
+    {
+      "name": "vvakame",
+      "url": "https://github.com/vvakame",
+      "githubUsername": "vvakame"
+    },
+    {
+      "name": "voy",
+      "url": "https://github.com/voy",
+      "githubUsername": "voy"
+    },
+    {
+      "name": "Klaus Meinhardt",
+      "url": "https://github.com/ajafff",
+      "githubUsername": "ajafff"
+    },
+    {
+      "name": "Piotr Błażejewicz",
+      "url": "https://github.com/peterblazejewicz",
+      "githubUsername": "peterblazejewicz"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/types/glob.min.json
+++ b/test/fixtures/registry-mocks/content/types/glob.min.json
@@ -1,0 +1,311 @@
+{
+  "name": "@types/glob",
+  "dist-tags": {
+    "latest": "7.1.3",
+    "ts2.0": "7.1.1",
+    "ts2.1": "7.1.1",
+    "ts2.2": "7.1.1",
+    "ts2.3": "7.1.1",
+    "ts2.4": "7.1.1",
+    "ts2.5": "7.1.1",
+    "ts2.6": "7.1.1",
+    "ts2.7": "7.1.1",
+    "ts2.8": "7.1.1",
+    "ts2.9": "7.1.1",
+    "ts3.0": "7.1.3",
+    "ts3.1": "7.1.3",
+    "ts3.2": "7.1.3",
+    "ts3.3": "7.1.3",
+    "ts3.4": "7.1.3",
+    "ts3.5": "7.1.3",
+    "ts3.6": "7.1.3",
+    "ts3.7": "7.1.3",
+    "ts3.8": "7.1.3",
+    "ts3.9": "7.1.3",
+    "ts4.0": "7.1.3",
+    "ts4.1": "7.1.3",
+    "ts4.2": "7.1.3"
+  },
+  "versions": {
+    "5.0.15-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.15-alpha",
+      "dependencies": {
+        "equire(\"events\"": "*",
+        "equire('fs'": "*",
+        "equire(\"../minimatch\"": "*"
+      },
+      "dist": {
+        "shasum": "ab78a059faef97381a7bcb55e33e5488bd3d7915",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.15-alpha.tgz"
+      }
+    },
+    "5.0.16-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.16-alpha",
+      "dependencies": {
+        "equire(\"events\"": "*",
+        "equire('fs'": "*",
+        "equire(\"../minimatch\"": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "shasum": "e759041f67b0e500a91fa10a1516230323d2a23c",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.16-alpha.tgz"
+      }
+    },
+    "5.0.21-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.21-alpha",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "dist": {
+        "shasum": "fbdfd766c739d804f76fa54a4dee8fef3ab8588a",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.21-alpha.tgz"
+      }
+    },
+    "5.0.22-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.22-alpha",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "dist": {
+        "shasum": "0c275df676c4ba7a1c92a9df440f1a9d43e32c78",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.22-alpha.tgz"
+      }
+    },
+    "5.0.23-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.23-alpha",
+      "dependencies": {
+        "@types/node": "4.0.*"
+      },
+      "dist": {
+        "shasum": "a772ff78f6d087563830752b578b89877863d7c1",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.23-alpha.tgz"
+      }
+    },
+    "5.0.24-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.24-alpha",
+      "dependencies": {
+        "@types/node": "4.0.23-alpha"
+      },
+      "dist": {
+        "shasum": "dff53edbc3f0946e28be64fed8144e6081354cbd",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.24-alpha.tgz"
+      }
+    },
+    "5.0.25-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.25-alpha",
+      "dependencies": {
+        "@types/node": "4.0.24-alpha"
+      },
+      "dist": {
+        "shasum": "a539932beb2d1d0d75287846c43e7ec7eaeddb89",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.25-alpha.tgz"
+      }
+    },
+    "5.0.26-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.26-alpha",
+      "dependencies": {
+        "@types/node": "4.0.26-alpha"
+      },
+      "dist": {
+        "shasum": "b2f5dc078fe88a7f7c5728c0230c80cff6540841",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.26-alpha.tgz"
+      }
+    },
+    "5.0.28-alpha": {
+      "name": "@types/glob",
+      "version": "5.0.28-alpha",
+      "dependencies": {
+        "@types/minimatch": "2.0.27-alpha",
+        "@types/node": "4.0.27-alpha"
+      },
+      "dist": {
+        "shasum": "d46f326ee3e9207e5b426f2dbd27436bda82fd13",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.28-alpha.tgz"
+      }
+    },
+    "5.0.29": {
+      "name": "@types/glob",
+      "version": "5.0.29",
+      "dependencies": {
+        "@types/minimatch": "2.0.*",
+        "@types/node": "4.0.*"
+      },
+      "dist": {
+        "shasum": "2a7940179f1e066d575579dc6e8309eb5cfe2d1a",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.29.tgz"
+      }
+    },
+    "5.0.30": {
+      "name": "@types/glob",
+      "version": "5.0.30",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "shasum": "1026409c5625a8689074602808d082b2867b8a51",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.30.tgz"
+      }
+    },
+    "5.0.31": {
+      "name": "@types/glob",
+      "version": "5.0.31",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-O6uyCgmMT58nQCdkxvDlil19iYodPTpWPtJc4tWAyjMTZUHjJyXaTJpxDfnuNyzTsLGba+AXIeYwFu3Y8lo+Jw==",
+        "shasum": "6cb8500bd170750c1948f785cc5828e9cff0c36a",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.31.tgz"
+      }
+    },
+    "5.0.32": {
+      "name": "@types/glob",
+      "version": "5.0.32",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-DMcj5b67Alb/e4KhpzyvphC5nVDHn1oCOGZao3oBddZVMH5vgI/cvdp+O/kcxZGZaPqs0ZLAsK4YrjbtZHO05g==",
+        "shasum": "aec5cfe987c72f099fdb1184452986aa506d5e8f",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.32.tgz"
+      }
+    },
+    "5.0.33": {
+      "name": "@types/glob",
+      "version": "5.0.33",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+        "shasum": "3dff7c6ce09d65abe919c7961dc3dee016f36ad7",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz"
+      }
+    },
+    "5.0.34": {
+      "name": "@types/glob",
+      "version": "5.0.34",
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
+        "shasum": "ee626c9be3da877d717911c6101eee0a9871bbf4",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz"
+      }
+    },
+    "5.0.35": {
+      "name": "@types/glob",
+      "version": "5.0.35",
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
+        "shasum": "1ae151c802cece940443b5ac246925c85189f32a",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz"
+      }
+    },
+    "5.0.36": {
+      "name": "@types/glob",
+      "version": "5.0.36",
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-KEzSKuP2+3oOjYYjujue6Z3Yqis5HKA1BsIC+jZ1v3lrRNdsqyNNtX0rQf6LSuI4DJJ2z5UV//zBZCcvM0xikg==",
+        "shasum": "0c80a9c8664fc7d19781de229f287077fd622cb2",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-5.0.36.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6024,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbomvKCRA9TVsSAnZWagAAj38P/RUvfZja7qOv44l/NqTU\nPPE8ftV8mcGjV8adviRU6N/YnAu4+UEvNW9Zpa00aYsC6gg2m8oEJlk+kl01\niaJd709d9urluFgiXOC3ZPjjAEf38JlCd7FNnwKj48OnD6EtY9SzZ0aHq2Zj\nNCf9mbMaBpyLyg3XQlY27GiEIm8GLvmagmc4kfGwObMUHZW07bdBeoBapI0h\nEONikG4qL2KeYgMXPWnf9vyelLcvixU/EzarKlgpKF5RYGZi+Ay32t9c4n5m\nIvi1tR5qiFQVuPN7AvJLwrWgsGQlCDTtfSPh6uncwPuVSeb1XNzADMOgPS8/\n1eMfcXltTAeSxTj30BaSE1c8A0v1mKb6JfbXqx9VojrBlB/ZvMp9HVL3cujN\nsjSxlf2Jau/F6zKd2nhZnZZKPhXY7XfPgF4Y40bfuVFY4rzVLYSUAwX7R6RL\nTTtC0Rxz84itN/WL9bd+JGtYwiUD488dha+AR+tGd0hKzNcZQQbXb65fL6Qa\nb7f8AE93/TK3+MFLrdcCZI+yVwSsP/9b5ywBxseSLwsoZtvmpi9gj7rKDBkL\nsaK7VLZRbzDK6MjGWONZWf0kepe6w2bWJMYcXH5bGs41KaHOeqvKn12rWjgi\nkOT9gmhR/sZA2akIRjO/fYaATvwKwvSRzIOLTlUKvVlrsDf+0wErRLuezGWl\nU4SN\r\n=IbaC\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.1.0": {
+      "name": "@types/glob",
+      "version": "7.1.0",
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-k1M3Y8Ge0bOkG7U5IZObIhkrzZHMpuFpd5RJK9Gh8ekq0EhiezLLqv2ow14ylTKqXTHSqM6AMySbWEHRo+7qdQ==",
+        "shasum": "55ff6b216e9100b22eccec2cfe2e251ccb09a6ab",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-7.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5743,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbomvSCRA9TVsSAnZWagAAOKgQAI8RiEJEXdkWHXFbi19h\naARaygp1fK/VNHopeW68QkHb/S5TxVpkQbnK/x4uo9awA0jnOdXa2Z3PI0fI\n3pXupcC9rF7IvgO3XnD02v84HQffIBKnL+lfYbblgpfJlfcS7PXpKV651Gcj\nxDz6B02udybm/H0QFtBQnqtHc40t1wMALVqC4vgAAt70PRuD9Q5KzEx8KRYy\nKIfIcgDBnBYBf5ngNJqiOJI/1QGRJdAvSdrmBSZscg/Xol61wRBqyBsWgly5\n2KuJvnJQm37txr+WVUxrXTuFhXdrNZHOdvHoOgzrtjDfDMWxc5WCRgd1YfjA\nBfDAX5ivuOQbsrxl3MKwBDMfSkMDZEYfTW4FxRTZUfq6/I7kIgzYDEM7r6ji\n+fZSkx6UfTthebzGqoU7aVaxWIo9GmPEb2nEBIVMFt7+BZAsQT8oWL8lV1wB\nFoWWzNMyVXkSBOKvPq1tHiELteeEVMxU8a14mYpIem9LvSBPTz0EXY2qc2Jj\nUN5WMbdLx4yc2J0+oLpbdTGuwfVfBOA/87XlxkSttUf+BOfqlyQ3tZPoLcsi\nrotfZVsIKc52xVVL/aE7L9nKSeOFL6IMW4/uENK6w1yiEDv3CdTx8hmADKVx\njNmT1qUPeHyB6pE+jLvv0/LcmiJWVIqJTFXnXzV9bTRKZd4bKl4H5sFNuE3u\n8MYp\r\n=o9lz\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.1.1": {
+      "name": "@types/glob",
+      "version": "7.1.1",
+      "dependencies": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+        "shasum": "aa59a1c6e3fbc421e07ccd31a944c30eba521575",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 5782,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbrNCZCRA9TVsSAnZWagAAeXwP/3VI0PE/NZlUx0ENknx+\nwyK5BlhAYCGBPBkdXj5+VTMBHUhPs7I+Dlh21teoLrf5CSregwHs4hO05W14\ny4fK8rNO2/dt9cM0kN7VPySeB1+Wu4u0SfYbTQEORSOokBvxYGUHZOGYR0oN\nK/gMa9aLSunfRZfHwME3lWQAGKzMnXM2KjqM0nEXYNnpvuQ6QjoAbkSCcqJ1\nUEJek81bK+0VBUhlzPfxVqzBX5UjUl6yIIsQv9HcGyKURXoJ46pnZ26+Cf2u\naPu+IFDzcBBAHXOxn6iV5krJrwDmXe2KrHVPxES6XzpPK3OxOFZmOm0odere\nTJ6f9CKLAI8SIa7R1lngarRepo2O8+5g7hDJ01z/KvC2n6WHXoq9kC1BtyuL\nQ9Xoxj7QymwmpIa0g6FSDp56k8yj+7RMgTqBEwgtnUMS2Qg3oHdyv6qLslbo\naM39vQJct0gBjr0kdMAoBBUAuR6nmcuXsFu1IZXxCYsmLjWrEOW5pEOv2Txe\nyqySSJSCoiP9tZvDdhgmtUmI+V/hu08KVdwX4kLGTuts358qkMeWKj9NCXBg\nPE0FyUsd4AiG4L45UzjxFM1TDBlJ7mG+SYMzv9CJOO3fWzzvqUp+03OBsUvn\nBmb/PhMpkrnKozpSBZB9+VMXuO61KN5iETV5nS550CX0FBs4GbTQp6Q4Rz/9\nszf2\r\n=MFu9\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.1.2": {
+      "name": "@types/glob",
+      "version": "7.1.2",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
+        "shasum": "06ca26521353a545d94a0adc74f38a59d232c987",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6104,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe2YauCRA9TVsSAnZWagAA3d4P/2Ff4+sXK6zpz+94sdu8\nE/BHIr8WYe1dC16oeDQNCqxGK1RokLO4pwB+vR8o1OyZ1rYXiJNYkiU73PxF\nrIGvo+341lKN2PzjYwzZVLmSfV6rcx5DSfgM9raGpCQsUM4htkhgk8Ay6W+S\nBI9HMSAd9azB0bpigju1S2fFGHaVp2cDZzexAgT3TB6hpMN21C8EdS+iuTQP\nXAjooCaM4x/aIjsh0chXZdhzlF4JVGnacOUK2F1uzjx+metv+aKCOj24hKiE\niHHy0LKMENeAJvmuJvMsjmp14DN3qO0pM02cMdr2okBIQ+yKvTbF3s2jReFL\noACaM99F5QX40nLaXmtDFTnk+8StzZcnC6xjfa+kLk6RFUaZPzTIcMNfgknX\nx6xEuDBALXm7zERkSa+v1vIJ7t7+qW7PRrLW1us/vqbTCkarenKjMbim3/yz\neTwOIi1PJsjdGcaM2BkrTRLud66ETNMcNXti6ZiFRy3TLaH7CAzOlUXK/nWU\nk/HT5ss+g6Tm43hL9Fvjz5Tk4bw6XMZzARz/T4Z/b/dj57yyNMptGzqGOinG\nA+rfE+Y5TNT5xb0Kqz168RvtjXFfINaT+dJuO8UfRne2sFvYBjl6pqv+VQ2H\nhpvMLszBlnbHHApUn42CFCrcJQd2LhXzp6WUyvF3pzlVxZK85/t/CvYVOtVt\n5HpN\r\n=Ggx4\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "7.1.3": {
+      "name": "@types/glob",
+      "version": "7.1.3",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      },
+      "dist": {
+        "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+        "shasum": "e6ba80f36b7daad2c685acd9266382e68985c183",
+        "tarball": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+        "fileCount": 4,
+        "unpackedSize": 6128,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfA7jnCRA9TVsSAnZWagAAckQP/jXoz0ANdqPAIsZ0FbEU\noogAjBpPXv+DItUtwTCeRfr4WM1pLorZW6MvLmHtO5CAc5f4IGUiRuc8suJH\nim+304lE58kU2PlzV/U5mDRcHe50z+Kz9w2oIGYzH9i9GDxvsf0d31b9SOTB\n7oHcTeAnpMLKn2dfe/1g5NHd88t3rNW/x5u+Av49ucwaPSTFx/7y7Te3lSlX\n5A3pi2Le9Uns7C+2Tyz8696qP2f85JsL/Bzfw+U85Y7W786yOe1HPhMTWU7E\nVKAJ5AEfAsCxPteSyueCD1/4eciTzr6Uksr3uCpsGNkaAgSCFqaNeVXGIK2+\niaFjym0cUHtJ6TJ9sz2apuI2NQcc2agDlskVZtvPWF0VS4ZR1oPLJ/eyPRjf\nKiE2pmf6K1SBgUidWRTT/6RbWTeBJ0Mmsk6d8LdqIVXeAXkcbS1dnQ/vjdIj\nDfK/buC7l6znPdxM97Q0MTlfpFHQAgm/5O60Ueu2Ct8SajNDDHka0hNZ75cm\nEvJWo+VECTEc92ATWXbou+xTN97HqjFYHvbXuvzpG0bXgLeCtc8QkrTTN1pF\nKrssW9j0BeZ89TLC+T1Abv+P3EMdMlDhZcay7t/UpMzYq8KqiXfM9j4zed4n\nQ/uzlCKy+/4Uy2J7KBy/cemTShPbtrB5QZM0W4QMjL4tinX1cD4cJJtXONsi\nCQQ7\r\n=Cj1T\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-11-11T17:25:54.251Z"
+}

--- a/test/fixtures/registry-mocks/content/types/minimatch.json
+++ b/test/fixtures/registry-mocks/content/types/minimatch.json
@@ -1,0 +1,717 @@
+{
+  "_id": "@types/minimatch",
+  "_rev": "473-d8aff0591b2fff93d5d497864bd5c15e",
+  "name": "@types/minimatch",
+  "description": "TypeScript definitions for Minimatch",
+  "dist-tags": {
+    "latest": "3.0.3",
+    "ts2.0": "3.0.3",
+    "ts2.1": "3.0.3",
+    "ts2.2": "3.0.3",
+    "ts2.3": "3.0.3",
+    "ts2.4": "3.0.3",
+    "ts2.5": "3.0.3",
+    "ts2.6": "3.0.3",
+    "ts2.7": "3.0.3",
+    "ts2.8": "3.0.3",
+    "ts2.9": "3.0.3",
+    "ts3.0": "3.0.3",
+    "ts3.1": "3.0.3",
+    "ts3.2": "3.0.3",
+    "ts3.3": "3.0.3",
+    "ts3.4": "3.0.3",
+    "ts3.5": "3.0.3",
+    "ts3.6": "3.0.3",
+    "ts3.7": "3.0.3",
+    "ts3.8": "3.0.3",
+    "ts3.9": "3.0.3",
+    "ts4.0": "3.0.3",
+    "ts4.1": "3.0.3",
+    "ts4.2": "3.0.3"
+  },
+  "versions": {
+    "2.0.15-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.15-alpha",
+      "description": "Type definitions for Minimatch 2.0.8 from https://www.github.com/DefinitelyTyped/DefinitelyTyped",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.15-alpha",
+      "_shasum": "4b82bee6424e2ae36794532c97200c431b0cdb7e",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "4b82bee6424e2ae36794532c97200c431b0cdb7e",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.15-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.15-alpha.tgz_1463509260437_0.06881573633290827"
+      },
+      "directories": {}
+    },
+    "2.0.16-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.16-alpha",
+      "description": "Type definitions for Minimatch 2.0.8 from https://www.github.com/DefinitelyTyped/DefinitelyTyped",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.16-alpha",
+      "_shasum": "24a4ee49643195ee525f3c1fffe027d724eac0c0",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "24a4ee49643195ee525f3c1fffe027d724eac0c0",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.16-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.16-alpha.tgz_1463694205189_0.48880110937170684"
+      },
+      "directories": {}
+    },
+    "2.0.21-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.21-alpha",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.21-alpha",
+      "_shasum": "4958036cdb07bb3d4dfe494c147b975c6e2acbab",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "4958036cdb07bb3d4dfe494c147b975c6e2acbab",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.21-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.21-alpha.tgz_1463775071545_0.22542174719274044"
+      },
+      "directories": {}
+    },
+    "2.0.22-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.22-alpha",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.22-alpha",
+      "_shasum": "0d07c7dc320d82b3bc05983f160dfa9832f806bd",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.8.2",
+      "_nodeVersion": "5.5.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "0d07c7dc320d82b3bc05983f160dfa9832f806bd",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.22-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.22-alpha.tgz_1464154121994_0.246622504433617"
+      },
+      "directories": {}
+    },
+    "2.0.23-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.23-alpha",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.23-alpha",
+      "_shasum": "61ebef68202309855917d7d6861e827fb95dcfaf",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "61ebef68202309855917d7d6861e827fb95dcfaf",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.23-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.23-alpha.tgz_1467403424361_0.3357722582295537"
+      },
+      "directories": {}
+    },
+    "2.0.24-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.24-alpha",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.24-alpha",
+      "_shasum": "7959c62c651cd4855073b584f2a72d1271f1a575",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.7.2",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "7959c62c651cd4855073b584f2a72d1271f1a575",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.24-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.24-alpha.tgz_1467415515603_0.12237580446526408"
+      },
+      "directories": {}
+    },
+    "2.0.25-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.25-alpha",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.25-alpha",
+      "_shasum": "1164590196d8ca7cd13e4a234888d73ae638c2a6",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.7.2",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "1164590196d8ca7cd13e4a234888d73ae638c2a6",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.25-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.25-alpha.tgz_1467428294835_0.4672903090249747"
+      },
+      "directories": {}
+    },
+    "2.0.26-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.26-alpha",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.26-alpha",
+      "_shasum": "e3f3072c6f6102b3bcfbe477f9cbbe0e9675ea8e",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.7.2",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "e3f3072c6f6102b3bcfbe477f9cbbe0e9675ea8e",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.26-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.26-alpha.tgz_1467593618491_0.3523154004942626"
+      },
+      "directories": {}
+    },
+    "2.0.27-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.27-alpha",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.27-alpha",
+      "_shasum": "53880efc2cc4994cd78ff20367ac426c538732ae",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ryan.cavanaugh@microsoft.com"
+      },
+      "dist": {
+        "shasum": "53880efc2cc4994cd78ff20367ac426c538732ae",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.27-alpha.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.27-alpha.tgz_1468011318069_0.23097137291915715"
+      },
+      "directories": {}
+    },
+    "2.0.28": {
+      "name": "@types/minimatch",
+      "version": "2.0.28",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "main": "",
+      "scripts": {},
+      "author": {
+        "name": "vvakame",
+        "email": "https://github.com/vvakame/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "license": "MIT",
+      "typings": "index.d.ts",
+      "dependencies": {},
+      "_id": "@types/minimatch@2.0.28",
+      "_shasum": "639343a6db0f4b3ab29f9ef5d4be64e58a6901e3",
+      "_from": "output\\minimatch",
+      "_resolved": "file:output\\minimatch",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.3.0",
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "dist": {
+        "shasum": "639343a6db0f4b3ab29f9ef5d4be64e58a6901e3",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.28.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.28.tgz_1468509857946_0.13842021790333092"
+      },
+      "directories": {}
+    },
+    "2.0.29": {
+      "name": "@types/minimatch",
+      "version": "2.0.29",
+      "description": "TypeScript definitions for Minimatch 2.0.8",
+      "license": "MIT",
+      "author": "vvakame <https://github.com/vvakame/>",
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {},
+      "typings": "index.d.ts",
+      "typesPublisherContentHash": "ecb8ae21708ffcd19d5ee21679b417d267e93ef05c1538f93b002dbd59fa5678",
+      "_id": "@types/minimatch@2.0.29",
+      "dist": {
+        "shasum": "5002e14f75e2d71e564281df0431c8c1b4a2a36a",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/minimatch-2.0.29.tgz_1474307523681_0.08793415850959718"
+      },
+      "directories": {}
+    },
+    "3.0.0": {
+      "name": "@types/minimatch",
+      "version": "3.0.0",
+      "description": "TypeScript definitions for Minimatch",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame/"
+        },
+        {
+          "name": "Shant Marouti",
+          "url": "https://github.com/shantmarouti"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {},
+      "peerDependencies": {},
+      "typesPublisherContentHash": "26473cc9b7b22e020ed0ce41df1f1bb8bbbb9e92243d38ce4052817ca7c02f21",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/minimatch@3.0.0",
+      "dist": {
+        "integrity": "sha512-BnRgLPs1oy9gV8b4dAW8jilIa7Kpe3uNucAvv4RkY7Yt6rj9E6Kk4Qa/18LOSinA+XDBPdzx3MqYPEP5mw8rDA==",
+        "shasum": "a8b68c324817169b6004b432a598478a5d8f025a",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "types",
+          "email": "ryan.cavanaugh@microsoft.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/minimatch-3.0.0.tgz_1502740052461_0.4426619743462652"
+      },
+      "directories": {}
+    },
+    "3.0.1": {
+      "name": "@types/minimatch",
+      "version": "3.0.1",
+      "description": "TypeScript definitions for Minimatch",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame"
+        },
+        {
+          "name": "Shant Marouti",
+          "url": "https://github.com/shantmarouti"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {},
+      "typesPublisherContentHash": "ff0924df2b181138d3a12e599083774880ccc0b9d31457017534e79a04bfba47",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/minimatch@3.0.1",
+      "dist": {
+        "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+        "shasum": "b683eb60be358304ef146f5775db4c0e3696a550",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/minimatch-3.0.1.tgz_1503352705164_0.3187303929589689"
+      },
+      "directories": {}
+    },
+    "3.0.2": {
+      "name": "@types/minimatch",
+      "version": "3.0.2",
+      "description": "TypeScript definitions for Minimatch",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "Shant Marouti",
+          "url": "https://github.com/shantmarouti",
+          "githubUsername": "shantmarouti"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {},
+      "typesPublisherContentHash": "a7d303b43c8df61588af3a4a0fbf4ea61a484ef0fbad093c052ed30cbdce909e",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/minimatch@3.0.2",
+      "dist": {
+        "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
+        "shasum": "09c06877e478a5d5f32ce5017c2eb2b33006f6f5",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/minimatch-3.0.2.tgz_1513192431324_0.6330664707347751"
+      },
+      "directories": {}
+    },
+    "3.0.3": {
+      "name": "@types/minimatch",
+      "version": "3.0.3",
+      "description": "TypeScript definitions for Minimatch",
+      "license": "MIT",
+      "contributors": [
+        {
+          "name": "vvakame",
+          "url": "https://github.com/vvakame",
+          "githubUsername": "vvakame"
+        },
+        {
+          "name": "Shant Marouti",
+          "url": "https://github.com/shantmarouti",
+          "githubUsername": "shantmarouti"
+        }
+      ],
+      "main": "",
+      "repository": {
+        "type": "git",
+        "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+      },
+      "scripts": {},
+      "dependencies": {},
+      "typesPublisherContentHash": "e768e36348874adcc93ac67e9c3c7b5fcbd39079c0610ec16e410b8f851308d1",
+      "typeScriptVersion": "2.0",
+      "_id": "@types/minimatch@3.0.3",
+      "dist": {
+        "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+        "shasum": "3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "ts-npm-types@microsoft.com",
+          "name": "types"
+        }
+      ],
+      "_npmUser": {
+        "name": "types",
+        "email": "ts-npm-types@microsoft.com"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/minimatch-3.0.3.tgz_1515108411163_0.2248273955192417"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# Installation\r\n> `npm install --save @types/minimatch`\r\n\r\n# Summary\r\nThis package contains type definitions for Minimatch (https://github.com/isaacs/minimatch).\r\n\r\n# Details\r\nFiles were exported from https://www.github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/minimatch\r\n\r\nAdditional Details\r\n * Last updated: Thu, 04 Jan 2018 23:26:01 GMT\r\n * Dependencies: none\r\n * Global values: none\r\n\r\n# Credits\r\nThese definitions were written by vvakame <https://github.com/vvakame>, Shant Marouti <https://github.com/shantmarouti>.\r\n",
+  "maintainers": [
+    {
+      "email": "ts-npm-types@microsoft.com",
+      "name": "types"
+    }
+  ],
+  "time": {
+    "modified": "2020-11-11T17:46:51.187Z",
+    "created": "2016-05-17T18:21:01.002Z",
+    "2.0.15-alpha": "2016-05-17T18:21:01.002Z",
+    "2.0.16-alpha": "2016-05-19T21:43:25.854Z",
+    "2.0.21-alpha": "2016-05-20T20:11:11.950Z",
+    "2.0.22-alpha": "2016-05-25T05:28:42.439Z",
+    "2.0.23-alpha": "2016-07-01T20:03:44.971Z",
+    "2.0.24-alpha": "2016-07-01T23:25:19.050Z",
+    "2.0.25-alpha": "2016-07-02T02:58:18.035Z",
+    "2.0.26-alpha": "2016-07-04T00:53:38.943Z",
+    "2.0.27-alpha": "2016-07-08T20:55:20.385Z",
+    "2.0.28": "2016-07-14T15:24:20.476Z",
+    "2.0.29": "2016-09-19T17:52:06.732Z",
+    "3.0.0": "2017-08-14T19:47:32.577Z",
+    "3.0.1": "2017-08-21T21:58:25.276Z",
+    "3.0.2": "2017-12-13T19:13:51.386Z",
+    "3.0.3": "2018-01-04T23:26:51.283Z"
+  },
+  "license": "MIT",
+  "readmeFilename": "",
+  "repository": {
+    "type": "git",
+    "url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"
+  },
+  "contributors": [
+    {
+      "name": "vvakame",
+      "url": "https://github.com/vvakame",
+      "githubUsername": "vvakame"
+    },
+    {
+      "name": "Shant Marouti",
+      "url": "https://github.com/shantmarouti",
+      "githubUsername": "shantmarouti"
+    }
+  ]
+}

--- a/test/fixtures/registry-mocks/content/types/minimatch.min.json
+++ b/test/fixtures/registry-mocks/content/types/minimatch.min.json
@@ -1,0 +1,156 @@
+{
+  "name": "@types/minimatch",
+  "dist-tags": {
+    "latest": "3.0.3",
+    "ts2.0": "3.0.3",
+    "ts2.1": "3.0.3",
+    "ts2.2": "3.0.3",
+    "ts2.3": "3.0.3",
+    "ts2.4": "3.0.3",
+    "ts2.5": "3.0.3",
+    "ts2.6": "3.0.3",
+    "ts2.7": "3.0.3",
+    "ts2.8": "3.0.3",
+    "ts2.9": "3.0.3",
+    "ts3.0": "3.0.3",
+    "ts3.1": "3.0.3",
+    "ts3.2": "3.0.3",
+    "ts3.3": "3.0.3",
+    "ts3.4": "3.0.3",
+    "ts3.5": "3.0.3",
+    "ts3.6": "3.0.3",
+    "ts3.7": "3.0.3",
+    "ts3.8": "3.0.3",
+    "ts3.9": "3.0.3",
+    "ts4.0": "3.0.3",
+    "ts4.1": "3.0.3",
+    "ts4.2": "3.0.3"
+  },
+  "versions": {
+    "2.0.15-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.15-alpha",
+      "dist": {
+        "shasum": "4b82bee6424e2ae36794532c97200c431b0cdb7e",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.15-alpha.tgz"
+      }
+    },
+    "2.0.16-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.16-alpha",
+      "dist": {
+        "shasum": "24a4ee49643195ee525f3c1fffe027d724eac0c0",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.16-alpha.tgz"
+      }
+    },
+    "2.0.21-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.21-alpha",
+      "dist": {
+        "shasum": "4958036cdb07bb3d4dfe494c147b975c6e2acbab",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.21-alpha.tgz"
+      }
+    },
+    "2.0.22-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.22-alpha",
+      "dist": {
+        "shasum": "0d07c7dc320d82b3bc05983f160dfa9832f806bd",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.22-alpha.tgz"
+      }
+    },
+    "2.0.23-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.23-alpha",
+      "dist": {
+        "shasum": "61ebef68202309855917d7d6861e827fb95dcfaf",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.23-alpha.tgz"
+      }
+    },
+    "2.0.24-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.24-alpha",
+      "dist": {
+        "shasum": "7959c62c651cd4855073b584f2a72d1271f1a575",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.24-alpha.tgz"
+      }
+    },
+    "2.0.25-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.25-alpha",
+      "dist": {
+        "shasum": "1164590196d8ca7cd13e4a234888d73ae638c2a6",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.25-alpha.tgz"
+      }
+    },
+    "2.0.26-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.26-alpha",
+      "dist": {
+        "shasum": "e3f3072c6f6102b3bcfbe477f9cbbe0e9675ea8e",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.26-alpha.tgz"
+      }
+    },
+    "2.0.27-alpha": {
+      "name": "@types/minimatch",
+      "version": "2.0.27-alpha",
+      "dist": {
+        "shasum": "53880efc2cc4994cd78ff20367ac426c538732ae",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.27-alpha.tgz"
+      }
+    },
+    "2.0.28": {
+      "name": "@types/minimatch",
+      "version": "2.0.28",
+      "dist": {
+        "shasum": "639343a6db0f4b3ab29f9ef5d4be64e58a6901e3",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.28.tgz"
+      }
+    },
+    "2.0.29": {
+      "name": "@types/minimatch",
+      "version": "2.0.29",
+      "dist": {
+        "shasum": "5002e14f75e2d71e564281df0431c8c1b4a2a36a",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-2.0.29.tgz"
+      }
+    },
+    "3.0.0": {
+      "name": "@types/minimatch",
+      "version": "3.0.0",
+      "dist": {
+        "integrity": "sha512-BnRgLPs1oy9gV8b4dAW8jilIa7Kpe3uNucAvv4RkY7Yt6rj9E6Kk4Qa/18LOSinA+XDBPdzx3MqYPEP5mw8rDA==",
+        "shasum": "a8b68c324817169b6004b432a598478a5d8f025a",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.0.tgz"
+      }
+    },
+    "3.0.1": {
+      "name": "@types/minimatch",
+      "version": "3.0.1",
+      "dist": {
+        "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+        "shasum": "b683eb60be358304ef146f5775db4c0e3696a550",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz"
+      }
+    },
+    "3.0.2": {
+      "name": "@types/minimatch",
+      "version": "3.0.2",
+      "dist": {
+        "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
+        "shasum": "09c06877e478a5d5f32ce5017c2eb2b33006f6f5",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz"
+      }
+    },
+    "3.0.3": {
+      "name": "@types/minimatch",
+      "version": "3.0.3",
+      "dist": {
+        "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+        "shasum": "3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d",
+        "tarball": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz"
+      }
+    }
+  },
+  "modified": "2020-11-11T17:46:51.187Z"
+}

--- a/test/fixtures/registry-mocks/content/unique-filename.json
+++ b/test/fixtures/registry-mocks/content/unique-filename.json
@@ -1,0 +1,221 @@
+{
+  "_id": "unique-filename",
+  "_rev": "21-583d19b84cd34086d9f2726bc41365bb",
+  "name": "unique-filename",
+  "description": "Generate a unique filename for use in temporary directories or caches.",
+  "dist-tags": {
+    "latest": "1.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "unique-filename",
+      "version": "1.0.0",
+      "description": "Generate a unique filename for use in temporary directories or caches.",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tap test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/iarna/unique-filename.git"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/unique-filename/issues"
+      },
+      "homepage": "https://github.com/iarna/unique-filename",
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap": "^1.0.0"
+      },
+      "dependencies": {
+        "unique-slug": "^1.0.0"
+      },
+      "gitHead": "935739361f6ecc7b613c5daf66a57b67938796d4",
+      "_id": "unique-filename@1.0.0",
+      "_shasum": "0bee4219e192e86da3c4ffc0cc6e054d8634eab9",
+      "_from": ".",
+      "_npmVersion": "2.7.6",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "dist": {
+        "shasum": "0bee4219e192e86da3c4ffc0cc6e054d8634eab9",
+        "tarball": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "unique-filename",
+      "version": "1.1.0",
+      "description": "Generate a unique filename for use in temporary directories or caches.",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tap test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/unique-filename.git"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/unique-filename/issues"
+      },
+      "homepage": "https://github.com/iarna/unique-filename",
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      },
+      "gitHead": "cb31644c71f842258a8019e0e6ef8f2b8533a5c0",
+      "_id": "unique-filename@1.1.0",
+      "_shasum": "d05f2fe4032560871f30e93cbe735eea201514f3",
+      "_from": ".",
+      "_npmVersion": "2.14.13",
+      "_nodeVersion": "4.2.2",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "shasum": "d05f2fe4032560871f30e93cbe735eea201514f3",
+        "tarball": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "unique-filename",
+      "version": "1.1.1",
+      "description": "Generate a unique filename for use in temporary directories or caches.",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tap test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/iarna/unique-filename.git"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org/"
+      },
+      "license": "ISC",
+      "bugs": {
+        "url": "https://github.com/iarna/unique-filename/issues"
+      },
+      "homepage": "https://github.com/iarna/unique-filename",
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      },
+      "gitHead": "3653bb94c8ae4497636f0767e0a35eb442b27d9f",
+      "_id": "unique-filename@1.1.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.10.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+        "shasum": "1d69769369ada0583103a1e6ae87681b56573230",
+        "tarball": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+        "fileCount": 15,
+        "unpackedSize": 41421,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbo83nCRA9TVsSAnZWagAAGUIP/RHKLBFB/61Nc2H7LVQj\n6aGrKRjQ+ZkQCGQODloPtfU8nQ94IJ7ZaD1ArcdDWu6oP2k5xJFsDKd/zxyQ\nPMPuAwkNDVZ4ndmRbKJ2Fzxq8B4eN20Q7t9PyvHWS2x8WOE1zzeLwDeBZI1f\nK8EUaTcaAj5du6TKUbnqVzqi5K2deWovlvDBPbFMqm84nO07Zbu50t0wHqDi\nIja76zlA8o2UiY2X4I044h8dV3n7wLF/yJoj7DPgcr+jrHY2R4BP/zMyjkZh\nRHiB+50TCHXUuvfnxmeoVNhAqnrUGVw4FE1NBRgVqgl1SX5KKhZO0XRRVMAN\nCN1dxQOoXFnLT4TZp8jgCQdtRkrTH/Um4Alz0gOPf39KTU96DFm+XmoTJGKK\nI2p7GsnC8zroAktlpXSuEJZp8sG9+35k9kdda/pQO8GjVPPUsA2E4US4iIpU\nAQUptUfNLIYHzYADJqEriiWjw4/ZH2spyvq4e4jPReQWq/P3flhqv+CPYrX2\n/hGTtopd5TfEwYAUxtMUZKXBh3RNnFr6Q2NPnUD+gddSyEdee+6nheaB9B7e\nYJaPyQ8/noK8NaWNUTnLV3/pkjT9BpDHduEvL0uGvc5jkH/DSPYGqSE0D6+s\n5xNHocG6mKADtl2qTXVEwoqZldEPc7x5trUxukSSJGGREImNwGgN1/faKeEj\nUHiH\r\n=/EXC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/unique-filename_1.1.1_1537461734124_0.8229183281578927"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "unique-filename\n===============\n\nGenerate a unique filename for use in temporary directories or caches.\n\n```\nvar uniqueFilename = require('unique-filename')\n\n// returns something like: /tmp/912ec803b2ce49e4a541068d495ab570\nvar randomTmpfile = uniqueFilename(os.tmpdir())\n\n// returns something like: /tmp/my-test-912ec803b2ce49e4a541068d495ab570\nvar randomPrefixedTmpfile = uniqueFilename(os.tmpdir(), 'my-test')\n\nvar uniqueTmpfile = uniqueFilename('/tmp', 'testing', '/my/thing/to/uniq/on')\n```\n\n### uniqueFilename(*dir*, *fileprefix*, *uniqstr*) → String\n\nReturns the full path of a unique filename that looks like:\n`dir/prefix-7ddd44c0`\nor `dir/7ddd44c0`\n\n*dir* – The path you want the filename in. `os.tmpdir()` is a good choice for this.\n\n*fileprefix* – A string to append prior to the unique part of the filename.\nThe parameter is required if *uniqstr* is also passed in but is otherwise\noptional and can be `undefined`/`null`/`''`. If present and not empty\nthen this string plus a hyphen are prepended to the unique part.\n\n*uniqstr* – Optional, if not passed the unique part of the resulting\nfilename will be random.  If passed in it will be generated from this string\nin a reproducable way.\n",
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-19T13:51:11.820Z",
+    "created": "2015-05-07T23:12:09.667Z",
+    "1.0.0": "2015-05-07T23:12:09.667Z",
+    "1.1.0": "2015-12-03T23:00:37.437Z",
+    "1.1.1": "2018-09-20T16:42:14.396Z"
+  },
+  "homepage": "https://github.com/iarna/unique-filename",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iarna/unique-filename.git"
+  },
+  "author": {
+    "name": "Rebecca Turner",
+    "email": "me@re-becca.org",
+    "url": "http://re-becca.org/"
+  },
+  "bugs": {
+    "url": "https://github.com/iarna/unique-filename/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "mattmcfarland": true,
+    "iarna": true,
+    "shiva127": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/unique-filename.min.json
+++ b/test/fixtures/registry-mocks/content/unique-filename.min.json
@@ -1,0 +1,58 @@
+{
+  "name": "unique-filename",
+  "dist-tags": {
+    "latest": "1.1.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "unique-filename",
+      "version": "1.0.0",
+      "dependencies": {
+        "unique-slug": "^1.0.0"
+      },
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "0bee4219e192e86da3c4ffc0cc6e054d8634eab9",
+        "tarball": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "unique-filename",
+      "version": "1.1.0",
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "dist": {
+        "shasum": "d05f2fe4032560871f30e93cbe735eea201514f3",
+        "tarball": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "unique-filename",
+      "version": "1.1.1",
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+        "shasum": "1d69769369ada0583103a1e6ae87681b56573230",
+        "tarball": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+        "fileCount": 15,
+        "unpackedSize": 41421,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbo83nCRA9TVsSAnZWagAAGUIP/RHKLBFB/61Nc2H7LVQj\n6aGrKRjQ+ZkQCGQODloPtfU8nQ94IJ7ZaD1ArcdDWu6oP2k5xJFsDKd/zxyQ\nPMPuAwkNDVZ4ndmRbKJ2Fzxq8B4eN20Q7t9PyvHWS2x8WOE1zzeLwDeBZI1f\nK8EUaTcaAj5du6TKUbnqVzqi5K2deWovlvDBPbFMqm84nO07Zbu50t0wHqDi\nIja76zlA8o2UiY2X4I044h8dV3n7wLF/yJoj7DPgcr+jrHY2R4BP/zMyjkZh\nRHiB+50TCHXUuvfnxmeoVNhAqnrUGVw4FE1NBRgVqgl1SX5KKhZO0XRRVMAN\nCN1dxQOoXFnLT4TZp8jgCQdtRkrTH/Um4Alz0gOPf39KTU96DFm+XmoTJGKK\nI2p7GsnC8zroAktlpXSuEJZp8sG9+35k9kdda/pQO8GjVPPUsA2E4US4iIpU\nAQUptUfNLIYHzYADJqEriiWjw4/ZH2spyvq4e4jPReQWq/P3flhqv+CPYrX2\n/hGTtopd5TfEwYAUxtMUZKXBh3RNnFr6Q2NPnUD+gddSyEdee+6nheaB9B7e\nYJaPyQ8/noK8NaWNUTnLV3/pkjT9BpDHduEvL0uGvc5jkH/DSPYGqSE0D6+s\n5xNHocG6mKADtl2qTXVEwoqZldEPc7x5trUxukSSJGGREImNwGgN1/faKeEj\nUHiH\r\n=/EXC\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:51:11.820Z"
+}

--- a/test/fixtures/registry-mocks/content/unique-slug.json
+++ b/test/fixtures/registry-mocks/content/unique-slug.json
@@ -1,0 +1,292 @@
+{
+  "_id": "unique-slug",
+  "_rev": "22-7111bcfd57566c170253abc9647d56c0",
+  "name": "unique-slug",
+  "description": "Generate a unique character string suitible for use in files and URLs.",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "unique-slug",
+      "version": "1.0.0",
+      "description": "Generate a unique character string suitible for use in files and URLs.",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tap test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap": "^1.0.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iarna/unique-slug.git"
+      },
+      "gitHead": "024b3bd3c0184550702c93f088822e3f38da5c17",
+      "bugs": {
+        "url": "https://github.com/iarna/unique-slug/issues"
+      },
+      "homepage": "https://github.com/iarna/unique-slug",
+      "_id": "unique-slug@1.0.0",
+      "_shasum": "4459d12416f576cc091a3deb19939ec99c735626",
+      "_from": ".",
+      "_npmVersion": "2.7.6",
+      "_nodeVersion": "1.6.2",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        }
+      ],
+      "dist": {
+        "shasum": "4459d12416f576cc091a3deb19939ec99c735626",
+        "tarball": "https://registry.npmjs.org/unique-slug/-/unique-slug-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "unique-slug",
+      "version": "2.0.0",
+      "description": "Generate a unique character string suitible for use in files and URLs.",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iarna/unique-slug.git"
+      },
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "gitHead": "b1d9d082ee5bd381961a2011a9aa3d9988e83ca7",
+      "bugs": {
+        "url": "https://github.com/iarna/unique-slug/issues"
+      },
+      "homepage": "https://github.com/iarna/unique-slug#readme",
+      "_id": "unique-slug@2.0.0",
+      "_shasum": "db6676e7c7cc0629878ff196097c78855ae9f4ab",
+      "_from": ".",
+      "_npmVersion": "3.5.1",
+      "_nodeVersion": "5.1.0",
+      "_npmUser": {
+        "name": "othiym23",
+        "email": "ogd@aoaioxxysz.net"
+      },
+      "dist": {
+        "shasum": "db6676e7c7cc0629878ff196097c78855ae9f4ab",
+        "tarball": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "iarna",
+          "email": "me@re-becca.org"
+        },
+        {
+          "name": "othiym23",
+          "email": "ogd@aoaioxxysz.net"
+        }
+      ],
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "unique-slug",
+      "version": "2.0.1",
+      "description": "Generate a unique character string suitible for use in files and URLs.",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iarna/unique-slug.git"
+      },
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "gitHead": "b5c58f7086b55e0cb3311de5cfcbefdc7d3fb295",
+      "bugs": {
+        "url": "https://github.com/iarna/unique-slug/issues"
+      },
+      "homepage": "https://github.com/iarna/unique-slug#readme",
+      "_id": "unique-slug@2.0.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.10.0",
+      "_npmUser": {
+        "name": "iarna",
+        "email": "me@re-becca.org"
+      },
+      "dist": {
+        "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+        "shasum": "5e9edc6d1ce8fb264db18a507ef9bd8544451ca6",
+        "tarball": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 3107,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbo85TCRA9TVsSAnZWagAAqFIP/2I5qpBTE3kR9xJGnE9t\nXKUvEd+2iJ7UsuQMG9CJwdWIwUa6tGGGpkKEXZBAjnFgfqK1I/iGG5t3oIuP\nwVECLNnPGCxkHhDp9XZJL3RPXWBX8X+3APE056uX8ad0CA0zOoJBvRip4/3Y\nXbZHHkd37hdi0o29Uunwt4g7Qz5TASFTVwn8jwMgPgMLPHZrMt4ZZgpOW+2U\npJOEm2pdGCjT3ANoauMBMdawMhGxIQimI2M27RsBIp16JqjrHSyNfdMJjxLw\nvGJ+QnGJL1WCI/BAB1KC8OK8PHKvIUixM1zNdB9w15wRHRwelajhvOuhCdKe\nWRPJ1I9bsp7ZMSA35bNb3y/UH6Dh1GccmtrRdD1B5iRtlA0LRSy21tauDCa5\nMVQNbS1HQcRGptq/uTODxQc69BAsR+r/N9MNe134c6ppcYlP5xI/qS+yzD9t\nJofFoOYC8FbZOvxXL8p3N1i2AcYI10XkOnZNGCn4TWV3NBVpJA1BmkDIG4zE\nkV94TaTRlh3aDQFaQr7r5osHTSKjGf+noUFs+DKNgeAWhS1ZEj7DtyT6UE6m\nLa7o7RRIhqzo9o17yZOeb61G0qFB17rBoE0WETKzC2SEtnCQtCU/H08xpn2E\nfo173Qa9pYNe9jK3cx/+Y9fAMbnMtMD+9U8wmXEsWqItNgczS2J+cVWKYAau\nfsr0\r\n=3e5B\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "me@re-becca.org",
+          "name": "iarna"
+        },
+        {
+          "email": "ogd@aoaioxxysz.net",
+          "name": "othiym23"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/unique-slug_2.0.1_1537461842981_0.0688486787472038"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.2": {
+      "name": "unique-slug",
+      "version": "2.0.2",
+      "description": "Generate a unique character string suitible for use in files and URLs.",
+      "main": "index.js",
+      "scripts": {
+        "test": "standard && tap --coverage test"
+      },
+      "keywords": [],
+      "author": {
+        "name": "Rebecca Turner",
+        "email": "me@re-becca.org",
+        "url": "http://re-becca.org"
+      },
+      "license": "ISC",
+      "devDependencies": {
+        "standard": "^12.0.1",
+        "tap": "^12.7.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/iarna/unique-slug.git"
+      },
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "gitHead": "36b094bac6905e0bd199971ef3c646dd982d5c30",
+      "bugs": {
+        "url": "https://github.com/iarna/unique-slug/issues"
+      },
+      "homepage": "https://github.com/iarna/unique-slug#readme",
+      "_id": "unique-slug@2.0.2",
+      "_nodeVersion": "10.15.3",
+      "_npmVersion": "6.9.1-next.0",
+      "dist": {
+        "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+        "shasum": "baabce91083fc64e945b0f3ad613e264f7cd4e6c",
+        "tarball": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 2679,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/+93CRA9TVsSAnZWagAASukP/0eBevExHSP+c2nl4MQS\nH3Yrnzt72mB75TWwTvyqZkEx7OH+usPcfSfFVAfZmALrYdHCb8GTIYOYFtXI\n1W58L2hrf+bBF/9PUstsF/nOwFiybflsH2GM0tRDJMVT798t1rnBueNXtn5p\nG2ARm20PAmD5OaRhq5yIwdO1/xbmM2F/5E0AeP8P2VdvBAvl+p0euZ4JCIUB\n4B0eybM+/bvWAlnVAHfrCH6gtfN6tKi2nmlhpqS+MPS285OXsttXzCB54I6F\np2JFvQtLrW1/kWTS3wojBazId/CXER/Qdlo7slkTLj6vjJCD5jqRaf5GmvOU\nXdJJHjt1jdXmpFfikhkeRDUgE1S+ANPMvwV3UDy8/YEYhCxCx4Nr2UkrPgiN\nBNE9tUvng6yxWCcXal8ES17FdA6xbSjOLqPlXkzZ71af8uIZ4JK6V1ybyerg\n0oAG7ucd1a6roQfZ+gu/TES85JxVycQpQWrsZReP3+wiFoai9tkdAdxyp+pB\n+8Ahm0WyVWifR/UvDvQ+NN1bwr1eQSNV51/y+Kj70fD5Cn35PvVDaowA3QwF\n251tETG2uebnbXzbuInYPS1GBOTZSqigZsVxCQc9SCelt5bf3oRg81SHfAZM\nWuFmOjzkLQ01Abw9FECMFCZ3lML2YI2Qk7Kw899PNH8Tc6X1hLL4+Ri9O6cl\nyC1E\r\n=XASP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "me@re-becca.org",
+          "name": "iarna"
+        },
+        {
+          "email": "ogd@aoaioxxysz.net",
+          "name": "othiym23"
+        },
+        {
+          "email": "npm@zkat.tech",
+          "name": "zkat"
+        }
+      ],
+      "_npmUser": {
+        "name": "zkat",
+        "email": "npm@zkat.tech"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/unique-slug_2.0.2_1560276854352_0.9545905133271473"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "unique-slug\n===========\n\nGenerate a unique character string suitible for use in files and URLs.\n\n```\nvar uniqueSlug = require('unique-slug')\n\nvar randomSlug = uniqueSlug()\nvar fileSlug = uniqueSlug('/etc/passwd')\n```\n\n### uniqueSlug(*str*) → String (8 chars)\n\nIf *str* is passed in then the return value will be its murmur hash in\nhex.\n\nIf *str* is not passed in, it will be 4 randomly generated bytes\nconverted into 8 hexadecimal characters.\n",
+  "maintainers": [
+    {
+      "email": "quitlahok@gmail.com",
+      "name": "nlf"
+    },
+    {
+      "email": "ruyadorno@hotmail.com",
+      "name": "ruyadorno"
+    },
+    {
+      "email": "darcy@darcyclarke.me",
+      "name": "darcyclarke"
+    },
+    {
+      "email": "i@izs.me",
+      "name": "isaacs"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-19T13:51:01.005Z",
+    "created": "2015-05-07T22:25:31.152Z",
+    "1.0.0": "2015-05-07T22:25:31.152Z",
+    "2.0.0": "2015-12-03T22:44:34.276Z",
+    "2.0.1": "2018-09-20T16:44:03.228Z",
+    "2.0.2": "2019-06-11T18:14:14.530Z"
+  },
+  "homepage": "https://github.com/iarna/unique-slug#readme",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/iarna/unique-slug.git"
+  },
+  "author": {
+    "name": "Rebecca Turner",
+    "email": "me@re-becca.org",
+    "url": "http://re-becca.org"
+  },
+  "bugs": {
+    "url": "https://github.com/iarna/unique-slug/issues"
+  },
+  "license": "ISC",
+  "readmeFilename": "README.md",
+  "users": {
+    "iarna": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/unique-slug.min.json
+++ b/test/fixtures/registry-mocks/content/unique-slug.min.json
@@ -1,0 +1,74 @@
+{
+  "name": "unique-slug",
+  "dist-tags": {
+    "latest": "2.0.2"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "unique-slug",
+      "version": "1.0.0",
+      "devDependencies": {
+        "standard": "^3.7.3",
+        "tap": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "4459d12416f576cc091a3deb19939ec99c735626",
+        "tarball": "https://registry.npmjs.org/unique-slug/-/unique-slug-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "unique-slug",
+      "version": "2.0.0",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "dist": {
+        "shasum": "db6676e7c7cc0629878ff196097c78855ae9f4ab",
+        "tarball": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz"
+      }
+    },
+    "2.0.1": {
+      "name": "unique-slug",
+      "version": "2.0.1",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "devDependencies": {
+        "standard": "^5.4.1",
+        "tap": "^2.3.1"
+      },
+      "dist": {
+        "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+        "shasum": "5e9edc6d1ce8fb264db18a507ef9bd8544451ca6",
+        "tarball": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
+        "fileCount": 6,
+        "unpackedSize": 3107,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbo85TCRA9TVsSAnZWagAAqFIP/2I5qpBTE3kR9xJGnE9t\nXKUvEd+2iJ7UsuQMG9CJwdWIwUa6tGGGpkKEXZBAjnFgfqK1I/iGG5t3oIuP\nwVECLNnPGCxkHhDp9XZJL3RPXWBX8X+3APE056uX8ad0CA0zOoJBvRip4/3Y\nXbZHHkd37hdi0o29Uunwt4g7Qz5TASFTVwn8jwMgPgMLPHZrMt4ZZgpOW+2U\npJOEm2pdGCjT3ANoauMBMdawMhGxIQimI2M27RsBIp16JqjrHSyNfdMJjxLw\nvGJ+QnGJL1WCI/BAB1KC8OK8PHKvIUixM1zNdB9w15wRHRwelajhvOuhCdKe\nWRPJ1I9bsp7ZMSA35bNb3y/UH6Dh1GccmtrRdD1B5iRtlA0LRSy21tauDCa5\nMVQNbS1HQcRGptq/uTODxQc69BAsR+r/N9MNe134c6ppcYlP5xI/qS+yzD9t\nJofFoOYC8FbZOvxXL8p3N1i2AcYI10XkOnZNGCn4TWV3NBVpJA1BmkDIG4zE\nkV94TaTRlh3aDQFaQr7r5osHTSKjGf+noUFs+DKNgeAWhS1ZEj7DtyT6UE6m\nLa7o7RRIhqzo9o17yZOeb61G0qFB17rBoE0WETKzC2SEtnCQtCU/H08xpn2E\nfo173Qa9pYNe9jK3cx/+Y9fAMbnMtMD+9U8wmXEsWqItNgczS2J+cVWKYAau\nfsr0\r\n=3e5B\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "2.0.2": {
+      "name": "unique-slug",
+      "version": "2.0.2",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "devDependencies": {
+        "standard": "^12.0.1",
+        "tap": "^12.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+        "shasum": "baabce91083fc64e945b0f3ad613e264f7cd4e6c",
+        "tarball": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+        "fileCount": 6,
+        "unpackedSize": 2679,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/+93CRA9TVsSAnZWagAASukP/0eBevExHSP+c2nl4MQS\nH3Yrnzt72mB75TWwTvyqZkEx7OH+usPcfSfFVAfZmALrYdHCb8GTIYOYFtXI\n1W58L2hrf+bBF/9PUstsF/nOwFiybflsH2GM0tRDJMVT798t1rnBueNXtn5p\nG2ARm20PAmD5OaRhq5yIwdO1/xbmM2F/5E0AeP8P2VdvBAvl+p0euZ4JCIUB\n4B0eybM+/bvWAlnVAHfrCH6gtfN6tKi2nmlhpqS+MPS285OXsttXzCB54I6F\np2JFvQtLrW1/kWTS3wojBazId/CXER/Qdlo7slkTLj6vjJCD5jqRaf5GmvOU\nXdJJHjt1jdXmpFfikhkeRDUgE1S+ANPMvwV3UDy8/YEYhCxCx4Nr2UkrPgiN\nBNE9tUvng6yxWCcXal8ES17FdA6xbSjOLqPlXkzZ71af8uIZ4JK6V1ybyerg\n0oAG7ucd1a6roQfZ+gu/TES85JxVycQpQWrsZReP3+wiFoai9tkdAdxyp+pB\n+8Ahm0WyVWifR/UvDvQ+NN1bwr1eQSNV51/y+Kj70fD5Cn35PvVDaowA3QwF\n251tETG2uebnbXzbuInYPS1GBOTZSqigZsVxCQc9SCelt5bf3oRg81SHfAZM\nWuFmOjzkLQ01Abw9FECMFCZ3lML2YI2Qk7Kw899PNH8Tc6X1hLL4+Ri9O6cl\nyC1E\r\n=XASP\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-19T13:51:01.005Z"
+}

--- a/test/fixtures/registry-mocks/content/unpipe.json
+++ b/test/fixtures/registry-mocks/content/unpipe.json
@@ -1,0 +1,95 @@
+{
+  "_id": "unpipe",
+  "_rev": "3-e77ee0a101fa5c862788cbece7f56f10",
+  "name": "unpipe",
+  "description": "Unpipe a stream from all destinations",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "unpipe",
+      "description": "Unpipe a stream from all destinations",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/stream-utils/unpipe"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.15",
+        "mocha": "2.2.5",
+        "readable-stream": "1.1.13"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "d2df901c06487430e78dca62b6edb8bb2fc5e99d",
+      "bugs": {
+        "url": "https://github.com/stream-utils/unpipe/issues"
+      },
+      "homepage": "https://github.com/stream-utils/unpipe",
+      "_id": "unpipe@1.0.0",
+      "_shasum": "b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+        "tarball": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# unpipe\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-image]][node-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nUnpipe a stream from all destinations.\n\n## Installation\n\n```sh\n$ npm install unpipe\n```\n\n## API\n\n```js\nvar unpipe = require('unpipe')\n```\n\n### unpipe(stream)\n\nUnpipes all destinations from a given stream. With stream 2+, this is\nequivalent to `stream.unpipe()`. When used with streams 1 style streams\n(typically Node.js 0.8 and below), this module attempts to undo the\nactions done in `stream.pipe(dest)`.\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/unpipe.svg\n[npm-url]: https://npmjs.org/package/unpipe\n[node-image]: https://img.shields.io/node/v/unpipe.svg\n[node-url]: http://nodejs.org/download/\n[travis-image]: https://img.shields.io/travis/stream-utils/unpipe.svg\n[travis-url]: https://travis-ci.org/stream-utils/unpipe\n[coveralls-image]: https://img.shields.io/coveralls/stream-utils/unpipe.svg\n[coveralls-url]: https://coveralls.io/r/stream-utils/unpipe?branch=master\n[downloads-image]: https://img.shields.io/npm/dm/unpipe.svg\n[downloads-url]: https://npmjs.org/package/unpipe\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2016-02-04T18:32:34.452Z",
+    "created": "2015-06-14T20:30:19.934Z",
+    "1.0.0": "2015-06-14T20:30:19.934Z"
+  },
+  "homepage": "https://github.com/stream-utils/unpipe",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stream-utils/unpipe"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/stream-utils/unpipe/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/unpipe.min.json
+++ b/test/fixtures/registry-mocks/content/unpipe.min.json
@@ -1,0 +1,25 @@
+{
+  "name": "unpipe",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "unpipe",
+      "version": "1.0.0",
+      "devDependencies": {
+        "istanbul": "0.3.15",
+        "mocha": "2.2.5",
+        "readable-stream": "1.1.13"
+      },
+      "dist": {
+        "shasum": "b2bf4ee8514aae6165b4817829d21b2ef49904ec",
+        "tarball": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2016-02-04T18:32:34.452Z"
+}

--- a/test/fixtures/registry-mocks/content/unset-value.json
+++ b/test/fixtures/registry-mocks/content/unset-value.json
@@ -1,0 +1,438 @@
+{
+  "_id": "unset-value",
+  "_rev": "5-d7f85086b168326e601d17fa1bf333c2",
+  "name": "unset-value",
+  "description": "Delete nested properties from an object using dot notation.",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "unset-value",
+      "description": "Delete nested properties from an object using dot notation.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/jonschlinkert/unset-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/unset-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/unset-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "has-value": "^0.2.0",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [],
+      "verb": {
+        "related": {
+          "list": [
+            "get-value",
+            "get-values",
+            "omit-value",
+            "put-value",
+            "set-value",
+            "union-value",
+            "upsert-value"
+          ]
+        }
+      },
+      "_id": "unset-value@0.1.0",
+      "_shasum": "fbaafe2fe1f17a9a58e25d1fc48c58fb47cf0ec6",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fbaafe2fe1f17a9a58e25d1fc48c58fb47cf0ec6",
+        "tarball": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "unset-value",
+      "description": "Delete nested properties from an object using dot notation.",
+      "version": "0.1.1",
+      "homepage": "https://github.com/jonschlinkert/unset-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/unset-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/unset-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "has-value": "^0.2.1",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "verb": {
+        "related": {
+          "description": "",
+          "list": [
+            "get-value",
+            "get-values",
+            "omit-value",
+            "put-value",
+            "set-value",
+            "union-value",
+            "upsert-value"
+          ]
+        }
+      },
+      "keywords": [
+        "del",
+        "delete",
+        "key",
+        "object",
+        "omit",
+        "prop",
+        "property",
+        "remove",
+        "unset",
+        "value"
+      ],
+      "gitHead": "6fc6e855657bec006a2adbe136391a5cbd169724",
+      "_id": "unset-value@0.1.1",
+      "_shasum": "60bfdcaeaa16a4db88c95e6e79c18dd1eef97922",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "60bfdcaeaa16a4db88c95e6e79c18dd1eef97922",
+        "tarball": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "unset-value",
+      "description": "Delete nested properties from an object using dot notation.",
+      "version": "0.1.2",
+      "homepage": "https://github.com/jonschlinkert/unset-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "email": "wtgtybhertgeghgtwtg@gmail.com",
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/unset-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/unset-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "del",
+        "delete",
+        "key",
+        "object",
+        "omit",
+        "prop",
+        "property",
+        "remove",
+        "unset",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "get-value",
+            "get-values",
+            "omit-value",
+            "put-value",
+            "set-value",
+            "union-value",
+            "upsert-value"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "b4eb4edfca512c173cb91eea08a0f0effa5df9fc",
+      "_id": "unset-value@0.1.2",
+      "_shasum": "506810b867f27c2a5a6e9b04833631f6de58d310",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "506810b867f27c2a5a6e9b04833631f6de58d310",
+        "tarball": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/unset-value-0.1.2.tgz_1488061615885_0.7473359440919012"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "unset-value",
+      "description": "Delete nested properties from an object using dot notation.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/jonschlinkert/unset-value",
+      "author": {
+        "name": "Jon Schlinkert",
+        "url": "https://github.com/jonschlinkert"
+      },
+      "contributors": [
+        {
+          "email": "wtgtybhertgeghgtwtg@gmail.com",
+          "url": "https://github.com/wtgtybhertgeghgtwtg"
+        },
+        {
+          "name": "Jon Schlinkert",
+          "email": "jon.schlinkert@sellside.com",
+          "url": "http://twitter.com/jonschlinkert"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jonschlinkert/unset-value.git"
+      },
+      "bugs": {
+        "url": "https://github.com/jonschlinkert/unset-value/issues"
+      },
+      "license": "MIT",
+      "files": [
+        "index.js"
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "scripts": {
+        "test": "mocha"
+      },
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "keywords": [
+        "del",
+        "delete",
+        "key",
+        "object",
+        "omit",
+        "prop",
+        "property",
+        "remove",
+        "unset",
+        "value"
+      ],
+      "verb": {
+        "related": {
+          "list": [
+            "get-value",
+            "get-values",
+            "omit-value",
+            "put-value",
+            "set-value",
+            "union-value",
+            "upsert-value"
+          ]
+        },
+        "toc": false,
+        "layout": "default",
+        "tasks": [
+          "readme"
+        ],
+        "plugins": [
+          "gulp-format-md"
+        ],
+        "lint": {
+          "reflinks": true
+        }
+      },
+      "gitHead": "36b62353cde18d6be17a1c0dc080fddcc262d2da",
+      "_id": "unset-value@1.0.0",
+      "_shasum": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "jonschlinkert",
+        "email": "github@sellside.com"
+      },
+      "maintainers": [
+        {
+          "name": "jonschlinkert",
+          "email": "github@sellside.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+        "tarball": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/unset-value-1.0.0.tgz_1488061635259_0.42952891532331705"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# unset-value [![NPM version](https://img.shields.io/npm/v/unset-value.svg?style=flat)](https://www.npmjs.com/package/unset-value) [![NPM monthly downloads](https://img.shields.io/npm/dm/unset-value.svg?style=flat)](https://npmjs.org/package/unset-value)  [![NPM total downloads](https://img.shields.io/npm/dt/unset-value.svg?style=flat)](https://npmjs.org/package/unset-value) [![Linux Build Status](https://img.shields.io/travis/jonschlinkert/unset-value.svg?style=flat&label=Travis)](https://travis-ci.org/jonschlinkert/unset-value)\n\n> Delete nested properties from an object using dot notation.\n\n## Install\n\nInstall with [npm](https://www.npmjs.com/):\n\n```sh\n$ npm install --save unset-value\n```\n\n## Usage\n\n```js\nvar unset = require('unset-value');\n\nvar obj = {a: {b: {c: 'd', e: 'f'}}};\nunset(obj, 'a.b.c');\nconsole.log(obj);\n//=> {a: {b: {e: 'f'}}};\n```\n\n## Examples\n\n### Updates the object when a property is deleted\n\n```js\nvar obj = {a: 'b'};\nunset(obj, 'a');\nconsole.log(obj);\n//=> {}\n```\n\n### Returns true when a property is deleted\n\n```js\nunset({a: 'b'}, 'a') // true\n```\n\n### Returns `true` when a property does not exist\n\nThis is consistent with `delete` behavior in that it does not\nthrow when a property does not exist.\n\n```js\nunset({a: {b: {c: 'd'}}}, 'd') // true\n```\n\n### delete nested values\n\n```js\nvar one = {a: {b: {c: 'd'}}};\nunset(one, 'a.b');\nconsole.log(one);\n//=> {a: {}}\n\nvar two = {a: {b: {c: 'd'}}};\nunset(two, 'a.b.c');\nconsole.log(two);\n//=> {a: {b: {}}}\n\nvar three = {a: {b: {c: 'd', e: 'f'}}};\nunset(three, 'a.b.c');\nconsole.log(three);\n//=> {a: {b: {e: 'f'}}}\n```\n\n### throws on invalid args\n\n```js\nunset();\n// 'expected an object.'\n```\n\n## About\n\n### Related projects\n\n* [get-value](https://www.npmjs.com/package/get-value): Use property paths (`a.b.c`) to get a nested value from an object. | [homepage](https://github.com/jonschlinkert/get-value \"Use property paths (`a.b.c`) to get a nested value from an object.\")\n* [get-values](https://www.npmjs.com/package/get-values): Return an array of all values from the given object. | [homepage](https://github.com/jonschlinkert/get-values \"Return an array of all values from the given object.\")\n* [omit-value](https://www.npmjs.com/package/omit-value): Omit properties from an object or deeply nested property of an object using object path… [more](https://github.com/jonschlinkert/omit-value) | [homepage](https://github.com/jonschlinkert/omit-value \"Omit properties from an object or deeply nested property of an object using object path notation.\")\n* [put-value](https://www.npmjs.com/package/put-value): Update only existing values from an object, works with dot notation paths like `a.b.c` and… [more](https://github.com/tunnckocore/put-value#readme) | [homepage](https://github.com/tunnckocore/put-value#readme \"Update only existing values from an object, works with dot notation paths like `a.b.c` and support deep nesting.\")\n* [set-value](https://www.npmjs.com/package/set-value): Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths. | [homepage](https://github.com/jonschlinkert/set-value \"Create nested values and any intermediaries using dot notation (`'a.b.c'`) paths.\")\n* [union-value](https://www.npmjs.com/package/union-value): Set an array of unique values as the property of an object. Supports setting deeply… [more](https://github.com/jonschlinkert/union-value) | [homepage](https://github.com/jonschlinkert/union-value \"Set an array of unique values as the property of an object. Supports setting deeply nested properties using using object-paths/dot notation.\")\n* [upsert-value](https://www.npmjs.com/package/upsert-value): Update or set nested values and any intermediaries with dot notation (`'a.b.c'`) paths. | [homepage](https://github.com/doowb/upsert-value \"Update or set nested values and any intermediaries with dot notation (`'a.b.c'`) paths.\")\n\n### Contributing\n\nPull requests and stars are always welcome. For bugs and feature requests, [please create an issue](../../issues/new).\n\n### Contributors\n\n| **Commits** | **Contributor** | \n| --- | --- |\n| 6 | [jonschlinkert](https://github.com/jonschlinkert) |\n| 2 | [wtgtybhertgeghgtwtg](https://github.com/wtgtybhertgeghgtwtg) |\n\n### Building docs\n\n_(This project's readme.md is generated by [verb](https://github.com/verbose/verb-generate-readme), please don't edit the readme directly. Any changes to the readme must be made in the [.verb.md](.verb.md) readme template.)_\n\nTo generate the readme, run the following command:\n\n```sh\n$ npm install -g verbose/verb#dev verb-generate-readme && verb\n```\n\n### Running tests\n\nRunning and reviewing unit tests is a great way to get familiarized with a library and its API. You can install dependencies and run tests with the following command:\n\n```sh\n$ npm install && npm test\n```\n\n### Author\n\n**Jon Schlinkert**\n\n* [github/jonschlinkert](https://github.com/jonschlinkert)\n* [twitter/jonschlinkert](https://twitter.com/jonschlinkert)\n\n### License\n\nCopyright © 2017, [Jon Schlinkert](https://github.com/jonschlinkert).\nReleased under the [MIT License](LICENSE).\n\n***\n\n_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.4.2, on February 25, 2017._",
+  "maintainers": [
+    {
+      "name": "jonschlinkert",
+      "email": "github@sellside.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-10-21T06:50:53.712Z",
+    "created": "2015-08-27T07:59:45.273Z",
+    "0.1.0": "2015-08-27T07:59:45.273Z",
+    "0.1.1": "2015-10-30T19:55:39.243Z",
+    "0.1.2": "2017-02-25T22:26:57.734Z",
+    "1.0.0": "2017-02-25T22:27:15.940Z"
+  },
+  "homepage": "https://github.com/jonschlinkert/unset-value",
+  "keywords": [
+    "del",
+    "delete",
+    "key",
+    "object",
+    "omit",
+    "prop",
+    "property",
+    "remove",
+    "unset",
+    "value"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonschlinkert/unset-value.git"
+  },
+  "author": {
+    "name": "Jon Schlinkert",
+    "url": "https://github.com/jonschlinkert"
+  },
+  "bugs": {
+    "url": "https://github.com/jonschlinkert/unset-value/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "contributors": [
+    {
+      "email": "wtgtybhertgeghgtwtg@gmail.com",
+      "url": "https://github.com/wtgtybhertgeghgtwtg"
+    },
+    {
+      "name": "Jon Schlinkert",
+      "email": "jon.schlinkert@sellside.com",
+      "url": "http://twitter.com/jonschlinkert"
+    }
+  ],
+  "users": {
+    "rocket0191": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/unset-value.min.json
+++ b/test/fixtures/registry-mocks/content/unset-value.min.json
@@ -1,0 +1,87 @@
+{
+  "name": "unset-value",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "unset-value",
+      "version": "0.1.0",
+      "dependencies": {
+        "has-value": "^0.2.0",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "fbaafe2fe1f17a9a58e25d1fc48c58fb47cf0ec6",
+        "tarball": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.1": {
+      "name": "unset-value",
+      "version": "0.1.1",
+      "dependencies": {
+        "has-value": "^0.2.1",
+        "isobject": "^2.0.0"
+      },
+      "devDependencies": {
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "60bfdcaeaa16a4db88c95e6e79c18dd1eef97922",
+        "tarball": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "0.1.2": {
+      "name": "unset-value",
+      "version": "0.1.2",
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "506810b867f27c2a5a6e9b04833631f6de58d310",
+        "tarball": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "1.0.0": {
+      "name": "unset-value",
+      "version": "1.0.0",
+      "dependencies": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "devDependencies": {
+        "gulp-format-md": "^0.1.11",
+        "mocha": "*",
+        "should": "*"
+      },
+      "dist": {
+        "shasum": "8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559",
+        "tarball": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  },
+  "modified": "2017-10-21T06:50:53.712Z"
+}

--- a/test/fixtures/registry-mocks/content/upath.json
+++ b/test/fixtures/registry-mocks/content/upath.json
@@ -1,0 +1,1774 @@
+{
+  "_id": "upath",
+  "_rev": "38-eee2771ed34419b4d21b2b3b442e1199",
+  "name": "upath",
+  "description": "A proxy to `path`, replacing `\\` with `/` for all results (supports UNC paths) & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & methods to add, change, default, trim file extensions.",
+      "version": "0.1.0",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Agelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": "0.10.x"
+      },
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "gitHead": "75f8bb50dc920a4f68f4a930e7b0946d3a413f0c",
+      "_id": "upath@0.1.0",
+      "_shasum": "823665902b2c9b37a5efcfb79a9b53b91738aa9b",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "823665902b2c9b37a5efcfb79a9b53b91738aa9b",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & methods to add, change, default, trim file extensions.",
+      "version": "0.1.1",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Agelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": "0.10.x"
+      },
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "gitHead": "a85237754056be321492164043485e7cf56a529a",
+      "_id": "upath@0.1.1",
+      "_shasum": "203a77784555e133c5bde9c8698693defaf3e9e7",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "203a77784555e133c5bde9c8698693defaf3e9e7",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & methods to add, change, default, trim file extensions.",
+      "version": "0.1.2",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Agelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": "0.10.x"
+      },
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "gitHead": "4cc6ced23237872d66a38087c28d740d3b6d98b3",
+      "_id": "upath@0.1.2",
+      "_shasum": "2306202c6b65cfa5d150b1b76388e81427a4f221",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "2306202c6b65cfa5d150b1b76388e81427a4f221",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & methods to add, change, default, trim file extensions.",
+      "version": "0.1.3",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Agelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": "0.10.x"
+      },
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "gitHead": "4e6006015baa7f00ecf7c64868fe82728422819a",
+      "_id": "upath@0.1.3",
+      "_shasum": "7b195b998f469dd1a021fd1c48fb6046dd9064dc",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7b195b998f469dd1a021fd1c48fb6046dd9064dc",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & methods to add, change, default, trim file extensions.",
+      "version": "0.1.4",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Agelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": "0.10.x"
+      },
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "gitHead": "c0f7cdd53721872c88b3101dfacac3d735c1079f",
+      "_id": "upath@0.1.4",
+      "_shasum": "7008becb374e3b75063235848e4bacd6d3c4d9b3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7008becb374e3b75063235848e4bacd6d3c4d9b3",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & methods to add, change, default, trim file extensions.",
+      "version": "0.1.5",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Agelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": "0.10.x"
+      },
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~0.5.x",
+        "grunt-urequire": "0.7.x",
+        "urequire": "0.7.x",
+        "uberscore": "0.0.16",
+        "urequire-ab-specrunner": "^0.1.10",
+        "urequire-rc-inject-version": "^0.1.2"
+      },
+      "gitHead": "0ba92813c422b6137b5cda10538a745fbf20227e",
+      "_id": "upath@0.1.5",
+      "_shasum": "04eb8709ce6ee7f5067ea112a2b60c6eba544485",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "04eb8709ce6ee7f5067ea112a2b60c6eba544485",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.5.tgz"
+      }
+    },
+    "0.1.6": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "0.1.6",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=0.10.x <=0.12.x"
+      },
+      "dependencies": {
+        "lodash": ">=2.x",
+        "underscore.string": "2.3.x"
+      },
+      "devDependencies": {
+        "chai": "1.9.x",
+        "mocha": "2.0.x",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "0.5.x",
+        "grunt-urequire": "0.7.x",
+        "urequire": "0.7.0-beta.20",
+        "uberscore": "0.0.16",
+        "urequire-ab-specrunner": "0.2.x",
+        "urequire-rc-inject-version": "0.1.x"
+      },
+      "gitHead": "aebcd89d227675b473c870aa2dbd3302d98dfc36",
+      "_id": "upath@0.1.6",
+      "_shasum": "4809de430e55c5845b1cec6319f0fe6c877aa958",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4809de430e55c5845b1cec6319f0fe6c877aa958",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.6.tgz"
+      }
+    },
+    "0.1.7": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "0.1.7",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=0.10 <=5"
+      },
+      "typescript": {
+        "definition": "upath.d.ts"
+      },
+      "dependencies": {
+        "lodash": "3.x",
+        "underscore.string": "2.3.x"
+      },
+      "devDependencies": {
+        "chai": "3.5.x",
+        "mocha": "2.4.x",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "0.6.x",
+        "grunt-urequire": "0.7.x",
+        "urequire": "0.7.0-beta.25",
+        "uberscore": "0.0.16",
+        "urequire-ab-specrunner": "^0.2.2",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "512f6605511c66ca79600dc8c3594476705b2320",
+      "_id": "upath@0.1.7",
+      "_shasum": "7c5bbfe9a4e074ff0b83131ad0c13c2d8601383b",
+      "_from": ".",
+      "_npmVersion": "2.14.12",
+      "_nodeVersion": "4.3.1",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7c5bbfe9a4e074ff0b83131ad0c13c2d8601383b",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.7.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-5-east.internal.npmjs.com",
+        "tmp": "tmp/upath-0.1.7.tgz_1456101854015_0.8668476182501763"
+      }
+    },
+    "0.2.0": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "0.2.0",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=0.10 <=5"
+      },
+      "typescript": {
+        "definition": "upath.d.ts"
+      },
+      "dependencies": {
+        "lodash": "3.x",
+        "underscore.string": "2.3.x"
+      },
+      "devDependencies": {
+        "chai": "3.5.x",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "0.6.x",
+        "grunt-urequire": "0.7.x",
+        "mocha": "2.4.x",
+        "uberscore": "0.0.19",
+        "urequire": "0.7.0-beta.29",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "037431d3b8217397045055364029deddbba4194d",
+      "_id": "upath@0.2.0",
+      "_shasum": "bdbad0f2c60afea165f8127dbb1b5bdee500ad81",
+      "_from": ".",
+      "_npmVersion": "2.15.0",
+      "_nodeVersion": "0.10.44",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bdbad0f2c60afea165f8127dbb1b5bdee500ad81",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.2.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/upath-0.2.0.tgz_1467507212666_0.4532309107016772"
+      }
+    },
+    "1.0.0": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.0.0",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=0.10 <=7"
+      },
+      "dependencies": {
+        "lodash": "3.x",
+        "underscore.string": "2.3.x"
+      },
+      "devDependencies": {
+        "chai": "3.5.x",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "0.6.x",
+        "grunt-urequire": "0.7.x",
+        "mocha": "2.4.x",
+        "uberscore": "0.0.19",
+        "urequire": "0.7.0-beta.29",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "dd3b692bdfbcc327f07e62a73de6a1d27ea90dee",
+      "_id": "upath@1.0.0",
+      "_shasum": "b4706b9461ca8473adf89133d235689ca17f3656",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.5",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b4706b9461ca8473adf89133d235689ca17f3656",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/upath-1.0.0.tgz_1486482461557_0.5026046861894429"
+      }
+    },
+    "1.0.2": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.0.2",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4 <=9"
+      },
+      "dependencies": {
+        "lodash.endswith": "^4.2.1",
+        "lodash.startswith": "^4.2.1",
+        "lodash.isfunction": "^3.0.8",
+        "lodash.isstring": "^4.0.1"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "a28b9a893684a51f94e8454a1a99e1200b8b962b",
+      "_id": "upath@1.0.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.1.0",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-fCmij7T5LnwUme3dbnVSejvOHHlARjB3ikJFwgZfz386pHmf/gueuTLRFU94FZEaeCLlbQrweiUU700gG41tUw==",
+        "shasum": "80aaae5395abc5fd402933ae2f58694f0860204c",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath-1.0.2.tgz_1510614878269_0.19207502622157335"
+      }
+    },
+    "1.0.3": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.0.3",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4 <=9"
+      },
+      "dependencies": {
+        "lodash.endswith": "^4.2.1",
+        "lodash.startswith": "^4.2.1",
+        "lodash.isfunction": "^3.0.8",
+        "lodash.isstring": "^4.0.1"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "f2a64fc55e984324083d61cd9938c312df7e53b6",
+      "_id": "upath@1.0.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-oubdFMfUobEIMojWoHXA3Xh794XY+MWvQVtLNf1Pv8cjPVumqEsxll7+5t7HwjNRGEch30h1yQN0kCeK/GOC5Q==",
+        "shasum": "18a4822d3f668cc69876245d3c2ca74a498eba9b",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33736
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_1.0.3_1519600460285_0.9068103125432261"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.4": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.0.4",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4 <=9"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "3bdcd474017e7635ecbc7509ea03c6b036df3b8d",
+      "_id": "upath@1.0.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.4.0",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+        "shasum": "ee2321ba0a786c50973db043a50b7bcba822361d",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33783
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_1.0.4_1519604006586_0.1287124338797132"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.5": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.0.5",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "2b181f4f1a19f2c919e452e5b837d4719d93118c",
+      "_id": "upath@1.0.5",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "10.0.0",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww==",
+        "shasum": "02cab9ecebe95bbec6d5fc2566325725ab6d1a73",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33787,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa42TwCRA9TVsSAnZWagAA9QIP/206dH8DHDUquF4oPOzU\nJepJ6H+XcmdcMtLf+EOrsD0xSH3YzIFovmUpOByJif5rmqj4lQ8QcNu4iuJf\nP7FzTQgWTkvtFtG13FIPkggu0gKr/5kEdjLar1Zh4lU65vh1LGOQGwquyEAQ\nLlIa9uxbV6z6erd2oV6hBM8LsdNocVNuYp/LOWWISbH1hrn4VAbFixd17fj+\nNvKVSWkxZiXdHw8BAbp6fQaOtVEizbQ9+V/6J6IAUMDiTmJKLanZDgsBGjHM\nKyfzVVId3nPlVxuTC5FZRYz7TYaDqhY6v1K9jAgraEZirbqcWcJjDAEBBrJD\nJ70rZ3xMvwHVRM+c73ob7DoUv0DJGNmsanTzx6LZSyjvefD/1ir8HSa/wZ2S\nXO4OqDFdF4PLA3cH1xf7qxZRkhEeGJr9QDG5bA/XsuFhE+QhaSPIUMikxREl\n8HNmjIenGGZcVizOaBywX6qfZ8LEIVUG0T5Di1M/zLONpHp1CmTTktDLXI54\nkPzrphxX3dMVrwQ2IML8kI4H3iDekh0lMjOF1piyjB5d8UHymOLlD2Yy95Xv\nXOwWAOtRksCjySr8oU84r7e6J6p1+JCmLquXEYcWTJGGxrooCfO4Y9X10dR6\ndCF2uhxFaqFVg8FAIUsGgC7OA1FMpypg0j2uan/S9sWFfhaBxbxs9AVLmWEj\ngIGb\r\n=e5xJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_1.0.5_1524851951300_0.5330775232308282"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.0": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.1.0",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "34fe330e405caacacf201a9abbb91e81b114518e",
+      "_id": "upath@1.1.0",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "9.9.0",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+        "shasum": "35256597e46a581db4793d0ce47fa9aebfc9fabd",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33919,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa+1CWCRA9TVsSAnZWagAAHlUP/05vdAPUSMWKDe63Bq40\n8egTXxFeSpx9PsBIHdKOdbe3Tn3TEId8MKOdeEZspr8VEhR6RX5IwwvZDfx1\n6O/SUgzxRzddXS2YnqrFI4E68FkHScRMLpFfDdKrG2BQr1tXunDQf4/Z/wVo\nn64g558Sul8piyNypeXFegohFFYpifAeeDSrN5hMGLtmmwAAd4Io7N+smtST\nTRuMoSGez7atwSN9SJjxjfUgvIqdBkpavwmzEsOAW6OeqNQtqw8SmtbAMKqJ\nzzuolUbBoQFQVKylqYnxni2Q1lFcQCuvUeO00fc4pBkt+rWZT0R0HANMjkW3\nWdU/YDqz0K/T8rwhgG8641uP8j/MzpwhLH6hqJ1FB2VHQveB2nAtbvRhergJ\nBZc71lF+JKbTIjrjQzpwgnXWstj6JXt3EO2ny8pcB57vKpZTSXapnJJztijp\nXFCp3hfBSTZLYFWwuJB0OpPTUJUfXOr/CHPQZMXf3tgSqai1JiUwgWcKlMtn\n0BEvm3DGUXFs8l2dCyDoHmxZHmtuPwNil2ltZxCVChmRaoVc9S21I+dES2bV\nhOd82IObtF3pBPnauvYrmWCRm0y6PjMZoTcVZPi5DvBP6/NSAYVTBXvi/yqW\nUINWHr0wXYLFisgV4OXFou1CEhRnTALbrD/SSUtyWwLxY1B4c2kmFUTj3FD7\n63wv\r\n=tYTf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_1.1.0_1526419605863_0.9798545761860444"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.1": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.1.1",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": ">=1"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "8cbc8538e2e127eede7c891ff350a4d42bd8f4a8",
+      "_id": "upath@1.1.1",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "11.8.0",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-D0yetkpIOKiZQquxjM2Syvy48Y1DbZ0SWxgsZiwd9GCWRpc75vN8ytzem14WDSg+oiX6+Qt31FpiS/ExODCrLg==",
+        "shasum": "497f7c1090b0818f310bbfb06783586a68d28014",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.1.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33939,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcgPZ1CRA9TVsSAnZWagAAhKkP/2yweS1mn17+S+BQYAsF\nt30FP3g3FwNWdR3fKzf328+tWvR6cv4w/Mqzlyodw3TN7nYkzG/r73sTcFUV\nFCUBa6gby59SJakMIG7mJ3WNv41TlEgRt8BpVH0YdmNDhEYjfvl46/RJH3US\n4ps4w1tbc0K8qQzwl2fpj62AGQhaFz2YhhL6Z/tPUq3HKJTcY7MN1oH3pbML\nZOQuKt9F5Co7pIRPiwwbZzPet6HIJD1WRNurQQtV5iFHXlsGGL0d93a64TXa\n1BxWGIalCxLUxPCqLAeldO2mFFqigqX4FZ942KqV5wyAbWso/aBHLTSmNzKK\nCZKT99HXlUlQgl37UqaTsN64HN0eT62L4aLOeE+4WUstn6/bfSUu+zssWUj/\n6vip/Yv2m187gHrcN1BoO4IsFqK4CZOVZ2iDHOhux73wyINFrKjr47JH2oPM\nMmcF7YxiUHq19Nex0RwBWeG4N8IJDpI6T7S4cQQwwsF+cLKg/469wbvFnIZG\nJkP0AZohNclOBcKVAewckqHct5QZKTLreUkIp+fyc7BIAP31AdxLERzdHVLp\nEs9GLzkG+XSlstbIDA7vpSeVFZ075RTa1qw3/NYfKRk4VTBZnfonyDpjOvVa\ntWC7EwcYHEelrqcgRHiUZCisehe0IlISgXAyyXJmFS00G7DFqmc350TbqoiW\nvjcd\r\n=I66C\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_1.1.1_1551955572495_0.18914717102935752"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.2": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.1.2",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "611e9861a4f5411e28123e43bcdc4c8cbd264819",
+      "_id": "upath@1.1.2",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "11.8.0",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+        "shasum": "3db658600edaeeccbe6db5e684d67ee8c2acd068",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33937,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJchlt/CRA9TVsSAnZWagAA3BgP/iAh9ECWWJz3wwVA5rVW\nnI/xr0Tjny30nDwTBLDStq3Gc5cxwnUWZ4EWakUQjKQThYaUtDn6awTBqJ76\nhRM/XpJN9Kxj0SK8NxOcMgSy3p/hnot+7kvJeF5qaAfpikA4xULuNDex6Spf\nWxIkaxHTViwpK9toXDySrb1CyXK59ZGjig5OZz6Z715si8w5crpk2SB49Je1\nMgh4xUGuGB8HJh8CBvkY26jZENZj+NzlDB53fQ9fu3u2Y7URMKekGOwhfJYE\nWGag2SaQBOTy9vspukKfTbBPd5h6p+BosBR7xF0CnUVyE6wPT0NVDUU2Tbzp\ncXBYGCCdgNuOP2/DNUezb4fwxj3paqrJaoqomUNQJGNT+kRkEJiB6KCvcDxt\ngfhLbUxFrmn/Hksz3TCdXtLnTFcompphxjozczKWvKXahs9cEtoLlefTPpW1\npXTmWCQivdvzQ6FiCPk8hcAltzXu305e9mUPCyIPeJvuchfhoA6q8BTeKUFy\nnPLi/1W+2l3YckrwdrCMD+gnEE3l6GgrqMelbutgfr3JGXKh7AJ3JxJiNs50\nZdV7ayb9InombHtwI7934kvYj7D4wD+M4VGzekX1p9NIL4GYV+E/MH7hz7/y\nDgYxeRlPZqFGsRE1b6qByHKANb1Xd9cGWVm+ZZMbE2oCmqDlWa2XXhP8JXxB\npnE8\r\n=Y6le\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_1.1.2_1552309119040_0.3862582480498318"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.0": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "1.2.0",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "grunt",
+        "build": "grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "^1.1.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.15",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "^3.3.5",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "48138967b05a828abcb626f83fcf6795fa0bf405",
+      "_id": "upath@1.2.0",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.14.2",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+        "shasum": "8f66dbcd55a883acdae4408af8b035a5044c1894",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 34250,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdbX6wCRA9TVsSAnZWagAAU9sP/jnoeR6l+2uqYUBsremU\nXjhxv+U015g9ycp7YVPNR+dO8O4jepBzchhBLeB1bPoP432Gm4Z04XJaT158\njiAUAFrWu5ccyz2kr2dl1Ycj/U0QtCwalcgkTJvU1hsSIZQPO/8Lculz8jID\nXl/LG1lWoI9oFlnXuRUtimjMeqfAUAoysMc+CcfeAji8mCKkxKYL6cRq03DH\njzO0j/uWodld8vl8RVgl4BlaEfrIuXeSnlIPMjvgoDzYwvxOCtE3uZzn3J8E\nGowIHXyz7iB3OQZBf0+Q0BOoJcdZWALut28U/0Q0ojiyBtnUP5hO0j8rovHx\nQxd9DWO9W0ugxzeeeKWPSMLrui9YtLf3ADuoFnbhyfE3I98Qzmf21jIj5E35\nywEre0NfRtv8SxyUrpeh+vs0ZRizvw2ePi0JiOi91IGL22JRx50Qy0Xxwrci\nJSnvwWkWqmx6dUB1pHV3zGwtleurpocfW7/HPdZOBoKMbH8s/Ih4UNVFse3A\nhd/Z4WLKz4UahSrGBR2NhlzsOaVTJXJg850271scDjSMJ9bmUEwky9nIa/Jy\nT+SKIVbW0JDXxRBqcEpyExxRh6B3PKui5AHO4PukGP81ZxX3zJAdzB2RF1jF\n8MLiZW2k/KbPu8Fc+oKuqJBdDJwGkqY8TBZ2Sny8fMxreq0yvOr7Txmedg7f\ne45Y\r\n=Y6jJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_1.2.0_1567456943891_0.766137715814621"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results (supports UNC paths) & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "2.0.0",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension",
+        "UNC paths"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "npx grunt",
+        "build": "npx grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "^1.1.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.20",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "^3.3.5",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "6d71bca2b3dc1a9972158906cfe22477531a4776",
+      "_id": "upath@2.0.0",
+      "_nodeVersion": "12.16.3",
+      "_npmVersion": "6.14.5",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-ghi1XxsVYPOZPDsOZrfOJIwQU5I3JVYB3Q6IbBGn1KFeOa89i0nUy5tCEkY9pVm83U83qZ1QG40RQKGknllV4w==",
+        "shasum": "7234f3c1e7fd2bcb4f6aaba3e5565ee13ce6d287",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 36731,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJffLQyCRA9TVsSAnZWagAA8osP/2f8GcngYjckypwVf1ki\nE5YA4p5rsEBm4WxVnJblq/9h4fB5oFNR4LB9w2e4GX2cNbXaSFH/HNDq7H8x\nA9Sg2vQXN/ERVAqZef8Rf7pkzeSuVaET5WmU98j4W7CwyVTfxW7/nzGp925u\nUaS9lAFtZrPKZ+psxr8BkB0m/h+dRxUFVOqwLzzYL2vS4wo8qMgF+HvnGFhl\nLiyHyNr4p7eQFBrER4dkpOPfmYheU3k/FJJOBkvMMU7rFydqNBgLMzclFkg7\nfvbuwi7TwacAOLV9fBCmuMXNdUvOTDkn153AoZiIvKtBNK1A95OkCDI4urT4\nMRQruluZ+JL7bYVbbNa+kL9dR7XgBpGV3vNu87tyX56cf4D/saii5pilZKuH\nvQPwV3ijZmOrJdrVhiWk7ZYZSIZ9KrKPBOoaV0QxWfT5vFOZod+/BQS0/O0y\nO9f8zdW+Bny5zafy3YT+wDQa9CQsGKlazj+Dg5vv0ur/8EzTc1+I1gYqHXam\nFXUt8/aymSyY7GLnPa03CRMgyTxLz3luumLRjdFzIw9C+hA5jhINQXZ3R/zT\nO4E5VgUrd1qLk8BGNPigrFIdB+vDohptcnuTFJhaRCgC7LNRm6gRLGNv0/Gd\ns+zhv5Fbq1aInoFFJZn+NjNsfbB79+2FIhYALnKhatxhqxRk2Y9AlFI7gWQX\nHJIN\r\n=Wsd1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_2.0.0_1602008114576_0.49612663397823287"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "upath",
+      "description": "A proxy to `path`, replacing `\\` with `/` for all results (supports UNC paths) & new methods to normalize & join keeping leading `./` and add, change, default, trim file extensions.",
+      "version": "2.0.1",
+      "homepage": "http://github.com/anodynos/upath/",
+      "author": {
+        "name": "Angelos Pikoulas",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "path",
+        "unix",
+        "windows",
+        "extension",
+        "file extension",
+        "replace extension",
+        "change extension",
+        "trim extension",
+        "add extension",
+        "default extension",
+        "UNC paths"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/anodynos/upath.git"
+      },
+      "bugs": {
+        "url": "http://github.com/anodynos/upath/issues",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "main": "./build/code/upath.js",
+      "types": "./upath.d.ts",
+      "preferGlobal": false,
+      "scripts": {
+        "test": "npx grunt",
+        "build": "npx grunt lib"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "^1.1.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.20",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "^3.3.5",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "gitHead": "04a89182fd2029365876e44896f828182369618f",
+      "_id": "upath@2.0.1",
+      "_nodeVersion": "12.16.3",
+      "_npmVersion": "6.14.5",
+      "_npmUser": {
+        "name": "anodynos",
+        "email": "agelos.pikoulas@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "anodynos",
+          "email": "agelos.pikoulas@gmail.com"
+        }
+      ],
+      "dist": {
+        "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+        "shasum": "50c73dea68d6f6b990f51d279ce6081665d61a8b",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 36733,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfptLuCRA9TVsSAnZWagAABwoP/iHAlLEgwmZlPREjBfwt\nf0beWKwvOTYptE5bDgkxblXU65+L7aWotxdxeSkCEaD71JO70eihdOxQrrQo\nK4p6eD7WnlEmvSHup2wlUWDR3A/xcW3TBQrSqoHaY/+6P1YVdtJR7I+F4BEi\nAwbdCTQ8REJBoW8soS6P+vVdxgBhi2745CdVKeOv+y+GV1IynL2OUvmIvG1y\nkYTZYRDCrjHzgq9pKJgheLb2sbl9MhY248xAf+Jyiw8TYCJmNVvvkfNbqkrQ\nxyWQQi72ACUUZbJVanMU5Tm5OlWTgazNqOhyLXKhmT/xstXqKDlGP0b+QOOf\nnyjCaMt43HNCoGHkS0VIBudvczvgYh+fofWuH+aW+sSrCaY/xbhmMS9jPMku\n5tpc2PTAt3OMyQGZ3DpyzsFflmJ9nfEQiFdDQAVqHhGANNBSYe7ZWEGadtWi\nt9yrND9MgvMoecpylQqOFPMtJcZAmj3t0tGxGAvNoHuOX7pF4lbWd4bI8lVq\n/GJ9Hr7s1YQUGGQ8FQNpG0l70qqnDPfwzDAQgV9yVcAm5Av86w8WC/FaHbXU\ndt/4MBxHBEYFv6EDVxUVQzYvh06PxQ/WFEg8yuplEWZy//9VbuQJnon5FIgs\nERFgQKK0cyRlUcCLkjOexk3l3APoJ+McU5s+CujGp6AELcMszEbE0QZIUYuE\nRBJo\r\n=C/BT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/upath_2.0.1_1604768493989_0.6257685547230398"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# upath v2.0.1\n\n[![Build Status](https://travis-ci.org/anodynos/upath.svg?branch=master)](https://travis-ci.org/anodynos/upath)\n[![Up to date Status](https://david-dm.org/anodynos/upath.png)](https://david-dm.org/anodynos/upath)\n\nA drop-in replacement / proxy to nodejs's `path` that:\n\n  * Replaces the windows `\\` with the unix `/` in all string params & results. This has significant positives - see below.\n\n  * Adds **filename extensions** functions `addExt`, `trimExt`, `removeExt`, `changeExt`, and `defaultExt`.\n\n  * Add a `normalizeSafe` function to preserve any meaningful leading `./` & a `normalizeTrim` which additionally trims any useless ending `/`.\n\n  * Plus a helper `toUnix` that simply converts `\\` to `/` and consolidates duplicates.\n\n**Useful note: these docs are actually auto generated from [specs](https://github.com/anodynos/upath/blob/master/source/spec/upath-spec.coffee), running on Linux.**\n\nNotes:\n\n * `upath.sep` is set to `'/'` for seamless replacement (as of 1.0.3).\n\n * upath has no runtime dependencies, except built-in `path` (as of 1.0.4)\n\n * travis-ci tested in node versions 8 to 14 (on linux)\n\n * Also tested on Windows / node@12.18.0 (without CI)  \n\nHistory brief:\n\n * 1.x   : Initial release and various features / fixes\n\n * 2.0.0 : Adding UNC paths support - see https://github.com/anodynos/upath/pull/38\n\n## Why ?\n\nNormal `path` doesn't convert paths to a unified format (ie `/`) before calculating paths (`normalize`, `join`), which can lead to numerous problems.\nAlso path joining, normalization etc on the two formats is not consistent, depending on where it runs. Running `path` on Windows yields different results than when it runs on Linux / Mac.\n\nIn general, if you code your paths logic while developing on Unix/Mac and it runs on Windows, you may run into problems when using `path`.\n\nNote that using **Unix `/` on Windows** works perfectly inside nodejs (and other languages), so there's no reason to stick to the Windows legacy at all.\n\n##### Examples / specs\n        \n\nCheck out the different (improved) behavior to vanilla `path`:\n\n    `upath.normalize(path)`        --returns-->\n\n          ✓ `'c:/windows/nodejs/path'`         --->      `'c:/windows/nodejs/path'`  // equal to `path.normalize()`\n          ✓ `'c:/windows/../nodejs/path'`      --->              `'c:/nodejs/path'`  // equal to `path.normalize()`\n          ✓ `'c:\\\\windows\\\\nodejs\\\\path'`      --->      `'c:/windows/nodejs/path'`  // `path.normalize()` gives `'c:\\windows\\nodejs\\path'`\n          ✓ `'c:\\\\windows\\\\..\\\\nodejs\\\\path'`  --->              `'c:/nodejs/path'`  // `path.normalize()` gives `'c:\\windows\\..\\nodejs\\path'`\n          ✓ `'/windows\\\\unix/mixed'`           --->         `'/windows/unix/mixed'`  // `path.normalize()` gives `'/windows\\unix/mixed'`\n          ✓ `'\\\\windows//unix/mixed'`          --->         `'/windows/unix/mixed'`  // `path.normalize()` gives `'\\windows/unix/mixed'`\n          ✓ `'\\\\windows\\\\..\\\\unix/mixed/'`     --->                `'/unix/mixed/'`  // `path.normalize()` gives `'\\windows\\..\\unix/mixed/'`\n        \n\nJoining paths can also be a problem:\n\n    `upath.join(paths...)`        --returns-->\n\n          ✓ `'some/nodejs/deep', '../path'`       --->       `'some/nodejs/path'`  // equal to `path.join()`\n          ✓ `'some/nodejs\\\\windows', '../path'`   --->       `'some/nodejs/path'`  // `path.join()` gives `'some/path'`\n          ✓ `'some\\\\windows\\\\only', '..\\\\path'`   --->      `'some/windows/path'`  // `path.join()` gives `'some\\windows\\only/..\\path'`\n        \n\nParsing with `path.parse()` should also be consistent across OSes:\n\n  `upath.parse(path)`        --returns-->\n\n          ✓ `'c:\\Windows\\Directory\\somefile.ext'`      ---> `{ root: '', dir: 'c:/Windows/Directory', base: 'somefile.ext', ext: '.ext', name: 'somefile'\n}`\n                                    // `path.parse()` gives `'{ root: '', dir: '', base: 'c:\\\\Windows\\\\Directory\\\\somefile.ext', ext: '.ext', name: 'c:\\\\Windows\\\\Directory\\\\somefile'\n}'`\n          ✓ `'/root/of/unix/somefile.ext'`             ---> `{ root: '/', dir: '/root/of/unix', base: 'somefile.ext', ext: '.ext', name: 'somefile'\n}`  // equal to `path.parse()`\n    \n\n## Added functions\n      \n\n#### `upath.toUnix(path)`\n\nJust converts all `` to `/` and consolidates duplicates, without performing any normalization.\n\n##### Examples / specs\n\n    `upath.toUnix(path)`        --returns-->\n\n        ✓ `'.//windows\\//unix//mixed////'`      --->         `'./windows/unix/mixed/'`\n        ✓ `'..///windows\\..\\\\unix/mixed'`       --->      `'../windows/../unix/mixed'`\n      \n\n#### `upath.normalizeSafe(path)`\n\nExactly like `path.normalize(path)`, but it keeps the first meaningful `./` or `//`.\n\nNote that the unix `/` is returned everywhere, so windows `\\` is always converted to unix `/`.\n\n##### Examples / specs & how it differs from vanilla `path`\n\n    `upath.normalizeSafe(path)`        --returns-->\n\n        ✓ `''`                               --->                              `'.'`  // equal to `path.normalize()`\n        ✓ `'.'`                              --->                              `'.'`  // equal to `path.normalize()`\n        ✓ `'./'`                             --->                             `'./'`  // equal to `path.normalize()`\n        ✓ `'.//'`                            --->                             `'./'`  // equal to `path.normalize()`\n        ✓ `'.\\\\'`                            --->                             `'./'`  // `path.normalize()` gives `'.\\'`\n        ✓ `'.\\\\//'`                          --->                             `'./'`  // `path.normalize()` gives `'.\\/'`\n        ✓ `'./..'`                           --->                             `'..'`  // equal to `path.normalize()`\n        ✓ `'.//..'`                          --->                             `'..'`  // equal to `path.normalize()`\n        ✓ `'./../'`                          --->                            `'../'`  // equal to `path.normalize()`\n        ✓ `'.\\\\..\\\\'`                        --->                            `'../'`  // `path.normalize()` gives `'.\\..\\'`\n        ✓ `'./../dep'`                       --->                         `'../dep'`  // equal to `path.normalize()`\n        ✓ `'../dep'`                         --->                         `'../dep'`  // equal to `path.normalize()`\n        ✓ `'../path/dep'`                    --->                    `'../path/dep'`  // equal to `path.normalize()`\n        ✓ `'../path/../dep'`                 --->                         `'../dep'`  // equal to `path.normalize()`\n        ✓ `'dep'`                            --->                            `'dep'`  // equal to `path.normalize()`\n        ✓ `'path//dep'`                      --->                       `'path/dep'`  // equal to `path.normalize()`\n        ✓ `'./dep'`                          --->                          `'./dep'`  // `path.normalize()` gives `'dep'`\n        ✓ `'./path/dep'`                     --->                     `'./path/dep'`  // `path.normalize()` gives `'path/dep'`\n        ✓ `'./path/../dep'`                  --->                          `'./dep'`  // `path.normalize()` gives `'dep'`\n        ✓ `'.//windows\\\\unix/mixed/'`        --->          `'./windows/unix/mixed/'`  // `path.normalize()` gives `'windows\\unix/mixed/'`\n        ✓ `'..//windows\\\\unix/mixed'`        --->          `'../windows/unix/mixed'`  // `path.normalize()` gives `'../windows\\unix/mixed'`\n        ✓ `'windows\\\\unix/mixed/'`           --->            `'windows/unix/mixed/'`  // `path.normalize()` gives `'windows\\unix/mixed/'`\n        ✓ `'..//windows\\\\..\\\\unix/mixed'`    --->                  `'../unix/mixed'`  // `path.normalize()` gives `'../windows\\..\\unix/mixed'`\n        ✓ `'\\\\\\\\server\\\\share\\\\file'`        --->            `'//server/share/file'`  // `path.normalize()` gives `'\\\\server\\share\\file'`\n        ✓ `'//server/share/file'`            --->            `'//server/share/file'`  // `path.normalize()` gives `'/server/share/file'`\n        ✓ `'\\\\\\\\?\\\\UNC\\\\server\\\\share\\\\file'` --->      `'//?/UNC/server/share/file'`  // `path.normalize()` gives `'\\\\?\\UNC\\server\\share\\file'`\n        ✓ `'\\\\\\\\LOCALHOST\\\\c$\\\\temp\\\\file'`  --->       `'//LOCALHOST/c$/temp/file'`  // `path.normalize()` gives `'\\\\LOCALHOST\\c$\\temp\\file'`\n        ✓ `'\\\\\\\\?\\\\c:\\\\temp\\\\file'`          --->               `'//?/c:/temp/file'`  // `path.normalize()` gives `'\\\\?\\c:\\temp\\file'`\n        ✓ `'\\\\\\\\.\\\\c:\\\\temp\\\\file'`          --->               `'//./c:/temp/file'`  // `path.normalize()` gives `'\\\\.\\c:\\temp\\file'`\n        ✓ `'//./c:/temp/file'`               --->               `'//./c:/temp/file'`  // `path.normalize()` gives `'/c:/temp/file'`\n        ✓ `'////\\\\.\\\\c:/temp\\\\//file'`       --->               `'//./c:/temp/file'`  // `path.normalize()` gives `'/\\.\\c:/temp\\/file'`\n      \n\n#### `upath.normalizeTrim(path)`\n\nExactly like `path.normalizeSafe(path)`, but it trims any useless ending `/`.\n\n##### Examples / specs\n\n    `upath.normalizeTrim(path)`        --returns-->\n\n        ✓ `'./'`                          --->                         `'.'`  // `upath.normalizeSafe()` gives `'./'`\n        ✓ `'./../'`                       --->                        `'..'`  // `upath.normalizeSafe()` gives `'../'`\n        ✓ `'./../dep/'`                   --->                    `'../dep'`  // `upath.normalizeSafe()` gives `'../dep/'`\n        ✓ `'path//dep\\\\'`                 --->                  `'path/dep'`  // `upath.normalizeSafe()` gives `'path/dep/'`\n        ✓ `'.//windows\\\\unix/mixed/'`     --->      `'./windows/unix/mixed'`  // `upath.normalizeSafe()` gives `'./windows/unix/mixed/'`\n      \n\n#### `upath.joinSafe([path1][, path2][, ...])`\n\nExactly like `path.join()`, but it keeps the first meaningful `./` or `//`.\n\nNote that the unix `/` is returned everywhere, so windows `\\` is always converted to unix `/`.\n\n##### Examples / specs & how it differs from vanilla `path`\n\n    `upath.joinSafe(path)`        --returns-->\n\n        ✓ `'some/nodejs/deep', '../path'`                --->           `'some/nodejs/path'`  // equal to `path.join()`\n        ✓ `'./some/local/unix/', '../path'`              --->          `'./some/local/path'`  // `path.join()` gives `'some/local/path'`\n        ✓ `'./some\\\\current\\\\mixed', '..\\\\path'`         --->        `'./some/current/path'`  // `path.join()` gives `'some\\current\\mixed/..\\path'`\n        ✓ `'../some/relative/destination', '..\\\\path'`   --->      `'../some/relative/path'`  // `path.join()` gives `'../some/relative/destination/..\\path'`\n        ✓ `'\\\\\\\\server\\\\share\\\\file', '..\\\\path'`        --->        `'//server/share/path'`  // `path.join()` gives `'\\\\server\\share\\file/..\\path'`\n        ✓ `'\\\\\\\\.\\\\c:\\\\temp\\\\file', '..\\\\path'`          --->           `'//./c:/temp/path'`  // `path.join()` gives `'\\\\.\\c:\\temp\\file/..\\path'`\n        ✓ `'//server/share/file', '../path'`             --->        `'//server/share/path'`  // `path.join()` gives `'/server/share/path'`\n        ✓ `'//./c:/temp/file', '../path'`                --->           `'//./c:/temp/path'`  // `path.join()` gives `'/c:/temp/path'`\n    \n\n## Added functions for *filename extension* manipulation.\n\n**Happy notes:**\n\n  In all functions you can:\n\n  * use both `.ext` & `ext` - the dot `.` on the extension is always adjusted correctly.\n\n  * omit the `ext` param (pass null/undefined/empty string) and the common sense thing will happen.\n\n  * ignore specific extensions from being considered as valid ones (eg `.min`, `.dev` `.aLongExtIsNotAnExt` etc), hence no trimming or replacement takes place on them.\n\n       \n\n#### `upath.addExt(filename, [ext])`\n\nAdds `.ext` to `filename`, but only if it doesn't already have the exact extension.\n\n##### Examples / specs\n\n    `upath.addExt(filename, 'js')`     --returns-->\n\n        ✓ `'myfile/addExt'`           --->           `'myfile/addExt.js'`\n        ✓ `'myfile/addExt.txt'`       --->       `'myfile/addExt.txt.js'`\n        ✓ `'myfile/addExt.js'`        --->           `'myfile/addExt.js'`\n        ✓ `'myfile/addExt.min.'`      --->      `'myfile/addExt.min..js'`\n        \n\nIt adds nothing if no `ext` param is passed.\n\n    `upath.addExt(filename)`           --returns-->\n\n          ✓ `'myfile/addExt'`           --->              `'myfile/addExt'`\n          ✓ `'myfile/addExt.txt'`       --->          `'myfile/addExt.txt'`\n          ✓ `'myfile/addExt.js'`        --->           `'myfile/addExt.js'`\n          ✓ `'myfile/addExt.min.'`      --->         `'myfile/addExt.min.'`\n      \n\n#### `upath.trimExt(filename, [ignoreExts], [maxSize=7])`\n\nTrims a filename's extension.\n\n  * Extensions are considered to be up to `maxSize` chars long, counting the dot (defaults to 7).\n\n  * An `Array` of `ignoreExts` (eg `['.min']`) prevents these from being considered as extension, thus are not trimmed.\n\n##### Examples / specs\n\n    `upath.trimExt(filename)`          --returns-->\n\n        ✓ `'my/trimedExt.txt'`             --->                 `'my/trimedExt'`\n        ✓ `'my/trimedExt'`                 --->                 `'my/trimedExt'`\n        ✓ `'my/trimedExt.min'`             --->                 `'my/trimedExt'`\n        ✓ `'my/trimedExt.min.js'`          --->             `'my/trimedExt.min'`\n        ✓ `'../my/trimedExt.longExt'`      --->      `'../my/trimedExt.longExt'`\n        \n\nIt is ignoring `.min` & `.dev` as extensions, and considers exts with up to 8 chars.\n\n    `upath.trimExt(filename, ['min', '.dev'], 8)`          --returns-->\n\n          ✓ `'my/trimedExt.txt'`              --->                  `'my/trimedExt'`\n          ✓ `'my/trimedExt.min'`              --->              `'my/trimedExt.min'`\n          ✓ `'my/trimedExt.dev'`              --->              `'my/trimedExt.dev'`\n          ✓ `'../my/trimedExt.longExt'`       --->               `'../my/trimedExt'`\n          ✓ `'../my/trimedExt.longRExt'`      --->      `'../my/trimedExt.longRExt'`\n      \n\n#### `upath.removeExt(filename, ext)`\n\nRemoves the specific `ext` extension from filename, if it has it. Otherwise it leaves it as is.\nAs in all upath functions, it be `.ext` or `ext`.\n\n##### Examples / specs\n\n    `upath.removeExt(filename, '.js')`          --returns-->\n\n        ✓ `'removedExt.js'`          --->          `'removedExt'`\n        ✓ `'removedExt.txt.js'`      --->      `'removedExt.txt'`\n        ✓ `'notRemoved.txt'`         --->      `'notRemoved.txt'`\n      \n\nIt does not care about the length of exts.\n\n    `upath.removeExt(filename, '.longExt')`          --returns-->\n\n        ✓ `'removedExt.longExt'`          --->          `'removedExt'`\n        ✓ `'removedExt.txt.longExt'`      --->      `'removedExt.txt'`\n        ✓ `'notRemoved.txt'`              --->      `'notRemoved.txt'`\n      \n\n#### `upath.changeExt(filename, [ext], [ignoreExts], [maxSize=7])`\n\nChanges a filename's extension to `ext`. If it has no (valid) extension, it adds it.\n\n  * Valid extensions are considered to be up to `maxSize` chars long, counting the dot (defaults to 7).\n\n  * An `Array` of `ignoreExts` (eg `['.min']`) prevents these from being considered as extension, thus are not changed - the new extension is added instead.\n\n##### Examples / specs\n\n    `upath.changeExt(filename, '.js')`  --returns-->\n\n        ✓ `'my/module.min'`            --->                `'my/module.js'`\n        ✓ `'my/module.coffee'`         --->                `'my/module.js'`\n        ✓ `'my/module'`                --->                `'my/module.js'`\n        ✓ `'file/withDot.'`            --->             `'file/withDot.js'`\n        ✓ `'file/change.longExt'`      --->      `'file/change.longExt.js'`\n        \n\nIf no `ext` param is given, it trims the current extension (if any).\n\n    `upath.changeExt(filename)`        --returns-->\n\n          ✓ `'my/module.min'`            --->                   `'my/module'`\n          ✓ `'my/module.coffee'`         --->                   `'my/module'`\n          ✓ `'my/module'`                --->                   `'my/module'`\n          ✓ `'file/withDot.'`            --->                `'file/withDot'`\n          ✓ `'file/change.longExt'`      --->         `'file/change.longExt'`\n        \n\nIt is ignoring `.min` & `.dev` as extensions, and considers exts with up to 8 chars.\n\n    `upath.changeExt(filename, 'js', ['min', '.dev'], 8)`        --returns-->\n\n          ✓ `'my/module.coffee'`          --->                 `'my/module.js'`\n          ✓ `'file/notValidExt.min'`      --->      `'file/notValidExt.min.js'`\n          ✓ `'file/notValidExt.dev'`      --->      `'file/notValidExt.dev.js'`\n          ✓ `'file/change.longExt'`       --->               `'file/change.js'`\n          ✓ `'file/change.longRExt'`      --->      `'file/change.longRExt.js'`\n      \n\n#### `upath.defaultExt(filename, [ext], [ignoreExts], [maxSize=7])`\n\nAdds `.ext` to `filename`, only if it doesn't already have _any_ *old* extension.\n\n  * (Old) extensions are considered to be up to `maxSize` chars long, counting the dot (defaults to 7).\n\n  * An `Array` of `ignoreExts` (eg `['.min']`) will force adding default `.ext` even if one of these is present.\n\n##### Examples / specs\n\n    `upath.defaultExt(filename, 'js')`   --returns-->\n\n        ✓ `'fileWith/defaultExt'`              --->              `'fileWith/defaultExt.js'`\n        ✓ `'fileWith/defaultExt.js'`           --->              `'fileWith/defaultExt.js'`\n        ✓ `'fileWith/defaultExt.min'`          --->             `'fileWith/defaultExt.min'`\n        ✓ `'fileWith/defaultExt.longExt'`      --->      `'fileWith/defaultExt.longExt.js'`\n        \n\nIf no `ext` param is passed, it leaves filename intact.\n\n    `upath.defaultExt(filename)`       --returns-->\n\n          ✓ `'fileWith/defaultExt'`              --->                 `'fileWith/defaultExt'`\n          ✓ `'fileWith/defaultExt.js'`           --->              `'fileWith/defaultExt.js'`\n          ✓ `'fileWith/defaultExt.min'`          --->             `'fileWith/defaultExt.min'`\n          ✓ `'fileWith/defaultExt.longExt'`      --->         `'fileWith/defaultExt.longExt'`\n        \n\nIt is ignoring `.min` & `.dev` as extensions, and considers exts with up to 8 chars.\n\n    `upath.defaultExt(filename, 'js', ['min', '.dev'], 8)` --returns-->\n\n          ✓ `'fileWith/defaultExt'`               --->               `'fileWith/defaultExt.js'`\n          ✓ `'fileWith/defaultExt.min'`           --->           `'fileWith/defaultExt.min.js'`\n          ✓ `'fileWith/defaultExt.dev'`           --->           `'fileWith/defaultExt.dev.js'`\n          ✓ `'fileWith/defaultExt.longExt'`       --->          `'fileWith/defaultExt.longExt'`\n          ✓ `'fileWith/defaultExt.longRext'`      --->      `'fileWith/defaultExt.longRext.js'`\n\n  \nCopyright(c) 2014-2020 Angelos Pikoulas (agelos.pikoulas@gmail.com)\n\nPermission is hereby granted, free of charge, to any person\nobtaining a copy of this software and associated documentation\nfiles (the \"Software\"), to deal in the Software without\nrestriction, including without limitation the rights to use,\ncopy, modify, merge, publish, distribute, sublicense, and/or sell\ncopies of the Software, and to permit persons to whom the\nSoftware is furnished to do so, subject to the following\nconditions:\n\nThe above copyright notice and this permission notice shall be\nincluded in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\nEXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES\nOF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\nNONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT\nHOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,\nWHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\nFROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR\nOTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "anodynos",
+      "email": "agelos.pikoulas@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-11-07T17:01:36.528Z",
+    "created": "2014-10-29T02:29:05.388Z",
+    "0.1.0": "2014-10-29T02:29:05.388Z",
+    "0.1.1": "2014-10-29T03:16:42.083Z",
+    "0.1.2": "2014-10-29T20:35:51.915Z",
+    "0.1.3": "2014-10-29T23:38:16.925Z",
+    "0.1.4": "2014-11-08T18:39:33.427Z",
+    "0.1.5": "2014-11-17T22:52:30.607Z",
+    "0.1.6": "2015-08-20T22:41:00.942Z",
+    "0.1.7": "2016-02-22T00:44:17.009Z",
+    "0.2.0": "2016-07-03T00:53:34.833Z",
+    "1.0.0": "2017-02-07T15:47:42.333Z",
+    "1.0.2": "2017-11-13T23:14:39.343Z",
+    "1.0.3": "2018-02-25T23:14:20.642Z",
+    "1.0.4": "2018-02-26T00:13:26.634Z",
+    "1.0.5": "2018-04-27T17:59:11.364Z",
+    "1.1.0": "2018-05-15T21:26:45.945Z",
+    "1.1.1": "2019-03-07T10:46:12.624Z",
+    "1.1.2": "2019-03-11T12:58:39.143Z",
+    "1.2.0": "2019-09-02T20:42:24.075Z",
+    "2.0.0": "2020-10-06T18:15:14.685Z",
+    "2.0.1": "2020-11-07T17:01:34.154Z"
+  },
+  "homepage": "http://github.com/anodynos/upath/",
+  "keywords": [
+    "path",
+    "unix",
+    "windows",
+    "extension",
+    "file extension",
+    "replace extension",
+    "change extension",
+    "trim extension",
+    "add extension",
+    "default extension",
+    "UNC paths"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/anodynos/upath.git"
+  },
+  "author": {
+    "name": "Angelos Pikoulas",
+    "email": "agelos.pikoulas@gmail.com"
+  },
+  "bugs": {
+    "url": "http://github.com/anodynos/upath/issues",
+    "email": "agelos.pikoulas@gmail.com"
+  },
+  "readmeFilename": "readme.md",
+  "users": {
+    "thoroc": true,
+    "n03024735": true,
+    "vonthar": true,
+    "anodynos": true,
+    "rochejul": true,
+    "zand3rs": true
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/upath.min.json
+++ b/test/fixtures/registry-mocks/content/upath.min.json
@@ -1,0 +1,650 @@
+{
+  "name": "upath",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "upath",
+      "version": "0.1.0",
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "823665902b2c9b37a5efcfb79a9b53b91738aa9b",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.0.tgz"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "0.1.1": {
+      "name": "upath",
+      "version": "0.1.1",
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "203a77784555e133c5bde9c8698693defaf3e9e7",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.1.tgz"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "0.1.2": {
+      "name": "upath",
+      "version": "0.1.2",
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "2306202c6b65cfa5d150b1b76388e81427a4f221",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.2.tgz"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "0.1.3": {
+      "name": "upath",
+      "version": "0.1.3",
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "7b195b998f469dd1a021fd1c48fb6046dd9064dc",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.3.tgz"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "0.1.4": {
+      "name": "upath",
+      "version": "0.1.4",
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "coffee-script": "^1.8.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.x",
+        "grunt-contrib-clean": "0.4.x",
+        "grunt-contrib-concat": "0.1.x",
+        "grunt-shell": "~0.3.x",
+        "grunt-contrib-watch": "~0.5.x",
+        "uberscore": "0.0.16"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "7008becb374e3b75063235848e4bacd6d3c4d9b3",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.4.tgz"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "0.1.5": {
+      "name": "upath",
+      "version": "0.1.5",
+      "dependencies": {
+        "lodash": "*",
+        "underscore.string": "^2.3.0"
+      },
+      "devDependencies": {
+        "chai": "^1.9.0",
+        "mocha": "^2.0.0",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~0.5.x",
+        "grunt-urequire": "0.7.x",
+        "urequire": "0.7.x",
+        "uberscore": "0.0.16",
+        "urequire-ab-specrunner": "^0.1.10",
+        "urequire-rc-inject-version": "^0.1.2"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "04eb8709ce6ee7f5067ea112a2b60c6eba544485",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.5.tgz"
+      },
+      "engines": {
+        "node": "0.10.x"
+      }
+    },
+    "0.1.6": {
+      "name": "upath",
+      "version": "0.1.6",
+      "dependencies": {
+        "lodash": ">=2.x",
+        "underscore.string": "2.3.x"
+      },
+      "devDependencies": {
+        "chai": "1.9.x",
+        "mocha": "2.0.x",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "0.5.x",
+        "grunt-urequire": "0.7.x",
+        "urequire": "0.7.0-beta.20",
+        "uberscore": "0.0.16",
+        "urequire-ab-specrunner": "0.2.x",
+        "urequire-rc-inject-version": "0.1.x"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "4809de430e55c5845b1cec6319f0fe6c877aa958",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.10.x <=0.12.x"
+      }
+    },
+    "0.1.7": {
+      "name": "upath",
+      "version": "0.1.7",
+      "dependencies": {
+        "lodash": "3.x",
+        "underscore.string": "2.3.x"
+      },
+      "devDependencies": {
+        "chai": "3.5.x",
+        "mocha": "2.4.x",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "0.6.x",
+        "grunt-urequire": "0.7.x",
+        "urequire": "0.7.0-beta.25",
+        "uberscore": "0.0.16",
+        "urequire-ab-specrunner": "^0.2.2",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "7c5bbfe9a4e074ff0b83131ad0c13c2d8601383b",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.1.7.tgz"
+      },
+      "engines": {
+        "node": ">=0.10 <=5"
+      }
+    },
+    "0.2.0": {
+      "name": "upath",
+      "version": "0.2.0",
+      "dependencies": {
+        "lodash": "3.x",
+        "underscore.string": "2.3.x"
+      },
+      "devDependencies": {
+        "chai": "3.5.x",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "0.6.x",
+        "grunt-urequire": "0.7.x",
+        "mocha": "2.4.x",
+        "uberscore": "0.0.19",
+        "urequire": "0.7.0-beta.29",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "bdbad0f2c60afea165f8127dbb1b5bdee500ad81",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10 <=5"
+      }
+    },
+    "1.0.0": {
+      "name": "upath",
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "3.x",
+        "underscore.string": "2.3.x"
+      },
+      "devDependencies": {
+        "chai": "3.5.x",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "0.6.x",
+        "grunt-urequire": "0.7.x",
+        "mocha": "2.4.x",
+        "uberscore": "0.0.19",
+        "urequire": "0.7.0-beta.29",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "shasum": "b4706b9461ca8473adf89133d235689ca17f3656",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.10 <=7"
+      }
+    },
+    "1.0.2": {
+      "name": "upath",
+      "version": "1.0.2",
+      "dependencies": {
+        "lodash.endswith": "^4.2.1",
+        "lodash.startswith": "^4.2.1",
+        "lodash.isfunction": "^3.0.8",
+        "lodash.isstring": "^4.0.1"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-fCmij7T5LnwUme3dbnVSejvOHHlARjB3ikJFwgZfz386pHmf/gueuTLRFU94FZEaeCLlbQrweiUU700gG41tUw==",
+        "shasum": "80aaae5395abc5fd402933ae2f58694f0860204c",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=4 <=9"
+      }
+    },
+    "1.0.3": {
+      "name": "upath",
+      "version": "1.0.3",
+      "dependencies": {
+        "lodash.endswith": "^4.2.1",
+        "lodash.startswith": "^4.2.1",
+        "lodash.isfunction": "^3.0.8",
+        "lodash.isstring": "^4.0.1"
+      },
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-oubdFMfUobEIMojWoHXA3Xh794XY+MWvQVtLNf1Pv8cjPVumqEsxll7+5t7HwjNRGEch30h1yQN0kCeK/GOC5Q==",
+        "shasum": "18a4822d3f668cc69876245d3c2ca74a498eba9b",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.3.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33736
+      },
+      "engines": {
+        "node": ">=4 <=9"
+      }
+    },
+    "1.0.4": {
+      "name": "upath",
+      "version": "1.0.4",
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+        "shasum": "ee2321ba0a786c50973db043a50b7bcba822361d",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33783
+      },
+      "engines": {
+        "node": ">=4 <=9"
+      }
+    },
+    "1.0.5": {
+      "name": "upath",
+      "version": "1.0.5",
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww==",
+        "shasum": "02cab9ecebe95bbec6d5fc2566325725ab6d1a73",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33787,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa42TwCRA9TVsSAnZWagAA9QIP/206dH8DHDUquF4oPOzU\nJepJ6H+XcmdcMtLf+EOrsD0xSH3YzIFovmUpOByJif5rmqj4lQ8QcNu4iuJf\nP7FzTQgWTkvtFtG13FIPkggu0gKr/5kEdjLar1Zh4lU65vh1LGOQGwquyEAQ\nLlIa9uxbV6z6erd2oV6hBM8LsdNocVNuYp/LOWWISbH1hrn4VAbFixd17fj+\nNvKVSWkxZiXdHw8BAbp6fQaOtVEizbQ9+V/6J6IAUMDiTmJKLanZDgsBGjHM\nKyfzVVId3nPlVxuTC5FZRYz7TYaDqhY6v1K9jAgraEZirbqcWcJjDAEBBrJD\nJ70rZ3xMvwHVRM+c73ob7DoUv0DJGNmsanTzx6LZSyjvefD/1ir8HSa/wZ2S\nXO4OqDFdF4PLA3cH1xf7qxZRkhEeGJr9QDG5bA/XsuFhE+QhaSPIUMikxREl\n8HNmjIenGGZcVizOaBywX6qfZ8LEIVUG0T5Di1M/zLONpHp1CmTTktDLXI54\nkPzrphxX3dMVrwQ2IML8kI4H3iDekh0lMjOF1piyjB5d8UHymOLlD2Yy95Xv\nXOwWAOtRksCjySr8oU84r7e6J6p1+JCmLquXEYcWTJGGxrooCfO4Y9X10dR6\ndCF2uhxFaqFVg8FAIUsGgC7OA1FMpypg0j2uan/S9sWFfhaBxbxs9AVLmWEj\ngIGb\r\n=e5xJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.1.0": {
+      "name": "upath",
+      "version": "1.1.0",
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+        "shasum": "35256597e46a581db4793d0ce47fa9aebfc9fabd",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33919,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa+1CWCRA9TVsSAnZWagAAHlUP/05vdAPUSMWKDe63Bq40\n8egTXxFeSpx9PsBIHdKOdbe3Tn3TEId8MKOdeEZspr8VEhR6RX5IwwvZDfx1\n6O/SUgzxRzddXS2YnqrFI4E68FkHScRMLpFfDdKrG2BQr1tXunDQf4/Z/wVo\nn64g558Sul8piyNypeXFegohFFYpifAeeDSrN5hMGLtmmwAAd4Io7N+smtST\nTRuMoSGez7atwSN9SJjxjfUgvIqdBkpavwmzEsOAW6OeqNQtqw8SmtbAMKqJ\nzzuolUbBoQFQVKylqYnxni2Q1lFcQCuvUeO00fc4pBkt+rWZT0R0HANMjkW3\nWdU/YDqz0K/T8rwhgG8641uP8j/MzpwhLH6hqJ1FB2VHQveB2nAtbvRhergJ\nBZc71lF+JKbTIjrjQzpwgnXWstj6JXt3EO2ny8pcB57vKpZTSXapnJJztijp\nXFCp3hfBSTZLYFWwuJB0OpPTUJUfXOr/CHPQZMXf3tgSqai1JiUwgWcKlMtn\n0BEvm3DGUXFs8l2dCyDoHmxZHmtuPwNil2ltZxCVChmRaoVc9S21I+dES2bV\nhOd82IObtF3pBPnauvYrmWCRm0y6PjMZoTcVZPi5DvBP6/NSAYVTBXvi/yqW\nUINWHr0wXYLFisgV4OXFou1CEhRnTALbrD/SSUtyWwLxY1B4c2kmFUTj3FD7\n63wv\r\n=tYTf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "1.1.1": {
+      "name": "upath",
+      "version": "1.1.1",
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-D0yetkpIOKiZQquxjM2Syvy48Y1DbZ0SWxgsZiwd9GCWRpc75vN8ytzem14WDSg+oiX6+Qt31FpiS/ExODCrLg==",
+        "shasum": "497f7c1090b0818f310bbfb06783586a68d28014",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.1.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33939,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcgPZ1CRA9TVsSAnZWagAAhKkP/2yweS1mn17+S+BQYAsF\nt30FP3g3FwNWdR3fKzf328+tWvR6cv4w/Mqzlyodw3TN7nYkzG/r73sTcFUV\nFCUBa6gby59SJakMIG7mJ3WNv41TlEgRt8BpVH0YdmNDhEYjfvl46/RJH3US\n4ps4w1tbc0K8qQzwl2fpj62AGQhaFz2YhhL6Z/tPUq3HKJTcY7MN1oH3pbML\nZOQuKt9F5Co7pIRPiwwbZzPet6HIJD1WRNurQQtV5iFHXlsGGL0d93a64TXa\n1BxWGIalCxLUxPCqLAeldO2mFFqigqX4FZ942KqV5wyAbWso/aBHLTSmNzKK\nCZKT99HXlUlQgl37UqaTsN64HN0eT62L4aLOeE+4WUstn6/bfSUu+zssWUj/\n6vip/Yv2m187gHrcN1BoO4IsFqK4CZOVZ2iDHOhux73wyINFrKjr47JH2oPM\nMmcF7YxiUHq19Nex0RwBWeG4N8IJDpI6T7S4cQQwwsF+cLKg/469wbvFnIZG\nJkP0AZohNclOBcKVAewckqHct5QZKTLreUkIp+fyc7BIAP31AdxLERzdHVLp\nEs9GLzkG+XSlstbIDA7vpSeVFZ075RTa1qw3/NYfKRk4VTBZnfonyDpjOvVa\ntWC7EwcYHEelrqcgRHiUZCisehe0IlISgXAyyXJmFS00G7DFqmc350TbqoiW\nvjcd\r\n=I66C\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": ">=1"
+      }
+    },
+    "1.1.2": {
+      "name": "upath",
+      "version": "1.1.2",
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "~1.0.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.4",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "~3.3.4",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
+        "shasum": "3db658600edaeeccbe6db5e684d67ee8c2acd068",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+        "fileCount": 5,
+        "unpackedSize": 33937,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJchlt/CRA9TVsSAnZWagAA3BgP/iAh9ECWWJz3wwVA5rVW\nnI/xr0Tjny30nDwTBLDStq3Gc5cxwnUWZ4EWakUQjKQThYaUtDn6awTBqJ76\nhRM/XpJN9Kxj0SK8NxOcMgSy3p/hnot+7kvJeF5qaAfpikA4xULuNDex6Spf\nWxIkaxHTViwpK9toXDySrb1CyXK59ZGjig5OZz6Z715si8w5crpk2SB49Je1\nMgh4xUGuGB8HJh8CBvkY26jZENZj+NzlDB53fQ9fu3u2Y7URMKekGOwhfJYE\nWGag2SaQBOTy9vspukKfTbBPd5h6p+BosBR7xF0CnUVyE6wPT0NVDUU2Tbzp\ncXBYGCCdgNuOP2/DNUezb4fwxj3paqrJaoqomUNQJGNT+kRkEJiB6KCvcDxt\ngfhLbUxFrmn/Hksz3TCdXtLnTFcompphxjozczKWvKXahs9cEtoLlefTPpW1\npXTmWCQivdvzQ6FiCPk8hcAltzXu305e9mUPCyIPeJvuchfhoA6q8BTeKUFy\nnPLi/1W+2l3YckrwdrCMD+gnEE3l6GgrqMelbutgfr3JGXKh7AJ3JxJiNs50\nZdV7ayb9InombHtwI7934kvYj7D4wD+M4VGzekX1p9NIL4GYV+E/MH7hz7/y\nDgYxeRlPZqFGsRE1b6qByHKANb1Xd9cGWVm+ZZMbE2oCmqDlWa2XXhP8JXxB\npnE8\r\n=Y6le\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "1.2.0": {
+      "name": "upath",
+      "version": "1.2.0",
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "^1.1.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.15",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "^3.3.5",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+        "shasum": "8f66dbcd55a883acdae4408af8b035a5044c1894",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 34250,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdbX6wCRA9TVsSAnZWagAAU9sP/jnoeR6l+2uqYUBsremU\nXjhxv+U015g9ycp7YVPNR+dO8O4jepBzchhBLeB1bPoP432Gm4Z04XJaT158\njiAUAFrWu5ccyz2kr2dl1Ycj/U0QtCwalcgkTJvU1hsSIZQPO/8Lculz8jID\nXl/LG1lWoI9oFlnXuRUtimjMeqfAUAoysMc+CcfeAji8mCKkxKYL6cRq03DH\njzO0j/uWodld8vl8RVgl4BlaEfrIuXeSnlIPMjvgoDzYwvxOCtE3uZzn3J8E\nGowIHXyz7iB3OQZBf0+Q0BOoJcdZWALut28U/0Q0ojiyBtnUP5hO0j8rovHx\nQxd9DWO9W0ugxzeeeKWPSMLrui9YtLf3ADuoFnbhyfE3I98Qzmf21jIj5E35\nywEre0NfRtv8SxyUrpeh+vs0ZRizvw2ePi0JiOi91IGL22JRx50Qy0Xxwrci\nJSnvwWkWqmx6dUB1pHV3zGwtleurpocfW7/HPdZOBoKMbH8s/Ih4UNVFse3A\nhd/Z4WLKz4UahSrGBR2NhlzsOaVTJXJg850271scDjSMJ9bmUEwky9nIa/Jy\nT+SKIVbW0JDXxRBqcEpyExxRh6B3PKui5AHO4PukGP81ZxX3zJAdzB2RF1jF\n8MLiZW2k/KbPu8Fc+oKuqJBdDJwGkqY8TBZ2Sny8fMxreq0yvOr7Txmedg7f\ne45Y\r\n=Y6jJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "2.0.0": {
+      "name": "upath",
+      "version": "2.0.0",
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "^1.1.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.20",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "^3.3.5",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-ghi1XxsVYPOZPDsOZrfOJIwQU5I3JVYB3Q6IbBGn1KFeOa89i0nUy5tCEkY9pVm83U83qZ1QG40RQKGknllV4w==",
+        "shasum": "7234f3c1e7fd2bcb4f6aaba3e5565ee13ce6d287",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-2.0.0.tgz",
+        "fileCount": 5,
+        "unpackedSize": 36731,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJffLQyCRA9TVsSAnZWagAA8osP/2f8GcngYjckypwVf1ki\nE5YA4p5rsEBm4WxVnJblq/9h4fB5oFNR4LB9w2e4GX2cNbXaSFH/HNDq7H8x\nA9Sg2vQXN/ERVAqZef8Rf7pkzeSuVaET5WmU98j4W7CwyVTfxW7/nzGp925u\nUaS9lAFtZrPKZ+psxr8BkB0m/h+dRxUFVOqwLzzYL2vS4wo8qMgF+HvnGFhl\nLiyHyNr4p7eQFBrER4dkpOPfmYheU3k/FJJOBkvMMU7rFydqNBgLMzclFkg7\nfvbuwi7TwacAOLV9fBCmuMXNdUvOTDkn153AoZiIvKtBNK1A95OkCDI4urT4\nMRQruluZ+JL7bYVbbNa+kL9dR7XgBpGV3vNu87tyX56cf4D/saii5pilZKuH\nvQPwV3ijZmOrJdrVhiWk7ZYZSIZ9KrKPBOoaV0QxWfT5vFOZod+/BQS0/O0y\nO9f8zdW+Bny5zafy3YT+wDQa9CQsGKlazj+Dg5vv0ur/8EzTc1+I1gYqHXam\nFXUt8/aymSyY7GLnPa03CRMgyTxLz3luumLRjdFzIw9C+hA5jhINQXZ3R/zT\nO4E5VgUrd1qLk8BGNPigrFIdB+vDohptcnuTFJhaRCgC7LNRm6gRLGNv0/Gd\ns+zhv5Fbq1aInoFFJZn+NjNsfbB79+2FIhYALnKhatxhqxRk2Y9AlFI7gWQX\nHJIN\r\n=Wsd1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    },
+    "2.0.1": {
+      "name": "upath",
+      "version": "2.0.1",
+      "devDependencies": {
+        "chai": "~4.0.2",
+        "coffee-script": "1.12.6",
+        "grunt": "0.4.5",
+        "grunt-contrib-watch": "^1.1.0",
+        "grunt-urequire": "0.7.x",
+        "lodash": "^4.17.20",
+        "mocha": "~3.4.2",
+        "uberscore": "0.0.19",
+        "underscore.string": "^3.3.5",
+        "urequire": "0.7.0-beta.33",
+        "urequire-ab-specrunner": "^0.2.5",
+        "urequire-rc-inject-version": "^0.1.6"
+      },
+      "directories": {
+        "doc": "./doc",
+        "dist": "./build"
+      },
+      "dist": {
+        "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+        "shasum": "50c73dea68d6f6b990f51d279ce6081665d61a8b",
+        "tarball": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+        "fileCount": 5,
+        "unpackedSize": 36733,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfptLuCRA9TVsSAnZWagAABwoP/iHAlLEgwmZlPREjBfwt\nf0beWKwvOTYptE5bDgkxblXU65+L7aWotxdxeSkCEaD71JO70eihdOxQrrQo\nK4p6eD7WnlEmvSHup2wlUWDR3A/xcW3TBQrSqoHaY/+6P1YVdtJR7I+F4BEi\nAwbdCTQ8REJBoW8soS6P+vVdxgBhi2745CdVKeOv+y+GV1IynL2OUvmIvG1y\nkYTZYRDCrjHzgq9pKJgheLb2sbl9MhY248xAf+Jyiw8TYCJmNVvvkfNbqkrQ\nxyWQQi72ACUUZbJVanMU5Tm5OlWTgazNqOhyLXKhmT/xstXqKDlGP0b+QOOf\nnyjCaMt43HNCoGHkS0VIBudvczvgYh+fofWuH+aW+sSrCaY/xbhmMS9jPMku\n5tpc2PTAt3OMyQGZ3DpyzsFflmJ9nfEQiFdDQAVqHhGANNBSYe7ZWEGadtWi\nt9yrND9MgvMoecpylQqOFPMtJcZAmj3t0tGxGAvNoHuOX7pF4lbWd4bI8lVq\n/GJ9Hr7s1YQUGGQ8FQNpG0l70qqnDPfwzDAQgV9yVcAm5Av86w8WC/FaHbXU\ndt/4MBxHBEYFv6EDVxUVQzYvh06PxQ/WFEg8yuplEWZy//9VbuQJnon5FIgs\nERFgQKK0cyRlUcCLkjOexk3l3APoJ+McU5s+CujGp6AELcMszEbE0QZIUYuE\nRBJo\r\n=C/BT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4",
+        "yarn": "*"
+      }
+    }
+  },
+  "modified": "2020-11-07T17:01:36.528Z"
+}

--- a/test/fixtures/registry-mocks/content/urix.json
+++ b/test/fixtures/registry-mocks/content/urix.json
@@ -1,0 +1,98 @@
+{
+  "_id": "urix",
+  "_rev": "3-7aa540e202a191f23ee5b039279eb982",
+  "name": "urix",
+  "description": "Makes Windows-style paths more unix and URI friendly.",
+  "dist-tags": {
+    "latest": "0.1.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "urix",
+      "version": "0.1.0",
+      "author": {
+        "name": "Simon Lydell"
+      },
+      "license": "MIT",
+      "description": "Makes Windows-style paths more unix and URI friendly.",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/lydell/urix"
+      },
+      "keywords": [
+        "path",
+        "url",
+        "uri",
+        "unix",
+        "windows",
+        "backslash",
+        "slash"
+      ],
+      "scripts": {
+        "test": "jshint index.js test/ && mocha"
+      },
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "jshint": "^2.4.4"
+      },
+      "bugs": {
+        "url": "https://github.com/lydell/urix/issues"
+      },
+      "homepage": "https://github.com/lydell/urix",
+      "_id": "urix@0.1.0",
+      "dist": {
+        "shasum": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
+        "tarball": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.4",
+      "_npmUser": {
+        "name": "lydell",
+        "email": "simon.lydell@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "lydell",
+          "email": "simon.lydell@gmail.com"
+        }
+      ],
+      "directories": {},
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated"
+    }
+  },
+  "readme": "[![Build Status](https://travis-ci.org/lydell/urix.png?branch=master)](https://travis-ci.org/lydell/urix)\r\n\r\nOverview\r\n========\r\n\r\nMakes Windows-style paths more unix and URI friendly. Useful if you work with\r\npaths that eventually will be used in URLs.\r\n\r\n```js\r\nvar urix = require(\"urix\")\r\n\r\n// On Windows:\r\nurix(\"c:\\\\users\\\\you\\\\foo\")\r\n// /users/you/foo\r\n\r\n// On unix-like systems:\r\nurix(\"c:\\\\users\\\\you\\\\foo\")\r\n// c:\\users\\you\\foo\r\n```\r\n\r\n\r\nInstallation\r\n============\r\n\r\n`npm install urix`\r\n\r\n```js\r\nvar urix = require(\"urix\")\r\n```\r\n\r\n\r\nUsage\r\n=====\r\n\r\n### `urix(path)` ###\r\n\r\nOn Windows, replaces all backslashes with slashes and uses a slash instead of a\r\ndrive letter and a colon for absolute paths.\r\n\r\nOn unix-like systems it is a no-op.\r\n\r\n\r\nLicense\r\n=======\r\n\r\n[The X11 (“MIT”) License](LICENSE).\r\n",
+  "maintainers": [
+    {
+      "name": "lydell",
+      "email": "simon.lydell@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-03-28T23:09:30.452Z",
+    "created": "2014-03-01T21:02:32.481Z",
+    "0.1.0": "2014-03-01T21:02:32.481Z"
+  },
+  "homepage": "https://github.com/lydell/urix",
+  "keywords": [
+    "path",
+    "url",
+    "uri",
+    "unix",
+    "windows",
+    "backslash",
+    "slash"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/lydell/urix"
+  },
+  "author": {
+    "name": "Simon Lydell"
+  },
+  "bugs": {
+    "url": "https://github.com/lydell/urix/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "readme.md"
+}

--- a/test/fixtures/registry-mocks/content/urix.min.json
+++ b/test/fixtures/registry-mocks/content/urix.min.json
@@ -1,0 +1,22 @@
+{
+  "name": "urix",
+  "dist-tags": {
+    "latest": "0.1.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "urix",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "^1.17.1",
+        "jshint": "^2.4.4"
+      },
+      "dist": {
+        "shasum": "da937f7a62e21fec1fd18d49b35c2935067a6c72",
+        "tarball": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+      },
+      "deprecated": "Please see https://github.com/lydell/urix#deprecated"
+    }
+  },
+  "modified": "2020-03-28T23:09:30.452Z"
+}

--- a/test/fixtures/registry-mocks/content/url-parse.json
+++ b/test/fixtures/registry-mocks/content/url-parse.json
@@ -1,0 +1,3577 @@
+{
+  "_id": "url-parse",
+  "_rev": "113-30afac8e8cfb6d18b38238eb819e5c41",
+  "name": "url-parse",
+  "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+  "dist-tags": {
+    "latest": "1.4.7"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "url-parse",
+      "version": "0.0.0",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "_id": "url-parse@0.0.0",
+      "_shasum": "7e844d6570e52a3b756604f8f0b0ed9165df34e8",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7e844d6570e52a3b756604f8f0b0ed9165df34e8",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "url-parse",
+      "version": "0.0.1",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "gitHead": "3dbce4bb499943f7f8a4c3421a8b09a3386ba669",
+      "_id": "url-parse@0.0.1",
+      "_shasum": "a1083ef43383301eac4a0d746379e0c51bb502c3",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a1083ef43383301eac4a0d746379e0c51bb502c3",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "url-parse",
+      "version": "0.0.2",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "gitHead": "dbc52d092a6239d35eec95b7ac69aff46c1d67ad",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.0.2",
+      "_shasum": "e40c9dca6a877340307ddd29cdb2a1824be505ca",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e40c9dca6a877340307ddd29cdb2a1824be505ca",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "url-parse",
+      "version": "0.0.3",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "gitHead": "43a239b5e2cd02807c300368fc1b2e5243dfcc2c",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.0.3",
+      "_shasum": "7f9cd84e2b501fcf39ebe5f6d2faade79c339d47",
+      "_from": ".",
+      "_npmVersion": "1.4.27",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7f9cd84e2b501fcf39ebe5f6d2faade79c339d47",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "url-parse",
+      "version": "0.0.4",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o browserified.js"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "gitHead": "19f18f8c42e56d61ea0b4256426745ffebc554d9",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.0.4",
+      "_shasum": "4eb3e5af0f46c0a9fcc84f157b7d236d0583ce27",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4eb3e5af0f46c0a9fcc84f157b7d236d0583ce27",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "url-parse",
+      "version": "0.1.0",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o dist/url-parse.js --standalone URLParse"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "500d074a4e6359ee83e0704cd8985e29b615f032",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.1.0",
+      "_shasum": "e770ff34faa8f0c0b86f2b0b8d93933e85c5fc03",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "e770ff34faa8f0c0b86f2b0b8d93933e85c5fc03",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "url-parse",
+      "version": "0.1.1",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o dist/url-parse.js --standalone URLParse"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "c29eed7b83010c05e79e7869b293d5f34b395ad3",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.1.1",
+      "_shasum": "b9c9efd9a371c515ae60f23c4845c6148777e558",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "b9c9efd9a371c515ae60f23c4845c6148777e558",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "url-parse",
+      "version": "0.1.2",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o dist/url-parse.js --standalone URLParse"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "9063b38f0416e2490e76facd528e40e48f07799b",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.1.2",
+      "_shasum": "ce598501dcb100ec06b960a26bed3f1e5dd3d6ab",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "ce598501dcb100ec06b960a26bed3f1e5dd3d6ab",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "url-parse",
+      "version": "0.1.3",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o dist/url-parse.js --standalone URLParse"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "0465715be2d287d1c061bff32e03806676f27264",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.1.3",
+      "_shasum": "e0355f9fce17f5181e875f59d74a00e1c32ac5aa",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "e0355f9fce17f5181e875f59d74a00e1c32ac5aa",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "url-parse",
+      "version": "0.1.4",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o dist/url-parse.js --standalone URLParse"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "42a1341d9a6a00fcb9b2920c753cb3c651069dd2",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.1.4",
+      "_shasum": "6e82e0f4387aa85b1036d66d36e6413bd8810223",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "unshift",
+        "email": "npm@unshift.io"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "6e82e0f4387aa85b1036d66d36e6413bd8810223",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.5": {
+      "name": "url-parse",
+      "version": "0.1.5",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o dist/url-parse.js --standalone URLParse"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "f08e0cd8ae3f201dc7d0fb4db4adf40821651e7c",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.1.5",
+      "_shasum": "85b5285054298d715007d479d5b150dfccbd1bd3",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "85b5285054298d715007d479d5b150dfccbd1bd3",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "url-parse",
+      "version": "0.2.0",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o dist/url-parse.js --standalone URLParse"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "be53c253989f764f6e4af89f853ecad2d0c60c85",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.2.0",
+      "_shasum": "5d1e0e7965e93f6e14ecbcd100641804c6a0006f",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "5d1e0e7965e93f6e14ecbcd100641804c6a0006f",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "url-parse",
+      "version": "0.2.1",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "browserify index.js -o dist/url-parse.js --standalone URLParse"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "1f09808274199a2c227c39c511e3f54fdc5e248e",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.2.1",
+      "_shasum": "79bf15b300047409c771e5f8f65680f1f581bf08",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "79bf15b300047409c771e5f8f65680f1f581bf08",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "url-parse",
+      "version": "0.2.2",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd test.js",
+        "browserify": "mkdir dist && browserify index.js -o dist/url-parse.js --standalone URLParse",
+        "phantomjs": "mocha-phantomjs --reporter spec --ui bdd test.js",
+        "testling": "testling -u"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "mocha-phantomjs": "3.5.x",
+        "pre-commit": "0.0.x",
+        "testling": "1.7.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "ac8e8d45584d24d77649e417e2d83a611d61efac",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.2.2",
+      "_shasum": "d733ad09eb68c56a010e2cca63faf998339b8f19",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "d733ad09eb68c56a010e2cca63faf998339b8f19",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.3": {
+      "name": "url-parse",
+      "version": "0.2.3",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd ./test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd ./test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd ./test.js",
+        "browserify": "mkdir dist && browserify index.js -o dist/url-parse.js --standalone URLParse",
+        "phantomjs": "mochify --reporter spec --ui bdd ./test.js",
+        "testling": "testling -u"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "mochify": "2.1.x",
+        "pre-commit": "0.0.x",
+        "testling": "1.7.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "3cecefe3f284c8ba0af754298fbfe4640a03099e",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@0.2.3",
+      "_shasum": "00d3d6f0b4e4f319ea77f763c56f0c4c951ed273",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "00d3d6f0b4e4f319ea77f763c56f0c4c951ed273",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "url-parse",
+      "version": "1.0.0",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha --reporter spec --ui bdd ./test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- --reporter spec --ui bdd ./test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- --reporter spec --ui bdd ./test.js",
+        "browserify": "mkdir -p dist && browserify index.js -o dist/url-parse.js --standalone URLParse",
+        "phantomjs": "mochify --reporter spec --ui bdd ./test.js",
+        "testling": "testling -u"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "1.0.x",
+        "browserify": "8.1.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.1.x",
+        "mochify": "2.1.x",
+        "pre-commit": "0.0.x",
+        "testling": "1.7.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "1d0b9344ba915a3a52bb0f573b4ddd9a520562e3",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@1.0.0",
+      "_shasum": "aa20eb22d44b3102f98a8ee4e0c2e42ecc20d68a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "V1",
+        "email": "info@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "V1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        }
+      ],
+      "dist": {
+        "shasum": "aa20eb22d44b3102f98a8ee4e0c2e42ecc20d68a",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "url-parse",
+      "version": "1.0.1",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js",
+        "browserify": "mkdir -p dist && browserify index.js -o dist/url-parse.js --standalone URLParse",
+        "phantomjs": "mochify --reporter spec --ui bdd ./test.js",
+        "testling": "testling -u"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "1.1.x",
+        "browserify": "8.1.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.1.x",
+        "mochify": "2.4.x",
+        "pre-commit": "1.0.x",
+        "testling": "1.7.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/unshiftio/url-parse"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "a717d5a97920966cb23ae940e4d2105599edfc42",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse",
+      "_id": "url-parse@1.0.1",
+      "_shasum": "6ead2ca6ab0e3a258bbfb4ed8a152189b81dd0c1",
+      "_from": ".",
+      "_npmVersion": "2.7.5",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6ead2ca6ab0e3a258bbfb4ed8a152189b81dd0c1",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "url-parse",
+      "version": "1.0.2",
+      "description": "Parse URL in node using the URL module and in the browser using the DOM",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js",
+        "browserify": "mkdir -p dist && browserify index.js -o dist/url-parse.js --standalone URLParse",
+        "phantomjs": "mochify --reporter spec --ui bdd ./test.js",
+        "testling": "testling -u"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "1.1.x",
+        "browserify": "8.1.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.1.x",
+        "mochify": "2.4.x",
+        "pre-commit": "1.0.x",
+        "testling": "1.7.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "c7ef9cb59073d1e11aa29aeadda89deb1a28c37e",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.0.2",
+      "_shasum": "8c7bf70cd49a89024a032280e6eb33f22a79035c",
+      "_from": ".",
+      "_npmVersion": "2.9.1",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8c7bf70cd49a89024a032280e6eb33f22a79035c",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "url-parse",
+      "version": "1.0.3",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js",
+        "browserify": "mkdir -p dist && browserify index.js -o dist/url-parse.js --standalone URLParse",
+        "phantomjs": "mochify --reporter spec --ui bdd ./test.js",
+        "testling": "testling -u"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "1.3.x",
+        "browserify": "11.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "mochify": "2.13.x",
+        "pre-commit": "1.1.x",
+        "testling": "1.7.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "cc192195a5064c45285eff9c2578b6c5dbfce9c2",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.0.3",
+      "_shasum": "a80ca4e0249401cb509e09d603c19a9feddc5bba",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a80ca4e0249401cb509e09d603c19a9feddc5bba",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "url-parse",
+      "version": "1.0.4",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "test": "mocha test.js",
+        "watch": "mocha --watch test.js",
+        "coverage": "istanbul cover ./node_modules/.bin/_mocha -- test.js",
+        "test-travis": "istanbul cover node_modules/.bin/_mocha --report lcovonly -- test.js",
+        "browserify": "mkdir -p dist && browserify index.js -o dist/url-parse.js --standalone URLParse",
+        "phantomjs": "mochify --reporter spec --ui bdd ./test.js",
+        "testling": "testling -u"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "assume": "1.3.x",
+        "browserify": "11.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.3.x",
+        "mochify": "2.13.x",
+        "pre-commit": "1.1.x",
+        "testling": "1.7.x"
+      },
+      "testling": {
+        "files": "test.js",
+        "harness": "mocha-bdd",
+        "browsers": [
+          "ie/6..latest",
+          "chrome/22..latest",
+          "firefox/16..latest",
+          "safari/latest",
+          "opera/11.0..latest",
+          "iphone/6",
+          "ipad/6",
+          "android-browser/latest"
+        ]
+      },
+      "browser": {
+        "url": false
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "gitHead": "4796751f8b983ee462d4d8871ee953c9853cf583",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.0.4",
+      "_shasum": "4498cb51eb01ec1245313ff34a434cfaaaac0cc0",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4498cb51eb01ec1245313ff34a434cfaaaac0cc0",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "url-parse",
+      "version": "1.0.5",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.3.x",
+        "browserify": "12.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.3.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.7.x"
+      },
+      "gitHead": "7926d56fc0ee9089bc296ed19e5106dd7f0d7b3b",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.0.5",
+      "_shasum": "0854860422afdcfefeb6c965c662d4800169927b",
+      "_from": ".",
+      "_npmVersion": "2.14.3",
+      "_nodeVersion": "0.12.3",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0854860422afdcfefeb6c965c662d4800169927b",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "url-parse",
+      "version": "1.1.0",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.4.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "gitHead": "f30e236d4f39b1f8ee47f6fc29564944e65a721a",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.0",
+      "_shasum": "04cd63082a88820b2cb5c775872bbae5f1ac0a74",
+      "_from": ".",
+      "_npmVersion": "3.8.0",
+      "_nodeVersion": "4.3.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "04cd63082a88820b2cb5c775872bbae5f1ac0a74",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.0.tgz_1459163953178_0.2773168694693595"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "url-parse",
+      "version": "1.1.1",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.4.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "gitHead": "325c631e89ef6ce3e15a082d9787cf1a7f14bedf",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.1",
+      "_shasum": "d1507970728c9a5f80f471530c57325c3fb0e868",
+      "_from": ".",
+      "_npmVersion": "3.8.0",
+      "_nodeVersion": "4.3.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d1507970728c9a5f80f471530c57325c3fb0e868",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.1.tgz_1459345809210_0.3875826171133667"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "url-parse",
+      "version": "1.1.2",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.5.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "gitHead": "992bfba06a57a1c42ecb22ba880b5e19e3e7e196",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.2",
+      "_shasum": "51b375f8bb4d17c32a6fdfd83dde527f6c2e5309",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "51b375f8bb4d17c32a6fdfd83dde527f6c2e5309",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.2.tgz_1471249528809_0.4470774589572102"
+      },
+      "directories": {}
+    },
+    "1.1.3": {
+      "name": "url-parse",
+      "version": "1.1.3",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.5.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "gitHead": "1b164fbe3a35210e3f92dd57ca0897c2206d9b93",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.3",
+      "_shasum": "cefdd24be2e71ffd91effc6ba56886c225bd1124",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "info@3rd-Eden.com"
+        },
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "cefdd24be2e71ffd91effc6ba56886c225bd1124",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.3.tgz_1471257690611_0.5654388114344329"
+      },
+      "directories": {}
+    },
+    "1.1.4": {
+      "name": "url-parse",
+      "version": "1.1.4",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.1.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.0.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "5ffabdd8e558e01eccfb304f9c477e926e69fa2c",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.4",
+      "_shasum": "5cd835a39f4b6c1dc00bad07bc492efe3815eea6",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "swaagie",
+        "email": "info@martijnswaagman.nl"
+      },
+      "dist": {
+        "shasum": "5cd835a39f4b6c1dc00bad07bc492efe3815eea6",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "swaagie",
+          "email": "info@martijnswaagman.nl"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.4.tgz_1475744279000_0.6669016974046826"
+      },
+      "directories": {}
+    },
+    "1.1.5": {
+      "name": "url-parse",
+      "version": "1.1.5",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.1.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.1.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "ac420e1b084a2744f1a28fc47adbad46081dd4f6",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.5",
+      "_shasum": "9e2c741539397e03e399928788f2bd616915bc7c",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "swaagie",
+          "email": "info@martijnswaagman.nl"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9e2c741539397e03e399928788f2bd616915bc7c",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.5.tgz_1476110527688_0.12110764789395034"
+      },
+      "directories": {}
+    },
+    "1.1.6": {
+      "name": "url-parse",
+      "version": "1.1.6",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.1.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.1.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "3d2d76444a27de0498694b0170ee6a5d8bc4d266",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.6",
+      "_shasum": "ab8ff5aea1388071961255e2236147c52ca5fc48",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.7.0",
+      "_npmUser": {
+        "name": "swaagie",
+        "email": "info@martijnswaagman.nl"
+      },
+      "dist": {
+        "shasum": "ab8ff5aea1388071961255e2236147c52ca5fc48",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "swaagie",
+          "email": "info@martijnswaagman.nl"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.6.tgz_1476110780981_0.8418173941317946"
+      },
+      "directories": {}
+    },
+    "1.1.7": {
+      "name": "url-parse",
+      "version": "1.1.7",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.1.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.1.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "062638cf0dc9d1de18640b3da1b0024394cae284",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.7",
+      "_shasum": "025cff999653a459ab34232147d89514cc87d74a",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "swaagie",
+        "email": "info@martijnswaagman.nl"
+      },
+      "dist": {
+        "shasum": "025cff999653a459ab34232147d89514cc87d74a",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "swaagie",
+          "email": "info@martijnswaagman.nl"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.7.tgz_1477927661531_0.7949320878833532"
+      },
+      "directories": {}
+    },
+    "1.1.8": {
+      "name": "url-parse",
+      "version": "1.1.8",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "~14.1.0",
+        "istanbul": "0.4.x",
+        "mocha": "~3.2.0",
+        "pre-commit": "~1.2.0",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "daacb5a98f64e69ba9cfb01bb7afbde68b756c12",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.8",
+      "_shasum": "7a65b3a8d57a1e86af6b4e2276e34774167c0156",
+      "_from": ".",
+      "_npmVersion": "3.9.3",
+      "_nodeVersion": "6.2.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "swaagie",
+          "email": "info@martijnswaagman.nl"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7a65b3a8d57a1e86af6b4e2276e34774167c0156",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.8.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.8.tgz_1487433490798_0.6194642025511712"
+      },
+      "directories": {}
+    },
+    "1.1.9": {
+      "name": "url-parse",
+      "version": "1.1.9",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "100%": "istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "test-node": "istanbul cover _mocha --report lcovonly -- test.js",
+        "coverage": "istanbul cover _mocha -- test.js",
+        "test-browser": "zuul -- test.js",
+        "watch": "mocha --watch test.js",
+        "test": "mocha test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "~1.0.0",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~14.3.0",
+        "istanbul": "0.4.x",
+        "mocha": "~3.3.0",
+        "pre-commit": "~1.2.0",
+        "zuul": "3.11.x"
+      },
+      "gitHead": "86d3d6d2ca638530d06ee5f780ac9c654e96f011",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.1.9",
+      "_shasum": "c67f1d775d51f0a18911dd7b3ffad27bb9e5bd19",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "maintainers": [
+        {
+          "name": "3rdeden",
+          "email": "npm@3rd-Eden.com"
+        },
+        {
+          "name": "swaagie",
+          "email": "info@martijnswaagman.nl"
+        },
+        {
+          "name": "unshift",
+          "email": "npm@unshift.io"
+        },
+        {
+          "name": "v1",
+          "email": "npm@3rd-Eden.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c67f1d775d51f0a18911dd7b3ffad27bb9e5bd19",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/url-parse-1.1.9.tgz_1493830143379_0.4407927531283349"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "url-parse",
+      "version": "1.2.0",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "mkdir -p dist && browserify index.js -s URLParse | uglifyjs -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "files": [
+        "index.js",
+        "dist"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "~1.0.0",
+        "requires-port": "~1.0.0"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~14.5.0",
+        "mocha": "~4.0.0",
+        "nyc": "~11.3.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.1.0"
+      },
+      "gitHead": "45e05571478e3901e30716f3ee5fcfb83fe5b5aa",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.2.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+        "shasum": "3a19e8aaa6d023ddd27dcc44cb4fc8f7fec23986",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse-1.2.0.tgz_1509631143262_0.2793838828802109"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "url-parse",
+      "version": "1.3.0",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "rm -rf dist && mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "minify": "uglifyjs dist/url-parse.js --source-map -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "files": [
+        "index.js",
+        "dist"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "~1.0.0",
+        "requires-port": "~1.0.0"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~16.1.0",
+        "mocha": "~5.0.0",
+        "nyc": "~11.6.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.2.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.3.0"
+      },
+      "gitHead": "8c2a5e7952f64ae91f8ceaf2ea817584a5800210",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.3.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-zPvPA3T7P6M+0iNsgX+iAcAz4GshKrowtQBHHc/28tVsBc8jK7VRCNX+2GEcoE6zDB6XqXhcyiUWPVZY6C70Cg==",
+        "shasum": "04a06c420d22beb9804f7ada2d57ad13160a4258",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.3.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 47094
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse_1.3.0_1522973522625_0.7403948563137179"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.0": {
+      "name": "url-parse",
+      "version": "1.4.0",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "rm -rf dist && mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "minify": "uglifyjs dist/url-parse.js --source-map -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "files": [
+        "index.js",
+        "dist"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^2.0.1",
+        "browserify": "^16.2.0",
+        "mocha": "^5.1.1",
+        "nyc": "^11.7.1",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^1.2.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "gitHead": "d54bdbefcdfa6641e02e2051e35aa3b86f5138cf",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.4.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+        "shasum": "6bfdaad60098c7fe06f623e42b22de62de0d3d75",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 47238,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2KGTCRA9TVsSAnZWagAAEfQP/AxkCXdHCpvM7TMDsxIu\nuxk8j02qpXgsCta8xslosDwN/pEYepE1HW02vd+swuws+t/LTq4EtX4oKR1V\n7CeP4rw0TDp8HbQyU+M+Wj9wORe97V6+CuF/Xy4BYQJH2B0OJs0GF6H+nEUo\n/2rYeZ0zlUQKtP+Bo9zDtm0g1y5vWeeg1QtxOAg0Vflv08MSCVUQcA0QRmC0\n2ZeJLfsAbwRo5w/G1Fqy9RYXgQ/1PBH6k9bztVSVRDMjL6n8+adLXd6u4OTm\nte86sOu5TJ0sDm/LxqOpGbvmKV9U7qTW5qw5XHQ1Sp+uhwIuFmTOArrI7juB\n38mz/Y/ajWXQKA2Vs501SVzIuzOvIKyGICvv52S35DiiQ9VFjpJt6xrw9fjt\n7uhZW33Q8HBQw81PEd+DWxN57OmL4CFegofWMN0xYPlkCSlwvfezvl3NkATj\ncfSJPT9NQWL26Q5TxMku8mr8tUgS+dOyRFg99UuWeban9Fly6to71f+Dx/5r\nQCBispKWUihTXFcjWXfxE7sY1UNmt74u8x3pDgS8oXvdAYlxLIzWURHkvozC\n3lT0/MhxBVVI4A6KevJK03tiWO51Bx0nT8S5lZwHN9JBhKj0F5kwEBHzWGbF\nMKpJI65QxBhPYaknatxofVYPsMRnSlkNKPrXB5MXIMWxHlYvrt3vG9f1ZnLp\nHXRv\r\n=wo9+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse_1.4.0_1524146577962_0.09067833515519474"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.1": {
+      "name": "url-parse",
+      "version": "1.4.1",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "rm -rf dist && mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "minify": "uglifyjs dist/url-parse.js --source-map -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "files": [
+        "index.js",
+        "dist"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^1.5.2",
+        "browserify": "^16.2.0",
+        "mocha": "^5.1.1",
+        "nyc": "^12.0.1",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^1.2.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "gitHead": "89045148cd7adb753c961d05f1fa3acaa8471e74",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.4.1",
+      "_npmVersion": "6.0.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+        "shasum": "4dec9dad3dc8585f862fed461d2e19bbf623df30",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 47340,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbFpZPCRA9TVsSAnZWagAAdjsP/09O+zYMP7bndAQhml3l\n5GS2gc3vvaVYi4sSJRrja8ptXpEr9W33KFxmE6CiIQeGTcxICeq6nwcBdsPn\nP+XBw6gW80u0+16mRa/g3SEPP7uEIng6ndNrgCcPtPML6YEl/6K0x69CUL0H\nZRNvmp8cf9TS0mZveqmGtbmqkCRydXb191i17ki84JBadlex4UXlfs8ue6zk\ngoWm1IszymFNOA9T8zcyMkQT7V+oUz/AfM0H3qDmHS5a6NvIyVuNnBNzeNP7\n4iVarvcC/Jv/qETPWhyLht+aiF/pFO6a3AI75DdmwvGh8xeW2L2nS5AB3IdH\n+rz3mg8DUSsTBxo8kCxhO1Q8GIDKY4zd49kMl8fTS0OFjSMVlTy8Ul3CZp1D\n0JJ50Zsx5KhsQI+Z4vHY7K4RdNunAS2S342mwJ/YKtfTPgJXVf+t2yQzLRqi\n/6IyEioiabeXecqfkduyBiUHDy6qtOCTs2qPH4IyAZCN1zn/MNtBxp8qvdEI\nACaUdC1cgqtwG+axlVQgQgZv3Ulpb5YXlMW79UFpnN2bhFlsBHWXv35wyIey\nRU1p65jtgVQMDilg753kLTwBTRvCAXF6R251iqzs6qvawfIkKMaui+NWMw2J\n1g+RSUdc9NkQlkyX2gKOTulU9xzkbqYjfl7J7dLNxWk7EV+MQQrNiKX60G2p\nMkod\r\n=2Ez4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse_1.4.1_1528206926881_0.6451218438752133"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.3": {
+      "name": "url-parse",
+      "version": "1.4.3",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "rm -rf dist && mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "minify": "uglifyjs dist/url-parse.js --source-map -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "files": [
+        "index.js",
+        "dist"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^1.5.2",
+        "browserify": "^16.2.0",
+        "mocha": "^5.1.1",
+        "nyc": "^12.0.1",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "gitHead": "426e92933d1eca6469bf3490fd76676f80ad0108",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.4.3",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+        "shasum": "bfaee455c889023219d757e045fa6a684ec36c15",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 48337,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbXbaaCRA9TVsSAnZWagAAHwkP+gM4sfP4zF3749eay2Xb\nNl1xApOMlhNJK0s7ZfFw36m6iLl4kHDwdENq2S+HEHgq/+0hiJFOCeFdDUYQ\ne2Sun0Y6kQdYMwLqMch68jrBV7cZpzsHI8hqs0BFKEk0serr1Os7dJWe9KSR\nM0hp4ThgLeMgiGNYbYqabldNZ+4jL1ApjUw3uSGrDaETbV2c3difWoJiBLtk\nbcGqWGIYONZ8Jue61ikZWlk4QwNhpjexPR5c1ZucsbD/0ErgQkTTQkpAZDV/\nHJOPEmPVORhQsA6kcJaQFLpjVTxNU5oZgQnc3oQN8I18R6IyPs0isySoMJg5\nLVH+Z8kOc/7QYSAbxYESUMQ7miIkAU5sMvMDd83uAiARgv1UmA4Rhpmv4mjp\nfSeM4iRe381Ezj8wP0qm77QKjF0krdwGQ0K1obOXzoP1QY9N5LeC9Z9FOpl0\nk1TWQXbQKrCcsSGikC6u1zmCSZeuH1zD6Vb21r8ae8z5Y0ZmhemJNdYz8aZc\ngv8Ffz4/0xDfvxXN4U46VIkQlNybt6b4vFudx8hbTXvDd31ffMSHGDm6JLsC\n/cD8Sn6beq8K7BTHmBTeOiIBozFExkNpCbDoHdrQeCiEibVUxJMb4xY2GQ7N\nWRSTlud9Cpuz8UB3mE+nvETSmJfYDh1tNdZLnbGSstrAn4rJoQc92FQJAXxm\nUalb\r\n=KLA3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse_1.4.3_1532868250237_0.82068547986872"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.4": {
+      "name": "url-parse",
+      "version": "1.4.4",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "rm -rf dist && mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "minify": "uglifyjs dist/url-parse.js --source-map -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^1.5.2",
+        "browserify": "^16.2.0",
+        "mocha": "^5.1.1",
+        "nyc": "^12.0.1",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "gitHead": "bc9da1ec19a86199be663a7f0ba40091834d73f7",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.4.4",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+        "shasum": "cac1556e95faa0303691fec5cf9d5a1bc34648f8",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+        "fileCount": 7,
+        "unpackedSize": 48899,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4Ed1CRA9TVsSAnZWagAA39EQAJ7N+PzjE87KLg5H+0ZE\nOKfnyTBfcuzd2K5AlwKhpf0ER4cgdQ91XChWW402cb9O6rQk99i9TjWwbr7+\nEaoMVzd0vpCKOv/2pqFXyPXy33Dv3mVWN2xYRygB2GUfZ2Em6nJuNEE1sb//\nd78N7cy2srJa/5/1+QrRedk7pu8Eqb8vSsgldDOYiEXrCetAs9fQK3gfCUSa\nvDodwYMFYXKQVIxlo27rHtnnaXxRlBRw7Zl+zD/FqE2ET32LrvprL6ho18T/\nuljqz48bRfsiMOzgIzk+Oe/Y6TrPcQHTliEqy/3Yu5GTlbZb9Wtf6SbJ3b/z\nt+FBw61NOVuZ+ypG6AFUY8juSihQYJNt/58cAjH3KpemZeIaSVA9nSXB0sDY\n3kKoBjwevoNilQHLfWW78Bd6suPY81FJrK3gHmx0cqjsS3skf3KqfMP//Vdl\nk7uIVbADmbHGIF9PkLqqmwAz5pMJld4PgPJpA2X8NantyyVvC+VJq/qqSi1U\n5ovrIbarNIvu4UC3Dho0sdMduLvKFOJRss6sWycsb/gEXEtPskmf2ftmKflM\nW4vvCC4aDam19QACETZjWO2m74q0ozxYBQ83zqSs41748fUTfMhGrQz7uC00\nQ2oeKX7utWK81b5UAh5ZU63dryx4tPbYcAk5cv+8RrOe2sQIwObh713batvP\n9qps\r\n=Fsjq\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse_1.4.4_1541425012832_0.2829189248448962"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.5": {
+      "name": "url-parse",
+      "version": "1.4.5",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "rm -rf dist && mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "minify": "uglifyjs dist/url-parse.js --source-map -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.2.0",
+        "mocha": "^6.1.1",
+        "nyc": "^13.2.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "gitHead": "b21a365bc441d8be4022458266a4d9f311a725a6",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.4.5",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-4XDvC5vZRjEpjP0L4znrWeoH8P8F0XGBlfLdABi/6oV4o8xUVbTpyrxWHxkK2bT0pSIpcjdIzSoWUhlUfawCAQ==",
+        "shasum": "04cbb6ba2be682a18e4417fa2245aa7e3dfdcc50",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.5.tgz",
+        "fileCount": 7,
+        "unpackedSize": 50413,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcr8HICRA9TVsSAnZWagAAWuYP/Rt8nKMoDrTK4NxBxHxw\n25ld4D7yuq5k9aLRxNdBACFjL5O0Dz8k8WSoq4lCJv3AVqHo0e6bhfTtoEWe\nh4yndBrCMJvVulH7LE3decQON9huplfBb2SeaLSedCZoXEbzUFXMSNr0cJec\nf5SumyvpC6NQhpqcHxFMbfbDUnPbj/H5DJ1JcJKyoM054lrviSGiloMnE9AW\njjXnsWeWeV+6PCqQu0t89KLLpx8092X4A2uBUj9Jgcydtuw4xF+JYYBN8RZu\nvsQ2YnmFPpan2EJT1K1xXe1Rsu1AfPc03IL6jtt0kL2yW4xgRuqM1sWsPDmC\nQgFCn1ySvTAgliKdnec3J5cZoqSBc+cr83FUjnOGimAhhCW9e3ZdDMAewkGg\n+E1YvqMioXfyu7GrEPWCQBZrqGPDzU61DuJK00PInIGiAcgXkmihs1TAIznj\nRCtReTmjmUu5OwJGbakzLudi2nJP0DzDTXh7fcoBMJyVBQfFx4pQ+thVWHzf\n+WIYjUcC1BLT4G8RpwVnE52+kYWLVJJ9o6OYwnb2Ryqnmfi9l0SGMQoi6DTb\nJsSOrwumysjY8SXYsX/AzR8Tw9sRyv1xcRs1krZTMqNel1elhjCyRXAiaSYp\n5/mElhw7ze3zwgvAaY7LrYo0IjFXHJvuNUVMgUaTBC3rN4S+UXjIMjrQ2F2t\nbM6Z\r\n=u+Cc\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse_1.4.5_1555022280100_0.20699351912167852"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.6": {
+      "name": "url-parse",
+      "version": "1.4.6",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "rm -rf dist && mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "minify": "uglifyjs dist/url-parse.js --source-map -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.2.0",
+        "mocha": "^6.1.1",
+        "nyc": "^13.2.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "gitHead": "50a6877824185bd294bde858d4372179d51aec8c",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.4.6",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-/B8AD9iQ01seoXmXf9z/MjLZQIdOoYl/+gvsQF6+mpnxaTfG9P7srYaiqaDMyKkR36XMXfhqSHss5MyFAO8lew==",
+        "shasum": "baf91d6e6783c8a795eb476892ffef2737fc0456",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.6.tgz",
+        "fileCount": 7,
+        "unpackedSize": 50463,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcsL3yCRA9TVsSAnZWagAAIK8P/RBsuy2nkvdPhIfO98Vs\n9+QVf6oA56QM+7hRiJ+udhtkpDg8fVQFtJj8LewMSjZZHTqpj0C7UgBmtVys\ncXIrbJGkoncWsL58bI9LwvyssCOtuhF+D2O7ObaOZ/xcN8RGpv2I+3AiGAlW\niNAEgaKYPY9QsPBklYAvjuWasfzmNwRUEZ4HHKk+8FjDSzgsTGmKnd87tURg\n5adDgrrrhUg9Oi33e/8yldfAiygC5Oa+Uo0R0ZT79sVOvOEk1PBnoRlb8zvW\n2KyZ5FKEc10xEUuyMiROiqeXdejEBgqJqCpJkjzYRsP3UB23EH5g/B7yl7B+\n8hdE07ZUXsh68KesKIGAVOfc7ZsOWCa3SR13BMf359ybTTijTuXOOt/i+WHg\n4XC99L1Lmz12GM6g/8DTuCS7qoUS0h8ReyD7zgKpY0zLS2m5ec6MZgh+BXS2\nA6m4WCP6phgjoJJcv3l0Gf+waETPsBJKl7SlEQJ9ZVNC1RVIddazu4ecw1Gs\nLkhd5KV+SptnuGk1+Zc4XnY2uhHMF9Rzk0nOInmRrhC5LL0o0k9DL6r5K5gh\n6nvFjFL/qGM6FsLZyVwneP8/OyusY7u+kXnLn/8wDxtUNvf/3/NY0r9NDdxS\nO9iVV4Ed7kDOfbYzMy6KA833R1g66vznoiB7F6OStRDv/DXlg4OYHVZgwKAz\n4n+K\r\n=K4FH\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse_1.4.6_1555086833681_0.46834135414209666"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.4.7": {
+      "name": "url-parse",
+      "version": "1.4.7",
+      "description": "Small footprint URL parser that works seamlessly across Node.js and browser environments",
+      "main": "index.js",
+      "scripts": {
+        "browserify": "rm -rf dist && mkdir -p dist && browserify index.js -s URLParse -o dist/url-parse.js",
+        "minify": "uglifyjs dist/url-parse.js --source-map -cm -o dist/url-parse.min.js",
+        "test": "nyc --reporter=html --reporter=text mocha test/test.js",
+        "test-browser": "node test/browser.js",
+        "prepublishOnly": "npm run browserify && npm run minify",
+        "watch": "mocha --watch test/test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/unshiftio/url-parse.git"
+      },
+      "keywords": [
+        "URL",
+        "parser",
+        "uri",
+        "url",
+        "parse",
+        "query",
+        "string",
+        "querystring",
+        "stringify"
+      ],
+      "author": {
+        "name": "Arnout Kazemier"
+      },
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.2.3",
+        "mocha": "^6.1.4",
+        "nyc": "^14.0.0",
+        "pre-commit": "^1.2.2",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.5.7"
+      },
+      "gitHead": "0cde3dcd2742759c4f1d3647129dc1166f0a25c6",
+      "bugs": {
+        "url": "https://github.com/unshiftio/url-parse/issues"
+      },
+      "homepage": "https://github.com/unshiftio/url-parse#readme",
+      "_id": "url-parse@1.4.7",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "3rdeden",
+        "email": "npm@3rd-Eden.com"
+      },
+      "dist": {
+        "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+        "shasum": "a8a83535e8c00a316e403a5db4ac1b9b853ae278",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+        "fileCount": 7,
+        "unpackedSize": 50462,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwyATCRA9TVsSAnZWagAAPDAP/1AK1XsHrBwBpN/yS0wR\nu9b/FR60TP+an4Z33sGBJtPDOv+3nzyQ3q22bsmQhVWSTxgweyluN16BGyKG\nZ3qZlauJFVnGD8MBNu3lolFGF8rE80E7AROb4Lp+cprQMdHc7zgLgwjOMupB\nmUEW9QeQzpDd33G3plnAOjn1DkGRZzX6sK3ZFrD7ifeioqO8tIxSSmZxpEt9\nTSOEm64238rysl6ZijD3/yI0NPAeE+tGYYmnISQv1er6O3S1qyu5maoz8Rsc\naYJA/8YTyNOMxbc1HAccN3il68KilJdQkHBq62H4N/jLd0a+uUCaVBggc8ul\nzXsMGTAcDJGPBvw/TP5QnU99rX8i5TUyxfhMawcAA+P38HHv+wbeGmC/upBD\nHJTa9KVFdORO7WKmr0imCvl1kRkcu/fGSuxorJtEOqwLfpvt/o/lsL3bFRIa\nj8nu4oRaC9vdevK5g3Pc+Y0WiOO3Eik1kAFt7M7W7JSJa+mWbKGc9cA0tBhL\nQeTB9x6SmdWZh/SzCwY4UZBhrZe/8wR4GxS1CJoZjNdiE46QEigfkC3XMsf2\nTRtoC+lH1oGBBwuglg2QQlR1fxwWmGLiT9ztr/uro01D1IdbV9lvqZxjc9WJ\n0PjWFkqpNoIPdhIA+YnHU0oLe34Hnj1OZEQVDDQ+QP9aFynZV9xuj1m9BxQq\naq+2\r\n=kXPf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "3rdeden"
+        },
+        {
+          "email": "info@martijnswaagman.nl",
+          "name": "swaagie"
+        },
+        {
+          "email": "npm@unshift.io",
+          "name": "unshift"
+        },
+        {
+          "email": "npm@3rd-Eden.com",
+          "name": "v1"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/url-parse_1.4.7_1556291603210_0.13082610745376777"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# url-parse\n\n[![Made by unshift](https://img.shields.io/badge/made%20by-unshift-00ffcc.svg?style=flat-square)](http://unshift.io)[![Version npm](https://img.shields.io/npm/v/url-parse.svg?style=flat-square)](https://www.npmjs.com/package/url-parse)[![Build Status](https://img.shields.io/travis/unshiftio/url-parse/master.svg?style=flat-square)](https://travis-ci.org/unshiftio/url-parse)[![Dependencies](https://img.shields.io/david/unshiftio/url-parse.svg?style=flat-square)](https://david-dm.org/unshiftio/url-parse)[![Coverage Status](https://img.shields.io/coveralls/unshiftio/url-parse/master.svg?style=flat-square)](https://coveralls.io/r/unshiftio/url-parse?branch=master)[![IRC channel](https://img.shields.io/badge/IRC-irc.freenode.net%23unshift-00a8ff.svg?style=flat-square)](https://webchat.freenode.net/?channels=unshift)\n\n[![Sauce Test Status](https://saucelabs.com/browser-matrix/url-parse.svg)](https://saucelabs.com/u/url-parse)\n\nThe `url-parse` method exposes two different API interfaces. The\n[`url`](https://nodejs.org/api/url.html) interface that you know from Node.js\nand the new [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)\ninterface that is available in the latest browsers.\n\nIn version `0.1` we moved from a DOM based parsing solution, using the `<a>`\nelement, to a full Regular Expression solution. The main reason for this was\nto make the URL parser available in different JavaScript environments as you\ndon't always have access to the DOM. An example of such environment is the\n[`Worker`](https://developer.mozilla.org/en/docs/Web/API/Worker) interface.\nThe RegExp based solution didn't work well as it required a lot of lookups\ncausing major problems in FireFox. In version `1.0.0` we ditched the RegExp\nbased solution in favor of a pure string parsing solution which chops up the\nURL into smaller pieces. This module still has a really small footprint as it\nhas been designed to be used on the client side.\n\nIn addition to URL parsing we also expose the bundled `querystringify` module.\n\n## Installation\n\nThis module is designed to be used using either browserify or Node.js it's\nreleased in the public npm registry and can be installed using:\n\n```\nnpm install url-parse\n```\n\n## Usage\n\nAll examples assume that this library is bootstrapped using:\n\n```js\n'use strict';\n\nvar Url = require('url-parse');\n```\n\nTo parse an URL simply call the `URL` method with the URL that needs to be\ntransformed into an object.\n\n```js\nvar url = new Url('https://github.com/foo/bar');\n```\n\nThe `new` keyword is optional but it will save you an extra function invocation.\nThe constructor takes the following arguments:\n\n- `url` (`String`): A string representing an absolute or relative URL.\n- `baseURL` (`Object` | `String`): An object or string representing\n  the base URL to use in case `url` is a relative URL. This argument is\n  optional and defaults to [`location`](https://developer.mozilla.org/en-US/docs/Web/API/Location)\n  in the browser.\n- `parser` (`Boolean` | `Function`): This argument is optional and specifies\n  how to parse the query string. By default it is `false` so the query string\n  is not parsed. If you pass `true` the query string is parsed using the\n  embedded `querystringify` module. If you pass a function the query string\n  will be parsed using this function.\n\nAs said above we also support the Node.js interface so you can also use the\nlibrary in this way:\n\n```js\n'use strict';\n\nvar parse = require('url-parse')\n  , url = parse('https://github.com/foo/bar', true);\n```\n\nThe returned `url` instance contains the following properties:\n\n- `protocol`: The protocol scheme of the URL (e.g. `http:`).\n- `slashes`: A boolean which indicates whether the `protocol` is followed by two\n  forward slashes (`//`).\n- `auth`: Authentication information portion (e.g. `username:password`).\n- `username`: Username of basic authentication.\n- `password`: Password of basic authentication.\n- `host`: Host name with port number.\n- `hostname`: Host name without port number.\n- `port`: Optional port number.\n- `pathname`: URL path.\n- `query`: Parsed object containing query string, unless parsing is set to false.\n- `hash`: The \"fragment\" portion of the URL including the pound-sign (`#`).\n- `href`: The full URL.\n- `origin`: The origin of the URL.\n\nNote that when `url-parse` is used in a browser environment, it will default to\nusing the browser's current window location as the base URL when parsing all\ninputs. To parse an input independently of the browser's current URL (e.g. for\nfunctionality parity with the library in a Node environment), pass an empty\nlocation object as the second parameter:\n\n```js\nvar parse = require('url-parse');\nparse('hostname', {});\n```\n\n### Url.set(key, value)\n\nA simple helper function to change parts of the URL and propagating it through\nall properties. When you set a new `host` you want the same value to be applied\nto `port` if has a different port number, `hostname` so it has a correct name\nagain and `href` so you have a complete URL.\n\n```js\nvar parsed = parse('http://google.com/parse-things');\n\nparsed.set('hostname', 'yahoo.com');\nconsole.log(parsed.href); // http://yahoo.com/parse-things\n```\n\nIt's aware of default ports so you cannot set a port 80 on an URL which has\n`http` as protocol.\n\n### Url.toString()\n\nThe returned `url` object comes with a custom `toString` method which will\ngenerate a full URL again when called. The method accepts an extra function\nwhich will stringify the query string for you. If you don't supply a function we\nwill use our default method.\n\n```js\nvar location = url.toString(); // http://example.com/whatever/?qs=32\n```\n\nYou would rarely need to use this method as the full URL is also available as\n`href` property. If you are using the `URL.set` method to make changes, this\nwill automatically update.\n\n## Testing\n\nThe testing of this module is done in 3 different ways:\n\n1. We have unit tests that run under Node.js. You can run these tests with the\n  `npm test` command.\n2. Code coverage can be run manually using `npm run coverage`.\n3. For browser testing we use Sauce Labs and `zuul`. You can run browser tests\n  using the `npm run test-browser` command.\n\n## License\n\n[MIT](LICENSE)\n",
+  "maintainers": [
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "3rdeden"
+    },
+    {
+      "email": "info@martijnswaagman.nl",
+      "name": "swaagie"
+    },
+    {
+      "email": "npm@unshift.io",
+      "name": "unshift"
+    },
+    {
+      "email": "npm@3rd-Eden.com",
+      "name": "v1"
+    }
+  ],
+  "time": {
+    "modified": "2019-04-26T15:13:25.910Z",
+    "created": "2014-10-08T14:47:45.158Z",
+    "0.0.0": "2014-10-08T14:47:45.158Z",
+    "0.0.1": "2014-10-09T14:25:32.785Z",
+    "0.0.2": "2014-10-13T19:59:41.394Z",
+    "0.0.3": "2014-10-17T11:13:04.720Z",
+    "0.0.4": "2014-10-29T17:50:51.773Z",
+    "0.1.0": "2014-11-09T22:52:35.366Z",
+    "0.1.1": "2014-11-21T21:06:03.458Z",
+    "0.1.2": "2014-11-21T22:05:36.372Z",
+    "0.1.3": "2014-11-22T18:58:05.384Z",
+    "0.1.4": "2014-11-27T09:45:17.766Z",
+    "0.1.5": "2014-12-08T17:36:10.876Z",
+    "0.2.0": "2014-12-08T22:47:54.810Z",
+    "0.2.1": "2014-12-16T22:42:13.253Z",
+    "0.2.2": "2014-12-17T11:07:14.920Z",
+    "0.2.3": "2014-12-17T19:07:02.987Z",
+    "1.0.0": "2015-01-18T21:31:55.934Z",
+    "1.0.1": "2015-05-06T09:44:49.172Z",
+    "1.0.2": "2015-07-03T07:26:05.371Z",
+    "1.0.3": "2015-09-25T06:46:36.669Z",
+    "1.0.4": "2015-10-09T12:13:30.044Z",
+    "1.0.5": "2015-10-30T14:43:32.842Z",
+    "1.1.0": "2016-03-28T11:19:15.294Z",
+    "1.1.1": "2016-03-30T13:50:10.212Z",
+    "1.1.2": "2016-08-15T08:25:30.415Z",
+    "1.1.3": "2016-08-15T10:41:33.356Z",
+    "1.1.4": "2016-10-06T08:58:00.711Z",
+    "1.1.5": "2016-10-10T14:42:09.483Z",
+    "1.1.6": "2016-10-10T14:46:22.618Z",
+    "1.1.7": "2016-10-31T15:27:42.243Z",
+    "1.1.8": "2017-02-18T15:58:11.450Z",
+    "1.1.9": "2017-05-03T16:49:04.462Z",
+    "1.2.0": "2017-11-02T13:59:04.266Z",
+    "1.3.0": "2018-04-06T00:12:02.700Z",
+    "1.4.0": "2018-04-19T14:02:58.027Z",
+    "1.4.1": "2018-06-05T13:55:26.937Z",
+    "1.4.3": "2018-07-29T12:44:10.337Z",
+    "1.4.4": "2018-11-05T13:36:52.984Z",
+    "1.4.5": "2019-04-11T22:38:00.194Z",
+    "1.4.6": "2019-04-12T16:33:53.772Z",
+    "1.4.7": "2019-04-26T15:13:23.330Z"
+  },
+  "keywords": [
+    "URL",
+    "parser",
+    "uri",
+    "url",
+    "parse",
+    "query",
+    "string",
+    "querystring",
+    "stringify"
+  ],
+  "author": {
+    "name": "Arnout Kazemier"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/unshiftio/url-parse#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unshiftio/url-parse.git"
+  },
+  "bugs": {
+    "url": "https://github.com/unshiftio/url-parse/issues"
+  },
+  "users": {
+    "fmoliveira": true,
+    "thebearingedge": true,
+    "curioussavage": true,
+    "pandao": true,
+    "m80126colin": true,
+    "jakedetels": true,
+    "piecioshka": true,
+    "jovinbm": true,
+    "steel1990": true,
+    "dchem": true,
+    "mjasso": true,
+    "xinwangwang": true,
+    "mikestaub": true,
+    "klimnikita": true,
+    "rpnna": true,
+    "filmplane": true,
+    "staydan": true,
+    "qddegtya": true,
+    "bobxuyang": true,
+    "itesic": true,
+    "sixertoy": true,
+    "dyaa": true,
+    "shuoshubao": true,
+    "rocket0191": true,
+    "shakakira": true,
+    "brend": true,
+    "kakaman": true,
+    "swansontec": true,
+    "zvit": true,
+    "orenschwartz": true,
+    "r_java": true,
+    "tmiame": true,
+    "chalassa": true,
+    "meganekick": true,
+    "zuojiang": true,
+    "flftfqwxf": true,
+    "cestrensem": true,
+    "yusef.ho.tw": true,
+    "akamaozu": true,
+    "black-black-cat": true,
+    "usex": true,
+    "sternelee": true,
+    "xiaobing": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/url-parse.min.json
+++ b/test/fixtures/registry-mocks/content/url-parse.min.json
@@ -1,0 +1,823 @@
+{
+  "name": "url-parse",
+  "dist-tags": {
+    "latest": "1.4.7"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "url-parse",
+      "version": "0.0.0",
+      "dist": {
+        "shasum": "7e844d6570e52a3b756604f8f0b0ed9165df34e8",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "url-parse",
+      "version": "0.0.1",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "a1083ef43383301eac4a0d746379e0c51bb502c3",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.1.tgz"
+      }
+    },
+    "0.0.2": {
+      "name": "url-parse",
+      "version": "0.0.2",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "e40c9dca6a877340307ddd29cdb2a1824be505ca",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "url-parse",
+      "version": "0.0.3",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "1.21.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "7f9cd84e2b501fcf39ebe5f6d2faade79c339d47",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "url-parse",
+      "version": "0.0.4",
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "4eb3e5af0f46c0a9fcc84f157b7d236d0583ce27",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.0.4.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "url-parse",
+      "version": "0.1.0",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "e770ff34faa8f0c0b86f2b0b8d93933e85c5fc03",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.0.tgz"
+      }
+    },
+    "0.1.1": {
+      "name": "url-parse",
+      "version": "0.1.1",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "b9c9efd9a371c515ae60f23c4845c6148777e558",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.1.tgz"
+      }
+    },
+    "0.1.2": {
+      "name": "url-parse",
+      "version": "0.1.2",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "ce598501dcb100ec06b960a26bed3f1e5dd3d6ab",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.2.tgz"
+      }
+    },
+    "0.1.3": {
+      "name": "url-parse",
+      "version": "0.1.3",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "e0355f9fce17f5181e875f59d74a00e1c32ac5aa",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.3.tgz"
+      }
+    },
+    "0.1.4": {
+      "name": "url-parse",
+      "version": "0.1.4",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "6.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "6e82e0f4387aa85b1036d66d36e6413bd8810223",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.4.tgz"
+      }
+    },
+    "0.1.5": {
+      "name": "url-parse",
+      "version": "0.1.5",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "85b5285054298d715007d479d5b150dfccbd1bd3",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.1.5.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "url-parse",
+      "version": "0.2.0",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "5d1e0e7965e93f6e14ecbcd100641804c6a0006f",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "url-parse",
+      "version": "0.2.1",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "pre-commit": "0.0.x"
+      },
+      "dist": {
+        "shasum": "79bf15b300047409c771e5f8f65680f1f581bf08",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.1.tgz"
+      }
+    },
+    "0.2.2": {
+      "name": "url-parse",
+      "version": "0.2.2",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "mocha-phantomjs": "3.5.x",
+        "pre-commit": "0.0.x",
+        "testling": "1.7.x"
+      },
+      "dist": {
+        "shasum": "d733ad09eb68c56a010e2cca63faf998339b8f19",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.2.tgz"
+      }
+    },
+    "0.2.3": {
+      "name": "url-parse",
+      "version": "0.2.3",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "0.0.x",
+        "browserify": "7.0.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.0.x",
+        "mochify": "2.1.x",
+        "pre-commit": "0.0.x",
+        "testling": "1.7.x"
+      },
+      "dist": {
+        "shasum": "00d3d6f0b4e4f319ea77f763c56f0c4c951ed273",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-0.2.3.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "url-parse",
+      "version": "1.0.0",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.0.x",
+        "browserify": "8.1.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.1.x",
+        "mochify": "2.1.x",
+        "pre-commit": "0.0.x",
+        "testling": "1.7.x"
+      },
+      "dist": {
+        "shasum": "aa20eb22d44b3102f98a8ee4e0c2e42ecc20d68a",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "url-parse",
+      "version": "1.0.1",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.1.x",
+        "browserify": "8.1.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.1.x",
+        "mochify": "2.4.x",
+        "pre-commit": "1.0.x",
+        "testling": "1.7.x"
+      },
+      "dist": {
+        "shasum": "6ead2ca6ab0e3a258bbfb4ed8a152189b81dd0c1",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "url-parse",
+      "version": "1.0.2",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.1.x",
+        "browserify": "8.1.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.1.x",
+        "mochify": "2.4.x",
+        "pre-commit": "1.0.x",
+        "testling": "1.7.x"
+      },
+      "dist": {
+        "shasum": "8c7bf70cd49a89024a032280e6eb33f22a79035c",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.2.tgz"
+      }
+    },
+    "1.0.3": {
+      "name": "url-parse",
+      "version": "1.0.3",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.3.x",
+        "browserify": "11.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.2.x",
+        "mochify": "2.13.x",
+        "pre-commit": "1.1.x",
+        "testling": "1.7.x"
+      },
+      "dist": {
+        "shasum": "a80ca4e0249401cb509e09d603c19a9feddc5bba",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.3.tgz"
+      }
+    },
+    "1.0.4": {
+      "name": "url-parse",
+      "version": "1.0.4",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "0.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.3.x",
+        "browserify": "11.2.x",
+        "istanbul": "0.3.x",
+        "mocha": "2.3.x",
+        "mochify": "2.13.x",
+        "pre-commit": "1.1.x",
+        "testling": "1.7.x"
+      },
+      "dist": {
+        "shasum": "4498cb51eb01ec1245313ff34a434cfaaaac0cc0",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.4.tgz"
+      }
+    },
+    "1.0.5": {
+      "name": "url-parse",
+      "version": "1.0.5",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.3.x",
+        "browserify": "12.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.3.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.7.x"
+      },
+      "dist": {
+        "shasum": "0854860422afdcfefeb6c965c662d4800169927b",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "url-parse",
+      "version": "1.1.0",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.4.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "dist": {
+        "shasum": "04cd63082a88820b2cb5c775872bbae5f1ac0a74",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.0.tgz"
+      }
+    },
+    "1.1.1": {
+      "name": "url-parse",
+      "version": "1.1.1",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.4.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "dist": {
+        "shasum": "d1507970728c9a5f80f471530c57325c3fb0e868",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.1.tgz"
+      }
+    },
+    "1.1.2": {
+      "name": "url-parse",
+      "version": "1.1.2",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.5.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "dist": {
+        "shasum": "51b375f8bb4d17c32a6fdfd83dde527f6c2e5309",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.2.tgz"
+      }
+    },
+    "1.1.3": {
+      "name": "url-parse",
+      "version": "1.1.3",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.0.x",
+        "istanbul": "0.4.x",
+        "mocha": "2.5.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.10.x"
+      },
+      "dist": {
+        "shasum": "cefdd24be2e71ffd91effc6ba56886c225bd1124",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.3.tgz"
+      }
+    },
+    "1.1.4": {
+      "name": "url-parse",
+      "version": "1.1.4",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.1.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.0.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "5cd835a39f4b6c1dc00bad07bc492efe3815eea6",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.4.tgz"
+      }
+    },
+    "1.1.5": {
+      "name": "url-parse",
+      "version": "1.1.5",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.1.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.1.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "9e2c741539397e03e399928788f2bd616915bc7c",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.5.tgz"
+      }
+    },
+    "1.1.6": {
+      "name": "url-parse",
+      "version": "1.1.6",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.1.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.1.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "ab8ff5aea1388071961255e2236147c52ca5fc48",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.6.tgz"
+      }
+    },
+    "1.1.7": {
+      "name": "url-parse",
+      "version": "1.1.7",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "13.1.x",
+        "istanbul": "0.4.x",
+        "mocha": "3.1.x",
+        "pre-commit": "1.1.x",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "025cff999653a459ab34232147d89514cc87d74a",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.7.tgz"
+      }
+    },
+    "1.1.8": {
+      "name": "url-parse",
+      "version": "1.1.8",
+      "dependencies": {
+        "querystringify": "0.0.x",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "1.4.x",
+        "browserify": "~14.1.0",
+        "istanbul": "0.4.x",
+        "mocha": "~3.2.0",
+        "pre-commit": "~1.2.0",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "7a65b3a8d57a1e86af6b4e2276e34774167c0156",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.8.tgz"
+      }
+    },
+    "1.1.9": {
+      "name": "url-parse",
+      "version": "1.1.9",
+      "dependencies": {
+        "querystringify": "~1.0.0",
+        "requires-port": "1.0.x"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~14.3.0",
+        "istanbul": "0.4.x",
+        "mocha": "~3.3.0",
+        "pre-commit": "~1.2.0",
+        "zuul": "3.11.x"
+      },
+      "dist": {
+        "shasum": "c67f1d775d51f0a18911dd7b3ffad27bb9e5bd19",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "url-parse",
+      "version": "1.2.0",
+      "dependencies": {
+        "querystringify": "~1.0.0",
+        "requires-port": "~1.0.0"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~14.5.0",
+        "mocha": "~4.0.0",
+        "nyc": "~11.3.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.0.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.1.0"
+      },
+      "dist": {
+        "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+        "shasum": "3a19e8aaa6d023ddd27dcc44cb4fc8f7fec23986",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "url-parse",
+      "version": "1.3.0",
+      "dependencies": {
+        "querystringify": "~1.0.0",
+        "requires-port": "~1.0.0"
+      },
+      "devDependencies": {
+        "assume": "~1.5.0",
+        "browserify": "~16.1.0",
+        "mocha": "~5.0.0",
+        "nyc": "~11.6.0",
+        "pre-commit": "~1.2.0",
+        "sauce-browsers": "~1.2.0",
+        "sauce-test": "~1.3.3",
+        "uglify-js": "~3.3.0"
+      },
+      "dist": {
+        "integrity": "sha512-zPvPA3T7P6M+0iNsgX+iAcAz4GshKrowtQBHHc/28tVsBc8jK7VRCNX+2GEcoE6zDB6XqXhcyiUWPVZY6C70Cg==",
+        "shasum": "04a06c420d22beb9804f7ada2d57ad13160a4258",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.3.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 47094
+      }
+    },
+    "1.4.0": {
+      "name": "url-parse",
+      "version": "1.4.0",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^2.0.1",
+        "browserify": "^16.2.0",
+        "mocha": "^5.1.1",
+        "nyc": "^11.7.1",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^1.2.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "dist": {
+        "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+        "shasum": "6bfdaad60098c7fe06f623e42b22de62de0d3d75",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 47238,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa2KGTCRA9TVsSAnZWagAAEfQP/AxkCXdHCpvM7TMDsxIu\nuxk8j02qpXgsCta8xslosDwN/pEYepE1HW02vd+swuws+t/LTq4EtX4oKR1V\n7CeP4rw0TDp8HbQyU+M+Wj9wORe97V6+CuF/Xy4BYQJH2B0OJs0GF6H+nEUo\n/2rYeZ0zlUQKtP+Bo9zDtm0g1y5vWeeg1QtxOAg0Vflv08MSCVUQcA0QRmC0\n2ZeJLfsAbwRo5w/G1Fqy9RYXgQ/1PBH6k9bztVSVRDMjL6n8+adLXd6u4OTm\nte86sOu5TJ0sDm/LxqOpGbvmKV9U7qTW5qw5XHQ1Sp+uhwIuFmTOArrI7juB\n38mz/Y/ajWXQKA2Vs501SVzIuzOvIKyGICvv52S35DiiQ9VFjpJt6xrw9fjt\n7uhZW33Q8HBQw81PEd+DWxN57OmL4CFegofWMN0xYPlkCSlwvfezvl3NkATj\ncfSJPT9NQWL26Q5TxMku8mr8tUgS+dOyRFg99UuWeban9Fly6to71f+Dx/5r\nQCBispKWUihTXFcjWXfxE7sY1UNmt74u8x3pDgS8oXvdAYlxLIzWURHkvozC\n3lT0/MhxBVVI4A6KevJK03tiWO51Bx0nT8S5lZwHN9JBhKj0F5kwEBHzWGbF\nMKpJI65QxBhPYaknatxofVYPsMRnSlkNKPrXB5MXIMWxHlYvrt3vG9f1ZnLp\nHXRv\r\n=wo9+\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.4.1": {
+      "name": "url-parse",
+      "version": "1.4.1",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^1.5.2",
+        "browserify": "^16.2.0",
+        "mocha": "^5.1.1",
+        "nyc": "^12.0.1",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^1.2.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "dist": {
+        "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+        "shasum": "4dec9dad3dc8585f862fed461d2e19bbf623df30",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 47340,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbFpZPCRA9TVsSAnZWagAAdjsP/09O+zYMP7bndAQhml3l\n5GS2gc3vvaVYi4sSJRrja8ptXpEr9W33KFxmE6CiIQeGTcxICeq6nwcBdsPn\nP+XBw6gW80u0+16mRa/g3SEPP7uEIng6ndNrgCcPtPML6YEl/6K0x69CUL0H\nZRNvmp8cf9TS0mZveqmGtbmqkCRydXb191i17ki84JBadlex4UXlfs8ue6zk\ngoWm1IszymFNOA9T8zcyMkQT7V+oUz/AfM0H3qDmHS5a6NvIyVuNnBNzeNP7\n4iVarvcC/Jv/qETPWhyLht+aiF/pFO6a3AI75DdmwvGh8xeW2L2nS5AB3IdH\n+rz3mg8DUSsTBxo8kCxhO1Q8GIDKY4zd49kMl8fTS0OFjSMVlTy8Ul3CZp1D\n0JJ50Zsx5KhsQI+Z4vHY7K4RdNunAS2S342mwJ/YKtfTPgJXVf+t2yQzLRqi\n/6IyEioiabeXecqfkduyBiUHDy6qtOCTs2qPH4IyAZCN1zn/MNtBxp8qvdEI\nACaUdC1cgqtwG+axlVQgQgZv3Ulpb5YXlMW79UFpnN2bhFlsBHWXv35wyIey\nRU1p65jtgVQMDilg753kLTwBTRvCAXF6R251iqzs6qvawfIkKMaui+NWMw2J\n1g+RSUdc9NkQlkyX2gKOTulU9xzkbqYjfl7J7dLNxWk7EV+MQQrNiKX60G2p\nMkod\r\n=2Ez4\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.4.3": {
+      "name": "url-parse",
+      "version": "1.4.3",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^1.5.2",
+        "browserify": "^16.2.0",
+        "mocha": "^5.1.1",
+        "nyc": "^12.0.1",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "dist": {
+        "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+        "shasum": "bfaee455c889023219d757e045fa6a684ec36c15",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+        "fileCount": 7,
+        "unpackedSize": 48337,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbXbaaCRA9TVsSAnZWagAAHwkP+gM4sfP4zF3749eay2Xb\nNl1xApOMlhNJK0s7ZfFw36m6iLl4kHDwdENq2S+HEHgq/+0hiJFOCeFdDUYQ\ne2Sun0Y6kQdYMwLqMch68jrBV7cZpzsHI8hqs0BFKEk0serr1Os7dJWe9KSR\nM0hp4ThgLeMgiGNYbYqabldNZ+4jL1ApjUw3uSGrDaETbV2c3difWoJiBLtk\nbcGqWGIYONZ8Jue61ikZWlk4QwNhpjexPR5c1ZucsbD/0ErgQkTTQkpAZDV/\nHJOPEmPVORhQsA6kcJaQFLpjVTxNU5oZgQnc3oQN8I18R6IyPs0isySoMJg5\nLVH+Z8kOc/7QYSAbxYESUMQ7miIkAU5sMvMDd83uAiARgv1UmA4Rhpmv4mjp\nfSeM4iRe381Ezj8wP0qm77QKjF0krdwGQ0K1obOXzoP1QY9N5LeC9Z9FOpl0\nk1TWQXbQKrCcsSGikC6u1zmCSZeuH1zD6Vb21r8ae8z5Y0ZmhemJNdYz8aZc\ngv8Ffz4/0xDfvxXN4U46VIkQlNybt6b4vFudx8hbTXvDd31ffMSHGDm6JLsC\n/cD8Sn6beq8K7BTHmBTeOiIBozFExkNpCbDoHdrQeCiEibVUxJMb4xY2GQ7N\nWRSTlud9Cpuz8UB3mE+nvETSmJfYDh1tNdZLnbGSstrAn4rJoQc92FQJAXxm\nUalb\r\n=KLA3\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.4.4": {
+      "name": "url-parse",
+      "version": "1.4.4",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^1.5.2",
+        "browserify": "^16.2.0",
+        "mocha": "^5.1.1",
+        "nyc": "^12.0.1",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "dist": {
+        "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+        "shasum": "cac1556e95faa0303691fec5cf9d5a1bc34648f8",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+        "fileCount": 7,
+        "unpackedSize": 48899,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb4Ed1CRA9TVsSAnZWagAA39EQAJ7N+PzjE87KLg5H+0ZE\nOKfnyTBfcuzd2K5AlwKhpf0ER4cgdQ91XChWW402cb9O6rQk99i9TjWwbr7+\nEaoMVzd0vpCKOv/2pqFXyPXy33Dv3mVWN2xYRygB2GUfZ2Em6nJuNEE1sb//\nd78N7cy2srJa/5/1+QrRedk7pu8Eqb8vSsgldDOYiEXrCetAs9fQK3gfCUSa\nvDodwYMFYXKQVIxlo27rHtnnaXxRlBRw7Zl+zD/FqE2ET32LrvprL6ho18T/\nuljqz48bRfsiMOzgIzk+Oe/Y6TrPcQHTliEqy/3Yu5GTlbZb9Wtf6SbJ3b/z\nt+FBw61NOVuZ+ypG6AFUY8juSihQYJNt/58cAjH3KpemZeIaSVA9nSXB0sDY\n3kKoBjwevoNilQHLfWW78Bd6suPY81FJrK3gHmx0cqjsS3skf3KqfMP//Vdl\nk7uIVbADmbHGIF9PkLqqmwAz5pMJld4PgPJpA2X8NantyyVvC+VJq/qqSi1U\n5ovrIbarNIvu4UC3Dho0sdMduLvKFOJRss6sWycsb/gEXEtPskmf2ftmKflM\nW4vvCC4aDam19QACETZjWO2m74q0ozxYBQ83zqSs41748fUTfMhGrQz7uC00\nQ2oeKX7utWK81b5UAh5ZU63dryx4tPbYcAk5cv+8RrOe2sQIwObh713batvP\n9qps\r\n=Fsjq\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.4.5": {
+      "name": "url-parse",
+      "version": "1.4.5",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.2.0",
+        "mocha": "^6.1.1",
+        "nyc": "^13.2.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "dist": {
+        "integrity": "sha512-4XDvC5vZRjEpjP0L4znrWeoH8P8F0XGBlfLdABi/6oV4o8xUVbTpyrxWHxkK2bT0pSIpcjdIzSoWUhlUfawCAQ==",
+        "shasum": "04cbb6ba2be682a18e4417fa2245aa7e3dfdcc50",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.5.tgz",
+        "fileCount": 7,
+        "unpackedSize": 50413,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcr8HICRA9TVsSAnZWagAAWuYP/Rt8nKMoDrTK4NxBxHxw\n25ld4D7yuq5k9aLRxNdBACFjL5O0Dz8k8WSoq4lCJv3AVqHo0e6bhfTtoEWe\nh4yndBrCMJvVulH7LE3decQON9huplfBb2SeaLSedCZoXEbzUFXMSNr0cJec\nf5SumyvpC6NQhpqcHxFMbfbDUnPbj/H5DJ1JcJKyoM054lrviSGiloMnE9AW\njjXnsWeWeV+6PCqQu0t89KLLpx8092X4A2uBUj9Jgcydtuw4xF+JYYBN8RZu\nvsQ2YnmFPpan2EJT1K1xXe1Rsu1AfPc03IL6jtt0kL2yW4xgRuqM1sWsPDmC\nQgFCn1ySvTAgliKdnec3J5cZoqSBc+cr83FUjnOGimAhhCW9e3ZdDMAewkGg\n+E1YvqMioXfyu7GrEPWCQBZrqGPDzU61DuJK00PInIGiAcgXkmihs1TAIznj\nRCtReTmjmUu5OwJGbakzLudi2nJP0DzDTXh7fcoBMJyVBQfFx4pQ+thVWHzf\n+WIYjUcC1BLT4G8RpwVnE52+kYWLVJJ9o6OYwnb2Ryqnmfi9l0SGMQoi6DTb\nJsSOrwumysjY8SXYsX/AzR8Tw9sRyv1xcRs1krZTMqNel1elhjCyRXAiaSYp\n5/mElhw7ze3zwgvAaY7LrYo0IjFXHJvuNUVMgUaTBC3rN4S+UXjIMjrQ2F2t\nbM6Z\r\n=u+Cc\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.4.6": {
+      "name": "url-parse",
+      "version": "1.4.6",
+      "dependencies": {
+        "querystringify": "^2.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.2.0",
+        "mocha": "^6.1.1",
+        "nyc": "^13.2.0",
+        "pre-commit": "^1.2.0",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.3.21"
+      },
+      "dist": {
+        "integrity": "sha512-/B8AD9iQ01seoXmXf9z/MjLZQIdOoYl/+gvsQF6+mpnxaTfG9P7srYaiqaDMyKkR36XMXfhqSHss5MyFAO8lew==",
+        "shasum": "baf91d6e6783c8a795eb476892ffef2737fc0456",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.6.tgz",
+        "fileCount": 7,
+        "unpackedSize": 50463,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcsL3yCRA9TVsSAnZWagAAIK8P/RBsuy2nkvdPhIfO98Vs\n9+QVf6oA56QM+7hRiJ+udhtkpDg8fVQFtJj8LewMSjZZHTqpj0C7UgBmtVys\ncXIrbJGkoncWsL58bI9LwvyssCOtuhF+D2O7ObaOZ/xcN8RGpv2I+3AiGAlW\niNAEgaKYPY9QsPBklYAvjuWasfzmNwRUEZ4HHKk+8FjDSzgsTGmKnd87tURg\n5adDgrrrhUg9Oi33e/8yldfAiygC5Oa+Uo0R0ZT79sVOvOEk1PBnoRlb8zvW\n2KyZ5FKEc10xEUuyMiROiqeXdejEBgqJqCpJkjzYRsP3UB23EH5g/B7yl7B+\n8hdE07ZUXsh68KesKIGAVOfc7ZsOWCa3SR13BMf359ybTTijTuXOOt/i+WHg\n4XC99L1Lmz12GM6g/8DTuCS7qoUS0h8ReyD7zgKpY0zLS2m5ec6MZgh+BXS2\nA6m4WCP6phgjoJJcv3l0Gf+waETPsBJKl7SlEQJ9ZVNC1RVIddazu4ecw1Gs\nLkhd5KV+SptnuGk1+Zc4XnY2uhHMF9Rzk0nOInmRrhC5LL0o0k9DL6r5K5gh\n6nvFjFL/qGM6FsLZyVwneP8/OyusY7u+kXnLn/8wDxtUNvf/3/NY0r9NDdxS\nO9iVV4Ed7kDOfbYzMy6KA833R1g66vznoiB7F6OStRDv/DXlg4OYHVZgwKAz\n4n+K\r\n=K4FH\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.4.7": {
+      "name": "url-parse",
+      "version": "1.4.7",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      },
+      "devDependencies": {
+        "assume": "^2.2.0",
+        "browserify": "^16.2.3",
+        "mocha": "^6.1.4",
+        "nyc": "^14.0.0",
+        "pre-commit": "^1.2.2",
+        "sauce-browsers": "^2.0.0",
+        "sauce-test": "^1.3.3",
+        "uglify-js": "^3.5.7"
+      },
+      "dist": {
+        "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+        "shasum": "a8a83535e8c00a316e403a5db4ac1b9b853ae278",
+        "tarball": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+        "fileCount": 7,
+        "unpackedSize": 50462,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcwyATCRA9TVsSAnZWagAAPDAP/1AK1XsHrBwBpN/yS0wR\nu9b/FR60TP+an4Z33sGBJtPDOv+3nzyQ3q22bsmQhVWSTxgweyluN16BGyKG\nZ3qZlauJFVnGD8MBNu3lolFGF8rE80E7AROb4Lp+cprQMdHc7zgLgwjOMupB\nmUEW9QeQzpDd33G3plnAOjn1DkGRZzX6sK3ZFrD7ifeioqO8tIxSSmZxpEt9\nTSOEm64238rysl6ZijD3/yI0NPAeE+tGYYmnISQv1er6O3S1qyu5maoz8Rsc\naYJA/8YTyNOMxbc1HAccN3il68KilJdQkHBq62H4N/jLd0a+uUCaVBggc8ul\nzXsMGTAcDJGPBvw/TP5QnU99rX8i5TUyxfhMawcAA+P38HHv+wbeGmC/upBD\nHJTa9KVFdORO7WKmr0imCvl1kRkcu/fGSuxorJtEOqwLfpvt/o/lsL3bFRIa\nj8nu4oRaC9vdevK5g3Pc+Y0WiOO3Eik1kAFt7M7W7JSJa+mWbKGc9cA0tBhL\nQeTB9x6SmdWZh/SzCwY4UZBhrZe/8wR4GxS1CJoZjNdiE46QEigfkC3XMsf2\nTRtoC+lH1oGBBwuglg2QQlR1fxwWmGLiT9ztr/uro01D1IdbV9lvqZxjc9WJ\n0PjWFkqpNoIPdhIA+YnHU0oLe34Hnj1OZEQVDDQ+QP9aFynZV9xuj1m9BxQq\naq+2\r\n=kXPf\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-04-26T15:13:25.910Z"
+}

--- a/test/fixtures/registry-mocks/content/url.json
+++ b/test/fixtures/registry-mocks/content/url.json
@@ -1,0 +1,465 @@
+{
+  "_id": "url",
+  "_rev": "100-2138b90ec57750cb4f5c800021be46f0",
+  "name": "url",
+  "description": "The core `url` packaged standalone for use with Browserify.",
+  "dist-tags": {
+    "latest": "0.11.0"
+  },
+  "versions": {
+    "0.4.9": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "url",
+      "description": "Node.JS url module",
+      "keywords": [
+        "ender",
+        "url"
+      ],
+      "version": "0.4.9",
+      "homepage": "http://nodejs.org/docs/v0.4.9/api/url.html",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/coolaj86/nodejs-libs-4-browser.git"
+      },
+      "main": "./url.js",
+      "directories": {
+        "lib": "."
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      },
+      "dependencies": {
+        "querystring": ">= 0.0.0"
+      },
+      "devDependencies": {},
+      "_npmJsonOpts": {
+        "file": "/Users/coolaj86/.npm/url/0.4.9/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "url@0.4.9",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.15",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "d8ae654e43779d5dcc120c282cf51717b62427ba",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.4.9.tgz"
+      },
+      "scripts": {}
+    },
+    "0.7.9": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "url",
+      "description": "Node.JS url module",
+      "keywords": [
+        "ender",
+        "pakmanager",
+        "url"
+      ],
+      "publishConfig": {
+        "registry": "http://registry.npmjs.org"
+      },
+      "version": "0.7.9",
+      "homepage": "http://nodejs.org/api/url.html",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/coolaj86/node.git"
+      },
+      "main": "./url.js",
+      "directories": {
+        "lib": "."
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      },
+      "dependencies": {
+        "querystring": ">=0.1.0 <0.2.0",
+        "punycode": ">=1.0.0 <1.1.0"
+      },
+      "devDependencies": {},
+      "_id": "url@0.7.9",
+      "dist": {
+        "shasum": "1959b1a8b361fc017b59513a7c7fa9827f5e4ed0",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.7.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        }
+      ]
+    },
+    "0.10.0": {
+      "name": "url",
+      "description": "The core `url` packaged standalone for use with Browserify.",
+      "version": "0.10.0",
+      "dependencies": {
+        "punycode": "1.2.4"
+      },
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "1.6.3"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js",
+        "test-local": "zuul --local -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/defunctzombie/node-url.git"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-url/issues"
+      },
+      "homepage": "https://github.com/defunctzombie/node-url",
+      "_id": "url@0.10.0",
+      "dist": {
+        "shasum": "fa391953a4a89eb9d94f54b823fce1ce98c9413c",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.10.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.1": {
+      "name": "url",
+      "description": "The core `url` packaged standalone for use with Browserify.",
+      "version": "0.10.1",
+      "dependencies": {
+        "punycode": "1.2.4"
+      },
+      "main": "./url.js",
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "1.6.3"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js",
+        "test-local": "zuul --local -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/defunctzombie/node-url.git"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-url/issues"
+      },
+      "homepage": "https://github.com/defunctzombie/node-url",
+      "_id": "url@0.10.1",
+      "dist": {
+        "shasum": "d8eba8f267cec7645ddd93d2cdcf2320c876d25b",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.10.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.6",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.2": {
+      "name": "url",
+      "description": "The core `url` packaged standalone for use with Browserify.",
+      "version": "0.10.2",
+      "dependencies": {
+        "punycode": "1.3.2"
+      },
+      "main": "./url.js",
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "1.16.3"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js",
+        "test-local": "zuul --local -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/defunctzombie/node-url.git"
+      },
+      "gitHead": "9a64b9ab8703d1d38d1a39793bd9841224962eb4",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-url/issues"
+      },
+      "homepage": "https://github.com/defunctzombie/node-url",
+      "_id": "url@0.10.2",
+      "_shasum": "68621d6929ea1cad344ebf135d82fcf7eb1a7469",
+      "_from": ".",
+      "_npmVersion": "2.1.12",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "68621d6929ea1cad344ebf135d82fcf7eb1a7469",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.10.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.10.3": {
+      "name": "url",
+      "description": "The core `url` packaged standalone for use with Browserify.",
+      "version": "0.10.3",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "main": "./url.js",
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "2.0.0"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js",
+        "test-local": "zuul --local -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/defunctzombie/node-url.git"
+      },
+      "license": "MIT",
+      "gitHead": "575b428ae37eb43f243d0228dea1b44ecf744f3d",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-url/issues"
+      },
+      "homepage": "https://github.com/defunctzombie/node-url",
+      "_id": "url@0.10.3",
+      "_shasum": "021e4d9c7705f21bbf37d03ceb58767402774c64",
+      "_from": ".",
+      "_npmVersion": "2.2.0",
+      "_nodeVersion": "0.10.35",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "021e4d9c7705f21bbf37d03ceb58767402774c64",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.10.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "url",
+      "description": "The core `url` packaged standalone for use with Browserify.",
+      "version": "0.11.0",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "main": "./url.js",
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "3.3.0"
+      },
+      "scripts": {
+        "test": "mocha --ui qunit test.js && zuul -- test.js",
+        "test-local": "zuul --local -- test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/defunctzombie/node-url.git"
+      },
+      "license": "MIT",
+      "gitHead": "7f82d6b09acba099163fede09b4226b4e55a5377",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-url/issues"
+      },
+      "homepage": "https://github.com/defunctzombie/node-url#readme",
+      "_id": "url@0.11.0",
+      "_shasum": "3838e97cfc60521eb73c525a8e55bfdd9e2e28f1",
+      "_from": ".",
+      "_npmVersion": "2.11.1",
+      "_nodeVersion": "0.10.38",
+      "_npmUser": {
+        "name": "defunctzombie",
+        "email": "shtylman@gmail.com"
+      },
+      "dist": {
+        "shasum": "3838e97cfc60521eb73c525a8e55bfdd9e2e28f1",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.11.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "defunctzombie",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    }
+  },
+  "maintainers": [
+    {
+      "name": "coolaj86",
+      "email": "coolaj86@gmail.com"
+    },
+    {
+      "name": "defunctzombie",
+      "email": "shtylman@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-03-20T07:15:39.838Z",
+    "created": "2011-07-07T22:16:05.456Z",
+    "0.4.9": "2011-07-07T22:16:05.853Z",
+    "0.7.9": "2012-06-19T20:14:13.396Z",
+    "0.10.0": "2014-04-21T23:45:22.022Z",
+    "0.10.1": "2014-04-22T02:04:20.272Z",
+    "0.10.2": "2015-01-02T03:40:11.078Z",
+    "0.10.3": "2015-02-27T18:37:21.243Z",
+    "0.11.0": "2015-08-27T15:36:57.674Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/defunctzombie/node-url.git"
+  },
+  "users": {
+    "326060588": true,
+    "m42am": true,
+    "wenbing": true,
+    "jonathandion": true,
+    "piotr23": true,
+    "tophsic": true,
+    "wangnan0610": true,
+    "pavel.shirobok": true,
+    "haeck": true,
+    "satblip": true,
+    "kulakowka": true,
+    "zambon": true,
+    "iamveen": true,
+    "simplyianm": true,
+    "itonyyo": true,
+    "kubens": true,
+    "luuhoangnam": true,
+    "nichoth": true,
+    "parkerproject": true,
+    "wzbg": true,
+    "matiasmarani": true,
+    "nketchum": true,
+    "r3nya": true,
+    "tujiaw": true,
+    "98edoardo": true,
+    "antixrist": true,
+    "moimikey": true,
+    "novalu": true,
+    "dittodhole": true,
+    "detj": true,
+    "barinbritva": true,
+    "vutran": true,
+    "dduran1967": true,
+    "mshwery": true,
+    "aahz": true,
+    "yatsu": true,
+    "koulmomo": true,
+    "bjmin": true,
+    "ahme-t": true,
+    "moosecouture": true,
+    "algonzo": true,
+    "yanndinendal": true,
+    "esanz91": true,
+    "diegorbaquero": true,
+    "mluberry": true,
+    "jacks": true,
+    "x-cold": true,
+    "gurunate": true,
+    "landy2014": true,
+    "onemoon": true,
+    "boulakar": true,
+    "leonzhao": true,
+    "zixinliango": true,
+    "abdullahceylan": true,
+    "latinosoft": true,
+    "aidenzou": true,
+    "chinawolf_wyp": true,
+    "usex": true,
+    "banyudu": true,
+    "mrxf": true,
+    "asaupup": true,
+    "shuoshubao": true,
+    "huhgawz": true,
+    "nuwaio": true,
+    "wfalkwallace": true,
+    "eyson": true,
+    "doctoruseful": true,
+    "brainpoint": true,
+    "mwyatt": true,
+    "rubiadias": true,
+    "sternelee": true,
+    "yanghcc": true,
+    "pftom": true,
+    "valenwave": true,
+    "shreyawhiz": true
+  },
+  "readme": "# node-url\n\n[![Build Status](https://travis-ci.org/defunctzombie/node-url.svg?branch=master)](https://travis-ci.org/defunctzombie/node-url)\n\nThis module has utilities for URL resolution and parsing meant to have feature parity with node.js core [url](http://nodejs.org/api/url.html) module.\n\n```js\nvar url = require('url');\n```\n\n## api\n\nParsed URL objects have some or all of the following fields, depending on\nwhether or not they exist in the URL string. Any parts that are not in the URL\nstring will not be in the parsed object. Examples are shown for the URL\n\n`'http://user:pass@host.com:8080/p/a/t/h?query=string#hash'`\n\n* `href`: The full URL that was originally parsed. Both the protocol and host are lowercased.\n\n    Example: `'http://user:pass@host.com:8080/p/a/t/h?query=string#hash'`\n\n* `protocol`: The request protocol, lowercased.\n\n    Example: `'http:'`\n\n* `host`: The full lowercased host portion of the URL, including port\n  information.\n\n    Example: `'host.com:8080'`\n\n* `auth`: The authentication information portion of a URL.\n\n    Example: `'user:pass'`\n\n* `hostname`: Just the lowercased hostname portion of the host.\n\n    Example: `'host.com'`\n\n* `port`: The port number portion of the host.\n\n    Example: `'8080'`\n\n* `pathname`: The path section of the URL, that comes after the host and\n  before the query, including the initial slash if present.\n\n    Example: `'/p/a/t/h'`\n\n* `search`: The 'query string' portion of the URL, including the leading\n  question mark.\n\n    Example: `'?query=string'`\n\n* `path`: Concatenation of `pathname` and `search`.\n\n    Example: `'/p/a/t/h?query=string'`\n\n* `query`: Either the 'params' portion of the query string, or a\n  querystring-parsed object.\n\n    Example: `'query=string'` or `{'query':'string'}`\n\n* `hash`: The 'fragment' portion of the URL including the pound-sign.\n\n    Example: `'#hash'`\n\nThe following methods are provided by the URL module:\n\n### url.parse(urlStr, [parseQueryString], [slashesDenoteHost])\n\nTake a URL string, and return an object.\n\nPass `true` as the second argument to also parse\nthe query string using the `querystring` module.\nDefaults to `false`.\n\nPass `true` as the third argument to treat `//foo/bar` as\n`{ host: 'foo', pathname: '/bar' }` rather than\n`{ pathname: '//foo/bar' }`. Defaults to `false`.\n\n### url.format(urlObj)\n\nTake a parsed URL object, and return a formatted URL string.\n\n* `href` will be ignored.\n* `protocol` is treated the same with or without the trailing `:` (colon).\n  * The protocols `http`, `https`, `ftp`, `gopher`, `file` will be\n    postfixed with `://` (colon-slash-slash).\n  * All other protocols `mailto`, `xmpp`, `aim`, `sftp`, `foo`, etc will\n    be postfixed with `:` (colon)\n* `auth` will be used if present.\n* `hostname` will only be used if `host` is absent.\n* `port` will only be used if `host` is absent.\n* `host` will be used in place of `hostname` and `port`\n* `pathname` is treated the same with or without the leading `/` (slash)\n* `search` will be used in place of `query`\n* `query` (object; see `querystring`) will only be used if `search` is absent.\n* `search` is treated the same with or without the leading `?` (question mark)\n* `hash` is treated the same with or without the leading `#` (pound sign, anchor)\n\n### url.resolve(from, to)\n\nTake a base URL, and a href URL, and resolve them as a browser would for\nan anchor tag.  Examples:\n\n    url.resolve('/one/two/three', 'four')         // '/one/two/four'\n    url.resolve('http://example.com/', '/one')    // 'http://example.com/one'\n    url.resolve('http://example.com/one', '/two') // 'http://example.com/two'\n",
+  "homepage": "https://github.com/defunctzombie/node-url#readme",
+  "bugs": {
+    "url": "https://github.com/defunctzombie/node-url/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/url.min.json
+++ b/test/fixtures/registry-mocks/content/url.min.json
@@ -1,0 +1,128 @@
+{
+  "name": "url",
+  "dist-tags": {
+    "latest": "0.11.0"
+  },
+  "versions": {
+    "0.4.9": {
+      "name": "url",
+      "version": "0.4.9",
+      "dependencies": {
+        "querystring": ">= 0.0.0"
+      },
+      "directories": {
+        "lib": "."
+      },
+      "dist": {
+        "shasum": "d8ae654e43779d5dcc120c282cf51717b62427ba",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.4.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      }
+    },
+    "0.7.9": {
+      "name": "url",
+      "version": "0.7.9",
+      "dependencies": {
+        "querystring": ">=0.1.0 <0.2.0",
+        "punycode": ">=1.0.0 <1.1.0"
+      },
+      "directories": {
+        "lib": "."
+      },
+      "dist": {
+        "shasum": "1959b1a8b361fc017b59513a7c7fa9827f5e4ed0",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.7.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      }
+    },
+    "0.10.0": {
+      "name": "url",
+      "version": "0.10.0",
+      "dependencies": {
+        "punycode": "1.2.4"
+      },
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "1.6.3"
+      },
+      "dist": {
+        "shasum": "fa391953a4a89eb9d94f54b823fce1ce98c9413c",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.10.0.tgz"
+      }
+    },
+    "0.10.1": {
+      "name": "url",
+      "version": "0.10.1",
+      "dependencies": {
+        "punycode": "1.2.4"
+      },
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "1.6.3"
+      },
+      "dist": {
+        "shasum": "d8eba8f267cec7645ddd93d2cdcf2320c876d25b",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.10.1.tgz"
+      }
+    },
+    "0.10.2": {
+      "name": "url",
+      "version": "0.10.2",
+      "dependencies": {
+        "punycode": "1.3.2"
+      },
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "1.16.3"
+      },
+      "dist": {
+        "shasum": "68621d6929ea1cad344ebf135d82fcf7eb1a7469",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.10.2.tgz"
+      }
+    },
+    "0.10.3": {
+      "name": "url",
+      "version": "0.10.3",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "2.0.0"
+      },
+      "dist": {
+        "shasum": "021e4d9c7705f21bbf37d03ceb58767402774c64",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.10.3.tgz"
+      }
+    },
+    "0.11.0": {
+      "name": "url",
+      "version": "0.11.0",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "devDependencies": {
+        "assert": "1.1.1",
+        "mocha": "1.18.2",
+        "zuul": "3.3.0"
+      },
+      "dist": {
+        "shasum": "3838e97cfc60521eb73c525a8e55bfdd9e2e28f1",
+        "tarball": "https://registry.npmjs.org/url/-/url-0.11.0.tgz"
+      }
+    }
+  },
+  "modified": "2018-03-20T07:15:39.838Z"
+}

--- a/test/fixtures/registry-mocks/content/util.json
+++ b/test/fixtures/registry-mocks/content/util.json
@@ -1,0 +1,1257 @@
+{
+  "_id": "util",
+  "_rev": "73-2c71f790b7e9e326085dcd630a801f56",
+  "name": "util",
+  "description": "Node.js's util module for all engines",
+  "dist-tags": {
+    "latest": "0.12.3"
+  },
+  "versions": {
+    "0.4.9": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "util",
+      "description": "Node.JS util module",
+      "keywords": [
+        "ender",
+        "util"
+      ],
+      "version": "0.4.9",
+      "homepage": "http://nodejs.org/docs/v0.4.9/api/util.html",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/coolaj86/nodejs-libs-4-browser.git"
+      },
+      "main": "./util.js",
+      "directories": {
+        "lib": "."
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      },
+      "dependencies": {
+        "events.node": ">= 0.4.0"
+      },
+      "devDependencies": {},
+      "_npmJsonOpts": {
+        "file": "/Users/coolaj86/.npm/util/0.4.9/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "util@0.4.9",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.22",
+      "_nodeVersion": "v0.4.8",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "d95d5830d2328ec17dee3c80bfc50c33562b75a3",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.4.9.tgz"
+      },
+      "scripts": {},
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        }
+      ]
+    },
+    "0.10.0": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "util",
+      "description": "Node.JS util module",
+      "keywords": [
+        "util"
+      ],
+      "version": "0.10.0",
+      "homepage": "https://github.com/defunctzombie/node-util",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/node-util"
+      },
+      "main": "./util.js",
+      "scripts": {
+        "test": "node test/node/*.js"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.3"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-util/issues"
+      },
+      "_id": "util@0.10.0",
+      "dist": {
+        "shasum": "b11c0823c74c077ea6911ad334394055b680fb5e",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.1": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "util",
+      "description": "Node.JS util module",
+      "keywords": [
+        "util"
+      ],
+      "version": "0.10.1",
+      "homepage": "https://github.com/defunctzombie/node-util",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/node-util"
+      },
+      "main": "./util.js",
+      "scripts": {
+        "test": "node test/node/*.js"
+      },
+      "dependencies": {
+        "inherits": "2.0.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.3"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-util/issues"
+      },
+      "_id": "util@0.10.1",
+      "dist": {
+        "shasum": "5062a0152d4afa1a243b4129947e9965eff594f8",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "coolaj86",
+          "email": "coolaj86@gmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.2": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "util",
+      "description": "Node.JS util module",
+      "keywords": [
+        "util"
+      ],
+      "version": "0.10.2",
+      "homepage": "https://github.com/defunctzombie/node-util",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/node-util"
+      },
+      "main": "./util.js",
+      "scripts": {
+        "test": "node test/node/*.js && zuul test/browser/*.js"
+      },
+      "dependencies": {
+        "inherits": "2.0.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-util/issues"
+      },
+      "_id": "util@0.10.2",
+      "dist": {
+        "shasum": "8180519cf690fb88bc56480fe55087531f446304",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.3": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "util",
+      "description": "Node.JS util module",
+      "keywords": [
+        "util"
+      ],
+      "version": "0.10.3",
+      "homepage": "https://github.com/defunctzombie/node-util",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/node-util"
+      },
+      "main": "./util.js",
+      "scripts": {
+        "test": "node test/node/*.js && zuul test/browser/*.js"
+      },
+      "dependencies": {
+        "inherits": "2.0.1"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "zuul": "~1.0.9"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-util/issues"
+      },
+      "_id": "util@0.10.3",
+      "dist": {
+        "shasum": "7afb1afe50805246489e3db7fe0ed379336ac0f9",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "shtylman",
+        "email": "shtylman@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.4": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "util",
+      "description": "Node.JS util module",
+      "keywords": [
+        "util"
+      ],
+      "version": "0.10.4",
+      "homepage": "https://github.com/defunctzombie/node-util",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/node-util.git"
+      },
+      "main": "./util.js",
+      "files": [
+        "util.js",
+        "support"
+      ],
+      "scripts": {
+        "test": "node test/node/*.js && zuul test/browser/*.js"
+      },
+      "dependencies": {
+        "inherits": "2.0.3"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "zuul": "~1.0.9"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "gitHead": "4efa901ab644197688f2799a79d5b21e151fee21",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-util/issues"
+      },
+      "_id": "util@0.10.4",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.3.0",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+        "shasum": "3aa0125bfe668a4672de58857d3ace27ecb76901",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+        "fileCount": 6,
+        "unpackedSize": 18043,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbFF6kCRA9TVsSAnZWagAAaiUP/jEDGXGQ9fB0vw5eOErV\nGQRbp6UN3uox9XNFtUu8VWWDjfPMoEfkg7vblnwznueMycDzcS4Nb87iIO0E\nzSC/x/ytI5Vt0tZJ3cb52aQpP+Hmcz6s5E5mLVQyRAFOFtx9GMN/IYlYNPRO\npFs4g4ICPdxxCSEeqnj3EucmEH5NiUkD6NGgs5fCsxIBMCfCdh/0LOzmbIC3\nUIwzdd/CyFW8PBR5v64Pc2SfpaK8lidg+8ieaglaaYsisUzuGYjcRC7nJ9y7\n7eVnasRGuitotXUO48E3Z8j0lR3/HuG6WEIimC5rGEZdMx9iqRnB8K3X9okq\nKvm4hTnRuvIemzGUF44r4mx8twgrR9/RLvZLo+kCg5v9ayPAMOauJTtnSwHO\nNFCoOWK89WOSdTZ8wXiBnUoon5iM18pSB1i4Nl+WQDqiJdPOo0rZxFwdLa6i\nhdqE+34fjw21QXUNZz99d5Z8qIjNVQxc0tQ9dNW87Kn5Insn4pvaVfJjuK02\nVOfv1fVFzs6LubDP8aphqeGv/gchR3KfGzYSiA4Yb7bY5sedMvE9rE4SH5Gg\nsDzjDeYDC9r8YsFOGkovdF5rNoVVXSntAUSIwW31X5CGd48xW/4Q/qhrl4Op\nQZNuK4PxOH2lCKUNg+keLYCevxT/9w8V7pv0b0Nu2JEe5EWGJ+CIOx1Y5G6J\n2s++\r\n=f4Zj\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "coolaj86@gmail.com",
+          "name": "coolaj86"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/util_0.10.4_1528061603804_0.9595471831761384"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.11.0": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "util",
+      "description": "Node.JS util module",
+      "keywords": [
+        "util"
+      ],
+      "version": "0.11.0",
+      "homepage": "https://github.com/defunctzombie/node-util",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/node-util.git"
+      },
+      "main": "./util.js",
+      "files": [
+        "util.js",
+        "support"
+      ],
+      "scripts": {
+        "test": "node test/node/index.js",
+        "test:browsers": "airtap test/browser/index.js"
+      },
+      "dependencies": {
+        "inherits": "2.0.3"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "airtap": "0.0.6",
+        "is-async-supported": "~1.2.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "gitHead": "0915f593c45eb131e3e7f4718e0b4861433acaff",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-util/issues"
+      },
+      "_id": "util@0.11.0",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.4.0",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==",
+        "shasum": "c5f391beb244103d799b21077a926fef8769e1fb",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.11.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 24307,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbGk4CCRA9TVsSAnZWagAAyssP+wa3dq5eMUuoC0kLo6aC\nihwQa5vFru9zlpdfQaDawcdzOXlNiutOUuT6nqLmn6Q6W9FwOIVBGHB3aR3m\neGJjPXLSGY5h4sUNMiyUFKHAdfT8BkKS3odYmzXQSB/q0LxAQng5HsY+gfP8\n4087Vxmco4PWvHCSQp7GScjw4jTsF8DtgkUe77hKR/1b+hFtm3koJ7ou0j52\nLxabDsFEvkLmjeQMcTsKMfCR666HS+/iSNXSu6FKcYduy6Ub83BPvUE1YzYs\npExPSN6YuVjlvnxv0857pzOhpA5JaYM2OtquyHES8OzGhnraqe3Sr7avJdiW\nbO3t+fG9kjyXIqy+JZRopDCRjl5bx7C40jsj8id5VQX4mw390dLXM3YFScqe\nb0HwT0s0A15UnZKEwp/vo8O7NZHacRz3epCZKQm4yZkUrt/Ijgi9QK4zJfBl\nmKjx9dr96Q9MgoqKhNbcJZecZ7E1Fg6fxNhxEormpZOk9cqhsDHXV6ZSoMkg\nJBz5Jr6erSYSDEoi4Qs47Wtyrc/rqlUUxawHacPSyeF6180NGRQz8AHG9Jg9\nB15mZvH+1YDA2wXA7UpXMAvo3kdQ9gnPm97caSc6MXu19P2fpHm5GRQKhdJF\nYXB+DuXsJ7r+N50INIUxL4Z1XnxHCUIWfPA5QsMWbtCGCfEHT3011JvxS8c/\nk1RF\r\n=Qkjv\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "coolaj86@gmail.com",
+          "name": "coolaj86"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/util_0.11.0_1528450561638_0.4109525947691539"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.11.1": {
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "name": "util",
+      "description": "Node.JS util module",
+      "keywords": [
+        "util"
+      ],
+      "version": "0.11.1",
+      "homepage": "https://github.com/defunctzombie/node-util",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/defunctzombie/node-util.git"
+      },
+      "main": "./util.js",
+      "scripts": {
+        "test": "node test/node/index.js",
+        "test:browsers": "airtap test/browser/index.js"
+      },
+      "dependencies": {
+        "inherits": "2.0.3"
+      },
+      "license": "MIT",
+      "devDependencies": {
+        "airtap": "~0.1.0",
+        "is-async-supported": "~1.2.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "gitHead": "cfbf5d0acf112759a8aa7c2339a1694c52cf82d6",
+      "bugs": {
+        "url": "https://github.com/defunctzombie/node-util/issues"
+      },
+      "_id": "util@0.11.1",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "11.0.0",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+        "shasum": "3236733720ec64bb27f6e26f421aaa2e1b588d61",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 24542,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb2vVoCRA9TVsSAnZWagAAdgEP/3Z5DtoDvgdbb/1lbKmX\nE0YTwdfT1t89qRAYSc+jdXRShhfhAwxuxv2lVDX/F1YiBFlaPqsE0fEEEjkS\nwynBQyyHFl2LC7wdKv+b0xhWgDFS8DMOCxbLKs7mvvTZJ28SQq4nkoajTVfE\nFedTQWW62scivc7ZgRWavOjnicoaQjrLIoPQeKaUTgMP/LYefzT6D0TK5A7D\nB0zH6HfUxbcvsuUMyhwnrYcuhJZjfIcHt4uRlFk+gplzp124IBfgw+a/dRcs\nwWuiJRpshM1PGbYNuteuw9Fdws5P5QE61HpUKXKRaj6LplAf35+pWv6mfiW+\nNi7ECX48gk4sVdsmYPRsmA8oUZSwghkdK8VqpwPRq6giqg68RE4d8pZ4+n8J\nFHy7v1F2sfiTFl23ca8Hxkl66ijgMRx1Oth+7THOdHaNf22geJmDmQR+FQzL\nXnaqTFfVh1u1iX4DMNWt+2/aHi0ZhjzhauoDtUp7Rwk87/XUmdxkVRhAlhWC\nvrPm3ucAK868eFOf1CxaagVwkJAc6MUT4jmOnl7sk5vqQEMpVPQXSuwx7i46\n2n7MWyoWkoGtibwSddXo/gFvBA2sdObudiU9e8d4QNFilLaFzOKYVXB+5Nk1\nCtxQk5bS+AR1IKgMqXy+lKh1BPlHNPlHQdyViwSgN0ARll8EOrZGXN1I93bY\ng+17\r\n=WrLS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "coolaj86@gmail.com",
+          "name": "coolaj86"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/util_0.11.1_1541076327427_0.9736836321835605"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.12.0": {
+      "name": "util",
+      "description": "Node.js's util module for all engines",
+      "version": "0.12.0",
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "dependencies": {
+        "inherits": "2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "airtap": "~1.0.0",
+        "is-async-supported": "~1.2.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "homepage": "https://github.com/browserify/node-util",
+      "keywords": [
+        "util"
+      ],
+      "license": "MIT",
+      "main": "./util.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/node-util.git"
+      },
+      "scripts": {
+        "test": "node test/node/index.js",
+        "test:browsers": "airtap test/browser/index.js",
+        "test:browsers:local": "npm run test:browsers -- --local"
+      },
+      "gitHead": "53026a2923edeaa0a113f479298f555b761f8042",
+      "bugs": {
+        "url": "https://github.com/browserify/node-util/issues"
+      },
+      "_id": "util@0.12.0",
+      "_nodeVersion": "11.14.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-pPSOFl7VLhZ7LO/SFABPraZEEurkJUWSMn3MuA/r3WQZc+Z1fqou2JqLSOZbCLl73EUIxuUVX8X4jkX2vfJeAA==",
+        "shasum": "bb5e3d29ba2703c7add0ad337003be3ca477798a",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.12.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 36564,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcyY4uCRA9TVsSAnZWagAAlOEQAJ6X6u4Eu+t8/fOdVZ42\nQu8sYHK7GJgSMlpDmC06saVT7TeEbw65O2IUb7nE2de6Q5PqHPLxYihJgQ/J\nfWWWi+zEihoKIFQzKj/PEg1QAkewPvdUUo6T97plp/r+Ytb3Hzwvr5fA0oVh\n69wqfogkS33F0YQtVYwp/T5xXtJuCsKM88D4Jbysw09zDPIoSEy2qMchy/LC\nC4t8w/ndIKdYzMzGEg+XW9REvfsBg7D1wNKy207XrW1T7IgxveC4LvuVzDtR\n4yAlWTSEgw9BCM+3wNO1klMgrtdrqeLDl0wnMnMMAvtVtCqAorHAqlPpIUoW\nijH84imWCOmih5eCzLy1idH7+ETQcug5pxQwHIYiwhZqj7b/PhgQiCX+I5XT\nx0NBuBfgbUEpe6kTbZgcnhIC104MOx+meKLJavnfL38dzc/bA5uvNnqq7Ucz\nH6AS+WFMWceOCeUiuPZWv8FBCTUAxPwiCYdP22DerSJKLrI2IXJNCaEy+J+S\nG+laZ/PiXKKq/0GLGDHTPBmixnPO2AxJP2pmeNqNx8oMBQvppDrrl6C6kfek\n+a5B7l99dgf6WxlLAQTad5NxVh7GVmP2nIiZN5KULj+CGQkDAaVt6qP7UIGw\noVYZLqJtZ9xiL3EpQG2Lh3/XeCO3+p1REuNLD28iddJMycS6Z8xIeoK2vq9x\nQJIG\r\n=c3WE\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "coolaj86@gmail.com",
+          "name": "coolaj86"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/util_0.12.0_1556713005190_0.5006879798798092"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.12.1": {
+      "name": "util",
+      "description": "Node.js's util module for all engines",
+      "version": "0.12.1",
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "airtap": "~1.0.0",
+        "is-async-supported": "~1.2.0",
+        "object.assign": "~4.1.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "homepage": "https://github.com/browserify/node-util",
+      "keywords": [
+        "util"
+      ],
+      "license": "MIT",
+      "main": "./util.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/node-util.git"
+      },
+      "scripts": {
+        "test": "node test/node/index.js",
+        "test:browsers": "airtap test/browser/index.js",
+        "test:browsers:local": "npm run test:browsers -- --local"
+      },
+      "gitHead": "3c895410f1816110edeeb4c8e5427942ee97d65e",
+      "bugs": {
+        "url": "https://github.com/browserify/node-util/issues"
+      },
+      "_id": "util@0.12.1",
+      "_nodeVersion": "11.15.0",
+      "_npmVersion": "6.10.0",
+      "dist": {
+        "integrity": "sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==",
+        "shasum": "f908e7b633e7396c764e694dd14e716256ce8ade",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37071,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdH2GJCRA9TVsSAnZWagAAN9gP/3BOS665JB2IAW4Sy4cV\ndpIqglap2Q0qu4ee0wjQ6cgmamyUfx4KuE4MqMyFtyFZr0E/ppy+I8JehZk7\ngtIuIl1TUrJQ0q0g0iLcTErbKxBGi+pGy+A3M0AHBRzrWGmmfjMy5pBu9eOY\nRFW7bWP2sGCLUnJD4eVV9gm7J0PZsfM1wDnjj7l/VZOg1lKsFCLc6Q20aIwl\nulLfr3CSDeTOrAzdz+KBtRuVA/lmJX4LptxwX1GJ6BUENDxMhhQPfvafnUwG\nTq6tASk08pdr5sOqVS6SFiq2/OMxc6CWJt80VZ8PRMaMXSJLMonXiu7JVZn+\nQPUxHRuUCxU8QzGruxDPEcCjlL/lDOflBj9bBnBoJWRkjk/rlEUlrMAhy06F\nHXsNNk83x4qmVsGdInFoLRCXHUcnz3nqRf3gO30HfJJcvr1C7kcdzbTAiPgU\n9tm0jsbjfxChaZy7m0l+4Ntc45YxOXuIYkIEovZLki3lOthAfL4Ivn8Wo/QW\n8okURK54mLdjlMLW/8gNK7RYEU31nwZuOVxFPhN7aEKeAZ0p9LMaZIhOOrZ1\n2xsEdm6TBAygVH8y1sg/VS1ZTl3yuzKAIVhRC42yzjORaK5a8EN/l5QAXzGt\nQGwRbkcUeT/9nyp3gUw/1JXmeD0cfh7Mt8gXPKOQVXTUtf/l1miRA7fmu5fY\nXKLE\r\n=htq/\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "coolaj86@gmail.com",
+          "name": "coolaj86"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/util_0.12.1_1562337672740_0.948704949052033"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.12.2": {
+      "name": "util",
+      "description": "Node.js's util module for all engines",
+      "version": "0.12.2",
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "airtap": "~1.0.0",
+        "is-async-supported": "~1.2.0",
+        "object.assign": "~4.1.0",
+        "object.entries": "^1.1.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "homepage": "https://github.com/browserify/node-util",
+      "keywords": [
+        "util"
+      ],
+      "license": "MIT",
+      "main": "./util.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/node-util.git"
+      },
+      "scripts": {
+        "test": "node test/node/index.js",
+        "test:browsers": "airtap test/browser/index.js",
+        "test:browsers:local": "npm run test:browsers -- --local"
+      },
+      "gitHead": "9364e7db4d7bae7212a7927e304006a06e4571bc",
+      "bugs": {
+        "url": "https://github.com/browserify/node-util/issues"
+      },
+      "_id": "util@0.12.2",
+      "_nodeVersion": "13.9.0",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-XE+MkWQvglYa+IOfBt5UFG93EmncEMP23UqpgDvVZVFBPxwmkK10QRp6pgU4xICPnWRf/t0zPv4noYSUq9gqUQ==",
+        "shasum": "54adb634c9e7c748707af2bf5a8c7ab640cbba2b",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37298,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeU4/zCRA9TVsSAnZWagAA17wP/RP4JsDG6cnlTnFYhdbt\nvACkT+554LWzFYmfgvImqIVEJt844HWMt86QHGP/Y9Bpy6p1HawR57rfEHTz\n6jwtUpPt2UC58QjdumJaYeOwXnPhtyq8h8gOXRzDK7Nf1eEuLPo/iF7zxCEc\nrcs7vf4FV1zDmXlOKdKPS2sZU4ISB8lDgkLCpSdB4G9Qm7pn4ZoJLMcCbsSt\ngRYMWKwqdANnx85YoSlNy4nlMID6hWT7yeLSkZtBBVH0eS6vD6TW8pojvuSp\n5VK4JynNUydGGIis5trtXSoilSAmIIj8M2gwnqlroAzm20A1UpFSzKlqtQp4\nnrSX4biKkFKvYfSmkmns6gkNriT+5upePfTdUYgb9Sxn5rvCmN0tNBxrZLKU\nMKvKCkLUL0GolQA2EGzudyQBNXsrOZ5f3Kedg5JobNFxj+HAu9cmb+CgkWD5\nMWpoaAbgGccTHuFuJfZQuCf0SIETQsYSH5XWqtGYLTmMJKJx2werMw0HvP/0\n0ij3ZT2EaJbYiMq0AEx5fWrkGBbHBkdfnbeiUuJdmhI/wzDq9psFffaFH69R\nhfvuJRHzBOFuxrSw6YXwVa7OiiW750XZiPrL6x4tvxTg9cDlXyFN6zuGJ292\nCeHR/XmeSjPNkDLnt1MDWOz1VG7Rr7uRjgjmhnW0yLtnqlAL1IWLhcyrVn9F\nqyHs\r\n=3cgz\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "coolaj86@gmail.com",
+          "name": "coolaj86"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/util_0.12.2_1582534641951_0.5087693081122073"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.12.3": {
+      "name": "util",
+      "description": "Node.js's util module for all engines",
+      "version": "0.12.3",
+      "author": {
+        "name": "Joyent",
+        "url": "http://www.joyent.com"
+      },
+      "browser": {
+        "./support/isBuffer.js": "./support/isBufferBrowser.js"
+      },
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      },
+      "devDependencies": {
+        "airtap": "~1.0.0",
+        "core-js": "^3.6.5",
+        "is-async-supported": "~1.2.0",
+        "object.assign": "~4.1.0",
+        "object.entries": "^1.1.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "homepage": "https://github.com/browserify/node-util",
+      "keywords": [
+        "util"
+      ],
+      "license": "MIT",
+      "main": "./util.js",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/browserify/node-util.git"
+      },
+      "scripts": {
+        "test": "node test/node/index.js",
+        "test:browsers": "airtap test/browser/index.js",
+        "test:browsers:with-polyfills": "airtap test/browser/with-polyfills.js",
+        "test:browsers:with-polyfills:local": "npm run test:browsers:with-polyfills -- --local",
+        "test:browsers:local": "npm run test:browsers -- --local"
+      },
+      "gitHead": "4b1c0c79790d9968eabecd2e9c786454713e200f",
+      "bugs": {
+        "url": "https://github.com/browserify/node-util/issues"
+      },
+      "_id": "util@0.12.3",
+      "_nodeVersion": "14.0.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+        "shasum": "971bb0292d2cc0c892dab7c6a5d37c2bec707888",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+        "fileCount": 8,
+        "unpackedSize": 34827,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeqpWsCRA9TVsSAnZWagAAmfUQAJ8v5j/m0fvlqOepvJYm\nfi88glLGNrODbx9OUr1Npj7tYEofDokv+e9Z12btsLVghGFy0chFNV8XgSDE\nsNprZOZi7cq79oT9+YpEidFJmlBKnZL/Ex6UrdVU8cG7QLH6wv1+C10iuj44\nFXZy5Mu0cRTUHi7Qs5J07mGQRdbrIBUAAz7mfRm6n3nAHjzzENRaEc9/dy2Y\nglQCXKgiCRXDsYCmkMUW6lD9f4QZ+48m2YMC3QNaR8QAFTrmho/LMd6SwapK\nKHlbyL/qo9pEEmPpZINZ/I/j32ltIIwRvjZXuBqRzZ/Q5UPw8d+Iz4cETteq\nghftwJ1HPzX2Cxs56dTpHP3nbrguIwMHoO4ttTBlme3/S85GJ/j4al5wAOC1\n1Lqxo5HKjCURV8JBlGXQz/i4vbfNQQcL8ZkbI8DYfIWQjp05dx+13f9aKCPy\nR3h4D1RZ1gxAx3EkmgdVzgUxF1PKW5mpWXjFPIi4FNOc05vxm5112GSL74OD\nbeGU1qDJdiSjTDxL6VWvgUBscdwAGKlDqs1/DXIXjL5u9leeGJpuvPlAF13A\nn3gXzdsdFcuJWV+bh65C6qnWtWRkEAgotPz7QOrsZKz7XHq5+rBJ7E4Z83TJ\ndXXY7eRSajR4uiDCmps/Y9MO2STz5DAVVzFbE/fa5IEg90U/3hvSuOt9Mn2E\nAsub\r\n=qu2r\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "coolaj86@gmail.com",
+          "name": "coolaj86"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "ljharb@gmail.com",
+          "name": "ljharb"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/util_0.12.3_1588237739835_0.6259599712536057"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "email": "coolaj86@gmail.com",
+      "name": "coolaj86"
+    },
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "shtylman@gmail.com",
+      "name": "defunctzombie"
+    },
+    {
+      "email": "renee@kooi.me",
+      "name": "goto-bus-stop"
+    },
+    {
+      "email": "ljharb@gmail.com",
+      "name": "ljharb"
+    },
+    {
+      "email": "lukechilds123@gmail.com",
+      "name": "lukechilds"
+    },
+    {
+      "email": "substack@gmail.com",
+      "name": "substack"
+    }
+  ],
+  "time": {
+    "modified": "2020-04-30T09:09:05.753Z",
+    "created": "2011-09-07T07:57:03.366Z",
+    "0.4.9": "2011-09-07T07:57:03.759Z",
+    "0.10.0": "2013-11-22T18:33:15.755Z",
+    "0.10.1": "2013-12-06T17:05:58.468Z",
+    "0.10.2": "2013-12-20T15:25:29.294Z",
+    "0.10.3": "2014-02-07T17:15:14.138Z",
+    "0.10.4": "2018-06-03T21:33:23.853Z",
+    "0.11.0": "2018-06-08T09:36:01.740Z",
+    "0.11.1": "2018-11-01T12:45:27.575Z",
+    "0.12.0": "2019-05-01T12:16:45.334Z",
+    "0.12.1": "2019-07-05T14:41:12.911Z",
+    "0.12.2": "2020-02-24T08:57:22.652Z",
+    "0.12.3": "2020-04-30T09:08:59.972Z"
+  },
+  "author": {
+    "name": "Joyent",
+    "url": "http://www.joyent.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/browserify/node-util.git"
+  },
+  "users": {
+    "m42am": true,
+    "tunnckocore": true,
+    "wenbing": true,
+    "snekse": true,
+    "cameronjroe": true,
+    "wangnan0610": true,
+    "hagb4rd": true,
+    "leonardorb": true,
+    "haeck": true,
+    "alejcerro": true,
+    "happy-coding": true,
+    "simplyianm": true,
+    "jerkovicl": true,
+    "mr.vingo": true,
+    "chinaqstar": true,
+    "nketchum": true,
+    "nickeltobias": true,
+    "stany": true,
+    "samhou1988": true,
+    "pdedkov": true,
+    "stuart.shi": true,
+    "tobiasnickel": true,
+    "zhenghorse": true,
+    "tbear79": true,
+    "shekharreddy": true,
+    "wangfeia": true,
+    "mobeicaoyuan": true,
+    "rickyrattlesnake": true,
+    "rocket0191": true,
+    "mife": true,
+    "millercl": true,
+    "bryan.ygf": true,
+    "pasturn": true,
+    "morogasper": true,
+    "chinawolf_wyp": true,
+    "keelvin": true
+  },
+  "readme": "# util [![Build Status](https://travis-ci.org/browserify/node-util.png?branch=master)](https://travis-ci.org/browserify/node-util)\n\n> Node.js's [util][util] module for all engines.\n\nThis implements the Node.js [`util`][util] module for environments that do not have it, like browsers.\n\n## Install\n\nYou usually do not have to install `util` yourself. If your code runs in Node.js, `util` is built in. If your code runs in the browser, bundlers like [browserify](https://github.com/browserify/browserify) or [webpack](https://github.com/webpack/webpack) also include the `util` module.\n\nBut if none of those apply, with npm do:\n\n```shell\nnpm install util\n```\n\n## Usage\n\n```javascript\nvar util = require('util')\nvar EventEmitter = require('events')\n\nfunction MyClass() { EventEmitter.call(this) }\nutil.inherits(MyClass, EventEmitter)\n```\n\n## Browser Support\n\nThe `util` module uses ES5 features. If you need to support very old browsers like IE8, use a shim like [`es5-shim`](https://www.npmjs.com/package/es5-shim). You need both the shim and the sham versions of `es5-shim`.\n\nTo use `util.promisify` and `util.callbackify`, Promises must already be available. If you need to support browsers like IE11 that do not support Promises, use a shim. [es6-promise](https://github.com/stefanpenner/es6-promise) is a popular one but there are many others available on npm.\n\n## API\n\nSee the [Node.js util docs][util].  `util` currently supports the Node 8 LTS API. However, some of the methods are outdated. The `inspect` and `format` methods included in this module are a lot more simple and barebones than the ones in Node.js.\n\n## Contributing\n\nPRs are very welcome! The main way to contribute to `util` is by porting features, bugfixes and tests from Node.js. Ideally, code contributions to this module are copy-pasted from Node.js and transpiled to ES5, rather than reimplemented from scratch. Matching the Node.js code as closely as possible makes maintenance simpler when new changes land in Node.js.\nThis module intends to provide exactly the same API as Node.js, so features that are not available in the core `util` module will not be accepted. Feature requests should instead be directed at [nodejs/node](https://github.com/nodejs/node) and will be added to this module once they are implemented in Node.js.\n\nIf there is a difference in behaviour between Node.js's `util` module and this module, please open an issue!\n\n## License\n\n[MIT](./LICENSE)\n\n[util]: https://nodejs.org/docs/latest-v8.x/api/util.html\n",
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/browserify/node-util",
+  "keywords": [
+    "util"
+  ],
+  "bugs": {
+    "url": "https://github.com/browserify/node-util/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/util.min.json
+++ b/test/fixtures/registry-mocks/content/util.min.json
@@ -1,0 +1,246 @@
+{
+  "name": "util",
+  "dist-tags": {
+    "latest": "0.12.3"
+  },
+  "versions": {
+    "0.4.9": {
+      "name": "util",
+      "version": "0.4.9",
+      "dependencies": {
+        "events.node": ">= 0.4.0"
+      },
+      "directories": {
+        "lib": "."
+      },
+      "dist": {
+        "shasum": "d95d5830d2328ec17dee3c80bfc50c33562b75a3",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.4.9.tgz"
+      },
+      "engines": {
+        "node": ">= 0.2.0",
+        "ender": ">= 0.5.0"
+      }
+    },
+    "0.10.0": {
+      "name": "util",
+      "version": "0.10.0",
+      "devDependencies": {
+        "zuul": "~1.0.3"
+      },
+      "dist": {
+        "shasum": "b11c0823c74c077ea6911ad334394055b680fb5e",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.0.tgz"
+      }
+    },
+    "0.10.1": {
+      "name": "util",
+      "version": "0.10.1",
+      "dependencies": {
+        "inherits": "2.0.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.3"
+      },
+      "dist": {
+        "shasum": "5062a0152d4afa1a243b4129947e9965eff594f8",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.1.tgz"
+      }
+    },
+    "0.10.2": {
+      "name": "util",
+      "version": "0.10.2",
+      "dependencies": {
+        "inherits": "2.0.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9"
+      },
+      "dist": {
+        "shasum": "8180519cf690fb88bc56480fe55087531f446304",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.2.tgz"
+      }
+    },
+    "0.10.3": {
+      "name": "util",
+      "version": "0.10.3",
+      "dependencies": {
+        "inherits": "2.0.1"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9"
+      },
+      "dist": {
+        "shasum": "7afb1afe50805246489e3db7fe0ed379336ac0f9",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+      }
+    },
+    "0.10.4": {
+      "name": "util",
+      "version": "0.10.4",
+      "dependencies": {
+        "inherits": "2.0.3"
+      },
+      "devDependencies": {
+        "zuul": "~1.0.9"
+      },
+      "dist": {
+        "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+        "shasum": "3aa0125bfe668a4672de58857d3ace27ecb76901",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+        "fileCount": 6,
+        "unpackedSize": 18043,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbFF6kCRA9TVsSAnZWagAAaiUP/jEDGXGQ9fB0vw5eOErV\nGQRbp6UN3uox9XNFtUu8VWWDjfPMoEfkg7vblnwznueMycDzcS4Nb87iIO0E\nzSC/x/ytI5Vt0tZJ3cb52aQpP+Hmcz6s5E5mLVQyRAFOFtx9GMN/IYlYNPRO\npFs4g4ICPdxxCSEeqnj3EucmEH5NiUkD6NGgs5fCsxIBMCfCdh/0LOzmbIC3\nUIwzdd/CyFW8PBR5v64Pc2SfpaK8lidg+8ieaglaaYsisUzuGYjcRC7nJ9y7\n7eVnasRGuitotXUO48E3Z8j0lR3/HuG6WEIimC5rGEZdMx9iqRnB8K3X9okq\nKvm4hTnRuvIemzGUF44r4mx8twgrR9/RLvZLo+kCg5v9ayPAMOauJTtnSwHO\nNFCoOWK89WOSdTZ8wXiBnUoon5iM18pSB1i4Nl+WQDqiJdPOo0rZxFwdLa6i\nhdqE+34fjw21QXUNZz99d5Z8qIjNVQxc0tQ9dNW87Kn5Insn4pvaVfJjuK02\nVOfv1fVFzs6LubDP8aphqeGv/gchR3KfGzYSiA4Yb7bY5sedMvE9rE4SH5Gg\nsDzjDeYDC9r8YsFOGkovdF5rNoVVXSntAUSIwW31X5CGd48xW/4Q/qhrl4Op\nQZNuK4PxOH2lCKUNg+keLYCevxT/9w8V7pv0b0Nu2JEe5EWGJ+CIOx1Y5G6J\n2s++\r\n=f4Zj\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.11.0": {
+      "name": "util",
+      "version": "0.11.0",
+      "dependencies": {
+        "inherits": "2.0.3"
+      },
+      "devDependencies": {
+        "airtap": "0.0.6",
+        "is-async-supported": "~1.2.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==",
+        "shasum": "c5f391beb244103d799b21077a926fef8769e1fb",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.11.0.tgz",
+        "fileCount": 7,
+        "unpackedSize": 24307,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbGk4CCRA9TVsSAnZWagAAyssP+wa3dq5eMUuoC0kLo6aC\nihwQa5vFru9zlpdfQaDawcdzOXlNiutOUuT6nqLmn6Q6W9FwOIVBGHB3aR3m\neGJjPXLSGY5h4sUNMiyUFKHAdfT8BkKS3odYmzXQSB/q0LxAQng5HsY+gfP8\n4087Vxmco4PWvHCSQp7GScjw4jTsF8DtgkUe77hKR/1b+hFtm3koJ7ou0j52\nLxabDsFEvkLmjeQMcTsKMfCR666HS+/iSNXSu6FKcYduy6Ub83BPvUE1YzYs\npExPSN6YuVjlvnxv0857pzOhpA5JaYM2OtquyHES8OzGhnraqe3Sr7avJdiW\nbO3t+fG9kjyXIqy+JZRopDCRjl5bx7C40jsj8id5VQX4mw390dLXM3YFScqe\nb0HwT0s0A15UnZKEwp/vo8O7NZHacRz3epCZKQm4yZkUrt/Ijgi9QK4zJfBl\nmKjx9dr96Q9MgoqKhNbcJZecZ7E1Fg6fxNhxEormpZOk9cqhsDHXV6ZSoMkg\nJBz5Jr6erSYSDEoi4Qs47Wtyrc/rqlUUxawHacPSyeF6180NGRQz8AHG9Jg9\nB15mZvH+1YDA2wXA7UpXMAvo3kdQ9gnPm97caSc6MXu19P2fpHm5GRQKhdJF\nYXB+DuXsJ7r+N50INIUxL4Z1XnxHCUIWfPA5QsMWbtCGCfEHT3011JvxS8c/\nk1RF\r\n=Qkjv\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.11.1": {
+      "name": "util",
+      "version": "0.11.1",
+      "dependencies": {
+        "inherits": "2.0.3"
+      },
+      "devDependencies": {
+        "airtap": "~0.1.0",
+        "is-async-supported": "~1.2.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+        "shasum": "3236733720ec64bb27f6e26f421aaa2e1b588d61",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+        "fileCount": 7,
+        "unpackedSize": 24542,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJb2vVoCRA9TVsSAnZWagAAdgEP/3Z5DtoDvgdbb/1lbKmX\nE0YTwdfT1t89qRAYSc+jdXRShhfhAwxuxv2lVDX/F1YiBFlaPqsE0fEEEjkS\nwynBQyyHFl2LC7wdKv+b0xhWgDFS8DMOCxbLKs7mvvTZJ28SQq4nkoajTVfE\nFedTQWW62scivc7ZgRWavOjnicoaQjrLIoPQeKaUTgMP/LYefzT6D0TK5A7D\nB0zH6HfUxbcvsuUMyhwnrYcuhJZjfIcHt4uRlFk+gplzp124IBfgw+a/dRcs\nwWuiJRpshM1PGbYNuteuw9Fdws5P5QE61HpUKXKRaj6LplAf35+pWv6mfiW+\nNi7ECX48gk4sVdsmYPRsmA8oUZSwghkdK8VqpwPRq6giqg68RE4d8pZ4+n8J\nFHy7v1F2sfiTFl23ca8Hxkl66ijgMRx1Oth+7THOdHaNf22geJmDmQR+FQzL\nXnaqTFfVh1u1iX4DMNWt+2/aHi0ZhjzhauoDtUp7Rwk87/XUmdxkVRhAlhWC\nvrPm3ucAK868eFOf1CxaagVwkJAc6MUT4jmOnl7sk5vqQEMpVPQXSuwx7i46\n2n7MWyoWkoGtibwSddXo/gFvBA2sdObudiU9e8d4QNFilLaFzOKYVXB+5Nk1\nCtxQk5bS+AR1IKgMqXy+lKh1BPlHNPlHQdyViwSgN0ARll8EOrZGXN1I93bY\ng+17\r\n=WrLS\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.12.0": {
+      "name": "util",
+      "version": "0.12.0",
+      "dependencies": {
+        "inherits": "2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "airtap": "~1.0.0",
+        "is-async-supported": "~1.2.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-pPSOFl7VLhZ7LO/SFABPraZEEurkJUWSMn3MuA/r3WQZc+Z1fqou2JqLSOZbCLl73EUIxuUVX8X4jkX2vfJeAA==",
+        "shasum": "bb5e3d29ba2703c7add0ad337003be3ca477798a",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.12.0.tgz",
+        "fileCount": 8,
+        "unpackedSize": 36564,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcyY4uCRA9TVsSAnZWagAAlOEQAJ6X6u4Eu+t8/fOdVZ42\nQu8sYHK7GJgSMlpDmC06saVT7TeEbw65O2IUb7nE2de6Q5PqHPLxYihJgQ/J\nfWWWi+zEihoKIFQzKj/PEg1QAkewPvdUUo6T97plp/r+Ytb3Hzwvr5fA0oVh\n69wqfogkS33F0YQtVYwp/T5xXtJuCsKM88D4Jbysw09zDPIoSEy2qMchy/LC\nC4t8w/ndIKdYzMzGEg+XW9REvfsBg7D1wNKy207XrW1T7IgxveC4LvuVzDtR\n4yAlWTSEgw9BCM+3wNO1klMgrtdrqeLDl0wnMnMMAvtVtCqAorHAqlPpIUoW\nijH84imWCOmih5eCzLy1idH7+ETQcug5pxQwHIYiwhZqj7b/PhgQiCX+I5XT\nx0NBuBfgbUEpe6kTbZgcnhIC104MOx+meKLJavnfL38dzc/bA5uvNnqq7Ucz\nH6AS+WFMWceOCeUiuPZWv8FBCTUAxPwiCYdP22DerSJKLrI2IXJNCaEy+J+S\nG+laZ/PiXKKq/0GLGDHTPBmixnPO2AxJP2pmeNqNx8oMBQvppDrrl6C6kfek\n+a5B7l99dgf6WxlLAQTad5NxVh7GVmP2nIiZN5KULj+CGQkDAaVt6qP7UIGw\noVYZLqJtZ9xiL3EpQG2Lh3/XeCO3+p1REuNLD28iddJMycS6Z8xIeoK2vq9x\nQJIG\r\n=c3WE\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.12.1": {
+      "name": "util",
+      "version": "0.12.1",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "airtap": "~1.0.0",
+        "is-async-supported": "~1.2.0",
+        "object.assign": "~4.1.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-MREAtYOp+GTt9/+kwf00IYoHZyjM8VU4aVrkzUlejyqaIjd2GztVl5V9hGXKlvBKE3gENn/FMfHE5v6hElXGcQ==",
+        "shasum": "f908e7b633e7396c764e694dd14e716256ce8ade",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37071,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdH2GJCRA9TVsSAnZWagAAN9gP/3BOS665JB2IAW4Sy4cV\ndpIqglap2Q0qu4ee0wjQ6cgmamyUfx4KuE4MqMyFtyFZr0E/ppy+I8JehZk7\ngtIuIl1TUrJQ0q0g0iLcTErbKxBGi+pGy+A3M0AHBRzrWGmmfjMy5pBu9eOY\nRFW7bWP2sGCLUnJD4eVV9gm7J0PZsfM1wDnjj7l/VZOg1lKsFCLc6Q20aIwl\nulLfr3CSDeTOrAzdz+KBtRuVA/lmJX4LptxwX1GJ6BUENDxMhhQPfvafnUwG\nTq6tASk08pdr5sOqVS6SFiq2/OMxc6CWJt80VZ8PRMaMXSJLMonXiu7JVZn+\nQPUxHRuUCxU8QzGruxDPEcCjlL/lDOflBj9bBnBoJWRkjk/rlEUlrMAhy06F\nHXsNNk83x4qmVsGdInFoLRCXHUcnz3nqRf3gO30HfJJcvr1C7kcdzbTAiPgU\n9tm0jsbjfxChaZy7m0l+4Ntc45YxOXuIYkIEovZLki3lOthAfL4Ivn8Wo/QW\n8okURK54mLdjlMLW/8gNK7RYEU31nwZuOVxFPhN7aEKeAZ0p9LMaZIhOOrZ1\n2xsEdm6TBAygVH8y1sg/VS1ZTl3yuzKAIVhRC42yzjORaK5a8EN/l5QAXzGt\nQGwRbkcUeT/9nyp3gUw/1JXmeD0cfh7Mt8gXPKOQVXTUtf/l1miRA7fmu5fY\nXKLE\r\n=htq/\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.12.2": {
+      "name": "util",
+      "version": "0.12.2",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "safe-buffer": "^5.1.2"
+      },
+      "devDependencies": {
+        "airtap": "~1.0.0",
+        "is-async-supported": "~1.2.0",
+        "object.assign": "~4.1.0",
+        "object.entries": "^1.1.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-XE+MkWQvglYa+IOfBt5UFG93EmncEMP23UqpgDvVZVFBPxwmkK10QRp6pgU4xICPnWRf/t0zPv4noYSUq9gqUQ==",
+        "shasum": "54adb634c9e7c748707af2bf5a8c7ab640cbba2b",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.12.2.tgz",
+        "fileCount": 8,
+        "unpackedSize": 37298,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeU4/zCRA9TVsSAnZWagAA17wP/RP4JsDG6cnlTnFYhdbt\nvACkT+554LWzFYmfgvImqIVEJt844HWMt86QHGP/Y9Bpy6p1HawR57rfEHTz\n6jwtUpPt2UC58QjdumJaYeOwXnPhtyq8h8gOXRzDK7Nf1eEuLPo/iF7zxCEc\nrcs7vf4FV1zDmXlOKdKPS2sZU4ISB8lDgkLCpSdB4G9Qm7pn4ZoJLMcCbsSt\ngRYMWKwqdANnx85YoSlNy4nlMID6hWT7yeLSkZtBBVH0eS6vD6TW8pojvuSp\n5VK4JynNUydGGIis5trtXSoilSAmIIj8M2gwnqlroAzm20A1UpFSzKlqtQp4\nnrSX4biKkFKvYfSmkmns6gkNriT+5upePfTdUYgb9Sxn5rvCmN0tNBxrZLKU\nMKvKCkLUL0GolQA2EGzudyQBNXsrOZ5f3Kedg5JobNFxj+HAu9cmb+CgkWD5\nMWpoaAbgGccTHuFuJfZQuCf0SIETQsYSH5XWqtGYLTmMJKJx2werMw0HvP/0\n0ij3ZT2EaJbYiMq0AEx5fWrkGBbHBkdfnbeiUuJdmhI/wzDq9psFffaFH69R\nhfvuJRHzBOFuxrSw6YXwVa7OiiW750XZiPrL6x4tvxTg9cDlXyFN6zuGJ292\nCeHR/XmeSjPNkDLnt1MDWOz1VG7Rr7uRjgjmhnW0yLtnqlAL1IWLhcyrVn9F\nqyHs\r\n=3cgz\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "0.12.3": {
+      "name": "util",
+      "version": "0.12.3",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "safe-buffer": "^5.1.2",
+        "which-typed-array": "^1.1.2"
+      },
+      "devDependencies": {
+        "airtap": "~1.0.0",
+        "core-js": "^3.6.5",
+        "is-async-supported": "~1.2.0",
+        "object.assign": "~4.1.0",
+        "object.entries": "^1.1.0",
+        "run-series": "~1.1.4",
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+        "shasum": "971bb0292d2cc0c892dab7c6a5d37c2bec707888",
+        "tarball": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
+        "fileCount": 8,
+        "unpackedSize": 34827,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeqpWsCRA9TVsSAnZWagAAmfUQAJ8v5j/m0fvlqOepvJYm\nfi88glLGNrODbx9OUr1Npj7tYEofDokv+e9Z12btsLVghGFy0chFNV8XgSDE\nsNprZOZi7cq79oT9+YpEidFJmlBKnZL/Ex6UrdVU8cG7QLH6wv1+C10iuj44\nFXZy5Mu0cRTUHi7Qs5J07mGQRdbrIBUAAz7mfRm6n3nAHjzzENRaEc9/dy2Y\nglQCXKgiCRXDsYCmkMUW6lD9f4QZ+48m2YMC3QNaR8QAFTrmho/LMd6SwapK\nKHlbyL/qo9pEEmPpZINZ/I/j32ltIIwRvjZXuBqRzZ/Q5UPw8d+Iz4cETteq\nghftwJ1HPzX2Cxs56dTpHP3nbrguIwMHoO4ttTBlme3/S85GJ/j4al5wAOC1\n1Lqxo5HKjCURV8JBlGXQz/i4vbfNQQcL8ZkbI8DYfIWQjp05dx+13f9aKCPy\nR3h4D1RZ1gxAx3EkmgdVzgUxF1PKW5mpWXjFPIi4FNOc05vxm5112GSL74OD\nbeGU1qDJdiSjTDxL6VWvgUBscdwAGKlDqs1/DXIXjL5u9leeGJpuvPlAF13A\nn3gXzdsdFcuJWV+bh65C6qnWtWRkEAgotPz7QOrsZKz7XHq5+rBJ7E4Z83TJ\ndXXY7eRSajR4uiDCmps/Y9MO2STz5DAVVzFbE/fa5IEg90U/3hvSuOt9Mn2E\nAsub\r\n=qu2r\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-04-30T09:09:05.753Z"
+}

--- a/test/fixtures/registry-mocks/content/utils-merge.json
+++ b/test/fixtures/registry-mocks/content/utils-merge.json
@@ -1,0 +1,178 @@
+{
+  "_id": "utils-merge",
+  "_rev": "19-7bfd688b048615cd1315611e5c8e0535",
+  "name": "utils-merge",
+  "description": "merge() utility function",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "utils-merge",
+      "version": "1.0.0",
+      "description": "merge() utility function",
+      "keywords": [
+        "util"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jaredhanson/utils-merge.git"
+      },
+      "bugs": {
+        "url": "http://github.com/jaredhanson/utils-merge/issues"
+      },
+      "author": {
+        "name": "Jared Hanson",
+        "email": "jaredhanson@gmail.com",
+        "url": "http://www.jaredhanson.net/"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/MIT"
+        }
+      ],
+      "main": "./index",
+      "dependencies": {},
+      "devDependencies": {
+        "mocha": "1.x.x",
+        "chai": "1.x.x"
+      },
+      "scripts": {
+        "test": "node_modules/.bin/mocha --reporter spec --require test/bootstrap/node test/*.test.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "_id": "utils-merge@1.0.0",
+      "dist": {
+        "shasum": "0294fb922bb9375153541c4f7096231f287c8af8",
+        "tarball": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.25",
+      "_npmUser": {
+        "name": "jaredhanson",
+        "email": "jaredhanson@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jaredhanson",
+          "email": "jaredhanson@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "utils-merge",
+      "version": "1.0.1",
+      "description": "merge() utility function",
+      "keywords": [
+        "util"
+      ],
+      "author": {
+        "name": "Jared Hanson",
+        "email": "jaredhanson@gmail.com",
+        "url": "http://www.jaredhanson.net/"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/jaredhanson/utils-merge.git"
+      },
+      "bugs": {
+        "url": "http://github.com/jaredhanson/utils-merge/issues"
+      },
+      "license": "MIT",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://opensource.org/licenses/MIT"
+        }
+      ],
+      "main": "./index",
+      "dependencies": {},
+      "devDependencies": {
+        "make-node": "0.3.x",
+        "mocha": "1.x.x",
+        "chai": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --require test/bootstrap/node test/*.test.js"
+      },
+      "gitHead": "680a65305312a990751fd32b83bd2c12d67809d4",
+      "homepage": "https://github.com/jaredhanson/utils-merge#readme",
+      "_id": "utils-merge@1.0.1",
+      "_shasum": "9f95710f50a267947b2ccc124741c1028427e713",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.9.1",
+      "_npmUser": {
+        "name": "jaredhanson",
+        "email": "jaredhanson@gmail.com"
+      },
+      "dist": {
+        "shasum": "9f95710f50a267947b2ccc124741c1028427e713",
+        "tarball": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jaredhanson",
+          "email": "jaredhanson@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/utils-merge-1.0.1.tgz_1505866719585_0.7930543632246554"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# utils-merge\n\n[![Version](https://img.shields.io/npm/v/utils-merge.svg?label=version)](https://www.npmjs.com/package/utils-merge)\n[![Build](https://img.shields.io/travis/jaredhanson/utils-merge.svg)](https://travis-ci.org/jaredhanson/utils-merge)\n[![Quality](https://img.shields.io/codeclimate/github/jaredhanson/utils-merge.svg?label=quality)](https://codeclimate.com/github/jaredhanson/utils-merge)\n[![Coverage](https://img.shields.io/coveralls/jaredhanson/utils-merge.svg)](https://coveralls.io/r/jaredhanson/utils-merge)\n[![Dependencies](https://img.shields.io/david/jaredhanson/utils-merge.svg)](https://david-dm.org/jaredhanson/utils-merge)\n\n\nMerges the properties from a source object into a destination object.\n\n## Install\n\n```bash\n$ npm install utils-merge\n```\n\n## Usage\n\n```javascript\nvar a = { foo: 'bar' }\n  , b = { bar: 'baz' };\n\nmerge(a, b);\n// => { foo: 'bar', bar: 'baz' }\n```\n\n## License\n\n[The MIT License](http://opensource.org/licenses/MIT)\n\nCopyright (c) 2013-2017 Jared Hanson <[http://jaredhanson.net/](http://jaredhanson.net/)>\n\n<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/vK9dyjRnnWsMzzJTQ57fRJpH/jaredhanson/utils-merge'>  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/vK9dyjRnnWsMzzJTQ57fRJpH/jaredhanson/utils-merge.svg' /></a>\n",
+  "maintainers": [
+    {
+      "name": "jaredhanson",
+      "email": "jaredhanson@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-09-20T00:18:39.692Z",
+    "created": "2013-07-11T19:00:16.016Z",
+    "1.0.0": "2013-07-11T19:00:17.317Z",
+    "1.0.1": "2017-09-20T00:18:39.692Z"
+  },
+  "author": {
+    "name": "Jared Hanson",
+    "email": "jaredhanson@gmail.com",
+    "url": "http://www.jaredhanson.net/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jaredhanson/utils-merge.git"
+  },
+  "users": {
+    "cmj": true,
+    "simplyianm": true,
+    "princetoad": true,
+    "fengchenxiujisd": true,
+    "456wyc": true,
+    "iori20091101": true,
+    "mojaray2k": true,
+    "sunggun": true,
+    "chinawolf_wyp": true,
+    "wjszxli": true,
+    "wanglq80": true
+  },
+  "keywords": [
+    "util"
+  ],
+  "bugs": {
+    "url": "http://github.com/jaredhanson/utils-merge/issues"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/jaredhanson/utils-merge#readme",
+  "license": "MIT",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/utils-merge.min.json
+++ b/test/fixtures/registry-mocks/content/utils-merge.min.json
@@ -1,0 +1,40 @@
+{
+  "name": "utils-merge",
+  "dist-tags": {
+    "latest": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "utils-merge",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "1.x.x",
+        "chai": "1.x.x"
+      },
+      "dist": {
+        "shasum": "0294fb922bb9375153541c4f7096231f287c8af8",
+        "tarball": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "1.0.1": {
+      "name": "utils-merge",
+      "version": "1.0.1",
+      "devDependencies": {
+        "make-node": "0.3.x",
+        "mocha": "1.x.x",
+        "chai": "1.x.x"
+      },
+      "dist": {
+        "shasum": "9f95710f50a267947b2ccc124741c1028427e713",
+        "tarball": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    }
+  },
+  "modified": "2017-09-20T00:18:39.692Z"
+}

--- a/test/fixtures/registry-mocks/content/vary.json
+++ b/test/fixtures/registry-mocks/content/vary.json
@@ -1,0 +1,543 @@
+{
+  "_id": "vary",
+  "_rev": "30-8d9c2f80a516b236fdad744c607b23e8",
+  "name": "vary",
+  "description": "Manipulate the HTTP Vary header",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "vary",
+      "description": "Update the Vary header of a response",
+      "version": "0.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "res",
+        "vary"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/vary"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/vary/issues"
+      },
+      "homepage": "https://github.com/expressjs/vary",
+      "_id": "vary@0.0.0",
+      "dist": {
+        "shasum": "9edfb6837236e6fa500788995cd85a11c62c482d",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-0.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "vary",
+      "description": "Update the Vary header of a response",
+      "version": "0.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "res",
+        "vary"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/expressjs/vary"
+      },
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter dot test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec test/"
+      },
+      "bugs": {
+        "url": "https://github.com/expressjs/vary/issues"
+      },
+      "homepage": "https://github.com/expressjs/vary",
+      "_id": "vary@0.1.0",
+      "dist": {
+        "shasum": "df0945899e93c0cc5bd18cc8321d9d21e74f6176",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        },
+        {
+          "name": "tjholowaychuk",
+          "email": "tj@vision-media.ca"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "vary",
+      "description": "Manipulate the HTTP Vary header",
+      "version": "1.0.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "res",
+        "vary"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/vary"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "56acecd9fa20888132563b00576625ea02a69a35",
+      "bugs": {
+        "url": "https://github.com/jshttp/vary/issues"
+      },
+      "homepage": "https://github.com/jshttp/vary",
+      "_id": "vary@1.0.0",
+      "_shasum": "c5e76cec20d3820d8f2a96e7bee38731c34da1e7",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        },
+        {
+          "name": "shtylman",
+          "email": "shtylman@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c5e76cec20d3820d8f2a96e7bee38731c34da1e7",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "vary",
+      "description": "Manipulate the HTTP Vary header",
+      "version": "1.0.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "res",
+        "vary"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/vary"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "650282ff8e614731837040a23e10f51c20728392",
+      "bugs": {
+        "url": "https://github.com/jshttp/vary/issues"
+      },
+      "homepage": "https://github.com/jshttp/vary",
+      "_id": "vary@1.0.1",
+      "_shasum": "99e4981566a286118dfb2b817357df7993376d10",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "99e4981566a286118dfb2b817357df7993376d10",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "vary",
+      "description": "Manipulate the HTTP Vary header",
+      "version": "1.1.0",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "res",
+        "vary"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/jshttp/vary"
+      },
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "2.3.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "13b03e9bf97da9d83bfeac84d84144137d84c257",
+      "bugs": {
+        "url": "https://github.com/jshttp/vary/issues"
+      },
+      "homepage": "https://github.com/jshttp/vary",
+      "_id": "vary@1.1.0",
+      "_shasum": "e1e5affbbd16ae768dd2674394b9ad3022653140",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        },
+        {
+          "name": "jongleberry",
+          "email": "jonathanrichardong@gmail.com"
+        },
+        {
+          "name": "fishrock123",
+          "email": "fishrock123@rocketmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e1e5affbbd16ae768dd2674394b9ad3022653140",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "vary",
+      "description": "Manipulate the HTTP Vary header",
+      "version": "1.1.1",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "res",
+        "vary"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/vary.git"
+      },
+      "devDependencies": {
+        "eslint": "3.18.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "ca7edac6b919a45bf9e2c5cb6ba31c1790e9f046",
+      "bugs": {
+        "url": "https://github.com/jshttp/vary/issues"
+      },
+      "homepage": "https://github.com/jshttp/vary#readme",
+      "_id": "vary@1.1.1",
+      "_shasum": "67535ebb694c1d52257457984665323f587e8d37",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.7.3",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "67535ebb694c1d52257457984665323f587e8d37",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/vary-1.1.1.tgz_1490045547529_0.9355870047584176"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "vary",
+      "description": "Manipulate the HTTP Vary header",
+      "version": "1.1.2",
+      "author": {
+        "name": "Douglas Christopher Wilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "license": "MIT",
+      "keywords": [
+        "http",
+        "res",
+        "vary"
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/jshttp/vary.git"
+      },
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "files": [
+        "HISTORY.md",
+        "LICENSE",
+        "README.md",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "scripts": {
+        "bench": "node benchmark/index.js",
+        "lint": "eslint --plugin markdown --ext js,md .",
+        "test": "mocha --reporter spec --bail --check-leaks test/",
+        "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/",
+        "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter spec --check-leaks test/"
+      },
+      "gitHead": "4067e646233fbc8ec9e7a9cd78d6f063c6fdc17e",
+      "bugs": {
+        "url": "https://github.com/jshttp/vary/issues"
+      },
+      "homepage": "https://github.com/jshttp/vary#readme",
+      "_id": "vary@1.1.2",
+      "_shasum": "2299f02c6ded30d4a5961b0b9f74524a18f634fc",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.1",
+      "_npmUser": {
+        "name": "dougwilson",
+        "email": "doug@somethingdoug.com"
+      },
+      "dist": {
+        "shasum": "2299f02c6ded30d4a5961b0b9f74524a18f634fc",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "dougwilson",
+          "email": "doug@somethingdoug.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/vary-1.1.2.tgz_1506217630296_0.28528453782200813"
+      },
+      "directories": {}
+    }
+  },
+  "readme": "# vary\n\n[![NPM Version][npm-image]][npm-url]\n[![NPM Downloads][downloads-image]][downloads-url]\n[![Node.js Version][node-version-image]][node-version-url]\n[![Build Status][travis-image]][travis-url]\n[![Test Coverage][coveralls-image]][coveralls-url]\n\nManipulate the HTTP Vary header\n\n## Installation\n\nThis is a [Node.js](https://nodejs.org/en/) module available through the\n[npm registry](https://www.npmjs.com/). Installation is done using the\n[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally): \n\n```sh\n$ npm install vary\n```\n\n## API\n\n<!-- eslint-disable no-unused-vars -->\n\n```js\nvar vary = require('vary')\n```\n\n### vary(res, field)\n\nAdds the given header `field` to the `Vary` response header of `res`.\nThis can be a string of a single field, a string of a valid `Vary`\nheader, or an array of multiple fields.\n\nThis will append the header if not already listed, otherwise leaves\nit listed in the current location.\n\n<!-- eslint-disable no-undef -->\n\n```js\n// Append \"Origin\" to the Vary header of the response\nvary(res, 'Origin')\n```\n\n### vary.append(header, field)\n\nAdds the given header `field` to the `Vary` response header string `header`.\nThis can be a string of a single field, a string of a valid `Vary` header,\nor an array of multiple fields.\n\nThis will append the header if not already listed, otherwise leaves\nit listed in the current location. The new header string is returned.\n\n<!-- eslint-disable no-undef -->\n\n```js\n// Get header string appending \"Origin\" to \"Accept, User-Agent\"\nvary.append('Accept, User-Agent', 'Origin')\n```\n\n## Examples\n\n### Updating the Vary header when content is based on it\n\n```js\nvar http = require('http')\nvar vary = require('vary')\n\nhttp.createServer(function onRequest (req, res) {\n  // about to user-agent sniff\n  vary(res, 'User-Agent')\n\n  var ua = req.headers['user-agent'] || ''\n  var isMobile = /mobi|android|touch|mini/i.test(ua)\n\n  // serve site, depending on isMobile\n  res.setHeader('Content-Type', 'text/html')\n  res.end('You are (probably) ' + (isMobile ? '' : 'not ') + 'a mobile user')\n})\n```\n\n## Testing\n\n```sh\n$ npm test\n```\n\n## License\n\n[MIT](LICENSE)\n\n[npm-image]: https://img.shields.io/npm/v/vary.svg\n[npm-url]: https://npmjs.org/package/vary\n[node-version-image]: https://img.shields.io/node/v/vary.svg\n[node-version-url]: https://nodejs.org/en/download\n[travis-image]: https://img.shields.io/travis/jshttp/vary/master.svg\n[travis-url]: https://travis-ci.org/jshttp/vary\n[coveralls-image]: https://img.shields.io/coveralls/jshttp/vary/master.svg\n[coveralls-url]: https://coveralls.io/r/jshttp/vary\n[downloads-image]: https://img.shields.io/npm/dm/vary.svg\n[downloads-url]: https://npmjs.org/package/vary\n",
+  "maintainers": [
+    {
+      "name": "dougwilson",
+      "email": "doug@somethingdoug.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-08-03T00:42:18.119Z",
+    "created": "2014-06-04T20:52:53.541Z",
+    "0.0.0": "2014-06-04T20:52:53.541Z",
+    "0.1.0": "2014-06-05T13:18:33.789Z",
+    "1.0.0": "2014-08-10T21:03:28.918Z",
+    "1.0.1": "2015-07-09T00:03:07.257Z",
+    "1.1.0": "2015-09-30T05:05:50.045Z",
+    "1.1.1": "2017-03-20T21:32:29.340Z",
+    "1.1.2": "2017-09-24T01:47:11.325Z"
+  },
+  "homepage": "https://github.com/jshttp/vary#readme",
+  "keywords": [
+    "http",
+    "res",
+    "vary"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jshttp/vary.git"
+  },
+  "author": {
+    "name": "Douglas Christopher Wilson",
+    "email": "doug@somethingdoug.com"
+  },
+  "bugs": {
+    "url": "https://github.com/jshttp/vary/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "users": {
+    "goodseller": true,
+    "simplyianm": true,
+    "jessaustin": true,
+    "wangnan0610": true,
+    "mojaray2k": true,
+    "giussa_dan": true,
+    "leland-kwong": true,
+    "netoperatorwibby": true
+  },
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/vary.min.json
+++ b/test/fixtures/registry-mocks/content/vary.min.json
@@ -1,0 +1,136 @@
+{
+  "name": "vary",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "vary",
+      "version": "0.0.0",
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "9edfb6837236e6fa500788995cd85a11c62c482d",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-0.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "0.1.0": {
+      "name": "vary",
+      "version": "0.1.0",
+      "devDependencies": {
+        "istanbul": "0.2.10",
+        "mocha": "~1.20.0",
+        "should": "~4.0.0"
+      },
+      "dist": {
+        "shasum": "df0945899e93c0cc5bd18cc8321d9d21e74f6176",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.0": {
+      "name": "vary",
+      "version": "1.0.0",
+      "devDependencies": {
+        "istanbul": "0.3.0",
+        "mocha": "~1.21.4",
+        "should": "~4.0.4",
+        "supertest": "~0.13.0"
+      },
+      "dist": {
+        "shasum": "c5e76cec20d3820d8f2a96e7bee38731c34da1e7",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "1.0.1": {
+      "name": "vary",
+      "version": "1.0.1",
+      "devDependencies": {
+        "istanbul": "0.3.17",
+        "mocha": "2.2.5",
+        "supertest": "1.0.1"
+      },
+      "dist": {
+        "shasum": "99e4981566a286118dfb2b817357df7993376d10",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.0": {
+      "name": "vary",
+      "version": "1.1.0",
+      "devDependencies": {
+        "istanbul": "0.3.21",
+        "mocha": "2.3.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "e1e5affbbd16ae768dd2674394b9ad3022653140",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.1": {
+      "name": "vary",
+      "version": "1.1.1",
+      "devDependencies": {
+        "eslint": "3.18.0",
+        "eslint-config-standard": "7.1.0",
+        "eslint-plugin-markdown": "1.0.0-beta.4",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "2.1.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "67535ebb694c1d52257457984665323f587e8d37",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "1.1.2": {
+      "name": "vary",
+      "version": "1.1.2",
+      "devDependencies": {
+        "beautify-benchmark": "0.2.4",
+        "benchmark": "2.1.4",
+        "eslint": "3.19.0",
+        "eslint-config-standard": "10.2.1",
+        "eslint-plugin-import": "2.7.0",
+        "eslint-plugin-markdown": "1.0.0-beta.6",
+        "eslint-plugin-node": "5.1.1",
+        "eslint-plugin-promise": "3.5.0",
+        "eslint-plugin-standard": "3.0.1",
+        "istanbul": "0.4.5",
+        "mocha": "2.5.3",
+        "supertest": "1.1.0"
+      },
+      "dist": {
+        "shasum": "2299f02c6ded30d4a5961b0b9f74524a18f634fc",
+        "tarball": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  },
+  "modified": "2018-08-03T00:42:18.119Z"
+}

--- a/test/fixtures/registry-mocks/content/vm-browserify.json
+++ b/test/fixtures/registry-mocks/content/vm-browserify.json
@@ -1,0 +1,1617 @@
+{
+  "_id": "vm-browserify",
+  "_rev": "51-8f6345186e66c53c4b6723812f045631",
+  "name": "vm-browserify",
+  "description": "vm module for the browser",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "vm-browserify",
+      "version": "0.0.0",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "directories": {
+        "example": "example",
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "devDependencies": {
+        "tap": "~0.2.1",
+        "browserify": "1.9.x"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "MIT/X11",
+      "engine": {
+        "node": ">=0.4.0"
+      },
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "_id": "vm-browserify@0.0.0",
+      "dependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.0.106",
+      "_nodeVersion": "v0.4.12",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "03c515fbc168ee1ba50cd78e67de9afe9e0425a9",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "0.0.1": {
+      "name": "vm-browserify",
+      "version": "0.0.1",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "directories": {
+        "example": "example",
+        "test": "test"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "devDependencies": {
+        "tap": "~0.2.1",
+        "browserify": "1.9.x"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "MIT/X11",
+      "engine": {
+        "node": ">=0.4.0"
+      },
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "_id": "vm-browserify@0.0.1",
+      "dependencies": {},
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "1.1.1",
+      "_nodeVersion": "v0.6.11",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "51d25979366ab219dfe35a3fc65ecd6af3631d54",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ]
+    },
+    "0.0.2": {
+      "name": "vm-browserify",
+      "version": "0.0.2",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "dependencies": {
+        "indexof": "0.0.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "firefox/16..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/substack/vm-browserify/issues"
+      },
+      "homepage": "https://github.com/substack/vm-browserify",
+      "_id": "vm-browserify@0.0.2",
+      "dist": {
+        "shasum": "8d5808b6ceeb13bab29ce5c5bf440fe8f2cadc0e",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "vm-browserify",
+      "version": "0.0.3",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "dependencies": {
+        "indexof": "0.0.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "firefox/16..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/substack/vm-browserify/issues"
+      },
+      "homepage": "https://github.com/substack/vm-browserify",
+      "_id": "vm-browserify@0.0.3",
+      "dist": {
+        "shasum": "2bea9acf5418b24bb5041c1398a058ec965657f6",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "vm-browserify",
+      "version": "0.0.4",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "http://github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "dependencies": {
+        "indexof": "0.0.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "tap test/*.js"
+      },
+      "license": "MIT",
+      "testling": {
+        "files": "test/*.js",
+        "browsers": [
+          "ie/6..latest",
+          "firefox/16..latest",
+          "firefox/nightly",
+          "chrome/22..latest",
+          "chrome/canary",
+          "opera/12..latest",
+          "opera/next",
+          "safari/5.1..latest",
+          "ipad/6.0..latest",
+          "iphone/6.0..latest",
+          "android-browser/4.2..latest"
+        ]
+      },
+      "bugs": {
+        "url": "https://github.com/substack/vm-browserify/issues"
+      },
+      "homepage": "https://github.com/substack/vm-browserify",
+      "_id": "vm-browserify@0.0.4",
+      "dist": {
+        "shasum": "5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "substack",
+        "email": "mail@substack.net"
+      },
+      "maintainers": [
+        {
+          "name": "substack",
+          "email": "mail@substack.net"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "vm-browserify",
+      "version": "1.0.0",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "dependencies": {
+        "component-indexof": "0.0.3"
+      },
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "~2.3.2",
+        "tape-run": "^3.0.4"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "browserify test/vm.js | tape-run"
+      },
+      "license": "MIT",
+      "gitHead": "1bbbed5a1e09502d2b63cb6f14a067c48bb36790",
+      "bugs": {
+        "url": "https://github.com/substack/vm-browserify/issues"
+      },
+      "homepage": "https://github.com/substack/vm-browserify#readme",
+      "_id": "vm-browserify@1.0.0",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.9.0",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "rene@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-ahvL2UPdjtYBtxlCKCGM3i5DnaZgroG0XlAVkkkDVa4ZQA0gjhNg5Nc3QOlLdRjKqg9JporusAOlHZmB+mYqmA==",
+        "shasum": "88768214567fd00a27be2f553712c9fc5aeb548f",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.0.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 21874
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/vm-browserify_1.0.0_1521796435940_0.5088384540307842"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.1": {
+      "name": "vm-browserify",
+      "version": "1.0.1",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "~2.3.2",
+        "tape-run": "^3.0.4"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "browserify test/vm.js | tape-run"
+      },
+      "license": "MIT",
+      "gitHead": "ed8503236fe9e1580f5426a19c32f2398ad47efe",
+      "bugs": {
+        "url": "https://github.com/substack/vm-browserify/issues"
+      },
+      "homepage": "https://github.com/substack/vm-browserify#readme",
+      "_id": "vm-browserify@1.0.1",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "9.11.1",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "rene@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-EqzLchIMYLBjRPoqVsEkZOa/4Vr2RfOWbd58F+I/Gj79AYTrsseMunxbbSkbYfrqZaXSuPBBXNSOhtJgg0PpmA==",
+        "shasum": "a15d7762c4c48fa6bf9f3309a21340f00ed23063",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.0.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 22157
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/vm-browserify_1.0.1_1523605055552_0.3738760981685074"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.0": {
+      "name": "vm-browserify",
+      "version": "1.1.0",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "~2.3.2",
+        "tape-run": "^3.0.4"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "browserify test/vm.js | tape-run"
+      },
+      "license": "MIT",
+      "gitHead": "7364fe7142b527f27c9fb0c6bdaca34d900d40a8",
+      "bugs": {
+        "url": "https://github.com/substack/vm-browserify/issues"
+      },
+      "homepage": "https://github.com/substack/vm-browserify#readme",
+      "_id": "vm-browserify@1.1.0",
+      "_npmVersion": "6.1.0",
+      "_nodeVersion": "10.4.1",
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "dist": {
+        "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+        "shasum": "bd76d6a23323e2ca8ffa12028dc04559c75f9019",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 22389,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbI8rmCRA9TVsSAnZWagAAEGMP+QED+3780YvDmUucZorg\nJJiE7WvS5EfCHMCvdH7ZVp6q+mVbNxBEX24hE2ofaNwU8txd6qF4HJ26dg5r\nw+OeaFImXMps5i+CR4j9r6XwPdazKTB3iQER2YI2qeHvTZIhd+5iMgkwskU9\nVv08I8O+9kCgCouta840F4hKMbNOOIRoitL7lsyvNBMowUQbK9Q5ciWhl0uV\n/jkz3lseNkMJoSlX3Kk3c2hGxNyHeLMu+OtDMovIMhAfs9PmY9w9hTLCP8bE\nnejHz3QcD/CxnW+Pli/7hD7nGfyj5XE1DbMMdlAT1n1tLSK8JO2Fiuh+0pam\nnjvykFFYKcq6419ZhXD577Zu1kpAKRnBVAHg36RTfAosshOy/y+r7WjQgpoN\ngLBoLqsKUKvb0m+08MZelckUrqx0yYq0EIq3e+91yDMtqzvlJQNUeNj7xB2x\n+rCaeNeyQei7fpky7ENJqar82FmelJqRTXQgJAHdPCljm5uQyK4f1KCCHxL7\nordLd8pP00iiDamJZCVbt3Fwd7yjDGccpIJylE0GI5zZwmJypMP684xvImXa\nEouw20Dm5x7LVgfV3Sk9kqjOr7UDM6i8WaBW5Ps4M5Q+NpjNYu5Uh25igfrd\naXNplo7wwDJlY57zdST72EY3NnqQxVOPio0AccyusHMfCseZZQrLQLGr3Kon\nLxlQ\r\n=9BGl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "npm@dcousens.com",
+          "name": "dcousens"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "rene@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/vm-browserify_1.1.0_1529072357727_0.5795175715068641"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.1": {
+      "name": "vm-browserify",
+      "version": "1.1.1",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "^4.11.0",
+        "tape-run": "^6.0.1"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "browserify test/vm.js | tape-run"
+      },
+      "license": "MIT",
+      "gitHead": "5727a86957dcf721b96fc5e87686e23f36d1bc6d",
+      "bugs": {
+        "url": "https://github.com/substack/vm-browserify/issues"
+      },
+      "homepage": "https://github.com/substack/vm-browserify#readme",
+      "_id": "vm-browserify@1.1.1",
+      "_nodeVersion": "12.13.0",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-VdaJ/et1OKy9VDEqH6epLQ/DlNMuHvtDgwjPYvDvqNOlgFSMAL4ucZvyIpz0D4x5qT+8wCSK19YjWicJuc00hQ==",
+        "shasum": "9d81bf6c0a56ba3c6e787b2e56d48ac0b003574a",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 23298,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdv/8BCRA9TVsSAnZWagAAVkwP/1N1g7uA9Tos99bzSfJ9\nQJ3FJk8KRjHHy3eEmtaR1SdniLXvpdQM9zyD6n9iJSew2ovVajui2XJQz6Sy\n+/rfvrhT1zbXG+8ZrC0Nkc2WE06hJ/KnAA/WcpBZW48pExchtz8IGnyGpaE1\nBN3aLfttRgTmh4VT9SoBYO9/goMM2olKPIOlkruz3H2yfZ2I3GTax66ji5vI\nw9Bdy4V+cc64Nyj8ZP5uUtm2PynhStg1rzcbviBzwzmWJSSamHXTBOLPaDaQ\nWgFwdq5RAqayXhlTDdiOOiYiEb4nfHlXGZa/E+4XFiMoQrbAECUVetbpBmlo\nC5Tckihd6Ad+DYjJTtcQTCYg833iYGTgtVM3pgjKnaKESolJ00Khis3uJBkn\nLf6hHhcaw/uSTqzon5Mq1H81o6SPBoiJfbT/VquMvi8eL0nrNCDTbxgpbGM/\n6ScnrZlTeBhFxNohoFl4qHQBy407cp4rAIQE/U59m9LZlKGSSWmIZ8Ko8HmT\nhJRICemtw5XJnDNJubLN8yWZSKCXnwekR6ag1qOEOTu2IRkO3zVzyfcRZ6ZW\niCi55etbCicbgNtxFtTI135dh+sLJ+YG2LxzhdMkOMQL/JPr7F1/Rq6A6ACd\nWzbETqGqCGCZ6Jx4MR3+9IXE39MFoJvGCPgrLfUG/BSl91rj/5In+KieZH90\n8n/X\r\n=Vi2S\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/vm-browserify_1.1.1_1572863744725_0.8713127352998609"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.1.2": {
+      "name": "vm-browserify",
+      "version": "1.1.2",
+      "description": "vm module for the browser",
+      "main": "index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/substack/vm-browserify.git"
+      },
+      "keywords": [
+        "vm",
+        "browser",
+        "eval"
+      ],
+      "dependencies": {},
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "^4.11.0",
+        "tape-run": "^6.0.1"
+      },
+      "author": {
+        "name": "James Halliday",
+        "email": "mail@substack.net",
+        "url": "http://substack.net"
+      },
+      "scripts": {
+        "test": "browserify test/vm.js | tape-run"
+      },
+      "license": "MIT",
+      "gitHead": "a8fe8f62f418c3ff529632ef0a3398b5f4ad9258",
+      "bugs": {
+        "url": "https://github.com/substack/vm-browserify/issues"
+      },
+      "homepage": "https://github.com/substack/vm-browserify#readme",
+      "_id": "vm-browserify@1.1.2",
+      "_nodeVersion": "12.13.0",
+      "_npmVersion": "6.12.1",
+      "dist": {
+        "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+        "shasum": "78641c488b8e6ca91a75f511e7a3b32a86e5dda0",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 15503,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdwBorCRA9TVsSAnZWagAA8LcP+QB4C3B4loaGry0Oi+ff\n+lfFjsZOTQ5H1QGK+2GzMA1NWeZWdieKId8yp4M0avvWszXXiUfmuBL7LgiF\nETG1cLXgzWaSn2cPd0fp0TbrLA3EIDxDPmwQjvTuB3aAvFcQ9/5hSI4xQdQC\ncd6i8cGiXVg3Wr97NN33jldRAQ9UNjBNkyJZRAPruEnwtdHwVojcIj7WXdbS\nliTmOQNFJBgctJ258oLng9qe83gCubLAqEunolw75sePxu5d2Jei94GEQolm\nN/hvFez4STKK8ShSje2ncj0vuq8wt07L8ju0axULVgFMH1/oW1ZSCKOvE8Uz\nk6qhh7zBqkLM7ROYgVnQfxZ1WEVPIvi3PidjbN9JtKXyu49bq+gWnOvpSMSD\n+gCwCzv7RP7xjTBOPCwj6HgLG/z6Zz6hIYS1krY6iwqfdKUgrHwmVgTxwjg/\nWjU5lPSjvQAexmMJEficFOk4dr4u7e8ZjQx0bk5CZQYr60DQlIUBCIRyBsNQ\nCu2Q5YMjJ6NJeGhtO7qcPbvN9cfF1kNfnHq/1lgINIAFtrcQQirDnztWwtJU\nbl4VU9bwky3hgpFnvYIkkO5IFp8J/XJXotbKvmb9I7Y585z68Wzf92PRof24\nII4aP0S0S8dpxXey16KkGsTrCue7fCp0BoKeNAc8a0r6Ekdqwneiuz45098N\n8pfb\r\n=9+Cd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "michael.williams@enspiral.com",
+          "name": "ahdinosaur"
+        },
+        {
+          "email": "vestibule@anandthakker.net",
+          "name": "anandthakker"
+        },
+        {
+          "email": "darawk@gmail.com",
+          "name": "ashaffer88"
+        },
+        {
+          "email": "b@lupton.cc",
+          "name": "balupton"
+        },
+        {
+          "email": "post.ben.here@gmail.com",
+          "name": "bpostlethwaite"
+        },
+        {
+          "email": "bcomnes@gmail.com",
+          "name": "bret"
+        },
+        {
+          "email": "calvin.metcalf@gmail.com",
+          "name": "cwmma"
+        },
+        {
+          "email": "shtylman@gmail.com",
+          "name": "defunctzombie"
+        },
+        {
+          "email": "dominic.tarr@gmail.com",
+          "name": "dominictarr"
+        },
+        {
+          "email": "contact@elnounch.net",
+          "name": "elnounch"
+        },
+        {
+          "email": "github@tixz.dk",
+          "name": "emilbayes"
+        },
+        {
+          "email": "feross@feross.org",
+          "name": "feross"
+        },
+        {
+          "email": "forbes@lindesay.co.uk",
+          "name": "forbeslindesay"
+        },
+        {
+          "email": "pereira.filype@gmail.com",
+          "name": "fpereira1"
+        },
+        {
+          "email": "garann@gmail.com",
+          "name": "garann"
+        },
+        {
+          "email": "me@gkatsev.com",
+          "name": "gkatsev"
+        },
+        {
+          "email": "renee@kooi.me",
+          "name": "goto-bus-stop"
+        },
+        {
+          "email": "hughskennedy@gmail.com",
+          "name": "hughsk"
+        },
+        {
+          "email": "fedor@indutny.com",
+          "name": "indutny"
+        },
+        {
+          "email": "npm-public@jessemccarthy.net",
+          "name": "jmm"
+        },
+        {
+          "email": "jprichardson@gmail.com",
+          "name": "jprichardson"
+        },
+        {
+          "email": "jryans@gmail.com",
+          "name": "jryans"
+        },
+        {
+          "email": "martin.heidegger@gmail.com",
+          "name": "leichtgewicht"
+        },
+        {
+          "email": "lukechilds123@gmail.com",
+          "name": "lukechilds"
+        },
+        {
+          "email": "mathiasbuus@gmail.com",
+          "name": "mafintosh"
+        },
+        {
+          "email": "dave.des@gmail.com",
+          "name": "mattdesl"
+        },
+        {
+          "email": "max@maxogden.com",
+          "name": "maxogden"
+        },
+        {
+          "email": "palmermebane@gmail.com",
+          "name": "mellowmelon"
+        },
+        {
+          "email": "parshap+npm@gmail.com",
+          "name": "parshap"
+        },
+        {
+          "email": "peteris.krumins@gmail.com",
+          "name": "pkrumins"
+        },
+        {
+          "email": "sethvincent@gmail.com",
+          "name": "sethvincent"
+        },
+        {
+          "email": "maochenyan@gmail.com",
+          "name": "stevemao"
+        },
+        {
+          "email": "substack@gmail.com",
+          "name": "substack"
+        },
+        {
+          "email": "me@JoshDuff.com",
+          "name": "tehshrike"
+        },
+        {
+          "email": "terinjokes@gmail.com",
+          "name": "terinjokes"
+        },
+        {
+          "email": "thlorenz@gmx.de",
+          "name": "thlorenz"
+        },
+        {
+          "email": "ungoldman@gmail.com",
+          "name": "ungoldman"
+        },
+        {
+          "email": "yerko.palma@usach.cl",
+          "name": "yerkopalma"
+        },
+        {
+          "email": "yoshuawuyts@gmail.com",
+          "name": "yoshuawuyts"
+        },
+        {
+          "email": "zertosh@gmail.com",
+          "name": "zertosh"
+        }
+      ],
+      "_npmUser": {
+        "name": "goto-bus-stop",
+        "email": "renee@kooi.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/vm-browserify_1.1.2_1572870698920_0.8552473875318365"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# vm-browserify\n\nemulate node's vm module for the browser\n\n[![Build Status](https://travis-ci.org/browserify/vm-browserify.svg?branch=master)](https://travis-ci.org/browserify/vm-browserify)\n\n# example\n\nJust write some client-side javascript:\n\n``` js\nvar vm = require('vm');\n\nwindow.addEventListener('load', function () {\n    var res = vm.runInNewContext('a + 5', { a : 100 });\n    document.querySelector('#res').textContent = res;\n});\n```\n\ncompile it with [browserify](http://github.com/substack/node-browserify):\n\n```\nbrowserify entry.js -o bundle.js\n```\n\nthen whip up some html:\n\n``` html\n<html>\n  <head>\n    <script src=\"/bundle.js\"></script>\n  </head>\n  <body>\n    result = <span id=\"res\"></span>\n  </body>\n</html>\n```\n\nand when you load the page you should see:\n\n```\nresult = 105\n```\n\n# methods\n\n## vm.runInNewContext(code, context={})\n\nEvaluate some `code` in a new iframe with a `context`.\n\nContexts are like wrapping your code in a `with()` except slightly less terrible\nbecause the code is sandboxed into a new iframe.\n\n# install\n\nThis module is depended upon by browserify, so you should just be able to\n`require('vm')` and it will just work. However if you want to use this module\ndirectly you can install it with [npm](http://npmjs.org):\n\n```\nnpm install vm-browserify\n```\n\n# license\n\nMIT\n",
+  "maintainers": [
+    {
+      "email": "raynos2@gmail.com",
+      "name": "raynos"
+    },
+    {
+      "email": "lukechilds123@gmail.com",
+      "name": "lukechilds"
+    },
+    {
+      "email": "shtylman@gmail.com",
+      "name": "defunctzombie"
+    },
+    {
+      "email": "substack@gmail.com",
+      "name": "substack"
+    },
+    {
+      "email": "feross@feross.org",
+      "name": "feross"
+    },
+    {
+      "email": "me@gkatsev.com",
+      "name": "gkatsev"
+    },
+    {
+      "email": "zertosh@gmail.com",
+      "name": "zertosh"
+    },
+    {
+      "email": "mathiasbuus@gmail.com",
+      "name": "mafintosh"
+    },
+    {
+      "email": "max@maxogden.com",
+      "name": "maxogden"
+    },
+    {
+      "email": "dominic.tarr@gmail.com",
+      "name": "dominictarr"
+    },
+    {
+      "email": "thlorenz10@gmail.com",
+      "name": "thlorenz"
+    },
+    {
+      "email": "terinjokes@gmail.com",
+      "name": "terinjokes"
+    },
+    {
+      "email": "npm-public@jessemccarthy.net",
+      "name": "jmm"
+    },
+    {
+      "email": "palmermebane@gmail.com",
+      "name": "mellowmelon"
+    },
+    {
+      "email": "darawk@gmail.com",
+      "name": "ashaffer88"
+    },
+    {
+      "email": "b@lupton.cc",
+      "name": "balupton"
+    },
+    {
+      "email": "calvin.metcalf@gmail.com",
+      "name": "cwmma"
+    },
+    {
+      "email": "jprichardson@gmail.com",
+      "name": "jprichardson"
+    },
+    {
+      "email": "fedor@indutny.com",
+      "name": "indutny"
+    },
+    {
+      "email": "jryans@gmail.com",
+      "name": "jryans"
+    },
+    {
+      "email": "sethvincent@gmail.com",
+      "name": "sethvincent"
+    },
+    {
+      "email": "yoshuawuyts@gmail.com",
+      "name": "yoshuawuyts"
+    },
+    {
+      "email": "ungoldman@gmail.com",
+      "name": "ungoldman"
+    },
+    {
+      "email": "michael.williams@enspiral.com",
+      "name": "ahdinosaur"
+    },
+    {
+      "email": "contact@elnounch.net",
+      "name": "elnounch"
+    },
+    {
+      "email": "parshap+npm@gmail.com",
+      "name": "parshap"
+    },
+    {
+      "email": "yerko.palma@usach.cl",
+      "name": "yerkopalma"
+    },
+    {
+      "email": "forbes@lindesay.co.uk",
+      "name": "forbeslindesay"
+    },
+    {
+      "email": "martin.heidegger@gmail.com",
+      "name": "leichtgewicht"
+    },
+    {
+      "email": "garann@gmail.com",
+      "name": "garann"
+    },
+    {
+      "email": "bcomnes@gmail.com",
+      "name": "bret"
+    },
+    {
+      "email": "vestibule@anandthakker.net",
+      "name": "anandthakker"
+    },
+    {
+      "email": "dave.des@gmail.com",
+      "name": "mattdesl"
+    },
+    {
+      "email": "hughskennedy@gmail.com",
+      "name": "hughsk"
+    },
+    {
+      "email": "pereira.filype@gmail.com",
+      "name": "fpereira1"
+    },
+    {
+      "email": "renee@kooi.me",
+      "name": "goto-bus-stop"
+    },
+    {
+      "email": "post.ben.here@gmail.com",
+      "name": "bpostlethwaite"
+    },
+    {
+      "email": "github@tixz.dk",
+      "name": "emilbayes"
+    },
+    {
+      "email": "maochenyan@gmail.com",
+      "name": "stevemao"
+    },
+    {
+      "email": "peteris.krumins@gmail.com",
+      "name": "pkrumins"
+    },
+    {
+      "email": "me@JoshDuff.com",
+      "name": "tehshrike"
+    }
+  ],
+  "time": {
+    "modified": "2020-10-09T12:54:41.377Z",
+    "created": "2012-02-27T06:36:38.385Z",
+    "0.0.0": "2012-02-27T06:36:39.722Z",
+    "0.0.1": "2012-04-06T17:22:22.103Z",
+    "0.0.2": "2013-12-28T10:04:36.530Z",
+    "0.0.3": "2014-01-28T08:49:34.218Z",
+    "0.0.4": "2014-01-28T08:51:26.129Z",
+    "1.0.0": "2018-03-23T09:13:56.018Z",
+    "1.0.1": "2018-04-13T07:37:35.621Z",
+    "1.1.0": "2018-06-15T14:19:17.789Z",
+    "1.1.1": "2019-11-04T10:35:45.655Z",
+    "1.1.2": "2019-11-04T12:31:39.026Z"
+  },
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/substack/vm-browserify.git"
+  },
+  "readmeFilename": "readme.markdown",
+  "users": {
+    "wenbing": true,
+    "simplyianm": true,
+    "paroe": true,
+    "keyanzhang": true
+  },
+  "homepage": "https://github.com/substack/vm-browserify#readme",
+  "keywords": [
+    "vm",
+    "browser",
+    "eval"
+  ],
+  "bugs": {
+    "url": "https://github.com/substack/vm-browserify/issues"
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/vm-browserify.min.json
+++ b/test/fixtures/registry-mocks/content/vm-browserify.min.json
@@ -1,0 +1,175 @@
+{
+  "name": "vm-browserify",
+  "dist-tags": {
+    "latest": "1.1.2"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "vm-browserify",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tap": "~0.2.1",
+        "browserify": "1.9.x"
+      },
+      "directories": {
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "03c515fbc168ee1ba50cd78e67de9afe9e0425a9",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.0.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.1": {
+      "name": "vm-browserify",
+      "version": "0.0.1",
+      "devDependencies": {
+        "tap": "~0.2.1",
+        "browserify": "1.9.x"
+      },
+      "directories": {
+        "example": "example",
+        "test": "test"
+      },
+      "dist": {
+        "shasum": "51d25979366ab219dfe35a3fc65ecd6af3631d54",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.1.tgz"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "0.0.2": {
+      "name": "vm-browserify",
+      "version": "0.0.2",
+      "dependencies": {
+        "indexof": "0.0.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "8d5808b6ceeb13bab29ce5c5bf440fe8f2cadc0e",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.2.tgz"
+      }
+    },
+    "0.0.3": {
+      "name": "vm-browserify",
+      "version": "0.0.3",
+      "dependencies": {
+        "indexof": "0.0.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "2bea9acf5418b24bb5041c1398a058ec965657f6",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.3.tgz"
+      }
+    },
+    "0.0.4": {
+      "name": "vm-browserify",
+      "version": "0.0.4",
+      "dependencies": {
+        "indexof": "0.0.1"
+      },
+      "devDependencies": {
+        "tape": "~2.3.2"
+      },
+      "dist": {
+        "shasum": "5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "vm-browserify",
+      "version": "1.0.0",
+      "dependencies": {
+        "component-indexof": "0.0.3"
+      },
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "~2.3.2",
+        "tape-run": "^3.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-ahvL2UPdjtYBtxlCKCGM3i5DnaZgroG0XlAVkkkDVa4ZQA0gjhNg5Nc3QOlLdRjKqg9JporusAOlHZmB+mYqmA==",
+        "shasum": "88768214567fd00a27be2f553712c9fc5aeb548f",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.0.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 21874
+      }
+    },
+    "1.0.1": {
+      "name": "vm-browserify",
+      "version": "1.0.1",
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "~2.3.2",
+        "tape-run": "^3.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-EqzLchIMYLBjRPoqVsEkZOa/4Vr2RfOWbd58F+I/Gj79AYTrsseMunxbbSkbYfrqZaXSuPBBXNSOhtJgg0PpmA==",
+        "shasum": "a15d7762c4c48fa6bf9f3309a21340f00ed23063",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.0.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 22157
+      }
+    },
+    "1.1.0": {
+      "name": "vm-browserify",
+      "version": "1.1.0",
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "~2.3.2",
+        "tape-run": "^3.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+        "shasum": "bd76d6a23323e2ca8ffa12028dc04559c75f9019",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 22389,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbI8rmCRA9TVsSAnZWagAAEGMP+QED+3780YvDmUucZorg\nJJiE7WvS5EfCHMCvdH7ZVp6q+mVbNxBEX24hE2ofaNwU8txd6qF4HJ26dg5r\nw+OeaFImXMps5i+CR4j9r6XwPdazKTB3iQER2YI2qeHvTZIhd+5iMgkwskU9\nVv08I8O+9kCgCouta840F4hKMbNOOIRoitL7lsyvNBMowUQbK9Q5ciWhl0uV\n/jkz3lseNkMJoSlX3Kk3c2hGxNyHeLMu+OtDMovIMhAfs9PmY9w9hTLCP8bE\nnejHz3QcD/CxnW+Pli/7hD7nGfyj5XE1DbMMdlAT1n1tLSK8JO2Fiuh+0pam\nnjvykFFYKcq6419ZhXD577Zu1kpAKRnBVAHg36RTfAosshOy/y+r7WjQgpoN\ngLBoLqsKUKvb0m+08MZelckUrqx0yYq0EIq3e+91yDMtqzvlJQNUeNj7xB2x\n+rCaeNeyQei7fpky7ENJqar82FmelJqRTXQgJAHdPCljm5uQyK4f1KCCHxL7\nordLd8pP00iiDamJZCVbt3Fwd7yjDGccpIJylE0GI5zZwmJypMP684xvImXa\nEouw20Dm5x7LVgfV3Sk9kqjOr7UDM6i8WaBW5Ps4M5Q+NpjNYu5Uh25igfrd\naXNplo7wwDJlY57zdST72EY3NnqQxVOPio0AccyusHMfCseZZQrLQLGr3Kon\nLxlQ\r\n=9BGl\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.1": {
+      "name": "vm-browserify",
+      "version": "1.1.1",
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "^4.11.0",
+        "tape-run": "^6.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-VdaJ/et1OKy9VDEqH6epLQ/DlNMuHvtDgwjPYvDvqNOlgFSMAL4ucZvyIpz0D4x5qT+8wCSK19YjWicJuc00hQ==",
+        "shasum": "9d81bf6c0a56ba3c6e787b2e56d48ac0b003574a",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 23298,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdv/8BCRA9TVsSAnZWagAAVkwP/1N1g7uA9Tos99bzSfJ9\nQJ3FJk8KRjHHy3eEmtaR1SdniLXvpdQM9zyD6n9iJSew2ovVajui2XJQz6Sy\n+/rfvrhT1zbXG+8ZrC0Nkc2WE06hJ/KnAA/WcpBZW48pExchtz8IGnyGpaE1\nBN3aLfttRgTmh4VT9SoBYO9/goMM2olKPIOlkruz3H2yfZ2I3GTax66ji5vI\nw9Bdy4V+cc64Nyj8ZP5uUtm2PynhStg1rzcbviBzwzmWJSSamHXTBOLPaDaQ\nWgFwdq5RAqayXhlTDdiOOiYiEb4nfHlXGZa/E+4XFiMoQrbAECUVetbpBmlo\nC5Tckihd6Ad+DYjJTtcQTCYg833iYGTgtVM3pgjKnaKESolJ00Khis3uJBkn\nLf6hHhcaw/uSTqzon5Mq1H81o6SPBoiJfbT/VquMvi8eL0nrNCDTbxgpbGM/\n6ScnrZlTeBhFxNohoFl4qHQBy407cp4rAIQE/U59m9LZlKGSSWmIZ8Ko8HmT\nhJRICemtw5XJnDNJubLN8yWZSKCXnwekR6ag1qOEOTu2IRkO3zVzyfcRZ6ZW\niCi55etbCicbgNtxFtTI135dh+sLJ+YG2LxzhdMkOMQL/JPr7F1/Rq6A6ACd\nWzbETqGqCGCZ6Jx4MR3+9IXE39MFoJvGCPgrLfUG/BSl91rj/5In+KieZH90\n8n/X\r\n=Vi2S\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.1.2": {
+      "name": "vm-browserify",
+      "version": "1.1.2",
+      "devDependencies": {
+        "browserify": "^16.1.1",
+        "tape": "^4.11.0",
+        "tape-run": "^6.0.1"
+      },
+      "dist": {
+        "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+        "shasum": "78641c488b8e6ca91a75f511e7a3b32a86e5dda0",
+        "tarball": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 15503,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdwBorCRA9TVsSAnZWagAA8LcP+QB4C3B4loaGry0Oi+ff\n+lfFjsZOTQ5H1QGK+2GzMA1NWeZWdieKId8yp4M0avvWszXXiUfmuBL7LgiF\nETG1cLXgzWaSn2cPd0fp0TbrLA3EIDxDPmwQjvTuB3aAvFcQ9/5hSI4xQdQC\ncd6i8cGiXVg3Wr97NN33jldRAQ9UNjBNkyJZRAPruEnwtdHwVojcIj7WXdbS\nliTmOQNFJBgctJ258oLng9qe83gCubLAqEunolw75sePxu5d2Jei94GEQolm\nN/hvFez4STKK8ShSje2ncj0vuq8wt07L8ju0axULVgFMH1/oW1ZSCKOvE8Uz\nk6qhh7zBqkLM7ROYgVnQfxZ1WEVPIvi3PidjbN9JtKXyu49bq+gWnOvpSMSD\n+gCwCzv7RP7xjTBOPCwj6HgLG/z6Zz6hIYS1krY6iwqfdKUgrHwmVgTxwjg/\nWjU5lPSjvQAexmMJEficFOk4dr4u7e8ZjQx0bk5CZQYr60DQlIUBCIRyBsNQ\nCu2Q5YMjJ6NJeGhtO7qcPbvN9cfF1kNfnHq/1lgINIAFtrcQQirDnztWwtJU\nbl4VU9bwky3hgpFnvYIkkO5IFp8J/XJXotbKvmb9I7Y585z68Wzf92PRof24\nII4aP0S0S8dpxXey16KkGsTrCue7fCp0BoKeNAc8a0r6Ekdqwneiuz45098N\n8pfb\r\n=9+Cd\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-10-09T12:54:41.377Z"
+}

--- a/test/fixtures/registry-mocks/content/watchpack-chokidar2.json
+++ b/test/fixtures/registry-mocks/content/watchpack-chokidar2.json
@@ -1,0 +1,131 @@
+{
+  "_id": "watchpack-chokidar2",
+  "_rev": "1-502f713489efd59ed50dc6961f9d0d9e",
+  "name": "watchpack-chokidar2",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "2.0.0": {
+      "name": "watchpack-chokidar2",
+      "version": "2.0.0",
+      "engines": {
+        "node": "<8.10.0"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/watchpack.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/watchpack/issues"
+      },
+      "homepage": "https://github.com/webpack/watchpack",
+      "dependencies": {
+        "chokidar": "^2.1.8"
+      },
+      "_id": "watchpack-chokidar2@2.0.0",
+      "_nodeVersion": "14.0.0",
+      "_npmVersion": "6.14.4",
+      "dist": {
+        "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+        "shasum": "9948a1866cbbd6cb824dea13a7ed691f6c8ddff0",
+        "tarball": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 469,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJev/00CRA9TVsSAnZWagAABaYP/Rx0Rm6ugUtlW8imQs3e\nc9CtCnIdG8BZ1lNuM+n+r/GP0G7lR2Dsn07W+SZuHAiw7ngdO7gSxDlZl7gl\n4igSQLFEMHV9GL4uxKn5W19Co0EvPH7UPkkRK1i28mpIHMzvLM/pz5ojehO4\nKsG++JabtLGfX/5wOgXtp4ZkWsgL+8Pyb37jMdZ85QDgLb51RfH7OBfcSiC7\nPPKZpaK90JqNg8E7xt5OpabNnHfQ/oohtriTPOPKISJCtLg3Kb/hQGHAGyuu\ntwk94/kWSsHPTJFR4hG8nXlLI0n267v9fpyD3t6mfXeh4PYfEi3lefMBEcoV\nvTco9r9fjfHzSuiMKKUJRhuyesmWgb/RWY9F+7FPjTRkdE5Fi42StOlWxypY\njMAoD0b7pup2C3qJKSkUGHkN0OfFV7+yTpc6eaRhipFYMvWVvesy4W2QbTa6\nSvV0eyUwrMdFYNmXqsfL+FNctAiw9iXtZtKtdTItrRD0yz2yHzKSBEH5gpzU\nqlkJwBajQOT8n7Q6DEkMaIvXS7nhHHfVQOszlJ0bZBzrUUvT1lri7zi3JDmA\n9ec4XzSxkU/499+PPJSUYSEBkH8mCT3l2I8D3waiA77ixrG6sA0I1R58lW56\n8I3/zHdu/clxrh7xVgDEl+S2tFFhQHrtuy1hurrAlVo5ozltZuaxJPFri/q9\nKN4x\r\n=qjeQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/watchpack-chokidar2_2.0.0_1589640499940_0.050286210101330164"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.1": {
+      "name": "watchpack-chokidar2",
+      "version": "2.0.1",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/watchpack.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/webpack/watchpack/issues"
+      },
+      "homepage": "https://github.com/webpack/watchpack",
+      "dependencies": {
+        "chokidar": "^2.1.8"
+      },
+      "_id": "watchpack-chokidar2@2.0.1",
+      "_nodeVersion": "15.1.0",
+      "_npmVersion": "7.0.8",
+      "dist": {
+        "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
+        "shasum": "38500072ee6ece66f3769936950ea1771be1c957",
+        "tarball": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+        "fileCount": 2,
+        "unpackedSize": 427,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfqjBDCRA9TVsSAnZWagAAqNgP/RZTe/3z8K0Dwcept8+W\nrKlz7tu2pkwLqTIM2A0YWRYWVrZB2WbMkCmt/p02dTApyvahusfeWPKCIQQt\nzZ6DQEADCZhkgA9OCxxVnlybe6THQuh/FaQMSENLaDyEVTIeQTsob0E5K1G2\nG+F09Js+tifNKxUvsMGbDzXBICFbA4DBjzi3ZphrtGICaXeUK+TeDmnu8GKW\nnetKFo8+odaR75uAUbzJq9w0/YDxwxtVTvdNSjKqGXAFZVEc+zNxcDytR0n2\n/Vm0/VGFRPy/rfcxRKlo3t9HD2i8sJ+mn7osbSF1ECotn99uKeI4vuvldZeV\n405ztHmU4bc+r098AqG3hDOkMCP8L4UvNqMzVxMZBMfUXSMf9yRKFlZihGpT\nAYILl6iDbaOs+0wDYkq/G2u4n/k2QRLwEh4v33eeSu+HZQkhtL+ELfhLL3wq\n4o3a5n/TCxFNFXvfcLNzQpjC+bOoaOMR00H1ZnOtW+DMneof8xTxwjs5wlbt\n+cQr+5Mh8BrEzbl/afTkVnem2n0jsC9Jxcne80RCxKZ76vZmJAASllShG4rF\ni//QprJXA/TwPajZGPJKt+FfNLWNYdi3x4VFsz545QfXCLkEH40pegIV9/CB\n0bsFqQEIdHA1uM8TX4vw0rbKUyqHSNd6DEEh2+6cY0aOs75gCJEtYG8Q4F45\nMCGv\r\n=r+YM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/watchpack-chokidar2_2.0.1_1604988995046_0.4847632983184944"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2020-05-16T14:48:19.939Z",
+    "2.0.0": "2020-05-16T14:48:20.061Z",
+    "modified": "2020-11-10T06:16:37.510Z",
+    "2.0.1": "2020-11-10T06:16:35.194Z"
+  },
+  "maintainers": [
+    {
+      "name": "sokra",
+      "email": "tobias.koppers@googlemail.com"
+    }
+  ],
+  "homepage": "https://github.com/webpack/watchpack",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webpack/watchpack.git"
+  },
+  "author": {
+    "name": "Tobias Koppers @sokra"
+  },
+  "bugs": {
+    "url": "https://github.com/webpack/watchpack/issues"
+  },
+  "license": "MIT",
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/test/fixtures/registry-mocks/content/watchpack-chokidar2.min.json
+++ b/test/fixtures/registry-mocks/content/watchpack-chokidar2.min.json
@@ -1,0 +1,42 @@
+{
+  "name": "watchpack-chokidar2",
+  "dist-tags": {
+    "latest": "2.0.1"
+  },
+  "versions": {
+    "2.0.0": {
+      "name": "watchpack-chokidar2",
+      "version": "2.0.0",
+      "dependencies": {
+        "chokidar": "^2.1.8"
+      },
+      "dist": {
+        "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+        "shasum": "9948a1866cbbd6cb824dea13a7ed691f6c8ddff0",
+        "tarball": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+        "fileCount": 2,
+        "unpackedSize": 469,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJev/00CRA9TVsSAnZWagAABaYP/Rx0Rm6ugUtlW8imQs3e\nc9CtCnIdG8BZ1lNuM+n+r/GP0G7lR2Dsn07W+SZuHAiw7ngdO7gSxDlZl7gl\n4igSQLFEMHV9GL4uxKn5W19Co0EvPH7UPkkRK1i28mpIHMzvLM/pz5ojehO4\nKsG++JabtLGfX/5wOgXtp4ZkWsgL+8Pyb37jMdZ85QDgLb51RfH7OBfcSiC7\nPPKZpaK90JqNg8E7xt5OpabNnHfQ/oohtriTPOPKISJCtLg3Kb/hQGHAGyuu\ntwk94/kWSsHPTJFR4hG8nXlLI0n267v9fpyD3t6mfXeh4PYfEi3lefMBEcoV\nvTco9r9fjfHzSuiMKKUJRhuyesmWgb/RWY9F+7FPjTRkdE5Fi42StOlWxypY\njMAoD0b7pup2C3qJKSkUGHkN0OfFV7+yTpc6eaRhipFYMvWVvesy4W2QbTa6\nSvV0eyUwrMdFYNmXqsfL+FNctAiw9iXtZtKtdTItrRD0yz2yHzKSBEH5gpzU\nqlkJwBajQOT8n7Q6DEkMaIvXS7nhHHfVQOszlJ0bZBzrUUvT1lri7zi3JDmA\n9ec4XzSxkU/499+PPJSUYSEBkH8mCT3l2I8D3waiA77ixrG6sA0I1R58lW56\n8I3/zHdu/clxrh7xVgDEl+S2tFFhQHrtuy1hurrAlVo5ozltZuaxJPFri/q9\nKN4x\r\n=qjeQ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": "<8.10.0"
+      }
+    },
+    "2.0.1": {
+      "name": "watchpack-chokidar2",
+      "version": "2.0.1",
+      "dependencies": {
+        "chokidar": "^2.1.8"
+      },
+      "dist": {
+        "integrity": "sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==",
+        "shasum": "38500072ee6ece66f3769936950ea1771be1c957",
+        "tarball": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz",
+        "fileCount": 2,
+        "unpackedSize": 427,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfqjBDCRA9TVsSAnZWagAAqNgP/RZTe/3z8K0Dwcept8+W\nrKlz7tu2pkwLqTIM2A0YWRYWVrZB2WbMkCmt/p02dTApyvahusfeWPKCIQQt\nzZ6DQEADCZhkgA9OCxxVnlybe6THQuh/FaQMSENLaDyEVTIeQTsob0E5K1G2\nG+F09Js+tifNKxUvsMGbDzXBICFbA4DBjzi3ZphrtGICaXeUK+TeDmnu8GKW\nnetKFo8+odaR75uAUbzJq9w0/YDxwxtVTvdNSjKqGXAFZVEc+zNxcDytR0n2\n/Vm0/VGFRPy/rfcxRKlo3t9HD2i8sJ+mn7osbSF1ECotn99uKeI4vuvldZeV\n405ztHmU4bc+r098AqG3hDOkMCP8L4UvNqMzVxMZBMfUXSMf9yRKFlZihGpT\nAYILl6iDbaOs+0wDYkq/G2u4n/k2QRLwEh4v33eeSu+HZQkhtL+ELfhLL3wq\n4o3a5n/TCxFNFXvfcLNzQpjC+bOoaOMR00H1ZnOtW+DMneof8xTxwjs5wlbt\n+cQr+5Mh8BrEzbl/afTkVnem2n0jsC9Jxcne80RCxKZ76vZmJAASllShG4rF\ni//QprJXA/TwPajZGPJKt+FfNLWNYdi3x4VFsz545QfXCLkEH40pegIV9/CB\n0bsFqQEIdHA1uM8TX4vw0rbKUyqHSNd6DEEh2+6cY0aOs75gCJEtYG8Q4F45\nMCGv\r\n=r+YM\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2020-11-10T06:16:37.510Z"
+}

--- a/test/fixtures/registry-mocks/content/wbuf.json
+++ b/test/fixtures/registry-mocks/content/wbuf.json
@@ -1,0 +1,822 @@
+{
+  "_id": "wbuf",
+  "_rev": "17-d7df9291546936e0f18b685f292a49b4",
+  "name": "wbuf",
+  "description": "Write buffer",
+  "dist-tags": {
+    "latest": "1.7.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "wbuf",
+      "version": "0.1.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indunty/wbuf"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indunty/wbuf/issues"
+      },
+      "homepage": "https://github.com/indunty/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "dc005eb9226e617254d7f3cdd78d12e3ba5be047",
+      "_id": "wbuf@0.1.0",
+      "_shasum": "3a51d4ccd08d522246850fcbc483fcba8e56da4e",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "3a51d4ccd08d522246850fcbc483fcba8e56da4e",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "wbuf",
+      "version": "0.2.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git@github.com:indunty/wbuf"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indunty/wbuf/issues"
+      },
+      "homepage": "https://github.com/indunty/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "e647d5c180acf48be67161fc05058708250ac9dd",
+      "_id": "wbuf@0.2.0",
+      "_shasum": "6cb0ac758610893b12d6f4f686445b12f18133ff",
+      "_from": ".",
+      "_npmVersion": "1.4.21",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "6cb0ac758610893b12d6f4f686445b12f18133ff",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-0.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "wbuf",
+      "version": "1.0.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indunty/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indunty/wbuf/issues"
+      },
+      "homepage": "https://github.com/indunty/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "85ccac18df9e8af051e169d11b1587a9756aff47",
+      "_id": "wbuf@1.0.0",
+      "_shasum": "5efd44f1db8f59821e25a67f8023b5ec532b5880",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5efd44f1db8f59821e25a67f8023b5ec532b5880",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "wbuf",
+      "version": "1.1.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indunty/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indunty/wbuf/issues"
+      },
+      "homepage": "https://github.com/indunty/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "69064a9b0fdb4bec15bbc2102413bc9b1a6ce598",
+      "_id": "wbuf@1.1.0",
+      "_shasum": "dd98cb7bc2f0968176075109ddec261c44de3a52",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dd98cb7bc2f0968176075109ddec261c44de3a52",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "wbuf",
+      "version": "1.2.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indunty/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indunty/wbuf/issues"
+      },
+      "homepage": "https://github.com/indunty/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "d9137e2c6cca9c865e1be08f382b1666525ee587",
+      "_id": "wbuf@1.2.0",
+      "_shasum": "0510b053b78e1e23a5c0d0ecdd59472942c367a4",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0510b053b78e1e23a5c0d0ecdd59472942c367a4",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "wbuf",
+      "version": "1.3.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indunty/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indunty/wbuf/issues"
+      },
+      "homepage": "https://github.com/indunty/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "8dcc92923ac4614958e319b8463aa4ce7cdac5b1",
+      "_id": "wbuf@1.3.0",
+      "_shasum": "239a2dd2681c16876920b59e89fd8f5e5e979679",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "239a2dd2681c16876920b59e89fd8f5e5e979679",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "wbuf",
+      "version": "1.4.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indunty/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indunty/wbuf/issues"
+      },
+      "homepage": "https://github.com/indunty/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "fcd39d41e53827b1d6c4b8b67cd0e02ed6c410af",
+      "_id": "wbuf@1.4.0",
+      "_shasum": "5cacf393a27f9f38b3f4443d6a8051b4ef61aacf",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5cacf393a27f9f38b3f4443d6a8051b4ef61aacf",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "wbuf",
+      "version": "1.4.1",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indunty/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indunty/wbuf/issues"
+      },
+      "homepage": "https://github.com/indunty/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "552cbd02c9efb366bf07211f6739ecbacfe59be2",
+      "_id": "wbuf@1.4.1",
+      "_shasum": "787cbc1bf3d1e59086e31c3ad2ebfb977c2c8bab",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "787cbc1bf3d1e59086e31c3ad2ebfb977c2c8bab",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.2": {
+      "name": "wbuf",
+      "version": "1.4.2",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/wbuf/issues"
+      },
+      "homepage": "https://github.com/indutny/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "cd7f8ee11ee8904028d2c23c805de418f8971e10",
+      "_id": "wbuf@1.4.2",
+      "_shasum": "40026342e4f068c9a8b964807fcb212fa98f59b6",
+      "_from": ".",
+      "_npmVersion": "2.11.0",
+      "_nodeVersion": "2.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "40026342e4f068c9a8b964807fcb212fa98f59b6",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.4.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "wbuf",
+      "version": "1.5.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/wbuf/issues"
+      },
+      "homepage": "https://github.com/indutny/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "53c98c36304ab6dcb82abbf1d3d97d41a5bd438b",
+      "_id": "wbuf@1.5.0",
+      "_shasum": "8cf09e51f4bebaebaa7fcba6d5cb14a6ebaa9de6",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8cf09e51f4bebaebaa7fcba6d5cb14a6ebaa9de6",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "wbuf",
+      "version": "1.6.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/wbuf/issues"
+      },
+      "homepage": "https://github.com/indutny/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "23de1bd429726cd04a0e3646bedfdafd6fafe176",
+      "_id": "wbuf@1.6.0",
+      "_shasum": "d50eb81e8618293825191d4f3ca88c1bded2e5fc",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d50eb81e8618293825191d4f3ca88c1bded2e5fc",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "wbuf",
+      "version": "1.7.0",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/wbuf/issues"
+      },
+      "homepage": "https://github.com/indutny/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "gitHead": "8b978dd7474ce63e3fb787fc02c953592be2e015",
+      "_id": "wbuf@1.7.0",
+      "_shasum": "4dd0913120639f54a7c85187f9fd79fff4dfdb3c",
+      "_from": ".",
+      "_npmVersion": "2.12.1",
+      "_nodeVersion": "2.3.4",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4dd0913120639f54a7c85187f9fd79fff4dfdb3c",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.1": {
+      "name": "wbuf",
+      "version": "1.7.1",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/wbuf/issues"
+      },
+      "homepage": "https://github.com/indutny/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "d36003104c90116f83db0b341c8b6da4290d3237",
+      "_id": "wbuf@1.7.1",
+      "_shasum": "1a67c4f87953f4b23b033eefea202ae5c206e518",
+      "_from": ".",
+      "_npmVersion": "2.14.7",
+      "_nodeVersion": "4.2.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "dist": {
+        "shasum": "1a67c4f87953f4b23b033eefea202ae5c206e518",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.2": {
+      "name": "wbuf",
+      "version": "1.7.2",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/wbuf/issues"
+      },
+      "homepage": "https://github.com/indutny/wbuf",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "557867724882c61c58e49c1b3bfd5ef793d9dc7f",
+      "_id": "wbuf@1.7.2",
+      "_shasum": "d697b99f1f59512df2751be42769c1580b5801fe",
+      "_from": ".",
+      "_npmVersion": "3.8.6",
+      "_nodeVersion": "6.0.0",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "shasum": "d697b99f1f59512df2751be42769c1580b5801fe",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/wbuf-1.7.2.tgz_1462925133747_0.2520239648874849"
+      },
+      "directories": {}
+    },
+    "1.7.3": {
+      "name": "wbuf",
+      "version": "1.7.3",
+      "description": "Write buffer",
+      "main": "index.js",
+      "scripts": {
+        "test": "mocha test/**/*-test.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/indutny/wbuf.git"
+      },
+      "keywords": [
+        "Write",
+        "Buffer"
+      ],
+      "author": {
+        "name": "Fedor Indutny",
+        "email": "fedor@indutny.com"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/indutny/wbuf/issues"
+      },
+      "homepage": "https://github.com/indutny/wbuf",
+      "devDependencies": {
+        "mocha": "^5.0.4"
+      },
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      },
+      "gitHead": "75620cb7166688045eb773b2c0a6d49f1c625d5f",
+      "_id": "wbuf@1.7.3",
+      "_npmVersion": "5.7.1",
+      "_nodeVersion": "9.6.1",
+      "_npmUser": {
+        "name": "indutny",
+        "email": "fedor@indutny.com"
+      },
+      "dist": {
+        "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+        "shasum": "c1d8d149316d3ea852848895cb6a0bfe887b87df",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+        "fileCount": 4,
+        "unpackedSize": 20902
+      },
+      "maintainers": [
+        {
+          "name": "indutny",
+          "email": "fedor@indutny.com"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/wbuf_1.7.3_1520718679064_0.751897486155537"
+      }
+    }
+  },
+  "readme": "# wbuf\n\n#### LICENSE\n\nThis software is licensed under the MIT License.\n\nCopyright Fedor Indutny, 2014.\n\nPermission is hereby granted, free of charge, to any person obtaining a\ncopy of this software and associated documentation files (the\n\"Software\"), to deal in the Software without restriction, including\nwithout limitation the rights to use, copy, modify, merge, publish,\ndistribute, sublicense, and/or sell copies of the Software, and to permit\npersons to whom the Software is furnished to do so, subject to the\nfollowing conditions:\n\nThe above copyright notice and this permission notice shall be included\nin all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS\nOR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\nMERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN\nNO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,\nDAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR\nOTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE\nUSE OR OTHER DEALINGS IN THE SOFTWARE.\n",
+  "maintainers": [
+    {
+      "name": "indutny",
+      "email": "fedor@indutny.com"
+    }
+  ],
+  "time": {
+    "modified": "2018-03-10T21:51:20.132Z",
+    "created": "2014-08-30T19:55:58.902Z",
+    "0.1.0": "2014-08-30T19:55:58.902Z",
+    "0.2.0": "2014-08-31T18:57:55.107Z",
+    "1.0.0": "2015-06-12T18:29:58.399Z",
+    "1.1.0": "2015-06-13T10:17:58.618Z",
+    "1.2.0": "2015-06-16T23:06:28.073Z",
+    "1.3.0": "2015-06-19T00:38:04.315Z",
+    "1.4.0": "2015-06-20T23:19:32.960Z",
+    "1.4.1": "2015-07-14T00:29:13.265Z",
+    "1.4.2": "2015-07-14T00:53:08.450Z",
+    "1.5.0": "2015-07-19T18:47:31.615Z",
+    "1.6.0": "2015-07-19T19:30:33.830Z",
+    "1.7.0": "2015-07-19T19:34:02.835Z",
+    "1.7.1": "2015-10-18T18:46:35.552Z",
+    "1.7.2": "2016-05-11T00:05:35.060Z",
+    "1.7.3": "2018-03-10T21:51:19.126Z"
+  },
+  "homepage": "https://github.com/indutny/wbuf",
+  "keywords": [
+    "Write",
+    "Buffer"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/indutny/wbuf.git"
+  },
+  "author": {
+    "name": "Fedor Indutny",
+    "email": "fedor@indutny.com"
+  },
+  "bugs": {
+    "url": "https://github.com/indutny/wbuf/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md",
+  "_attachments": {}
+}

--- a/test/fixtures/registry-mocks/content/wbuf.min.json
+++ b/test/fixtures/registry-mocks/content/wbuf.min.json
@@ -1,0 +1,186 @@
+{
+  "name": "wbuf",
+  "dist-tags": {
+    "latest": "1.7.3"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "wbuf",
+      "version": "0.1.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "3a51d4ccd08d522246850fcbc483fcba8e56da4e",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "wbuf",
+      "version": "0.2.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "6cb0ac758610893b12d6f4f686445b12f18133ff",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-0.2.0.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "wbuf",
+      "version": "1.0.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "5efd44f1db8f59821e25a67f8023b5ec532b5880",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.0.0.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "wbuf",
+      "version": "1.1.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "dd98cb7bc2f0968176075109ddec261c44de3a52",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "wbuf",
+      "version": "1.2.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "0510b053b78e1e23a5c0d0ecdd59472942c367a4",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "wbuf",
+      "version": "1.3.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "239a2dd2681c16876920b59e89fd8f5e5e979679",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.3.0.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "wbuf",
+      "version": "1.4.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "5cacf393a27f9f38b3f4443d6a8051b4ef61aacf",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.4.0.tgz"
+      }
+    },
+    "1.4.1": {
+      "name": "wbuf",
+      "version": "1.4.1",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "787cbc1bf3d1e59086e31c3ad2ebfb977c2c8bab",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.4.1.tgz"
+      }
+    },
+    "1.4.2": {
+      "name": "wbuf",
+      "version": "1.4.2",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "40026342e4f068c9a8b964807fcb212fa98f59b6",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.4.2.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "wbuf",
+      "version": "1.5.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "8cf09e51f4bebaebaa7fcba6d5cb14a6ebaa9de6",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.5.0.tgz"
+      }
+    },
+    "1.6.0": {
+      "name": "wbuf",
+      "version": "1.6.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "d50eb81e8618293825191d4f3ca88c1bded2e5fc",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.6.0.tgz"
+      }
+    },
+    "1.7.0": {
+      "name": "wbuf",
+      "version": "1.7.0",
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "4dd0913120639f54a7c85187f9fd79fff4dfdb3c",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.0.tgz"
+      }
+    },
+    "1.7.1": {
+      "name": "wbuf",
+      "version": "1.7.1",
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "1a67c4f87953f4b23b033eefea202ae5c206e518",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.1.tgz"
+      }
+    },
+    "1.7.2": {
+      "name": "wbuf",
+      "version": "1.7.2",
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^1.21.4"
+      },
+      "dist": {
+        "shasum": "d697b99f1f59512df2751be42769c1580b5801fe",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz"
+      }
+    },
+    "1.7.3": {
+      "name": "wbuf",
+      "version": "1.7.3",
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      },
+      "devDependencies": {
+        "mocha": "^5.0.4"
+      },
+      "dist": {
+        "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+        "shasum": "c1d8d149316d3ea852848895cb6a0bfe887b87df",
+        "tarball": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+        "fileCount": 4,
+        "unpackedSize": 20902
+      }
+    }
+  },
+  "modified": "2018-03-10T21:51:20.132Z"
+}

--- a/test/fixtures/registry-mocks/content/webpack-dev-middleware.json
+++ b/test/fixtures/registry-mocks/content/webpack-dev-middleware.json
@@ -1,0 +1,6655 @@
+{
+  "_id": "webpack-dev-middleware",
+  "_rev": "184-f118aee81b2cce402290af86567b7d4d",
+  "name": "webpack-dev-middleware",
+  "description": "A development middleware for webpack",
+  "dist-tags": {
+    "latest": "4.0.2",
+    "next": "4.0.0-rc.3"
+  },
+  "versions": {
+    "0.5.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.5.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "bin": {
+        "webpack-dev-middleware": "./webpack-dev-server.js"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.5.0",
+      "dist": {
+        "shasum": "e50416142d56f8597638efa5c02ddb681dfb6a1c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.5.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.5.1",
+      "dist": {
+        "shasum": "142825b36fbf322914c488e92003b82dbca6d7d4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.6.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.6.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.6.0",
+      "dist": {
+        "shasum": "f2c707c38b841c62884eb85d95de54844b7c9345",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.6.0.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.6.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.6.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.6.1",
+      "dist": {
+        "shasum": "154949e6b7b74c037c59dcf8fd6a42180c1c2bf4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.6.1.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.2": {
+      "name": "webpack-dev-middleware",
+      "version": "0.6.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.6.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.6.2",
+      "dist": {
+        "shasum": "122163d97ae0f42629d121772c08f1045968b8a7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.6.2.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.7.0",
+      "dist": {
+        "shasum": "6676758f35102b16638583903916b8b9d94b496c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.0.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.7.1",
+      "dist": {
+        "shasum": "95a7ede1ef2bd43943e7b11b91840ece1b1019eb",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.1.tgz"
+      },
+      "_npmVersion": "1.1.62",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.2": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.7.2",
+      "dist": {
+        "shasum": "ec6b82b64bbaf9e8905eb0a12e50fb8c2884990b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.2.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.3": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.7.3",
+      "dist": {
+        "shasum": "ef4fffc5efe335e4de630effa39070acf43e78bc",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.3.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.4": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.7.4",
+      "dist": {
+        "shasum": "56f606094fdd910611feba1bbf67606700f44262",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.4.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.8.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.8.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.8.0",
+      "dist": {
+        "shasum": "53963072b83217812ab58286fcf475134639c2bf",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.8.0.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.8.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.8.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.8.1",
+      "dist": {
+        "shasum": "51f449b2cfe60eb40eeaa36deb334e7067012ad6",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.8.1.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.2": {
+      "name": "webpack-dev-middleware",
+      "version": "0.8.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.8.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.1.30"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "license": "MIT",
+      "_id": "webpack-dev-middleware@0.8.2",
+      "dist": {
+        "shasum": "ce2061ccea4aa7d672774e79051b4473fdc79d55",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.8.2.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.9.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.8.x",
+        "enhanced-resolve": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@0.9.0",
+      "dist": {
+        "shasum": "e92b4ac2c387000106685721de310775220a01db",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.9.0.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.9.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.9.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.9.x",
+        "enhanced-resolve": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@0.9.1",
+      "dist": {
+        "shasum": "13c863ff5648a24596910b074ade81cd0c5934d4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.9.1.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.10.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "dependencies": {
+        "webpack": "0.10.x",
+        "enhanced-resolve": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@0.10.0",
+      "dist": {
+        "shasum": "337f5895d6314a37d6e8ae15b8bd09f745b295aa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.10.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.10.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "0.10.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.5.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@0.10.1",
+      "dist": {
+        "shasum": "793aa3bf369d6156fe7cfe7224846c1f4f87a7a5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.10.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.2": {
+      "name": "webpack-dev-middleware",
+      "version": "0.10.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "0.10.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.5.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@0.10.2",
+      "dist": {
+        "shasum": "746f0fa2f82b4d8d991c42b1b8eb12fa08d79ea3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.10.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.11.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "0.11.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.5.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@0.11.0",
+      "dist": {
+        "shasum": "293130808a718f8a75d2cc6337ee030c9746b7f2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.11.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.5.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@1.0.0",
+      "dist": {
+        "shasum": "a48fa02eda279adf95d221f96b687e5aa8b75e74",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.5.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@1.0.1",
+      "dist": {
+        "shasum": "2947c87fa8bb22784004e2b6ae0e6bcc373c9a1e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@1.0.2",
+      "dist": {
+        "shasum": "62fde19b4c08115cb275066b75e20ff7239f1789",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.3": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@1.0.3",
+      "dist": {
+        "shasum": "efca70a3ad465bf9f183e9cd27623b24a178fc02",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.4": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@1.0.4",
+      "dist": {
+        "shasum": "8234d273e4f91fb3c6b8dbc3f36ae60202a562e5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.5": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.5",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "_id": "webpack-dev-middleware@1.0.5",
+      "dist": {
+        "shasum": "408343fc3b63052cc9c46b7117306e3186e8c9c2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.6": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.6",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.0.6",
+      "dist": {
+        "shasum": "7fc374b66f0c1448b129a709414917729cb83ec4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.7": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.7",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.0.7",
+      "dist": {
+        "shasum": "7b6a382d68ebfb7d27391c2fcd8b99b1dcbc0ffa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.8": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.8",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.0.8",
+      "dist": {
+        "shasum": "2d0395003b4b1922394b15de660436b9a6dd939a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.9": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.9",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "96881e84faa572a9f99da41923d0c960ce8f8cdc",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.0.9",
+      "scripts": {},
+      "_shasum": "37cec079e60b0c5db64b675e2d3ac3b03ea0f3d9",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "37cec079e60b0c5db64b675e2d3ac3b03ea0f3d9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.9.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.10": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.10",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "memory-fs": "~0.1.0",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "69b6c0343d10cd8995da83bbc8faf5e52541b9e6",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.0.10",
+      "scripts": {},
+      "_shasum": "15b3e8567fe961e18ed76af24f1f9c38081fb0d6",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "15b3e8567fe961e18ed76af24f1f9c38081fb0d6",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.10.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.11": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.11",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "memory-fs": "~0.1.0",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.0.11",
+      "dist": {
+        "shasum": "9b5ab7ecd0641cee31e87f7e902f6f59253674fd",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.11.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.1.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "memory-fs": "~0.1.0",
+        "mime": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "4f2b09eecc0470a2e0221e21f823bd02ba80df51",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.1.0",
+      "scripts": {},
+      "_shasum": "bc005ffbf2e1f4230e422670079cb3738f1e803f",
+      "_from": ".",
+      "_npmVersion": "2.10.0",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "bc005ffbf2e1f4230e422670079cb3738f1e803f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.2.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "^1.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.2.0",
+        "mime": "^1.3.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "15071bafc2da09b9b3b655d381a40890b9359545",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.2.0",
+      "scripts": {},
+      "_shasum": "13b76aa2c8476000cd6ffefeae3eef448ee474ed",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "13b76aa2c8476000cd6ffefeae3eef448ee474ed",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.3.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "^1.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "fded9c66e1fe745bed65d6afc2a043e603079e1e",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.3.0",
+      "scripts": {},
+      "_shasum": "0bf372a7dbd21dd4220f7d1b769dca0b71f55b5e",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0bf372a7dbd21dd4220f7d1b769dca0b71f55b5e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.4.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": ">=1.0.0 <3"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "75367b8cb14e541f144fcb8c6de58d00bd927621",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.4.0",
+      "scripts": {},
+      "_shasum": "326ec7725cde19692e70edb1ff8a570312ee6830",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "326ec7725cde19692e70edb1ff8a570312ee6830",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.5.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": ">=1.0.0 <3"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "e2a0298e6f5d058e16d6a194f0506833eef62959",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.5.0",
+      "scripts": {},
+      "_shasum": "bd24a4e627e3fd3b4fbae39041a56caf794a0713",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "bd24a4e627e3fd3b4fbae39041a56caf794a0713",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.5.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": ">=1.0.0 <3"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "a9fc7f47ad5e1f8b8ea9df930dc69ffa7715beb9",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.5.1",
+      "scripts": {},
+      "_shasum": "c46e075467881211e3fca34af1cdadf47163c89a",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "c46e075467881211e3fca34af1cdadf47163c89a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.6.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "7bad02693cfacda82eb150aeb35df340fe43d364",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.6.0",
+      "scripts": {},
+      "_shasum": "332a389776064556945aef3d75e51a6e091af228",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "332a389776064556945aef3d75e51a6e091af228",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-13-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.6.0.tgz_1458845785512_0.7115013131406158"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.6.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "gitHead": "8044d042a85848f7b7445f413e78e99e86e904e5",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.6.1",
+      "scripts": {},
+      "_shasum": "c25ef832abc7d360c38bb40eb918692720ced611",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "c25ef832abc7d360c38bb40eb918692720ced611",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.6.1.tgz_1459002207407_0.43884235760197043"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.7.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "eslint": "^3.4.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "scripts": {
+        "lint": "eslint *.js",
+        "beautify": "npm run lint -- --fix",
+        "travis": "npm run lint && node middleware.js"
+      },
+      "gitHead": "1e121fde0927ed03077534e003cf72e6e464af8d",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.7.0",
+      "_shasum": "e07246aa503d2ad0d35ce688ed24f0e739cca9e7",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "e07246aa503d2ad0d35ce688ed24f0e739cca9e7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.7.0.tgz_1473499085062_0.3048303942196071"
+      },
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "pretest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "1cb0bd681edc556f8ded809fb497aa96131a2655",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.8.0",
+      "_shasum": "f7571c93ee3949f587741bb78ab9ce748deda184",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "f7571c93ee3949f587741bb78ab9ce748deda184",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.8.0.tgz_1474139742570_0.15175360976718366"
+      },
+      "directories": {}
+    },
+    "1.8.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "pretest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "50fc331e8a8d57e4791914eca6a3fcf7b2f4555b",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.8.1",
+      "_shasum": "4855276fd89c3f5e2a4eadfc5e1e94f73c4a550d",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "4855276fd89c3f5e2a4eadfc5e1e94f73c4a550d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.8.1.tgz_1474185247131_0.5774109864141792"
+      },
+      "directories": {}
+    },
+    "1.8.2": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "pretest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "c3d0ee5a57c4af40c1f821d83120d2e02e3f8bc8",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.8.2",
+      "_shasum": "512b2c31b962482717d87e6e9c3ce01f5c46e775",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "512b2c31b962482717d87e6e9c3ce01f5c46e775",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.8.2.tgz_1474621389216_0.6562368397135288"
+      },
+      "directories": {}
+    },
+    "1.8.3": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "pretest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "ad72c833e2a405afad2a54121a9d46ac73a902dc",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.8.3",
+      "_shasum": "1c1a1bd39df3eedf3088eab72d980837e834e5da",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "1c1a1bd39df3eedf3088eab72d980837e834e5da",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.8.3.tgz_1474913735070_0.08130252920091152"
+      },
+      "directories": {}
+    },
+    "1.8.4": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "pretest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "4d8d106e05cf5370cca93df73c9bb836a3d64113",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.8.4",
+      "_shasum": "e8765c9122887ce9e3abd4cc9c3eb31b61e0948d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "e8765c9122887ce9e3abd4cc9c3eb31b61e0948d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.8.4.tgz_1475943353643_0.9199556617531925"
+      },
+      "directories": {}
+    },
+    "1.9.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.9.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "posttest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "fcd8c29ea3e613669c8b59519be2f639daabbdaf",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.9.0",
+      "_shasum": "a1c67a3dfd8a5c5d62740aa0babe61758b4c84aa",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "a1c67a3dfd8a5c5d62740aa0babe61758b4c84aa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.9.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.9.0.tgz_1481831937321_0.807177921757102"
+      },
+      "directories": {}
+    },
+    "1.10.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.10.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.2.0"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "posttest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "a34ae3e6312d03a690df8c1309d8f1504e405ade",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.10.0",
+      "_shasum": "7d5be2651e692fddfafd8aaed177c16ff51f0eb8",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "7d5be2651e692fddfafd8aaed177c16ff51f0eb8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.10.0.tgz_1485980412130_0.355493699433282"
+      },
+      "directories": {}
+    },
+    "1.10.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.10.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.2.0"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "posttest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "8e870fdb313e83bf2562e4fd4d5735035074903f",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.10.1",
+      "_shasum": "c6b4cf428139cf1aefbe06a0c00fdb4f8da2f893",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.5",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "c6b4cf428139cf1aefbe06a0c00fdb4f8da2f893",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.10.1.tgz_1487426124354_0.9857836843002588"
+      },
+      "directories": {}
+    },
+    "1.10.2": {
+      "name": "webpack-dev-middleware",
+      "version": "1.10.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.2.0"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "posttest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "9b03d791c6641ad7e8eaba2255b95777e30630ed",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.10.2",
+      "_shasum": "2e252ce1dfb020dbda1ccb37df26f30ab014dbd1",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "2e252ce1dfb020dbda1ccb37df26f30ab014dbd1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "peerigon",
+          "email": "developers@peerigon.com"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-middleware-1.10.2.tgz_1492855208221_0.35484315757639706"
+      },
+      "directories": {}
+    },
+    "1.11.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.11.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "should": "^11.1.0",
+        "sinon": "^2.3.5",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "posttest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "e26433598957b73ddafcb8c16a706fea87297a65",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.11.0",
+      "_shasum": "09691d0973a30ad1f82ac73a12e2087f0a4754f9",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "shasum": "09691d0973a30ad1f82ac73a12e2087f0a4754f9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.11.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-1.11.0.tgz_1498104507420_0.40035333135165274"
+      },
+      "directories": {}
+    },
+    "1.12.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.12.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "should": "^11.1.0",
+        "sinon": "^2.3.8",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "posttest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "762797e5a04e69c3f97745eb23c7c4e2992b774e",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.12.0",
+      "_shasum": "d34efefb2edda7e1d3b5dbe07289513219651709",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "shasum": "d34efefb2edda7e1d3b5dbe07289513219651709",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-1.12.0.tgz_1501505532116_0.09315880201756954"
+      },
+      "directories": {}
+    },
+    "1.12.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.12.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.4.1",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "should": "^11.1.0",
+        "sinon": "^2.3.8",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "posttest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "9ab1d96bc01ceeab162ba74ef268ffb47f071693",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.12.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-UzyVg/CKBKkymDpqOoQ4mWTs9zQp0DPCY8zbol9K0tPhqoM+JU5knKGXyMQ/Cdrmzb9Cw3eetm67fIsJ7u7ryg==",
+        "shasum": "338be3ca930973be1c2ce07d84d275e997e1a25a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.1.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-1.12.1.tgz_1511373025871_0.5806551817804575"
+      },
+      "directories": {}
+    },
+    "1.12.2": {
+      "name": "webpack-dev-middleware",
+      "version": "1.12.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Offers a dev middleware for webpack, which arguments a live bundle to a directory",
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.5.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "should": "^11.1.0",
+        "sinon": "^2.3.8",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "main": "middleware.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "scripts": {
+        "lint": "eslint *.js lib test",
+        "posttest": "npm run -s lint",
+        "test": "mocha --full-trace --check-leaks",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "8db879404f523f11f2902b1365a3ffaf6166f6a9",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@1.12.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+        "shasum": "f8fc1120ce3b4fc5680ceecb43d777966b21105e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-1.12.2.tgz_1511791596311_0.6842846956569701"
+      },
+      "directories": {}
+    },
+    "2.0.0": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.0",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "publishConfig": {
+        "tag": "next"
+      },
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "middleware.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "lint": "eslint index.js lib",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "files": [
+        "middleware.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "chalk": "^2.3.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.0.3",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0",
+        "url-join": "^2.0.2",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "gitHead": "e879bd7e63f800f6c208077d2e5b95553da0e642",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@2.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-E6cK3zBo8Afkju3x19ZJ0SCX/f8lE+KRUStaFJplHTwyP+0OlWyD/4OYgeC8ewvNi+SsElNTo/q5CFZgV4dIEg==",
+        "shasum": "5a22e866dd68e15cbb335378816b8bc064c5f03d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-2.0.0.tgz_1513210112594_0.04832793725654483"
+      },
+      "directories": {}
+    },
+    "2.0.1": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.1",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "middleware.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "lint": "eslint index.js lib",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "chalk": "^2.3.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.0.3",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0",
+        "url-join": "^2.0.2",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "gitHead": "278484ea264fd241d2c76ccc86b8f627a7c1867e",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@2.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-jEQgJK+eblBzE4blKmNuJqNd4cz3t4K3mFmN6uZz4Iq44x2vc1r+CwZBgcX+GzQoSOk5iWSVB3bIN5AYKpFRTw==",
+        "shasum": "22c8ecef27f08fca6dfa95504d57f66a8f37cc13",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-2.0.1.tgz_1513224044408_0.6272585520055145"
+      },
+      "directories": {}
+    },
+    "2.0.2": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.2",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "middleware.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "lint": "eslint index.js lib",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.0.3",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "gitHead": "97a3c0f87fb9bd69cef3692ebffe7f51d4f7dcc5",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@2.0.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-3hhjH5wDkddWHNrxcbVuIgHsovCKbtuCOsiwXKYP7PgG6j/F4y+LaIMqiAi7M/jiOLoVACX18eell7wrPGN1Rw==",
+        "shasum": "cbfaf5477e2179a2be0a989752acaa9bbd38b02c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-2.0.2.tgz_1513618285482_0.36648906162008643"
+      },
+      "directories": {}
+    },
+    "2.0.3": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.3",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "middleware.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "lint": "eslint index.js lib",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "gitHead": "4edbc72992ee6cde477c38aadab249ed287ef082",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@2.0.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-8zIUzfCbpaDxKSAyC8ZhDA0P5EBvlafHcj4yoSP8lrvW0ZyWW7tsrqazI7q+zAhRi22TTE3g9sycQEZeyUbpqg==",
+        "shasum": "44e15480ec58d275417ac4d93a0126c7b72450bd",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-2.0.3.tgz_1513978658290_0.6369618973694742"
+      },
+      "directories": {}
+    },
+    "2.0.4": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.4",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "middleware.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "lint": "eslint index.js lib",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "gitHead": "bb57ce6dd966a3a8f910da06d281c123df184634",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@2.0.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-tq0VmEqam/77Q0wWXBQSZsjnX5rsJvb5kvyP42+MvhuLfS5RXozunAsW+ZGbRzqs/Asyxd6Cvr/V4bQ/218ALw==",
+        "shasum": "7d8943a609121021bb72772a41636e229346cb41",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware-2.0.4.tgz_1515305360795_0.6894845408387482"
+      },
+      "directories": {}
+    },
+    "2.0.5": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.5",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "main": "middleware.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "lint": "eslint index.js lib",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha || ^4.0.0-beta || ^4.0.0"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "gitHead": "0f9ccbe9ddf1e359c7b92f071fc4d811f83f1b7c",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@2.0.5",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-EPXudTrpQLksLt9klR0spnb7mt4dHtk3amGnohZNeQ+Y2QSqBbnWA7uNZ9+rqyfhEcYw18pUwcGIXuPFvIIELQ==",
+        "shasum": "2a1d07afb599e1993033d72c2181ec2344c15e31",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.5.tgz",
+        "fileCount": 8,
+        "unpackedSize": 28404
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_2.0.5_1518183822537_0.44983307647919824"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.6": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.6",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "main": "middleware.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "lint": "eslint index.js lib",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha",
+        "beautify": "npm run lint -- --fix",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha || ^4.0.0-beta || ^4.0.0"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "gitHead": "0d57c32aab3d238b0e5e18e9539934e7d31ba821",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@2.0.6",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==",
+        "shasum": "a51692801e8310844ef3e3790e1eacfe52326fd4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
+        "fileCount": 8,
+        "unpackedSize": 28473
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_2.0.6_1519328123702_0.4318577427701784"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.0.0",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "main": "middleware.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run lint && npm run test",
+        "cover": "nyc report --reporter=text-lcov > coverage.lcov && codecov --token=$WDM_CODECOV_TOKEN",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha test/test.js --full-trace --check-leaks --exit",
+        "test": "nyc npm run mocha"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.0.1"
+      },
+      "gitHead": "78e98794e5fff0728c1d33657cddbcc192a6ccb7",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@3.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-eoiOk7nr04ujorQp2QEbdmD+R39jGexwEfefqhT5kUBghMPzuF63JbGxgTOjimiszjRnJ0fZzvIRoYCYiq2UxA==",
+        "shasum": "ae8902596f1b1fa8f7eada874aabb64cba9cd53e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.0.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 27979
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.0.0_1519857063928_0.13977240361512822"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.0.1",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run lint && npm run test",
+        "cover": "nyc report --reporter=text-lcov > coverage.lcov && codecov --token=$WDM_CODECOV_TOKEN",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha test/test.js --full-trace --check-leaks --exit",
+        "test": "nyc npm run mocha"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.0.1"
+      },
+      "gitHead": "14de0b99cbdf2d3de54bdc24eeb5ab504d43685f",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@3.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-JCturcEZNGA0KHEpOJVRTC/VVazTcPfpR9c1Au6NO9a+jxCRchMi87Qe7y3JeOzc0v5eMMKpuGBnPdN52NA+CQ==",
+        "shasum": "7ffd6d0192883c83d3f262e8d7dec822493c6166",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 27984
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.0.1_1520343705597_0.002642415211079774"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.1.0",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run lint && npm run test",
+        "cover": "nyc report --reporter=text-lcov > coverage.lcov && codecov --token=$WDM_CODECOV_TOKEN",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha test/test.js --full-trace --check-leaks --exit",
+        "test": "nyc npm run mocha"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.2.0"
+      },
+      "gitHead": "4d53d7c4be0e1c3700d0612e1c531c0fb02ca129",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@3.1.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-UtAd5+J3IihQilwxOESie2BKaeo37yjmMSfV5G+UGEwPwqgL9+L/rShvjrfse8ARSRQGd3QwN2ANSk++KYZizQ==",
+        "shasum": "b354b17d0baa274ea3af38c6f005e66a16bdb76b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 31220
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.1.0_1522091384400_0.49701411237795745"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.1.1",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run lint && npm run test",
+        "cover": "nyc report --reporter=text-lcov > coverage.lcov && codecov --token=$WDM_CODECOV_TOKEN",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha test/test.js --full-trace --check-leaks --exit",
+        "test": "nyc npm run mocha"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "chalk": "^2.1.0",
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.2.0"
+      },
+      "gitHead": "986d69e10bb5f0fb3134fd411bb8104c2f19451f",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@3.1.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-jgi67sYoEDTx8HF1u+pskW2RT8uzdelOsoMzlR6auaayF9f571dlK1ZBit1L8mg4afvzVdDDF2k9QeTbAq7THA==",
+        "shasum": "82e175d6c34ff4d1851ce88284238bc97a5160a7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.1.tgz",
+        "fileCount": 10,
+        "unpackedSize": 31243
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.1.1_1522887646787_0.5454380260548701"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.2": {
+      "name": "webpack-dev-middleware",
+      "version": "3.1.2",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run lint && npm run test",
+        "cover": "nyc report --reporter=text-lcov > coverage.lcov && codecov --token=$WDM_CODECOV_TOKEN",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha test/test.js --full-trace --check-leaks --exit",
+        "test": "nyc npm run mocha"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.2.0"
+      },
+      "gitHead": "884664ad07c3b3693745404b2bfe1e782839361f",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@3.1.2",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-Z11Zp3GTvCe6mGbbtma+lMB9xRfJcNtupXfmvFBujyXqLNms6onDnSi9f/Cb2rw6KkD5kgibOfxhN7npZwTiGA==",
+        "shasum": "be4d0c36a4fa7d69d6904093418514caa9df3a40",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.2.tgz",
+        "fileCount": 10,
+        "unpackedSize": 31173
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.1.2_1522951453804_0.9020910818813681"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.3": {
+      "name": "webpack-dev-middleware",
+      "version": "3.1.3",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-middleware",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run lint && npm run test",
+        "cover": "nyc report --reporter=text-lcov > coverage.lcov && codecov --token=$WDM_CODECOV_TOKEN",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha test/test.js --full-trace --check-leaks --exit",
+        "test": "nyc npm run mocha"
+      },
+      "files": [
+        "index.js",
+        "lib/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.2.0"
+      },
+      "gitHead": "27b6c1af28487263d30888751982b979ff267941",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "_id": "webpack-dev-middleware@3.1.3",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
+        "shasum": "8b32aa43da9ae79368c1bf1183f2b6cf5e1f39ed",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz",
+        "fileCount": 10,
+        "unpackedSize": 31468,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa4huMCRA9TVsSAnZWagAAzBgP/jRvaH3qKM0IDqDpb412\nkV+91mJG8At6lF8YQZCzZ4F0ekRtLMDmV0sQJtUutJVMVlKSSZUaFxDgrGd/\nO4LQCqgExgEeYsCUOZsYrvPRBnYgljMWfkdOIBIC95Fc16O5XE6pKfFybIA4\n2VVQ9aknsNmf3bV08r7d3D/CpK6uU8vxV3ztXzTdJAt4/Bfz7rijvQvGrK4m\neiWyxhyJ1MK8OFeMUD640C3R+pEutbVmPaaN6FfsIrt/GZD4yVF4I4IFEFDn\nVLgr8j7hG7cfkXUZpwf8BYuH8AnkYQGgwlKwI+zgozJmS4nmPrntmC0k7N63\nZJjnNmQID/d0hnBxnMyySef4lyMTl2BHT55YMDmscIY/yAaa/KnfAigwlP/o\nrcr82y/zCCcF5NhOz71VN2+8hHj7Pxr4bvGzO3o12rxQaOKTAUKCYEBG3sbe\n7K8K3qRVU5LXiM9Ctr1nZj3O/YTsoUR96UKXkrNVe/SrzwQZ0+nYEkJYv5A+\nhdl74WegrBrFLIhy6JvT29rD39cHgxAgaZx6OySSjwPaiAIQzuzSpbos64Oj\n3NSv6HNuOtVriOWhGfyTKKgi1vhg2yrpnEULURTWBuHjzCY+e6Enu2Kz5cCY\n0Lrh2e2MspbPjWRwM2KEpmP6z50WzHxLAsKtzKh7Xq8hsk9CaUAZc6Hciss9\ng2bu\r\n=cPwR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.1.3_1524767626313_0.1533983236945673"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.2.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.2.0",
+      "description": "A development middleware for webpack",
+      "main": "index.js",
+      "files": [
+        "lib",
+        "index.js"
+      ],
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "license": "MIT",
+      "gitHead": "610e260a755f7abd1e850c416a6c456896d5e13d",
+      "_id": "webpack-dev-middleware@3.2.0",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "michael-ciniawsky",
+        "email": "michael.ciniawsky@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-YJLMF/96TpKXaEQwaLEo+Z4NDK8aV133ROF6xp9pe3gQoS7sxfpXh4Rv9eC+8vCvWfmDjRQaMSlRPbO+9G6jgA==",
+        "shasum": "a20ceef194873710052da678f3c6ee0aeed92552",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.2.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 32320,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfxOFCRA9TVsSAnZWagAAmREQAJQIEJwGnAOwrWmSq+bK\nMQSrk7RrilJCnBD7HrsCocO238TXNjRal3h2syAGBo4BzUYt6DrH69KrnGXw\nnQul9ASjR27BXtjTZjNsYJsDXeJlGUifc4/ac9OHVonNVRASsjIThI0zM6Ke\nvSZAuDVA0PY3huaaUBVIpVmBSFYR/FUuqP/ZJAPsFJi+Nsp/ZoXso8ioRI+x\nED8XiCWKzH8zW/MDuOvKyOfx9kNv2Ul+NiOP2Ll6nmPn8LvKjShGpWhsbfwp\n1MnNs/C8LNYj2J3q7UyVrCh8mU4oeYLBTx/Ixm6zY/PeP+YxPUg53vzec7X4\n/Gy/BzGeNpwdbZzfXxgsscxKC5A4F/Yxc/Q2DpcZD6oxKeebrCNxaE2oK7G5\njtQ9hzEnsdejgbOebcYKmzo0PD99tX55NIadXHkMAojTqBH8nQL5HF9kcCLa\nkZUIrTlM8hPBaxvf46UFlOIFh3/St8pOXJb/tHM4FS1g6bom3DcVrEeO4Ynd\nVAUt4brmEQqwDm7o9ES5USVs9ZUhma7gFFpRGpdqVz2xWrPl1yL3cuAds3W4\nsFqWWi3C8dQq6yf5GIVVY+LoNV2L1FVoHUs1SJR2CkovonlPbbhYz1VV0Sj+\n6B1wgO7GFFrO9BJ1hSEvHAo+ZEbFbki0KQdT0PLTfLPlhrHUIfmkRHqNQ1aB\nNoKx\r\n=kVxs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.2.0_1535054725284_0.9537904772183567"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.3.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.3.0",
+      "description": "A development middleware for webpack",
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "license": "MIT",
+      "gitHead": "0f9e2e71f2e97842cb2249b1b51f3df9def98ed5",
+      "_id": "webpack-dev-middleware@3.3.0",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "michael-ciniawsky",
+        "email": "michael.ciniawsky@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-5C5gXtOo1I6+0AEg4UPglYEtu3Rai6l5IiO6aUu65scHXz29dc3oIWMiRwvcNLXgL0HwRkRxa9N02ZjFt4hY8w==",
+        "shasum": "8104daf4d4f65defe06ee2eaaeea612a7c541462",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.3.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 32821,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbllwECRA9TVsSAnZWagAASLwP/15zbGTRTE4nLNzoWdjW\neDWDX9bQKRfm9SBH6fDGnB8eOan9AGy9PYEuPxsT7P0r6cHb+XqTs3n48wul\nEF/TM8st2oOQuQlrbvZYHKkC4Eq6QHORr8YzWyuVzcXnylrNNTcx1HQYEgO8\nz9BhMZ/Hih5MkILwUvzkJCDFxvnbj67Bd3z4R29bsuLpr7Sjxb+ZGr9vGSWb\nlaMNuhcDiYrXBUyA0FWYWj4TMWETMeB8J/Vdr7zF4juhsiEkVQAfuSpeW8C7\n9v33nXOfM9k7uNjryFvdEml+F3KIoq6bjPNye9xu/Q5fJocCFroLaKFaHtsA\niz5THb7/9cyP4zNYCKHgMKvYT/PmIueG6AlyaSb/2dNxRaMaN/EytCedXQES\nA8fGJwNxpl1SdjSKaqGbXAxavyrX3A4dzraoCXA9AdYu20k0huPSrGEfQTZU\ngi91+B4RXFsZFk5K693JTLhn4MOrtskisZDNUAfNMmRyfwiggaoy9Str75+j\n3dtgqsU/6UbItI+RQm70K9sxUenWNOYMLjqUK272hy+PTWjPsEzJ+oLNM167\nwnyiPxT8yc7J+aabSwAqP/XMrUCPI5PPl+dpocv/OF9bM6qosB9UKfR/9nqR\ner2n9vVm+iLrg1xasqn2oypDDW88rPpAK8NmwIVEpTcrUNgUXkDTJ72jAGUr\n+suZ\r\n=MPHx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.3.0_1536580611076_0.3454947993668469"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.4.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.4.0",
+      "description": "A development middleware for webpack",
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "license": "MIT",
+      "gitHead": "8a5d6615fbe03e889fd58557d970c262d2e1f3e4",
+      "_id": "webpack-dev-middleware@3.4.0",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+        "shasum": "1132fecc9026fd90f0ecedac5cbff75d1fb45890",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 32706,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqS9ICRA9TVsSAnZWagAAbPsQAILZAWvndRuCMjMoWXJo\nzIJYVVXVWrscc0HBQ+lDZkdyaww8fK9X9gA65Hf/JwERF8vAr6K8fbEjABYm\np1NnS3Zz4P4BDjpiHM1s1ZtitAxL06JjX8KmlMevTQwbEDqzWYFxaGE+9MkI\n8QFz1JkhOkQUeEH8K6/lnov07Pc8PBKKqUrteRq0FA5dSp6hO4pV1P8UY0Q4\nXnrnVWv2AdPMtoPPDE/RqN5fzlRh0Wr+hbZYAUV0CQLlEyHG0JedDkGe8RZm\nVuJ9zRPhF5gPIePGCDFP9asWnWKNwFkGMHZtO9J4rQAzI5xsO9h32EyVWZvW\nBuY0uTnlrcWtkHypidGurUQXEyfcm+nLQeOI8p9+LhTj3HB0cCKnBEL9lt9m\nS42TEaCN870sG/BOLcQwkSm+uGsr1QxVmvZQrtL2JY7bxHAtMZV1cqkfLn60\nXUO0wzrueQQu1Q8gn39SLOIJSv27WskEahr2EZTH+RIv6vHKIW0KYsokQZoa\n4V5pW/TbqoLE8jwvSMgjM7NnXBLvrESWvMC4xRjLPrYDWK+GFrASHWbNM1U7\nveA1Sh0jWgIwmQ5XkAlgeyR7iyEMPEI5/Hardo34khhhzUQQN5Z2yzU/2sVl\n59wrKG6Nmnk4ospLOEH3vsiiM3MUFw1gFYPr4Yi0T4Yvtt5y2BuTmcg3x8sg\nh6Yl\r\n=R834\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.4.0_1537814344006_0.27871491692630324"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.5.0",
+      "description": "A development middleware for webpack",
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "license": "MIT",
+      "gitHead": "0e8ac8259e2802a2e2e112e061f095534e7f2667",
+      "_id": "webpack-dev-middleware@3.5.0",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.15.0",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-1Zie7+dMr4Vv3nGyhr8mxGQkzTQK1PTS8K3yJ4yB1mfRGwO1DzQibgmNfUqbEfQY6eEtEEUzC+o7vhpm/Sfn5w==",
+        "shasum": "fff0a07b0461314fb6ca82df3642c2423f768429",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.5.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 33716,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcL6DxCRA9TVsSAnZWagAAWMUP/Ak97JjoW/AFKKPoMb2+\nmi9zUsPnGJo1BxswrZvlMak89Jaq85xwoec8xk+HcKBZJhhTgICAZH9itet+\nssl3DwrqSnWD6zVEDCPXzeCMt7bNwABaULwafSbtbQkvpUycLB+Q6v3ZsH7L\nN78OQ6vZvzLT4Wvxfk+pO62NT20QhO/XbpXCV4BDxXoYKz5aSI+NRV/AdnjO\nQcd6G2nA+iNwBrj+DVSFco/d0ibf5rTlAo0OPSIdm303pB0mtLzm1DD5QZ0U\nDQ6lxTjBe3iU9dvjelAaSvQEqo3YuYr4Pjh3EmWZ/dxpHcd9WycmTAxv0f8b\nBkDavmZgFY1d+alPCIw6/jKQbM+ZNVe04EO3p6hhjIrCh5pXEUdGYkXXfwbR\nlExBrXq0SGX9rUp9yjclaY1iHhDaLKd7RaCaxFheljD4ctvLqqpVjnDp8BAa\nBPky+sCUyA89ItLNpfUC6dUSgWLxz27DDoIqIZRMKI9LOqROLt1mYKMFEJoe\niCoZGQJ3mgy4bUI+YXAGUO7I6rX+X/WGY9KLvNKgA42U4iNje/g9rpqGVruo\nX9MJJ/avfuVTSp/jjbNZDFo/WO3pEQpi8xHwtKJGDFvMqC+kIik4hgqqFPT7\nLGEw2UvjRWhmxe6m52Q7MBCuucPBVU6NuWwBIXTmCJoHhEMXceqfvFcTUROW\n/frQ\r\n=QYRk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.5.0_1546625264241_0.9738603863135553"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.5.1",
+      "description": "A development middleware for webpack",
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "mocha": "^5.2.0",
+        "nyc": "^13.1.0",
+        "sinon": "^7.2.2",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "license": "MIT",
+      "gitHead": "71c3e20fa0fe59d5dcfebdd64f5fda55dd8f2ab6",
+      "_id": "webpack-dev-middleware@3.5.1",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.15.0",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-4dwCh/AyMOYAybggUr8fiCkRnjVDp+Cqlr9c+aaNB3GJYgRGYQWJ1YX/WAKUNA9dPNHZ6QSN2lYDKqjKSI8Vqw==",
+        "shasum": "9265b7742ef50f54f54c1d9af022fc17c1be9b88",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.5.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 34134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQGr3CRA9TVsSAnZWagAAUQkP/1wSS4bVQHvKL+/gxUye\ngqHqpeVdLIIKEH6maZeEs9UsvcQo9SKyFKewhLpswWQGKeygGrglX+4gVHSL\nspRetHUValgAQAb4bbKKKnHy0TmCflQEWBrafkZ6Y3DrBP5+zeLv0wNb3CSr\nCF8O+5ifnZSoO//yUftKdbev2TVp2s6LM6UqP7D87Sn72afkLBCbH4xFHwKv\n7o1Mg4OITLtwUEC31gVhcHfqfQUIA+yBAxzWx/KHpzubunZ2QkuslJiWZ3vX\nLxHhKzSBQhCJxFcLwi4cXU5fzRljOJym1AIxO1cugl/i1Kuu0oxgHGD5WXOz\na0o+a6umrHd+S5344oG+ss0cHc7gKxBW+IDD21e+Uzkm9HpHMbVesKT5Zv3H\ny9MXdnyLoWGlQ/tm5uVKPIL6QBe86ywegrRBqxNKSPIDCvClZCtfghvzJBNX\nWD0rjzmI9rXFW59UpG1K5q+Se3CmH8Q3gHmga2tJFoGmblJjJ7RDa3KJjxg0\nxbTOdUf4epSxJZG2s4KRnsggEc7jc+FjINTpOtA/hlYCeA4je8t1c+1CGNz/\nUmUDokmZXgJRVbCCEa43PDilr/39ycj27gx7KE1r6aaREUz26DVTdVfjhznT\n9AB1x2mz6stxgqoqVvfJRJByRQMnWWF0hSLpcJ7smy/M+4MEXZOGq7l2g0zF\necTH\r\n=Lgka\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.5.1_1547725559124_0.1743829949580955"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.2": {
+      "name": "webpack-dev-middleware",
+      "version": "3.5.2",
+      "description": "A development middleware for webpack",
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "mocha": "^5.2.0",
+        "nyc": "^13.1.0",
+        "sinon": "^7.2.2",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "license": "MIT",
+      "gitHead": "8e54af29ec18c01c0032300049c4d7333c09b707",
+      "_id": "webpack-dev-middleware@3.5.2",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-nPmshdt1ckcwWjI0Ubrdp8KroeuprW6xFKYqk0u3MflNMBXvHPnMATsC7/L/enwav2zvLCfj/Usr47qnF3KQyA==",
+        "shasum": "d768b6194f3fe8d72d51feded49de359e8d96ffb",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.5.2.tgz",
+        "fileCount": 11,
+        "unpackedSize": 34548,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcW06YCRA9TVsSAnZWagAAwZcP/3zKHLp4bT0sOZbH1k6g\n7MApFtGpIsiIMU9N5ndHNvV7nkSv+wyH0nWAY2IdzKI/RGWqqyQY8GmBvMrh\nK+ODoxA6dnJv4B7HNi1TcV9iaoGUta5D70g0p4P51S4pOkpnkE7oyTE6e6cM\nFDOA0HdY5i4th0/yW0qTAI3GGGg/Onnu12ZHEwyh+2nW2PJyRloj7j91l0iw\nD9SNMbIAhTaTKyLQLpxjGDHNehuiy4sJ+yrtUdJDAv0IcL/zTFAkKuQ6oeNd\nLSYspOuZ+JJGmOKVJFDmllHhoxRKJs9bHj/4u+OM/gCQSet7Rq59GL4nqure\n3vcltKKW0i2DANL9ik7f294l4EraIQcrX20LH8uePIEgfCG+7I4qt2BOIc/K\n7ZORc0bb+h7AJwdcJhaBYtN/pj8zBkS4Zf4LVUwU3Lh6b4x7VZDgp+AzKENj\n5aTSPRcY6l0hhSwnXRCdHyQ/nrUKS00cDwhZGdtZXIOt6DRZ30W3iBRvGig9\n1FvKzHGtFtgyZFDJkMgRHM1vR7IgRMVMnEeP4g7vxYWDYFcaCjbDOJTQDyIv\nvkomMUwS3TBkHjTHPHq+N9muExU4rqHVnH7ce8zuWPoDg7rCHC45rzm1ifV1\nfobV6+M9VRfXbqLTYmXlGLzAuMejJJeFswmti7q0He8IF3jo3rPR6tX7yfFo\nC+mj\r\n=kHvf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.5.2_1549487767911_0.5689181410441735"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.6.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.6.0",
+      "description": "A development middleware for webpack",
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "mocha": "^6.0.0",
+        "nyc": "^13.1.0",
+        "sinon": "^7.2.2",
+        "standard-version": "^5.0.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "license": "MIT",
+      "gitHead": "e5bd8f8d1b12543938601f1daab40e6173db7489",
+      "_id": "webpack-dev-middleware@3.6.0",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.8.0",
+      "dist": {
+        "integrity": "sha512-oeXA3m+5gbYbDBGo4SvKpAHJJEGMoekUbHgo1RK7CP1sz7/WOSeu/dWJtSTk+rzDCLkPwQhGocgIq6lQqOyOwg==",
+        "shasum": "71f1b04e52ff8d442757af2be3a658237d53a3e5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 36029,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcbAkzCRA9TVsSAnZWagAAzekP/04vox/TgPoYXQnbADCz\nadmM98VHSnD74oMQz1K33qu9BBJ0yNMzhr5jl9pO/GTnRKRT8KtEWIexsgE9\nAlAmRAxL2Kl70RMChvLb1qZAEbGnSC4KLMLJ30s/tiWP5DjY7lbgqgyMJrBh\nK6Ml3Q+ubLqnq78iWX23Bo1LTaVSS9xhrt4SYWpWHA0o04/Q5CaAIyglZgZS\n5su5lpgTeVNEHg0fJ1Z8ZVGC/645Rp6+3k9OzVeb+WRIMWNDLt8I/dl6R4kY\nIqwEVl/vLkV3GCPOLwBiYVAApBJbeWAR1vZPwPiSJLaCZsMynIBpF/0uZ41i\nhcNUJi21XIKdnyvyawhQaGtSs8Po5RI5wKVitf7KgqPegQigEbikPnaM5I6D\nHRgJmlGQCIObeb/lnMd+UXmOjNDKlWmNacDwPjWNwh1VI6XeoyuA66+WqmdE\nkpwBDPYRJZRrdTZEyM82Lrt627OtsGDzF5m4q6x862n1WMNCqTsETkuimjh1\noHJV4eoFO4HJoN3wbr638/m+EG6WS1/TvwOrh61s1Ap6mfK5ezlGfmSpVNvC\nzfadEbmAHNQ3wRFNLRW3SA26n+YJwhyDenHhVEeFPqkGkOSViPDvJpplrsi0\nWA+19qf1nbNCnTR9hkPQa08areH6URxrstTJ7muLv8Na/1unxTI3phS/0v8D\nBG0n\r\n=GR6h\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.6.0_1550584115206_0.25482124999895883"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.6.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.6.1",
+      "description": "A development middleware for webpack",
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "mocha": "^6.0.0",
+        "nyc": "^13.1.0",
+        "sinon": "^7.2.2",
+        "standard-version": "^5.0.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "license": "MIT",
+      "gitHead": "894ba2b5f84ff191c5cb2b7cc565f27661946cb6",
+      "_id": "webpack-dev-middleware@3.6.1",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.8.0",
+      "dist": {
+        "integrity": "sha512-XQmemun8QJexMEvNFbD2BIg4eSKrmSIMrTfnl2nql2Sc6OGAYFyb8rwuYrCjl/IiEYYuyTEiimMscu7EXji/Dw==",
+        "shasum": "91f2531218a633a99189f7de36045a331a4b9cd4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 36104,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcf+5MCRA9TVsSAnZWagAATREP/R2i0IfojUQflCYQkQO1\n/DIRyg1UtUMmilWK6r33hodM7ThepiXW5ybQyOfv5OxRqXuhPX5CVv4ayop2\nZwhJZ+P488NWXLfRZI8vMHegofQ5zmUMwXpNHdDJCYQXUCdZpyK6TqQo3z4M\nqAwtUnPB8TtByhS9W3s6CIPtYJuJtm9/MW8/3Jo5u3h+tzbHFaopKaDSlnbD\nHVV/uQsOd/Fufm2GqSEBAiVT+hnAevuRFQ5pOLCZw0xBEZa1uOFvxfdZEa3W\naTAkXY/q+Hh/jD3ba2O53mSbstDyAsoGlpthhBbI6GRjP+qL/0W5I0AmL7WU\nLn0dEjcd047EGootqFIzoUDEP5KpMJiGicFDOeKxKSJXoDi5O3wXa0WlxWfz\nCRqXdY2vCBTYjzmsWmDPRSZXeHx5u/52z5Od7Fenwq8s/cK9L7V/12dYT1w2\nyrexQCtL1NL3RI9U/8RPCkcM6K5l9rmNbcpjH+lnB2ZLvnP1DIy/UdbbHY+/\nMT+WYdBFLnT9MaaN+9sBaOgT1u16T6rpYaRitoCMbBJcZEpAxTZfhMP7q2Li\nyb/aEhuwwF6RMLzjOjXZ1M9qQMdwewlXJZpV6h1txWiehh3sSQGb4FeIfASv\nJQIlZRdjFzRjWJpcypyBELBpWk36WFoc88jAjAEn6mEB9JffdXM0+px1pay6\njgm+\r\n=aTx4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.6.1_1551887947676_0.7583881498587799"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.6.2": {
+      "name": "webpack-dev-middleware",
+      "version": "3.6.2",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint index.js lib test",
+        "pretest": "npm run lint",
+        "test:only": "jest",
+        "test:coverage": "jest --coverage",
+        "test": "jest",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "develompent"
+      ],
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "assert": "^1.4.1",
+        "eslint": "^5.15.3",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "husky": "^1.2.0",
+        "jest": "^24.5.0",
+        "lint-staged": "^8.1.0",
+        "prettier": "^1.16.4",
+        "standard-version": "^5.0.2",
+        "supertest": "^4.0.2",
+        "webpack": "^4.29.6"
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged",
+          "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+        }
+      },
+      "lint-staged": {
+        "*.js": [
+          "eslint --fix",
+          "git add"
+        ]
+      },
+      "commitlint": {
+        "extends": [
+          "@commitlint/config-conventional"
+        ]
+      },
+      "prettier": {
+        "singleQuote": true,
+        "trailingComma": "es5",
+        "arrowParens": "always"
+      },
+      "gitHead": "7942228c392304b26a079da69a4e71590eaf4fdc",
+      "_id": "webpack-dev-middleware@3.6.2",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-A47I5SX60IkHrMmZUlB0ZKSWi29TZTcPz7cha1Z75yYOsgWh/1AcPmQEbC8ZIbU3A1ytSv1PMU0PyPz2Lmz2jg==",
+        "shasum": "f37a27ad7c09cd7dc67cd97655413abaa1f55942",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.2.tgz",
+        "fileCount": 11,
+        "unpackedSize": 38047,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcpKiDCRA9TVsSAnZWagAATVIP/3yJY7jXEi45iughnMWz\nTSi60Xo66qvSwNSZqhKXTb9OziBr8KH8mXzEojMYmRe4kM7dUa60qYkOtvdc\n71HG+iRGvxp63qHbTwDzQCsKV/Zt0sG1sldgtZo6WSFR49TJR5hqMLuumME/\n7up6dfh7WpseG+TEr5K0c76D0FNljNfceNOkmtdVF5WyjhoWnFZFLK7GTTk4\nczt6NdDrImgiK+lvB0TjfjTB9flRz/Ptd08Wj5yRWhqJaaxV/gYX1fys4pYl\nH3eoDm7ojBg9YkZEasVL7DYDjkBN9G4sMLSaRS8W2nYLHLgnmZUt9vuXXppl\n3MA7+64ZluKUM/8apvsm6HaUdHx2GXnG/8CkA1KdCRyHMBiuF+HkuYjOvVsa\n/3T1JneuyC9yHT05ynNcIzylJh1fAP3HvHo9yvfZqxvM95qwfPSXorfihkEX\njMbdlYHjOYqTDNBSkO5gKkO2G8DQ4x25uulj1fDJZ6M/zF0g4LoWBkcV3Kua\nNam7AipqGpQSarWcTjngEh68NNK9EMvoKsBvznhVkMKOcXvEeKj/OANKcoPb\nz7hh+JJ4uRRR2Yl46z4JxKZlHKLWhoVrwVB0SXuBAxgh2S+mQOKOXQ0jOXY0\nN9bHsuRzVOllia13EQH1n7+A0/TfxpGxKoBnu+2qtHOurkPtpFHRHMpk5xrR\nRrJs\r\n=vRmd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.6.2_1554294914793_0.5631843652116963"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.7.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.7.0",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint": "eslint --cache lib test",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "jest",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:only --watch",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.2",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "7.4.4",
+        "@babel/core": "7.4.4",
+        "@babel/preset-env": "7.4.4",
+        "@commitlint/cli": "7.6.1",
+        "@commitlint/config-conventional": "7.6.0",
+        "@webpack-contrib/defaults": "4.0.1",
+        "@webpack-contrib/eslint-config-webpack": "3.0.0",
+        "babel-jest": "24.8.0",
+        "commitlint-azure-pipelines-cli": "1.0.1",
+        "cross-env": "5.2.0",
+        "del": "4.1.1",
+        "del-cli": "1.1.0",
+        "eslint": "5.16.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-prettier": "3.1.0",
+        "express": "4.16.4",
+        "file-loader": "3.0.1",
+        "husky": "2.3.0",
+        "jest": "24.8.0",
+        "jest-junit": "6.4.0",
+        "lint-staged": "8.1.7",
+        "prettier": "1.17.1",
+        "standard-version": "6.0.1",
+        "supertest": "4.0.2",
+        "webpack": "4.31.0"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "develompent"
+      ],
+      "gitHead": "81bc1f7341edd5d67f6e4d931044aea5b939354e",
+      "_id": "webpack-dev-middleware@3.7.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
+        "shasum": "ef751d25f4e9a5c8a35da600c5fda3582b5c6cff",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 38676,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc28j2CRA9TVsSAnZWagAA080QAJ7bsBkb+BMMfFdw7yM7\nahKLp4aTTjYD443cPR+OiWbY1YpqG/WVvNCP8rxgQXwePfDM9yq11xl6SBes\nj9XKnCuqCMeRRRwrhy8aFDXFLaDuDw7e/rHE4UI7765OUqmG/g4frnBtGbIp\nrGlnC7oMu9PKFbVx0Jn0Vsp4a3A9HS3uJ9TclvsW8cMNS9jgpjiIvgw73HSi\npYA/IFbT6yfwpR7H8VAz0qE9w4mqOg9d2HQH1DVDzt0NLTKs//wT50NrVShS\n34qa/Ra+EFIpQBMTQVKGI0g6NTKffFzGIhk7V5rpzqoCN4ZdtYol0XZL++KK\nRiLVaEpAtOtGKxGXBLAq/TQ+uApr7Cn+gmliNpibNdbmz+8Dr/8SoonpGvLl\nDh5esfrgjUPWWp1pQQjV2V9HDeMqPeXX6XJzLSrNxeqE5OfZMU+5SXCPwit4\nrg6EK27SQ2rQ8QVnvefygLfcPXb0OSOIZ3EqDVAR1dGjcDKHK6b4qbWVaL7q\n89JQ3TG4Pp2gao5DBSNV25pt0dPZQW4da5eX+uQ/yGQ9aYqENKuW/fWWCg6R\nTUnQ2vyOOffIBnjpPbHWGLEDQTxcsm+RX8c6Jh5N7KQIqp0DyBO67jqPHUWE\necb2OoQoVP5Cxjy1E2scXEqaw8qNwQOTwR9yONzFOIh/IyKduzaDR8N8IFdk\nW4WE\r\n=Ll8w\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.7.0_1557907701453_0.9592196316816639"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.7.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.7.1",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint": "eslint --cache lib test",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "jest",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:only --watch",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.5.5",
+        "@babel/core": "^7.5.5",
+        "@babel/preset-env": "^7.5.5",
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.1.0",
+        "@webpack-contrib/defaults": "^5.0.2",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^24.9.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "cross-env": "^5.2.1",
+        "del": "^4.1.1",
+        "del-cli": "^1.1.0",
+        "eslint": "^6.3.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-prettier": "^3.1.0",
+        "express": "^4.17.1",
+        "file-loader": "^4.2.0",
+        "husky": "^3.0.5",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "lint-staged": "^9.2.5",
+        "prettier": "^1.18.2",
+        "standard-version": "^7.0.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.39.3"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "develompent"
+      ],
+      "gitHead": "48fb647ce49a4a50589fc6f2a8282d5b22e918f9",
+      "_id": "webpack-dev-middleware@3.7.1",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.11.2",
+      "dist": {
+        "integrity": "sha512-5MWu9SH1z3hY7oHOV6Kbkz5x7hXbxK56mGHNqHTe6d+ewxOwKUxoUJBs7QIaJb33lPjl9bJZ3X0vCoooUzC36A==",
+        "shasum": "1167aea02afa034489869b8368fe9fed1aea7d09",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 39430,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdbkMGCRA9TVsSAnZWagAAnFYP/1AZqdjx8B8euZWzOURy\nRN49xNsBKj13bfX7cPmOHXUhuR6gTsau2oL+pYZ/Puthx3ulxd2BH/7u8UQQ\nRjWOBJJzANRsdcYmLmJNaULjvqAPdYO3ntUgSRnmrLN/Qmh3j17W0ZTABcYe\ns/iv85zqBumzY6dj6stva+iBgFEbn1cOAHi9hfh8e3N2nAocdOpwrgWfjyh4\nfNJQ2szJgfZv8GleZT/JH8rmTAqhUyKe6ZuBEHEzSNgQ8YE4FwlrrUwZllM2\nfNlPEH+0GrOVJb/r7JSth32TDAPCPdyhtu5HLhCp3/Qt2DWyexMmzXOHgsQZ\nfy9OzHg5FFQfU6gZTtPFyuAb0LrbWa0/KQeBZTxFm7c5XG6hVC/SoiUdq3F6\nbWXh0H9DTA6VVMflagk46FCr5R4yLxfGvmUE9SysTuq4bQL3dXd5dkthj8t5\nLagLdwXmPEImrTFQ3h7OM2IVc1uBksx4gKBzi378uvneZmLZQxDWBL6agBPi\n1wj8vHhqkFZR6bj8KYNlcKR0uJCfhsd7PmTXub2kFhVhTBLzE4zn4zgA5WLN\n6Jerfh+dwDjxW+Nx4Txbm0KDheqJSuPIo2MZwMYFJX1J6nOWwPPYYP0AbnZu\nHZl//wUwPMBxRxADppRWF4Uxgok4JGBuIagKXjKW+/Dt74agVEsbDVU2w2A6\njeFg\r\n=3CcS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.7.1_1567507206109_0.8341572747008776"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.7.2": {
+      "name": "webpack-dev-middleware",
+      "version": "3.7.2",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "index.js",
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint": "eslint --cache lib test",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "jest",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:only --watch",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.6.2",
+        "@babel/core": "^7.6.2",
+        "@babel/preset-env": "^7.6.2",
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "@webpack-contrib/defaults": "^5.0.2",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^24.9.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "cross-env": "^5.2.1",
+        "del": "^4.1.1",
+        "del-cli": "^1.1.0",
+        "eslint": "^6.4.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-prettier": "^3.1.1",
+        "express": "^4.17.1",
+        "file-loader": "^4.2.0",
+        "husky": "^3.0.7",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "lint-staged": "^9.4.0",
+        "prettier": "^1.18.2",
+        "standard-version": "^7.0.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.41.0"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "develompent"
+      ],
+      "gitHead": "68ae47b1838dbd08f83b7e10099a0eaebdc311e1",
+      "_id": "webpack-dev-middleware@3.7.2",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+        "shasum": "0019c3db716e3fa5cecbf64f2ab88a74bab331f3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+        "fileCount": 11,
+        "unpackedSize": 40311,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdj30xCRA9TVsSAnZWagAA8WsP/jow9mm85sBky7L+oO25\nRaNWNWTRm4BMCn+I1LX2Ab7beOeWs3drZkrE2fIYC9a8Q1S1mCmHujVXe0fK\n30JyllCxOWZ9fm9sb84+GPM2M8Z+ILJnQLTMBZmBdyHKdyZRJvBDHZ6XyacX\nkNpRKOzHs957uCKiq44Vtfft0sjnIo9IcXaVCvX6BL1lkPDLuq3VynHybvkk\ne8ejZy3Zy97Io6u9OKrr/T8QSITOLnoou3QEQP9qCznBBqYenzCm5KYg4afo\njmO6E1TCO8s3BoTRzedmXfL0MJwpLQ3azftlGKicVb1JSR/SnJyFfks2qVUA\nFRubxXeNzwlzo5SaHPevWDZ90DMioOjsciu+oK7ZJsSHU1q85ZTltYu7PlLG\nXyb/afTCrjbFJhE6DL3I9GVayg087A0I/tNLzjo2x2TaQZMZCX0NyzJGn/+I\n5pMeqrBxlrlBFGlw4ZPhRQ8G9BMxZUerCvhCuqZojuBsrpkudivv9Nv42GI/\nUSuHiw/hnGgpQAA8JJp/zfc6e59FFTORhXJwdzJ9SJ+1/fculyn1HjUAeZya\n4j3Ie+3MZh5YfHW49dYB5bZ77ZPLpaI0csVgCale8pYhy+kulScjV5GUV9sU\n/namMgVy0GtSxAdG5E4Zce5cwYYIQWzo3KIyPsMR04N9XMKJkxIATuPV6JLw\nZhYh\r\n=NxT+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_3.7.2_1569684785006_0.539944771613712"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0-rc.0": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0-rc.0",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "dist/index.js",
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint --cache src test",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "prepare": "npm run build",
+        "build": "del dist && babel src -d dist",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "cross-env NODE_ENV=test jest",
+        "test:watch": "npm run test:only -- --watch",
+        "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "mem": "^6.0.1",
+        "memfs": "^3.1.1",
+        "mime-types": "^2.1.26",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^2.6.4"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.8.4",
+        "@babel/preset-env": "^7.8.4",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^25.1.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "cross-env": "^7.0.0",
+        "del": "^5.1.0",
+        "del-cli": "^3.0.0",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-plugin-import": "^2.20.1",
+        "eslint-plugin-prettier": "^3.1.2",
+        "express": "^4.17.1",
+        "file-loader": "^5.0.2",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "jest-junit": "^10.0.0",
+        "lint-staged": "^10.0.7",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "standard-version": "^7.1.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.41.6"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "development"
+      ],
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n[![size][size]][size-url]\n\n# webpack-dev-middleware\n\nAn express-style development middleware for use with [webpack](https://webpack.js.org)\nbundles and allows for serving of the files emitted from webpack.\nThis should be used for **development only**.\n\nSome of the benefits of using this middleware include:\n\n- No files are written to disk, rather it handles files in memory\n- If files changed in watch mode, the middleware delays requests until compiling\n  has completed.\n- Supports hot module reload (HMR).\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-middleware --save-dev\n```\n\n_Note: We do not recommend installing this module globally._\n\n## Usage\n\n```js\nconst webpack = require('webpack');\nconst middleware = require('webpack-dev-middleware');\nconst compiler = webpack({\n  // webpack options\n});\nconst express = require('express');\nconst app = express();\n\napp.use(\n  middleware(compiler, {\n    // webpack-dev-middleware options\n  })\n);\n\napp.listen(3000, () => console.log('Example app listening on port 3000!'));\n```\n\n## Options\n\nThe middleware accepts an `options` Object. The following is a property reference for the Object.\n\n### methods\n\nType: `Array`  \nDefault: `[ 'GET', 'HEAD' ]`\n\nThis property allows a user to pass the list of HTTP request methods accepted by the server.\n\n### headers\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to pass custom HTTP headers on each request.\neg. `{ \"X-Custom-Header\": \"yes\" }`\n\n### index\n\nType: `Boolean|String`  \nDefault: `index.html`\n\nIf `false` (but not `undefined`), the server will not respond to requests to the root URL.\n\n### mimeTypes\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to register custom mime types or extension mappings.\neg. `mimeTypes: { phtml: 'text/html' }`.\n\nPlease see the documentation for [`mime-types`](https://github.com/jshttp/mime-types) for more information.\n\n### publicPath\n\nType: `String`\nDefault: `output.publicPath`\n\nThe public path that the middleware is bound to.\n_Best Practice: use the same `publicPath` defined in your webpack config.\nFor more information about `publicPath`, please see [the webpack documentation](https://webpack.js.org/guides/public-path)._\n\n### serverSideRender\n\nType: `Boolean`  \nDefault: `undefined`\n\nInstructs the module to enable or disable the server-side rendering mode. Please\nsee [Server-Side Rendering](#server-side-rendering) for more information.\n\n### writeToDisk\n\nType: `Boolean|Function`  \nDefault: `false`\n\nIf `true`, the option will instruct the module to write files to the configured\nlocation on disk as specified in your `webpack` config file. _Setting\n`writeToDisk: true` won't change the behavior of the `webpack-dev-middleware`,\nand bundle files accessed through the browser will still be served from memory._\nThis option provides the same capabilities as the\n[`WriteFilePlugin`](https://github.com/gajus/write-file-webpack-plugin/pulls).\n\nThis option also accepts a `Function` value, which can be used to filter which\nfiles are written to disk. The function follows the same premise as\n[`Array#filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)\nin which a return value of `false` _will not_ write the file, and a return value\nof `true` _will_ write the file to disk. eg.\n\n```js\nconst webpack = require('webpack');\nconst configuration = {\n  /* Webpack configuration */\n};\nconst compiler = webpack(configuration);\n\nmiddleware(compiler, {\n  writeToDisk: (filePath) => {\n    return /superman\\.css$/.test(filePath);\n  },\n});\n```\n\n### outputFileSystem\n\nType: `Object`  \nDefault: [memfs](https://github.com/streamich/memfs)\n\nSet the default file system which will be used by webpack as primary destination of generated files.\nThis option isn't affected by the [writeToDisk](#writeToDisk) option.\n\nYou have to provide `.join()` and `mkdirp` method to the `outputFileSystem` instance manually for compatibility with `webpack@4`.\n\nThis can be done simply by using `path.join`:\n\n```js\nconst webpack = require('webpack');\nconst path = require('path');\nconst myOutputFileSystem = require('my-fs');\nconst mkdirp = require('mkdirp');\n\nmyOutputFileSystem.join = path.join.bind(path); // no need to bind\nmyOutputFileSystem.mkdirp = mkdirp.bind(mkdirp); // no need to bind\n\nconst compiler = webpack({\n  /* Webpack configuration */\n});\n\nmiddleware(compiler, { outputFileSystem: myOutputFileSystem });\n```\n\n## API\n\n`webpack-dev-middleware` also provides convenience methods that can be use to\ninteract with the middleware at runtime:\n\n### `close(callback)`\n\nInstructs a webpack-dev-middleware instance to stop watching for file changes.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed once the middleware has stopped watching.\n\n### `invalidate()`\n\nInstructs a webpack-dev-middleware instance to recompile the bundle.\ne.g. after a change to the configuration.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\nsetTimeout(() => {\n  // After a short delay the configuration is changed and a banner plugin is added\n  // to the config\n  compiler.apply(new webpack.BannerPlugin('A new banner'));\n\n  // Recompile the bundle with the banner plugin:\n  instance.invalidate();\n}, 1000);\n```\n\n### `waitUntilValid(callback)`\n\nExecutes a callback function when the compiler bundle is valid, typically after\ncompilation.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed when the bundle becomes valid. If the bundle is\nvalid at the time of calling, the callback is executed immediately.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\ninstance.waitUntilValid(() => {\n  console.log('Package is in a valid state');\n});\n```\n\n## Known Issues\n\n### Multiple Successive Builds\n\nWatching will frequently cause multiple compilations\nas the bundle changes during compilation. This is due in part to cross-platform\ndifferences in file watchers, so that webpack doesn't loose file changes when\nwatched files change rapidly. If you run into this situation, please make use of\nthe [`TimeFixPlugin`](https://github.com/egoist/time-fix-plugin).\n\n## Server-Side Rendering\n\n_Note: this feature is experimental and may be removed or changed completely in the future._\n\nIn order to develop an app using server-side rendering, we need access to the\n[`stats`](https://github.com/webpack/docs/wiki/node.js-api#stats), which is\ngenerated with each build.\n\nWith server-side rendering enabled, `webpack-dev-middleware` sets the `stats` to `res.locals.webpack.devMiddleware.stats`\nand the filesystem to `res.locals.webpack.devMiddleware.outputFileSystem` before invoking the next middleware,\nallowing a developer to render the page body and manage the response to clients.\n\n_Note: Requests for bundle files will still be handled by\n`webpack-dev-middleware` and all requests will be pending until the build\nprocess is finished with server-side rendering enabled._\n\nExample Implementation:\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({\n  // webpack options\n});\nconst isObject = require('is-object');\nconst middleware = require('webpack-dev-middleware');\n\n// This function makes server rendering of asset references consistent with different webpack chunk/entry configurations\nfunction normalizeAssets(assets) {\n  if (isObject(assets)) {\n    return Object.values(assets);\n  }\n\n  return Array.isArray(assets) ? assets : [assets];\n}\n\napp.use(middleware(compiler, { serverSideRender: true }));\n\n// The following middleware would not be invoked until the latest build is finished.\napp.use((req, res) => {\n  const { devMiddleware } = res.locals.webpack;\n  const outputFileSystem = devMiddleware.outputFileSystem;\n  const jsonWebpackStats = devMiddleware.stats.toJson();\n  const { assetsByChunkName, outputPath } = jsonWebpackStats;\n\n  // Then use `assetsByChunkName` for server-side rendering\n  // For example, if you have only one main chunk:\n  res.send(`\n<html>\n  <head>\n    <title>My App</title>\n    <style>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.css'))\n      .map((path) => outputFileSystem.readFileSync(path.join(outputPath, path)))\n      .join('\\n')}\n    </style>\n  </head>\n  <body>\n    <div id=\"root\"></div>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.js'))\n      .map((path) => `<script src=\"${path}\"></script>`)\n      .join('\\n')}\n  </body>\n</html>\n  `);\n});\n```\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, or would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nPlease take a moment to read our contributing guidelines if you haven't yet done so.\n\n[CONTRIBUTING](./.github/CONTRIBUTING.md)\n\n## License\n\n[MIT](./LICENSE)\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-middleware.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-middleware\n[node]: https://img.shields.io/node/v/webpack-dev-middleware.svg\n[node-url]: https://nodejs.org\n[deps]: https://david-dm.org/webpack/webpack-dev-middleware.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-middleware\n[tests]: https://dev.azure.com/webpack/webpack-dev-middleware/_apis/build/status/webpack.webpack-dev-middleware?branchName=master\n[tests-url]: https://dev.azure.com/webpack/webpack-dev-middleware/_build/latest?definitionId=8&branchName=master\n[cover]: https://codecov.io/gh/webpack/webpack-dev-middleware/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-middleware\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n[size]: https://packagephobia.now.sh/badge?p=webpack-dev-middleware\n[size-url]: https://packagephobia.now.sh/result?p=webpack-dev-middleware\n[docs-url]: https://webpack.js.org/guides/development/#using-webpack-dev-middleware\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-middleware\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "ae2dec9e009bfc2d4468b0d709365586cfdcef84",
+      "_id": "webpack-dev-middleware@4.0.0-rc.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-5GHdz0zg26jcMaSBLzOaSd/C/UjtT0dLvZGslhWU3vO4wFVQflFF6KLjTWV69B5TnuDQPA2eqfP6nhofogXG9A==",
+        "shasum": "9b0bdb43f5fd2b8bd18ae743661e57c1c8570a1f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 39089,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTSR9CRA9TVsSAnZWagAAM7oP/AmZ4SgYrUsC2qwZsnMW\nVXAIf/+q6EXBrIgC8fP7XIAx1a6f/ui/ipyUB9y5z8fRJeDeXqz9x4V6tIv5\n8xgAaMFMTBTLMe6/DOWKF7s4+TzsP7soe50ETVLCxHopMKDDXI/7uBpilBE/\nIpIEgJD6/nLd9Xs9pS1Nac61AQ4TeSW7Fp4cedGYq00w7gNfVmbTzLAgjUIL\nteghEJYP6dTX3zqhL4juBDl/jtgW8UAj2CRid/1kPalJwKX/cZnB9oaIBnmi\nF670xivGaGjJcsYEVkbRYAPQvsdveiJ6TagodxOwYEvyrsR44k9kmTxMYkFt\nnUwPhuMcsKdz29pGqds66yxF8LhS9U3V/liQ52RLOo3HSHq5nOaXjw3BgVLN\n64GyB2XjNZpB0zEQigsB5Yr6g7TEoJxka6jBipoQQMlEjcVGxSpxxoathmcl\n8BaS2AjTwZoslB3Pq+/3IkdaDOcBKCYmub/8O2mSDCodOjQSw4erCYTPsjUB\nC95NS4jo4TrvhEOERLDopxscqXQ5Y862XGexNSGQBl498VK6lVxqIIHN1MEH\nYpsAbV/APbmqKCMfac+/DY/3Yg00a87s9MSWDza3QAJBycz0GGbf01ZbAiV7\nH48L+r8dc1P5tnIgNhlFMmLJ0eWxbCXFo+SiBLAY2bqMIT9t+IniMKc/+BVp\nVbrM\r\n=J9b3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_4.0.0-rc.0_1582113917325_0.38051374533767435"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0-rc.1": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0-rc.1",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "dist/index.js",
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint --cache src test",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "prepare": "npm run build",
+        "build": "del dist && babel src -d dist --copy-files",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "cross-env NODE_ENV=test jest",
+        "test:watch": "npm run test:only -- --watch",
+        "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "mem": "^6.0.1",
+        "memfs": "^3.1.1",
+        "mime-types": "^2.1.26",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^2.6.4"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.8.4",
+        "@babel/preset-env": "^7.8.4",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^25.1.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "cross-env": "^7.0.0",
+        "del": "^5.1.0",
+        "del-cli": "^3.0.0",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-plugin-import": "^2.20.1",
+        "eslint-plugin-prettier": "^3.1.2",
+        "express": "^4.17.1",
+        "file-loader": "^5.1.0",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "jest-junit": "^10.0.0",
+        "lint-staged": "^10.0.7",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "standard-version": "^7.1.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.41.6"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "development"
+      ],
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n[![size][size]][size-url]\n\n# webpack-dev-middleware\n\nAn express-style development middleware for use with [webpack](https://webpack.js.org)\nbundles and allows for serving of the files emitted from webpack.\nThis should be used for **development only**.\n\nSome of the benefits of using this middleware include:\n\n- No files are written to disk, rather it handles files in memory\n- If files changed in watch mode, the middleware delays requests until compiling\n  has completed.\n- Supports hot module reload (HMR).\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-middleware --save-dev\n```\n\n_Note: We do not recommend installing this module globally._\n\n## Usage\n\n```js\nconst webpack = require('webpack');\nconst middleware = require('webpack-dev-middleware');\nconst compiler = webpack({\n  // webpack options\n});\nconst express = require('express');\nconst app = express();\n\napp.use(\n  middleware(compiler, {\n    // webpack-dev-middleware options\n  })\n);\n\napp.listen(3000, () => console.log('Example app listening on port 3000!'));\n```\n\n## Options\n\nThe middleware accepts an `options` Object. The following is a property reference for the Object.\n\n### methods\n\nType: `Array`  \nDefault: `[ 'GET', 'HEAD' ]`\n\nThis property allows a user to pass the list of HTTP request methods accepted by the server.\n\n### headers\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to pass custom HTTP headers on each request.\neg. `{ \"X-Custom-Header\": \"yes\" }`\n\n### index\n\nType: `Boolean|String`  \nDefault: `index.html`\n\nIf `false` (but not `undefined`), the server will not respond to requests to the root URL.\n\n### mimeTypes\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to register custom mime types or extension mappings.\neg. `mimeTypes: { phtml: 'text/html' }`.\n\nPlease see the documentation for [`mime-types`](https://github.com/jshttp/mime-types) for more information.\n\n### publicPath\n\nType: `String`\nDefault: `output.publicPath`\n\nThe public path that the middleware is bound to.\n_Best Practice: use the same `publicPath` defined in your webpack config.\nFor more information about `publicPath`, please see [the webpack documentation](https://webpack.js.org/guides/public-path)._\n\n### serverSideRender\n\nType: `Boolean`  \nDefault: `undefined`\n\nInstructs the module to enable or disable the server-side rendering mode. Please\nsee [Server-Side Rendering](#server-side-rendering) for more information.\n\n### writeToDisk\n\nType: `Boolean|Function`  \nDefault: `false`\n\nIf `true`, the option will instruct the module to write files to the configured\nlocation on disk as specified in your `webpack` config file. _Setting\n`writeToDisk: true` won't change the behavior of the `webpack-dev-middleware`,\nand bundle files accessed through the browser will still be served from memory._\nThis option provides the same capabilities as the\n[`WriteFilePlugin`](https://github.com/gajus/write-file-webpack-plugin/pulls).\n\nThis option also accepts a `Function` value, which can be used to filter which\nfiles are written to disk. The function follows the same premise as\n[`Array#filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)\nin which a return value of `false` _will not_ write the file, and a return value\nof `true` _will_ write the file to disk. eg.\n\n```js\nconst webpack = require('webpack');\nconst configuration = {\n  /* Webpack configuration */\n};\nconst compiler = webpack(configuration);\n\nmiddleware(compiler, {\n  writeToDisk: (filePath) => {\n    return /superman\\.css$/.test(filePath);\n  },\n});\n```\n\n### outputFileSystem\n\nType: `Object`  \nDefault: [memfs](https://github.com/streamich/memfs)\n\nSet the default file system which will be used by webpack as primary destination of generated files.\nThis option isn't affected by the [writeToDisk](#writeToDisk) option.\n\nYou have to provide `.join()` and `mkdirp` method to the `outputFileSystem` instance manually for compatibility with `webpack@4`.\n\nThis can be done simply by using `path.join`:\n\n```js\nconst webpack = require('webpack');\nconst path = require('path');\nconst myOutputFileSystem = require('my-fs');\nconst mkdirp = require('mkdirp');\n\nmyOutputFileSystem.join = path.join.bind(path); // no need to bind\nmyOutputFileSystem.mkdirp = mkdirp.bind(mkdirp); // no need to bind\n\nconst compiler = webpack({\n  /* Webpack configuration */\n});\n\nmiddleware(compiler, { outputFileSystem: myOutputFileSystem });\n```\n\n## API\n\n`webpack-dev-middleware` also provides convenience methods that can be use to\ninteract with the middleware at runtime:\n\n### `close(callback)`\n\nInstructs a webpack-dev-middleware instance to stop watching for file changes.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed once the middleware has stopped watching.\n\n### `invalidate()`\n\nInstructs a webpack-dev-middleware instance to recompile the bundle.\ne.g. after a change to the configuration.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\nsetTimeout(() => {\n  // After a short delay the configuration is changed and a banner plugin is added\n  // to the config\n  compiler.apply(new webpack.BannerPlugin('A new banner'));\n\n  // Recompile the bundle with the banner plugin:\n  instance.invalidate();\n}, 1000);\n```\n\n### `waitUntilValid(callback)`\n\nExecutes a callback function when the compiler bundle is valid, typically after\ncompilation.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed when the bundle becomes valid. If the bundle is\nvalid at the time of calling, the callback is executed immediately.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\ninstance.waitUntilValid(() => {\n  console.log('Package is in a valid state');\n});\n```\n\n## Known Issues\n\n### Multiple Successive Builds\n\nWatching will frequently cause multiple compilations\nas the bundle changes during compilation. This is due in part to cross-platform\ndifferences in file watchers, so that webpack doesn't loose file changes when\nwatched files change rapidly. If you run into this situation, please make use of\nthe [`TimeFixPlugin`](https://github.com/egoist/time-fix-plugin).\n\n## Server-Side Rendering\n\n_Note: this feature is experimental and may be removed or changed completely in the future._\n\nIn order to develop an app using server-side rendering, we need access to the\n[`stats`](https://github.com/webpack/docs/wiki/node.js-api#stats), which is\ngenerated with each build.\n\nWith server-side rendering enabled, `webpack-dev-middleware` sets the `stats` to `res.locals.webpack.devMiddleware.stats`\nand the filesystem to `res.locals.webpack.devMiddleware.outputFileSystem` before invoking the next middleware,\nallowing a developer to render the page body and manage the response to clients.\n\n_Note: Requests for bundle files will still be handled by\n`webpack-dev-middleware` and all requests will be pending until the build\nprocess is finished with server-side rendering enabled._\n\nExample Implementation:\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({\n  // webpack options\n});\nconst isObject = require('is-object');\nconst middleware = require('webpack-dev-middleware');\n\n// This function makes server rendering of asset references consistent with different webpack chunk/entry configurations\nfunction normalizeAssets(assets) {\n  if (isObject(assets)) {\n    return Object.values(assets);\n  }\n\n  return Array.isArray(assets) ? assets : [assets];\n}\n\napp.use(middleware(compiler, { serverSideRender: true }));\n\n// The following middleware would not be invoked until the latest build is finished.\napp.use((req, res) => {\n  const { devMiddleware } = res.locals.webpack;\n  const outputFileSystem = devMiddleware.outputFileSystem;\n  const jsonWebpackStats = devMiddleware.stats.toJson();\n  const { assetsByChunkName, outputPath } = jsonWebpackStats;\n\n  // Then use `assetsByChunkName` for server-side rendering\n  // For example, if you have only one main chunk:\n  res.send(`\n<html>\n  <head>\n    <title>My App</title>\n    <style>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.css'))\n      .map((path) => outputFileSystem.readFileSync(path.join(outputPath, path)))\n      .join('\\n')}\n    </style>\n  </head>\n  <body>\n    <div id=\"root\"></div>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.js'))\n      .map((path) => `<script src=\"${path}\"></script>`)\n      .join('\\n')}\n  </body>\n</html>\n  `);\n});\n```\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, or would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nPlease take a moment to read our contributing guidelines if you haven't yet done so.\n\n[CONTRIBUTING](./.github/CONTRIBUTING.md)\n\n## License\n\n[MIT](./LICENSE)\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-middleware.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-middleware\n[node]: https://img.shields.io/node/v/webpack-dev-middleware.svg\n[node-url]: https://nodejs.org\n[deps]: https://david-dm.org/webpack/webpack-dev-middleware.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-middleware\n[tests]: https://dev.azure.com/webpack/webpack-dev-middleware/_apis/build/status/webpack.webpack-dev-middleware?branchName=master\n[tests-url]: https://dev.azure.com/webpack/webpack-dev-middleware/_build/latest?definitionId=8&branchName=master\n[cover]: https://codecov.io/gh/webpack/webpack-dev-middleware/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-middleware\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n[size]: https://packagephobia.now.sh/badge?p=webpack-dev-middleware\n[size-url]: https://packagephobia.now.sh/result?p=webpack-dev-middleware\n[docs-url]: https://webpack.js.org/guides/development/#using-webpack-dev-middleware\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-middleware\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "2daa4ddac3cd977f84ce4d25507f0d658447e359",
+      "_id": "webpack-dev-middleware@4.0.0-rc.1",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-n7dww33POOkzM5MElcZ94K8Mnt0DRjgywWsVYSmD/LHY57M8lyLu9mj5nuCBSoYgAacudjGDW1phcInFi1BWQg==",
+        "shasum": "445f85b8476505632dbbed99e84cb257c9d25a83",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 40180,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTlMlCRA9TVsSAnZWagAAVQsP/R7BP3hPW4mE00Bksf3H\nTwi4UfRF4K4g1pe2c4M5jH9/b5/K9OCVYV9Ib42Y4KKqcyX664+W08p2lnU7\nmHLSufJBbjC0BcpX+i0j0aCXWkpLTo85sWpzVLjAkO1y7lC+IwGhPOn1Ma6Y\nX1tsmBN9FGXD9j35268cMwybkJNkTCHvGM0aR2JK/l7FIxefquB0bbd8H1/g\nW9IZwmKgDjuJFevZGQNbquRjyR3mC88OV1ty/QKKY4ptb/4EUyvbY9/h0aYJ\nwGdCu8Qqha3JSRgjLLJrgzK2MRgVPVbz3rT4w/S+SsXXfaKbAtIdfvZRw8bX\nIqdcC2rtcYo7OegWm6mc7xVWeUrj1iCLY/vFCzWJ5RYluWriYzNKQ3rbEYdX\ng1zZ6mg3FCj1z5rHi9XQ/BlfSCOdIYml4hWC53IOdsTjn3YCFeoyTbVDIbB3\nRmm0xjOkksl+ORRqIQ0qfyGJ8D8ZrM8c5bJAiUXEpetbKf45KQl9U/n2Yef3\nPhcIYw9fmby1yYWAeKMkmKr9yDAotvSe9Py9+NDEdwp4QNeanCeAn1X2gwFV\ndEruRGnBfdNqoTJiqnSxL1C2rMaEzcquF/h00MTGqUWqXVIwcXwKumoPKNIQ\nDTyhtDmeD3yp+r7DoqgVAC4Lq2GaNaI4FAvt/Q3VXcqxPWtP5GQAizlE1nGE\nTuZ/\r\n=lf11\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_4.0.0-rc.1_1582191397190_0.14978674929189095"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0-rc.2": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0-rc.2",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "dist/index.js",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint --cache src test",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "prepare": "npm run build",
+        "build": "del dist && babel src -d dist --copy-files",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "cross-env NODE_ENV=test jest",
+        "test:watch": "npm run test:only -- --watch",
+        "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "mem": "^6.1.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^2.7.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.10.3",
+        "@babel/core": "^7.10.3",
+        "@babel/preset-env": "^7.10.3",
+        "@commitlint/cli": "^9.0.1",
+        "@commitlint/config-conventional": "^9.0.1",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.1.0",
+        "chokidar": "^3.4.0",
+        "cross-env": "^7.0.2",
+        "del": "^5.1.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.0.0",
+        "husky": "^4.2.5",
+        "jest": "^26.1.0",
+        "lint-staged": "^10.2.11",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.0.5",
+        "standard-version": "^8.0.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.43.0"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "development"
+      ],
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n[![size][size]][size-url]\n\n# webpack-dev-middleware\n\nAn express-style development middleware for use with [webpack](https://webpack.js.org)\nbundles and allows for serving of the files emitted from webpack.\nThis should be used for **development only**.\n\nSome of the benefits of using this middleware include:\n\n- No files are written to disk, rather it handles files in memory\n- If files changed in watch mode, the middleware delays requests until compiling\n  has completed.\n- Supports hot module reload (HMR).\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-middleware --save-dev\n```\n\n_Note: We do not recommend installing this module globally._\n\n## Usage\n\n```js\nconst webpack = require('webpack');\nconst middleware = require('webpack-dev-middleware');\nconst compiler = webpack({\n  // webpack options\n});\nconst express = require('express');\nconst app = express();\n\napp.use(\n  middleware(compiler, {\n    // webpack-dev-middleware options\n  })\n);\n\napp.listen(3000, () => console.log('Example app listening on port 3000!'));\n```\n\n## Options\n\nThe middleware accepts an `options` Object. The following is a property reference for the Object.\n\n### methods\n\nType: `Array`  \nDefault: `[ 'GET', 'HEAD' ]`\n\nThis property allows a user to pass the list of HTTP request methods accepted by the server.\n\n### headers\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to pass custom HTTP headers on each request.\neg. `{ \"X-Custom-Header\": \"yes\" }`\n\n### index\n\nType: `Boolean|String`  \nDefault: `index.html`\n\nIf `false` (but not `undefined`), the server will not respond to requests to the root URL.\n\n### mimeTypes\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to register custom mime types or extension mappings.\neg. `mimeTypes: { phtml: 'text/html' }`.\n\nPlease see the documentation for [`mime-types`](https://github.com/jshttp/mime-types) for more information.\n\n### publicPath\n\nType: `String`\nDefault: `output.publicPath`\n\nThe public path that the middleware is bound to.\n_Best Practice: use the same `publicPath` defined in your webpack config.\nFor more information about `publicPath`, please see [the webpack documentation](https://webpack.js.org/guides/public-path)._\n\n### serverSideRender\n\nType: `Boolean`  \nDefault: `undefined`\n\nInstructs the module to enable or disable the server-side rendering mode. Please\nsee [Server-Side Rendering](#server-side-rendering) for more information.\n\n### writeToDisk\n\nType: `Boolean|Function`  \nDefault: `false`\n\nIf `true`, the option will instruct the module to write files to the configured\nlocation on disk as specified in your `webpack` config file. _Setting\n`writeToDisk: true` won't change the behavior of the `webpack-dev-middleware`,\nand bundle files accessed through the browser will still be served from memory._\nThis option provides the same capabilities as the\n[`WriteFilePlugin`](https://github.com/gajus/write-file-webpack-plugin/pulls).\n\nThis option also accepts a `Function` value, which can be used to filter which\nfiles are written to disk. The function follows the same premise as\n[`Array#filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)\nin which a return value of `false` _will not_ write the file, and a return value\nof `true` _will_ write the file to disk. eg.\n\n```js\nconst webpack = require('webpack');\nconst configuration = {\n  /* Webpack configuration */\n};\nconst compiler = webpack(configuration);\n\nmiddleware(compiler, {\n  writeToDisk: (filePath) => {\n    return /superman\\.css$/.test(filePath);\n  },\n});\n```\n\n### outputFileSystem\n\nType: `Object`  \nDefault: [memfs](https://github.com/streamich/memfs)\n\nSet the default file system which will be used by webpack as primary destination of generated files.\nThis option isn't affected by the [writeToDisk](#writeToDisk) option.\n\nYou have to provide `.join()` and `mkdirp` method to the `outputFileSystem` instance manually for compatibility with `webpack@4`.\n\nThis can be done simply by using `path.join`:\n\n```js\nconst webpack = require('webpack');\nconst path = require('path');\nconst myOutputFileSystem = require('my-fs');\nconst mkdirp = require('mkdirp');\n\nmyOutputFileSystem.join = path.join.bind(path); // no need to bind\nmyOutputFileSystem.mkdirp = mkdirp.bind(mkdirp); // no need to bind\n\nconst compiler = webpack({\n  /* Webpack configuration */\n});\n\nmiddleware(compiler, { outputFileSystem: myOutputFileSystem });\n```\n\n## API\n\n`webpack-dev-middleware` also provides convenience methods that can be use to\ninteract with the middleware at runtime:\n\n### `close(callback)`\n\nInstructs a webpack-dev-middleware instance to stop watching for file changes.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed once the middleware has stopped watching.\n\n### `invalidate()`\n\nInstructs a webpack-dev-middleware instance to recompile the bundle.\ne.g. after a change to the configuration.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\nsetTimeout(() => {\n  // After a short delay the configuration is changed and a banner plugin is added\n  // to the config\n  compiler.apply(new webpack.BannerPlugin('A new banner'));\n\n  // Recompile the bundle with the banner plugin:\n  instance.invalidate();\n}, 1000);\n```\n\n### `waitUntilValid(callback)`\n\nExecutes a callback function when the compiler bundle is valid, typically after\ncompilation.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed when the bundle becomes valid. If the bundle is\nvalid at the time of calling, the callback is executed immediately.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\ninstance.waitUntilValid(() => {\n  console.log('Package is in a valid state');\n});\n```\n\n## Known Issues\n\n### Multiple Successive Builds\n\nWatching will frequently cause multiple compilations\nas the bundle changes during compilation. This is due in part to cross-platform\ndifferences in file watchers, so that webpack doesn't loose file changes when\nwatched files change rapidly. If you run into this situation, please make use of\nthe [`TimeFixPlugin`](https://github.com/egoist/time-fix-plugin).\n\n## Server-Side Rendering\n\n_Note: this feature is experimental and may be removed or changed completely in the future._\n\nIn order to develop an app using server-side rendering, we need access to the\n[`stats`](https://github.com/webpack/docs/wiki/node.js-api#stats), which is\ngenerated with each build.\n\nWith server-side rendering enabled, `webpack-dev-middleware` sets the `stats` to `res.locals.webpack.devMiddleware.stats`\nand the filesystem to `res.locals.webpack.devMiddleware.outputFileSystem` before invoking the next middleware,\nallowing a developer to render the page body and manage the response to clients.\n\n_Note: Requests for bundle files will still be handled by\n`webpack-dev-middleware` and all requests will be pending until the build\nprocess is finished with server-side rendering enabled._\n\nExample Implementation:\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({\n  // webpack options\n});\nconst isObject = require('is-object');\nconst middleware = require('webpack-dev-middleware');\n\n// This function makes server rendering of asset references consistent with different webpack chunk/entry configurations\nfunction normalizeAssets(assets) {\n  if (isObject(assets)) {\n    return Object.values(assets);\n  }\n\n  return Array.isArray(assets) ? assets : [assets];\n}\n\napp.use(middleware(compiler, { serverSideRender: true }));\n\n// The following middleware would not be invoked until the latest build is finished.\napp.use((req, res) => {\n  const { devMiddleware } = res.locals.webpack;\n  const outputFileSystem = devMiddleware.outputFileSystem;\n  const jsonWebpackStats = devMiddleware.stats.toJson();\n  const { assetsByChunkName, outputPath } = jsonWebpackStats;\n\n  // Then use `assetsByChunkName` for server-side rendering\n  // For example, if you have only one main chunk:\n  res.send(`\n<html>\n  <head>\n    <title>My App</title>\n    <style>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.css'))\n      .map((path) => outputFileSystem.readFileSync(path.join(outputPath, path)))\n      .join('\\n')}\n    </style>\n  </head>\n  <body>\n    <div id=\"root\"></div>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.js'))\n      .map((path) => `<script src=\"${path}\"></script>`)\n      .join('\\n')}\n  </body>\n</html>\n  `);\n});\n```\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, or would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nPlease take a moment to read our contributing guidelines if you haven't yet done so.\n\n[CONTRIBUTING](./CONTRIBUTING.md)\n\n## License\n\n[MIT](./LICENSE)\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-middleware.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-middleware\n[node]: https://img.shields.io/node/v/webpack-dev-middleware.svg\n[node-url]: https://nodejs.org\n[deps]: https://david-dm.org/webpack/webpack-dev-middleware.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-middleware\n[tests]: https://github.com/webpack/webpack-dev-middleware/workflows/webpack-dev-middleware/badge.svg\n[tests-url]: https://github.com/webpack/webpack-dev-middleware/actions\n[cover]: https://codecov.io/gh/webpack/webpack-dev-middleware/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-middleware\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n[size]: https://packagephobia.now.sh/badge?p=webpack-dev-middleware\n[size-url]: https://packagephobia.now.sh/result?p=webpack-dev-middleware\n[docs-url]: https://webpack.js.org/guides/development/#using-webpack-dev-middleware\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-middleware\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "61b62d086d44dc80b58ae64d546c1d9b03783ca3",
+      "_id": "webpack-dev-middleware@4.0.0-rc.2",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-yP04dRrpAVNq1yvRvtkXIP6UCw+hAbWFOgv6dF2rHNYsRYhQuDRVTc09YwbYzyOlmdJzyXxHfNJZ070HVd9cjA==",
+        "shasum": "26014e50482c9b0e561f708533b37a7ab1dc54ef",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 40444,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe+1ptCRA9TVsSAnZWagAA1XQQAJfARLzbd94qTqe8ZB7C\nWiQm3wpEHW2QubKU6yYLGmgHqf0ue46WFMu7EWvBHJucxVrC7/tbqnWqEerB\nGKsB6wiC6rMHRZ/oxdBNWY0JyGcnm2bO9tYZ75A2koKb+Lrad1NI8/u86rLK\nirvkakkXE1tJBA3rQhDVh7QyUMn+kXTPsu7+SHX31RmTlFwTecwNExp5G0oE\nSw8AwQYggrhXJrfjabqjIjWnISkSymhQe6KRGkdhI+XT4PyxuOSM1lPBgOaW\nxoK/z+loV+rWySUkvIxoyExiE2q6K8vy3dd8+lii6utg029vZR7MIFVVZ2ed\njLKKOYQzNSfDk9tkiMbFHsOwjpwByvFVgtwp//7QYPSQRltvx0CMFJKFqnRB\n5TWhu7ULnsupjqAX3/36pkv8v18OptH0f3MIBrpOex5ANoLYYWp6TWHT2P82\ndTIJKkPJWgyfwanb+LWjnPM+iIgTEfylkuk3daMSq5y1YHp+awaisATwouCs\nsXlThcqGnjo4SP4R+D0OblwEDGXGdjiAbYvYddmvlfhuqU1pgBK9JmgWgJ5K\nWGuMPfV3SYP/aD86ds/FkpJbXhaMGordfiP/eEhc1HNo264HkPqFIlkkRkNk\nk882VMJMLbFtycVXO3bYvUQRuDOsV8K3QqzncOQrcvFaPakb4dcVuWrHp0FE\nP0Mk\r\n=SU8g\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_4.0.0-rc.2_1593530988610_0.0551280482065597"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0-rc.3": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0-rc.3",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "dist/index.js",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint --cache src test",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "prepare": "npm run build",
+        "build": "del dist && babel src -d dist --copy-files",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "cross-env NODE_ENV=test jest",
+        "test:watch": "npm run test:only -- --watch",
+        "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dependencies": {
+        "mem": "^6.1.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^2.7.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.10.4",
+        "@babel/core": "^7.10.4",
+        "@babel/preset-env": "^7.10.4",
+        "@commitlint/cli": "^9.1.1",
+        "@commitlint/config-conventional": "^9.1.1",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.1.0",
+        "chokidar": "^3.4.0",
+        "cross-env": "^7.0.2",
+        "del": "^5.1.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.4.0",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.0.0",
+        "husky": "^4.2.5",
+        "jest": "^26.1.0",
+        "lint-staged": "^10.2.11",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.0.5",
+        "standard-version": "^8.0.2",
+        "supertest": "^4.0.2",
+        "webpack": "^4.43.0"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "development"
+      ],
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n[![size][size]][size-url]\n\n# webpack-dev-middleware\n\nAn express-style development middleware for use with [webpack](https://webpack.js.org)\nbundles and allows for serving of the files emitted from webpack.\nThis should be used for **development only**.\n\nSome of the benefits of using this middleware include:\n\n- No files are written to disk, rather it handles files in memory\n- If files changed in watch mode, the middleware delays requests until compiling\n  has completed.\n- Supports hot module reload (HMR).\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-middleware --save-dev\n```\n\n_Note: We do not recommend installing this module globally._\n\n## Usage\n\n```js\nconst webpack = require('webpack');\nconst middleware = require('webpack-dev-middleware');\nconst compiler = webpack({\n  // webpack options\n});\nconst express = require('express');\nconst app = express();\n\napp.use(\n  middleware(compiler, {\n    // webpack-dev-middleware options\n  })\n);\n\napp.listen(3000, () => console.log('Example app listening on port 3000!'));\n```\n\n## Options\n\nThe middleware accepts an `options` Object. The following is a property reference for the Object.\n\n### methods\n\nType: `Array`  \nDefault: `[ 'GET', 'HEAD' ]`\n\nThis property allows a user to pass the list of HTTP request methods accepted by the server.\n\n### headers\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to pass custom HTTP headers on each request.\neg. `{ \"X-Custom-Header\": \"yes\" }`\n\n### index\n\nType: `Boolean|String`  \nDefault: `index.html`\n\nIf `false` (but not `undefined`), the server will not respond to requests to the root URL.\n\n### mimeTypes\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to register custom mime types or extension mappings.\neg. `mimeTypes: { phtml: 'text/html' }`.\n\nPlease see the documentation for [`mime-types`](https://github.com/jshttp/mime-types) for more information.\n\n### publicPath\n\nType: `String`\nDefault: `output.publicPath`\n\nThe public path that the middleware is bound to.\n_Best Practice: use the same `publicPath` defined in your webpack config.\nFor more information about `publicPath`, please see [the webpack documentation](https://webpack.js.org/guides/public-path)._\n\n### serverSideRender\n\nType: `Boolean`  \nDefault: `undefined`\n\nInstructs the module to enable or disable the server-side rendering mode. Please\nsee [Server-Side Rendering](#server-side-rendering) for more information.\n\n### writeToDisk\n\nType: `Boolean|Function`  \nDefault: `false`\n\nIf `true`, the option will instruct the module to write files to the configured\nlocation on disk as specified in your `webpack` config file. _Setting\n`writeToDisk: true` won't change the behavior of the `webpack-dev-middleware`,\nand bundle files accessed through the browser will still be served from memory._\nThis option provides the same capabilities as the\n[`WriteFilePlugin`](https://github.com/gajus/write-file-webpack-plugin/pulls).\n\nThis option also accepts a `Function` value, which can be used to filter which\nfiles are written to disk. The function follows the same premise as\n[`Array#filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)\nin which a return value of `false` _will not_ write the file, and a return value\nof `true` _will_ write the file to disk. eg.\n\n```js\nconst webpack = require('webpack');\nconst configuration = {\n  /* Webpack configuration */\n};\nconst compiler = webpack(configuration);\n\nmiddleware(compiler, {\n  writeToDisk: (filePath) => {\n    return /superman\\.css$/.test(filePath);\n  },\n});\n```\n\n### outputFileSystem\n\nType: `Object`  \nDefault: [memfs](https://github.com/streamich/memfs)\n\nSet the default file system which will be used by webpack as primary destination of generated files.\nThis option isn't affected by the [writeToDisk](#writeToDisk) option.\n\nYou have to provide `.join()` and `mkdirp` method to the `outputFileSystem` instance manually for compatibility with `webpack@4`.\n\nThis can be done simply by using `path.join`:\n\n```js\nconst webpack = require('webpack');\nconst path = require('path');\nconst myOutputFileSystem = require('my-fs');\nconst mkdirp = require('mkdirp');\n\nmyOutputFileSystem.join = path.join.bind(path); // no need to bind\nmyOutputFileSystem.mkdirp = mkdirp.bind(mkdirp); // no need to bind\n\nconst compiler = webpack({\n  /* Webpack configuration */\n});\n\nmiddleware(compiler, { outputFileSystem: myOutputFileSystem });\n```\n\n## API\n\n`webpack-dev-middleware` also provides convenience methods that can be use to\ninteract with the middleware at runtime:\n\n### `close(callback)`\n\nInstructs a webpack-dev-middleware instance to stop watching for file changes.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed once the middleware has stopped watching.\n\n### `invalidate()`\n\nInstructs a webpack-dev-middleware instance to recompile the bundle.\ne.g. after a change to the configuration.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\nsetTimeout(() => {\n  // After a short delay the configuration is changed and a banner plugin is added\n  // to the config\n  compiler.apply(new webpack.BannerPlugin('A new banner'));\n\n  // Recompile the bundle with the banner plugin:\n  instance.invalidate();\n}, 1000);\n```\n\n### `waitUntilValid(callback)`\n\nExecutes a callback function when the compiler bundle is valid, typically after\ncompilation.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed when the bundle becomes valid. If the bundle is\nvalid at the time of calling, the callback is executed immediately.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\ninstance.waitUntilValid(() => {\n  console.log('Package is in a valid state');\n});\n```\n\n## Known Issues\n\n### Multiple Successive Builds\n\nWatching will frequently cause multiple compilations\nas the bundle changes during compilation. This is due in part to cross-platform\ndifferences in file watchers, so that webpack doesn't loose file changes when\nwatched files change rapidly. If you run into this situation, please make use of\nthe [`TimeFixPlugin`](https://github.com/egoist/time-fix-plugin).\n\n## Server-Side Rendering\n\n_Note: this feature is experimental and may be removed or changed completely in the future._\n\nIn order to develop an app using server-side rendering, we need access to the\n[`stats`](https://github.com/webpack/docs/wiki/node.js-api#stats), which is\ngenerated with each build.\n\nWith server-side rendering enabled, `webpack-dev-middleware` sets the `stats` to `res.locals.webpack.devMiddleware.stats`\nand the filesystem to `res.locals.webpack.devMiddleware.outputFileSystem` before invoking the next middleware,\nallowing a developer to render the page body and manage the response to clients.\n\n_Note: Requests for bundle files will still be handled by\n`webpack-dev-middleware` and all requests will be pending until the build\nprocess is finished with server-side rendering enabled._\n\nExample Implementation:\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({\n  // webpack options\n});\nconst isObject = require('is-object');\nconst middleware = require('webpack-dev-middleware');\n\n// This function makes server rendering of asset references consistent with different webpack chunk/entry configurations\nfunction normalizeAssets(assets) {\n  if (isObject(assets)) {\n    return Object.values(assets);\n  }\n\n  return Array.isArray(assets) ? assets : [assets];\n}\n\napp.use(middleware(compiler, { serverSideRender: true }));\n\n// The following middleware would not be invoked until the latest build is finished.\napp.use((req, res) => {\n  const { devMiddleware } = res.locals.webpack;\n  const outputFileSystem = devMiddleware.outputFileSystem;\n  const jsonWebpackStats = devMiddleware.stats.toJson();\n  const { assetsByChunkName, outputPath } = jsonWebpackStats;\n\n  // Then use `assetsByChunkName` for server-side rendering\n  // For example, if you have only one main chunk:\n  res.send(`\n<html>\n  <head>\n    <title>My App</title>\n    <style>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.css'))\n      .map((path) => outputFileSystem.readFileSync(path.join(outputPath, path)))\n      .join('\\n')}\n    </style>\n  </head>\n  <body>\n    <div id=\"root\"></div>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.js'))\n      .map((path) => `<script src=\"${path}\"></script>`)\n      .join('\\n')}\n  </body>\n</html>\n  `);\n});\n```\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, or would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nPlease take a moment to read our contributing guidelines if you haven't yet done so.\n\n[CONTRIBUTING](./CONTRIBUTING.md)\n\n## License\n\n[MIT](./LICENSE)\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-middleware.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-middleware\n[node]: https://img.shields.io/node/v/webpack-dev-middleware.svg\n[node-url]: https://nodejs.org\n[deps]: https://david-dm.org/webpack/webpack-dev-middleware.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-middleware\n[tests]: https://github.com/webpack/webpack-dev-middleware/workflows/webpack-dev-middleware/badge.svg\n[tests-url]: https://github.com/webpack/webpack-dev-middleware/actions\n[cover]: https://codecov.io/gh/webpack/webpack-dev-middleware/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-middleware\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n[size]: https://packagephobia.now.sh/badge?p=webpack-dev-middleware\n[size-url]: https://packagephobia.now.sh/result?p=webpack-dev-middleware\n[docs-url]: https://webpack.js.org/guides/development/#using-webpack-dev-middleware\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-middleware\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "7213deaf1ca6d653d72e71a27263aba9101deca0",
+      "_id": "webpack-dev-middleware@4.0.0-rc.3",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.14.6",
+      "dist": {
+        "integrity": "sha512-nuZHcVtI1qVJxGYWEnCeN9UiQesOTUYQZQiJnrt1ma5FSYK1OTH0ySG45yUE44aVSFrN+teZX7WQTH6hF2vgFA==",
+        "shasum": "986c047d579a320499e6217c96562265c2438abe",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.3.tgz",
+        "fileCount": 14,
+        "unpackedSize": 41174,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfDeUVCRA9TVsSAnZWagAAvdsP/ibOBLRQaXle5ADsXdxn\ndjWYU2ZsYnGfzCQBJoXq62/QheutfA8M1PrStk0dvFpVgc19gY1H2TsGyeQo\ncxPhfhPBBweRhqCEeiG37FCxRX4NsYkCFQgheELd/fOAblx9WRtZWbslR3J/\nrREtg0vXkKF666Ky8Ngkhw9duSiLe7SdHxhktx8M8Mkzhv0GuQdv481ImzQx\nDnfNPtDJSU59/UTOBgSp8lmcKlFyzr/cY9NC2L8s/DW9HE/9vIjawy76Ofdu\n+M/BxQBetwtwdnQWBXLJJHPDCTRk5CvA6iYByHzML1lAlHRKQqGQ2Ld6NPfg\n+kmHrA8672TKD+w5yvTewdabm1kF9ZENtYPXFsrX8UI1W9uPdYwlkr1DWDne\n66u9pgp6p7erf9KBeBgmj0QsDwpfJM5zrJPeAz3eBKPInfetWv9QzcIaDCJ/\nZUKYXuqhA/S+jSBuV8JzXgyo32sytSpdSgJuJd9rbHpvZfhc+3ejj4xKEZou\nbj4HZT5kg4uj0vTumSnXsoyznKwd17QZjSeOW/XMt+zptzy9QkROAlht6PSa\n6WiKZZ2qhXJCO2hJ0q2hEPKfPTk5FTcl7ma9AAtqTET9z/QHlxXjbAv5GBd+\nULp2YtD85mZucnMoxRkLxbK87fV1h1EI2b9Z+bZyrd2L7Oy9Rozu/FkvyICr\nS8Y2\r\n=Aj67\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "michael.ciniawsky@gmail.com",
+          "name": "michael-ciniawsky"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_4.0.0-rc.3_1594746132546_0.025165796816554176"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.0": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "dist/cjs.js",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint --cache src test",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "prepare": "npm run build",
+        "build": "del dist && babel src -d dist --copy-files",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "cross-env NODE_ENV=test jest",
+        "test:watch": "npm run test:only -- --watch",
+        "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "dependencies": {
+        "mem": "^8.0.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^3.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/preset-env": "^7.12.1",
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.6.1",
+        "chokidar": "^3.4.3",
+        "cross-env": "^7.0.2",
+        "del": "^6.0.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.12.1",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.2.0",
+        "husky": "^4.3.0",
+        "jest": "^26.6.1",
+        "lint-staged": "^10.5.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.1.2",
+        "standard-version": "^9.0.0",
+        "supertest": "^5.0.0",
+        "webpack": "^5.3.0"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "development"
+      ],
+      "gitHead": "9230c13d594dbe8e0a6c6c1cdf5bbfa01cbb4866",
+      "_id": "webpack-dev-middleware@4.0.0",
+      "_nodeVersion": "12.19.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-n6X6CxYQyYWGBfLzcNYya0oz1N8iTG5atGxrEacrMGc9pPjg3GHyHul6Z+hfs5x5voYtqr7mz1pbK/M4ZeMl1w==",
+        "shasum": "1725b2ebc78b66333672499d9dc7b1c244aebb1c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 42814,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmYPrCRA9TVsSAnZWagAAd5AP/0mI4G8YqH6pfuUWCi3S\nXrkg8ePeHoOGiG4An62RgdjigvxMsI+zPfl0MB1q3TE66R6+S/25ewO24n7b\n6LmhuGQlfmOUWonjlMa0SnoZxWk0G09pX2mYg8pMdakTEGMK4YwxVx0SpT4i\nUpU6pSYGpe2EJ0KqBaKfo6+PBaAqYbu6ySGB08VODtXbLh8xFOeTIxhbF1tu\nPsN95Pr5l9qtLk6tniLkSNuhY05vX672oL1nz1jiXENpylbQRKkFlz1obuQs\nfm6VdeE6xQTLR6LDS83LMQbwc0JlNpqWrHKEpHfrFZXr8qMSw8J7zCIFSu83\nIaiiW2tEyyaHJCGKSSNIbtgD81ECvY7dPUyvjBYyPQeCjQudE7LNe2u8/rtg\nUbGPVKY4/G+sf0jPL0eZSnbNxaSGvppJ1pDtzDlsYvPolth6NbSG6f+35/53\nrKhqDnWc8pJZeiZD4fPJqTNUheLcrMLUxOLYHafVkrO1IzVtqRStjWZszQbi\nrirbeUo6nwTVHdz21hv/jnExAaDHPSbdiJEgKkXnVVFl9KknpqVZHi7UhDlH\nY/59kYqKKIoAZVYClPqoNkqdB1g9LKF6drO/7Uf5smdYStfvOCrZ93moazQ3\nIFE9kk+wNLgco5pnkRVRWZ+Y+jGJT+G7GDMmno0Tyhv/fZTKOITwL25IPEiF\nB4Hk\r\n=ISXJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "michael-ciniawsky",
+          "email": "michael.ciniawsky@gmail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        },
+        {
+          "name": "evilebottnawi",
+          "email": "sheo13666q@gmail.com"
+        },
+        {
+          "name": "hiroppy",
+          "email": "hello@hiroppy.me"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_4.0.0_1603896299369_0.09781110820858374"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.1": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.1",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "dist/cjs.js",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint --cache src test",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "prepare": "npm run build",
+        "build": "del dist && babel src -d dist --copy-files",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "cross-env NODE_ENV=test jest",
+        "test:watch": "npm run test:only -- --watch",
+        "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "dependencies": {
+        "mem": "^8.0.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^3.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/preset-env": "^7.12.1",
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.6.3",
+        "chokidar": "^3.4.3",
+        "connect": "^3.7.0",
+        "cross-env": "^7.0.2",
+        "del": "^6.0.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.13.0",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.2.0",
+        "husky": "^4.3.0",
+        "jest": "^26.6.3",
+        "lint-staged": "^10.5.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.1.2",
+        "standard-version": "^9.0.0",
+        "supertest": "^6.0.1",
+        "webpack": "^5.4.0"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "development"
+      ],
+      "gitHead": "441b449a430cb2c85efb072704da7e06bce2ea5b",
+      "_id": "webpack-dev-middleware@4.0.1",
+      "_nodeVersion": "12.19.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-wg6IPwK8D/dwIiy1ZJpQAiDo+ZRgBsE+sne1fLLhyoQH4EY9jU7QQ67lwj4xhf/sJc0QBgatXXinVJ/dVwaZGg==",
+        "shasum": "e0201fe48a976cac24b548a398b1022e2ab73ff7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.1.tgz",
+        "fileCount": 15,
+        "unpackedSize": 44269,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfqaOaCRA9TVsSAnZWagAAar8P/RXxyGqMNeFLHI+4uSX7\nxyKglRAygqU9eYGomNGb97FkoqGxyeG2coFqaYoFAYqMh1tJEcXD8ZmIboHd\nZnX0nWa9dRw+nA5zYUkPyz99CjDGSDR6Nns9d0zjp6WIWqcWPgQ/GhUrnQd+\nOpGG3IWtKIVual+A/ycX97fTYbzlgIZaHH3PivM7FzNkKVIuQ427x7BiuQ0H\nMsujG1YmecTHhG5kCPimT1dh1WVneF6I8RTzpYN/00GaAAUqXhlblhO8BsiY\nyTPHlXx7gFjVM7xTkQIxBD2HiBxeUMZ1gIuBGGQEH8pCUz/Tfjx2sTXv17Mj\nN5azmw95UWLR33+af0DGq2bdnbNDSX8Gyag30uzanFPFYwskfTO5howKg5ht\n31e8jmhFuZwBmIcEM6knMB0vX3bns6uN4XNIuVRbGPy5PQvWjmmb+9N7fZ3d\nq/Dp4yEwG12gL4yQLLcqv6PlkNoWEoCbQ6tVUNzVMTwFzPgaG4NSX/KJx5Bd\nbR9IUb7Zvszt5AKLrzjJ2LAdotkDcNwW1kVQY7EZ10AneqBSf8OuBo8CdGRx\naL2QvWEJ07DUgNKb/6JRjB4/hd0xq0cMYNVbjwmiyFgaRoFotXFU4wyQrGPK\neVwXYqJTHOGh2mHtb92GqRaSQ8+e4tD7+rHJG8BFl293gpX166GoBVf8CDtH\ngFfQ\r\n=uU7w\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "michael-ciniawsky",
+          "email": "michael.ciniawsky@gmail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        },
+        {
+          "name": "evilebottnawi",
+          "email": "sheo13666q@gmail.com"
+        },
+        {
+          "name": "hiroppy",
+          "email": "hello@hiroppy.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_4.0.1_1604952985547_0.4004302181315198"
+      },
+      "_hasShrinkwrap": false
+    },
+    "4.0.2": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.2",
+      "description": "A development middleware for webpack",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-middleware",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+      },
+      "main": "dist/cjs.js",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "scripts": {
+        "commitlint": "commitlint --from=master",
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint --cache src test",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "prepare": "npm run build",
+        "build": "del dist && babel src -d dist --copy-files",
+        "release": "standard-version",
+        "security": "npm audit",
+        "test:only": "cross-env NODE_ENV=test jest",
+        "test:watch": "npm run test:only -- --watch",
+        "test:coverage": "npm run test:only -- --collectCoverageFrom=\"src/**/*.js\" --coverage",
+        "pretest": "npm run lint",
+        "test": "npm run test:coverage",
+        "defaults": "webpack-defaults"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "dependencies": {
+        "mem": "^8.0.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^3.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/preset-env": "^7.12.1",
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.6.3",
+        "chokidar": "^3.4.3",
+        "connect": "^3.7.0",
+        "cross-env": "^7.0.2",
+        "del": "^6.0.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.13.0",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.2.0",
+        "husky": "^4.3.0",
+        "jest": "^26.6.3",
+        "lint-staged": "^10.5.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.1.2",
+        "standard-version": "^9.0.0",
+        "supertest": "^6.0.1",
+        "webpack": "^5.4.0"
+      },
+      "keywords": [
+        "webpack",
+        "middleware",
+        "development"
+      ],
+      "gitHead": "05e4a3295dc1be69a9a75bf7702c9bd142d2ef1d",
+      "_id": "webpack-dev-middleware@4.0.2",
+      "_nodeVersion": "12.19.0",
+      "_npmVersion": "6.14.8",
+      "dist": {
+        "integrity": "sha512-xyAICqIugWtT1RRH5aMMmZlPhDhEqPTDL0TWhmMZsuZ+cFlAvRxv4thCbuxdk9MW+OYK4c9BkfmgdQ1/7imkJA==",
+        "shasum": "1436ae6cacee78475bd6bc1fbf063dfbfd6e577d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.2.tgz",
+        "fileCount": 15,
+        "unpackedSize": 44795,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfqoVNCRA9TVsSAnZWagAAEXYP+QBvogLBJM6p/OSJbV6L\nJRSnp73WQHbPRObUXlRpodemYmxEAdPXTwAh6peWvZXbIl9VC7bjsWQarxgF\nmUxZNajSI7X4VshkwdcQK2CAlXKTqVwtYTsVKt05PunkVyflAJ5/JcVAxHcn\noC8a6x88mxyLHeGVdrXdOVr8gf22Rlv3kDuPsoVfEby/PQsdPTsqrDRdwV9p\nNwDIC/PwOPfNmMlE9wJrLua4bQ3LFWKv0Wv+T5k7eP1iGNcIdSvrWWeykE5+\nHS+fAaey8OC1jXtBx+Bn/HF6fNvvMRBLdvAljs3i57hh52FlEnhGpV8wjII7\nLQkXgwPtMJYlJ/lvLcwBi3M8K+ceYt4rymT0dRijGCnme9P3kLsBKL9rp15t\nsBbFIg1aGPbjquNW8QexxeMJTJx8F9gwdY9b01n1/MEFNKqXkQTSh1djk5we\nUGuq4WJyfkC1eYjhH3nwfkQH1q+wFNHf8/p0/DIDY/z+zxP2HOOWjj0OdUOQ\n/hcAkpPo2hqXiHuvQ1GGq5Bmvlx0/cYjRsFeUvnZOpuixmO366bNUAEtvEak\ncUb/gdtJNLyxuUUXHfcWZrl85ny5vskIM5JIT71fCxBz6c0HAerriTYxpmx1\n7SYp9areQTUN+4Ff9ORRuBtOwQ/d1MrguvEd7rIZ/NL356fpm5yVZ1TeJ3P2\nnHb+\r\n=Wqr3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "michael-ciniawsky",
+          "email": "michael.ciniawsky@gmail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        },
+        {
+          "name": "evilebottnawi",
+          "email": "sheo13666q@gmail.com"
+        },
+        {
+          "name": "hiroppy",
+          "email": "hello@hiroppy.me"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-middleware_4.0.2_1605010765043_0.6411241301679635"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n[![size][size]][size-url]\n\n# webpack-dev-middleware\n\nAn express-style development middleware for use with [webpack](https://webpack.js.org)\nbundles and allows for serving of the files emitted from webpack.\nThis should be used for **development only**.\n\nSome of the benefits of using this middleware include:\n\n- No files are written to disk, rather it handles files in memory\n- If files changed in watch mode, the middleware delays requests until compiling\n  has completed.\n- Supports hot module reload (HMR).\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-middleware --save-dev\n```\n\n_Note: We do not recommend installing this module globally._\n\n## Usage\n\n```js\nconst webpack = require('webpack');\nconst middleware = require('webpack-dev-middleware');\nconst compiler = webpack({\n  // webpack options\n});\nconst express = require('express');\nconst app = express();\n\napp.use(\n  middleware(compiler, {\n    // webpack-dev-middleware options\n  })\n);\n\napp.listen(3000, () => console.log('Example app listening on port 3000!'));\n```\n\nSee [below](#other-servers) for an example of use with fastify.\n\n## Options\n\nThe middleware accepts an `options` Object. The following is a property reference for the Object.\n\n### methods\n\nType: `Array`  \nDefault: `[ 'GET', 'HEAD' ]`\n\nThis property allows a user to pass the list of HTTP request methods accepted by the server.\n\n### headers\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to pass custom HTTP headers on each request.\neg. `{ \"X-Custom-Header\": \"yes\" }`\n\n### index\n\nType: `Boolean|String`  \nDefault: `index.html`\n\nIf `false` (but not `undefined`), the server will not respond to requests to the root URL.\n\n### mimeTypes\n\nType: `Object`  \nDefault: `undefined`\n\nThis property allows a user to register custom mime types or extension mappings.\neg. `mimeTypes: { phtml: 'text/html' }`.\n\nPlease see the documentation for [`mime-types`](https://github.com/jshttp/mime-types) for more information.\n\n### publicPath\n\nType: `String`\nDefault: `output.publicPath`\n\nThe public path that the middleware is bound to.\n_Best Practice: use the same `publicPath` defined in your webpack config.\nFor more information about `publicPath`, please see [the webpack documentation](https://webpack.js.org/guides/public-path)._\n\n### serverSideRender\n\nType: `Boolean`  \nDefault: `undefined`\n\nInstructs the module to enable or disable the server-side rendering mode. Please\nsee [Server-Side Rendering](#server-side-rendering) for more information.\n\n### writeToDisk\n\nType: `Boolean|Function`  \nDefault: `false`\n\nIf `true`, the option will instruct the module to write files to the configured\nlocation on disk as specified in your `webpack` config file. _Setting\n`writeToDisk: true` won't change the behavior of the `webpack-dev-middleware`,\nand bundle files accessed through the browser will still be served from memory._\nThis option provides the same capabilities as the\n[`WriteFilePlugin`](https://github.com/gajus/write-file-webpack-plugin/pulls).\n\nThis option also accepts a `Function` value, which can be used to filter which\nfiles are written to disk. The function follows the same premise as\n[`Array#filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)\nin which a return value of `false` _will not_ write the file, and a return value\nof `true` _will_ write the file to disk. eg.\n\n```js\nconst webpack = require('webpack');\nconst configuration = {\n  /* Webpack configuration */\n};\nconst compiler = webpack(configuration);\n\nmiddleware(compiler, {\n  writeToDisk: (filePath) => {\n    return /superman\\.css$/.test(filePath);\n  },\n});\n```\n\n### outputFileSystem\n\nType: `Object`  \nDefault: [memfs](https://github.com/streamich/memfs)\n\nSet the default file system which will be used by webpack as primary destination of generated files.\nThis option isn't affected by the [writeToDisk](#writeToDisk) option.\n\nYou have to provide `.join()` and `mkdirp` method to the `outputFileSystem` instance manually for compatibility with `webpack@4`.\n\nThis can be done simply by using `path.join`:\n\n```js\nconst webpack = require('webpack');\nconst path = require('path');\nconst myOutputFileSystem = require('my-fs');\nconst mkdirp = require('mkdirp');\n\nmyOutputFileSystem.join = path.join.bind(path); // no need to bind\nmyOutputFileSystem.mkdirp = mkdirp.bind(mkdirp); // no need to bind\n\nconst compiler = webpack({\n  /* Webpack configuration */\n});\n\nmiddleware(compiler, { outputFileSystem: myOutputFileSystem });\n```\n\n## API\n\n`webpack-dev-middleware` also provides convenience methods that can be use to\ninteract with the middleware at runtime:\n\n### `close(callback)`\n\nInstructs a webpack-dev-middleware instance to stop watching for file changes.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed once the middleware has stopped watching.\n\n### `invalidate()`\n\nInstructs a webpack-dev-middleware instance to recompile the bundle.\ne.g. after a change to the configuration.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\nsetTimeout(() => {\n  // After a short delay the configuration is changed and a banner plugin is added\n  // to the config\n  compiler.apply(new webpack.BannerPlugin('A new banner'));\n\n  // Recompile the bundle with the banner plugin:\n  instance.invalidate();\n}, 1000);\n```\n\n### `waitUntilValid(callback)`\n\nExecutes a callback function when the compiler bundle is valid, typically after\ncompilation.\n\n### Parameters\n\n#### callback\n\nType: `Function`\n\nA function executed when the bundle becomes valid. If the bundle is\nvalid at the time of calling, the callback is executed immediately.\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({ ... });\nconst middleware = require('webpack-dev-middleware');\nconst instance = middleware(compiler);\n\napp.use(instance);\n\ninstance.waitUntilValid(() => {\n  console.log('Package is in a valid state');\n});\n```\n\n## Known Issues\n\n### Multiple Successive Builds\n\nWatching will frequently cause multiple compilations\nas the bundle changes during compilation. This is due in part to cross-platform\ndifferences in file watchers, so that webpack doesn't loose file changes when\nwatched files change rapidly. If you run into this situation, please make use of\nthe [`TimeFixPlugin`](https://github.com/egoist/time-fix-plugin).\n\n## Server-Side Rendering\n\n_Note: this feature is experimental and may be removed or changed completely in the future._\n\nIn order to develop an app using server-side rendering, we need access to the\n[`stats`](https://github.com/webpack/docs/wiki/node.js-api#stats), which is\ngenerated with each build.\n\nWith server-side rendering enabled, `webpack-dev-middleware` sets the `stats` to `res.locals.webpack.devMiddleware.stats`\nand the filesystem to `res.locals.webpack.devMiddleware.outputFileSystem` before invoking the next middleware,\nallowing a developer to render the page body and manage the response to clients.\n\n_Note: Requests for bundle files will still be handled by\n`webpack-dev-middleware` and all requests will be pending until the build\nprocess is finished with server-side rendering enabled._\n\nExample Implementation:\n\n```js\nconst webpack = require('webpack');\nconst compiler = webpack({\n  // webpack options\n});\nconst isObject = require('is-object');\nconst middleware = require('webpack-dev-middleware');\n\n// This function makes server rendering of asset references consistent with different webpack chunk/entry configurations\nfunction normalizeAssets(assets) {\n  if (isObject(assets)) {\n    return Object.values(assets);\n  }\n\n  return Array.isArray(assets) ? assets : [assets];\n}\n\napp.use(middleware(compiler, { serverSideRender: true }));\n\n// The following middleware would not be invoked until the latest build is finished.\napp.use((req, res) => {\n  const { devMiddleware } = res.locals.webpack;\n  const outputFileSystem = devMiddleware.outputFileSystem;\n  const jsonWebpackStats = devMiddleware.stats.toJson();\n  const { assetsByChunkName, outputPath } = jsonWebpackStats;\n\n  // Then use `assetsByChunkName` for server-side rendering\n  // For example, if you have only one main chunk:\n  res.send(`\n<html>\n  <head>\n    <title>My App</title>\n    <style>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.css'))\n      .map((path) => outputFileSystem.readFileSync(path.join(outputPath, path)))\n      .join('\\n')}\n    </style>\n  </head>\n  <body>\n    <div id=\"root\"></div>\n    ${normalizeAssets(assetsByChunkName.main)\n      .filter((path) => path.endsWith('.js'))\n      .map((path) => `<script src=\"${path}\"></script>`)\n      .join('\\n')}\n  </body>\n</html>\n  `);\n});\n```\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, or would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Other servers\n\nExamples of use with other servers will follow here.\n\n### Fastify\n\nFastify interop will require the use of `fastify-express` instead of `middie` for providing middleware support. As the authors of `fastify-express` recommend, this should only be used as a stopgap while full Fastify support is worked on.\n\n```js\nconst fastify = require('fastify')();\nconst webpack = require('webpack');\nconst webpackConfig = require('./webpack.config.js');\nconst devMiddleware = require('webpack-dev-middleware');\n\nconst compiler = webpack(webpackConfig);\nconst { publicPath } = webpackConfig.output;\n\n(async () => {\n  await fastify.register(require('fastify-express'));\n  await fastify.use(devMiddleware(compiler, { publicPath }));\n  await fastify.listen(3000);\n})();\n```\n\n## Contributing\n\nPlease take a moment to read our contributing guidelines if you haven't yet done so.\n\n[CONTRIBUTING](./CONTRIBUTING.md)\n\n## License\n\n[MIT](./LICENSE)\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-middleware.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-middleware\n[node]: https://img.shields.io/node/v/webpack-dev-middleware.svg\n[node-url]: https://nodejs.org\n[deps]: https://david-dm.org/webpack/webpack-dev-middleware.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-middleware\n[tests]: https://github.com/webpack/webpack-dev-middleware/workflows/webpack-dev-middleware/badge.svg\n[tests-url]: https://github.com/webpack/webpack-dev-middleware/actions\n[cover]: https://codecov.io/gh/webpack/webpack-dev-middleware/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-middleware\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n[size]: https://packagephobia.com/badge?p=webpack-dev-middleware\n[size-url]: https://packagephobia.com/result?p=webpack-dev-middleware\n[docs-url]: https://webpack.js.org/guides/development/#using-webpack-dev-middleware\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-middleware\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+  "maintainers": [
+    {
+      "name": "sokra",
+      "email": "tobias.koppers@googlemail.com"
+    },
+    {
+      "name": "jhnns",
+      "email": "mail@johannesewald.de"
+    },
+    {
+      "name": "michael-ciniawsky",
+      "email": "michael.ciniawsky@gmail.com"
+    },
+    {
+      "name": "spacek33z",
+      "email": "kees@webduck.nl"
+    },
+    {
+      "name": "evilebottnawi",
+      "email": "sheo13666q@gmail.com"
+    },
+    {
+      "name": "hiroppy",
+      "email": "hello@hiroppy.me"
+    }
+  ],
+  "time": {
+    "modified": "2020-11-10T12:19:27.572Z",
+    "created": "2012-08-08T20:19:25.926Z",
+    "0.5.0": "2012-08-08T20:19:28.843Z",
+    "0.5.1": "2012-08-08T20:24:13.309Z",
+    "0.6.0": "2012-09-11T15:16:42.427Z",
+    "0.6.1": "2012-09-11T15:37:39.383Z",
+    "0.6.2": "2012-09-19T11:49:28.762Z",
+    "0.7.0": "2012-09-25T18:56:04.436Z",
+    "0.7.1": "2012-10-08T12:46:29.221Z",
+    "0.7.2": "2012-11-08T14:58:34.090Z",
+    "0.7.3": "2012-11-08T15:07:59.949Z",
+    "0.7.4": "2012-11-09T07:04:07.287Z",
+    "0.8.0": "2012-11-09T07:27:01.013Z",
+    "0.8.1": "2012-11-20T18:07:33.676Z",
+    "0.8.2": "2013-01-24T13:23:17.516Z",
+    "0.9.0": "2013-02-04T08:57:58.764Z",
+    "0.9.1": "2013-02-04T09:17:21.792Z",
+    "0.10.0": "2013-03-26T17:25:30.817Z",
+    "0.10.1": "2013-03-26T19:07:14.786Z",
+    "0.10.2": "2013-05-12T21:27:19.172Z",
+    "0.11.0": "2013-06-19T12:11:47.892Z",
+    "1.0.0": "2013-12-17T22:47:30.889Z",
+    "1.0.1": "2014-01-05T00:08:11.837Z",
+    "1.0.2": "2014-01-22T15:40:36.556Z",
+    "1.0.3": "2014-01-22T22:29:55.753Z",
+    "1.0.4": "2014-01-27T21:44:29.407Z",
+    "1.0.5": "2014-03-12T10:35:51.185Z",
+    "1.0.6": "2014-05-22T10:17:44.963Z",
+    "1.0.7": "2014-06-04T06:39:46.924Z",
+    "1.0.8": "2014-06-06T20:57:27.585Z",
+    "1.0.9": "2014-06-18T21:08:57.788Z",
+    "1.0.10": "2014-07-02T20:26:00.411Z",
+    "1.0.11": "2014-08-19T08:45:09.065Z",
+    "1.1.0": "2015-06-21T20:26:42.291Z",
+    "1.2.0": "2015-06-28T06:29:21.124Z",
+    "1.3.0": "2015-11-24T07:01:57.014Z",
+    "1.4.0": "2015-11-24T19:47:12.751Z",
+    "1.5.0": "2016-01-21T20:36:43.214Z",
+    "1.5.1": "2016-01-22T16:16:49.411Z",
+    "1.6.0": "2016-03-24T18:56:27.861Z",
+    "1.6.1": "2016-03-26T14:23:28.421Z",
+    "1.7.0": "2016-09-10T09:18:06.705Z",
+    "1.8.0": "2016-09-17T19:15:44.356Z",
+    "1.8.1": "2016-09-18T07:54:09.032Z",
+    "1.8.2": "2016-09-23T09:03:10.120Z",
+    "1.8.3": "2016-09-26T18:15:36.883Z",
+    "1.8.4": "2016-10-08T16:15:55.134Z",
+    "1.9.0": "2016-12-15T19:58:58.030Z",
+    "1.10.0": "2017-02-01T20:20:14.097Z",
+    "1.10.1": "2017-02-18T13:55:26.236Z",
+    "1.10.2": "2017-04-22T10:00:10.205Z",
+    "1.11.0": "2017-06-22T04:08:28.446Z",
+    "1.12.0": "2017-07-31T12:52:13.076Z",
+    "1.12.1": "2017-11-22T17:50:27.130Z",
+    "1.12.2": "2017-11-27T14:06:37.313Z",
+    "2.0.0": "2017-12-14T00:08:33.865Z",
+    "2.0.1": "2017-12-14T04:00:45.323Z",
+    "2.0.2": "2017-12-18T17:31:26.678Z",
+    "2.0.3": "2017-12-22T21:37:39.355Z",
+    "2.0.4": "2018-01-07T06:09:20.901Z",
+    "2.0.5": "2018-02-09T13:43:43.695Z",
+    "2.0.6": "2018-02-22T19:35:23.842Z",
+    "3.0.0": "2018-02-28T22:31:03.972Z",
+    "3.0.1": "2018-03-06T13:41:45.721Z",
+    "3.1.0": "2018-03-26T19:09:44.519Z",
+    "3.1.1": "2018-04-05T00:20:46.882Z",
+    "3.1.2": "2018-04-05T18:04:13.897Z",
+    "3.1.3": "2018-04-26T18:33:46.400Z",
+    "3.2.0": "2018-08-23T20:05:25.358Z",
+    "3.3.0": "2018-09-10T11:56:51.280Z",
+    "3.4.0": "2018-09-24T18:39:04.197Z",
+    "3.5.0": "2019-01-04T18:07:44.617Z",
+    "3.5.1": "2019-01-17T11:45:59.313Z",
+    "3.5.2": "2019-02-06T21:16:08.057Z",
+    "3.6.0": "2019-02-19T13:48:35.343Z",
+    "3.6.1": "2019-03-06T15:59:07.818Z",
+    "3.6.2": "2019-04-03T12:35:15.065Z",
+    "3.7.0": "2019-05-15T08:08:21.596Z",
+    "3.7.1": "2019-09-03T10:40:06.223Z",
+    "3.7.2": "2019-09-28T15:33:05.181Z",
+    "4.0.0-rc.0": "2020-02-19T12:05:17.461Z",
+    "4.0.0-rc.1": "2020-02-20T09:36:37.364Z",
+    "4.0.0-rc.2": "2020-06-30T15:29:48.750Z",
+    "4.0.0-rc.3": "2020-07-14T17:02:12.646Z",
+    "4.0.0": "2020-10-28T14:44:59.503Z",
+    "4.0.1": "2020-11-09T20:16:25.694Z",
+    "4.0.2": "2020-11-10T12:19:25.243Z"
+  },
+  "author": {
+    "name": "Tobias Koppers @sokra"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/webpack/webpack-dev-middleware",
+  "users": {
+    "wkaifang": true,
+    "panlw": true,
+    "junjiansyu": true,
+    "sqrtthree": true,
+    "linjianhang": true,
+    "princetoad": true,
+    "handane123": true,
+    "iori20091101": true,
+    "scotchulous": true,
+    "rubychen": true,
+    "jetbug123": true,
+    "shanewholloway": true,
+    "stone-jin": true,
+    "wangfeia": true,
+    "wujr5": true,
+    "coolhanddev": true,
+    "appsparkler": true,
+    "drewigg": true,
+    "nickeltobias": true,
+    "kankungyip": true,
+    "sean-oneal": true,
+    "superchenney": true,
+    "cl0udw4lk3r": true,
+    "ferchoriverar": true,
+    "lore-w": true,
+    "dhanya-kr": true,
+    "rethinkflash": true,
+    "fengmiaosen": true,
+    "abhijitkalta": true,
+    "kodekracker": true,
+    "gxglwy": true,
+    "sternelee": true,
+    "tiggem1993": true,
+    "shuoshubao": true,
+    "largepuma": true,
+    "yeming": true,
+    "serge-nikitin": true,
+    "fakefarm": true,
+    "luffy84217": true,
+    "xfloops": true,
+    "mobeicaoyuan": true,
+    "isenricho": true,
+    "uzprocode": true,
+    "mrhuangyuhui": true,
+    "rajiff": true,
+    "ycjcl868": true,
+    "assiduous": true,
+    "kvn1351": true,
+    "joaquin.briceno": true,
+    "xiaobing": true,
+    "magicwager": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webpack/webpack-dev-middleware.git"
+  },
+  "bugs": {
+    "url": "https://github.com/webpack/webpack-dev-middleware/issues"
+  },
+  "license": "MIT",
+  "keywords": [
+    "webpack",
+    "middleware",
+    "development"
+  ]
+}

--- a/test/fixtures/registry-mocks/content/webpack-dev-middleware.min.json
+++ b/test/fixtures/registry-mocks/content/webpack-dev-middleware.min.json
@@ -1,0 +1,2534 @@
+{
+  "name": "webpack-dev-middleware",
+  "dist-tags": {
+    "latest": "4.0.2",
+    "next": "4.0.0-rc.3"
+  },
+  "versions": {
+    "0.5.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.5.0",
+      "dependencies": {
+        "webpack": "0.5.x"
+      },
+      "bin": {
+        "webpack-dev-middleware": "./webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "e50416142d56f8597638efa5c02ddb681dfb6a1c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.5.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.5.1",
+      "dependencies": {
+        "webpack": "0.5.x"
+      },
+      "dist": {
+        "shasum": "142825b36fbf322914c488e92003b82dbca6d7d4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.5.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.6.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.6.0",
+      "dependencies": {
+        "webpack": "0.6.x"
+      },
+      "dist": {
+        "shasum": "f2c707c38b841c62884eb85d95de54844b7c9345",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.6.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.6.1",
+      "dependencies": {
+        "webpack": "0.6.x"
+      },
+      "dist": {
+        "shasum": "154949e6b7b74c037c59dcf8fd6a42180c1c2bf4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.6.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.6.2": {
+      "name": "webpack-dev-middleware",
+      "version": "0.6.2",
+      "dependencies": {
+        "webpack": "0.6.x"
+      },
+      "dist": {
+        "shasum": "122163d97ae0f42629d121772c08f1045968b8a7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.6.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.7.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.0",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "dist": {
+        "shasum": "6676758f35102b16638583903916b8b9d94b496c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.7.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.1",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "dist": {
+        "shasum": "95a7ede1ef2bd43943e7b11b91840ece1b1019eb",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.7.2": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.2",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "dist": {
+        "shasum": "ec6b82b64bbaf9e8905eb0a12e50fb8c2884990b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.7.3": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.3",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "dist": {
+        "shasum": "ef4fffc5efe335e4de630effa39070acf43e78bc",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.7.4": {
+      "name": "webpack-dev-middleware",
+      "version": "0.7.4",
+      "dependencies": {
+        "webpack": "0.7.x"
+      },
+      "dist": {
+        "shasum": "56f606094fdd910611feba1bbf67606700f44262",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.7.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.8.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.8.0",
+      "dependencies": {
+        "webpack": "0.8.x"
+      },
+      "dist": {
+        "shasum": "53963072b83217812ab58286fcf475134639c2bf",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.8.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.8.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.8.1",
+      "dependencies": {
+        "webpack": "0.8.x"
+      },
+      "dist": {
+        "shasum": "51f449b2cfe60eb40eeaa36deb334e7067012ad6",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.8.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.8.2": {
+      "name": "webpack-dev-middleware",
+      "version": "0.8.2",
+      "dependencies": {
+        "webpack": "0.8.x"
+      },
+      "dist": {
+        "shasum": "ce2061ccea4aa7d672774e79051b4473fdc79d55",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.8.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.1.30"
+      }
+    },
+    "0.9.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.9.0",
+      "dependencies": {
+        "webpack": "0.8.x",
+        "enhanced-resolve": "0.5.x"
+      },
+      "dist": {
+        "shasum": "e92b4ac2c387000106685721de310775220a01db",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.9.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "0.9.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.9.1",
+      "dependencies": {
+        "webpack": "0.9.x",
+        "enhanced-resolve": "0.5.x"
+      },
+      "dist": {
+        "shasum": "13c863ff5648a24596910b074ade81cd0c5934d4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.9.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "0.10.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.10.0",
+      "dependencies": {
+        "webpack": "0.10.x",
+        "enhanced-resolve": "0.5.x"
+      },
+      "dist": {
+        "shasum": "337f5895d6314a37d6e8ae15b8bd09f745b295aa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.10.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "0.10.1": {
+      "name": "webpack-dev-middleware",
+      "version": "0.10.1",
+      "dependencies": {
+        "enhanced-resolve": "0.5.x"
+      },
+      "peerDependencies": {
+        "webpack": "0.10.x"
+      },
+      "dist": {
+        "shasum": "793aa3bf369d6156fe7cfe7224846c1f4f87a7a5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.10.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "0.10.2": {
+      "name": "webpack-dev-middleware",
+      "version": "0.10.2",
+      "dependencies": {
+        "enhanced-resolve": "0.5.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "0.10.x"
+      },
+      "dist": {
+        "shasum": "746f0fa2f82b4d8d991c42b1b8eb12fa08d79ea3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.10.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "0.11.0": {
+      "name": "webpack-dev-middleware",
+      "version": "0.11.0",
+      "dependencies": {
+        "enhanced-resolve": "0.5.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "0.11.x"
+      },
+      "dist": {
+        "shasum": "293130808a718f8a75d2cc6337ee030c9746b7f2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-0.11.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.0",
+      "dependencies": {
+        "enhanced-resolve": "0.5.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "a48fa02eda279adf95d221f96b687e5aa8b75e74",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.1",
+      "dependencies": {
+        "enhanced-resolve": "0.5.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "2947c87fa8bb22784004e2b6ae0e6bcc373c9a1e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.2": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.2",
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "62fde19b4c08115cb275066b75e20ff7239f1789",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.3": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.3",
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "efca70a3ad465bf9f183e9cd27623b24a178fc02",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.4": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.4",
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "8234d273e4f91fb3c6b8dbc3f36ae60202a562e5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.5": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.5",
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "408343fc3b63052cc9c46b7117306e3186e8c9c2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.6": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.6",
+      "dependencies": {
+        "enhanced-resolve": "0.6.x",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "7fc374b66f0c1448b129a709414917729cb83ec4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.7": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.7",
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "7b6a382d68ebfb7d27391c2fcd8b99b1dcbc0ffa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.7.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.8": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.8",
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "2d0395003b4b1922394b15de660436b9a6dd939a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.8.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.9": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.9",
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "37cec079e60b0c5db64b675e2d3ac3b03ea0f3d9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.9.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.10": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.10",
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "memory-fs": "~0.1.0",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "15b3e8567fe961e18ed76af24f1f9c38081fb0d6",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.10.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.0.11": {
+      "name": "webpack-dev-middleware",
+      "version": "1.0.11",
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "memory-fs": "~0.1.0",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "9b5ab7ecd0641cee31e87f7e902f6f59253674fd",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.0.11.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.1.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.1.0",
+      "dependencies": {
+        "enhanced-resolve": "~0.7.5",
+        "memory-fs": "~0.1.0",
+        "mime": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dist": {
+        "shasum": "bc005ffbf2e1f4230e422670079cb3738f1e803f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.2.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.2.0",
+      "dependencies": {
+        "memory-fs": "~0.2.0",
+        "mime": "^1.3.4"
+      },
+      "peerDependencies": {
+        "webpack": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "13b76aa2c8476000cd6ffefeae3eef448ee474ed",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.3.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.3.0",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4"
+      },
+      "peerDependencies": {
+        "webpack": "^1.0.0"
+      },
+      "dist": {
+        "shasum": "0bf372a7dbd21dd4220f7d1b769dca0b71f55b5e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.4.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.4.0",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.0.0 <3"
+      },
+      "dist": {
+        "shasum": "326ec7725cde19692e70edb1ff8a570312ee6830",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.5.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.5.0",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.0.0 <3"
+      },
+      "dist": {
+        "shasum": "bd24a4e627e3fd3b4fbae39041a56caf794a0713",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.5.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.5.1",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.0.0 <3"
+      },
+      "dist": {
+        "shasum": "c46e075467881211e3fca34af1cdadf47163c89a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.5.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.6.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.6.0",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dist": {
+        "shasum": "332a389776064556945aef3d75e51a6e091af228",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.6.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.6.1",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dist": {
+        "shasum": "c25ef832abc7d360c38bb40eb918692720ced611",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.6.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.7.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.7.0",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "eslint": "^3.4.0"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dist": {
+        "shasum": "e07246aa503d2ad0d35ce688ed24f0e739cca9e7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.7.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.8.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.0",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dist": {
+        "shasum": "f7571c93ee3949f587741bb78ab9ce748deda184",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.8.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.1",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dist": {
+        "shasum": "4855276fd89c3f5e2a4eadfc5e1e94f73c4a550d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.8.2": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.2",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dist": {
+        "shasum": "512b2c31b962482717d87e6e9c3ce01f5c46e775",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.8.3": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.3",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dist": {
+        "shasum": "1c1a1bd39df3eedf3088eab72d980837e834e5da",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.8.4": {
+      "name": "webpack-dev-middleware",
+      "version": "1.8.4",
+      "dependencies": {
+        "memory-fs": "~0.3.0",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta"
+      },
+      "dist": {
+        "shasum": "e8765c9122887ce9e3abd4cc9c3eb31b61e0948d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.8.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.9.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.9.0",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.1.0-beta.22"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+      },
+      "dist": {
+        "shasum": "a1c67a3dfd8a5c5d62740aa0babe61758b4c84aa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.9.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.10.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.10.0",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+      },
+      "dist": {
+        "shasum": "7d5be2651e692fddfafd8aaed177c16ff51f0eb8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.10.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.10.1",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+      },
+      "dist": {
+        "shasum": "c6b4cf428139cf1aefbe06a0c00fdb4f8da2f893",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.10.2": {
+      "name": "webpack-dev-middleware",
+      "version": "1.10.2",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^3.4.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.9.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "should": "^11.1.0",
+        "sinon": "^1.17.5",
+        "supertest": "^2.0.0",
+        "webpack": "^2.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "1 || ^2.1.0-beta || ^2.2.0-rc.0"
+      },
+      "dist": {
+        "shasum": "2e252ce1dfb020dbda1ccb37df26f30ab014dbd1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.11.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.11.0",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "should": "^11.1.0",
+        "sinon": "^2.3.5",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "dist": {
+        "shasum": "09691d0973a30ad1f82ac73a12e2087f0a4754f9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.11.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.12.0": {
+      "name": "webpack-dev-middleware",
+      "version": "1.12.0",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "should": "^11.1.0",
+        "sinon": "^2.3.8",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "dist": {
+        "shasum": "d34efefb2edda7e1d3b5dbe07289513219651709",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.12.1": {
+      "name": "webpack-dev-middleware",
+      "version": "1.12.1",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.4.1",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "should": "^11.1.0",
+        "sinon": "^2.3.8",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-UzyVg/CKBKkymDpqOoQ4mWTs9zQp0DPCY8zbol9K0tPhqoM+JU5knKGXyMQ/Cdrmzb9Cw3eetm67fIsJ7u7ryg==",
+        "shasum": "338be3ca930973be1c2ce07d84d275e997e1a25a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "1.12.2": {
+      "name": "webpack-dev-middleware",
+      "version": "1.12.2",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^1.5.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "should": "^11.1.0",
+        "sinon": "^2.3.8",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.0.0 || ^2.0.0 || ^3.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
+        "shasum": "f8fc1120ce3b4fc5680ceecb43d777966b21105e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "2.0.0": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.0",
+      "dependencies": {
+        "chalk": "^2.3.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.0.3",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0",
+        "url-join": "^2.0.2",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dist": {
+        "integrity": "sha512-E6cK3zBo8Afkju3x19ZJ0SCX/f8lE+KRUStaFJplHTwyP+0OlWyD/4OYgeC8ewvNi+SsElNTo/q5CFZgV4dIEg==",
+        "shasum": "5a22e866dd68e15cbb335378816b8bc064c5f03d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.1": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.1",
+      "dependencies": {
+        "chalk": "^2.3.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.0.3",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0",
+        "url-join": "^2.0.2",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dist": {
+        "integrity": "sha512-jEQgJK+eblBzE4blKmNuJqNd4cz3t4K3mFmN6uZz4Iq44x2vc1r+CwZBgcX+GzQoSOk5iWSVB3bIN5AYKpFRTw==",
+        "shasum": "22c8ecef27f08fca6dfa95504d57f66a8f37cc13",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.2": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.2",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.0.3",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dist": {
+        "integrity": "sha512-3hhjH5wDkddWHNrxcbVuIgHsovCKbtuCOsiwXKYP7PgG6j/F4y+LaIMqiAi7M/jiOLoVACX18eell7wrPGN1Rw==",
+        "shasum": "cbfaf5477e2179a2be0a989752acaa9bbd38b02c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.3": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.3",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dist": {
+        "integrity": "sha512-8zIUzfCbpaDxKSAyC8ZhDA0P5EBvlafHcj4yoSP8lrvW0ZyWW7tsrqazI7q+zAhRi22TTE3g9sycQEZeyUbpqg==",
+        "shasum": "44e15480ec58d275417ac4d93a0126c7b72450bd",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.3.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.4": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.4",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dist": {
+        "integrity": "sha512-tq0VmEqam/77Q0wWXBQSZsjnX5rsJvb5kvyP42+MvhuLfS5RXozunAsW+ZGbRzqs/Asyxd6Cvr/V4bQ/218ALw==",
+        "shasum": "7d8943a609121021bb72772a41636e229346cb41",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.4.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.5": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.5",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha || ^4.0.0-beta || ^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-EPXudTrpQLksLt9klR0spnb7mt4dHtk3amGnohZNeQ+Y2QSqBbnWA7uNZ9+rqyfhEcYw18pUwcGIXuPFvIIELQ==",
+        "shasum": "2a1d07afb599e1993033d72c2181ec2344c15e31",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.5.tgz",
+        "fileCount": 8,
+        "unpackedSize": 28404
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.6": {
+      "name": "webpack-dev-middleware",
+      "version": "2.0.6",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^2.0.2",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.5",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha || ^4.0.0-beta || ^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==",
+        "shasum": "a51692801e8310844ef3e3790e1eacfe52326fd4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz",
+        "fileCount": 8,
+        "unpackedSize": 28473
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.0.0",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.0.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-eoiOk7nr04ujorQp2QEbdmD+R39jGexwEfefqhT5kUBghMPzuF63JbGxgTOjimiszjRnJ0fZzvIRoYCYiq2UxA==",
+        "shasum": "ae8902596f1b1fa8f7eada874aabb64cba9cd53e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.0.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 27979
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.0.1",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.0.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-JCturcEZNGA0KHEpOJVRTC/VVazTcPfpR9c1Au6NO9a+jxCRchMi87Qe7y3JeOzc0v5eMMKpuGBnPdN52NA+CQ==",
+        "shasum": "7ffd6d0192883c83d3f262e8d7dec822493c6166",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.0.1.tgz",
+        "fileCount": 9,
+        "unpackedSize": 27984
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.1.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.1.0",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-UtAd5+J3IihQilwxOESie2BKaeo37yjmMSfV5G+UGEwPwqgL9+L/rShvjrfse8ARSRQGd3QwN2ANSk++KYZizQ==",
+        "shasum": "b354b17d0baa274ea3af38c6f005e66a16bdb76b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.0.tgz",
+        "fileCount": 10,
+        "unpackedSize": 31220
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.1.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.1.1",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.2.0"
+      },
+      "peerDependencies": {
+        "chalk": "^2.1.0",
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-jgi67sYoEDTx8HF1u+pskW2RT8uzdelOsoMzlR6auaayF9f571dlK1ZBit1L8mg4afvzVdDDF2k9QeTbAq7THA==",
+        "shasum": "82e175d6c34ff4d1851ce88284238bc97a5160a7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.1.tgz",
+        "fileCount": 10,
+        "unpackedSize": 31243
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.1.2": {
+      "name": "webpack-dev-middleware",
+      "version": "3.1.2",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Z11Zp3GTvCe6mGbbtma+lMB9xRfJcNtupXfmvFBujyXqLNms6onDnSi9f/Cb2rw6KkD5kgibOfxhN7npZwTiGA==",
+        "shasum": "be4d0c36a4fa7d69d6904093418514caa9df3a40",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.2.tgz",
+        "fileCount": 10,
+        "unpackedSize": 31173
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.1.3": {
+      "name": "webpack-dev-middleware",
+      "version": "3.1.3",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.1.0",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^1.0.1"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov": "^3.0.0",
+        "eslint": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.8.0",
+        "express": "^4.14.0",
+        "file-loader": "^1.1.10",
+        "mocha": "^5.0.1",
+        "nyc": "^11.4.1",
+        "sinon": "^4.1.3",
+        "supertest": "^3.0.0",
+        "webpack": "^4.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
+        "shasum": "8b32aa43da9ae79368c1bf1183f2b6cf5e1f39ed",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz",
+        "fileCount": 10,
+        "unpackedSize": 31468,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa4huMCRA9TVsSAnZWagAAzBgP/jRvaH3qKM0IDqDpb412\nkV+91mJG8At6lF8YQZCzZ4F0ekRtLMDmV0sQJtUutJVMVlKSSZUaFxDgrGd/\nO4LQCqgExgEeYsCUOZsYrvPRBnYgljMWfkdOIBIC95Fc16O5XE6pKfFybIA4\n2VVQ9aknsNmf3bV08r7d3D/CpK6uU8vxV3ztXzTdJAt4/Bfz7rijvQvGrK4m\neiWyxhyJ1MK8OFeMUD640C3R+pEutbVmPaaN6FfsIrt/GZD4yVF4I4IFEFDn\nVLgr8j7hG7cfkXUZpwf8BYuH8AnkYQGgwlKwI+zgozJmS4nmPrntmC0k7N63\nZJjnNmQID/d0hnBxnMyySef4lyMTl2BHT55YMDmscIY/yAaa/KnfAigwlP/o\nrcr82y/zCCcF5NhOz71VN2+8hHj7Pxr4bvGzO3o12rxQaOKTAUKCYEBG3sbe\n7K8K3qRVU5LXiM9Ctr1nZj3O/YTsoUR96UKXkrNVe/SrzwQZ0+nYEkJYv5A+\nhdl74WegrBrFLIhy6JvT29rD39cHgxAgaZx6OySSjwPaiAIQzuzSpbos64Oj\n3NSv6HNuOtVriOWhGfyTKKgi1vhg2yrpnEULURTWBuHjzCY+e6Enu2Kz5cCY\n0Lrh2e2MspbPjWRwM2KEpmP6z50WzHxLAsKtzKh7Xq8hsk9CaUAZc6Hciss9\ng2bu\r\n=cPwR\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.2.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.2.0",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-YJLMF/96TpKXaEQwaLEo+Z4NDK8aV133ROF6xp9pe3gQoS7sxfpXh4Rv9eC+8vCvWfmDjRQaMSlRPbO+9G6jgA==",
+        "shasum": "a20ceef194873710052da678f3c6ee0aeed92552",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.2.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 32320,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfxOFCRA9TVsSAnZWagAAmREQAJQIEJwGnAOwrWmSq+bK\nMQSrk7RrilJCnBD7HrsCocO238TXNjRal3h2syAGBo4BzUYt6DrH69KrnGXw\nnQul9ASjR27BXtjTZjNsYJsDXeJlGUifc4/ac9OHVonNVRASsjIThI0zM6Ke\nvSZAuDVA0PY3huaaUBVIpVmBSFYR/FUuqP/ZJAPsFJi+Nsp/ZoXso8ioRI+x\nED8XiCWKzH8zW/MDuOvKyOfx9kNv2Ul+NiOP2Ll6nmPn8LvKjShGpWhsbfwp\n1MnNs/C8LNYj2J3q7UyVrCh8mU4oeYLBTx/Ixm6zY/PeP+YxPUg53vzec7X4\n/Gy/BzGeNpwdbZzfXxgsscxKC5A4F/Yxc/Q2DpcZD6oxKeebrCNxaE2oK7G5\njtQ9hzEnsdejgbOebcYKmzo0PD99tX55NIadXHkMAojTqBH8nQL5HF9kcCLa\nkZUIrTlM8hPBaxvf46UFlOIFh3/St8pOXJb/tHM4FS1g6bom3DcVrEeO4Ynd\nVAUt4brmEQqwDm7o9ES5USVs9ZUhma7gFFpRGpdqVz2xWrPl1yL3cuAds3W4\nsFqWWi3C8dQq6yf5GIVVY+LoNV2L1FVoHUs1SJR2CkovonlPbbhYz1VV0Sj+\n6B1wgO7GFFrO9BJ1hSEvHAo+ZEbFbki0KQdT0PLTfLPlhrHUIfmkRHqNQ1aB\nNoKx\r\n=kVxs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.3.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.3.0",
+      "dependencies": {
+        "loud-rejection": "^1.6.0",
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "url-join": "^4.0.0",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-5C5gXtOo1I6+0AEg4UPglYEtu3Rai6l5IiO6aUu65scHXz29dc3oIWMiRwvcNLXgL0HwRkRxa9N02ZjFt4hY8w==",
+        "shasum": "8104daf4d4f65defe06ee2eaaeea612a7c541462",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.3.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 32821,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbllwECRA9TVsSAnZWagAASLwP/15zbGTRTE4nLNzoWdjW\neDWDX9bQKRfm9SBH6fDGnB8eOan9AGy9PYEuPxsT7P0r6cHb+XqTs3n48wul\nEF/TM8st2oOQuQlrbvZYHKkC4Eq6QHORr8YzWyuVzcXnylrNNTcx1HQYEgO8\nz9BhMZ/Hih5MkILwUvzkJCDFxvnbj67Bd3z4R29bsuLpr7Sjxb+ZGr9vGSWb\nlaMNuhcDiYrXBUyA0FWYWj4TMWETMeB8J/Vdr7zF4juhsiEkVQAfuSpeW8C7\n9v33nXOfM9k7uNjryFvdEml+F3KIoq6bjPNye9xu/Q5fJocCFroLaKFaHtsA\niz5THb7/9cyP4zNYCKHgMKvYT/PmIueG6AlyaSb/2dNxRaMaN/EytCedXQES\nA8fGJwNxpl1SdjSKaqGbXAxavyrX3A4dzraoCXA9AdYu20k0huPSrGEfQTZU\ngi91+B4RXFsZFk5K693JTLhn4MOrtskisZDNUAfNMmRyfwiggaoy9Str75+j\n3dtgqsU/6UbItI+RQm70K9sxUenWNOYMLjqUK272hy+PTWjPsEzJ+oLNM167\nwnyiPxT8yc7J+aabSwAqP/XMrUCPI5PPl+dpocv/OF9bM6qosB9UKfR/9nqR\ner2n9vVm+iLrg1xasqn2oypDDW88rPpAK8NmwIVEpTcrUNgUXkDTJ72jAGUr\n+suZ\r\n=MPHx\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.4.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.4.0",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Q9Iyc0X9dP9bAsYskAVJ/hmIZZQwf/3Sy4xCAZgL5cUkjZmUZLt4l5HpbST/Pdgjn3u6pE7u5OdGd1apgzRujA==",
+        "shasum": "1132fecc9026fd90f0ecedac5cbff75d1fb45890",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.4.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 32706,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqS9ICRA9TVsSAnZWagAAbPsQAILZAWvndRuCMjMoWXJo\nzIJYVVXVWrscc0HBQ+lDZkdyaww8fK9X9gA65Hf/JwERF8vAr6K8fbEjABYm\np1NnS3Zz4P4BDjpiHM1s1ZtitAxL06JjX8KmlMevTQwbEDqzWYFxaGE+9MkI\n8QFz1JkhOkQUeEH8K6/lnov07Pc8PBKKqUrteRq0FA5dSp6hO4pV1P8UY0Q4\nXnrnVWv2AdPMtoPPDE/RqN5fzlRh0Wr+hbZYAUV0CQLlEyHG0JedDkGe8RZm\nVuJ9zRPhF5gPIePGCDFP9asWnWKNwFkGMHZtO9J4rQAzI5xsO9h32EyVWZvW\nBuY0uTnlrcWtkHypidGurUQXEyfcm+nLQeOI8p9+LhTj3HB0cCKnBEL9lt9m\nS42TEaCN870sG/BOLcQwkSm+uGsr1QxVmvZQrtL2JY7bxHAtMZV1cqkfLn60\nXUO0wzrueQQu1Q8gn39SLOIJSv27WskEahr2EZTH+RIv6vHKIW0KYsokQZoa\n4V5pW/TbqoLE8jwvSMgjM7NnXBLvrESWvMC4xRjLPrYDWK+GFrASHWbNM1U7\nveA1Sh0jWgIwmQ5XkAlgeyR7iyEMPEI5/Hardo34khhhzUQQN5Z2yzU/2sVl\n59wrKG6Nmnk4ospLOEH3vsiiM3MUFw1gFYPr4Yi0T4Yvtt5y2BuTmcg3x8sg\nh6Yl\r\n=R834\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.5.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.5.0",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^2.0.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-1Zie7+dMr4Vv3nGyhr8mxGQkzTQK1PTS8K3yJ4yB1mfRGwO1DzQibgmNfUqbEfQY6eEtEEUzC+o7vhpm/Sfn5w==",
+        "shasum": "fff0a07b0461314fb6ca82df3642c2423f768429",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.5.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 33716,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcL6DxCRA9TVsSAnZWagAAWMUP/Ak97JjoW/AFKKPoMb2+\nmi9zUsPnGJo1BxswrZvlMak89Jaq85xwoec8xk+HcKBZJhhTgICAZH9itet+\nssl3DwrqSnWD6zVEDCPXzeCMt7bNwABaULwafSbtbQkvpUycLB+Q6v3ZsH7L\nN78OQ6vZvzLT4Wvxfk+pO62NT20QhO/XbpXCV4BDxXoYKz5aSI+NRV/AdnjO\nQcd6G2nA+iNwBrj+DVSFco/d0ibf5rTlAo0OPSIdm303pB0mtLzm1DD5QZ0U\nDQ6lxTjBe3iU9dvjelAaSvQEqo3YuYr4Pjh3EmWZ/dxpHcd9WycmTAxv0f8b\nBkDavmZgFY1d+alPCIw6/jKQbM+ZNVe04EO3p6hhjIrCh5pXEUdGYkXXfwbR\nlExBrXq0SGX9rUp9yjclaY1iHhDaLKd7RaCaxFheljD4ctvLqqpVjnDp8BAa\nBPky+sCUyA89ItLNpfUC6dUSgWLxz27DDoIqIZRMKI9LOqROLt1mYKMFEJoe\niCoZGQJ3mgy4bUI+YXAGUO7I6rX+X/WGY9KLvNKgA42U4iNje/g9rpqGVruo\nX9MJJ/avfuVTSp/jjbNZDFo/WO3pEQpi8xHwtKJGDFvMqC+kIik4hgqqFPT7\nLGEw2UvjRWhmxe6m52Q7MBCuucPBVU6NuWwBIXTmCJoHhEMXceqfvFcTUROW\n/frQ\r\n=QYRk\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.5.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.5.1",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "mocha": "^5.2.0",
+        "nyc": "^13.1.0",
+        "sinon": "^7.2.2",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-4dwCh/AyMOYAybggUr8fiCkRnjVDp+Cqlr9c+aaNB3GJYgRGYQWJ1YX/WAKUNA9dPNHZ6QSN2lYDKqjKSI8Vqw==",
+        "shasum": "9265b7742ef50f54f54c1d9af022fc17c1be9b88",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.5.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 34134,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcQGr3CRA9TVsSAnZWagAAUQkP/1wSS4bVQHvKL+/gxUye\ngqHqpeVdLIIKEH6maZeEs9UsvcQo9SKyFKewhLpswWQGKeygGrglX+4gVHSL\nspRetHUValgAQAb4bbKKKnHy0TmCflQEWBrafkZ6Y3DrBP5+zeLv0wNb3CSr\nCF8O+5ifnZSoO//yUftKdbev2TVp2s6LM6UqP7D87Sn72afkLBCbH4xFHwKv\n7o1Mg4OITLtwUEC31gVhcHfqfQUIA+yBAxzWx/KHpzubunZ2QkuslJiWZ3vX\nLxHhKzSBQhCJxFcLwi4cXU5fzRljOJym1AIxO1cugl/i1Kuu0oxgHGD5WXOz\na0o+a6umrHd+S5344oG+ss0cHc7gKxBW+IDD21e+Uzkm9HpHMbVesKT5Zv3H\ny9MXdnyLoWGlQ/tm5uVKPIL6QBe86ywegrRBqxNKSPIDCvClZCtfghvzJBNX\nWD0rjzmI9rXFW59UpG1K5q+Se3CmH8Q3gHmga2tJFoGmblJjJ7RDa3KJjxg0\nxbTOdUf4epSxJZG2s4KRnsggEc7jc+FjINTpOtA/hlYCeA4je8t1c+1CGNz/\nUmUDokmZXgJRVbCCEa43PDilr/39ycj27gx7KE1r6aaREUz26DVTdVfjhznT\n9AB1x2mz6stxgqoqVvfJRJByRQMnWWF0hSLpcJ7smy/M+4MEXZOGq7l2g0zF\necTH\r\n=Lgka\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.5.2": {
+      "name": "webpack-dev-middleware",
+      "version": "3.5.2",
+      "dependencies": {
+        "memory-fs": "~0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "mocha": "^5.2.0",
+        "nyc": "^13.1.0",
+        "sinon": "^7.2.2",
+        "standard-version": "^4.4.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-nPmshdt1ckcwWjI0Ubrdp8KroeuprW6xFKYqk0u3MflNMBXvHPnMATsC7/L/enwav2zvLCfj/Usr47qnF3KQyA==",
+        "shasum": "d768b6194f3fe8d72d51feded49de359e8d96ffb",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.5.2.tgz",
+        "fileCount": 11,
+        "unpackedSize": 34548,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcW06YCRA9TVsSAnZWagAAwZcP/3zKHLp4bT0sOZbH1k6g\n7MApFtGpIsiIMU9N5ndHNvV7nkSv+wyH0nWAY2IdzKI/RGWqqyQY8GmBvMrh\nK+ODoxA6dnJv4B7HNi1TcV9iaoGUta5D70g0p4P51S4pOkpnkE7oyTE6e6cM\nFDOA0HdY5i4th0/yW0qTAI3GGGg/Onnu12ZHEwyh+2nW2PJyRloj7j91l0iw\nD9SNMbIAhTaTKyLQLpxjGDHNehuiy4sJ+yrtUdJDAv0IcL/zTFAkKuQ6oeNd\nLSYspOuZ+JJGmOKVJFDmllHhoxRKJs9bHj/4u+OM/gCQSet7Rq59GL4nqure\n3vcltKKW0i2DANL9ik7f294l4EraIQcrX20LH8uePIEgfCG+7I4qt2BOIc/K\n7ZORc0bb+h7AJwdcJhaBYtN/pj8zBkS4Zf4LVUwU3Lh6b4x7VZDgp+AzKENj\n5aTSPRcY6l0hhSwnXRCdHyQ/nrUKS00cDwhZGdtZXIOt6DRZ30W3iBRvGig9\n1FvKzHGtFtgyZFDJkMgRHM1vR7IgRMVMnEeP4g7vxYWDYFcaCjbDOJTQDyIv\nvkomMUwS3TBkHjTHPHq+N9muExU4rqHVnH7ce8zuWPoDg7rCHC45rzm1ifV1\nfobV6+M9VRfXbqLTYmXlGLzAuMejJJeFswmti7q0He8IF3jo3rPR6tX7yfFo\nC+mj\r\n=kHvf\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.6.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.6.0",
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "mocha": "^6.0.0",
+        "nyc": "^13.1.0",
+        "sinon": "^7.2.2",
+        "standard-version": "^5.0.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-oeXA3m+5gbYbDBGo4SvKpAHJJEGMoekUbHgo1RK7CP1sz7/WOSeu/dWJtSTk+rzDCLkPwQhGocgIq6lQqOyOwg==",
+        "shasum": "71f1b04e52ff8d442757af2be3a658237d53a3e5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 36029,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcbAkzCRA9TVsSAnZWagAAzekP/04vox/TgPoYXQnbADCz\nadmM98VHSnD74oMQz1K33qu9BBJ0yNMzhr5jl9pO/GTnRKRT8KtEWIexsgE9\nAlAmRAxL2Kl70RMChvLb1qZAEbGnSC4KLMLJ30s/tiWP5DjY7lbgqgyMJrBh\nK6Ml3Q+ubLqnq78iWX23Bo1LTaVSS9xhrt4SYWpWHA0o04/Q5CaAIyglZgZS\n5su5lpgTeVNEHg0fJ1Z8ZVGC/645Rp6+3k9OzVeb+WRIMWNDLt8I/dl6R4kY\nIqwEVl/vLkV3GCPOLwBiYVAApBJbeWAR1vZPwPiSJLaCZsMynIBpF/0uZ41i\nhcNUJi21XIKdnyvyawhQaGtSs8Po5RI5wKVitf7KgqPegQigEbikPnaM5I6D\nHRgJmlGQCIObeb/lnMd+UXmOjNDKlWmNacDwPjWNwh1VI6XeoyuA66+WqmdE\nkpwBDPYRJZRrdTZEyM82Lrt627OtsGDzF5m4q6x862n1WMNCqTsETkuimjh1\noHJV4eoFO4HJoN3wbr638/m+EG6WS1/TvwOrh61s1Ap6mfK5ezlGfmSpVNvC\nzfadEbmAHNQ3wRFNLRW3SA26n+YJwhyDenHhVEeFPqkGkOSViPDvJpplrsi0\nWA+19qf1nbNCnTR9hkPQa08areH6URxrstTJ7muLv8Na/1unxTI3phS/0v8D\nBG0n\r\n=GR6h\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.6.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.6.1",
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "mocha": "^6.0.0",
+        "nyc": "^13.1.0",
+        "sinon": "^7.2.2",
+        "standard-version": "^5.0.0",
+        "supertest": "^3.1.0",
+        "webpack": "^4.17.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-XQmemun8QJexMEvNFbD2BIg4eSKrmSIMrTfnl2nql2Sc6OGAYFyb8rwuYrCjl/IiEYYuyTEiimMscu7EXji/Dw==",
+        "shasum": "91f2531218a633a99189f7de36045a331a4b9cd4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 36104,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcf+5MCRA9TVsSAnZWagAATREP/R2i0IfojUQflCYQkQO1\n/DIRyg1UtUMmilWK6r33hodM7ThepiXW5ybQyOfv5OxRqXuhPX5CVv4ayop2\nZwhJZ+P488NWXLfRZI8vMHegofQ5zmUMwXpNHdDJCYQXUCdZpyK6TqQo3z4M\nqAwtUnPB8TtByhS9W3s6CIPtYJuJtm9/MW8/3Jo5u3h+tzbHFaopKaDSlnbD\nHVV/uQsOd/Fufm2GqSEBAiVT+hnAevuRFQ5pOLCZw0xBEZa1uOFvxfdZEa3W\naTAkXY/q+Hh/jD3ba2O53mSbstDyAsoGlpthhBbI6GRjP+qL/0W5I0AmL7WU\nLn0dEjcd047EGootqFIzoUDEP5KpMJiGicFDOeKxKSJXoDi5O3wXa0WlxWfz\nCRqXdY2vCBTYjzmsWmDPRSZXeHx5u/52z5Od7Fenwq8s/cK9L7V/12dYT1w2\nyrexQCtL1NL3RI9U/8RPCkcM6K5l9rmNbcpjH+lnB2ZLvnP1DIy/UdbbHY+/\nMT+WYdBFLnT9MaaN+9sBaOgT1u16T6rpYaRitoCMbBJcZEpAxTZfhMP7q2Li\nyb/aEhuwwF6RMLzjOjXZ1M9qQMdwewlXJZpV6h1txWiehh3sSQGb4FeIfASv\nJQIlZRdjFzRjWJpcypyBELBpWk36WFoc88jAjAEn6mEB9JffdXM0+px1pay6\njgm+\r\n=aTx4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.6.2": {
+      "name": "webpack-dev-middleware",
+      "version": "3.6.2",
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.3.1",
+        "range-parser": "^1.0.3",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^7.2.1",
+        "@commitlint/config-conventional": "^7.1.2",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "assert": "^1.4.1",
+        "eslint": "^5.15.3",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-prettier": "^3.0.0",
+        "express": "^4.14.0",
+        "file-loader": "^3.0.1",
+        "husky": "^1.2.0",
+        "jest": "^24.5.0",
+        "lint-staged": "^8.1.0",
+        "prettier": "^1.16.4",
+        "standard-version": "^5.0.2",
+        "supertest": "^4.0.2",
+        "webpack": "^4.29.6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-A47I5SX60IkHrMmZUlB0ZKSWi29TZTcPz7cha1Z75yYOsgWh/1AcPmQEbC8ZIbU3A1ytSv1PMU0PyPz2Lmz2jg==",
+        "shasum": "f37a27ad7c09cd7dc67cd97655413abaa1f55942",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.2.tgz",
+        "fileCount": 11,
+        "unpackedSize": 38047,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcpKiDCRA9TVsSAnZWagAATVIP/3yJY7jXEi45iughnMWz\nTSi60Xo66qvSwNSZqhKXTb9OziBr8KH8mXzEojMYmRe4kM7dUa60qYkOtvdc\n71HG+iRGvxp63qHbTwDzQCsKV/Zt0sG1sldgtZo6WSFR49TJR5hqMLuumME/\n7up6dfh7WpseG+TEr5K0c76D0FNljNfceNOkmtdVF5WyjhoWnFZFLK7GTTk4\nczt6NdDrImgiK+lvB0TjfjTB9flRz/Ptd08Wj5yRWhqJaaxV/gYX1fys4pYl\nH3eoDm7ojBg9YkZEasVL7DYDjkBN9G4sMLSaRS8W2nYLHLgnmZUt9vuXXppl\n3MA7+64ZluKUM/8apvsm6HaUdHx2GXnG/8CkA1KdCRyHMBiuF+HkuYjOvVsa\n/3T1JneuyC9yHT05ynNcIzylJh1fAP3HvHo9yvfZqxvM95qwfPSXorfihkEX\njMbdlYHjOYqTDNBSkO5gKkO2G8DQ4x25uulj1fDJZ6M/zF0g4LoWBkcV3Kua\nNam7AipqGpQSarWcTjngEh68NNK9EMvoKsBvznhVkMKOcXvEeKj/OANKcoPb\nz7hh+JJ4uRRR2Yl46z4JxKZlHKLWhoVrwVB0SXuBAxgh2S+mQOKOXQ0jOXY0\nN9bHsuRzVOllia13EQH1n7+A0/TfxpGxKoBnu+2qtHOurkPtpFHRHMpk5xrR\nRrJs\r\n=vRmd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.7.0": {
+      "name": "webpack-dev-middleware",
+      "version": "3.7.0",
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.2",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "7.4.4",
+        "@babel/core": "7.4.4",
+        "@babel/preset-env": "7.4.4",
+        "@commitlint/cli": "7.6.1",
+        "@commitlint/config-conventional": "7.6.0",
+        "@webpack-contrib/defaults": "4.0.1",
+        "@webpack-contrib/eslint-config-webpack": "3.0.0",
+        "babel-jest": "24.8.0",
+        "commitlint-azure-pipelines-cli": "1.0.1",
+        "cross-env": "5.2.0",
+        "del": "4.1.1",
+        "del-cli": "1.1.0",
+        "eslint": "5.16.0",
+        "eslint-plugin-import": "2.17.2",
+        "eslint-plugin-prettier": "3.1.0",
+        "express": "4.16.4",
+        "file-loader": "3.0.1",
+        "husky": "2.3.0",
+        "jest": "24.8.0",
+        "jest-junit": "6.4.0",
+        "lint-staged": "8.1.7",
+        "prettier": "1.17.1",
+        "standard-version": "6.0.1",
+        "supertest": "4.0.2",
+        "webpack": "4.31.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==",
+        "shasum": "ef751d25f4e9a5c8a35da600c5fda3582b5c6cff",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.0.tgz",
+        "fileCount": 11,
+        "unpackedSize": 38676,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc28j2CRA9TVsSAnZWagAA080QAJ7bsBkb+BMMfFdw7yM7\nahKLp4aTTjYD443cPR+OiWbY1YpqG/WVvNCP8rxgQXwePfDM9yq11xl6SBes\nj9XKnCuqCMeRRRwrhy8aFDXFLaDuDw7e/rHE4UI7765OUqmG/g4frnBtGbIp\nrGlnC7oMu9PKFbVx0Jn0Vsp4a3A9HS3uJ9TclvsW8cMNS9jgpjiIvgw73HSi\npYA/IFbT6yfwpR7H8VAz0qE9w4mqOg9d2HQH1DVDzt0NLTKs//wT50NrVShS\n34qa/Ra+EFIpQBMTQVKGI0g6NTKffFzGIhk7V5rpzqoCN4ZdtYol0XZL++KK\nRiLVaEpAtOtGKxGXBLAq/TQ+uApr7Cn+gmliNpibNdbmz+8Dr/8SoonpGvLl\nDh5esfrgjUPWWp1pQQjV2V9HDeMqPeXX6XJzLSrNxeqE5OfZMU+5SXCPwit4\nrg6EK27SQ2rQ8QVnvefygLfcPXb0OSOIZ3EqDVAR1dGjcDKHK6b4qbWVaL7q\n89JQ3TG4Pp2gao5DBSNV25pt0dPZQW4da5eX+uQ/yGQ9aYqENKuW/fWWCg6R\nTUnQ2vyOOffIBnjpPbHWGLEDQTxcsm+RX8c6Jh5N7KQIqp0DyBO67jqPHUWE\necb2OoQoVP5Cxjy1E2scXEqaw8qNwQOTwR9yONzFOIh/IyKduzaDR8N8IFdk\nW4WE\r\n=Ll8w\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.7.1": {
+      "name": "webpack-dev-middleware",
+      "version": "3.7.1",
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.5.5",
+        "@babel/core": "^7.5.5",
+        "@babel/preset-env": "^7.5.5",
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.1.0",
+        "@webpack-contrib/defaults": "^5.0.2",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^24.9.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "cross-env": "^5.2.1",
+        "del": "^4.1.1",
+        "del-cli": "^1.1.0",
+        "eslint": "^6.3.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-prettier": "^3.1.0",
+        "express": "^4.17.1",
+        "file-loader": "^4.2.0",
+        "husky": "^3.0.5",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "lint-staged": "^9.2.5",
+        "prettier": "^1.18.2",
+        "standard-version": "^7.0.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.39.3"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-5MWu9SH1z3hY7oHOV6Kbkz5x7hXbxK56mGHNqHTe6d+ewxOwKUxoUJBs7QIaJb33lPjl9bJZ3X0vCoooUzC36A==",
+        "shasum": "1167aea02afa034489869b8368fe9fed1aea7d09",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.1.tgz",
+        "fileCount": 11,
+        "unpackedSize": 39430,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdbkMGCRA9TVsSAnZWagAAnFYP/1AZqdjx8B8euZWzOURy\nRN49xNsBKj13bfX7cPmOHXUhuR6gTsau2oL+pYZ/Puthx3ulxd2BH/7u8UQQ\nRjWOBJJzANRsdcYmLmJNaULjvqAPdYO3ntUgSRnmrLN/Qmh3j17W0ZTABcYe\ns/iv85zqBumzY6dj6stva+iBgFEbn1cOAHi9hfh8e3N2nAocdOpwrgWfjyh4\nfNJQ2szJgfZv8GleZT/JH8rmTAqhUyKe6ZuBEHEzSNgQ8YE4FwlrrUwZllM2\nfNlPEH+0GrOVJb/r7JSth32TDAPCPdyhtu5HLhCp3/Qt2DWyexMmzXOHgsQZ\nfy9OzHg5FFQfU6gZTtPFyuAb0LrbWa0/KQeBZTxFm7c5XG6hVC/SoiUdq3F6\nbWXh0H9DTA6VVMflagk46FCr5R4yLxfGvmUE9SysTuq4bQL3dXd5dkthj8t5\nLagLdwXmPEImrTFQ3h7OM2IVc1uBksx4gKBzi378uvneZmLZQxDWBL6agBPi\n1wj8vHhqkFZR6bj8KYNlcKR0uJCfhsd7PmTXub2kFhVhTBLzE4zn4zgA5WLN\n6Jerfh+dwDjxW+Nx4Txbm0KDheqJSuPIo2MZwMYFJX1J6nOWwPPYYP0AbnZu\nHZl//wUwPMBxRxADppRWF4Uxgok4JGBuIagKXjKW+/Dt74agVEsbDVU2w2A6\njeFg\r\n=3CcS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.7.2": {
+      "name": "webpack-dev-middleware",
+      "version": "3.7.2",
+      "dependencies": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.6.2",
+        "@babel/core": "^7.6.2",
+        "@babel/preset-env": "^7.6.2",
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "@webpack-contrib/defaults": "^5.0.2",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^24.9.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "cross-env": "^5.2.1",
+        "del": "^4.1.1",
+        "del-cli": "^1.1.0",
+        "eslint": "^6.4.0",
+        "eslint-plugin-import": "^2.18.2",
+        "eslint-plugin-prettier": "^3.1.1",
+        "express": "^4.17.1",
+        "file-loader": "^4.2.0",
+        "husky": "^3.0.7",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "lint-staged": "^9.4.0",
+        "prettier": "^1.18.2",
+        "standard-version": "^7.0.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.41.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==",
+        "shasum": "0019c3db716e3fa5cecbf64f2ab88a74bab331f3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+        "fileCount": 11,
+        "unpackedSize": 40311,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdj30xCRA9TVsSAnZWagAA8WsP/jow9mm85sBky7L+oO25\nRaNWNWTRm4BMCn+I1LX2Ab7beOeWs3drZkrE2fIYC9a8Q1S1mCmHujVXe0fK\n30JyllCxOWZ9fm9sb84+GPM2M8Z+ILJnQLTMBZmBdyHKdyZRJvBDHZ6XyacX\nkNpRKOzHs957uCKiq44Vtfft0sjnIo9IcXaVCvX6BL1lkPDLuq3VynHybvkk\ne8ejZy3Zy97Io6u9OKrr/T8QSITOLnoou3QEQP9qCznBBqYenzCm5KYg4afo\njmO6E1TCO8s3BoTRzedmXfL0MJwpLQ3azftlGKicVb1JSR/SnJyFfks2qVUA\nFRubxXeNzwlzo5SaHPevWDZ90DMioOjsciu+oK7ZJsSHU1q85ZTltYu7PlLG\nXyb/afTCrjbFJhE6DL3I9GVayg087A0I/tNLzjo2x2TaQZMZCX0NyzJGn/+I\n5pMeqrBxlrlBFGlw4ZPhRQ8G9BMxZUerCvhCuqZojuBsrpkudivv9Nv42GI/\nUSuHiw/hnGgpQAA8JJp/zfc6e59FFTORhXJwdzJ9SJ+1/fculyn1HjUAeZya\n4j3Ie+3MZh5YfHW49dYB5bZ77ZPLpaI0csVgCale8pYhy+kulScjV5GUV9sU\n/namMgVy0GtSxAdG5E4Zce5cwYYIQWzo3KIyPsMR04N9XMKJkxIATuPV6JLw\nZhYh\r\n=NxT+\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "4.0.0-rc.0": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0-rc.0",
+      "dependencies": {
+        "mem": "^6.0.1",
+        "memfs": "^3.1.1",
+        "mime-types": "^2.1.26",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^2.6.4"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.8.4",
+        "@babel/preset-env": "^7.8.4",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^25.1.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "cross-env": "^7.0.0",
+        "del": "^5.1.0",
+        "del-cli": "^3.0.0",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-plugin-import": "^2.20.1",
+        "eslint-plugin-prettier": "^3.1.2",
+        "express": "^4.17.1",
+        "file-loader": "^5.0.2",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "jest-junit": "^10.0.0",
+        "lint-staged": "^10.0.7",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "standard-version": "^7.1.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.41.6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-5GHdz0zg26jcMaSBLzOaSd/C/UjtT0dLvZGslhWU3vO4wFVQflFF6KLjTWV69B5TnuDQPA2eqfP6nhofogXG9A==",
+        "shasum": "9b0bdb43f5fd2b8bd18ae743661e57c1c8570a1f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.0.tgz",
+        "fileCount": 12,
+        "unpackedSize": 39089,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTSR9CRA9TVsSAnZWagAAM7oP/AmZ4SgYrUsC2qwZsnMW\nVXAIf/+q6EXBrIgC8fP7XIAx1a6f/ui/ipyUB9y5z8fRJeDeXqz9x4V6tIv5\n8xgAaMFMTBTLMe6/DOWKF7s4+TzsP7soe50ETVLCxHopMKDDXI/7uBpilBE/\nIpIEgJD6/nLd9Xs9pS1Nac61AQ4TeSW7Fp4cedGYq00w7gNfVmbTzLAgjUIL\nteghEJYP6dTX3zqhL4juBDl/jtgW8UAj2CRid/1kPalJwKX/cZnB9oaIBnmi\nF670xivGaGjJcsYEVkbRYAPQvsdveiJ6TagodxOwYEvyrsR44k9kmTxMYkFt\nnUwPhuMcsKdz29pGqds66yxF8LhS9U3V/liQ52RLOo3HSHq5nOaXjw3BgVLN\n64GyB2XjNZpB0zEQigsB5Yr6g7TEoJxka6jBipoQQMlEjcVGxSpxxoathmcl\n8BaS2AjTwZoslB3Pq+/3IkdaDOcBKCYmub/8O2mSDCodOjQSw4erCYTPsjUB\nC95NS4jo4TrvhEOERLDopxscqXQ5Y862XGexNSGQBl498VK6lVxqIIHN1MEH\nYpsAbV/APbmqKCMfac+/DY/3Yg00a87s9MSWDza3QAJBycz0GGbf01ZbAiV7\nH48L+r8dc1P5tnIgNhlFMmLJ0eWxbCXFo+SiBLAY2bqMIT9t+IniMKc/+BVp\nVbrM\r\n=J9b3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "4.0.0-rc.1": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0-rc.1",
+      "dependencies": {
+        "mem": "^6.0.1",
+        "memfs": "^3.1.1",
+        "mime-types": "^2.1.26",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^2.6.4"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.8.4",
+        "@babel/preset-env": "^7.8.4",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^25.1.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "cross-env": "^7.0.0",
+        "del": "^5.1.0",
+        "del-cli": "^3.0.0",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-plugin-import": "^2.20.1",
+        "eslint-plugin-prettier": "^3.1.2",
+        "express": "^4.17.1",
+        "file-loader": "^5.1.0",
+        "husky": "^4.2.3",
+        "jest": "^25.1.0",
+        "jest-junit": "^10.0.0",
+        "lint-staged": "^10.0.7",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "standard-version": "^7.1.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.41.6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-n7dww33POOkzM5MElcZ94K8Mnt0DRjgywWsVYSmD/LHY57M8lyLu9mj5nuCBSoYgAacudjGDW1phcInFi1BWQg==",
+        "shasum": "445f85b8476505632dbbed99e84cb257c9d25a83",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.1.tgz",
+        "fileCount": 13,
+        "unpackedSize": 40180,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeTlMlCRA9TVsSAnZWagAAVQsP/R7BP3hPW4mE00Bksf3H\nTwi4UfRF4K4g1pe2c4M5jH9/b5/K9OCVYV9Ib42Y4KKqcyX664+W08p2lnU7\nmHLSufJBbjC0BcpX+i0j0aCXWkpLTo85sWpzVLjAkO1y7lC+IwGhPOn1Ma6Y\nX1tsmBN9FGXD9j35268cMwybkJNkTCHvGM0aR2JK/l7FIxefquB0bbd8H1/g\nW9IZwmKgDjuJFevZGQNbquRjyR3mC88OV1ty/QKKY4ptb/4EUyvbY9/h0aYJ\nwGdCu8Qqha3JSRgjLLJrgzK2MRgVPVbz3rT4w/S+SsXXfaKbAtIdfvZRw8bX\nIqdcC2rtcYo7OegWm6mc7xVWeUrj1iCLY/vFCzWJ5RYluWriYzNKQ3rbEYdX\ng1zZ6mg3FCj1z5rHi9XQ/BlfSCOdIYml4hWC53IOdsTjn3YCFeoyTbVDIbB3\nRmm0xjOkksl+ORRqIQ0qfyGJ8D8ZrM8c5bJAiUXEpetbKf45KQl9U/n2Yef3\nPhcIYw9fmby1yYWAeKMkmKr9yDAotvSe9Py9+NDEdwp4QNeanCeAn1X2gwFV\ndEruRGnBfdNqoTJiqnSxL1C2rMaEzcquF/h00MTGqUWqXVIwcXwKumoPKNIQ\nDTyhtDmeD3yp+r7DoqgVAC4Lq2GaNaI4FAvt/Q3VXcqxPWtP5GQAizlE1nGE\nTuZ/\r\n=lf11\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "4.0.0-rc.2": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0-rc.2",
+      "dependencies": {
+        "mem": "^6.1.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^2.7.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.10.3",
+        "@babel/core": "^7.10.3",
+        "@babel/preset-env": "^7.10.3",
+        "@commitlint/cli": "^9.0.1",
+        "@commitlint/config-conventional": "^9.0.1",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.1.0",
+        "chokidar": "^3.4.0",
+        "cross-env": "^7.0.2",
+        "del": "^5.1.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.3.1",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.0.0",
+        "husky": "^4.2.5",
+        "jest": "^26.1.0",
+        "lint-staged": "^10.2.11",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.0.5",
+        "standard-version": "^8.0.0",
+        "supertest": "^4.0.2",
+        "webpack": "^4.43.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-yP04dRrpAVNq1yvRvtkXIP6UCw+hAbWFOgv6dF2rHNYsRYhQuDRVTc09YwbYzyOlmdJzyXxHfNJZ070HVd9cjA==",
+        "shasum": "26014e50482c9b0e561f708533b37a7ab1dc54ef",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.2.tgz",
+        "fileCount": 13,
+        "unpackedSize": 40444,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe+1ptCRA9TVsSAnZWagAA1XQQAJfARLzbd94qTqe8ZB7C\nWiQm3wpEHW2QubKU6yYLGmgHqf0ue46WFMu7EWvBHJucxVrC7/tbqnWqEerB\nGKsB6wiC6rMHRZ/oxdBNWY0JyGcnm2bO9tYZ75A2koKb+Lrad1NI8/u86rLK\nirvkakkXE1tJBA3rQhDVh7QyUMn+kXTPsu7+SHX31RmTlFwTecwNExp5G0oE\nSw8AwQYggrhXJrfjabqjIjWnISkSymhQe6KRGkdhI+XT4PyxuOSM1lPBgOaW\nxoK/z+loV+rWySUkvIxoyExiE2q6K8vy3dd8+lii6utg029vZR7MIFVVZ2ed\njLKKOYQzNSfDk9tkiMbFHsOwjpwByvFVgtwp//7QYPSQRltvx0CMFJKFqnRB\n5TWhu7ULnsupjqAX3/36pkv8v18OptH0f3MIBrpOex5ANoLYYWp6TWHT2P82\ndTIJKkPJWgyfwanb+LWjnPM+iIgTEfylkuk3daMSq5y1YHp+awaisATwouCs\nsXlThcqGnjo4SP4R+D0OblwEDGXGdjiAbYvYddmvlfhuqU1pgBK9JmgWgJ5K\nWGuMPfV3SYP/aD86ds/FkpJbXhaMGordfiP/eEhc1HNo264HkPqFIlkkRkNk\nk882VMJMLbFtycVXO3bYvUQRuDOsV8K3QqzncOQrcvFaPakb4dcVuWrHp0FE\nP0Mk\r\n=SU8g\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "4.0.0-rc.3": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0-rc.3",
+      "dependencies": {
+        "mem": "^6.1.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^2.7.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.10.4",
+        "@babel/core": "^7.10.4",
+        "@babel/preset-env": "^7.10.4",
+        "@commitlint/cli": "^9.1.1",
+        "@commitlint/config-conventional": "^9.1.1",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.1.0",
+        "chokidar": "^3.4.0",
+        "cross-env": "^7.0.2",
+        "del": "^5.1.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.4.0",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.0.0",
+        "husky": "^4.2.5",
+        "jest": "^26.1.0",
+        "lint-staged": "^10.2.11",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.0.5",
+        "standard-version": "^8.0.2",
+        "supertest": "^4.0.2",
+        "webpack": "^4.43.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-nuZHcVtI1qVJxGYWEnCeN9UiQesOTUYQZQiJnrt1ma5FSYK1OTH0ySG45yUE44aVSFrN+teZX7WQTH6hF2vgFA==",
+        "shasum": "986c047d579a320499e6217c96562265c2438abe",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0-rc.3.tgz",
+        "fileCount": 14,
+        "unpackedSize": 41174,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfDeUVCRA9TVsSAnZWagAAvdsP/ibOBLRQaXle5ADsXdxn\ndjWYU2ZsYnGfzCQBJoXq62/QheutfA8M1PrStk0dvFpVgc19gY1H2TsGyeQo\ncxPhfhPBBweRhqCEeiG37FCxRX4NsYkCFQgheELd/fOAblx9WRtZWbslR3J/\nrREtg0vXkKF666Ky8Ngkhw9duSiLe7SdHxhktx8M8Mkzhv0GuQdv481ImzQx\nDnfNPtDJSU59/UTOBgSp8lmcKlFyzr/cY9NC2L8s/DW9HE/9vIjawy76Ofdu\n+M/BxQBetwtwdnQWBXLJJHPDCTRk5CvA6iYByHzML1lAlHRKQqGQ2Ld6NPfg\n+kmHrA8672TKD+w5yvTewdabm1kF9ZENtYPXFsrX8UI1W9uPdYwlkr1DWDne\n66u9pgp6p7erf9KBeBgmj0QsDwpfJM5zrJPeAz3eBKPInfetWv9QzcIaDCJ/\nZUKYXuqhA/S+jSBuV8JzXgyo32sytSpdSgJuJd9rbHpvZfhc+3ejj4xKEZou\nbj4HZT5kg4uj0vTumSnXsoyznKwd17QZjSeOW/XMt+zptzy9QkROAlht6PSa\n6WiKZZ2qhXJCO2hJ0q2hEPKfPTk5FTcl7ma9AAtqTET9z/QHlxXjbAv5GBd+\nULp2YtD85mZucnMoxRkLxbK87fV1h1EI2b9Z+bZyrd2L7Oy9Rozu/FkvyICr\nS8Y2\r\n=Aj67\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "4.0.0": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.0",
+      "dependencies": {
+        "mem": "^8.0.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^3.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/preset-env": "^7.12.1",
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.6.1",
+        "chokidar": "^3.4.3",
+        "cross-env": "^7.0.2",
+        "del": "^6.0.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.12.1",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.2.0",
+        "husky": "^4.3.0",
+        "jest": "^26.6.1",
+        "lint-staged": "^10.5.0",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.1.2",
+        "standard-version": "^9.0.0",
+        "supertest": "^5.0.0",
+        "webpack": "^5.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-n6X6CxYQyYWGBfLzcNYya0oz1N8iTG5atGxrEacrMGc9pPjg3GHyHul6Z+hfs5x5voYtqr7mz1pbK/M4ZeMl1w==",
+        "shasum": "1725b2ebc78b66333672499d9dc7b1c244aebb1c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.0.tgz",
+        "fileCount": 15,
+        "unpackedSize": 42814,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfmYPrCRA9TVsSAnZWagAAd5AP/0mI4G8YqH6pfuUWCi3S\nXrkg8ePeHoOGiG4An62RgdjigvxMsI+zPfl0MB1q3TE66R6+S/25ewO24n7b\n6LmhuGQlfmOUWonjlMa0SnoZxWk0G09pX2mYg8pMdakTEGMK4YwxVx0SpT4i\nUpU6pSYGpe2EJ0KqBaKfo6+PBaAqYbu6ySGB08VODtXbLh8xFOeTIxhbF1tu\nPsN95Pr5l9qtLk6tniLkSNuhY05vX672oL1nz1jiXENpylbQRKkFlz1obuQs\nfm6VdeE6xQTLR6LDS83LMQbwc0JlNpqWrHKEpHfrFZXr8qMSw8J7zCIFSu83\nIaiiW2tEyyaHJCGKSSNIbtgD81ECvY7dPUyvjBYyPQeCjQudE7LNe2u8/rtg\nUbGPVKY4/G+sf0jPL0eZSnbNxaSGvppJ1pDtzDlsYvPolth6NbSG6f+35/53\nrKhqDnWc8pJZeiZD4fPJqTNUheLcrMLUxOLYHafVkrO1IzVtqRStjWZszQbi\nrirbeUo6nwTVHdz21hv/jnExAaDHPSbdiJEgKkXnVVFl9KknpqVZHi7UhDlH\nY/59kYqKKIoAZVYClPqoNkqdB1g9LKF6drO/7Uf5smdYStfvOCrZ93moazQ3\nIFE9kk+wNLgco5pnkRVRWZ+Y+jGJT+G7GDMmno0Tyhv/fZTKOITwL25IPEiF\nB4Hk\r\n=ISXJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "4.0.1": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.1",
+      "dependencies": {
+        "mem": "^8.0.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^3.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/preset-env": "^7.12.1",
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.6.3",
+        "chokidar": "^3.4.3",
+        "connect": "^3.7.0",
+        "cross-env": "^7.0.2",
+        "del": "^6.0.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.13.0",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.2.0",
+        "husky": "^4.3.0",
+        "jest": "^26.6.3",
+        "lint-staged": "^10.5.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.1.2",
+        "standard-version": "^9.0.0",
+        "supertest": "^6.0.1",
+        "webpack": "^5.4.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-wg6IPwK8D/dwIiy1ZJpQAiDo+ZRgBsE+sne1fLLhyoQH4EY9jU7QQ67lwj4xhf/sJc0QBgatXXinVJ/dVwaZGg==",
+        "shasum": "e0201fe48a976cac24b548a398b1022e2ab73ff7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.1.tgz",
+        "fileCount": 15,
+        "unpackedSize": 44269,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfqaOaCRA9TVsSAnZWagAAar8P/RXxyGqMNeFLHI+4uSX7\nxyKglRAygqU9eYGomNGb97FkoqGxyeG2coFqaYoFAYqMh1tJEcXD8ZmIboHd\nZnX0nWa9dRw+nA5zYUkPyz99CjDGSDR6Nns9d0zjp6WIWqcWPgQ/GhUrnQd+\nOpGG3IWtKIVual+A/ycX97fTYbzlgIZaHH3PivM7FzNkKVIuQ427x7BiuQ0H\nMsujG1YmecTHhG5kCPimT1dh1WVneF6I8RTzpYN/00GaAAUqXhlblhO8BsiY\nyTPHlXx7gFjVM7xTkQIxBD2HiBxeUMZ1gIuBGGQEH8pCUz/Tfjx2sTXv17Mj\nN5azmw95UWLR33+af0DGq2bdnbNDSX8Gyag30uzanFPFYwskfTO5howKg5ht\n31e8jmhFuZwBmIcEM6knMB0vX3bns6uN4XNIuVRbGPy5PQvWjmmb+9N7fZ3d\nq/Dp4yEwG12gL4yQLLcqv6PlkNoWEoCbQ6tVUNzVMTwFzPgaG4NSX/KJx5Bd\nbR9IUb7Zvszt5AKLrzjJ2LAdotkDcNwW1kVQY7EZ10AneqBSf8OuBo8CdGRx\naL2QvWEJ07DUgNKb/6JRjB4/hd0xq0cMYNVbjwmiyFgaRoFotXFU4wyQrGPK\neVwXYqJTHOGh2mHtb92GqRaSQ8+e4tD7+rHJG8BFl293gpX166GoBVf8CDtH\ngFfQ\r\n=uU7w\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "4.0.2": {
+      "name": "webpack-dev-middleware",
+      "version": "4.0.2",
+      "dependencies": {
+        "mem": "^8.0.0",
+        "memfs": "^3.2.0",
+        "mime-types": "^2.1.27",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^3.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.12.1",
+        "@babel/core": "^7.12.3",
+        "@babel/preset-env": "^7.12.1",
+        "@commitlint/cli": "^11.0.0",
+        "@commitlint/config-conventional": "^11.0.0",
+        "@webpack-contrib/defaults": "^6.3.0",
+        "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+        "babel-jest": "^26.6.3",
+        "chokidar": "^3.4.3",
+        "connect": "^3.7.0",
+        "cross-env": "^7.0.2",
+        "del": "^6.0.0",
+        "del-cli": "^3.0.1",
+        "eslint": "^7.13.0",
+        "eslint-config-prettier": "^6.15.0",
+        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-prettier": "^3.1.4",
+        "express": "^4.17.1",
+        "file-loader": "^6.2.0",
+        "husky": "^4.3.0",
+        "jest": "^26.6.3",
+        "lint-staged": "^10.5.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^2.1.2",
+        "standard-version": "^9.0.0",
+        "supertest": "^6.0.1",
+        "webpack": "^5.4.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-xyAICqIugWtT1RRH5aMMmZlPhDhEqPTDL0TWhmMZsuZ+cFlAvRxv4thCbuxdk9MW+OYK4c9BkfmgdQ1/7imkJA==",
+        "shasum": "1436ae6cacee78475bd6bc1fbf063dfbfd6e577d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.0.2.tgz",
+        "fileCount": 15,
+        "unpackedSize": 44795,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.13\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJfqoVNCRA9TVsSAnZWagAAEXYP+QBvogLBJM6p/OSJbV6L\nJRSnp73WQHbPRObUXlRpodemYmxEAdPXTwAh6peWvZXbIl9VC7bjsWQarxgF\nmUxZNajSI7X4VshkwdcQK2CAlXKTqVwtYTsVKt05PunkVyflAJ5/JcVAxHcn\noC8a6x88mxyLHeGVdrXdOVr8gf22Rlv3kDuPsoVfEby/PQsdPTsqrDRdwV9p\nNwDIC/PwOPfNmMlE9wJrLua4bQ3LFWKv0Wv+T5k7eP1iGNcIdSvrWWeykE5+\nHS+fAaey8OC1jXtBx+Bn/HF6fNvvMRBLdvAljs3i57hh52FlEnhGpV8wjII7\nLQkXgwPtMJYlJ/lvLcwBi3M8K+ceYt4rymT0dRijGCnme9P3kLsBKL9rp15t\nsBbFIg1aGPbjquNW8QexxeMJTJx8F9gwdY9b01n1/MEFNKqXkQTSh1djk5we\nUGuq4WJyfkC1eYjhH3nwfkQH1q+wFNHf8/p0/DIDY/z+zxP2HOOWjj0OdUOQ\n/hcAkpPo2hqXiHuvQ1GGq5Bmvlx0/cYjRsFeUvnZOpuixmO366bNUAEtvEak\ncUb/gdtJNLyxuUUXHfcWZrl85ny5vskIM5JIT71fCxBz6c0HAerriTYxpmx1\n7SYp9areQTUN+4Ff9ORRuBtOwQ/d1MrguvEd7rIZ/NL356fpm5yVZ1TeJ3P2\nnHb+\r\n=Wqr3\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    }
+  },
+  "modified": "2020-11-10T12:19:27.572Z"
+}

--- a/test/fixtures/registry-mocks/content/webpack-dev-server.json
+++ b/test/fixtures/registry-mocks/content/webpack-dev-server.json
@@ -1,0 +1,18799 @@
+{
+  "_id": "webpack-dev-server",
+  "_rev": "397-627bccdc151e8ddf83d05c8b6e770eb7",
+  "name": "webpack-dev-server",
+  "description": "Serves a webpack app. Updates the browser on changes.",
+  "dist-tags": {
+    "latest": "3.11.0",
+    "webpack-1": "1.16.5",
+    "next": "3.0.0-alpha6",
+    "beta": "3.0.1-beta.0",
+    "webpack-3": "2.11.5"
+  },
+  "versions": {
+    "0.6.0": {
+      "name": "webpack-dev-server",
+      "version": "0.6.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.6.x",
+        "webpack": "0.6.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node node_modules/webpack/bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.6.0",
+      "dist": {
+        "shasum": "857e51f0aa42248e8d9d68901768960c48955544",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.6.0.tgz"
+      },
+      "_npmVersion": "1.1.61",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "webpack-dev-server",
+      "version": "0.6.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.6.x",
+        "webpack": "0.6.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node ./bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.6.1",
+      "dist": {
+        "shasum": "00414f1e54813a8512d4df1795928b4baa5e4eec",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.6.1.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.6.2": {
+      "name": "webpack-dev-server",
+      "version": "0.6.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.6.x",
+        "webpack": "0.6.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node ./bin/webpack client/live.js client/live.bundle.js --colors",
+        "postupdate": "node ./bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.6.2",
+      "dist": {
+        "shasum": "b4fa22bfff00eff614915e65f4626612b1274a4a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.6.2.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "webpack-dev-server",
+      "version": "0.7.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.7.x",
+        "webpack": "0.7.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node ./bin/webpack client/live.js client/live.bundle.js --colors",
+        "postupdate": "node ./bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.7.0",
+      "dist": {
+        "shasum": "344944c2692c684c091a84193f307720a4cd7d69",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.7.0.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "webpack-dev-server",
+      "version": "0.7.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.7.x",
+        "webpack": "0.7.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node ./bin/webpack client/live.js client/live.bundle.js --colors",
+        "postupdate": "node ./bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.7.1",
+      "dist": {
+        "shasum": "be461e7e80339dd4f3f07ab67f0138c58dc2d2d2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.7.1.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.7.2": {
+      "name": "webpack-dev-server",
+      "version": "0.7.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.7.x",
+        "webpack": "0.7.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node ./bin/webpack client/live.js client/live.bundle.js --colors",
+        "postupdate": "node ./bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.7.2",
+      "dist": {
+        "shasum": "ebc7ba0fc739f85ffce7e486b5f4e1c433213362",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.7.2.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.0": {
+      "name": "webpack-dev-server",
+      "version": "0.8.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.8.x",
+        "webpack": "0.8.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node ./bin/webpack client/live.js client/live.bundle.js --colors",
+        "postupdate": "node ./bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.8.0",
+      "dist": {
+        "shasum": "989ca1ea24d515a4fee96b883834bdc2bb1d2e93",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.8.0.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.1": {
+      "name": "webpack-dev-server",
+      "version": "0.8.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.8.x",
+        "webpack": "0.8.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node ./bin/webpack client/live.js client/live.bundle.js --colors",
+        "postupdate": "node ./bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.8.1",
+      "dist": {
+        "shasum": "b8de036256db62cd039d324be0e9cb5744a0d633",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.8.1.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.8.2": {
+      "name": "webpack-dev-server",
+      "version": "0.8.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.8.x",
+        "webpack": "0.8.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "postinstall": "node ./bin/webpack client/live.js client/live.bundle.js --colors",
+        "postupdate": "node ./bin/webpack client/live.js client/live.bundle.js --colors"
+      },
+      "license": "MIT",
+      "_id": "webpack-dev-server@0.8.2",
+      "dist": {
+        "shasum": "22892d4cb042b65e41665c5f70a2b737944bb21c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.8.2.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.9.0": {
+      "name": "webpack-dev-server",
+      "version": "0.9.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js"
+      },
+      "_id": "webpack-dev-server@0.9.0",
+      "dist": {
+        "shasum": "512b8427a754bf44d4359b9bde942f7598156f3a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.0.tgz"
+      },
+      "_npmVersion": "1.1.65",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.9.1": {
+      "name": "webpack-dev-server",
+      "version": "0.9.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js"
+      },
+      "_id": "webpack-dev-server@0.9.1",
+      "dist": {
+        "shasum": "27a1dabea8699e242b06986d85f5af83af148a4f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.1.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.9.2": {
+      "name": "webpack-dev-server",
+      "version": "0.9.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js"
+      },
+      "_id": "webpack-dev-server@0.9.2",
+      "dist": {
+        "shasum": "d0507992a56ab8c7ba0992f1e9a89cc7168b863b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.2.tgz"
+      },
+      "_npmVersion": "1.1.59",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.9.3": {
+      "name": "webpack-dev-server",
+      "version": "0.9.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js"
+      },
+      "_id": "webpack-dev-server@0.9.3",
+      "dist": {
+        "shasum": "0f3d855b55efd8d62c8f8e0cad3e3eb6f3351213",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.9.4": {
+      "name": "webpack-dev-server",
+      "version": "0.9.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "file-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js"
+      },
+      "_id": "webpack-dev-server@0.9.4",
+      "dist": {
+        "shasum": "695b727e0c55e389cfb5cd38d94c672f92e2c238",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.0": {
+      "name": "webpack-dev-server",
+      "version": "0.10.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "dependencies": {
+        "webpack-dev-middleware": "0.10.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.5.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.10.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@0.10.0",
+      "dist": {
+        "shasum": "0166b95d9779821748072f6d2567e7b3ea7c1984",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.10.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.10.1": {
+      "name": "webpack-dev-server",
+      "version": "0.10.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=0.10"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "0.10.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.5.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.10.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@0.10.1",
+      "dist": {
+        "shasum": "89fe4c2fed3e84e30da7d6c8cfeb995773f8810d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.10.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.11.0": {
+      "name": "webpack-dev-server",
+      "version": "0.11.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=0.11"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "0.11.x",
+        "express": "3.2.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.5.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.5.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.11.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@0.11.0",
+      "dist": {
+        "shasum": "863b83ed5299c3c08add53bd6fda58950d178a51",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.11.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.11.1": {
+      "name": "webpack-dev-server",
+      "version": "0.11.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=0.11"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "0.11.x",
+        "express": "3.2.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.5.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.11.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@0.11.1",
+      "dist": {
+        "shasum": "f2f307ce8ccd8138cc913d3a89e9d24292246bbb",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.11.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "webpack-dev-server",
+      "version": "1.0.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.11.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.0.0",
+      "dist": {
+        "shasum": "f2c031e4fc73e61c2e17c23ea917311cbfd1d721",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.0.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.30",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "webpack-dev-server",
+      "version": "1.0.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.0.1",
+      "dist": {
+        "shasum": "c3cf407278c80c6ec37e73d3cf30d04517f96cb8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.0.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "webpack-dev-server",
+      "version": "1.0.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.0.2",
+      "dist": {
+        "shasum": "00a2bdcc905e90c4ebf29dce0d7e1eabd5dfef1c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.0.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "webpack-dev-server",
+      "version": "1.1.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.1.0",
+      "dist": {
+        "shasum": "7bd807ee2c8cd9885005b592ce56298de44bf600",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "webpack-dev-server",
+      "version": "1.2.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.2.0",
+      "dist": {
+        "shasum": "d5f131b68c1da31c1ceb205465b44b6f4bf7cd1c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.1": {
+      "name": "webpack-dev-server",
+      "version": "1.2.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.2.1",
+      "dist": {
+        "shasum": "197f526f57a322d3837c177d0ed02dccf302e28c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.17",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.2": {
+      "name": "webpack-dev-server",
+      "version": "1.2.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.2.2",
+      "dist": {
+        "shasum": "48f689d76c2d631dca67e45e0d1ae569c36c796a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.3": {
+      "name": "webpack-dev-server",
+      "version": "1.2.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.2.3",
+      "dist": {
+        "shasum": "084fb22127f14ea894eb914bbfd0762495fa4d39",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.4": {
+      "name": "webpack-dev-server",
+      "version": "1.2.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.2.4",
+      "dist": {
+        "shasum": "5875f3c918c71ff7132695d945027e3bfff3ab77",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.4.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.24",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.5": {
+      "name": "webpack-dev-server",
+      "version": "1.2.5",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "_id": "webpack-dev-server@1.2.5",
+      "dist": {
+        "shasum": "bf2ffb72578e4e6e3df46eb45516757f87906abd",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.5.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.6": {
+      "name": "webpack-dev-server",
+      "version": "1.2.6",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.2.6",
+      "dist": {
+        "shasum": "d28311dc4d5836d6419c91efea4c1a1e39165238",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.6.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.7": {
+      "name": "webpack-dev-server",
+      "version": "1.2.7",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.2.7",
+      "dist": {
+        "shasum": "58c7d7830a87ff6055dbdc02f392927d4f77000f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.7.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.8": {
+      "name": "webpack-dev-server",
+      "version": "1.2.8",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.2.8",
+      "dist": {
+        "shasum": "2d0614891deffd56be91e6a849381aab05a8047c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.8.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.2.9": {
+      "name": "webpack-dev-server",
+      "version": "1.2.9",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.2.9",
+      "dist": {
+        "shasum": "3780f42400d068e89744061ff3d8002016de948b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "webpack-dev-server",
+      "version": "1.3.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.6",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.3.0",
+      "dist": {
+        "shasum": "798461e3d8114d5c1c9dbd9cd93bbb3a17176aff",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "webpack-dev-server",
+      "version": "1.3.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.6",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.3.1",
+      "dist": {
+        "shasum": "53874737194aa5accd702999c7067283729620c2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.3.2": {
+      "name": "webpack-dev-server",
+      "version": "1.3.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.3.2",
+      "dist": {
+        "shasum": "cb12280e22df11450792613208dd76b032a1eddc",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.3.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "webpack-dev-server",
+      "version": "1.4.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.0",
+      "_shasum": "c69ef837daeb3e2f6524f39fb53660012a8978ac",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c69ef837daeb3e2f6524f39fb53660012a8978ac",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "webpack-dev-server",
+      "version": "1.4.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.1",
+      "_shasum": "813bbabc4280c31d02ab140000f0c70bafd5b17f",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "813bbabc4280c31d02ab140000f0c70bafd5b17f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.2": {
+      "name": "webpack-dev-server",
+      "version": "1.4.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.2",
+      "dist": {
+        "shasum": "491e8a6cbe6cca446b6be1208289f2727363b8fe",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.3": {
+      "name": "webpack-dev-server",
+      "version": "1.4.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "29d96a0eb4cf3c837d0cc62da5cbe19bad305ad3",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.3",
+      "_shasum": "c8603c8f7013c19b8ac43e696e22f141b9ec0f1a",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c8603c8f7013c19b8ac43e696e22f141b9ec0f1a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.4": {
+      "name": "webpack-dev-server",
+      "version": "1.4.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "8259857a3bf5aa92f03304d147731fab59266ba6",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.4",
+      "_shasum": "166ef8e675f31bd0d661f4b4c0cd68bbd6bbbf44",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "166ef8e675f31bd0d661f4b4c0cd68bbd6bbbf44",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.5": {
+      "name": "webpack-dev-server",
+      "version": "1.4.5",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "bbac776233643fb1c083408b14c82b3e4fc828a2",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.5",
+      "_shasum": "c362f9b57780035ddce0c53b4060cca195a6420f",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "c362f9b57780035ddce0c53b4060cca195a6420f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.6": {
+      "name": "webpack-dev-server",
+      "version": "1.4.6",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "0c2afc236548b78720e958b5a4f666c678d8b7b4",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.6",
+      "_shasum": "9942f10dc87195174e5573e1d0c45b1a9a9a9dd2",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "9942f10dc87195174e5573e1d0c45b1a9a9a9dd2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.7": {
+      "name": "webpack-dev-server",
+      "version": "1.4.7",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "34938eda0a88bb19baf48d26ebdc5eb5009b790a",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.7",
+      "_shasum": "0db8468fc4db5c9fd10bbb839cc620d1322ceffa",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0db8468fc4db5c9fd10bbb839cc620d1322ceffa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.7.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.9": {
+      "name": "webpack-dev-server",
+      "version": "1.4.9",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.9",
+      "dist": {
+        "shasum": "56d273573fa6e80bcae31180d42cf2a690a6af72",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.9.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.4.10": {
+      "name": "webpack-dev-server",
+      "version": "1.4.10",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.4.10",
+      "dist": {
+        "shasum": "c1c95a754377561149f1b93c1989b5bfd684dda8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.10.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "webpack-dev-server",
+      "version": "1.5.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.6.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.5.0",
+      "dist": {
+        "shasum": "ec2f332c80d6a9e05eec3f2cc067ce06d4c95a00",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.5.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.6.0": {
+      "name": "webpack-dev-server",
+      "version": "1.6.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "636340540b724329d888fde93abcd0f106af1660",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.6.0",
+      "_shasum": "d53bc7342ad5b7ae7c129a4978b19f76207465b3",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d53bc7342ad5b7ae7c129a4978b19f76207465b3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.1": {
+      "name": "webpack-dev-server",
+      "version": "1.6.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "4a4f2517cffcaa79af7eecbf853dad558b07bd9e",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.6.1",
+      "_shasum": "95d8fd94e5eacd92b86c54280e4e2492b700da46",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "95d8fd94e5eacd92b86c54280e4e2492b700da46",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.2": {
+      "name": "webpack-dev-server",
+      "version": "1.6.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "728a27adf501040b4afe3405d8f2c6c2d0c21c3c",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.6.2",
+      "_shasum": "91877b0252b22cf114baea064d4be50d1fc80ff1",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "91877b0252b22cf114baea064d4be50d1fc80ff1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.3": {
+      "name": "webpack-dev-server",
+      "version": "1.6.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "5e4d19ac2dc8cc361d509d86de1b381cef221de4",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.6.3",
+      "_shasum": "95cac815f23d4bdca0d3a4c4fe22c2141d581e80",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "95cac815f23d4bdca0d3a4c4fe22c2141d581e80",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.4": {
+      "name": "webpack-dev-server",
+      "version": "1.6.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "1ad1ab792592ea3baab5a309b6c4e4342bd62099",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.6.4",
+      "_shasum": "64d4d7db5fde192b5267f48cc1a9428482eace85",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "64d4d7db5fde192b5267f48cc1a9428482eace85",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.5": {
+      "name": "webpack-dev-server",
+      "version": "1.6.5",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "20685049feb7b95cfb0d3e01d8e4692191c551c7",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.6.5",
+      "_shasum": "4caf6c1632aa7803d694d7690d54c024126b49c6",
+      "_from": ".",
+      "_npmVersion": "1.4.16",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4caf6c1632aa7803d694d7690d54c024126b49c6",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.5.tgz"
+      },
+      "directories": {}
+    },
+    "1.6.6": {
+      "name": "webpack-dev-server",
+      "version": "1.6.6",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0",
+        "connect-history-api-fallback": "0.0.5"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "016632d3d8986b49e7bd7b706a53c6e52618d054",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.6.6",
+      "_shasum": "5ecc19accdcfe0939270f5061fd748e315005267",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5ecc19accdcfe0939270f5061fd748e315005267",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.6.tgz"
+      },
+      "directories": {}
+    },
+    "1.7.0": {
+      "name": "webpack-dev-server",
+      "version": "1.7.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0",
+        "connect-history-api-fallback": "0.0.5"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "206a0ad5cf3abfb14468adb0ec910fc18fa0a6d2",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.7.0",
+      "_shasum": "21975f86082693a9e65593276ebc14900047587a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "21975f86082693a9e65593276ebc14900047587a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.7.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.0": {
+      "name": "webpack-dev-server",
+      "version": "1.8.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "connect-history-api-fallback": "0.0.5",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "dd6da4fc827aa236b3c69687eb55b9a72d7e955b",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.8.0",
+      "_shasum": "d98f511dac3824d2f30ff51083cb41f54a06b7ec",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "d98f511dac3824d2f30ff51083cb41f54a06b7ec",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.8.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.1": {
+      "name": "webpack-dev-server",
+      "version": "1.8.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "connect-history-api-fallback": "0.0.5",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "93a8701d1e4515fb1cfb0951006e448cb6cf24e4",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.8.1",
+      "_shasum": "5d65de3eeda6dcc0f0bc405f4385b40d4d8bd95e",
+      "_from": ".",
+      "_npmVersion": "2.7.4",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5d65de3eeda6dcc0f0bc405f4385b40d4d8bd95e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.8.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.8.2": {
+      "name": "webpack-dev-server",
+      "version": "1.8.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "connect-history-api-fallback": "0.0.5",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "242cf1206dbbd0be35d41fecc47c7eb2d7eecc45",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.8.2",
+      "_shasum": "43c075600a524ac30130b5c2b25aa413bc3b75db",
+      "_from": ".",
+      "_npmVersion": "1.4.23",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43c075600a524ac30130b5c2b25aa413bc3b75db",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.8.2.tgz"
+      },
+      "directories": {}
+    },
+    "1.9.0": {
+      "name": "webpack-dev-server",
+      "version": "1.9.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "8e8f540b2f7b35f7b6c3ce616a7fd2215aaa6eea",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.9.0",
+      "_shasum": "7044d787d5447be0149d14916d8444cb9f5bed72",
+      "_from": ".",
+      "_npmVersion": "2.10.0",
+      "_nodeVersion": "0.12.2",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7044d787d5447be0149d14916d8444cb9f5bed72",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.9.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.0": {
+      "name": "webpack-dev-server",
+      "version": "1.10.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.15.1",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.10.0"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "6ba377a0cea7c36b95d9355b1ed306406b63e808",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.10.0",
+      "_shasum": "a4e72f0301b1eced5d3f5539f79ffc4786aca655",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "a4e72f0301b1eced5d3f5539f79ffc4786aca655",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.10.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.10.1": {
+      "name": "webpack-dev-server",
+      "version": "1.10.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.15.1",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.10.0"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "8fddb2adbf71582d4728d85021a32bd3175571c4",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.10.1",
+      "_shasum": "55ace76bacc8916749542af439ac4971e4e12691",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "55ace76bacc8916749542af439ac4971e4e12691",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.10.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.11.0": {
+      "name": "webpack-dev-server",
+      "version": "1.11.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "socket.io": "^1.3.6",
+        "socket.io-client": "^1.3.6",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.18.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "30d0cc9e7c3eb5485242867a49388b0b265f148d",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.11.0",
+      "_shasum": "f89a140686d83667935534fb1f757e7d6e8fd5e8",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f89a140686d83667935534fb1f757e7d6e8fd5e8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.11.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.12.0": {
+      "name": "webpack-dev-server",
+      "version": "1.12.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "socket.io": "^1.3.6",
+        "socket.io-client": "^1.3.6",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.18.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "c52035ef0664fecc74a4a0dc481e39c523426f88",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.12.0",
+      "_shasum": "1417becba96b366a9bebf5de4422c86de7716bde",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "1417becba96b366a9bebf5de4422c86de7716bde",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.12.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.12.1": {
+      "name": "webpack-dev-server",
+      "version": "1.12.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "socket.io": "^1.3.6",
+        "socket.io-client": "^1.3.6",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.18.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "24b356ec1610ea6d7033b3e01bb7b09429612ba5",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.12.1",
+      "_shasum": "c6dc855520c8ee9cba9256241b3390c1348b0d5c",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "4.0.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "c6dc855520c8ee9cba9256241b3390c1348b0d5c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.12.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "1.13.0": {
+      "name": "webpack-dev-server",
+      "version": "1.13.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.23.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "b090b6659b480135d8b6cde3f2cb4466713b711b",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.13.0",
+      "_shasum": "51d4f519409b96578ba2a6962ad5d490f75c0d57",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "51d4f519409b96578ba2a6962ad5d490f75c0d57",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.13.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.14.0": {
+      "name": "webpack-dev-server",
+      "version": "1.14.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.23.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "0cc94c07b93b234503de43c64e6e9cef801224cc",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.14.0",
+      "_shasum": "ace376e571a84162f229ba6598e9180f7efc9eec",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "ace376e571a84162f229ba6598e9180f7efc9eec",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.14.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.14.1": {
+      "name": "webpack-dev-server",
+      "version": "1.14.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.23.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p"
+      },
+      "gitHead": "eae3a0c73fb847521b42ac2accae1c0906dd6023",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.14.1",
+      "_shasum": "e51de228071258b0db6d55e0f5fee55eec6755de",
+      "_from": ".",
+      "_npmVersion": "2.10.1",
+      "_nodeVersion": "0.12.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e51de228071258b0db6d55e0f5fee55eec6755de",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.14.1.tgz"
+      },
+      "directories": {}
+    },
+    "2.0.0-beta": {
+      "name": "webpack-dev-server",
+      "version": "2.0.0-beta",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=2.0.3-beta <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.9.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^3.32.0"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint lib test",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "3dd3e2abfe2f914764a7e89bda5b7bee9f31bd84",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.0.0-beta",
+      "_shasum": "1973bc18a71601280170150b076b55f46e9fcf20",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "5.4.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "1973bc18a71601280170150b076b55f46e9fcf20",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.0.0-beta.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "2.1.0-beta.0": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.15.0",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^2.10.1",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jquery": "^2.2.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "lint": "eslint lib test",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "dd61b9930fdfa49b96ce3ecdd6ec668b99d7ac80",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.0",
+      "_shasum": "b5605bb8db11c5312b0dbb14aa2d3f205bc9b4a9",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "b5605bb8db11c5312b0dbb14aa2d3f205bc9b4a9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.0.tgz_1463353541777_0.8820632435381413"
+      },
+      "directories": {}
+    },
+    "1.15.0": {
+      "name": "webpack-dev-server",
+      "version": "1.15.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "f1ce64f848bf5165b457fbdfff4cc5432b1f313a",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.15.0",
+      "_shasum": "981607690d405671902c198134d8e35c7932acda",
+      "_from": ".",
+      "_npmVersion": "3.8.3",
+      "_nodeVersion": "5.10.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "981607690d405671902c198134d8e35c7932acda",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.15.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.15.0.tgz_1471866629942_0.519205707591027"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.1": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.15.0",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^2.10.1",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.8.4",
+        "pug": "2.0.0-beta5",
+        "pug-loader": "~2.3.0",
+        "jquery": "^2.2.0",
+        "js-beautify": "^1.6.3",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "66067171b7c50b5837659de634e4c1b3c4d192a7",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.1",
+      "_shasum": "d52f935b65cc724ddde7ceefc4002eb8797d3636",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "d52f935b65cc724ddde7ceefc4002eb8797d3636",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.1.tgz_1472652175716_0.8906425088644028"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.2": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.15.0",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.24.0",
+        "eslint": "^2.10.1",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jquery": "^2.2.0",
+        "js-beautify": "^1.6.3",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "4cdb14c9f533b4d946fd2a1cb5e5a3cefc109e5a",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.2",
+      "_shasum": "fbf1b933b9a28efb853ca8ddcb3eab6476c996ff",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "fbf1b933b9a28efb853ca8ddcb3eab6476c996ff",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.2.tgz_1472679094173_0.9485197891481221"
+      },
+      "directories": {}
+    },
+    "1.15.1": {
+      "name": "webpack-dev-server",
+      "version": "1.15.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "2f3163befa7378de56e22a23c9d70ab4af470585",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.15.1",
+      "_shasum": "d9496676a54ffe53ccb8fbb3225b88e21e8eac13",
+      "_from": ".",
+      "_npmVersion": "3.3.3",
+      "_nodeVersion": "6.3.1",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "d9496676a54ffe53ccb8fbb3225b88e21e8eac13",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.15.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.15.1.tgz_1472679293234_0.01644317083992064"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.3": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "travis": "npm run lint && node lib/Server.js"
+      },
+      "gitHead": "565f4f903f94ba72d0ce697b7f3f0c337d5f1cb8",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.3",
+      "_shasum": "2ac09b7f73560800161e78887242cf1f2ac49486",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "2ac09b7f73560800161e78887242cf1f2ac49486",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.3.tgz_1473151359088_0.6230159013066441"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.4": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.17",
+        "sockjs-client": "1.1.1",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "travis": "npm run lint && node lib/Server.js"
+      },
+      "gitHead": "8d286b1dcae851a83884a0f0cd576d95a86c8b4a",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.4",
+      "_shasum": "c8bde096207a66819121874bc1b0787cdbedbb55",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "c8bde096207a66819121874bc1b0787cdbedbb55",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.4.tgz_1473344909583_0.9421967270318419"
+      },
+      "directories": {}
+    },
+    "1.15.2": {
+      "name": "webpack-dev-server",
+      "version": "1.15.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "0611792daa5aebcb8a024476c464ee49920228ac",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.15.2",
+      "_shasum": "d1a73b8f2df98312f8b520e316a80c7259322129",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "d1a73b8f2df98312f8b520e316a80c7259322129",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.15.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.15.2.tgz_1473860724694_0.004579306347295642"
+      },
+      "directories": {}
+    },
+    "1.16.0": {
+      "name": "webpack-dev-server",
+      "version": "1.16.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,socket,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "6b712fa7bbd8e3814eff04561f17e43009932150",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.16.0",
+      "_shasum": "a9532a0e1120e438d24c0148bb869e5f19027cf9",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "a9532a0e1120e438d24c0148bb869e5f19027cf9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.16.0.tgz_1474147821486_0.5615413300693035"
+      },
+      "directories": {}
+    },
+    "1.16.1": {
+      "name": "webpack-dev-server",
+      "version": "1.16.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,socket,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "8ecb9a4d1f1b2046db8305c45de178fe1c15131f",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.16.1",
+      "_shasum": "af58e93b1dc040520d28dce42755b3a4c7cc822b",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "af58e93b1dc040520d28dce42755b3a4c7cc822b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.16.1.tgz_1474189294840_0.4990407971199602"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.5": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.5",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.17",
+        "sockjs-client": "1.1.1",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "travis": "npm run lint && node lib/Server.js"
+      },
+      "gitHead": "2eebcfd4f050bb2b86149c881f07d4ea111ad09c",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.5",
+      "_shasum": "d860da30b82442814a2ed5f6f0e92237b5a8fac1",
+      "_from": ".",
+      "_npmVersion": "3.9.5",
+      "_nodeVersion": "6.2.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "d860da30b82442814a2ed5f6f0e92237b5a8fac1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.5.tgz_1474453827153_0.4625011917669326"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.6": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.6",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.17",
+        "sockjs-client": "1.1.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "6466363aab4c2b10e6073ef45c64ca081db6411b",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.6",
+      "_shasum": "385df8893b7200d14774ca500c7cd62f11f98c71",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "385df8893b7200d14774ca500c7cd62f11f98c71",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.6.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.6.tgz_1474883868302_0.5686018869746476"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.7": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.7",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "d316d77dff02fc2be173b6d5b6ab3dac80cb9552",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.7",
+      "_shasum": "ca23bef3e8d8f7b07057b67b7843f2cfc7659e6d",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "ca23bef3e8d8f7b07057b67b7843f2cfc7659e6d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.7.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.7.tgz_1474984223233_0.5798456384800375"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.8": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.8",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "ffb1e560d5cf14cc037db1ce1027c528599bc1f9",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.8",
+      "_shasum": "64cf17bc30da6fa6b70848dd735fe1386f430cf1",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "64cf17bc30da6fa6b70848dd735fe1386f430cf1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.8.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.8.tgz_1475313508626_0.5943936645053327"
+      },
+      "directories": {}
+    },
+    "1.16.2": {
+      "name": "webpack-dev-server",
+      "version": "1.16.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,socket,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "bf741ce8143dc61e3e946536d1b1b42d3ed16355",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.16.2",
+      "_shasum": "8bebc2c4ce1c45a15c72dd769d9ba08db306a793",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "8bebc2c4ce1c45a15c72dd769d9ba08db306a793",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.16.2.tgz_1475745172017_0.5996910983230919"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.9": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.9",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "b32174c272040918eb2a9d10d4c80d622d4b6f04",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.9",
+      "_shasum": "45745a4a6b84849c63e3a21dfab3be7bdb897554",
+      "_from": ".",
+      "_npmVersion": "3.10.3",
+      "_nodeVersion": "6.6.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "45745a4a6b84849c63e3a21dfab3be7bdb897554",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.9.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-16-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.9.tgz_1476212967005_0.23231707396917045"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.10": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.10",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "af9c3712561effce0e4596806779531430b7c9e1",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.10",
+      "_shasum": "8ea8a1d7366e747c53423be77ecf49437f66cd7e",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "8ea8a1d7366e747c53423be77ecf49437f66cd7e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.10.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.10.tgz_1477752689070_0.24573221942409873"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.11": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.11",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta.26"
+      },
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.26"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "a8743036b881e801dd5109466de45d56dbe97bc0",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.11",
+      "_shasum": "5a1e11590bf9e520ea8a559ee436779125647c28",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "5a1e11590bf9e520ea8a559ee436779125647c28",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.11.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.11.tgz_1479123154219_0.9671662640757859"
+      },
+      "directories": {}
+    },
+    "2.1.0-beta.12": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.12",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta.26"
+      },
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.26"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "1f603090a7ddcb7bd439fda11a2a33dd86e95473",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.1.0-beta.12",
+      "_shasum": "f717e7b69214dae0e7a2061c12d128432d7520ef",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "f717e7b69214dae0e7a2061c12d128432d7520ef",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.12.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.1.0-beta.12.tgz_1480067257505_0.9744372388813645"
+      },
+      "directories": {}
+    },
+    "2.2.0-rc.0": {
+      "name": "webpack-dev-server",
+      "version": "2.2.0-rc.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta.26 || ^2.2.0-rc.0"
+      },
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.26"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "00bdcd5de0487ea31263c39abd748b2d6e190a31",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.2.0-rc.0",
+      "_shasum": "ea8a11e211d9524b8999945fe5645481a51fdf46",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "ea8a11e211d9524b8999945fe5645481a51fdf46",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.2.0-rc.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.2.0-rc.0.tgz_1481832238149_0.6379645040724427"
+      },
+      "directories": {}
+    },
+    "2.2.0": {
+      "name": "webpack-dev-server",
+      "version": "2.2.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "7e18f6a733162af022423db68a519b5186bdd6e4",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.2.0",
+      "_shasum": "364967eccaf8ff1d7e1681b7a8cc24fab4ced8a6",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "364967eccaf8ff1d7e1681b7a8cc24fab4ced8a6",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.2.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.2.0.tgz_1484692433398_0.9343265951611102"
+      },
+      "directories": {}
+    },
+    "2.2.1": {
+      "name": "webpack-dev-server",
+      "version": "2.2.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "aa989975ec628099cc32f5967d217f0d663e5618",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.2.1",
+      "_shasum": "91c442161afe9b5334e0bf1869b143880ece92fa",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "91c442161afe9b5334e0bf1869b143880ece92fa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.2.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.2.1.tgz_1485862056693_0.05203100643120706"
+      },
+      "directories": {}
+    },
+    "1.16.3": {
+      "name": "webpack-dev-server",
+      "version": "1.16.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,socket,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "59348b263cfb0e937de4fe98b244cf9f633106e7",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.16.3",
+      "_shasum": "cbb6a0d3e7c8eb5453b3e9befcbe843219f62661",
+      "_from": ".",
+      "_npmVersion": "3.10.8",
+      "_nodeVersion": "6.8.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "cbb6a0d3e7c8eb5453b3e9befcbe843219f62661",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.16.3.tgz_1485901124715_0.5931641201023012"
+      },
+      "directories": {}
+    },
+    "2.3.0": {
+      "name": "webpack-dev-server",
+      "version": "2.3.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "04eafa56244b186ff370ee2a98511993bd4e3b48",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.3.0",
+      "_shasum": "0437704bbd4d941a6e4c061eb3cc232ed7d06101",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.5.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "0437704bbd4d941a6e4c061eb3cc232ed7d06101",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.3.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.3.0.tgz_1486134738236_0.7737399148754776"
+      },
+      "directories": {}
+    },
+    "2.4.0": {
+      "name": "webpack-dev-server",
+      "version": "2.4.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "3f7c9f7303d2fab380f4178844d52ed361599a2a",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.4.0",
+      "_shasum": "1dba2f57a7b253d62b4f7c5d0cc48e74b9953236",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.5",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "1dba2f57a7b253d62b4f7c5d0cc48e74b9953236",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.4.0.tgz_1487501578965_0.25114165362901986"
+      },
+      "directories": {}
+    },
+    "2.4.1": {
+      "name": "webpack-dev-server",
+      "version": "2.4.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "50ab2f07d363ee1c30660b7c3f13cf2e100dcf82",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.4.1",
+      "_shasum": "48556f793186eac0758df94730c034ed9a4d0f12",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.9.5",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "48556f793186eac0758df94730c034ed9a4d0f12",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.4.1.tgz_1487542448431_0.6656234972178936"
+      },
+      "directories": {}
+    },
+    "2.4.2": {
+      "name": "webpack-dev-server",
+      "version": "2.4.2",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "60e47270860165d41fe4654d78aa2fee8dbdcdc1",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.4.2",
+      "_shasum": "cf595d6b40878452b6d2ad7229056b686f8a16be",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "cf595d6b40878452b6d2ad7229056b686f8a16be",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.4.2.tgz_1489487052584_0.16502785519696772"
+      },
+      "directories": {}
+    },
+    "2.4.3": {
+      "name": "webpack-dev-server",
+      "version": "2.4.3",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "ca93284ca7256097c2e7dd2737dd2239f6f10be9",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.4.3",
+      "_shasum": "ead74bfdc78049684734724ca54000a17509c5f5",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "ead74bfdc78049684734724ca54000a17509c5f5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.4.3.tgz_1492855438842_0.02429781574755907"
+      },
+      "directories": {}
+    },
+    "1.16.4": {
+      "name": "webpack-dev-server",
+      "version": "1.16.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,socket,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "da20bc241847f22d7d6ae105354794a7a923f015",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.16.4",
+      "_shasum": "9a5b8e86aafa2c478e8a24d29ddb282ac696ef50",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "9a5b8e86aafa2c478e8a24d29ddb282ac696ef50",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.16.4.tgz_1492855581471_0.15353068034164608"
+      },
+      "directories": {}
+    },
+    "2.4.4": {
+      "name": "webpack-dev-server",
+      "version": "2.4.4",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "7d08d1e02218e8a21c81aeb216834843955e766b",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.4.4",
+      "_shasum": "1adb41640970421ec7b866e82384e8cebeed85de",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "1adb41640970421ec7b866e82384e8cebeed85de",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.4.4.tgz_1492947245622_0.9602907060179859"
+      },
+      "directories": {}
+    },
+    "2.4.5": {
+      "name": "webpack-dev-server",
+      "version": "2.4.5",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "662bc31a4fc44b6888b5a0baff9ee96fef049cdb",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.4.5",
+      "_shasum": "31384ce81136be1080b4b4cde0eb9b90e54ee6cf",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "31384ce81136be1080b4b4cde0eb9b90e54ee6cf",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-2.4.5.tgz_1493212734344_0.6084479475393891"
+      },
+      "directories": {}
+    },
+    "1.16.5": {
+      "name": "webpack-dev-server",
+      "version": "1.16.5",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "webpack ./client/live.js client/live.bundle.js --colors --config client/webpack.config.js -p && webpack ./client/index.js client/index.bundle.js --colors --config client/webpack.config.js -p",
+        "lint": "eslint bin lib test client/{index,live,socket,webpack.config}.js",
+        "beautify-lint": "beautify-lint lib/**.js bin/**.js",
+        "beautify": "beautify-rewrite lib/**.js bin/**.js",
+        "travis": "npm run lint && npm run beautify-lint && node lib/Server.js"
+      },
+      "gitHead": "cc67bff22284c9663ace4271f2ddd0ee7bb4424d",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@1.16.5",
+      "_shasum": "0cbd5f2d2ac8d4e593aacd5c9702e7bbd5e59892",
+      "_from": ".",
+      "_npmVersion": "4.0.5",
+      "_nodeVersion": "7.4.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "0cbd5f2d2ac8d4e593aacd5c9702e7bbd5e59892",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "packages-18-east.internal.npmjs.com",
+        "tmp": "tmp/webpack-dev-server-1.16.5.tgz_1493213322374_0.10638767411001027"
+      },
+      "directories": {}
+    },
+    "2.5.0": {
+      "name": "webpack-dev-server",
+      "version": "2.5.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "bbcdca70dda70b4c6360435306c307a01ce32278",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.5.0",
+      "_shasum": "4d36a728b03b8b2afa48ed302428847cea2840ad",
+      "_from": ".",
+      "_npmVersion": "3.10.10",
+      "_nodeVersion": "6.11.0",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "shasum": "4d36a728b03b8b2afa48ed302428847cea2840ad",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.5.0.tgz_1497940417521_0.4825704467948526"
+      },
+      "directories": {}
+    },
+    "2.5.1": {
+      "name": "webpack-dev-server",
+      "version": "2.5.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "7c8b1f677f779c685e47ce32577ed4d888b7df9c",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.5.1",
+      "_shasum": "a02e726a87bb603db5d71abb7d6d2649bf10c769",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.9.0",
+      "_npmUser": {
+        "name": "thelarkinn",
+        "email": "sean.larkin@cuw.edu"
+      },
+      "dist": {
+        "shasum": "a02e726a87bb603db5d71abb7d6d2649bf10c769",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.5.1.tgz_1499406936488_0.7524401133414358"
+      },
+      "directories": {}
+    },
+    "2.6.0": {
+      "name": "webpack-dev-server",
+      "version": "2.6.0",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "loglevel": "^1.4.1",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "adc9a0d28a4e4a27db18bb50d798530c45cbde78",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.6.0",
+      "_shasum": "8a861acac73097afed031f35826447a3013a4eb3",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "8a861acac73097afed031f35826447a3013a4eb3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.6.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.6.0.tgz_1500735396144_0.8972719523590058"
+      },
+      "directories": {}
+    },
+    "2.6.1": {
+      "name": "webpack-dev-server",
+      "version": "2.6.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "loglevel": "^1.4.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "09ffe239a889c22f13809e9c39478e92a4c69879",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.6.1",
+      "_shasum": "0b292a9da96daf80a65988f69f87b4166e5defe7",
+      "_from": ".",
+      "_npmVersion": "4.1.2",
+      "_nodeVersion": "7.7.2",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "shasum": "0b292a9da96daf80a65988f69f87b4166e5defe7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.6.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.6.1.tgz_1500803955833_0.42655801749788225"
+      },
+      "directories": {}
+    },
+    "2.7.1": {
+      "name": "webpack-dev-server",
+      "version": "2.7.1",
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^1.1.1"
+      },
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/webpack/webpack-dev-server.git"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "scripts": {
+        "prepublish": "npm run -s client-live && npm run -s client-index && npm run -s client-sockjs",
+        "client-live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js -p",
+        "client-index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js -p",
+        "client-sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js -p",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "beautify": "npm run lint -- --fix",
+        "test": "mocha --full-trace --check-leaks",
+        "posttest": "npm run -s lint",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "travis": "npm run cover -- --report lcovonly && npm run lint"
+      },
+      "gitHead": "65f05864b8a14dd06f2c9dcbdeee3e6ef7828bc6",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.7.1",
+      "_shasum": "21580f5a08cd065c71144cf6f61c345bca59a8b8",
+      "_from": ".",
+      "_npmVersion": "4.2.0",
+      "_nodeVersion": "7.8.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "shasum": "21580f5a08cd065c71144cf6f61c345bca59a8b8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.7.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jhnns",
+          "email": "mail@johannesewald.de"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        },
+        {
+          "name": "sokra",
+          "email": "tobias.koppers@googlemail.com"
+        },
+        {
+          "name": "spacek33z",
+          "email": "kees@webduck.nl"
+        },
+        {
+          "name": "thelarkinn",
+          "email": "sean.larkin@cuw.edu"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.7.1.tgz_1502215920001_0.5402056723833084"
+      },
+      "directories": {}
+    },
+    "2.8.0": {
+      "name": "webpack-dev-server",
+      "version": "2.8.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^2.0.2",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^8.0.2"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "0df1fa7e79be355f0418a099b21b7b3bac858189",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.8.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-uIHpSWqeAca//nDjACAHkhBDG2wJg3hD/sICImLj4ResZsc2t+WaBQ0f4FL50jd89NLaZjvlLRKu7ayMOTdOhg==",
+        "shasum": "bc3072d699fd367078c67f90410f4028b3d008fe",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.8.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.8.0.tgz_1505314583301_0.5669508657883853"
+      },
+      "directories": {}
+    },
+    "2.8.1": {
+      "name": "webpack-dev-server",
+      "version": "2.8.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^2.0.2",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^8.0.2"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "e8cbdadd4e7632c1bbf4e6b683d485d254887d45",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.8.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-3EqjiJWctcOdZPRPhfcf/JWK8wly43AJRdPIPvtMUcFvyhASGysKOe34r3M+hGJXh8gQwf4/BipYYpuurOhBHQ==",
+        "shasum": "344e312bf560498ee0c518f2fcc709951630f667",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.8.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.8.1.tgz_1505330575846_0.630337979644537"
+      },
+      "directories": {}
+    },
+    "2.8.2": {
+      "name": "webpack-dev-server",
+      "version": "2.8.2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^2.0.2",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "bc229352cde89eeb53e5d2e8501cbefb7e97b6c0",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.8.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-wD9bs+Z1uwvf3Jc+8ZkyMI0Xi+aJJYjC2UZplOWoo/vStelK5Mv62X2uXYEYIQEjy9wJQMzC0fEFqQsg7vVEIg==",
+        "shasum": "abd61f410778cc4c843d7cebbf41465b1ab7734c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.8.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.8.2.tgz_1505417269279_0.38105466100387275"
+      },
+      "directories": {}
+    },
+    "2.9.0": {
+      "name": "webpack-dev-server",
+      "version": "2.9.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "59828060699e64ceb1cce4ef69c6def441064abb",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.9.0",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-npeTKI/ydk+D+iDPxKAeDuYM9lwpGzJjrqePbFHas94zxQ6Nu9C1RfEPEyzFrtTEZd1QkfKX3l647Im7mcl7+w==",
+        "shasum": "59bb3be387250e2295617859ddc14d4d8525de7d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.9.0.tgz_1506520782841_0.7235300785396248"
+      },
+      "directories": {}
+    },
+    "2.9.1": {
+      "name": "webpack-dev-server",
+      "version": "2.9.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "97484a9cebad152e67b2fa5ca40058962295675c",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.9.1",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.2.1",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-qFKs4Wg6JI6FkAQ6WFqeDCCxXEBLsDHkqJB3f9tmlqx8C68Y9vQWwcaMT4Q9H8WF32Q6QUNmgK4qQkdHfXvj/g==",
+        "shasum": "7ac9320b61b00eb65b2109f15c82747fc5b93585",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.9.1.tgz_1506536725434_0.9127065683715045"
+      },
+      "directories": {}
+    },
+    "2.9.2": {
+      "name": "webpack-dev-server",
+      "version": "2.9.2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "32412bbbabd832ce1f1b6e0c9c8e53bc55875785",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.9.2",
+      "_npmVersion": "5.3.0",
+      "_nodeVersion": "8.6.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-ppL53TttdTPfiZA4EphKRE4QgtXssjLdHBwNs/MOx/fWLHCrZ0JeyE+eFcHrAcv7qOJgvR5jFZ1quO7i1LNieA==",
+        "shasum": "0fbab915701d25a905a60e1e784df19727da800f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.9.2.tgz_1508075810473_0.4948214120231569"
+      },
+      "directories": {}
+    },
+    "2.9.3": {
+      "name": "webpack-dev-server",
+      "version": "2.9.3",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "3d7285835bd4934b688ec9669b9712e72567f8cf",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.9.3",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "8.7.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-bwq7sj452FRH+oVfgOA8xXKkLYPTNsYB4dQ0Jhz3ydjNJ9MvhpGJtehFW8Z0cEcwNkRRiF4aYbReiSGQ4pbS1w==",
+        "shasum": "f0554e88d129e87796a6f74a016b991743ca6f81",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.9.3.tgz_1508462998980_0.26354463770985603"
+      },
+      "directories": {}
+    },
+    "2.9.4": {
+      "name": "webpack-dev-server",
+      "version": "2.9.4",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "2e501c86fb52ecb9b275e1c21eac9efa402f9974",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.9.4",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-thrqC0EQEoSjXeYgP6pUXcUCZ+LNrKsDPn+mItLnn5VyyNZOJKd06hUP5vqkYwL8nWWXsii0loSF9NHNccT6ow==",
+        "shasum": "7883e61759c6a4b33e9b19ec4037bd4ab61428d1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.9.4.tgz_1509629822180_0.44327410869300365"
+      },
+      "directories": {}
+    },
+    "2.9.5": {
+      "name": "webpack-dev-server",
+      "version": "2.9.5",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^0.11.2",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "6c1d3e4a6cf692e97af44bae56f78bdbe920ee25",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.9.5",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-o0lS6enIxyOPiRJTh8vcgK5TsGNTn7lH1q/pNniAgs46mCE8sQYeqv7Y/oAIh/+u4kiBsFizLJo5EWC+ezz6FQ==",
+        "shasum": "79336fba0087a66ae491f4869f6545775b18daa8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.9.5.tgz_1511801206620_0.26273985719308257"
+      },
+      "directories": {}
+    },
+    "2.9.6": {
+      "name": "webpack-dev-server",
+      "version": "2.9.6",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^0.11.2",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "271959000b15a65b0f889cab4bb666e774455040",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.9.6",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-cxk/h18Z/1qWOBTMup5PxvZ9N+vBRmmbh1/TCiCJnjGtLsvYtg7gTrjAmaa9J3kdkmxx6K5jwk6F0aZ+oOrAyA==",
+        "shasum": "3e3b56c4222694d2b900c3e8e19dd2e990a817f3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.6.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.9.6.tgz_1512591862567_0.28037266712635756"
+      },
+      "directories": {}
+    },
+    "2.9.7": {
+      "name": "webpack-dev-server",
+      "version": "2.9.7",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^0.11.2",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "gitHead": "fd3c176d9a84c0e5e6d0ad579910ab0dccd3fe42",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.9.7",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-Pu7uoQFgQj5RE5wmlfkpYSzihMKxulwEuO2xCsaMnAnyRSApwoVi3B8WCm9XbigyWTHaIMzYGkB90Vr6leAeTQ==",
+        "shasum": "100ad6a14775478924d417ca6dcfb9d52a98faed",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.7.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.9.7.tgz_1512618097049_0.9350820418912917"
+      },
+      "directories": {}
+    },
+    "3.0.0-alpha1": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "publishConfig": {
+        "tag": "next"
+      },
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "index.js",
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run build",
+        "test": "npm run lint && npm run mocha",
+        "build": "npm run build:clean && npm run -s build:bundles && npm run -s build:copy",
+        "build:bundles": "npm run -s build:live && npm run -s build:index",
+        "build:clean": "(rm ssl/*.pem || true) && rm -rf public",
+        "build:copy": "cp lib/client/*.html public && cp lib/client/css/*.css public",
+        "build:index": "webpack lib/client/js/index.js --config lib/client/config/webpack.config.js",
+        "build:live": "webpack lib/client/js/live.js --config lib/client/config/webpack.config.live.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../cli.js"
+      },
+      "files": [
+        "lib/",
+        "public/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "style-loader": "^0.19.0",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "gitHead": "2cb70167fd7185adc6cf7d7998e5864b207e2ca0",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0-alpha1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-46wk9D/IT83gz75OltJxB11K63gmDA6cbdLFNHceZCh5t85d2AWA9Cs7bQy80r+vSdXG9eRchgfIgsD4XIY6nw==",
+        "shasum": "1ef63a654e40290677cadeebcd6313d76ac03a52",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-3.0.0-alpha1.tgz_1512746494347_0.32094232691451907"
+      },
+      "directories": {}
+    },
+    "3.0.0-alpha2": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "publishConfig": {
+        "tag": "next"
+      },
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "index.js",
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run build",
+        "test": "npm run lint && npm run mocha",
+        "build": "npm run build:clean && npm run -s build:bundles && npm run -s build:copy",
+        "build:bundles": "npm run -s build:live && npm run -s build:index",
+        "build:clean": "(rm ssl/*.pem || true) && rm -rf public",
+        "build:copy": "cp lib/client/*.html public && cp lib/client/css/*.css public",
+        "build:index": "webpack lib/client/js/index.js --config lib/client/config/webpack.config.js",
+        "build:live": "webpack lib/client/js/live.js --config lib/client/config/webpack.config.live.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../cli.js"
+      },
+      "files": [
+        "lib/",
+        "public/",
+        "ssl/",
+        "cli.js"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "style-loader": "^0.19.0",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "gitHead": "af537374b43857d3ed075b5d0437566e24af5065",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0-alpha2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-LY05dkHivSZFFWYFtbcAhYAA+oG9ywOiMOBbItDCbemEgGjevRnJ0VoiRGRXXy980pwtCyE7kYf+fO8kB9HDwQ==",
+        "shasum": "5bbff703aefa02cacec9f81b5bb3bafb96843bf7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-3.0.0-alpha2.tgz_1512764453772_0.07286260975524783"
+      },
+      "directories": {}
+    },
+    "3.0.0-alpha3": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha3",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "publishConfig": {
+        "tag": "next"
+      },
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "index.js",
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run build",
+        "test": "npm run lint && npm run mocha",
+        "build": "npm run build:clean && npm run -s build:bundles && npm run -s build:copy",
+        "build:bundles": "npm run -s build:live && npm run -s build:index",
+        "build:clean": "(rm ssl/*.pem || true) && rm -rf public",
+        "build:copy": "cp lib/client/*.html public && cp lib/client/css/*.css public",
+        "build:index": "webpack lib/client/js/index.js --config lib/client/config/webpack.config.js",
+        "build:live": "webpack lib/client/js/live.js --config lib/client/config/webpack.config.live.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../cli.js"
+      },
+      "files": [
+        "lib/",
+        "public/",
+        "ssl/",
+        "cli.js"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "style-loader": "^0.19.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "gitHead": "03cdce74b2f486a033f52048a80f73a38f149d79",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0-alpha3",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-j6D7ERihB9fBCL9KRK/xZ8aCNfkKfuXmBM6zNvqkHfHF6iT7P3pwmQf+QJZ6wS9nb6eVlNbIlU+HrEM3Pp8u1A==",
+        "shasum": "619d121ac2204e1bd4faad6b5e4f5960a08ade40",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha3.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-3.0.0-alpha3.tgz_1512854733315_0.04808548046275973"
+      },
+      "directories": {}
+    },
+    "3.0.0-alpha4": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha4",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "publishConfig": {
+        "tag": "next"
+      },
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "index.js",
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run build",
+        "test": "npm run lint && npm run mocha",
+        "build": "npm run build:clean && npm run -s build:bundles && npm run -s build:copy",
+        "build:bundles": "npm run -s build:live && npm run -s build:index",
+        "build:clean": "(rm ssl/*.pem || true) && rm -rf public",
+        "build:copy": "cp lib/client/*.html public && cp lib/client/css/*.css public",
+        "build:index": "webpack lib/client/js/index.js --config lib/client/config/webpack.config.js",
+        "build:live": "webpack lib/client/js/live.js --config lib/client/config/webpack.config.live.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../cli.js"
+      },
+      "files": [
+        "lib/",
+        "public/",
+        "ssl/",
+        "cli.js"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "css-loader": "^0.28.5",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "style-loader": "^0.19.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "gitHead": "765c11261b60dba962c4ac0a9f1d45c62bde0bda",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0-alpha4",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-MzTIh/uYPG2EuF41uQSMGxCsFUl39XYOiO3Rsgf1Cu7vkqeWKPlbKoAiQiLBGm3RualsI+/brF6fIIKiSohkXA==",
+        "shasum": "9fdbb9ca4c3b672dcc031f47f93bd5f66c4f775c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha4.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-3.0.0-alpha4.tgz_1512861240807_0.480392956873402"
+      },
+      "directories": {}
+    },
+    "3.0.0-alpha5": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha5",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "publishConfig": {
+        "tag": "next"
+      },
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "index.js",
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run build",
+        "test": "npm run lint && npm run mocha",
+        "build": "npm run build:clean && npm run -s build:bundles && npm run -s build:copy",
+        "build:bundles": "npm run -s build:live && npm run -s build:index",
+        "build:clean": "(rm ssl/*.pem || true) && rm -rf public",
+        "build:copy": "cp lib/client/*.html public && cp lib/client/css/*.css public",
+        "build:index": "webpack lib/client/js/index.js --config lib/client/config/webpack.config.js",
+        "build:live": "webpack lib/client/js/live.js --config lib/client/config/webpack.config.live.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../cli.js"
+      },
+      "files": [
+        "lib/",
+        "public/",
+        "ssl/",
+        "cli.js"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "css-loader": "^0.28.5",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "style-loader": "^0.19.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "gitHead": "108989c9f6b3afe7876ccf17643478d360a05426",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0-alpha5",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-emIaIQOeJUTaPZhWlVF0a0860PSfLA9N7maQWHBWdLRVlwBElpuppu2D0uoMiDzcnQNwd8+hnWGFWrgZJa1BJg==",
+        "shasum": "a336a129879ca331e59aa2aa2bab4bf0f08dac57",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-3.0.0-alpha5.tgz_1512862905409_0.5009246121626347"
+      },
+      "directories": {}
+    },
+    "3.0.0-alpha6": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha6",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "http://github.com/webpack/webpack-dev-server",
+      "publishConfig": {
+        "tag": "next"
+      },
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "index.js",
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js cli.js bin lib test examples",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "npm run build",
+        "test": "npm run lint && npm run mocha",
+        "build": "npm run build:clean && npm run -s build:bundles && npm run -s build:copy",
+        "build:bundles": "npm run -s build:live && npm run -s build:index",
+        "build:clean": "(rm ssl/*.pem || true) && rm -rf public",
+        "build:copy": "cp lib/client/*.html public && cp lib/client/css/*.css public",
+        "build:index": "webpack lib/client/js/index.js --config lib/client/config/webpack.config.js",
+        "build:live": "webpack lib/client/js/live.js --config lib/client/config/webpack.config.live.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../cli.js"
+      },
+      "files": [
+        "lib/",
+        "public/",
+        "ssl/",
+        "cli.js"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.3.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "css-loader": "^0.28.5",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "style-loader": "^0.19.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-cli": "^1.5.2",
+        "webpack-dev-middleware": "^2.0.1",
+        "webpack-log": "^1.0.2",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "gitHead": "24630302dc975437a43a0b9a63ede2140cba21b9",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0-alpha6",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-zbpj45xwoqAOg7CNof+Jnc/5geNk00VEMDSj9u6LCt55t+LJe2Hx+mYG2IdI7BCxfR8rI1e6PHHVIvQtfRup5A==",
+        "shasum": "0fa5d1cd1b6af582a813cfe28615cd982210a138",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha6.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-3.0.0-alpha6.tgz_1513664569727_0.9236728460527956"
+      },
+      "directories": {}
+    },
+    "2.10.0": {
+      "name": "webpack-dev-server",
+      "version": "2.10.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "gitHead": "ca8b5aa689220ce70d3fd6db8bfcfa62b1fa14f4",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.10.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-mFq5S5Sg6nbiGXry+nRlaUoaCcl0IH/LVP60kwwJKBT/8IcwK/ZKduOSBK8bsLwRBh1yFoUYJMKfCo6oeP07+g==",
+        "shasum": "6db9c77c8cf2e2d7ff85c89fb5e4de6f7227be19",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.10.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.10.0.tgz_1515207775274_0.8353301354218274"
+      },
+      "directories": {}
+    },
+    "2.10.1": {
+      "name": "webpack-dev-server",
+      "version": "2.10.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client/{index,live,socket,sockjs,overlay,webpack.config}.js",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "build:live": "webpack ./client/live.js client/live.bundle.js --color --config client/webpack.config.js",
+        "build:index": "webpack ./client/index.js client/index.bundle.js --color --config client/webpack.config.js",
+        "build:sockjs": "webpack ./client/sockjs.js client/sockjs.bundle.js --color --config client/webpack.sockjs.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "gitHead": "3e220fe1c9dcdc7b688090f0f4661e06a1e87c91",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.10.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-R9iZOrbIIsP2mw2j172HVjf479Zb9kcG0chjzHRrE/4M333NZ+3jOWRWJMGEQXwJzUtRNvVKzX2o27qM59TIhQ==",
+        "shasum": "a9768375346e62155860fe3cef3d4d641b24273e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.10.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.10.1.tgz_1515505967796_0.05748319090344012"
+      },
+      "directories": {}
+    },
+    "2.11.0": {
+      "name": "webpack-dev-server",
+      "version": "2.11.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "gitHead": "8c1ed7aad263f6a7b850e63cf945388ddac84441",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.11.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.9.4",
+      "_npmUser": {
+        "name": "sokra",
+        "email": "tobias.koppers@googlemail.com"
+      },
+      "dist": {
+        "integrity": "sha512-lXzc36DGjKUVinETNmDWhfZFRbHMhatuF+lKex+czqY+JVe0Qf2V+Ig6/svDdbt/DmXFXuLQmSqhncYCqYf3qA==",
+        "shasum": "e9d4830ab7eb16c6f92ed68b92f6089027960e1b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.11.0.tgz_1515929112984_0.11727507202886045"
+      },
+      "directories": {}
+    },
+    "2.11.1": {
+      "name": "webpack-dev-server",
+      "version": "2.11.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "gitHead": "83c16251a16794b61fa22761d43b6450bfb18207",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.11.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-ombhu5KsO/85sVshIDTyQ5HF3xjZR3N0sf5Ao6h3vFwpNyzInEzA1GV3QPVjTMLTNckp8PjfG1PFGznzBwS5lg==",
+        "shasum": "6f9358a002db8403f016e336816f4485384e5ec0",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server-2.11.1.tgz_1516482550281_0.8439375127200037"
+      },
+      "directories": {}
+    },
+    "3.0.0-beta.1": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-beta.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.5",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "github:Graham42/html-webpack-plugin#4df601b7fa89e0e30535f759b469bcfe7073a018",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.1.8",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0-beta.1",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n\n# webpack-dev-server\n\nUse [webpack](https://webpack.js.org) with a development server that provides\nlive reloading. This should be used for **development only**.\n\nIt uses [webpack-dev-middleware][middleware-url] under the hood, which provides\nfast in-memory access to the webpack assets.\n\n## Project in Maintenance\n\n**Please note that `webpack-dev-server` is presently in a maintenance-only mode**\nand will not be accepting any additional features in the near term. Most new feature\nrequests can be accomplished with Express middleware; please look into using\nthe [`before`](https://webpack.js.org/configuration/dev-server/#devserver-before)\nand [`after`](https://webpack.js.org/configuration/dev-server/#devserver-after)\nhooks in the documentation.\n\nUse [webpack-serve](https://github.com/webpack-contrib/webpack-serve) for a fast alternative. Use webpack-dev-server if you need to test on old browsers.\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-server --save-dev\n```\n\n_Note: While you can install and run webpack-dev-server globally, we recommend\ninstalling it locally. webpack-dev-server will always use a local installation\nover a global one._\n\n## Usage\n\nThere are two main, recommended methods of using the module:\n\n### With the CLI\n\nThe easiest way to use it is with the CLI. In the directory where your\n`webpack.config.js` is, run:\n\n```console\nnode_modules/.bin/webpack-dev-server\n```\n\n### With NPM Scripts\n\nNPM package.json scripts are a convenient and useful means to run locally installed\nbinaries without having to be concerned about their full paths. Simply define a\nscript as such:\n\n```json\n\"scripts\": {\n  \"start:dev\": \"webpack-dev-server\"\n}\n```\n\nAnd run the following in your terminal/console:\n\n```console\nnpm run start:dev\n```\n\nNPM will automagically reference the binary in `node_modules` for you, and\nexecute the file or command.\n\n### The Result\n\nEither method will start a server instance and begin listening for connections\nfrom `localhost` on port `8080`.\n\nwebpack-dev-server is configured by default to support live-reload of files as\nyou edit your assets while the server is running.\n\nSee [**the documentation**][docs-url] for more use cases and options.\n\n## Browser Support\n\nWhile `webpack-dev-server` transpiles the client (browser) scripts to an ES5\nstate, the project only officially supports the _last two versions of major\nbrowsers_. We simply don't have the resources to support every whacky\nbrowser out there.\n\nIf you find an bug with an obscure / old browser, we would actively welcome a\nPull Request to resolve the bug.\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, of would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nWe welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.\n\n## Maintainers\n\n<table>\n  <tbody>\n    <tr>\n      <td align=\"center\">\n        <img src=\"https://avatars.githubusercontent.com/SpaceK33z?v=4&s=150\">\n        <br />\n        <a href=\"https://github.com/SpaceK33z\">Kees Kluskens</a>\n      </td>\n      <td align=\"center\">\n        <img src=\"https://i.imgur.com/4v6pgxh.png\">\n        <br />\n        <a href=\"https://github.com/shellscape\">Andrew Powell</a>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n## Attribution\n\nThis project is heavily inspired by [peerigon/nof5](https://github.com/peerigon/nof5).\n\n## License\n\n#### [MIT](./LICENSE)\n\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-server.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-server\n\n[node]: https://img.shields.io/node/v/webpack-dev-server.svg\n[node-url]: https://nodejs.org\n\n[deps]: https://david-dm.org/webpack/webpack-dev-server.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-server\n\n[tests]: http://img.shields.io/travis/webpack/webpack-dev-server.svg\n[tests-url]: https://travis-ci.org/webpack/webpack-dev-server\n\n[cover]: https://codecov.io/gh/webpack/webpack-dev-server/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-server\n\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n\n[docs-url]: https://webpack.js.org/configuration/dev-server/#devserver\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-server\n[uglify-url]: https://github.com/webpack-contrib/uglifyjs-webpack-plugin\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "9852a5fe47308d2f10d9f29b72f11796eec9d4a9",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0-beta.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-cl694I2sP7pRhPG2MH1yT2xAAJefe1Wgtq1m6utPHKtAxwgOf/eJJCJvRZ1l3ZXyRXi9FIIBX0895ejauOYK8A==",
+        "shasum": "1a8b3e107dd57f536b15b23456791ea7966d4ef0",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-beta.1.tgz",
+        "fileCount": 19,
+        "unpackedSize": 1155811
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.0.0-beta.1_1518646489945_0.14933609091210154"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0-beta.2": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-beta.2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.5",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "github:Graham42/html-webpack-plugin#4df601b7fa89e0e30535f759b469bcfe7073a018",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0-beta.1",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n\n# webpack-dev-server\n\nUse [webpack](https://webpack.js.org) with a development server that provides\nlive reloading. This should be used for **development only**.\n\nIt uses [webpack-dev-middleware][middleware-url] under the hood, which provides\nfast in-memory access to the webpack assets.\n\n## Project in Maintenance\n\n**Please note that `webpack-dev-server` is presently in a maintenance-only mode**\nand will not be accepting any additional features in the near term. Most new feature\nrequests can be accomplished with Express middleware; please look into using\nthe [`before`](https://webpack.js.org/configuration/dev-server/#devserver-before)\nand [`after`](https://webpack.js.org/configuration/dev-server/#devserver-after)\nhooks in the documentation.\n\nUse [webpack-serve](https://github.com/webpack-contrib/webpack-serve) for a fast alternative. Use webpack-dev-server if you need to test on old browsers.\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-server --save-dev\n```\n\n_Note: While you can install and run webpack-dev-server globally, we recommend\ninstalling it locally. webpack-dev-server will always use a local installation\nover a global one._\n\n## Usage\n\nThere are two main, recommended methods of using the module:\n\n### With the CLI\n\nThe easiest way to use it is with the CLI. In the directory where your\n`webpack.config.js` is, run:\n\n```console\nnode_modules/.bin/webpack-dev-server\n```\n\n### With NPM Scripts\n\nNPM package.json scripts are a convenient and useful means to run locally installed\nbinaries without having to be concerned about their full paths. Simply define a\nscript as such:\n\n```json\n\"scripts\": {\n  \"start:dev\": \"webpack-dev-server\"\n}\n```\n\nAnd run the following in your terminal/console:\n\n```console\nnpm run start:dev\n```\n\nNPM will automagically reference the binary in `node_modules` for you, and\nexecute the file or command.\n\n### The Result\n\nEither method will start a server instance and begin listening for connections\nfrom `localhost` on port `8080`.\n\nwebpack-dev-server is configured by default to support live-reload of files as\nyou edit your assets while the server is running.\n\nSee [**the documentation**][docs-url] for more use cases and options.\n\n## Browser Support\n\nWhile `webpack-dev-server` transpiles the client (browser) scripts to an ES5\nstate, the project only officially supports the _last two versions of major\nbrowsers_. We simply don't have the resources to support every whacky\nbrowser out there.\n\nIf you find an bug with an obscure / old browser, we would actively welcome a\nPull Request to resolve the bug.\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, of would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nWe welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.\n\n## Maintainers\n\n<table>\n  <tbody>\n    <tr>\n      <td align=\"center\">\n        <img src=\"https://avatars.githubusercontent.com/SpaceK33z?v=4&s=150\">\n        <br />\n        <a href=\"https://github.com/SpaceK33z\">Kees Kluskens</a>\n      </td>\n      <td align=\"center\">\n        <img src=\"https://i.imgur.com/4v6pgxh.png\">\n        <br />\n        <a href=\"https://github.com/shellscape\">Andrew Powell</a>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n## Attribution\n\nThis project is heavily inspired by [peerigon/nof5](https://github.com/peerigon/nof5).\n\n## License\n\n#### [MIT](./LICENSE)\n\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-server.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-server\n\n[node]: https://img.shields.io/node/v/webpack-dev-server.svg\n[node-url]: https://nodejs.org\n\n[deps]: https://david-dm.org/webpack/webpack-dev-server.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-server\n\n[tests]: http://img.shields.io/travis/webpack/webpack-dev-server.svg\n[tests-url]: https://travis-ci.org/webpack/webpack-dev-server\n\n[cover]: https://codecov.io/gh/webpack/webpack-dev-server/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-server\n\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n\n[docs-url]: https://webpack.js.org/configuration/dev-server/#devserver\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-server\n[uglify-url]: https://github.com/webpack-contrib/uglifyjs-webpack-plugin\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "398c773a54974c7f8317f181c31bbfd84c4e76aa",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0-beta.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-wdjvB8kn0+tRjwgh6XJoTC8j01FEUMB217tpi+gRxAbwtRh9eQDNkUV8ge7LCmgcyhNhJLH9jBIRJ6UhaWgrcw==",
+        "shasum": "f31fc521d7d681452fd8257db4ffce3e2c61b2ac",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-beta.2.tgz",
+        "fileCount": 19,
+        "unpackedSize": 446489
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.0.0-beta.2_1518864356394_0.8964314046173871"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.6",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "github:webpack-contrib/html-webpack-plugin#ebfc2771d41a6ab043595d3c621528aee020e2f9",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "gitHead": "6e1d886d30bc8067067d33ba85c2ed810a4d1e2c",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-oqGjPBE4XKmo2VPDrBcFaU4PzXuhEkpmt7p01tAHfDV5OHv/NGJHem0shd20/3IuTG/H70KgwGPLkZkeP9151w==",
+        "shasum": "0ca2d293dc7a7b1a94fc5fd62cfca2a9fa61bcf7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0.tgz",
+        "fileCount": 19,
+        "unpackedSize": 446631
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.0.0_1519557337019_0.32695871612314487"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.11.2": {
+      "name": "webpack-dev-server",
+      "version": "2.11.2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n\n# webpack-dev-server\n\nUse [webpack](https://webpack.js.org) with a development server that provides\nlive reloading. This should be used for **development only**.\n\nIt uses [webpack-dev-middleware][middleware-url] under the hood, which provides\nfast in-memory access to the webpack assets.\n\n## Project in Maintenance\n\n**Please note that `webpack-dev-server` is presently in a maintenance-only mode**\nand will not be accepting any additional features in the near term. Most new feature\nrequests can be accomplished with Express middleware; please look into using\nthe [`before`](https://webpack.js.org/configuration/dev-server/#devserver-before)\nand [`after`](https://webpack.js.org/configuration/dev-server/#devserver-after)\nhooks in the documentation.\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-server --save-dev\n```\n\n_Note: While you can install and run webpack-dev-server globally, we recommend\ninstalling it locally. webpack-dev-server will always use a local installation\nover a global one._\n\n## Usage\n\nThere are two main, recommended methods of using the module:\n\n### With the CLI\n\nThe easiest way to use it is with the CLI. In the directory where your\n`webpack.config.js` is, run:\n\n```console\nnode_modules/.bin/webpack-dev-server\n```\n\n### With NPM Scripts\n\nNPM package.json scripts are a convenient and useful means to run locally installed\nbinaries without having to be concerned about their full paths. Simply define a\nscript as such:\n\n```json\n\"scripts\": {\n  \"start:dev\": \"webpack-dev-server\"\n}\n```\n\nAnd run the following in your terminal/console:\n\n```console\nnpm run start:dev\n```\n\nNPM will automagically reference the binary in `node_modules` for you, and\nexecute the file or command.\n\n### The Result\n\nEither method will start a server instance and begin listening for connections\nfrom `localhost` on port `8080`.\n\nwebpack-dev-server is configured by default to support live-reload of files as\nyou edit your assets while the server is running.\n\nSee [**the documentation**][docs-url] for more use cases and options.\n\n## Browser Support\n\nWhile `webpack-dev-server` transpiles the client (browser) scripts to an ES5\nstate, the project only officially supports the _last two versions of major\nbrowsers_. We simply don't have the resources to support every whacky\nbrowser out there.\n\nIf you find an bug with an obscure / old browser, we would actively welcome a\nPull Request to resolve the bug.\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, of would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nWe welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.\n\n## Maintainers\n\n<table>\n  <tbody>\n    <tr>\n      <td align=\"center\">\n        <img src=\"https://avatars.githubusercontent.com/SpaceK33z?v=4&s=150\">\n        <br />\n        <a href=\"https://github.com/SpaceK33z\">Kees Kluskens</a>\n      </td>\n      <td align=\"center\">\n        <img src=\"https://i.imgur.com/4v6pgxh.png\">\n        <br />\n        <a href=\"https://github.com/shellscape\">Andrew Powell</a>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n## Attribution\n\nThis project is heavily inspired by [peerigon/nof5](https://github.com/peerigon/nof5).\n\n## License\n\n#### [MIT](./LICENSE)\n\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-server.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-server\n\n[node]: https://img.shields.io/node/v/webpack-dev-server.svg\n[node-url]: https://nodejs.org\n\n[deps]: https://david-dm.org/webpack/webpack-dev-server.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-server\n\n[tests]: http://img.shields.io/travis/webpack/webpack-dev-server.svg\n[tests-url]: https://travis-ci.org/webpack/webpack-dev-server\n\n[cover]: https://codecov.io/gh/webpack/webpack-dev-server/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-server\n\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n\n[docs-url]: https://webpack.js.org/configuration/dev-server/#devserver\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-server\n[uglify-url]: https://github.com/webpack-contrib/uglifyjs-webpack-plugin\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "f33be5bc150b732b6bb8cc6d3a285f441d80cfb8",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.11.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
+        "shasum": "1f4f4c78bf1895378f376815910812daf79a216f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+        "fileCount": 19,
+        "unpackedSize": 457368
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_2.11.2_1519676426125_0.607629878949649"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1-beta.0": {
+      "name": "webpack-dev-server",
+      "version": "3.0.1-beta.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.6",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "github:webpack-contrib/html-webpack-plugin#ebfc2771d41a6ab043595d3c621528aee020e2f9",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n\n# webpack-dev-server\n\nUse [webpack](https://webpack.js.org) with a development server that provides\nlive reloading. This should be used for **development only**.\n\nIt uses [webpack-dev-middleware][middleware-url] under the hood, which provides\nfast in-memory access to the webpack assets.\n\n## Project in Maintenance\n\n**Please note that `webpack-dev-server` is presently in a maintenance-only mode**\nand will not be accepting any additional features in the near term. Most new feature\nrequests can be accomplished with Express middleware; please look into using\nthe [`before`](https://webpack.js.org/configuration/dev-server/#devserver-before)\nand [`after`](https://webpack.js.org/configuration/dev-server/#devserver-after)\nhooks in the documentation.\n\nUse [webpack-serve](https://github.com/webpack-contrib/webpack-serve) for a fast alternative. Use webpack-dev-server if you need to test on old browsers.\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-server --save-dev\n```\n\n_Note: While you can install and run webpack-dev-server globally, we recommend\ninstalling it locally. webpack-dev-server will always use a local installation\nover a global one._\n\n## Usage\n\nThere are two main, recommended methods of using the module:\n\n### With the CLI\n\nThe easiest way to use it is with the CLI. In the directory where your\n`webpack.config.js` is, run:\n\n```console\nnode_modules/.bin/webpack-dev-server\n```\n\n### With NPM Scripts\n\nNPM package.json scripts are a convenient and useful means to run locally installed\nbinaries without having to be concerned about their full paths. Simply define a\nscript as such:\n\n```json\n\"scripts\": {\n  \"start:dev\": \"webpack-dev-server\"\n}\n```\n\nAnd run the following in your terminal/console:\n\n```console\nnpm run start:dev\n```\n\nNPM will automagically reference the binary in `node_modules` for you, and\nexecute the file or command.\n\n### The Result\n\nEither method will start a server instance and begin listening for connections\nfrom `localhost` on port `8080`.\n\nwebpack-dev-server is configured by default to support live-reload of files as\nyou edit your assets while the server is running.\n\nSee [**the documentation**][docs-url] for more use cases and options.\n\n## Browser Support\n\nWhile `webpack-dev-server` transpiles the client (browser) scripts to an ES5\nstate, the project only officially supports the _last two versions of major\nbrowsers_. We simply don't have the resources to support every whacky\nbrowser out there.\n\nIf you find an bug with an obscure / old browser, we would actively welcome a\nPull Request to resolve the bug.\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, of would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nWe welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.\n\n## Maintainers\n\n<table>\n  <tbody>\n    <tr>\n      <td align=\"center\">\n        <img src=\"https://avatars.githubusercontent.com/SpaceK33z?v=4&s=150\">\n        <br />\n        <a href=\"https://github.com/SpaceK33z\">Kees Kluskens</a>\n      </td>\n      <td align=\"center\">\n        <img src=\"https://i.imgur.com/4v6pgxh.png\">\n        <br />\n        <a href=\"https://github.com/shellscape\">Andrew Powell</a>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n## Attribution\n\nThis project is heavily inspired by [peerigon/nof5](https://github.com/peerigon/nof5).\n\n## License\n\n#### [MIT](./LICENSE)\n\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-server.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-server\n\n[node]: https://img.shields.io/node/v/webpack-dev-server.svg\n[node-url]: https://nodejs.org\n\n[deps]: https://david-dm.org/webpack/webpack-dev-server.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-server\n\n[tests]: http://img.shields.io/travis/webpack/webpack-dev-server.svg\n[tests-url]: https://travis-ci.org/webpack/webpack-dev-server\n\n[cover]: https://codecov.io/gh/webpack/webpack-dev-server/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-server\n\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n\n[docs-url]: https://webpack.js.org/configuration/dev-server/#devserver\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-server\n[uglify-url]: https://github.com/webpack-contrib/uglifyjs-webpack-plugin\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "f76182c981f78f9f0ef667615f4492a833f3e7ae",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.0.1-beta.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-yioaZmlqX9kCauxKQ5+bczEDGFuKbPsYwE+scd79Sk2RbAzBnBZSifZJ80vyB+NrK+EuR4XSQ208urwz/HdhMQ==",
+        "shasum": "cf0a194df30088f37563aa153e62f11c112c03da",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.1-beta.0.tgz",
+        "fileCount": 19,
+        "unpackedSize": 446874
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.0.1-beta.0_1519678797004_0.2466790352678574"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.0": {
+      "name": "webpack-dev-server",
+      "version": "3.1.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.6",
+        "webpack-log": "^1.1.2",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "github:webpack-contrib/html-webpack-plugin#ebfc2771d41a6ab043595d3c621528aee020e2f9",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "gitHead": "94398c40a27ee37c64f22c41777c74cc5f0dee17",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.1.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-ap7Fth7oh4sthC0nJkvRm2W3SaWryBeR19DWIcAwJlcooN0tB2fEKuZqckYR3uaJ6wXPCK1xMWAQWXhV5xVe8g==",
+        "shasum": "5d2365514d9dfa0d415502742d2cc28afc4a32d8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.0.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447503
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.0_1519765485513_0.055528175928323265"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.1": {
+      "name": "webpack-dev-server",
+      "version": "3.1.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.0.1",
+        "webpack-log": "^1.1.2",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.0.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.1.1",
+        "webpack-cli": "^2.0.10",
+        "ws": "^4.1.0"
+      },
+      "gitHead": "3a7f7d543889707725e5d60fc21fe2de975d627d",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.1.1",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-u5lz6REb3+KklgSIytUIOrmWgnpgFmfj/+I+GBXurhEoCsHXpG9twk4NO3bsu72GC9YtxIsiavjfRdhmNt0A/A==",
+        "shasum": "3c0fdd1ba3b50ebc79858a0e6b9ccdd1565b0c24",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.1.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447441
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.1_1520631472441_0.9324278290123802"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.2": {
+      "name": "webpack-dev-server",
+      "version": "3.1.2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.1.2",
+        "webpack-log": "^1.1.2",
+        "yargs": "11.0.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.0.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.1.1",
+        "webpack-cli": "^2.0.14",
+        "ws": "^4.1.0"
+      },
+      "gitHead": "74306486d4de1f6a696b5737f88971deb904fb9a",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.1.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.10.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-dIbLkWSJz9oxLbug9fFbt2/oPklY8/OH4dRaDWZU9gJoDyfCxoPvddXK3ip8hyE2sVXhUuvUNeKBFaxCg2aAqg==",
+        "shasum": "c67e7d16064ca910b8eb8b0da3f94e364425d106",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.2.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447498
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.2_1523107440550_0.5263287800595269"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.3": {
+      "name": "webpack-dev-server",
+      "version": "3.1.3",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.1.2",
+        "webpack-log": "^1.1.2",
+        "yargs": "11.0.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.0.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.1.1",
+        "webpack-cli": "^2.0.14",
+        "ws": "^4.1.0"
+      },
+      "gitHead": "69a90c7edc1983b4ffd968c829bb0d6f543f74dd",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.1.3",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.10.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-UXfgQIPpdw2rByoUnCrMAIXCS7IJJMp5N0MDQNk9CuQvirCkuWlu7gQpCS8Kaiz4kogC4TdAQHG3jzh/DdqEWg==",
+        "shasum": "5cecfd8a9d60c4638284813f1cf9562f04e5c1c5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.3.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447510
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.3_1523176361053_0.32241169027786976"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.4": {
+      "name": "webpack-dev-server",
+      "version": "3.1.4",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.1.3",
+        "webpack-log": "^1.1.2",
+        "yargs": "11.0.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.0.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.1.1",
+        "webpack-cli": "^2.0.14",
+        "ws": "^4.1.0"
+      },
+      "gitHead": "33be88db96d5d7ec76cfe7ef65367945da05df73",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.1.4",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.10.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-itcIUDFkHuj1/QQxzUFOEXXmxOj5bku2ScLEsOFPapnq2JRTm58gPdtnBphBJOKL2+M3p6+xygL64bI+3eyzzw==",
+        "shasum": "9a08d13c4addd1e3b6d8ace116e86715094ad5b4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.4.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447514,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa6i8gCRA9TVsSAnZWagAA8XoP/3+0YkZNIeABmCDMmGI+\n+7UQT/hKIGjRrBf29Oz/NK+uXGT366z+lFbkxW0Y004+u3DMF+GDnugPXQ11\nroEOk/zNXIuiCw47bMOL+AQQJbeHdhtz47Ib4EtKwtgGZa8VqNQOP6qFNQM0\nHvGiHLFdmNNdVEXifnWtTqJ2Fxo+jL4pAXzffQZuUo19lv9D5OpzoNWRiTWa\nohhHyZXLTOveBhv3Ye3MqQEK9awVAfO2cwZ82ZMXQMZ4IZ1/5HnsflutSOFL\nGRH+jLnioMF0P0ftjXYasdmjEGg6Wly1vY4JHbKMD7mgOH8HKXMV2gosvTHJ\nnvX/mAj/MlVFf3emsBx4E2mxQwq5XJreVcqO/qSAC14XYdJ8S3SQARHDVjbI\nrNLXf4bqg4dQXBZM4R7hmeMCdytnRap0HiynUtKHo1SOCTHSHsnqS6qWoA3j\nwR9AtQLCe+RkkO1gTg6s0b8i2brLrUj7DysGyZIXoWsX3hIcmsukxKXglWuV\nPM/lTZlTfcpcXP7uImsBI1qtZng/XYgrzgHlJn8nbPLT0yClcDKf+k2jEmiB\n5f0vfRf0TYrrK46nchwkx1UihRCKNEeiRASd81wxlQosYg26rb4XjZVViAmb\nMRbPTnildRnvnqc1jIzuT1XP4bF7yr2mXX8o7YB2a/JfQhEyQ9QaiTUQ6XoQ\nD1D+\r\n=f88Y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.4_1525296926524_0.3443234234690149"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.5": {
+      "name": "webpack-dev-server",
+      "version": "3.1.5",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.1.3",
+        "webpack-log": "^1.1.2",
+        "yargs": "11.0.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.16.1",
+        "webpack-cli": "^2.0.14",
+        "ws": "^4.1.0"
+      },
+      "gitHead": "e1bd264b9ce5fb0a05a62754883f6c8a36fbc51b",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@3.1.5",
+      "_npmVersion": "6.2.0",
+      "_nodeVersion": "9.10.1",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-LVHg+EPwZLHIlfvokSTgtJqO/vI5CQi89fASb5JEDtVMDjY0yuIEqPPdMiKaBJIB/Ab7v/UN/sYZ7WsZvntQKw==",
+        "shasum": "87477252e1ac6789303fb8cd3e585fa5d508a401",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.5.tgz",
+        "fileCount": 20,
+        "unpackedSize": 450108,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbVKDvCRA9TVsSAnZWagAAMiAP/1YqwG2SDbqtVCNb7g6Z\nDmMDks6gSAoewN4Nd4L+jGHAOxGbUO0zfcZiL9CixzkyUTaZ9BWLl7hul3r5\nR8EFsyqyBNCaVxTjvs2VJI7v/TThdftmxWyyOMhiqNLSnRxKzE9LUcjXPMFM\nOajmus4depo4awsudtyN08er0Pe1Hukjvc3Zrz8XEu2pF0o3QSCcGAmAMtmt\nR8EvHZtQ9aXRT3cfHDXpGC4fat4D9Yjiq4xG37snusvhN7NNfoA5XtwasPSJ\nQS+WCfVPV3lHAMjG8OUDOOkqq+yWD6wjPH3RYMTPvdg12iI4BUr4heeokdg6\n1tYrTcqrXr+csPHCFXbtCFYfG/85+rMGRZHP6HS0FIAsrps7hKQHvXJV21zj\nD4MAjlzZJOpUYvMPuwkVAfNLQn23mGbdz8CTPnhgiuk9ig24dhoX2W8RVV77\nnpCqCHoBCtlzkRBKSrPlmVURDxgKDbJBK05MGG3tW6B2QRKB+mnUPr6aaHdU\n8Gq+M8Do6CnJtSQJeLGwNCpyajWKTI3Wj7iaifQAISCoK+pjZX0BdC3YrbiB\nDOVOO1MvCbV/vFeBuUc6jgvucdqmKR/1ZB8IaClA0KsOmrOb/lNPkGQcxgCV\nhasf2YI1Bkr8hshd88rr4ZG7yKGjmBIeEZ4PrLhLzPpzvzTFBvgqNEKdCgem\nT8jx\r\n=wCHu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.5_1532272878921_0.21684313755225681"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.11.3": {
+      "name": "webpack-dev-server",
+      "version": "2.11.3",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "files": [
+        "lib/",
+        "bin",
+        "client/",
+        "ssl/"
+      ],
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n\n# webpack-dev-server\n\nUse [webpack](https://webpack.js.org) with a development server that provides\nlive reloading. This should be used for **development only**.\n\nIt uses [webpack-dev-middleware][middleware-url] under the hood, which provides\nfast in-memory access to the webpack assets.\n\n## Project in Maintenance\n\n**Please note that `webpack-dev-server` is presently in a maintenance-only mode**\nand will not be accepting any additional features in the near term. Most new feature\nrequests can be accomplished with Express middleware; please look into using\nthe [`before`](https://webpack.js.org/configuration/dev-server/#devserver-before)\nand [`after`](https://webpack.js.org/configuration/dev-server/#devserver-after)\nhooks in the documentation.\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-server --save-dev\n```\n\n_Note: While you can install and run webpack-dev-server globally, we recommend\ninstalling it locally. webpack-dev-server will always use a local installation\nover a global one._\n\n## Usage\n\nThere are two main, recommended methods of using the module:\n\n### With the CLI\n\nThe easiest way to use it is with the CLI. In the directory where your\n`webpack.config.js` is, run:\n\n```console\nnode_modules/.bin/webpack-dev-server\n```\n\n### With NPM Scripts\n\nNPM package.json scripts are a convenient and useful means to run locally installed\nbinaries without having to be concerned about their full paths. Simply define a\nscript as such:\n\n```json\n\"scripts\": {\n  \"start:dev\": \"webpack-dev-server\"\n}\n```\n\nAnd run the following in your terminal/console:\n\n```console\nnpm run start:dev\n```\n\nNPM will automagically reference the binary in `node_modules` for you, and\nexecute the file or command.\n\n### The Result\n\nEither method will start a server instance and begin listening for connections\nfrom `localhost` on port `8080`.\n\nwebpack-dev-server is configured by default to support live-reload of files as\nyou edit your assets while the server is running.\n\nSee [**the documentation**][docs-url] for more use cases and options.\n\n## Browser Support\n\nWhile `webpack-dev-server` transpiles the client (browser) scripts to an ES5\nstate, the project only officially supports the _last two versions of major\nbrowsers_. We simply don't have the resources to support every whacky\nbrowser out there.\n\nIf you find an bug with an obscure / old browser, we would actively welcome a\nPull Request to resolve the bug.\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, of would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nWe welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.\n\n## Maintainers\n\n<table>\n  <tbody>\n    <tr>\n      <td align=\"center\">\n        <img src=\"https://avatars.githubusercontent.com/SpaceK33z?v=4&s=150\">\n        <br />\n        <a href=\"https://github.com/SpaceK33z\">Kees Kluskens</a>\n      </td>\n      <td align=\"center\">\n        <img src=\"https://i.imgur.com/4v6pgxh.png\">\n        <br />\n        <a href=\"https://github.com/shellscape\">Andrew Powell</a>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n## Attribution\n\nThis project is heavily inspired by [peerigon/nof5](https://github.com/peerigon/nof5).\n\n## License\n\n#### [MIT](./LICENSE)\n\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-server.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-server\n\n[node]: https://img.shields.io/node/v/webpack-dev-server.svg\n[node-url]: https://nodejs.org\n\n[deps]: https://david-dm.org/webpack/webpack-dev-server.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-server\n\n[tests]: http://img.shields.io/travis/webpack/webpack-dev-server.svg\n[tests-url]: https://travis-ci.org/webpack/webpack-dev-server\n\n[cover]: https://codecov.io/gh/webpack/webpack-dev-server/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-server\n\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n\n[docs-url]: https://webpack.js.org/configuration/dev-server/#devserver\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-server\n[uglify-url]: https://github.com/webpack-contrib/uglifyjs-webpack-plugin\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "7cdfb742a89831a1f3421e6277463927bfb19332",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.11.3",
+      "_npmVersion": "6.3.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-Qz22YEFhWx+M2vvJ+rQppRv39JA0h5NNbOOdODApdX6iZ52Diz7vTPXjF7kJlfn+Uc24Qr48I3SZ9yncQwRycg==",
+        "shasum": "3fd48a402164a6569d94d3d17f131432631b4873",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.3.tgz",
+        "fileCount": 19,
+        "unpackedSize": 457534,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfae1CRA9TVsSAnZWagAAtFkP/RyYSrj02zD8gq6UBXnN\n+zSno8wMSFpkQdbrblvzcVVBtknl3BqxrTBtyCaaAu3Tc8bIhTWssyYJzVw7\nF54IUadgrzOqPy5hQYSIXjeRE2L5iXBHGgklfyxalhltNV6CjgjpcdvE2Fli\nQbHsQEBNyegH2BiBISmh0vdxpwwbZGDGM9lOUMmGoPGrPQWxASZteVzqAV7E\nAYMPMBWx4uxxi7h/ht84ADY97mE8LWrMxElrmcbd850Vk/YVt6YhZ4QcUGRe\nMWF1dY6UksgnVUlPKeWUuqch5utVOyH+JCoLJv+QPqeTBJPEh/R0dV+wNc51\n1NFyhS5mlCCz/tLPxoi3LsdhnrNgjhFply+wAZJx6Jk0V9csTX1Q0xuga5P5\nBcgWmdPbvdaxg4pNEOLKiQuu7ZW/FkLxijWu30VQDEUVtoozz5U3kaOxSiOm\nWHuWVU7NYx8L/l9d+kMspwdtrNs1H9xW4s5AlE/DHGORAaz9JrCw0J6AqG5Y\ncqh3bpGseSCMNzvHKHIhtvNolg7Xb4vxOvlXyAnNWqBvw3XEU3r/jZ/NQBki\nxpvh9sCcuaMZMNPWjJlO/C7PmOoggtngngX0JTXUIzbLx1SJgSlb/SQq2e+s\nxr6qmdA9PsC0AemTqfVnNKCVpQzNhh2JxFTGYOK4GqnhW903jnOSlqJl2kIX\niTW9\r\n=MgxC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_2.11.3_1534961589116_0.6060639470529967"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.6": {
+      "name": "webpack-dev-server",
+      "version": "3.1.6",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "files": [
+        "bin",
+        "lib",
+        "ssl",
+        "client"
+      ],
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.2.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "0e1f0c1b740f5123bd05179a959752f39273dc62",
+      "_id": "webpack-dev-server@3.1.6",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "michael-ciniawsky",
+        "email": "michael.ciniawsky@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-uc6YP0DzzW4870TDKoK73uONytLgu27h+x6XfgSvERRChkpd5Ils7US6d5k22LBoh0sDkmPZ6ERHSsrkwtkFFQ==",
+        "shasum": "8617503768b1131fd539cf43c3e2e63bd34c1521",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.6.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447069,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgkvyCRA9TVsSAnZWagAAw68P/jO+HLgTL2IJfOaarqES\nWUPTYhQjda5enEc/JQsmUozgSrZHrWe0b6oSrhhMHejWHwwXRpo3Ph0wcc+f\nqcxDPORRKB3/eEAFbNWFp0Mf44uVmhZ21BSzfmnhyD44qN2w8+pkwhmV/qVb\n/NqyZZxSXlDq0qiEmFhDPsjaGL0OKoWUfksPVlgL65hpbTPOtDbdl0a1CUY/\nNC62UnGKOcB4L2Aj03pNqg8gFNp56hQfzVgEZlaEdWRBz1g5Wc8ZL7jiS89B\n+kKPTcHrsvnt4fgflqTeoF3yDdQU4jkVYStq/Ch7sZ7qcu9KnZvnWc48Ule1\nhmIjw1llY3DAjz0fZF+ZWNPf7+SmkzMH+wIepHV/fJO3d1DQN2yJGFeu9E11\nFDWvyJ8+JngLJOqHApmLHDCaX/oieiXTimN7pcQEWpjsZJUp5hkA9E1T0RXE\nYR49R4cQYMo7Bt4YBlHyflRcNhfOUBw3NBQQzRbnUEldvFF89/0BFLQuU5bK\nk2uboK9nXMq8f3zpkBj+6jDuEEQbjjAASvAAarMdEeR6XJYHJBsJ/qs0UN60\nK1FfNfEU/DPjDqgIInRYblCIrcsPn4h/m6oVkHMplOsZjQKTULnJLtW6CX3H\nkIPq7Ady/TIsLmEnVkd8C9Snk9WoYDSCcFCXattB8esJAfhT0YLkFhSO4v9R\nv57s\r\n=A0Bp\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.6_1535265777932_0.904667942268478"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.7": {
+      "name": "webpack-dev-server",
+      "version": "3.1.7",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.2.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "f37f0a251c6e1815e1ca2a9dc24fe306bb789f1d",
+      "_id": "webpack-dev-server@3.1.7",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "michael-ciniawsky",
+        "email": "michael.ciniawsky@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-KagFrNHf3QKndS61cXqzkQ4gpdXo0d1LZTTplAJzNK1Ev2ZyJiu+BzerW/2dixYYfpnGzp0AcvCXpmYXIOkFOA==",
+        "shasum": "cbf8071cc092d9493732aee4f062f0e065994854",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.7.tgz",
+        "fileCount": 22,
+        "unpackedSize": 445797,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbhpARCRA9TVsSAnZWagAAfrwQAJz6OloxsZB/tZjtRy1g\nUCVCBNFgAOj4+jspni0+mtU0rYgR/2K0UJaa6OWMQbC/RxjeHJMTD6bg0Y09\ncDnk6AgDFKsQUPynwo5GzM6aTza40RBVxLcVGoOqSwNvAeotJqDfWbzTLLmv\ni4BQzWcNI84++MbuvfVcf9OT8vT7M6cPogip3fSxxqhI6+wLEozh2cfglAWY\n6KPI38lRU9Q3Xw50/F8Gh+1W7Z9Nv/OGoA6ZPMUN6D3xvGYxnkmG1gDzZ8Li\nnQR3DYYNWzcVvPa73SWxmEkkfpp8HFZHOCCwIgzk9eiY3H5A7V3CBqVr/0JZ\n5Mu1NUKjxay4MBdQR+kB4ggFG/GzQ8alzLMxHmAVI6eWqN3f+Vs++VoCmo6R\nrbZxWRlgev+mmOPoyzZj4EFtPwPaTbQzLJNhy866Q5/vaByaEt9Q+ZB1YC9w\nPk7Nq9bXPU1dqM0q0q+3/44jdZs57Tc0SNGrY2K57VE5LY4UEpk6H5UiO13N\npI/7mxEI+rl9wQuCzaFE2dgtYGIYq3I0z+hOP4KW8McWJeLpg76FM4kN8SNs\nPd+QFewahlOiLDoxlvjeVxM3XzHY96NL0BbI7h7HCAsm3djanjIaF1hgJCPg\ncM7n5ibN1QOo7gc1FdAfsmp8ogoz65AhB2V51UemJOvc+5EENcxz9mBP+Vvi\nA9lZ\r\n=0BoI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.7_1535545360164_0.743467782918668"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.8": {
+      "name": "webpack-dev-server",
+      "version": "3.1.8",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.2.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "3d37cc5a4a4fc06f0649db8d382ef8484ff73131",
+      "_id": "webpack-dev-server@3.1.8",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "michael-ciniawsky",
+        "email": "michael.ciniawsky@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-c+tcJtDqnPdxCAzEEZKdIPmg3i5i7cAHe+B+0xFNK0BlCc2HF/unYccbU7xTgfGc5xxhCztCQzFmsqim+KhI+A==",
+        "shasum": "eb7a95945d1108170f902604fb3b939533d9daeb",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.8.tgz",
+        "fileCount": 21,
+        "unpackedSize": 443492,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbkWlLCRA9TVsSAnZWagAAOqkP/2u1PinFKPWs7omj4ZMn\nTpqTfxVi3K6cT/9kLIUmVGdB+eXIGlCVEUykrYD9XEqoxbOExWAWhMheBXDr\n8CIhPWZCSsRrtIn5TGa17HKHMoIpUMLPYs4Hv/KEFn/78Jjz+H9aWpk+U3CW\nyfTqqIV4Gr0vkaxK4s7mMkqQUtPcwbdNEobxHBC2oVMuB4won2yEY+hzx8eb\nli/N5PczBBgvjwyfUCnpBgJlQ0Yt6W/D3uJxn/JXq+1vfT+GHczG/No+hi43\nDYQIp5BEYdPeMYc6KTYNbXER3k05y/BhMok/QAWvFuO/fvTwAOBbZcggzuL6\nrZxxv0j6aBzHn/NJVYZsvWDnNO7JNUfQtb1ZGGOE4+JR7V2QW1VIC1ra51Bx\nQdCp4Enjkm2UTyTEF7eadM1tyF6wWzOFaQILskR5uYvRM8Dhv0y1AlXiPJFz\n7Nu7IFdd+seFInK6XEhw6eBGkpVgR6AU+YYhKMo8ZKXqKeQsJ7F+90qvmJIz\na7E/9BH+6qadJUsToQp+Hxz2eDdkCHImS4p4e0yEvpB9xDCqlzgBO5WXaLkf\nSLsTAyuzWx5lYkMyT7CNwGuZ6w7K11nKPjBXMJm83jCGMMC0PqEiToW0P932\n1tsIJ8nEs5zlOUYsYuvLOg4l9xCozD6hDZJ3JOFyKfDTFbDjYvERMpwkw0UG\nw/Zy\r\n=uK/P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.8_1536256330526_0.8276094455225558"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.9": {
+      "name": "webpack-dev-server",
+      "version": "3.1.9",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "bb484adfcc55d5263fc0123442084d7e9453d4e5",
+      "_id": "webpack-dev-server@3.1.9",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.8.0",
+      "_npmUser": {
+        "name": "spacek33z",
+        "email": "kees@webduck.nl"
+      },
+      "dist": {
+        "integrity": "sha512-fqPkuNalLuc/hRC2QMkVYJkgNmRvxZQo7ykA2e1XRg/tMJm3qY7ZaD6d89/Fqjxtj9bOrn5wZzLD2n84lJdvWg==",
+        "shasum": "8b32167624d2faff40dcedc2cbce17ed1f34d3e0",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.9.tgz",
+        "fileCount": 22,
+        "unpackedSize": 449779,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqTiqCRA9TVsSAnZWagAApLAP/jcilJVkogU+NEsAWWaA\nbLtU959bX7G2+t3aeKDRUubVVsRJv33PHcWWoLyhMEOdDVVgjF9ckD51/iUJ\nwTdGAcplTNOPnCk2AKzYitGGwOt+DBOAFM9Kre0wrebfGGSAoSiAY9WjVqb8\njjEYz2RUuXaNkjECrGpdzoA3izhWP75zA1K0h5FYXqWD0/N/19BCeHsBEj2c\nxJUpPf66MvEkatyF1iHtuKR5rWIqVjMoW1GICowp31uOM603gOnNh415ggUD\n/ZJCh3qNa7AdZ7fnk9msSnaBpU/Mb2hCZcGTqGxv1IFTqb7a42ZTUZJID2sx\nT8sRfPrvVwd1GfvXwoxKhbrujV77fX1udueNI//9nVyz0A2uLqZOfSf/WppK\nAhgALiDhCVZ3PbOM2SqiyZMbgpQlPUiFkFX9KUJs0JQG90AZgVvj4bg8EgOu\nqvoFZUwADeWCbsDmvdH3hcaAZL4osAwtZ/RKwbgMCmol8eKE7urX5Y89xDh/\nSEkHOi2jCdcQuENqGw5Rlw82NUyIPxwQ1eFAUwR0PDrmhgi1qBbtcHXc41hn\n9rooew49Ee95M8e7e3VmAqY2xG+fwZqPl/DnSQdhaCZ3dN8j7QpA1NLBU69T\nPMHCmbNucgwkhVYOHf8Le3xzBiNmLcz58JYqF3E3cIU/9Yq9wvzJqBfVBq2O\nz+F5\r\n=ThU6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.9_1537816745406_0.9596684145919154"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.10": {
+      "name": "webpack-dev-server",
+      "version": "3.1.10",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "fe3219f614ad84afbaab1ecbd1d9aec4ff337d37",
+      "_id": "webpack-dev-server@3.1.10",
+      "_npmVersion": "6.4.1",
+      "_nodeVersion": "10.12.0",
+      "_npmUser": {
+        "name": "michael-ciniawsky",
+        "email": "michael.ciniawsky@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-RqOAVjfqZJtQcB0LmrzJ5y4Jp78lv9CK0MZ1YJDTaTmedMZ9PU9FLMQNrMCfVu8hHzaVLVOJKBlGEHMN10z+ww==",
+        "shasum": "507411bee727ee8d2fdffdc621b66a64ab3dea2b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.10.tgz",
+        "fileCount": 21,
+        "unpackedSize": 448536,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbzo4mCRA9TVsSAnZWagAA2a4P/1Umw4aItj3PzQrV3rj9\n/b7fb9cdb3a054piyzg2GsyTm6ZUOiwKFdreeh1gQ4lkmJPlYE6SseQv+82r\nSi+DrjlbDc2b9xNoQS9aw228S8nJmneA66ICtH3mCH+fVTO9MVuhyDjmX7P2\nodo3FMXyuRLCj3xkQLzfyagSI6S5+6ZnphsJHC1/zNVPhwg7lN0F+Kz3GD1G\nlfJQu9LfMt2osN5adsWYSeWHtOxIyeMAkuUGgxwL7kTM8Xod12ACBF4ZWz4i\nJEK1Al8+ij/E6bt5b7XoJSqBkxPP4todsQoZDhydvri+PIvyYGchy9yglwBo\n2kYp5oUOjiMxNobYABkI2l+quqC27h97Ha83T3JFujZD6vRS0hpDT2WW0pAY\nXKUN6fzs4iZG4al/+y+4zLi/IgcRD3a6TXduDmVDU9W6u2kG5q5jAUJsZyU0\no3cfN6ZMSmSUAQEAok2ie3Ga57Ogg5t/k+/KOWhHXWV6mJ+WnSHHJA27obZi\nFS8tRdW/JqL84QtfkdKetdMVBRNfKBLHrKRMn/fURxjTDOoDQh5VZx54LtWr\no4B3WHGDt14jIouRmEcPYwbWBK9h/9UGfUkgVvzSEArC/Ec30v+EwF28NThu\nrMYVhcxnF/hYJwJ95dowX50x3olPri5J6uBTgOEOYkGnIShX7LrqOtGdtphz\nQcUu\r\n=To2W\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.10_1540263461157_0.23925914026158868"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.11": {
+      "name": "webpack-dev-server",
+      "version": "3.1.11",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "ff2874f5f3a90e5727434cc10f69ac4d54896033",
+      "_id": "webpack-dev-server@3.1.11",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.1",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-E/uGbO9ndXrXgNUzw+O2UrrvYY/eIw10fpJnbvJf8VOH/NWZuY3nUG7arbgB/kbkORlF/sPHxnv10tKFtKf3aA==",
+        "shasum": "3b698b5b32476f1f0d3d4014952fcf42ab118205",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.11.tgz",
+        "fileCount": 21,
+        "unpackedSize": 450572,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcHSpGCRA9TVsSAnZWagAA3BIP/iZyGWjeN0MsfrhVTl7p\n/dI7RFYbmfJ8wQU6lytvZcUF0Q2ylhTDepkGq9mRHV+/Fq9gIbXjMwN+q1JE\nFJjYHoUWbFg5+ly50MdEpCoawGERR+Z8iFFSNGX1CmkpOoRpv+yHTrpFqVWu\nuqgFO6KceoRg7OZ/XuSaU2sj9ZVAlNQHMWZIks3uFIZvpTfW3IUtBVP/d8Km\nyE6tAaiinlJUr1Xykxq+Po75NJgoJL36DhJUGs2K5RsYJ3+9wqBdr5U5gASV\nlyFz9tljsEdT9TxctWIhUGatzcqYnj54r+qxz5dwdZPJswaTAN3hwaTYCTmz\nTPvoyN/NDZxX6tHL1KcF5icWsi6ugy9HLoBDNsAjg62jvblPKL3fGVfdxaup\naZK7U+VsFucWSLZHpmAMeNSFTMfhaLz0U2ljoT8+CwJDTT2D4LnLqClrqK/w\nyg3v0Rup5xFkAAQUyxRrwPDPKPDcypRhidMuTlIzc0OJcuavKAdxj3DW4I5S\noyTFjBVc6I3TkZt9r5Fc+YuaqMEuuVu+/EJ7iL9hAIYU0VwDITe5PfREhKtk\npvccjzDH2s7mguhM9Eluay5RKSoCYL+2zlV8MqxGiavVQsTzUTKtJaoCIOV6\na7avjc+zqvBT87FQvBQA4JRekaC5IEbOU1PiHViuTj6iCwX/yfcbOtVtPC6y\nEF4g\r\n=QGZm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.11_1545415237612_0.3604048485634008"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.12": {
+      "name": "webpack-dev-server",
+      "version": "3.1.12",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "94432393ed8659b340452ae7ef24c64c16891dcd",
+      "_id": "webpack-dev-server@3.1.12",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.1",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-BIh/RGi5GW0HQS3shpqoXThwxaROvwbi6eFb9VSkLCYflke8yrNSgbrtO+v/6BbUtpadyZPZiB/DpUEaKyYTCA==",
+        "shasum": "7419af1975877c37d1ab553c75932493a0709da3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.12.tgz",
+        "fileCount": 21,
+        "unpackedSize": 451035,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcHlIOCRA9TVsSAnZWagAAbVAP/ixJJieKM6mEN2HQoIlV\nY0txfS3gSstYk9EfTkicr/hFg/L/dsI8sMFmEAGxS47FnLyzYgKEHm9Bx/Zv\nMz1xuVRD3Ij7FIWn8IRUAPY/AakU9GOFOHk/V8BO1R2acD+y0ubBjxXeOUH+\nIQQ/7ML3qTbejhHFnPuMiLhWQx9MuLkjqxyjNpJIKFQTmjbyMTLvNlf1lBza\nQIvgNLSR7UHhQskZ5uU2lwEcZ260qJlmnjXriZJDPK1yxTaNu0WuM+idM908\nMpx+YeQaAf78kSJEfiHkmrPZjfqvE/ArUisTLtENQ45MXJvft21UVAHPbBJS\n9hUVO/A0BeJVmlhVS3QXWR2xZetEPH+CaSuXddcCxVsnOuG0xlUN9iT2kHMH\nF/stWDKzsGS/Qm2V0FwqL7l8PhROrH0JSoiuO7NZaubW4MgDIlDcgCNEve9I\n1xhiUPYGLk/z7nuOIB3pYBRGo7T7X0knC9ZQjfe4ycVz4PRGfy7J0LakR6gh\njfvKwihtY5+rneSe8eKbBxNwWdqOs60Ry6ihyGVHF3j0PO6PHVV+AotXFWR6\nf/fUTxpgB+RR7aE/pltA9aNFvqs9nvSVBK2RDDssRfSrhaxCQwcZ7DPSHKPo\nPI4hYrcL+GCR6aLkrPDSA0xdJPGuDksmGKROyinIk/nGcwAim8tbvBHlQr5c\nB4DH\r\n=FoPK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.12_1545490957827_0.9222641671915488"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.13": {
+      "name": "webpack-dev-server",
+      "version": "3.1.13",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "bddfe160808c54ac811eee77d0cd5aa4f157f7c9",
+      "_id": "webpack-dev-server@3.1.13",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.1",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-o+crjlyTDCAnkZe1CGlP2XLGCgnMN6oSotYdB+r5OGbnf52Dl9T/fCOdKObvanl1jEnMuLBVDnjTXEmCMMksww==",
+        "shasum": "72ebc8dab4551f8a8e1fdf6357da97571aee6a23",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.13.tgz",
+        "fileCount": 21,
+        "unpackedSize": 451354,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcHo+YCRA9TVsSAnZWagAAfJ8P/0dT8pyZ+OBIKXO9N1QR\nRo78zphTww8o+K/cp4VFsarwIMaKKDrdCtpJSn2k2sl4z8BZqtvJ2IEWKEGP\n8TShQibX54W5TOTnn8GcLPTDYDkD5waiOieFqndjH+eOWPrJayrSVHvtt8iI\n17KU3dTtawsFgGPb6f48Y1NN2fggIMp7wrVCmQCLmt0XqEYvJvNPl0b+BLj2\nCZxYqgB9lznYtKF+kCUPAMiavHZjljFUJbIvEE2ZHv48mSuiiH0p4UPIgF4G\na2MMsmspb+FZy+pcs/iKYOgmJT255DDlEQ80W3KFpvwokdS5uGsi9Acwq247\nZTciXz9+2eb7e/Fg0tTknUi034N0cQPLBwUG2uNgQWKrDY75UulvQYlRl3J+\ncJSAYJHjrep3i0Nc1BSIg/tlaeLgdz678EO6+kVvF+sZmo91iIgWzk0ZQAvg\nTyylFzvy9sLK3na6tB6o/FQrDe8/yLAvdsrFifp304+k0KBTNThJeUG2TmXb\ndxV7SYoKX3sX1Okc5qvfWfQ/W8+0RD+pI7TEOSLdvYcPDblz2thJx17lks2m\nqiuHe6TUdyJdrWldm1J+nn45A3z9B1jHOYlmNOv56EZkohhD08KEd2NuOdgN\nbPzy/idwGk4I72+7DXlBTESSaKH9qqhb08YgyGs7bXqb9zy1M7ItQ4IMHPNx\n9HKZ\r\n=n5V4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.13_1545506711546_0.5258767894700402"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.1.14": {
+      "name": "webpack-dev-server",
+      "version": "3.1.14",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks --exit",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "4b7a8283f4901a1894bbc93b09d2dcab96ee514b",
+      "_id": "webpack-dev-server@3.1.14",
+      "_npmVersion": "6.5.0",
+      "_nodeVersion": "10.14.1",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
+        "shasum": "60fb229b997fc5a0a1fc6237421030180959d469",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
+        "fileCount": 21,
+        "unpackedSize": 452381,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcIK3fCRA9TVsSAnZWagAAEk0QAJ6UdLc8M+vFBcWKry3S\ncFhLLNtqERo+8tv4oCvtnlNtIrw+xpkhNfVHTEKcq9hjnc/ENM2vSXqE5298\n8eDLob0f3pQhxhD1OgjYostUI8apwmuNVcPsYtgxQ95Nj6vc85fMVjOS9Kiq\n55ALJYY1RQ9RkXH16EtDyvbAjh42pDHgab/Vwu0V4OAZr7FgYRNn7AYFH5qV\nbHocbRH0CSXTFrQWY/54/RXN7I4lhRaEOfZJXkYRiqTErt1es0SEkAF+BJNG\ng/5sOF0ioBBTokjZmNwYo5fbCqptbNTlCuT37oyiLdhuJz7+7gYXhm4Y4a9V\nF9AH8vRc8A60avOqkgtHBOuRmvAV8cwBI/L8JsBFJBNBQ0P0rTaIhRGIM1H/\nhON3fqbeCsGLBkzRKGmcuTb8QEy8g3lHalx+QwAHhNdbbYAd4ptv9/5noeB1\nl5IOcunb2fFJXsDZoFKZDhCRC4/f9R4WGRz0OBByqh9Z71T3qV9nS/E+qSFO\nUcHdZxjJ4r9AZkiTwde+4M7L1XFyjKUgVPWQzUPD5sSpgDdwCpP9oEy2k6nB\n2bVQQZrffOVZ9GSqaitQo3xSf7AXJbBgpz4yxexDLpc+vWpElI//E8U/HVNX\nMqwX1yp3Hl8YAiKg/dIAjKn55UE3qh1eRZVLklCUQLkcghloUXbYbckoqyva\n2Wgg\r\n=Irb9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.1.14_1545645535069_0.34189996644117837"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.2.0": {
+      "name": "webpack-dev-server",
+      "version": "3.2.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "pretty": "prettier --loglevel warn --write \"**/*.{js,css,md,json,yml}\"",
+        "test": "jest --config jest.config.json --runInBand",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^4.1.1",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.5.1",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.2.3",
+        "@babel/core": "^7.2.2",
+        "@babel/preset-env": "^7.3.1",
+        "babel-loader": "^8.0.5",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^2.1.0",
+        "eslint": "^5.4.0",
+        "eslint-config-prettier": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "eslint-plugin-prettier": "^3.0.1",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "husky": "^1.3.1",
+        "jest": "^24.0.0",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "lint-staged": "^8.1.1",
+        "marked": "^0.6.0",
+        "nyc": "^13.3.0",
+        "prettier": "^1.16.3",
+        "rimraf": "^2.6.2",
+        "standard-version": "^5.0.0",
+        "style-loader": "^0.23.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.29.0",
+        "webpack-cli": "^3.2.1",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.js": [
+          "eslint --fix",
+          "prettier --write",
+          "git add"
+        ],
+        "*.{css,md,json,yml}": [
+          "prettier --write",
+          "git add"
+        ]
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "df113ebd3a3fe56fadff19f3495d75036274ac17",
+      "_id": "webpack-dev-server@3.2.0",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.8.0",
+      "dist": {
+        "integrity": "sha512-CUGPLQsUBVKa/qkZl1MMo8krm30bsOHAP8jtn78gUICpT+sR3esN4Zb0TSBzOEEQJF0zHNEbwx5GHInkqcmlsA==",
+        "shasum": "cf22c8819e0d41736ba1922dde985274716f1214",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.0.tgz",
+        "fileCount": 23,
+        "unpackedSize": 459766,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcbVoICRA9TVsSAnZWagAAXmsP/0SG/o9TTsxX4GFExHKc\nQY3RHMddqSwlp/7Oy/wNkNtIGkUuEoBu4+rHzakCBi8UlLQv32Lv7YNJiwJw\n86r0968oprJHNhBcEWaYuXJacRf5t3J+9bFbDkUd58PQjkXR/VCwAFU2KUq0\n/r2/Gy05SpnxbClXFj5AECZuAltAkjYO3YAcTV0pnDT5BO7Gxx+IrgtFQb3Q\nc57otglSQJupo/qw+pM15B91JsJN30cYsDsyrVw55rMIGSNDe4tGfEcwNbMi\nAlDx7C+PM2sSkQqIzvHrnC1hCdzeko4Bg3yjrL/8knGwPv80m948E5FT3FYs\nBFacBmg7VaoO5zrCMQRnAaTZK7gmzz1siUtxfN4KWehQcbFv6Q7xSyEUqVl8\nFsmEHdAdNG8mPWjnqMQ8b4TIwPwS7YqJkbfc7431a1TGFjyB4S6ff/r3gLjb\nIuhP688BhLk73R1xufftBbvc7piIuQoc+GsebUfdkn6BBimnH2FCBBXBHvLB\nsV4hAbdG5RevODZ5QMRf0TbtGUTjyaHn+PwsOeDzhVVSUc7obCnA2vroZ2Uy\ndlEaqvIUAsZRL9VR/QuuebWznTqmYYxDXElTfIz1450H09RK6QcosAY5OHNf\neVpy6UJLTvML59STdgpCPY0LREbZiFY4yIGBnurDP3kpR2dKLcZHwAWI+nkC\nAMMZ\r\n=BIsn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.2.0_1550670343993_0.6782393736862637"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.2.1": {
+      "name": "webpack-dev-server",
+      "version": "3.2.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "pretty": "prettier --loglevel warn --write \"**/*.{js,css,md,json,yml}\"",
+        "test": "jest --config jest.config.json --runInBand",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^4.1.1",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.5.1",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.2.3",
+        "@babel/core": "^7.2.2",
+        "@babel/preset-env": "^7.3.1",
+        "babel-loader": "^8.0.5",
+        "copy-webpack-plugin": "^5.0.0",
+        "css-loader": "^2.1.0",
+        "eslint": "^5.4.0",
+        "eslint-config-prettier": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "eslint-plugin-prettier": "^3.0.1",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "husky": "^1.3.1",
+        "jest": "^24.0.0",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "lint-staged": "^8.1.1",
+        "marked": "^0.6.1",
+        "nyc": "^13.3.0",
+        "prettier": "^1.16.3",
+        "rimraf": "^2.6.2",
+        "standard-version": "^5.0.0",
+        "style-loader": "^0.23.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.29.0",
+        "webpack-cli": "^3.2.1",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.js": [
+          "eslint --fix",
+          "prettier --write",
+          "git add"
+        ],
+        "*.{css,md,json,yml}": [
+          "prettier --write",
+          "git add"
+        ]
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "bf99c26bc3c8807ab7470e8da50fffc572780029",
+      "_id": "webpack-dev-server@3.2.1",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.8.0",
+      "dist": {
+        "integrity": "sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==",
+        "shasum": "1b45ce3ecfc55b6ebe5e36dab2777c02bc508c4e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
+        "fileCount": 27,
+        "unpackedSize": 460337,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcc8xwCRA9TVsSAnZWagAAcfsP/2rX9FxeTmsGXars/VE4\nRZ0s1LPfiAkSJi053A3BYL8EDVcnlvpeMf5LSFy+lbij8CRc6H/hY+ap+Lbk\n0ErcBLx1cZNb6OXzoaQHKZwPHd4csJZqU7woj3CBuBAgle3hJp7mJ1TOB57o\nadP2gWiZsCp724oFIZbG1D6VtzlzZYupauCX0JjqmEPkvVCbFELmA9EVk3NK\nST9mu9ASlfxfav+G6OJnOit8TMJWM8fQpXlfPc2L8RBBhjDClsv1Q0Nua4gv\nB/ccmoCuPwQvIFVcXTONYMMFdgucjNUpNwpsIqdSOMxdsTXykcchwxAlz4IO\nigmN/mv09ICpxI+wuNIGYkFnZsU6Ta55opNPDuVfL5Ux/06T4wulYpDCGH5I\n32D395Yjn7YffktWiMiu9MRVRmniadyU4IK/ifs229H/hjXo2eW3jcltyEYL\nMJCrgvwEo/l829OSt5l/AbLHP+DqiN1wEUb2YcJBtu0XJhgfHF/E7GyGnJIk\n7XgqA3N+HvJGn5tR5psusDtoPLm8uLx2tI/sLrgLvetNUyeUFYwoaOxkqIV+\nosWAzIEXJXLc3R78Jt3UNIYTdyiZOUtNuOGqNWO2rhvgijMaSBSwK5FBRaVf\niEkJZTihU1tSfqNsfdPfGgFnjAv+PtY8Xe9I6msuCwZvZu3/7fD86AAJVV+y\nTA3L\r\n=7OiM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.2.1_1551092847231_0.933433213368821"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.11.4": {
+      "name": "webpack-dev-server",
+      "version": "2.11.4",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.2",
+        "compression": "^1.7.3",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.3",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.7.0",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.3",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "gitHead": "298341f0757e871896c1a7a27983d15f977fb209",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.11.4",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-12gcsaFIdcOS6kPlVy0G/WpsYkbOsNDdLxBPdzgCT+yiRgUNiVSFj1rjfJcgOtGIqPDQjYh+njeM/T7XIs65ig==",
+        "shasum": "9a02a63efe54d772ced8fd5f0222e0edcaa053fe",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.4.tgz",
+        "fileCount": 19,
+        "unpackedSize": 452707,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJclQ+eCRA9TVsSAnZWagAACZsP/iHM3RbSCoVt5PTCdzJc\nQoQxpxAvRn20fNg2BjlroH2LJDLfBHuCu2KTmqAqClFy9RR9g9rqdcTGz/Zg\ni8Bu38nYq1x5NR6rEfcBrMl5PPt1DeHskC0vnsY3H0ik2Ubl8/bW0FJWVUIN\nitfYQK9fs1Clsc/0LGQC8ooHs3MeOn62pZNaaH2t6Jn1iDJtKosESh3Bt0Gw\nMD1hhWALVhJjv4E2Y4CKBDS7KsvOyyMahGGEqnDnmvL8NbIMMaa8KE05Epuw\n3PrAe6857n/e645dnig11dN88hGxNNoAzr0RYan8OBMPSA7GYlwM6plAHqRq\nXPR+uxipGUyuLCTCV4IIYqwICcjEkcOKrhyLp6h8dHDGaNHULKQp+/CsHfm3\n2bkK8GrGbCfdAE9fjLGR/ISIjvHhlEsl59acvZfP44Zha/JI+qjVVHrYS76w\nScJKNMsFTqXaqooi7iE2b0Ohote8xSzYbrivw2r6shM8WYaJ6gWi7b3eR4K6\nPu/VhSNz6VcA78DfEzfOzc6I44ZECn5HK7n/RSFzWL9QiX7bURcP75jK264n\n/K2iXDaHpKNr/yzX5HCI/uksB+m41sY4qa3D+BeU4kS0/lX60RtAH6VkjVis\nAUAUEKHLElNXC592m4x3DmfKFNfFul8fHjS8DJGsntepxnm0BySUzRr7b7dz\nE6QK\r\n=VC3H\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_2.11.4_1553272733325_0.31068663552156695"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.11.5": {
+      "name": "webpack-dev-server",
+      "version": "2.11.5",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server",
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "main": "lib/Server.js",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">=4.7"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint bin lib test examples client-src",
+        "mocha": "mocha --full-trace --check-leaks",
+        "prepublish": "(rm ssl/*.pem || true) && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "test": "npm run lint && npm run mocha",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.2",
+        "compression": "^1.7.3",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.3",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.7.0",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.3",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n\n# webpack-dev-server\n\nUse [webpack](https://webpack.js.org) with a development server that provides\nlive reloading. This should be used for **development only**.\n\nIt uses [webpack-dev-middleware][middleware-url] under the hood, which provides\nfast in-memory access to the webpack assets.\n\n## Project in Maintenance\n\n**Please note that `webpack-dev-server` is presently in a maintenance-only mode**\nand will not be accepting any additional features in the near term. Most new feature\nrequests can be accomplished with Express middleware; please look into using\nthe [`before`](https://webpack.js.org/configuration/dev-server/#devserver-before)\nand [`after`](https://webpack.js.org/configuration/dev-server/#devserver-after)\nhooks in the documentation.\n\n## Getting Started\n\nFirst thing's first, install the module:\n\n```console\nnpm install webpack-dev-server --save-dev\n```\n\n_Note: While you can install and run webpack-dev-server globally, we recommend\ninstalling it locally. webpack-dev-server will always use a local installation\nover a global one._\n\n## Usage\n\nThere are two main, recommended methods of using the module:\n\n### With the CLI\n\nThe easiest way to use it is with the CLI. In the directory where your\n`webpack.config.js` is, run:\n\n```console\nnode_modules/.bin/webpack-dev-server\n```\n\n### With NPM Scripts\n\nNPM package.json scripts are a convenient and useful means to run locally installed\nbinaries without having to be concerned about their full paths. Simply define a\nscript as such:\n\n```json\n\"scripts\": {\n  \"start:dev\": \"webpack-dev-server\"\n}\n```\n\nAnd run the following in your terminal/console:\n\n```console\nnpm run start:dev\n```\n\nNPM will automagically reference the binary in `node_modules` for you, and\nexecute the file or command.\n\n### The Result\n\nEither method will start a server instance and begin listening for connections\nfrom `localhost` on port `8080`.\n\nwebpack-dev-server is configured by default to support live-reload of files as\nyou edit your assets while the server is running.\n\nSee [**the documentation**][docs-url] for more use cases and options.\n\n## Browser Support\n\nWhile `webpack-dev-server` transpiles the client (browser) scripts to an ES5\nstate, the project only officially supports the _last two versions of major\nbrowsers_. We simply don't have the resources to support every whacky\nbrowser out there.\n\nIf you find an bug with an obscure / old browser, we would actively welcome a\nPull Request to resolve the bug.\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, of would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nWe welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.\n\n## Maintainers\n\n<table>\n  <tbody>\n    <tr>\n      <td align=\"center\">\n        <img src=\"https://avatars.githubusercontent.com/SpaceK33z?v=4&s=150\">\n        <br />\n        <a href=\"https://github.com/SpaceK33z\">Kees Kluskens</a>\n      </td>\n      <td align=\"center\">\n        <img src=\"https://i.imgur.com/4v6pgxh.png\">\n        <br />\n        <a href=\"https://github.com/shellscape\">Andrew Powell</a>\n      </td>\n    </tr>\n  </tbody>\n</table>\n\n## Attribution\n\nThis project is heavily inspired by [peerigon/nof5](https://github.com/peerigon/nof5).\n\n## License\n\n#### [MIT](./LICENSE)\n\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-server.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-server\n\n[node]: https://img.shields.io/node/v/webpack-dev-server.svg\n[node-url]: https://nodejs.org\n\n[deps]: https://david-dm.org/webpack/webpack-dev-server.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-server\n\n[tests]: http://img.shields.io/travis/webpack/webpack-dev-server.svg\n[tests-url]: https://travis-ci.org/webpack/webpack-dev-server\n\n[cover]: https://codecov.io/gh/webpack/webpack-dev-server/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-server\n\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n\n[docs-url]: https://webpack.js.org/configuration/dev-server/#devserver\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-server\n[uglify-url]: https://github.com/webpack-contrib/uglifyjs-webpack-plugin\n[wjo-url]: https://github.com/webpack/webpack.js.org\n",
+      "readmeFilename": "README.md",
+      "gitHead": "5807c7462f6dd15cade9c74216f2e829c2653351",
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "_id": "webpack-dev-server@2.11.5",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-7TdOKKt7G3sWEhPKV0zP+nD0c4V9YKUJ3wDdBwQsZNo58oZIRoVIu66pg7PYkBW8A74msP9C2kLwmxGHndz/pw==",
+        "shasum": "416fbdea0e04eebe44a626e791d5a2eb37fe8c48",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.5.tgz",
+        "fileCount": 19,
+        "unpackedSize": 452707,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJclmrjCRA9TVsSAnZWagAAtkwQAJmBAu7C35gY2QBJPke8\nUeu92F310fTlHT1zPoy8YYnBV01rEk7LaE+4JCwCKSPKq8ONYVStn6v8Kzcv\nzwNPRZR0mCT3mAbdG0Ke9cppRN2bg5B5sw/cdTqNZlOGsctMIS+b6wKwLMKk\nsb0lm1rgK9OybuQDE3l0RP+Qq3PeqcXSDpniyBNyRQ/u/h6c7wdpYLNL9mUV\nE/mw8YrcuzPD0mzauD5WsjHxAb5RcRE2Wk88riL+oDdEnlPRPX/Ke+TFVeWV\nK07q8AzgrLc9qHXFtDHWQsooLXjVXx2mKILQzZZLVyrn0ER2WI/9GP2bbVEN\nS3R2U+O7cHCWqWjOFC2+3PHy/tEOdwpptdHUsawtpFnEJbHAY7Tp7qyuTawP\nmMqPYgaDq92/SgYzRz4+a1LW6v9aPJgmrcD6nE2DGSiYIUJE6+CaHQno1SQ0\nihLxp/kFoVN4mVrtvNv3VSBQhBnQsjP/HkiN9rNQq8tVc9NanNDqeuSTZt8/\nowYsT5QVcQDUcgLf+vnQx+IkxNPwldrY9zpmjEAymtnt7IpF4TilYBFN/7xP\nq0ReektrrHREs506sPqc+sSR9lTGF6ZfC9suISyefPWYXzGLQwdyHzW9Y7Ei\nR6T/INfWkwnND9Ahg0VtH5olcfNzK9LgKcVf4zJzbqVr+P6Ex1ca4cmMfax0\nZtFv\r\n=7OVU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_2.11.5_1553361634413_0.36690573897737844"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.3.0": {
+      "name": "webpack-dev-server",
+      "version": "3.3.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "pretty": "prettier --loglevel warn --write \"**/*.{js,css,md,json,yml}\"",
+        "test": "jest --runInBand",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.5",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.0",
+        "express": "^4.16.4",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.1",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.0.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.6.2",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "7.4.3",
+        "@babel/core": "7.4.3",
+        "@babel/preset-env": "7.4.3",
+        "babel-loader": "8.0.5",
+        "copy-webpack-plugin": "5.0.2",
+        "css-loader": "2.1.1",
+        "eslint": "5.16.0",
+        "eslint-config-prettier": "4.1.0",
+        "eslint-config-webpack": "1.2.5",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-prettier": "3.0.1",
+        "execa": "1.0.0",
+        "file-loader": "3.0.1",
+        "html-loader": "0.5.5",
+        "html-webpack-plugin": "3.2.0",
+        "husky": "1.3.1",
+        "jest": "24.7.1",
+        "jquery": "3.3.1",
+        "less": "3.9.0",
+        "less-loader": "4.1.0",
+        "lint-staged": "8.1.5",
+        "marked": "0.6.2",
+        "nyc": "13.3.0",
+        "prettier": "1.16.4",
+        "puppeteer": "1.14.0",
+        "rimraf": "2.6.3",
+        "standard-version": "5.0.2",
+        "style-loader": "0.23.1",
+        "supertest": "4.0.2",
+        "url-loader": "1.1.2",
+        "webpack": "4.29.6",
+        "webpack-cli": "3.3.0",
+        "ws": "6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.js": [
+          "eslint --fix",
+          "prettier --write",
+          "git add"
+        ],
+        "*.{css,md,json,yml}": [
+          "prettier --write",
+          "git add"
+        ]
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "99e8db0f8cc441bb8f6acc60d786e33c38b8fc1d",
+      "_id": "webpack-dev-server@3.3.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.11.4",
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-75LTgV367MRDVIC+IBETrKEy9175+i5fy9nkw8MW+udnPCzNzSfZtKUIG5thQcooaNruPZZoEV8fCZqKJszOIw==",
+        "shasum": "eee6b5cf0f754661aed796ffdcc9c6493a963a8b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.3.0.tgz",
+        "fileCount": 30,
+        "unpackedSize": 470071,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcq3A5CRA9TVsSAnZWagAA8csP/jbv6witefOADNW0q2xS\nb86XVd+rtaLg8CD84IFzKGX6x28LC/VYMMh3Neme2N0HIZD8sbTteFWqzw0c\nf9WDciwHMEm44pqrLV+XI36ZVx1UA+lnkJJbJoAQmTKaEt6JMRu5c4rB2DwL\nuVyo+7doESmR5o/p2wxp/2hlfB1GbJVv+7PHL5foK2MadtMYuirzfb2N2eGH\nzhy1EbcumUxEAgf2at8AhbLg1gKFHnXq+gzOokv8RqATcEt8lJCBXVerSWpq\n05sVG98aA3n0Gzetrj6XRKp2QSLwhRB85smq6eknx28GltGgIFopZATMa2p2\nS7UuJfu2k8qFgmZ3UtUVa0l0CoaXciRfBKyXP8mq5wkMcTSnmQFDk8bMScmG\ndG69mXoCROupuQfARfUJ159EaIZpbC4MJ3WaIKH/46WZowEkGzK9CBrXxPMz\nUefSQe3cgmaIkSAaLoHXVvk7txUA6cDH7VLVE2zm3evUcICoi4wvMgCqPwpn\ne24M6IvysP9TMmfuRO46WE0rtL+j5wSrmPgsCxctmY+M26G4Sa3xhTO+c0TP\nm8oB/3oLh1zc4bNbbLOcRd5hcHuKw3pb6roatADFOWWS6DhX4vnha4UDGEy1\nmGCpOFpkbN3T1AVbi4Q7rObPvBGCg2T20x9wFBsxaa5+bIl7z6F44OFUHq3M\niPyS\r\n=UNm4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.3.0_1554739256081_0.874182336126708"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.3.1": {
+      "name": "webpack-dev-server",
+      "version": "3.3.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint": "eslint bin lib test examples client-src",
+        "pretty": "prettier --loglevel warn --write \"**/*.{js,css,md,json,yml}\"",
+        "test": "jest --runInBand",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore *.config.js",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.5",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.0",
+        "express": "^4.16.4",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.1",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.0.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.6.2",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "7.4.3",
+        "@babel/core": "7.4.3",
+        "@babel/preset-env": "7.4.3",
+        "babel-loader": "8.0.5",
+        "copy-webpack-plugin": "5.0.2",
+        "css-loader": "2.1.1",
+        "eslint": "5.16.0",
+        "eslint-config-prettier": "4.1.0",
+        "eslint-config-webpack": "1.2.5",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-prettier": "3.0.1",
+        "execa": "1.0.0",
+        "file-loader": "3.0.1",
+        "html-loader": "0.5.5",
+        "html-webpack-plugin": "3.2.0",
+        "husky": "1.3.1",
+        "jest": "24.7.1",
+        "jquery": "3.3.1",
+        "less": "3.9.0",
+        "less-loader": "4.1.0",
+        "lint-staged": "8.1.5",
+        "marked": "0.6.2",
+        "nyc": "13.3.0",
+        "prettier": "1.16.4",
+        "puppeteer": "1.14.0",
+        "rimraf": "2.6.3",
+        "standard-version": "5.0.2",
+        "style-loader": "0.23.1",
+        "supertest": "4.0.2",
+        "url-loader": "1.1.2",
+        "webpack": "4.29.6",
+        "webpack-cli": "3.3.0",
+        "ws": "6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "husky": {
+        "hooks": {
+          "pre-commit": "lint-staged"
+        }
+      },
+      "lint-staged": {
+        "*.js": [
+          "eslint --fix",
+          "prettier --write",
+          "git add"
+        ],
+        "*.{css,md,json,yml}": [
+          "prettier --write",
+          "git add"
+        ]
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "99b78dc3ddeb94af33fe71942ec0312a9be3e2c2",
+      "_id": "webpack-dev-server@3.3.1",
+      "_nodeVersion": "10.15.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-jY09LikOyGZrxVTXK0mgIq9y2IhCoJ05848dKZqX1gAGLU1YDqgpOT71+W53JH/wI4v6ky4hm+KvSyW14JEs5A==",
+        "shasum": "7046e49ded5c1255a82c5d942bcdda552b72a62d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.3.1.tgz",
+        "fileCount": 30,
+        "unpackedSize": 470509,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcrRSzCRA9TVsSAnZWagAAPNwQAIAif9PKVJX9tr9f9/GC\nFDshK0BOe2wX0n74Lo+pnqdKGI3YjpJvOc1QkkKImyoZrLnHEwdHlAWlQEPI\nL+gO+hXfa+MClJTtSiGCIhbsTtvrsCZAHqhIhzvvMtsd6SoKd95z3SrpaT0Z\nuJMSQuvbO4hk1kwQd3RetHnvilBmY90knuMV8qa+ex7z1OaIwVQXuAXCIuG6\nhB1LwD0v6ICyLKZsfbzBb8CfULyXniAO1nvCVz/LhI8lkRWFdDm0khQmeHtf\nigP0b1l/vnJRM3TvmPCx/RURHJzaNNnKlVdfxYM7sXdEKmXJfD4Z9UWs2qiu\nB2IAqt33Lz6l89voPEcm8nr25D7HqElk1aB3UjPtIKiNpikmNuG5Mrez1Tto\nvH5w8pRzT00mH/fCFG/l5mAWZRM/NmwLSD+9LIFWf5QZX1l3d9klR/0Cdpwl\n6K0LLyfxt8SBiK+N1IAcQJbOJ0Nh+i3HjZo2GnYAjtL6O6Bcb5Q0XNeE+vK5\nAqXTDLO0jX5Z+/82Anxu6tXtx8VYzRwAJ46NkObuRlWdNucaPAHedInGFq1R\nP8x+psQvjw0D02sMhCYBX3ngCV9AznRNFXsUeLplPguhd91Iu82OAkTAKVsO\njaKq8wXTagH2eomei07j1cKoHhRyWz8HE0PfKqAoDXx5E4gYzmr4xAi6jaGc\nK+7z\r\n=Eh6w\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.3.1_1554846898678_0.5892542805239911"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.4.0": {
+      "name": "webpack-dev-server",
+      "version": "3.4.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier '{**/*,*}.{js,json,md,yml,css}' --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p 'lint:**'",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --runInBand",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore './client-src/default/*.config.js'",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.0",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.1",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.0.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.4",
+        "@babel/preset-env": "^7.4.4",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "commitlint-azure-pipelines-cli": "^1.0.1",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.2",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^14.1.1",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.16.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.31.0",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "45d39acd80d474afcde5e0d946d5f367f808d509",
+      "_id": "webpack-dev-server@3.4.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-yOFL4Ol5B/aCRk0QN/DnSk1vjcJ0qLnEGE0l8pFjw6kYbkbEtt84D750yWHbyKWK9qVOGERk2oZGpEgoXo3cyw==",
+        "shasum": "d0928cb9dc77ca554593396f509b5ab4fa529c73",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.4.0.tgz",
+        "fileCount": 31,
+        "unpackedSize": 479641,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3qw9CRA9TVsSAnZWagAA2+4P/igmKz5ym7/fFtTEEZhb\nWGV39IuigSu+jt7G+W0xPgnNpgASYpZX8zsB9e7BQ1GvX3M5a77WI9RVqwFt\nAgccR3nYXyxWHDIUE9Rm+9s17E1j0roJJEsZgGxzsyw0JwCp0y3uQWJu1mF6\nN13i2GLoIztpJml6PFQsmP0PbvXmEcLvY33bQ5yugWYFIFGbrBnzzTMU49Ow\nO08SGwczt3l+8HuLYgKQLjtmZxKyl4ViCS9W3FHdBo+jnnlCw3CsN1n6qEYF\nj+LPjv3tB3t2DBkYwqoeuZ3DogvLauPNGB8uPWeGSIiZgA2RaqWDhJy87ka4\nj2zRZ70eF0pgFW5SKf1xmiOJU9XugHovAiPEfLh21fzduXUrx1B7ua9vXgTE\n08uQbW17WfaVQHhZbCcJ85NxrD9s2XkApxIuvd10YmdFGAHQk0qRITNtzp40\n/QsReGNYeHSx5p5x8+z/k/3rK9l+eQ7NJrvkKzDPCKjfu4tasgae0Vq8GRi2\nRkGzit1g0CAsM9QCI/uyWm09NbjOIUouwuMlW/zp+oYaGwPZydjHq/TXnXqH\nEC03m+jkwc3aEP4i65+SxXQX3kxHA9slO9yk1UewBo/F4oiHlGe+HFc1gfyl\nEHBnypyVbqF1IyLSs9tKGZWeECht67ovG4B+Kiu2QnReqxmogFdktKAnwcbn\nZzoF\r\n=ZSFC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.4.0_1558096956889_0.8298377570644893"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.4.1": {
+      "name": "webpack-dev-server",
+      "version": "3.4.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier '{**/*,*}.{js,json,md,yml,css}' --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p 'lint:**'",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --runInBand",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore './client-src/default/*.config.js'",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.0",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.1",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.0.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.4",
+        "@babel/preset-env": "^7.4.4",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "commitlint-azure-pipelines-cli": "^1.0.1",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.2",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^14.1.1",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.16.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.31.0",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "a32149469ac8524a42fb18372988cb8063dc040a",
+      "_id": "webpack-dev-server@3.4.1",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-CRqZQX2ryMtrg0r3TXQPpNh76eM1HD3Wmu6zDBxIKi/d2y+4aa28Ia8weNT0bfgWpY6Vs3Oq/K8+DjfbR+tWYw==",
+        "shasum": "a5fd8dec95dec410098e7d9a037ff9405395d51a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.4.1.tgz",
+        "fileCount": 31,
+        "unpackedSize": 480624,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3ufDCRA9TVsSAnZWagAAj5EQAKOVXuGe/bu5/AyL0pMS\n+hptSyd2117hcQsBpuckKZuM09CVZw2MZBp3gS5dk8PNr4ych2ZzxOnmFuV/\nphBxcTZnkKSo9QsWKa7wpA8gPzo7pNCt/NXf7KqFshwWDrYlv3m0LYUlLMOd\nz5VKl65rHA2g12wxMvVRiAHmCHOCSGw60uUjom39z3jRi2Okfj95oKbckuDu\nxf4/51NN5Dg2IOmr9OF6ZTtP54DRiiSeS2EFKSlWlz1Ga/nHfiU71lv37q/q\nMugmGMSi1Qh7papgV7++RRCJF09Kqbc2bZjJdpVhrGMmxEPlgybcfDO1ReBQ\n1Ey3Xm/sM4zx3+EMSKENOAsbbF/y/woYl6nICD0gF0A9CWXMjRzTmHlCEYDl\nNVKFr90T0o+egWRf5G3wURVJJlPOl2GRW5RMblp0ME2C2MIdvDVG8oFTvbhL\nJza4Ty/rKZxp5CGqhA56WadBmeFYCwpi8fC8f1Luaxy28e1IZrQtkTqdGykt\nQWmLFKRDq2SS8iw+jD/T8rv//JRTG5Z1E1htkZLrGHgc7IBl/kk1E7+8jK4x\nluj3gaGkRxRe8VigrOs1OJFySBrKxfKUBenaTPw7ayyXYoHSf2aKJUL3TNwP\n2u8kX6O5u2brYwsl4JkyW+qJ3XJ8ALhxu8ix0YVFs4sR3vzA/EX2529MHqK4\nTIht\r\n=Sxyl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.4.1_1558112194944_0.086590719055601"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.0": {
+      "name": "webpack-dev-server",
+      "version": "3.5.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --runInBand",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.1",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.2",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^14.1.1",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.32.2",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "a0b9c70bbb36a87deea28aabfdaf7c70a36244f8",
+      "_id": "webpack-dev-server@3.5.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-Gr4tBz+BRliDy1Jh9YJBOuwf13CipVxf4PCH7alB/rV/heszJ/U8M7KYekzlQn8XvoGgyozw7Uef2GDFd0ZLvg==",
+        "shasum": "f1bca520526181e11cd6a643f3233bc10c693c29",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.5.0.tgz",
+        "fileCount": 37,
+        "unpackedSize": 483558,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc8VaSCRA9TVsSAnZWagAA2DEP+QHiI37PGFY2AP9ot7Bv\n8OGSYHuOFmGiox1ZS59Km0Ky+tBUaCfh2/hOSDT2KSkIyK0AV+ybUo1i2Qpw\nW8fCxYgIoOfme/OCr6F97OImL1ZEgBC3gVj9uF7wysB4MiLT54PwDtDII4PM\n40/CHVc/pmhuxycQsqtg+bYc93u3B5B8aFbP3pTYZWIkRRuHSgxER0jC8ONn\nMamM6OBaeA/dCBIDaDOIgocxGlY2/Z+6KwVEW7CMYhVJLNQ0fWG5OBnq4tFj\nvQJgDg5MRL4mhzv2akIDx7Y7UEzLHc5prDfUBRz2fC0GZ5oDEfrfYfzyBHzN\nqJ534t8w1SAWSnlCdi7VtoEp0nfkh3W0/259kgvUMeWxTQ4ushK2pozVkIIq\nt+x0+gwKENHESZLEU+0N8l1cVmfJhCZauQ+ueqfEAK5vv+UytBAuOf+gOQY5\nTvoMspH2s1P5ewcIqv5znpZHdcrsOhZMN7AWyxJ47d0iy/O4X5Fjl4FL/fRQ\nAN+FKlhsKZzyHG+yM2b88YEypawHViKd0g+8fBce6ZcrBbqq/MQKkBMLWp56\nOlc3Sbrr9XLJm4SkpKlHyPZkjC6raC1NBpZo2IRv17ktX9TuJRmnUUoOO9K1\nsUbrD/gyPHA0jJk51UnA2xShqcvSogrO7x/wWJjHj5R+MxpkpuKo7hQQwRfo\n5Mi6\r\n=rWYT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.5.0_1559320209835_0.3818224675931221"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.5.1": {
+      "name": "webpack-dev-server",
+      "version": "3.5.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --runInBand",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.1",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^14.1.1",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.32.2",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "def98d825c65e75f532c444c44bcfbe6887f336c",
+      "_id": "webpack-dev-server@3.5.1",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-0IdMGddJcnK9zesZOeHWl4uAOVfypn7DSrdNWtclROkVBXy/TcBN+6eEG1wNfLT9dXVfaRZZsLTJt0mJtgTQgw==",
+        "shasum": "4290ac709bb989dc7382c912899f79fd5677dabf",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.5.1.tgz",
+        "fileCount": 41,
+        "unpackedSize": 485649,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc8ph+CRA9TVsSAnZWagAAAj8QAJ69NsfgXEubcF4UPIwR\nLnf6qz0+TGWDCr/CANrknc8xAYFw2iP7lopTZgrcJwhluMVl4Ou1IBm6RrtR\nwI53EjAOLksg0f3v7zs9A9fPG0g5Y6jW3rFA4LDUWkitYBGcdllvfKY/evwp\n08Mt9wjN7sQgl7RSiCHpH5OBfiHFvQR7vSn/4ykWbuzsRPDDlK6eNuQ7oDXK\nl/D5nTCIQMrZp+TbttL6FtEDnwD6S1olOvAeJC94XEwS8QyAyE1XHpMO8GlN\nvViQe3UoUZ4JPXDauZ+3GWqDY2ipCe9M3umhyWWxCUBKUq3ZNrmC8fyGrUTV\nyP4CCjZAaIyV3DOWYEsjWWjabwq2Kvd04aRzVh0/LR7eM1mBTMc7/iHeIvDR\nJzBqP4f+lO77yYeZ7kY/YZxH7pCJf6HHDXVScJoOg9f2dU7QjjR2xlSVZi2b\nWd3UvYZaJ+PIh7acZWCXvrE3rKd+rmCmy7tFFJcgl9GBPoqIxzMuEgR79TXt\na1leOqvnW0Mxg5lKup8sE9U3VC5x+X9i/LsQWNBSRt1p9K3OFT08FR+bm/fe\nASFD7tlmqy+cm09dmuMg95B9742FrTRYsX6Q7YapeRVxO91KmXItgVwLcfyh\nV7njCtlZVKtzSjdBfDs5uZJ1bZ3t29U9rOjcGLmE5LgrhKH0h38kQyock9q8\nTdtL\r\n=6Rrs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.5.1_1559402621641_0.26467706430036086"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.6.0": {
+      "name": "webpack-dev-server",
+      "version": "3.6.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --runInBand",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "958241817c0299067eb38caa82cadc8962687dc0",
+      "_id": "webpack-dev-server@3.6.0",
+      "_nodeVersion": "12.2.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-49CWhocbMzjNW2Dzo3ETnxtzifcKGx4Pa3Hx+sl0hBU5/t7zJTkOvMP1sCnu9/qGNDYW1PKCuszYQn5r2g5Sww==",
+        "shasum": "7f675f69bf0999e5f489d1e2532182cfdf55706c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.6.0.tgz",
+        "fileCount": 47,
+        "unpackedSize": 350340,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc98hyCRA9TVsSAnZWagAAObgQAJTkS1OxekyONpva/V9Q\nL6+OvgQ5DyJcSZeKA1vSCnb6Z2f0vIOKXjKcKIGaGjB78JhZFmTs9xUKosr7\niRv1T6KRHixfxoeG0ASEVMAOoFCehhRNwce+LNnENcTPvy2tM9dspM9FdEdA\nK7179S2+CkMnX9dsN5upRZd+eS1OOV2XNBJqWvv9XpQItLP1wTWzy8R2eDO4\n9BjRgcyLreIau8/ecQzAYQQmvw4qwmtfJkl0u18F/Xz+lLiwv67PLPX+hJs6\ns1r8EVIXnbsKbKBLapLy78GQUQG8sB5203P1QDJI9yNe0AiS8vOlQBNfeDAR\n1THoggSFONL8HkQzK2FCyjtlIa2X4BuaIgdFFBtNn5bFx8E5PITCuykpgtgP\nG7JQHsnr2TWqxfh8GJjoyl8TYnVbmY8C1oVQfKh17fMZe56lU6/QfBiua71e\nJHLdOgKTzAh7cWkoNb5pSB+ESR/icIEvMcaDFjDE9V6dgXlPUUBB5vJDeUW4\nuFXm+4INMR7z7YTc86khioTPmtm4E17EnFZX0cTm1YBeqPT1Mnydi1rQfKD2\njnCIm+7NhpkWJf+2tpuP8BaeO0WYKduF+iSmgTPcg1kXwmH5+gw4uSOkWQ1f\njT6rbJNV8Ip2UwyxN7CZ35WcHnnyrNlGZfLDZa8k4F8qTb0wZ6NS0ELhj5uT\ne/64\r\n=bxBm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "hiroppy",
+        "email": "hello@hiroppy.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.6.0_1559742577480_0.5318126092990532"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.7.0": {
+      "name": "webpack-dev-server",
+      "version": "3.7.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --runInBand",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run -s transpile:index && npm run transpile:clients && npm run -s build:live && npm run -s build:index && npm run -s build:sockjs",
+        "transpile:index": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "transpile:clients": "babel client-src/clients --out-dir client/clients",
+        "build:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.4.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.2.0",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "3d9288a34b715428c521cd22c6f70b6b2d6a04f4",
+      "_id": "webpack-dev-server@3.7.0",
+      "_nodeVersion": "12.2.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-B/c/aJoyOlhjgeGnxTWeJlDBvIEN/aBI2R6G1DiFHVluEs0KtuxylFcoDR2K6Um/edo4/BvZqMXS2tK+U7fsHw==",
+        "shasum": "7da016e4f5abec61c7b4af95a264d623bde4df3c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.7.0.tgz",
+        "fileCount": 47,
+        "unpackedSize": 356582,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc+TH6CRA9TVsSAnZWagAAQZAP/3eoNKV7bA/mjfguVaWx\n3alJDrcb0mGBaIIp/jwzTvcJOdUl8gkJYzqCVlqxqQi8RVWVLwceBR4j+NP4\nwRlweKnpCYei+g5fWOvcwghJ8NB6VIFQ0RFeubiiM59e04epspqz1/9134sB\nwQ1UZxDrmTe+9WpZUFdx/bO126q9Jnc26+WIjgEhPEnV23fUZdTCqQ3yBEdE\nsw9OKGmUt79AtMT5QXar0DWz4WNlh8q25IJm0UE1TO1A8fFfDOp85qdILH7s\n+ihjAXBo0jBHd2kiRco6Lvm/mxS+LIN3knLMIrbIHJl/sann4cN1vgx80OLm\n+/8srJuBGBb7MCgI6hYfZn+kvsSHwcyw+0vw8yfyBRi9ZdTqIsQT2ZmNGeqJ\n1PkZS0E+bQeVj2I0kDWvzY74U0hcRENxzz/hKYTWhMZvDmQaAx+QwiJSuN/r\nDAPaoJc8e9DocN25qaxEdIVbxBaqaNeF9audLH7/1ygmS0u0J618Q4eEs1IY\n58aqmWhQtOTkFpZsnrq8eIUHzb92AWFtXEYr1xpldQ0BGtEgBSe6yBC4ljoM\nyefkjmoyMqBf0B6TRfS/v9YHZjBp9ZE8Q0f5x81InsIBkbLibY5SkBJ8baFH\n73bGURzHkeMWEt9JWfP4erBXTJnMsSlJ9NELOwFV4bdPqEBpg+o91bKVzdFc\n2nOc\r\n=Uj6W\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "hiroppy",
+        "email": "hello@hiroppy.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.7.0_1559835129291_0.8917329096919415"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.7.1": {
+      "name": "webpack-dev-server",
+      "version": "3.7.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --runInBand",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.4.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.2.0",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.0",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.3",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "7fe3fbd95604d52d432174d797de3244e3ebc903",
+      "_id": "webpack-dev-server@3.7.1",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-GSBjjDMQ+uJI/Rcw/NfXDq5QpfE4HviafCy2SdbJ8Q22MwsnyoHd5TbWRfxgkbklsMx+ZNgWIKK+cB28ynjiDQ==",
+        "shasum": "ce10ca0ad6cf28b03e2ce9808684a8616039155d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.7.1.tgz",
+        "fileCount": 47,
+        "unpackedSize": 357167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc+m0+CRA9TVsSAnZWagAA72EQAJi8XXkFr6ObYbusorzR\n2359jDUu40ky4wB7tJZ8Uu8T074nr99v6pcwKDnbIeSe9t107gbBqI68J3O9\nNkaUK7Gt+WpG485u9KfC2qDd/gMmS6JVG03NV8Zm3szfnP3p3U/Xn/H4qjAo\ngbJGzFBRFHmy120qFyeTKCadq/CQFH/4h7dBkHoQwTvpQNFShyR0e0pF8/W5\nbQ0TqxwGJ+7MLE0xh1CLHwdMqzMzsCHh3x4vbA+UF/1NNG7acpO9FUz99dBf\n+lsmSmo0gyucFs2UrhUWToAT9aan1jOGLaTUs31l5QB9Ysv3Nz7pYlQAkXZu\nUnpC+gzdpGXIWARO1sHmUcnC9uyvpNiFg1s1MUn6obhCukQrI1KL3d9/GSuX\neaOqaGCB8vOZtDO7G1shrSyKOLA6nXUmMq7UqfWMzZhD9bafhjDlv/KhmtKG\n0J75fqO/TUIKPgI3Dz2mQX3/xgKzXLQ2+hz7wLdLp++QGvjGD4LApoCmgfzG\nqaVHXj52fVJFtpPzibhAoaTy9DnjdgyylPCjjywUffK4BgoecxFM53uAsokI\nWAcT8tt3+2d3ihxj2nX2xW08PeOGdBhCDGHbU7SBR4xh4AyZxCu5LKaFKIOU\nDvTeWaxzSTWeDwfUAVxCqcqQcwqVcwf+3no24ie+mLGXGnAj7k5M9x5y174F\nGZ1S\r\n=EOPI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.7.1_1559915837483_0.13197857021639758"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.7.2": {
+      "name": "webpack-dev-server",
+      "version": "3.7.2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "cd $INIT_CWD && node ../../../bin/webpack-dev-server.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.3",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/plugin-transform-runtime": "^7.4.4",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^5.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.4.1",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.2.1",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.34.0",
+        "webpack-cli": "^3.3.4",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "26211fc87785052c3707f0a911fed0acde2c54ec",
+      "_id": "webpack-dev-server@3.7.2",
+      "_nodeVersion": "12.2.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-mjWtrKJW2T9SsjJ4/dxDC2fkFVUw8jlpemDERqV0ZJIkjjjamR2AbQlr3oz+j4JLhYCHImHnXZK5H06P2wvUew==",
+        "shasum": "f79caa5974b7f8b63268ef5421222a8486d792f5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.7.2.tgz",
+        "fileCount": 47,
+        "unpackedSize": 502935,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdCCoqCRA9TVsSAnZWagAAEHMP/0YxxeZc2LgeOTKvBeUm\nfxIebYeGyltTbjNXODo7hyMV/08EjWI7GMnraXhlkBrh4r0STo6XQwEmMsEk\nWSlICjECy1Fni5SHZvwHTFcFeV7vxImBgCymDTQbgkr8qnIm2tXo7kQLwOvI\njczU6BufZsclpdsGOw0wHdszcLoVp2gwCD2ZScT794jHfXM94AXDsIRWkYMH\nIyZDnmT/+KzFlWQWoseV4lpR5cdr4NXiLHRfctBaVsZ7jzC0ctno/Wfk9bSp\nnbRFHrKwItchX9GEuZ/wqXSJnv7cjyxPg3NpRRWsWP/ldWuwm0KCse26D72H\ndOmndrR8uu/eiNgNZuU6tR2xRH17tzvDCX8peGdnlJkRx7U5RO+s9WqNQ+/b\nxm5mn59sPl5GsieitCjEOCSKSJyTTA6M0Mnu66PWWgnKJzspdcDZNzaRbYHi\nsb3YfegJ/5kPpNMbcG0KC5/0RGJrtrtaOXayaKLKXAB6114Mv2Fcpk5Amsfz\nBCBeiCITW3aEqYToo3tdGOgugj+X7KNYUvHBkxk3TDeqQkCKcgVWqEoowrK7\ng+bq3WE7iC/S29LGeeAS6++Rv6H3+XjPszP/4doPU2foQEG2JkGd0EjOG4Se\nbWpP/wWUlwwqBkzE4jUEwOOTcQKKQv0UueqDC29GglSIbWkXNvvmoqHs50u3\noBPy\r\n=0SAd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "hiroppy",
+        "email": "hello@hiroppy.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.7.2_1560816169703_0.8227981012511287"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.8.0": {
+      "name": "webpack-dev-server",
+      "version": "3.8.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.0",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.3",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.21",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.5.5",
+        "@babel/core": "^7.5.5",
+        "@babel/plugin-transform-runtime": "^7.5.5",
+        "@babel/preset-env": "^7.5.5",
+        "@babel/runtime": "^7.5.5",
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.1.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.4",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.1.0",
+        "eslint-config-prettier": "^6.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.18.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.0.3",
+        "jest": "^24.8.0",
+        "jest-junit": "^7.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.2.1",
+        "marked": "^0.7.0",
+        "memfs": "^2.15.5",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.19.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^7.0.0",
+        "style-loader": "^1.0.0",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.5.3",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.39.1",
+        "webpack-cli": "^3.3.6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "84cb4817a3fb9d8d98ac84390964cd56d533a3f5",
+      "_id": "webpack-dev-server@3.8.0",
+      "_nodeVersion": "12.2.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-Hs8K9yI6pyMvGkaPTeTonhD6JXVsigXDApYk9JLW4M7viVBspQvb1WdAcWxqtmttxNW4zf2UFLsLNe0y87pIGQ==",
+        "shasum": "06cc4fc2f440428508d0e9770da1fef10e5ef28d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.0.tgz",
+        "fileCount": 49,
+        "unpackedSize": 510709,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdTalxCRA9TVsSAnZWagAApxUP/3mm21302yEoj3RE1k+n\nn2wIZTCexucDipFPO0of5jx4sztvE9/AMiCgH4DLPZgB8N6Wt6RYPtaTqfSF\nunSx1zPc/rlnlOk4k+spQk4MSp/Q7+CNmtiXRVjhm9IpKw0F65GSof3j+k8n\nlJfzbqlfnTopXZ7luS/f9A0UpQ8z/NuOmtrLSBzabqLf7nwEo/NH0m9l2RO6\nfFdUQFckFhEd+90d9ySDNPPl/g5u+jaQsLtNY3RAtMthaWc5fAw+7fa3YNVZ\nanAwmHEbVeCEYRS+yOGuQeOqsySeXAt5uAiNw2FoIK/GIK0dtSZ156m1UJH5\nxhm8aQ+Lmdl7/clwS8YtcO1fCURTjSWI/nynjAG0T7jt4uNdcDlkJ0/oZ6L1\nCLarbsZACfsHeWKfsP6UKK5qoE5JCuLLx3d2qTlGKTIOfTRAC/g0sfxSwBZ1\ny6AJIOlmx5D/EfsqAqb1YvnDQxoubUsa4ugnnkMMTUr2AIZ+pqyR7ElZL/9Y\n6xOlGB4L/b5w8NYdTwyfgoFwEzqNZLATo7MFIqApGMfWskkgFQE6WxIiczpS\nRBPMDxxl+6HBAaIWzZWFrCN8JXyzASaeT2sbdMsD5ac4eZ91ZanQAQBT+7p8\ntEIUndhTgR85kYcYzg9siXZkpHRdzffhRXH0fQ/xP5LwPX1Iovn1xuCF+wjn\nDpzF\r\n=+bLI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "hiroppy",
+        "email": "hello@hiroppy.me"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.8.0_1565370736793_0.14556171963056808"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.8.1": {
+      "name": "webpack-dev-server",
+      "version": "3.8.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.2",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.4",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.24",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.6",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.1",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.6.0",
+        "@babel/core": "^7.6.0",
+        "@babel/plugin-transform-runtime": "^7.6.0",
+        "@babel/preset-env": "^7.6.0",
+        "@babel/runtime": "^7.6.0",
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.1.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.4",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.4.0",
+        "eslint-config-prettier": "^6.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.18.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.0.5",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.2.5",
+        "marked": "^0.7.0",
+        "memfs": "^2.15.5",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.0",
+        "style-loader": "^1.0.0",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.6.3",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.40.2",
+        "webpack-cli": "^3.3.8"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "9d1c6d249fff293ee2d4c1b8792bb0a631f99fd6",
+      "_id": "webpack-dev-server@3.8.1",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-9F5DnfFA9bsrhpUCAfQic/AXBVHvq+3gQS+x6Zj0yc1fVVE0erKh2MV4IV12TBewuTrYeeTIRwCH9qLMvdNvTw==",
+        "shasum": "485b64c4aadc23f601e72114b40c1b1fea31d9f1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.1.tgz",
+        "fileCount": 49,
+        "unpackedSize": 512578,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdf5dWCRA9TVsSAnZWagAA2H8QAJdItidSQOssqckn9Rf9\njR1OeplaSpmqKt+R+X/eR39Zs0yitAqiWT11XqjUzktQrGOIDW40C7GDfaOd\nVqa/uqlpxyfIRghGewpXWKU6W/LmH0gMgh8cmq1HvhJHHhgd+pXaH/Hh7lPK\n3it59PXVphNLDvqNftgdRIS+e6rTqnsf16HFIqPdJKRxSJUwh1x+ChepsMIo\n6jnsjLdpOGwHiLKEtyjJTI2Uget2IgQbXkbG7ngBsZGrskjDsQlRR2TnIIlA\neXN/Ovsthgql2/oXFGBQex0g/0I1OxUQ5KQZekInyNDLJOlI/Z/KI1BEkJFI\nK+G28u5kI+EP8Icr6GVXQEfzIM1LkUccJftq+H6vW1+tFnyu8H2Qy4vYRJPq\nqnxMsxfcVRr0XoPGQGa/p9eXFx9DWn64Mwvf8moUltjOkrCaScdBfz2eW70u\n0HWBLQVAWL0no+RFxvrrrMgerFqqzdVr/nyamWOuVive7/XVcv6pAbyOk5Xx\ntu8QgbCErXRxaL/SvJGgXdDC1Jnyd9jpzybexIDswHltLxMiauBjxyRPKAEu\n82rhgm4uOuISNBQBBc7xyZum1gRbCX8yKEYuXPld6iingelzKjRjITcM44Zu\nO6eTEtzcF/zRN2ELEnB1tX8l1Sne4cY6cxFHxFEZhGRq+qi4gWOU/XlWEhx0\n6Bvq\r\n=HxGJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.8.1_1568642901859_0.6193095801456256"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.8.2": {
+      "name": "webpack-dev-server",
+      "version": "3.8.2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.4",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.24",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.6.2",
+        "@babel/core": "^7.6.2",
+        "@babel/plugin-transform-runtime": "^7.6.2",
+        "@babel/preset-env": "^7.6.2",
+        "@babel/runtime": "^7.6.2",
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.1.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.4",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.4.0",
+        "eslint-config-prettier": "^6.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.18.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.0.8",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.2.5",
+        "marked": "^0.7.0",
+        "memfs": "^2.15.5",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.0",
+        "style-loader": "^1.0.0",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.6.3",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.40.2",
+        "webpack-cli": "^3.3.9"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "9108d5ba1d427b5c96d4b24d0141f43be3394fc6",
+      "_id": "webpack-dev-server@3.8.2",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.11.3",
+      "dist": {
+        "integrity": "sha512-0xxogS7n5jHDQWy0WST0q6Ykp7UGj4YvWh+HVN71JoE7BwPxMZrwgraBvmdEMbDVMBzF0u+mEzn8TQzBm5NYJQ==",
+        "shasum": "3292427bf6510da9a3ac2d500b924a4197667ff9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.2.tgz",
+        "fileCount": 49,
+        "unpackedSize": 512719,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdlNGdCRA9TVsSAnZWagAAFnIP/2QAMo7OkEm+I/Jwj6Iy\nesZAoHUwzuY4jxgDYNDcJhsdzMDggCAdTRiqROXqOWg11qLh4orCoGel0Vgb\npSBLJxBnQWwMLUcXQlF9Bt3k6Zf+iBEGjlw0XkZjRYRMqjfFbf5uwZlQ42MS\nHid/u4zozvGy+TqqNZZLVR2gqrz0o51ugzaMwyVl1yEY9Vi6F32j0umK79mB\nm8GS+3vGFic1SLFAa+UzLolzqpSbM7oyCmIG+cWangIWUoY9OGy6loiHj32r\n4JAE+oS8teKZ1mga7G5kspwLGrO3/OLwtd0PTGAPoTQBBfVTHgjAQvhc6Mvw\nA2EU86nUxuRZyc3HtHTxJXZIh1+O7ekH/p/5oNgNGMt72oIbnMv+2GypfRBI\nvRErLH4VahdtT7snN3cgalAtXgywhNXp+eYfcTUM093UyGSeZDLGDS4XyS0j\nPg6xQkoiJAEccgWA7/8AuIpBjkXoSW7vVSv613WSKbDqEorTXQAQkESwFP4/\n+Deq3eANfm/KcflG/2FNAJ+30f0EnpwJRugzIZUWEDM1Dc5DkdK1mg73nvaS\n2KoP2WnHCCGUw7RBrH6CWGLhDqB8aUHTprSogZwh61kYDfOjogzUDhwUACZo\n070JkBMgXs/COG/5/Xbo39OkP/MI66HE1s9gUVx4/Q8LA3tQZN+dTsPd6X5w\n5/s2\r\n=qps1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.8.2_1570034076535_0.377515446375813"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.9.0": {
+      "name": "webpack-dev-server",
+      "version": "3.9.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.4",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.6.4",
+        "@babel/core": "^7.6.4",
+        "@babel/plugin-transform-runtime": "^7.6.2",
+        "@babel/preset-env": "^7.6.3",
+        "@babel/runtime": "^7.6.3",
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.4",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.5.1",
+        "eslint-config-prettier": "^6.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.18.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.4.2",
+        "marked": "^0.7.0",
+        "memfs": "^2.15.5",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.0",
+        "style-loader": "^1.0.0",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.6.4",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.41.2",
+        "webpack-cli": "^3.3.9"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "4d99f6d917c1db0f180490be86f794ba8e93089f",
+      "_id": "webpack-dev-server@3.9.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.12.0",
+      "dist": {
+        "integrity": "sha512-E6uQ4kRrTX9URN9s/lIbqTAztwEPdvzVrcmHE8EQ9YnuT9J8Es5Wrd8n9BKg1a0oZ5EgEke/EQFgUsp18dSTBw==",
+        "shasum": "27c3b5d0f6b6677c4304465ac817623c8b27b89c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.9.0.tgz",
+        "fileCount": 50,
+        "unpackedSize": 518685,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdrzMJCRA9TVsSAnZWagAAs+AP/R/cmZbCPE2NzjXjec/2\nm7w7VumfNMaZyHzoPABUK32qESyHvgGGso01rKzx+qzE96QT2HkFHt1nbAnF\nipIuUc1dRPzCwl1zJyso/hPI6hyo4dSQoT+CsnJHiQxTH+atzXOHwQ7bcQfz\n3EEGlyfVMLUh0DnIF7f0K/bNOZBrVAjO3CoL+6zhvwS1b4CKVJzntBAoCvqA\n3mhxirmpHXOOSFP5a66r15Qw997eCkrVCdaITqxSlC86vDW21aUSP3FUH1+l\nZR90mS/6+/zjdt2lY+b+T1E8i6QSbxQjrxm1+FMNSO9MVIk4+RqB9r9M3Aw/\nH5nQVD16fSQPqSAQLo5rAj6ZO+8muRFI/xcey3TncW6Gfg/bnxrt+allQ3cQ\nDkf3I6vnxj26AsUeEG/YXQDEOQySp/IhNTDpM0irdwZe13815jqA2bqfmjwK\nkmXHX/KzrtSAzAxJoAb8mwn9X0jtKK2+3fCL+Cg0ftqOIWe/JksqR9mXSg3h\ncFDqPdKgVO/5tQah4T3o/tSCIWP5aldMDFGWA2SH8pC9dPnNdxVdge14wY8V\n5LtZYwGyn7gbal2fN2Eab3zXeKZqipPEq1D4S1NdNr3K+6AJtdKbyxfltDmf\nLDAejSgr8mMIcLD43t689Fb1eOU9oaVuSmRpTc7t8l2ov/Lxb52KX9u/tmxG\nW3ax\r\n=m8P9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.9.0_1571762953219_0.8132888386715829"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.10.0": {
+      "name": "webpack-dev-server",
+      "version": "3.10.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.6",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.7.5",
+        "@babel/core": "^7.7.5",
+        "@babel/plugin-transform-runtime": "^7.7.6",
+        "@babel/preset-env": "^7.7.6",
+        "@babel/runtime": "^7.7.6",
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.7.2",
+        "eslint-config-prettier": "^6.7.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.19.1",
+        "execa": "^1.0.0",
+        "file-loader": "^5.0.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.5.0",
+        "marked": "^0.8.0",
+        "memfs": "^3.0.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.1",
+        "style-loader": "^1.0.1",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.7.3",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.41.3",
+        "webpack-cli": "^3.3.10"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "e330423d15a2a0df1fc2c058cce222479e119e8a",
+      "_id": "webpack-dev-server@3.10.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-dPNu0Kz9lh5QrRef/ulknAtEEHoZ/p49sUPE+4KbknmxkDU6V4evB2LdTWlw/DnDavxQC499+2jLHlgFjA6TmQ==",
+        "shasum": "725d0bdfd70a56d266a5a0ee167df8e6a422d533",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.0.tgz",
+        "fileCount": 53,
+        "unpackedSize": 518063,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd+jmVCRA9TVsSAnZWagAAHpIP/jCAFOpKFRgHP8jryLsH\nKlw4nhhO42AqVkHdBDKqCDyXDg2CYy8jnYD87WeEEtZHBmE4sicA0avTeGZD\nkPPRC5HgHxthfcBACxddZrfkzROkMIzQrx5FJczmMlPqE6YRoIJD0LJUYk6F\nQyAynX7gY+cny7bpWx5yn77fxuCoYm1/sCpKSbgc58+DeD6zemXLu7A08evc\nmK/TrLZKwTKjzvk9W8/GeF2drZrrplddFozXBXiTEkxZPtzVrK0IwUcMA/L+\n/nd5ZJIOdhqnpXSCBlu9S1eWfhRuniV5y7cv/NhYqVihlsFFdgq+KMpPfCg5\nphLUhZgpnr89rXEAbnkBe4WPLI/zVBSdnEHlVgdCvv2sq5+LgPA+zyqHjqjX\njbbccmkULxiQEqHWR3a/BzOYsf4nW6A1jFb+5QWlU7KBMun1h/laTRqWDSB9\ni//tSeMG37ZCemz8tsSzu7h+xjRvm+f2D2o2GMvyrfbpuGyh8vfqXmALl3Gh\nt9tYtidAg52ao1KhDiU3js7bnh4kVEqZfd7da4W6K+gI5K6ZtbiUYE7iloaH\nvOTXd0P0cLPQEIm8Det4lD8QjUXuI8xLgEq4iKGYZqMD3zp0s1jqsN/ICGOt\nmd3sFPAMmz0EihPD2suGtq13C+qrQD+1BcGJiY06cgWE9xWhYW8uxYSxzsIG\nJUXa\r\n=jUf6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.10.0_1576679829399_0.047321326185412405"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.10.1": {
+      "name": "webpack-dev-server",
+      "version": "3.10.1",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.6",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.7.5",
+        "@babel/core": "^7.7.5",
+        "@babel/plugin-transform-runtime": "^7.7.6",
+        "@babel/preset-env": "^7.7.6",
+        "@babel/runtime": "^7.7.6",
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.7.2",
+        "eslint-config-prettier": "^6.7.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.19.1",
+        "execa": "^1.0.0",
+        "file-loader": "^5.0.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.5.0",
+        "marked": "^0.8.0",
+        "memfs": "^3.0.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.1",
+        "style-loader": "^1.0.1",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.7.3",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.41.3",
+        "webpack-cli": "^3.3.10"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "cdf7c4f170b6030d8bb8af9a5fe71349267ae29a",
+      "_id": "webpack-dev-server@3.10.1",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.13.4",
+      "dist": {
+        "integrity": "sha512-AGG4+XrrXn4rbZUueyNrQgO4KGnol+0wm3MPdqGLmmA+NofZl3blZQKxZ9BND6RDNuvAK9OMYClhjOSnxpWRoA==",
+        "shasum": "1ff3e5cccf8e0897aa3f5909c654e623f69b1c0e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.1.tgz",
+        "fileCount": 53,
+        "unpackedSize": 518311,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd+10TCRA9TVsSAnZWagAABP4P+wZsneg/iqI4yt8VtLyq\ndpDKhN0FaBKxRL5/xB6X4yn6yq+Vl5ejrxAJyR+o5xg1Oo8sVFVi1HFpmuGw\nf29WMJxlgSfwcnu91L4rf2lXFqtyhRdzFJ8fj1cjaX9SlFFpx7hEXRQpZsqY\nctTzwq1A2mZf1IE8QegJu7YBJcY1ub0Bolll0cwBBP6Du59GJrqhaz0IGAxl\nOdYY2Cn1sBrIy+crp4XZ7K78QqrezyC/d3T7zQLH1zYX/ZL+rM01l3bThMnE\nyN3dULxqjPmVTKUxiPr0jOHncgpIYhN4ThTG+jCr3VdlXvGwLzoLVQMeXTyl\njprcIAtS0n15i6EBUn77EBvrEhA8Du91Fz9u/wGSnuwKnthpb/o0GAeeoVWF\ncf76FwG0aeTuLkAzq0zUABbowEuP3UHuSoP0wvSRkFu1aonZqNUlvCPQIxrQ\n59A83zU25awzYrHpYt0FSux8Zlo7ep62zzqgnaJPDM5HkYyS8NBchrPJfnFj\n3gJSzWuYUq+2RR++k7Qn2iTrzlNQi4yzjZseQh/Tsrs3F17BLFZWjUu5AKsU\nu+b9Z/sUx5RqE8FbUINoDesGjvvySfdgJjRm1pV1PUyPDrIZBsamlUVoSaDh\nWJWUG4EgkRO6aKUzx1l6zA76FC/UdZuO7KWI9RwbC5aoC5RRE9aMkKTS9q4c\n+0wp\r\n=5gO7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.10.1_1576754450591_0.778811821220925"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.10.2": {
+      "name": "webpack-dev-server",
+      "version": "3.10.2",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.6",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.8.4",
+        "@babel/plugin-transform-runtime": "^7.8.3",
+        "@babel/preset-env": "^7.8.4",
+        "@babel/runtime": "^7.8.4",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.20.0",
+        "execa": "^1.0.0",
+        "file-loader": "^5.0.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^10.0.5",
+        "marked": "^0.8.0",
+        "memfs": "^3.0.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.1",
+        "standard-version": "^7.1.0",
+        "style-loader": "^1.1.3",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.7.5",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.41.5",
+        "webpack-cli": "^3.3.10"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "5aa86b551d3655445966ffc192488a2086f97789",
+      "_id": "webpack-dev-server@3.10.2",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-pxZKPYb+n77UN8u9YxXT4IaIrGcNtijh/mi8TXbErHmczw0DtPnMTTjHj+eNjkqLOaAZM/qD7V59j/qJsEiaZA==",
+        "shasum": "3403287d674c7407aab6d9b3f72259ecd0aa0874",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.2.tgz",
+        "fileCount": 50,
+        "unpackedSize": 521140,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeNEnoCRA9TVsSAnZWagAAjYUQAJixEUAbl9g58BkRxxcd\n1glZA55gkx5pcES/yaydA9+vVeevSjpJc6gjOiU6nWb0b2Myqq1cUTZUfN0f\nGw7hdxo6UmTJVQo/MHD85G/DTur8rTIPzQYvp/J75340Rh54ENn4lZDU8Ncy\n9N5kGNznmAy//IXlS93HOGTAD0OSsCN7CxM5n/Fa8KSogzgSLlTNs5GN8ESB\npRi26SU6aCuehK2nh2pRmP0R/VSPYCpEPnalDKF+P1ScGbZPZ+WQTwcIgvbY\n2/z1Rvn7tDiyszEx5L8yLZDaeLoJXdtNwfFVBi7+nG1A5nlOZD7/FcN8WHBR\nv/TgjWnhSB8FMPWdS31wQ7GcEBcCTHCFOSIOvN/DisdE9RnuOLvE9YZYi6qV\nGX3F4lJOKsa1jHZwHH+gcbVnd05Zz1VsU1VN4an3FbsCMDvcTEWgqG8Wpiqk\niSxykG2n4VzAt/wRCq63rItbMHbQdwRJs4saX7D/T1GZAxUPeOMO6RLfqNpq\noKVBFVe7HNfybplYF/PVFxslz8j1JZU5qkTVGjtTPeC9W7dllmc+q0Re8367\nbsT6ceKI2l21Y+6w7x89Sv2S5crjXLWWMmoOL/t7NGBGkGqYpZ/ff7poIUwu\nyMLan8RbAQinkAAblyztSWOAJykQdQn8jOJy9zTluJJfq0GSyYg4cE2iHyBm\nCWnC\r\n=68+T\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.10.2_1580485096327_0.3897650310066598"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.10.3": {
+      "name": "webpack-dev-server",
+      "version": "3.10.3",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.6",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.8.4",
+        "@babel/plugin-transform-runtime": "^7.8.3",
+        "@babel/preset-env": "^7.8.4",
+        "@babel/runtime": "^7.8.4",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.20.1",
+        "execa": "^1.0.0",
+        "file-loader": "^5.0.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^10.0.7",
+        "marked": "^0.8.0",
+        "memfs": "^3.0.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.1",
+        "standard-version": "^7.1.0",
+        "style-loader": "^1.1.3",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.7.5",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.41.5",
+        "webpack-cli": "^3.3.10"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "f710b7df93e96c246a00b0362aac489b0857d92f",
+      "_id": "webpack-dev-server@3.10.3",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.13.7",
+      "dist": {
+        "integrity": "sha512-e4nWev8YzEVNdOMcNzNeCN947sWJNd43E5XvsJzbAL08kGc2frm1tQ32hTJslRS+H65LCb/AaUCYU7fjHCpDeQ==",
+        "shasum": "f35945036813e57ef582c2420ef7b470e14d3af0",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.3.tgz",
+        "fileCount": 50,
+        "unpackedSize": 521645,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeOqlnCRA9TVsSAnZWagAAmHQQAJdhKZUQqn47VkiKtQ+H\nz8Q02rFF3wG2W4lKBP4ZpTLnTmJiKgvu5Dg16GU4y2Av8dAr4NAfhEg6x2oI\nsExEJ3OGH9ObkegBoURQOA/yCDkiGj/xWYFryGk+gTKWZITQPmbimDq0UKol\nF9LuLmXi6QrVJ/8QCsVh3+pW6FhCgtScCEfAE/qTpRdlGP2vdzDqSIMbKkBi\nATkWlMNk3IP4Kbn64KU29WAxr+vPRJvF54nhdTUK4BncHchshka/JoCfmBAY\nDOYxcNN+BvpeC6mo76mUNlEgTVFR+ElBNuV23XBMAi2qAAO/YSvlAG8cP/hL\n8NQrCPe1hiIQw8emmxcwt1k8IBAuI/aDEk555nh0qWfNkhQL08NLj+6CGBaS\ni1Inuuwt6AKaQ8aysatQi4TbN2wCBu7AL7H/W0ZPeJqKfEdgJ1aowCNh4hs8\nD0Qati5fNcyqCT0lNKjQiao/fYdf4j3EBvYsKfOmpddxk3hNf+ZG4L7nOsbw\n1u0gZkikEmFxT279sK6GpM2eD5ryeLtceJ9LS9M+Dumc18e4zUuxRsnZfnX2\n0MC174CsoEiZ1ngWiXLxNlnqRG36jYv8BcsGhfoIkKgZyP2AypsbCVqbS+EU\nWGr0UyEmMIvXZD1yFTepiPjsJHNShERyIXl+SNhzYcrUi1k+SAWsw/D93UEL\nNr82\r\n=unCS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.10.3_1580902758980_0.5865023951941062"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.11.0": {
+      "name": "webpack-dev-server",
+      "version": "3.11.0",
+      "description": "Serves a webpack app. Updates the browser on changes.",
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "main": "lib/Server.js",
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "scripts": {
+        "lint:prettier": "prettier \"{**/*,*}.{js,json,md,yml,css}\" --list-different",
+        "lint:js": "eslint . --cache",
+        "lint": "npm-run-all -l -p \"lint:**\"",
+        "lint:type": "tsc --noEmit",
+        "commitlint": "commitlint --from=master",
+        "security": "npm audit",
+        "test:only": "jest --forceExit",
+        "test:coverage": "npm run test:only -- --coverage",
+        "test:watch": "npm run test:coverage --watch",
+        "test": "npm run test:coverage",
+        "pretest": "npm run lint",
+        "prepare": "rimraf ./ssl/*.pem && npm run build:client",
+        "build:client:default": "babel client-src/default --out-dir client --ignore \"./client-src/default/*.config.js\"",
+        "build:client:clients": "babel client-src/clients --out-dir client/clients",
+        "build:client:index": "webpack ./client-src/default/index.js -o client/index.bundle.js --color --config client-src/default/webpack.config.js",
+        "build:client:live": "webpack ./client-src/live/index.js -o client/live.bundle.js --color --config client-src/live/webpack.config.js",
+        "build:client:sockjs": "webpack ./client-src/sockjs/index.js -o client/sockjs.bundle.js --color --config client-src/sockjs/webpack.config.js",
+        "build:client": "rimraf ./client/* && npm-run-all -s -l -p \"build:client:**\"",
+        "webpack-dev-server": "node examples/run-example.js",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.3.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.8",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.26",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.20",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.2",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "^13.3.2"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.9.6",
+        "@babel/plugin-transform-runtime": "^7.9.6",
+        "@babel/preset-env": "^7.9.6",
+        "@babel/runtime": "^7.9.6",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "babel-loader": "^8.1.0",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.20.2",
+        "execa": "^1.0.0",
+        "file-loader": "^5.1.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^4.2.5",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.5.1",
+        "less": "^3.11.1",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^10.2.2",
+        "marked": "^0.8.2",
+        "memfs": "^3.1.2",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.2",
+        "standard-version": "^8.0.0",
+        "style-loader": "^1.2.1",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.8.3",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.43.0",
+        "webpack-cli": "^3.3.11"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      },
+      "author": {
+        "name": "Tobias Koppers @sokra"
+      },
+      "bugs": {
+        "url": "https://github.com/webpack/webpack-dev-server/issues"
+      },
+      "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack/webpack-dev-server.git"
+      },
+      "license": "MIT",
+      "gitHead": "4ab1f21bc85cc1695255c739160ad00dc14375f1",
+      "_id": "webpack-dev-server@3.11.0",
+      "_nodeVersion": "10.15.2",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
+        "shasum": "8f154a3bce1bcfd1cc618ef4e703278855e7ff8c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
+        "fileCount": 50,
+        "unpackedSize": 529149,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJetXgQCRA9TVsSAnZWagAAHnkP/0cRrVB4Zrk5U+6j3vU/\nLhxbtxMIQ2hE80xbJjAbY2nwR/EOTRb2TvbhY92PmtmUFrfUhS4+3Q4KIf5S\n/pDhnS1l778CG8WErp1Qge34njyu3aAzhdjTN5ZYdwoXn1X2Lsu6dHMDueJ5\nDgRnO2f7yqaBD62m7ltE+YKMFVXqfOtQ+ei8PgUCqPwuNuu57rEbBXb6py7j\nEyvfmvtKyUyjziXnvNJDXtjFdRJ7tpkHl2jzHHA3MqG8D/WujaEoKJMF0URd\nqJfAcoSoaL/isDiDLikTrW2HeudTyrwaEHs2BhOv3fQOfTIhXinp6l5goSxt\nndJ7FJttFikj9lz9uVMZDN78wkIlZpwwPXpD1Sx4Rvt0NiFh/PglJ3jXvOvF\n2/MXD7DZPDWERP+npFtnfqxlWPnGOCGaJBeyQ4kVGRPtelWNL0QkicK1qKaG\ned+s18J4e8zxy/34P5GjkCrqtFGVJEkMwU6L9Rd/pir9iCIQUHMxPoPOlDj3\nIdPnezo5wE0YAoff2cRIiD9BS8TgOCkXv5vPLuxBiDNHsmxgk84LH81E1aRn\nX/c7TfB2eW7u6GjZNCSgMQJwl+IE6yFXXT3LIZHASiaolCOsKZrPuq4WVHo2\nxT7JJ6CESoqm2ZGMxcZygfVkOwlOog43y2s4Uf/dEO2tGYoKCbFQFcaRzY2Y\nztLc\r\n=VywW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "sheo13666q@gmail.com",
+          "name": "evilebottnawi"
+        },
+        {
+          "email": "hello@hiroppy.me",
+          "name": "hiroppy"
+        },
+        {
+          "email": "mail@johannesewald.de",
+          "name": "jhnns"
+        },
+        {
+          "email": "tobias.koppers@googlemail.com",
+          "name": "sokra"
+        },
+        {
+          "email": "kees@webduck.nl",
+          "name": "spacek33z"
+        },
+        {
+          "email": "sean.larkin@cuw.edu",
+          "name": "thelarkinn"
+        }
+      ],
+      "_npmUser": {
+        "name": "evilebottnawi",
+        "email": "sheo13666q@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-dev-server_3.11.0_1588951055683_0.8409471276129803"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "<div align=\"center\">\n  <a href=\"https://github.com/webpack/webpack\">\n    <img width=\"200\" height=\"200\" src=\"https://webpack.js.org/assets/icon-square-big.svg\">\n  </a>\n</div>\n\n[![npm][npm]][npm-url]\n[![node][node]][node-url]\n[![deps][deps]][deps-url]\n[![tests][tests]][tests-url]\n[![coverage][cover]][cover-url]\n[![chat][chat]][chat-url]\n[![downloads][downloads]][npm-url]\n[![contributors][contributors]][contributors-url]\n\n# webpack-dev-server\n\nUse [webpack](https://webpack.js.org) with a development server that provides\nlive reloading. This should be used for **development only**.\n\nIt uses [webpack-dev-middleware][middleware-url] under the hood, which provides\nfast in-memory access to the webpack assets.\n\n## Table of Contents\n\n- [Getting Started](#getting-started)\n- [Usage](#usage)\n  - [With the CLI](#with-the-cli)\n  - [With NPM Scripts](#with-npm-scripts)\n  - [The Result](#the-result)\n- [Browser Support](#browser-support)\n- [Support](#support)\n- [Contributing](#contributing)\n- [Attribution](#attribution)\n- [License](#license)\n\n## Getting Started\n\nFirst things first, install the module:\n\n```console\nnpm install webpack-dev-server --save-dev\n```\n\n_Note: While you can install and run webpack-dev-server globally, we recommend\ninstalling it locally. webpack-dev-server will always use a local installation\nover a global one._\n\n## Usage\n\nThere are two main, recommended methods of using the module:\n\n### With the CLI\n\nThe easiest way to use it is with the CLI. In the directory where your\n`webpack.config.js` is, run:\n\n```console\nnode_modules/.bin/webpack-dev-server\n```\n\n_**Note**: Many CLI options are available with `webpack-dev-server`. Explore this [link](https://webpack.js.org/configuration/dev-server/)._\n\n### With NPM Scripts\n\nNPM package.json scripts are a convenient and useful means to run locally installed\nbinaries without having to be concerned about their full paths. Simply define a\nscript as such:\n\n```json\n\"scripts\": {\n  \"start:dev\": \"webpack-dev-server\"\n}\n```\n\nAnd run the following in your terminal/console:\n\n```console\nnpm run start:dev\n```\n\nNPM will automagically reference the binary in `node_modules` for you, and\nexecute the file or command.\n\n### The Result\n\nEither method will start a server instance and begin listening for connections\nfrom `localhost` on port `8080`.\n\nwebpack-dev-server is configured by default to support live-reload of files as\nyou edit your assets while the server is running.\n\nSee [**the documentation**][docs-url] for more use cases and options.\n\n## Browser Support\n\nWhile `webpack-dev-server` transpiles the client (browser) scripts to an ES5\nstate, the project only officially supports the _last two versions of major\nbrowsers_. We simply don't have the resources to support every whacky\nbrowser out there.\n\nIf you find a bug with an obscure / old browser, we would actively welcome a\nPull Request to resolve the bug.\n\n## Support\n\nWe do our best to keep Issues in the repository focused on bugs, features, and\nneeded modifications to the code for the module. Because of that, we ask users\nwith general support, \"how-to\", or \"why isn't this working\" questions to try one\nof the other support channels that are available.\n\nYour first-stop-shop for support for webpack-dev-server should by the excellent\n[documentation][docs-url] for the module. If you see an opportunity for improvement\nof those docs, please head over to the [webpack.js.org repo][wjo-url] and open a\npull request.\n\nFrom there, we encourage users to visit the [webpack Gitter chat][chat-url] and\ntalk to the fine folks there. If your quest for answers comes up dry in chat,\nhead over to [StackOverflow][stack-url] and do a quick search or open a new\nquestion. Remember; It's always much easier to answer questions that include your\n`webpack.config.js` and relevant files!\n\nIf you're twitter-savvy you can tweet [#webpack][hash-url] with your question\nand someone should be able to reach out and lend a hand.\n\nIf you have discovered a :bug:, have a feature suggestion, or would like to see\na modification, please feel free to create an issue on Github. _Note: The issue\ntemplate isn't optional, so please be sure not to remove it, and please fill it\nout completely._\n\n## Contributing\n\nWe welcome your contributions! Please have a read of [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get involved.\n\n## Attribution\n\nThis project is heavily inspired by [peerigon/nof5](https://github.com/peerigon/nof5).\n\n## License\n\n#### [MIT](./LICENSE)\n\n[npm]: https://img.shields.io/npm/v/webpack-dev-server.svg\n[npm-url]: https://npmjs.com/package/webpack-dev-server\n[node]: https://img.shields.io/node/v/webpack-dev-server.svg\n[node-url]: https://nodejs.org\n[deps]: https://david-dm.org/webpack/webpack-dev-server.svg\n[deps-url]: https://david-dm.org/webpack/webpack-dev-server\n[tests]: https://dev.azure.com/webpack/webpack-dev-server/_apis/build/status/webpack.webpack-dev-server?branchName=master\n[tests-url]: https://dev.azure.com/webpack/webpack-dev-server/_build/latest?definitionId=7&branchName=master\n[cover]: https://codecov.io/gh/webpack/webpack-dev-server/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/webpack/webpack-dev-server\n[chat]: https://badges.gitter.im/webpack/webpack.svg\n[chat-url]: https://gitter.im/webpack/webpack\n[docs-url]: https://webpack.js.org/configuration/dev-server/#devserver\n[hash-url]: https://twitter.com/search?q=webpack\n[middleware-url]: https://github.com/webpack/webpack-dev-middleware\n[stack-url]: https://stackoverflow.com/questions/tagged/webpack-dev-server\n[uglify-url]: https://github.com/webpack-contrib/uglifyjs-webpack-plugin\n[wjo-url]: https://github.com/webpack/webpack.js.org\n[downloads]: https://img.shields.io/npm/dm/webpack-dev-server.svg\n[contributors-url]: https://github.com/webpack/webpack-dev-server/graphs/contributors\n[contributors]: https://img.shields.io/github/contributors/webpack/webpack-dev-server.svg\n",
+  "maintainers": [
+    {
+      "email": "sheo13666q@gmail.com",
+      "name": "evilebottnawi"
+    },
+    {
+      "email": "hello@hiroppy.me",
+      "name": "hiroppy"
+    },
+    {
+      "email": "mail@johannesewald.de",
+      "name": "jhnns"
+    },
+    {
+      "email": "tobias.koppers@googlemail.com",
+      "name": "sokra"
+    },
+    {
+      "email": "kees@webduck.nl",
+      "name": "spacek33z"
+    },
+    {
+      "email": "sean.larkin@cuw.edu",
+      "name": "thelarkinn"
+    }
+  ],
+  "time": {
+    "modified": "2020-05-08T15:17:38.856Z",
+    "created": "2012-09-18T15:45:14.544Z",
+    "0.6.0": "2012-09-18T15:45:16.603Z",
+    "0.6.1": "2012-09-19T10:47:01.738Z",
+    "0.6.2": "2012-09-19T10:48:56.951Z",
+    "0.7.0": "2012-09-25T18:57:25.334Z",
+    "0.7.1": "2012-11-05T19:30:33.321Z",
+    "0.7.2": "2012-11-08T15:04:57.474Z",
+    "0.8.0": "2012-11-09T08:01:17.341Z",
+    "0.8.1": "2012-11-13T11:35:20.684Z",
+    "0.8.2": "2012-11-23T20:27:37.440Z",
+    "0.9.0": "2013-02-04T09:26:55.479Z",
+    "0.9.1": "2013-02-18T20:52:44.372Z",
+    "0.9.2": "2013-02-20T23:12:36.958Z",
+    "0.9.3": "2013-02-23T19:25:01.939Z",
+    "0.9.4": "2013-02-23T19:27:48.817Z",
+    "0.10.0": "2013-03-26T18:21:01.914Z",
+    "0.10.1": "2013-03-27T11:39:08.438Z",
+    "0.11.0": "2013-06-19T12:12:29.103Z",
+    "0.11.1": "2013-06-20T10:26:28.207Z",
+    "1.0.0": "2013-12-17T22:49:08.780Z",
+    "1.0.1": "2014-01-04T19:03:56.212Z",
+    "1.0.2": "2014-01-05T00:09:21.176Z",
+    "1.1.0": "2014-01-09T13:25:29.951Z",
+    "1.2.0": "2014-01-09T14:06:36.846Z",
+    "1.2.1": "2014-01-22T22:35:05.295Z",
+    "1.2.2": "2014-02-28T10:02:56.491Z",
+    "1.2.3": "2014-02-28T10:55:37.378Z",
+    "1.2.4": "2014-03-08T11:36:24.418Z",
+    "1.2.5": "2014-03-31T08:56:32.917Z",
+    "1.2.6": "2014-04-01T16:04:04.248Z",
+    "1.2.7": "2014-04-01T16:06:58.118Z",
+    "1.2.8": "2014-05-25T17:20:00.878Z",
+    "1.2.9": "2014-05-28T05:02:10.416Z",
+    "1.3.0": "2014-05-29T20:11:17.028Z",
+    "1.3.1": "2014-05-29T22:04:17.581Z",
+    "1.3.2": "2014-06-04T06:43:08.740Z",
+    "1.4.0": "2014-06-04T18:32:45.239Z",
+    "1.4.1": "2014-06-04T18:58:19.717Z",
+    "1.4.2": "2014-06-11T20:22:41.572Z",
+    "1.4.3": "2014-06-18T21:12:08.986Z",
+    "1.4.4": "2014-07-02T19:50:55.797Z",
+    "1.4.5": "2014-07-02T20:21:14.066Z",
+    "1.4.6": "2014-07-02T20:46:16.051Z",
+    "1.4.7": "2014-07-12T10:23:29.441Z",
+    "1.4.9": "2014-08-06T08:35:42.148Z",
+    "1.4.10": "2014-08-13T12:55:29.423Z",
+    "1.5.0": "2014-08-25T08:20:04.600Z",
+    "1.6.0": "2014-09-02T06:16:37.656Z",
+    "1.6.1": "2014-09-02T06:17:49.609Z",
+    "1.6.2": "2014-09-03T07:01:56.717Z",
+    "1.6.3": "2014-09-03T12:13:22.452Z",
+    "1.6.4": "2014-09-05T10:34:48.555Z",
+    "1.6.5": "2014-09-18T06:01:52.136Z",
+    "1.6.6": "2014-11-20T16:23:53.826Z",
+    "1.7.0": "2014-12-23T07:07:50.221Z",
+    "1.8.0": "2015-03-30T16:10:36.084Z",
+    "1.8.1": "2015-04-20T19:40:40.340Z",
+    "1.8.2": "2015-04-21T06:49:14.052Z",
+    "1.9.0": "2015-05-21T20:29:54.904Z",
+    "1.10.0": "2015-06-27T21:20:10.222Z",
+    "1.10.1": "2015-06-28T06:31:44.435Z",
+    "1.11.0": "2015-09-15T07:54:24.080Z",
+    "1.12.0": "2015-09-25T14:08:36.668Z",
+    "1.12.1": "2015-10-18T22:04:24.999Z",
+    "1.13.0": "2015-11-24T19:41:15.860Z",
+    "1.14.0": "2015-11-24T19:51:52.926Z",
+    "1.14.1": "2016-01-11T20:41:41.118Z",
+    "2.0.0-beta": "2016-01-21T20:38:44.145Z",
+    "2.1.0-beta.0": "2016-05-15T23:05:43.690Z",
+    "1.15.0": "2016-08-22T11:50:31.750Z",
+    "2.1.0-beta.1": "2016-08-31T14:02:57.666Z",
+    "2.1.0-beta.2": "2016-08-31T21:31:36.159Z",
+    "1.15.1": "2016-08-31T21:34:55.180Z",
+    "2.1.0-beta.3": "2016-09-06T08:42:41.356Z",
+    "2.1.0-beta.4": "2016-09-08T14:28:31.302Z",
+    "1.15.2": "2016-09-14T13:45:26.372Z",
+    "1.16.0": "2016-09-17T21:30:23.365Z",
+    "1.16.1": "2016-09-18T09:01:36.856Z",
+    "2.1.0-beta.5": "2016-09-21T10:30:29.484Z",
+    "2.1.0-beta.6": "2016-09-26T09:57:50.048Z",
+    "2.1.0-beta.7": "2016-09-27T13:50:24.747Z",
+    "2.1.0-beta.8": "2016-10-01T09:18:30.928Z",
+    "1.16.2": "2016-10-06T09:12:54.224Z",
+    "2.1.0-beta.9": "2016-10-11T19:09:27.669Z",
+    "2.1.0-beta.10": "2016-10-29T14:51:29.643Z",
+    "2.1.0-beta.11": "2016-11-14T11:32:36.821Z",
+    "2.1.0-beta.12": "2016-11-25T09:47:39.766Z",
+    "2.2.0-rc.0": "2016-12-15T20:04:00.423Z",
+    "2.2.0": "2017-01-17T22:33:55.693Z",
+    "2.2.1": "2017-01-31T11:27:38.760Z",
+    "1.16.3": "2017-01-31T22:18:46.733Z",
+    "2.3.0": "2017-02-03T15:12:18.889Z",
+    "2.4.0": "2017-02-19T10:53:01.259Z",
+    "2.4.1": "2017-02-19T22:14:09.057Z",
+    "2.4.2": "2017-03-14T10:24:14.635Z",
+    "2.4.3": "2017-04-22T10:04:01.048Z",
+    "1.16.4": "2017-04-22T10:06:23.600Z",
+    "2.4.4": "2017-04-23T11:34:07.657Z",
+    "2.4.5": "2017-04-26T13:18:56.602Z",
+    "1.16.5": "2017-04-26T13:28:43.536Z",
+    "2.5.0": "2017-06-20T06:33:38.933Z",
+    "2.5.1": "2017-07-07T05:55:38.042Z",
+    "2.6.0": "2017-07-22T14:56:37.444Z",
+    "2.6.1": "2017-07-23T09:59:17.175Z",
+    "2.7.0": "2017-08-08T12:19:57.400Z",
+    "2.7.1": "2017-08-08T18:12:01.384Z",
+    "2.8.0": "2017-09-13T14:56:24.628Z",
+    "2.8.1": "2017-09-13T19:22:57.254Z",
+    "2.8.2": "2017-09-14T19:27:50.517Z",
+    "2.9.0": "2017-09-27T13:59:44.207Z",
+    "2.9.1": "2017-09-27T18:25:27.153Z",
+    "2.9.2": "2017-10-15T13:56:51.945Z",
+    "2.9.3": "2017-10-20T01:30:00.453Z",
+    "2.9.4": "2017-11-02T13:37:03.679Z",
+    "2.9.5": "2017-11-27T16:46:48.633Z",
+    "2.9.6": "2017-12-06T20:24:22.711Z",
+    "2.9.7": "2017-12-07T03:41:38.809Z",
+    "3.0.0-alpha1": "2017-12-08T15:21:35.496Z",
+    "3.0.0-alpha2": "2017-12-08T20:20:55.175Z",
+    "3.0.0-alpha3": "2017-12-09T21:25:34.569Z",
+    "3.0.0-alpha4": "2017-12-09T23:14:00.904Z",
+    "3.0.0-alpha5": "2017-12-09T23:41:46.788Z",
+    "3.0.0-alpha6": "2017-12-19T06:22:50.973Z",
+    "2.10.0": "2018-01-06T03:02:56.759Z",
+    "2.10.1": "2018-01-09T13:52:49.848Z",
+    "2.11.0": "2018-01-14T11:25:14.442Z",
+    "2.11.1": "2018-01-20T21:09:11.739Z",
+    "3.0.0-beta.1": "2018-02-14T22:14:51.084Z",
+    "3.0.0-beta.2": "2018-02-17T10:45:56.550Z",
+    "3.0.0": "2018-02-25T11:15:37.200Z",
+    "2.11.2": "2018-02-26T20:20:26.254Z",
+    "3.0.1-beta.0": "2018-02-26T20:59:57.614Z",
+    "3.1.0": "2018-02-27T21:04:45.856Z",
+    "3.1.1": "2018-03-09T21:37:52.596Z",
+    "3.1.2": "2018-04-07T13:24:00.628Z",
+    "3.1.3": "2018-04-08T08:32:41.148Z",
+    "3.1.4": "2018-05-02T21:35:26.750Z",
+    "3.1.5": "2018-07-22T15:21:19.147Z",
+    "2.11.3": "2018-08-22T18:13:09.282Z",
+    "3.1.6": "2018-08-26T06:42:58.068Z",
+    "3.1.7": "2018-08-29T12:22:40.371Z",
+    "3.1.8": "2018-09-06T17:52:10.775Z",
+    "3.1.9": "2018-09-24T19:19:05.610Z",
+    "3.1.10": "2018-10-23T02:57:41.343Z",
+    "3.1.11": "2018-12-21T18:00:37.787Z",
+    "3.1.12": "2018-12-22T15:02:38.057Z",
+    "3.1.13": "2018-12-22T19:25:11.754Z",
+    "3.1.14": "2018-12-24T09:58:55.233Z",
+    "3.2.0": "2019-02-20T13:45:44.161Z",
+    "3.2.1": "2019-02-25T11:07:27.472Z",
+    "2.11.4": "2019-03-22T16:38:53.476Z",
+    "2.11.5": "2019-03-23T17:20:34.589Z",
+    "3.3.0": "2019-04-08T16:00:56.207Z",
+    "3.3.1": "2019-04-09T21:54:58.867Z",
+    "3.4.0": "2019-05-17T12:42:37.126Z",
+    "3.4.1": "2019-05-17T16:56:35.142Z",
+    "3.5.0": "2019-05-31T16:30:09.954Z",
+    "3.5.1": "2019-06-01T15:23:41.807Z",
+    "3.6.0": "2019-06-05T13:49:37.649Z",
+    "3.7.0": "2019-06-06T15:32:09.470Z",
+    "3.7.1": "2019-06-07T13:57:17.616Z",
+    "3.7.2": "2019-06-18T00:02:50.002Z",
+    "3.8.0": "2019-08-09T17:12:17.117Z",
+    "3.8.1": "2019-09-16T14:08:22.050Z",
+    "3.8.2": "2019-10-02T16:34:36.750Z",
+    "3.9.0": "2019-10-22T16:49:13.407Z",
+    "3.10.0": "2019-12-18T14:37:09.507Z",
+    "3.10.1": "2019-12-19T11:20:50.767Z",
+    "3.10.2": "2020-01-31T15:38:16.544Z",
+    "3.10.3": "2020-02-05T11:39:19.148Z",
+    "3.11.0": "2020-05-08T15:17:35.787Z"
+  },
+  "author": {
+    "name": "Tobias Koppers @sokra"
+  },
+  "readmeFilename": "README.md",
+  "homepage": "https://github.com/webpack/webpack-dev-server#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/webpack/webpack-dev-server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/webpack/webpack-dev-server/issues"
+  },
+  "users": {
+    "mahoutsuk.ai": true,
+    "borjes": true,
+    "hugov": true,
+    "kerry95": true,
+    "ugarz": true,
+    "yatsu": true,
+    "junjiansyu": true,
+    "draganhr": true,
+    "urbantumbleweed": true,
+    "almccann": true,
+    "lavir": true,
+    "edloidas": true,
+    "bjmin": true,
+    "thorsson": true,
+    "zhangyaochun": true,
+    "honpery": true,
+    "kytart": true,
+    "ubi": true,
+    "qbylucky": true,
+    "sammyteahan": true,
+    "apehead": true,
+    "dkannan": true,
+    "foto": true,
+    "cfleschhut": true,
+    "ridermansb": true,
+    "sternelee": true,
+    "dhampik": true,
+    "philiiiiiipp": true,
+    "princetoad": true,
+    "sunnylost": true,
+    "dskecse": true,
+    "ezeikel": true,
+    "asm2hex": true,
+    "piecioshka": true,
+    "enuobear": true,
+    "alexjsdev": true,
+    "landy2014": true,
+    "bpatel": true,
+    "camirmas": true,
+    "meluko": true,
+    "leonardorb": true,
+    "ajaegle": true,
+    "adamlu": true,
+    "finico": true,
+    "hal9zillion": true,
+    "gejiawen": true,
+    "amartelr": true,
+    "samersm": true,
+    "mors84": true,
+    "bapinney": true,
+    "staydan": true,
+    "holly": true,
+    "langri-sha": true,
+    "knoja4": true,
+    "yeoyou": true,
+    "goldencrow": true,
+    "evdokimovm": true,
+    "panlw": true,
+    "jenux": true,
+    "mjbeswick": true,
+    "e.luna92": true,
+    "bogdanvlviv": true,
+    "marlongrape": true,
+    "bh032": true,
+    "jimco": true,
+    "serge-nikitin": true,
+    "nate-river": true,
+    "luojianet": true,
+    "josokinas": true,
+    "leapm": true,
+    "terre": true,
+    "errol": true,
+    "cl0udw4lk3r": true,
+    "ungurys": true,
+    "orenschwartz": true,
+    "cattle": true,
+    "yong_a": true,
+    "borasta": true,
+    "hoanganh25991": true,
+    "nickolas_sv": true,
+    "albertico88": true,
+    "tiggem1993": true,
+    "yeming": true,
+    "icoon.li": true,
+    "akh-rman": true,
+    "rochejul": true,
+    "asfrom30": true,
+    "maddas": true,
+    "yangzw": true,
+    "luffy84217": true,
+    "shamilton": true,
+    "iceglaive": true,
+    "tcowley": true,
+    "xfloops": true,
+    "dnp1204": true,
+    "defmech": true,
+    "maxwelldu": true,
+    "chenyingxuan1996": true,
+    "uzprocode": true,
+    "double1000": true,
+    "flayks": true,
+    "smtnkc": true,
+    "maycon_ribeiro": true,
+    "th3mon": true,
+    "rogerthoang": true,
+    "derrickbeining": true,
+    "shuoshubao": true,
+    "dennisli87": true,
+    "omkar.sheral.1989": true,
+    "mrhuangyuhui": true,
+    "centiball": true,
+    "salvationz": true,
+    "natterstefan": true,
+    "adamduehansen": true,
+    "lqweb": true,
+    "lqblovezh": true,
+    "cygik": true,
+    "gpmetheny": true,
+    "rogeriera": true,
+    "daniheras": true,
+    "haoxiaodan": true,
+    "duooduo": true,
+    "xiaobing": true,
+    "demigodliu": true,
+    "ageofsys": true,
+    "edwardxyt": true,
+    "uptonking": true,
+    "tedyhy": true,
+    "jalik": true,
+    "wandyezj": true
+  },
+  "license": "MIT"
+}

--- a/test/fixtures/registry-mocks/content/webpack-dev-server.min.json
+++ b/test/fixtures/registry-mocks/content/webpack-dev-server.min.json
@@ -1,0 +1,9381 @@
+{
+  "name": "webpack-dev-server",
+  "dist-tags": {
+    "latest": "3.11.0",
+    "webpack-1": "1.16.5",
+    "next": "3.0.0-alpha6",
+    "beta": "3.0.1-beta.0",
+    "webpack-3": "2.11.5"
+  },
+  "versions": {
+    "0.6.0": {
+      "name": "webpack-dev-server",
+      "version": "0.6.0",
+      "dependencies": {
+        "webpack-dev-middleware": "0.6.x",
+        "webpack": "0.6.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "857e51f0aa42248e8d9d68901768960c48955544",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.6.0.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.6.1": {
+      "name": "webpack-dev-server",
+      "version": "0.6.1",
+      "dependencies": {
+        "webpack-dev-middleware": "0.6.x",
+        "webpack": "0.6.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "00414f1e54813a8512d4df1795928b4baa5e4eec",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.6.1.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.6.2": {
+      "name": "webpack-dev-server",
+      "version": "0.6.2",
+      "dependencies": {
+        "webpack-dev-middleware": "0.6.x",
+        "webpack": "0.6.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "b4fa22bfff00eff614915e65f4626612b1274a4a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.6.2.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.7.0": {
+      "name": "webpack-dev-server",
+      "version": "0.7.0",
+      "dependencies": {
+        "webpack-dev-middleware": "0.7.x",
+        "webpack": "0.7.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "344944c2692c684c091a84193f307720a4cd7d69",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.7.0.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.7.1": {
+      "name": "webpack-dev-server",
+      "version": "0.7.1",
+      "dependencies": {
+        "webpack-dev-middleware": "0.7.x",
+        "webpack": "0.7.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "be461e7e80339dd4f3f07ab67f0138c58dc2d2d2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.7.1.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.7.2": {
+      "name": "webpack-dev-server",
+      "version": "0.7.2",
+      "dependencies": {
+        "webpack-dev-middleware": "0.7.x",
+        "webpack": "0.7.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "ebc7ba0fc739f85ffce7e486b5f4e1c433213362",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.7.2.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.8.0": {
+      "name": "webpack-dev-server",
+      "version": "0.8.0",
+      "dependencies": {
+        "webpack-dev-middleware": "0.8.x",
+        "webpack": "0.8.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "989ca1ea24d515a4fee96b883834bdc2bb1d2e93",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.8.0.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.8.1": {
+      "name": "webpack-dev-server",
+      "version": "0.8.1",
+      "dependencies": {
+        "webpack-dev-middleware": "0.8.x",
+        "webpack": "0.8.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "b8de036256db62cd039d324be0e9cb5744a0d633",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.8.1.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.8.2": {
+      "name": "webpack-dev-server",
+      "version": "0.8.2",
+      "dependencies": {
+        "webpack-dev-middleware": "0.8.x",
+        "webpack": "0.8.x",
+        "express": "3.0.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "22892d4cb042b65e41665c5f70a2b737944bb21c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.8.2.tgz"
+      },
+      "hasInstallScript": true
+    },
+    "0.9.0": {
+      "name": "webpack-dev-server",
+      "version": "0.9.0",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "512b8427a754bf44d4359b9bde942f7598156f3a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.0.tgz"
+      }
+    },
+    "0.9.1": {
+      "name": "webpack-dev-server",
+      "version": "0.9.1",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "27a1dabea8699e242b06986d85f5af83af148a4f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.1.tgz"
+      }
+    },
+    "0.9.2": {
+      "name": "webpack-dev-server",
+      "version": "0.9.2",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d0507992a56ab8c7ba0992f1e9a89cc7168b863b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.2.tgz"
+      }
+    },
+    "0.9.3": {
+      "name": "webpack-dev-server",
+      "version": "0.9.3",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "0f3d855b55efd8d62c8f8e0cad3e3eb6f3351213",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.3.tgz"
+      }
+    },
+    "0.9.4": {
+      "name": "webpack-dev-server",
+      "version": "0.9.4",
+      "dependencies": {
+        "webpack-dev-middleware": "0.9.x",
+        "webpack": "0.9.x",
+        "css-loader": "0.5.x",
+        "style-loader": "0.5.x",
+        "file-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "695b727e0c55e389cfb5cd38d94c672f92e2c238",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.9.4.tgz"
+      }
+    },
+    "0.10.0": {
+      "name": "webpack-dev-server",
+      "version": "0.10.0",
+      "dependencies": {
+        "webpack-dev-middleware": "0.10.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.5.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.10.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "0166b95d9779821748072f6d2567e7b3ea7c1984",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.10.0.tgz"
+      }
+    },
+    "0.10.1": {
+      "name": "webpack-dev-server",
+      "version": "0.10.1",
+      "dependencies": {
+        "webpack-dev-middleware": "0.10.x",
+        "express": "3.1.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.3.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.5.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.10.x"
+      },
+      "peerDependencies": {
+        "webpack": ">=0.10"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "89fe4c2fed3e84e30da7d6c8cfeb995773f8810d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.10.1.tgz"
+      }
+    },
+    "0.11.0": {
+      "name": "webpack-dev-server",
+      "version": "0.11.0",
+      "dependencies": {
+        "webpack-dev-middleware": "0.11.x",
+        "express": "3.2.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.5.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.5.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.11.x"
+      },
+      "peerDependencies": {
+        "webpack": ">=0.11"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "863b83ed5299c3c08add53bd6fda58950d178a51",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.11.0.tgz"
+      }
+    },
+    "0.11.1": {
+      "name": "webpack-dev-server",
+      "version": "0.11.1",
+      "dependencies": {
+        "webpack-dev-middleware": "0.11.x",
+        "express": "3.2.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.5.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.11.x"
+      },
+      "peerDependencies": {
+        "webpack": ">=0.11"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "f2f307ce8ccd8138cc913d3a89e9d24292246bbb",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-0.11.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "webpack-dev-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "0.11.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "f2c031e4fc73e61c2e17c23ea917311cbfd1d721",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "webpack-dev-server",
+      "version": "1.0.1",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "c3cf407278c80c6ec37e73d3cf30d04517f96cb8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.0.1.tgz"
+      }
+    },
+    "1.0.2": {
+      "name": "webpack-dev-server",
+      "version": "1.0.2",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "00a2bdcc905e90c4ebf29dce0d7e1eabd5dfef1c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.0.2.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "webpack-dev-server",
+      "version": "1.1.0",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "7bd807ee2c8cd9885005b592ce56298de44bf600",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "webpack-dev-server",
+      "version": "1.2.0",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d5f131b68c1da31c1ceb205465b44b6f4bf7cd1c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.0.tgz"
+      }
+    },
+    "1.2.1": {
+      "name": "webpack-dev-server",
+      "version": "1.2.1",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "197f526f57a322d3837c177d0ed02dccf302e28c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.1.tgz"
+      }
+    },
+    "1.2.2": {
+      "name": "webpack-dev-server",
+      "version": "1.2.2",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "48f689d76c2d631dca67e45e0d1ae569c36c796a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.2.tgz"
+      }
+    },
+    "1.2.3": {
+      "name": "webpack-dev-server",
+      "version": "1.2.3",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "084fb22127f14ea894eb914bbfd0762495fa4d39",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.3.tgz"
+      }
+    },
+    "1.2.4": {
+      "name": "webpack-dev-server",
+      "version": "1.2.4",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "5875f3c918c71ff7132695d945027e3bfff3ab77",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.4.tgz"
+      }
+    },
+    "1.2.5": {
+      "name": "webpack-dev-server",
+      "version": "1.2.5",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "bf2ffb72578e4e6e3df46eb45516757f87906abd",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.5.tgz"
+      }
+    },
+    "1.2.6": {
+      "name": "webpack-dev-server",
+      "version": "1.2.6",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d28311dc4d5836d6419c91efea4c1a1e39165238",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.6.tgz"
+      }
+    },
+    "1.2.7": {
+      "name": "webpack-dev-server",
+      "version": "1.2.7",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "58c7d7830a87ff6055dbdc02f392927d4f77000f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.7.tgz"
+      }
+    },
+    "1.2.8": {
+      "name": "webpack-dev-server",
+      "version": "1.2.8",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "2d0614891deffd56be91e6a849381aab05a8047c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.8.tgz"
+      }
+    },
+    "1.2.9": {
+      "name": "webpack-dev-server",
+      "version": "1.2.9",
+      "dependencies": {
+        "webpack-dev-middleware": "1.x",
+        "express": "3.4.x",
+        "socket.io": "0.9.x",
+        "optimist": "0.6.x",
+        "stream-cache": "0.0.x",
+        "mime": "1.x"
+      },
+      "devDependencies": {
+        "css-loader": "0.6.x",
+        "less-loader": "0.6.x",
+        "style-loader": "0.6.x",
+        "file-loader": "0.5.x",
+        "jade-loader": "0.5.x",
+        "url-loader": "0.5.x",
+        "webpack": "1.x"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "3780f42400d068e89744061ff3d8002016de948b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.2.9.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "webpack-dev-server",
+      "version": "1.3.0",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.6",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "798461e3d8114d5c1c9dbd9cd93bbb3a17176aff",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.3.0.tgz"
+      }
+    },
+    "1.3.1": {
+      "name": "webpack-dev-server",
+      "version": "1.3.1",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.6",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "53874737194aa5accd702999c7067283729620c2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.3.1.tgz"
+      }
+    },
+    "1.3.2": {
+      "name": "webpack-dev-server",
+      "version": "1.3.2",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "cb12280e22df11450792613208dd76b032a1eddc",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.3.2.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "webpack-dev-server",
+      "version": "1.4.0",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "c69ef837daeb3e2f6524f39fb53660012a8978ac",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.0.tgz"
+      }
+    },
+    "1.4.1": {
+      "name": "webpack-dev-server",
+      "version": "1.4.1",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "813bbabc4280c31d02ab140000f0c70bafd5b17f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.1.tgz"
+      }
+    },
+    "1.4.2": {
+      "name": "webpack-dev-server",
+      "version": "1.4.2",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "491e8a6cbe6cca446b6be1208289f2727363b8fe",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.2.tgz"
+      }
+    },
+    "1.4.3": {
+      "name": "webpack-dev-server",
+      "version": "1.4.3",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "c8603c8f7013c19b8ac43e696e22f141b9ec0f1a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.3.tgz"
+      }
+    },
+    "1.4.4": {
+      "name": "webpack-dev-server",
+      "version": "1.4.4",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "166ef8e675f31bd0d661f4b4c0cd68bbd6bbbf44",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.4.tgz"
+      }
+    },
+    "1.4.5": {
+      "name": "webpack-dev-server",
+      "version": "1.4.5",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "c362f9b57780035ddce0c53b4060cca195a6420f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.5.tgz"
+      }
+    },
+    "1.4.6": {
+      "name": "webpack-dev-server",
+      "version": "1.4.6",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "9942f10dc87195174e5573e1d0c45b1a9a9a9dd2",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.6.tgz"
+      }
+    },
+    "1.4.7": {
+      "name": "webpack-dev-server",
+      "version": "1.4.7",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "0db8468fc4db5c9fd10bbb839cc620d1322ceffa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.7.tgz"
+      }
+    },
+    "1.4.9": {
+      "name": "webpack-dev-server",
+      "version": "1.4.9",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "56d273573fa6e80bcae31180d42cf2a690a6af72",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.9.tgz"
+      }
+    },
+    "1.4.10": {
+      "name": "webpack-dev-server",
+      "version": "1.4.10",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.6.3",
+        "file-loader": "~0.5.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "c1c95a754377561149f1b93c1989b5bfd684dda8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.4.10.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "webpack-dev-server",
+      "version": "1.5.0",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.0.3"
+      },
+      "devDependencies": {
+        "css-loader": "~0.6.12",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.6.1",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "1.x"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "ec2f332c80d6a9e05eec3f2cc067ce06d4c95a00",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.5.0.tgz"
+      }
+    },
+    "1.6.0": {
+      "name": "webpack-dev-server",
+      "version": "1.6.0",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d53bc7342ad5b7ae7c129a4978b19f76207465b3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.0.tgz"
+      }
+    },
+    "1.6.1": {
+      "name": "webpack-dev-server",
+      "version": "1.6.1",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "95d8fd94e5eacd92b86c54280e4e2492b700da46",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.1.tgz"
+      }
+    },
+    "1.6.2": {
+      "name": "webpack-dev-server",
+      "version": "1.6.2",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "91877b0252b22cf114baea064d4be50d1fc80ff1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.2.tgz"
+      }
+    },
+    "1.6.3": {
+      "name": "webpack-dev-server",
+      "version": "1.6.3",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "95cac815f23d4bdca0d3a4c4fe22c2141d581e80",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.3.tgz"
+      }
+    },
+    "1.6.4": {
+      "name": "webpack-dev-server",
+      "version": "1.6.4",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "64d4d7db5fde192b5267f48cc1a9428482eace85",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.4.tgz"
+      }
+    },
+    "1.6.5": {
+      "name": "webpack-dev-server",
+      "version": "1.6.5",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "4caf6c1632aa7803d694d7690d54c024126b49c6",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.5.tgz"
+      }
+    },
+    "1.6.6": {
+      "name": "webpack-dev-server",
+      "version": "1.6.6",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0",
+        "connect-history-api-fallback": "0.0.5"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "5ecc19accdcfe0939270f5061fd748e315005267",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.6.6.tgz"
+      }
+    },
+    "1.7.0": {
+      "name": "webpack-dev-server",
+      "version": "1.7.0",
+      "dependencies": {
+        "webpack-dev-middleware": "^1.0.7",
+        "express": "^4.3.2",
+        "socket.io": "^0.9.17",
+        "optimist": "~0.6.0",
+        "stream-cache": "~0.0.1",
+        "http-proxy": "^1.1.4",
+        "serve-index": "^1.2.0",
+        "connect-history-api-fallback": "0.0.5"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "21975f86082693a9e65593276ebc14900047587a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.7.0.tgz"
+      }
+    },
+    "1.8.0": {
+      "name": "webpack-dev-server",
+      "version": "1.8.0",
+      "dependencies": {
+        "connect-history-api-fallback": "0.0.5",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d98f511dac3824d2f30ff51083cb41f54a06b7ec",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.8.0.tgz"
+      }
+    },
+    "1.8.1": {
+      "name": "webpack-dev-server",
+      "version": "1.8.1",
+      "dependencies": {
+        "connect-history-api-fallback": "0.0.5",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "5d65de3eeda6dcc0f0bc405f4385b40d4d8bd95e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.8.1.tgz"
+      }
+    },
+    "1.8.2": {
+      "name": "webpack-dev-server",
+      "version": "1.8.2",
+      "dependencies": {
+        "connect-history-api-fallback": "0.0.5",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "43c075600a524ac30130b5c2b25aa413bc3b75db",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.8.2.tgz"
+      }
+    },
+    "1.9.0": {
+      "name": "webpack-dev-server",
+      "version": "1.9.0",
+      "dependencies": {
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.7.1",
+        "less-loader": "~0.7.5",
+        "style-loader": "~0.7.0",
+        "file-loader": "~0.7.2",
+        "jade-loader": "~0.6.1",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.3.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "7044d787d5447be0149d14916d8444cb9f5bed72",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.9.0.tgz"
+      }
+    },
+    "1.10.0": {
+      "name": "webpack-dev-server",
+      "version": "1.10.0",
+      "dependencies": {
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.15.1",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.10.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "a4e72f0301b1eced5d3f5539f79ffc4786aca655",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.10.0.tgz"
+      }
+    },
+    "1.10.1": {
+      "name": "webpack-dev-server",
+      "version": "1.10.1",
+      "dependencies": {
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.3.2",
+        "http-proxy": "^1.1.4",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.2.0",
+        "socket.io": "^1.3.3",
+        "socket.io-client": "^1.3.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^2.0.1",
+        "supports-color": "^1.3.1",
+        "webpack-dev-middleware": "^1.0.7"
+      },
+      "devDependencies": {
+        "css-loader": "~0.15.1",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.5",
+        "webpack": "^1.10.0"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "55ace76bacc8916749542af439ac4971e4e12691",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.10.1.tgz"
+      }
+    },
+    "1.11.0": {
+      "name": "webpack-dev-server",
+      "version": "1.11.0",
+      "dependencies": {
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "socket.io": "^1.3.6",
+        "socket.io-client": "^1.3.6",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.18.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "f89a140686d83667935534fb1f757e7d6e8fd5e8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.11.0.tgz"
+      }
+    },
+    "1.12.0": {
+      "name": "webpack-dev-server",
+      "version": "1.12.0",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "socket.io": "^1.3.6",
+        "socket.io-client": "^1.3.6",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.18.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "1417becba96b366a9bebf5de4422c86de7716bde",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.12.0.tgz"
+      }
+    },
+    "1.12.1": {
+      "name": "webpack-dev-server",
+      "version": "1.12.1",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "socket.io": "^1.3.6",
+        "socket.io-client": "^1.3.6",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.18.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.7.1",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.12.3",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "c6dc855520c8ee9cba9256241b3390c1348b0d5c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.12.1.tgz"
+      }
+    },
+    "1.13.0": {
+      "name": "webpack-dev-server",
+      "version": "1.13.0",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.2.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.23.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "peerDependencies": {
+        "webpack": "^1.3.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "51d4f519409b96578ba2a6962ad5d490f75c0d57",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.13.0.tgz"
+      }
+    },
+    "1.14.0": {
+      "name": "webpack-dev-server",
+      "version": "1.14.0",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.23.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "ace376e571a84162f229ba6598e9180f7efc9eec",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.14.0.tgz"
+      }
+    },
+    "1.14.1": {
+      "name": "webpack-dev-server",
+      "version": "1.14.1",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy": "^1.11.2",
+        "optimist": "~0.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.23.0",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "e51de228071258b0db6d55e0f5fee55eec6755de",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.14.1.tgz"
+      }
+    },
+    "2.0.0-beta": {
+      "name": "webpack-dev-server",
+      "version": "2.0.0-beta",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "1.1.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.9.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^3.32.0"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.12.1"
+      },
+      "peerDependencies": {
+        "webpack": ">=2.0.3-beta <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "1973bc18a71601280170150b076b55f46e9fcf20",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.0.0-beta.tgz"
+      }
+    },
+    "2.1.0-beta.0": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.0",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.15.0",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^2.10.1",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.8.4",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jquery": "^2.2.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "b5605bb8db11c5312b0dbb14aa2d3f205bc9b4a9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.0.tgz"
+      }
+    },
+    "1.15.0": {
+      "name": "webpack-dev-server",
+      "version": "1.15.0",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "981607690d405671902c198134d8e35c7932acda",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.15.0.tgz"
+      }
+    },
+    "2.1.0-beta.1": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.1",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.15.0",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^2.10.1",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.8.4",
+        "pug": "2.0.0-beta5",
+        "pug-loader": "~2.3.0",
+        "jquery": "^2.2.0",
+        "js-beautify": "^1.6.3",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d52f935b65cc724ddde7ceefc4002eb8797d3636",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.1.tgz"
+      }
+    },
+    "2.1.0-beta.2": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.2",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.15.0",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.24.0",
+        "eslint": "^2.10.1",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jquery": "^2.2.0",
+        "js-beautify": "^1.6.3",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "fbf1b933b9a28efb853ca8ddcb3eab6476c996ff",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.2.tgz"
+      }
+    },
+    "1.15.1": {
+      "name": "webpack-dev-server",
+      "version": "1.15.1",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d9496676a54ffe53ccb8fbb3225b88e21e8eac13",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.15.1.tgz"
+      }
+    },
+    "2.1.0-beta.3": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.3",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "2ac09b7f73560800161e78887242cf1f2ac49486",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.3.tgz"
+      }
+    },
+    "2.1.0-beta.4": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.4",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.17",
+        "sockjs-client": "1.1.1",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "c8bde096207a66819121874bc1b0787cdbedbb55",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.4.tgz"
+      }
+    },
+    "1.15.2": {
+      "name": "webpack-dev-server",
+      "version": "1.15.2",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d1a73b8f2df98312f8b520e316a80c7259322129",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.15.2.tgz"
+      }
+    },
+    "1.16.0": {
+      "name": "webpack-dev-server",
+      "version": "1.16.0",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "a9532a0e1120e438d24c0148bb869e5f19027cf9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.0.tgz"
+      }
+    },
+    "1.16.1": {
+      "name": "webpack-dev-server",
+      "version": "1.16.1",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "af58e93b1dc040520d28dce42755b3a4c7cc822b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.1.tgz"
+      }
+    },
+    "2.1.0-beta.5": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.5",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.17",
+        "sockjs-client": "1.1.1",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "d860da30b82442814a2ed5f6f0e92237b5a8fac1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.5.tgz"
+      }
+    },
+    "2.1.0-beta.6": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.6",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.17",
+        "sockjs-client": "1.1.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "385df8893b7200d14774ca500c7cd62f11f98c71",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.6.tgz"
+      }
+    },
+    "2.1.0-beta.7": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.7",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "ca23bef3e8d8f7b07057b67b7843f2cfc7659e6d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.7.tgz"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "2.1.0-beta.8": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.8",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.2.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "64cf17bc30da6fa6b70848dd735fe1386f430cf1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.8.tgz"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "1.16.2": {
+      "name": "webpack-dev-server",
+      "version": "1.16.2",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "8bebc2c4ce1c45a15c72dd769d9ba08db306a793",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.2.tgz"
+      }
+    },
+    "2.1.0-beta.9": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.9",
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^4.7.1"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "45745a4a6b84849c63e3a21dfab3be7bdb897554",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.9.tgz"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "2.1.0-beta.10": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.10",
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "8ea8a1d7366e747c53423be77ecf49437f66cd7e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.10.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "2.1.0-beta.11": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.11",
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.26"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta.26"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "5a1e11590bf9e520ea8a559ee436779125647c28",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.11.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "2.1.0-beta.12": {
+      "name": "webpack-dev-server",
+      "version": "2.1.0-beta.12",
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.26"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta.26"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "f717e7b69214dae0e7a2061c12d128432d7520ef",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.1.0-beta.12.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "2.2.0-rc.0": {
+      "name": "webpack-dev-server",
+      "version": "2.2.0-rc.0",
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.1.0-beta.26"
+      },
+      "peerDependencies": {
+        "webpack": "^2.1.0-beta.26 || ^2.2.0-rc.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "ea8a11e211d9524b8999945fe5645481a51fdf46",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.2.0-rc.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "2.2.0": {
+      "name": "webpack-dev-server",
+      "version": "2.2.0",
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "364967eccaf8ff1d7e1681b7a8cc24fab4ced8a6",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.2.1": {
+      "name": "webpack-dev-server",
+      "version": "2.2.1",
+      "dependencies": {
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "91c442161afe9b5334e0bf1869b143880ece92fa",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "1.16.3": {
+      "name": "webpack-dev-server",
+      "version": "1.16.3",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.4.0",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "cbb6a0d3e7c8eb5453b3e9befcbe843219f62661",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.3.tgz"
+      }
+    },
+    "2.3.0": {
+      "name": "webpack-dev-server",
+      "version": "2.3.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.1",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.25.0",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.9.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "0437704bbd4d941a6e4c061eb3cc232ed7d06101",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.4.0": {
+      "name": "webpack-dev-server",
+      "version": "2.4.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "1dba2f57a7b253d62b4f7c5d0cc48e74b9953236",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.4.1": {
+      "name": "webpack-dev-server",
+      "version": "2.4.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "48556f793186eac0758df94730c034ed9a4d0f12",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.4.2": {
+      "name": "webpack-dev-server",
+      "version": "2.4.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.9.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "cf595d6b40878452b6d2ad7229056b686f8a16be",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.2.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.4.3": {
+      "name": "webpack-dev-server",
+      "version": "2.4.3",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "ead74bfdc78049684734724ca54000a17509c5f5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.3.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "1.16.4": {
+      "name": "webpack-dev-server",
+      "version": "1.16.4",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "9a5b8e86aafa2c478e8a24d29ddb282ac696ef50",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.4.tgz"
+      }
+    },
+    "2.4.4": {
+      "name": "webpack-dev-server",
+      "version": "2.4.4",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "1adb41640970421ec7b866e82384e8cebeed85de",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.4.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.4.5": {
+      "name": "webpack-dev-server",
+      "version": "2.4.5",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "31384ce81136be1080b4b4cde0eb9b90e54ee6cf",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.4.5.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "1.16.5": {
+      "name": "webpack-dev-server",
+      "version": "1.16.5",
+      "dependencies": {
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "express": "^4.13.3",
+        "optimist": "~0.6.1",
+        "open": "0.0.5",
+        "serve-index": "^1.7.2",
+        "sockjs": "^0.3.15",
+        "sockjs-client": "^1.0.3",
+        "stream-cache": "~0.0.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "http-proxy-middleware": "~0.17.1"
+      },
+      "devDependencies": {
+        "beautify-lint": "^1.0.4",
+        "css-loader": "~0.23.0",
+        "eslint": "^1.10.3",
+        "eslint-plugin-nodeca": "^1.0.3",
+        "file-loader": "~0.9.0",
+        "jade": "^1.11.0",
+        "jade-loader": "~0.8.0",
+        "jsbeautify": "^0.3.6",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "style-loader": "~0.13.0",
+        "url-loader": "~0.5.6",
+        "webpack": "^1.13.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=1.3.0 <3"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "0cbd5f2d2ac8d4e593aacd5c9702e7bbd5e59892",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz"
+      }
+    },
+    "2.5.0": {
+      "name": "webpack-dev-server",
+      "version": "2.5.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.10.2",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^2.2.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "4d36a728b03b8b2afa48ed302428847cea2840ad",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.5.1": {
+      "name": "webpack-dev-server",
+      "version": "2.5.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.2",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "a02e726a87bb603db5d71abb7d6d2649bf10c769",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.5.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.6.0": {
+      "name": "webpack-dev-server",
+      "version": "2.6.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "loglevel": "^1.4.1",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "8a861acac73097afed031f35826447a3013a4eb3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.6.1": {
+      "name": "webpack-dev-server",
+      "version": "2.6.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "loglevel": "^1.4.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "0b292a9da96daf80a65988f69f87b4166e5defe7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.6.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.7.1": {
+      "name": "webpack-dev-server",
+      "version": "2.7.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "4.0.2",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "~0.26.1",
+        "eslint": "^3.4.0",
+        "file-loader": "~0.10.0",
+        "istanbul": "^0.4.5",
+        "jquery": "^2.2.0",
+        "less": "^2.5.1",
+        "less-loader": "~2.2.0",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^1.1.6",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^11.1.0",
+        "sinon": "^1.17.6",
+        "style-loader": "~0.13.0",
+        "supertest": "^2.0.1",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^1.1.1"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "shasum": "21580f5a08cd065c71144cf6f61c345bca59a8b8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.7.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.8.0": {
+      "name": "webpack-dev-server",
+      "version": "2.8.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^2.0.2",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^8.0.2"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-uIHpSWqeAca//nDjACAHkhBDG2wJg3hD/sICImLj4ResZsc2t+WaBQ0f4FL50jd89NLaZjvlLRKu7ayMOTdOhg==",
+        "shasum": "bc3072d699fd367078c67f90410f4028b3d008fe",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.8.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.8.1": {
+      "name": "webpack-dev-server",
+      "version": "2.8.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^2.0.2",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^8.0.2"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-3EqjiJWctcOdZPRPhfcf/JWK8wly43AJRdPIPvtMUcFvyhASGysKOe34r3M+hGJXh8gQwf4/BipYYpuurOhBHQ==",
+        "shasum": "344e312bf560498ee0c518f2fcc709951630f667",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.8.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.8.2": {
+      "name": "webpack-dev-server",
+      "version": "2.8.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^2.0.2",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-wD9bs+Z1uwvf3Jc+8ZkyMI0Xi+aJJYjC2UZplOWoo/vStelK5Mv62X2uXYEYIQEjy9wJQMzC0fEFqQsg7vVEIg==",
+        "shasum": "abd61f410778cc4c843d7cebbf41465b1ab7734c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.8.2.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.9.0": {
+      "name": "webpack-dev-server",
+      "version": "2.9.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-npeTKI/ydk+D+iDPxKAeDuYM9lwpGzJjrqePbFHas94zxQ6Nu9C1RfEPEyzFrtTEZd1QkfKX3l647Im7mcl7+w==",
+        "shasum": "59bb3be387250e2295617859ddc14d4d8525de7d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.9.1": {
+      "name": "webpack-dev-server",
+      "version": "2.9.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-qFKs4Wg6JI6FkAQ6WFqeDCCxXEBLsDHkqJB3f9tmlqx8C68Y9vQWwcaMT4Q9H8WF32Q6QUNmgK4qQkdHfXvj/g==",
+        "shasum": "7ac9320b61b00eb65b2109f15c82747fc5b93585",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.9.2": {
+      "name": "webpack-dev-server",
+      "version": "2.9.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-ppL53TttdTPfiZA4EphKRE4QgtXssjLdHBwNs/MOx/fWLHCrZ0JeyE+eFcHrAcv7qOJgvR5jFZ1quO7i1LNieA==",
+        "shasum": "0fbab915701d25a905a60e1e784df19727da800f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.2.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.9.3": {
+      "name": "webpack-dev-server",
+      "version": "2.9.3",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-bwq7sj452FRH+oVfgOA8xXKkLYPTNsYB4dQ0Jhz3ydjNJ9MvhpGJtehFW8Z0cEcwNkRRiF4aYbReiSGQ4pbS1w==",
+        "shasum": "f0554e88d129e87796a6f74a016b991743ca6f81",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.3.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.9.4": {
+      "name": "webpack-dev-server",
+      "version": "2.9.4",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^0.11.2",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-thrqC0EQEoSjXeYgP6pUXcUCZ+LNrKsDPn+mItLnn5VyyNZOJKd06hUP5vqkYwL8nWWXsii0loSF9NHNccT6ow==",
+        "shasum": "7883e61759c6a4b33e9b19ec4037bd4ab61428d1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.4.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.9.5": {
+      "name": "webpack-dev-server",
+      "version": "2.9.5",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^0.11.2",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-o0lS6enIxyOPiRJTh8vcgK5TsGNTn7lH1q/pNniAgs46mCE8sQYeqv7Y/oAIh/+u4kiBsFizLJo5EWC+ezz6FQ==",
+        "shasum": "79336fba0087a66ae491f4869f6545775b18daa8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.5.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.9.6": {
+      "name": "webpack-dev-server",
+      "version": "2.9.6",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^0.11.2",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-cxk/h18Z/1qWOBTMup5PxvZ9N+vBRmmbh1/TCiCJnjGtLsvYtg7gTrjAmaa9J3kdkmxx6K5jwk6F0aZ+oOrAyA==",
+        "shasum": "3e3b56c4222694d2b900c3e8e19dd2e990a817f3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.6.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.9.7": {
+      "name": "webpack-dev-server",
+      "version": "2.9.7",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.18",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^4.2.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.6.0"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^0.11.2",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^3.0.2",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^12.0.0",
+        "sinon": "^3.2.1",
+        "style-loader": "^0.18.2",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "~0.5.6",
+        "webpack": "^3.0.0",
+        "ws": "^3.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-Pu7uoQFgQj5RE5wmlfkpYSzihMKxulwEuO2xCsaMnAnyRSApwoVi3B8WCm9XbigyWTHaIMzYGkB90Vr6leAeTQ==",
+        "shasum": "100ad6a14775478924d417ca6dcfb9d52a98faed",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.7.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "3.0.0-alpha1": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "style-loader": "^0.19.0",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-46wk9D/IT83gz75OltJxB11K63gmDA6cbdLFNHceZCh5t85d2AWA9Cs7bQy80r+vSdXG9eRchgfIgsD4XIY6nw==",
+        "shasum": "1ef63a654e40290677cadeebcd6313d76ac03a52",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.0-alpha2": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "style-loader": "^0.19.0",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-LY05dkHivSZFFWYFtbcAhYAA+oG9ywOiMOBbItDCbemEgGjevRnJ0VoiRGRXXy980pwtCyE7kYf+fO8kB9HDwQ==",
+        "shasum": "5bbff703aefa02cacec9f81b5bb3bafb96843bf7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha2.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.0-alpha3": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha3",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "style-loader": "^0.19.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-j6D7ERihB9fBCL9KRK/xZ8aCNfkKfuXmBM6zNvqkHfHF6iT7P3pwmQf+QJZ6wS9nb6eVlNbIlU+HrEM3Pp8u1A==",
+        "shasum": "619d121ac2204e1bd4faad6b5e4f5960a08ade40",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha3.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.0-alpha4": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha4",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "css-loader": "^0.28.5",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "style-loader": "^0.19.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-MzTIh/uYPG2EuF41uQSMGxCsFUl39XYOiO3Rsgf1Cu7vkqeWKPlbKoAiQiLBGm3RualsI+/brF6fIIKiSohkXA==",
+        "shasum": "9fdbb9ca4c3b672dcc031f47f93bd5f66c4f775c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha4.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.0-alpha5": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha5",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.1.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "css-loader": "^0.28.5",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "log-symbols": "^2.1.0",
+        "loglevel": "^1.4.1",
+        "loglevel-plugin-prefix": "^0.5.3",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "style-loader": "^0.19.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-dev-middleware": "^1.11.0",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-emIaIQOeJUTaPZhWlVF0a0860PSfLA9N7maQWHBWdLRVlwBElpuppu2D0uoMiDzcnQNwd8+hnWGFWrgZJa1BJg==",
+        "shasum": "a336a129879ca331e59aa2aa2bab4bf0f08dac57",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha5.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "3.0.0-alpha6": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-alpha6",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chalk": "^2.3.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "css-loader": "^0.28.5",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^0.1.1",
+        "internal-ip": "^3.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loud-rejection": "^1.6.0",
+        "multistream": "^2.1.0",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "raw-loader": "^0.5.1",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "spdy": "^3.4.1",
+        "string-to-stream": "^1.1.0",
+        "strip-ansi": "^4.0.0",
+        "style-loader": "^0.19.0",
+        "supports-color": "^5.0.0",
+        "update-notifier": "^2.2.0",
+        "webpack-cli": "^1.5.2",
+        "webpack-dev-middleware": "^2.0.1",
+        "webpack-log": "^1.0.2",
+        "ws": "^3.2.0",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.4",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.6",
+        "mocha": "^4.0.0",
+        "mocha-sinon": "^2.0.0",
+        "node-fetch": "^1.7.3",
+        "should": "^13.1.2",
+        "sinon": "^4.0.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.0.0",
+        "wtfnode": "^0.5.6"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0-alpha"
+      },
+      "bin": {
+        "webpack-dev-server": "cli.js"
+      },
+      "dist": {
+        "integrity": "sha512-zbpj45xwoqAOg7CNof+Jnc/5geNk00VEMDSj9u6LCt55t+LJe2Hx+mYG2IdI7BCxfR8rI1e6PHHVIvQtfRup5A==",
+        "shasum": "0fa5d1cd1b6af582a813cfe28615cd982210a138",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-alpha6.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.10.0": {
+      "name": "webpack-dev-server",
+      "version": "2.10.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "^10.0.3"
+      },
+      "devDependencies": {
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-mFq5S5Sg6nbiGXry+nRlaUoaCcl0IH/LVP60kwwJKBT/8IcwK/ZKduOSBK8bsLwRBh1yFoUYJMKfCo6oeP07+g==",
+        "shasum": "6db9c77c8cf2e2d7ff85c89fb5e4de6f7227be19",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.10.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.10.1": {
+      "name": "webpack-dev-server",
+      "version": "2.10.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-R9iZOrbIIsP2mw2j172HVjf479Zb9kcG0chjzHRrE/4M333NZ+3jOWRWJMGEQXwJzUtRNvVKzX2o27qM59TIhQ==",
+        "shasum": "a9768375346e62155860fe3cef3d4d641b24273e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.10.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.11.0": {
+      "name": "webpack-dev-server",
+      "version": "2.11.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^4.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-lXzc36DGjKUVinETNmDWhfZFRbHMhatuF+lKex+czqY+JVe0Qf2V+Ig6/svDdbt/DmXFXuLQmSqhncYCqYf3qA==",
+        "shasum": "e9d4830ab7eb16c6f92ed68b92f6089027960e1b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.0.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.11.1": {
+      "name": "webpack-dev-server",
+      "version": "2.11.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-ombhu5KsO/85sVshIDTyQ5HF3xjZR3N0sf5Ao6h3vFwpNyzInEzA1GV3QPVjTMLTNckp8PjfG1PFGznzBwS5lg==",
+        "shasum": "6f9358a002db8403f016e336816f4485384e5ec0",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.1.tgz"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "3.0.0-beta.1": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-beta.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.5",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "github:Graham42/html-webpack-plugin#4df601b7fa89e0e30535f759b469bcfe7073a018",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.1.8",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0-beta.1",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-cl694I2sP7pRhPG2MH1yT2xAAJefe1Wgtq1m6utPHKtAxwgOf/eJJCJvRZ1l3ZXyRXi9FIIBX0895ejauOYK8A==",
+        "shasum": "1a8b3e107dd57f536b15b23456791ea7966d4ef0",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-beta.1.tgz",
+        "fileCount": 19,
+        "unpackedSize": 1155811
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "3.0.0-beta.2": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0-beta.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.5",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "github:Graham42/html-webpack-plugin#4df601b7fa89e0e30535f759b469bcfe7073a018",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0-beta.1",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-wdjvB8kn0+tRjwgh6XJoTC8j01FEUMB217tpi+gRxAbwtRh9eQDNkUV8ge7LCmgcyhNhJLH9jBIRJ6UhaWgrcw==",
+        "shasum": "f31fc521d7d681452fd8257db4ffce3e2c61b2ac",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0-beta.2.tgz",
+        "fileCount": 19,
+        "unpackedSize": 446489
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "3.0.0": {
+      "name": "webpack-dev-server",
+      "version": "3.0.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.6",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "github:webpack-contrib/html-webpack-plugin#ebfc2771d41a6ab043595d3c621528aee020e2f9",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-oqGjPBE4XKmo2VPDrBcFaU4PzXuhEkpmt7p01tAHfDV5OHv/NGJHem0shd20/3IuTG/H70KgwGPLkZkeP9151w==",
+        "shasum": "0ca2d293dc7a7b1a94fc5fd62cfca2a9fa61bcf7",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.0.tgz",
+        "fileCount": 19,
+        "unpackedSize": 446631
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "2.11.2": {
+      "name": "webpack-dev-server",
+      "version": "2.11.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-zrPoX97bx47vZiAXfDrkw8pe9QjJ+lunQl3dypojyWwWr1M5I2h0VSrMPfTjopHQPRNn+NqfjcMmhoLcUJe2gA==",
+        "shasum": "1f4f4c78bf1895378f376815910812daf79a216f",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz",
+        "fileCount": 19,
+        "unpackedSize": 457368
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "3.0.1-beta.0": {
+      "name": "webpack-dev-server",
+      "version": "3.0.1-beta.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.6",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "github:webpack-contrib/html-webpack-plugin#ebfc2771d41a6ab043595d3c621528aee020e2f9",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-yioaZmlqX9kCauxKQ5+bczEDGFuKbPsYwE+scd79Sk2RbAzBnBZSifZJ80vyB+NrK+EuR4XSQ208urwz/HdhMQ==",
+        "shasum": "cf0a194df30088f37563aa153e62f11c112c03da",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.0.1-beta.0.tgz",
+        "fileCount": 19,
+        "unpackedSize": 446874
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "3.1.0": {
+      "name": "webpack-dev-server",
+      "version": "3.1.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "2.0.6",
+        "webpack-log": "^1.1.2",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.6",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "github:webpack-contrib/html-webpack-plugin#ebfc2771d41a6ab043595d3c621528aee020e2f9",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.20.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.0.0",
+        "webpack-cli": "^2.0.6",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-ap7Fth7oh4sthC0nJkvRm2W3SaWryBeR19DWIcAwJlcooN0tB2fEKuZqckYR3uaJ6wXPCK1xMWAQWXhV5xVe8g==",
+        "shasum": "5d2365514d9dfa0d415502742d2cc28afc4a32d8",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.0.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447503
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "3.1.1": {
+      "name": "webpack-dev-server",
+      "version": "3.1.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.0.1",
+        "webpack-log": "^1.1.2",
+        "yargs": "9.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.0.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.1.1",
+        "webpack-cli": "^2.0.10",
+        "ws": "^4.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-u5lz6REb3+KklgSIytUIOrmWgnpgFmfj/+I+GBXurhEoCsHXpG9twk4NO3bsu72GC9YtxIsiavjfRdhmNt0A/A==",
+        "shasum": "3c0fdd1ba3b50ebc79858a0e6b9ccdd1565b0c24",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.1.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447441
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "3.1.2": {
+      "name": "webpack-dev-server",
+      "version": "3.1.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.1.2",
+        "webpack-log": "^1.1.2",
+        "yargs": "11.0.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.0.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.1.1",
+        "webpack-cli": "^2.0.14",
+        "ws": "^4.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-dIbLkWSJz9oxLbug9fFbt2/oPklY8/OH4dRaDWZU9gJoDyfCxoPvddXK3ip8hyE2sVXhUuvUNeKBFaxCg2aAqg==",
+        "shasum": "c67e7d16064ca910b8eb8b0da3f94e364425d106",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.2.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447498
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "3.1.3": {
+      "name": "webpack-dev-server",
+      "version": "3.1.3",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.1.2",
+        "webpack-log": "^1.1.2",
+        "yargs": "11.0.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.0.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.1.1",
+        "webpack-cli": "^2.0.14",
+        "ws": "^4.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-UXfgQIPpdw2rByoUnCrMAIXCS7IJJMp5N0MDQNk9CuQvirCkuWlu7gQpCS8Kaiz4kogC4TdAQHG3jzh/DdqEWg==",
+        "shasum": "5cecfd8a9d60c4638284813f1cf9562f04e5c1c5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.3.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447510
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "3.1.4": {
+      "name": "webpack-dev-server",
+      "version": "3.1.4",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.4",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.1.3",
+        "webpack-log": "^1.1.2",
+        "yargs": "11.0.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.0.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.1.1",
+        "webpack-cli": "^2.0.14",
+        "ws": "^4.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-itcIUDFkHuj1/QQxzUFOEXXmxOj5bku2ScLEsOFPapnq2JRTm58gPdtnBphBJOKL2+M3p6+xygL64bI+3eyzzw==",
+        "shasum": "9a08d13c4addd1e3b6d8ace116e86715094ad5b4",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.4.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447514,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJa6i8gCRA9TVsSAnZWagAA8XoP/3+0YkZNIeABmCDMmGI+\n+7UQT/hKIGjRrBf29Oz/NK+uXGT366z+lFbkxW0Y004+u3DMF+GDnugPXQ11\nroEOk/zNXIuiCw47bMOL+AQQJbeHdhtz47Ib4EtKwtgGZa8VqNQOP6qFNQM0\nHvGiHLFdmNNdVEXifnWtTqJ2Fxo+jL4pAXzffQZuUo19lv9D5OpzoNWRiTWa\nohhHyZXLTOveBhv3Ye3MqQEK9awVAfO2cwZ82ZMXQMZ4IZ1/5HnsflutSOFL\nGRH+jLnioMF0P0ftjXYasdmjEGg6Wly1vY4JHbKMD7mgOH8HKXMV2gosvTHJ\nnvX/mAj/MlVFf3emsBx4E2mxQwq5XJreVcqO/qSAC14XYdJ8S3SQARHDVjbI\nrNLXf4bqg4dQXBZM4R7hmeMCdytnRap0HiynUtKHo1SOCTHSHsnqS6qWoA3j\nwR9AtQLCe+RkkO1gTg6s0b8i2brLrUj7DysGyZIXoWsX3hIcmsukxKXglWuV\nPM/lTZlTfcpcXP7uImsBI1qtZng/XYgrzgHlJn8nbPLT0yClcDKf+k2jEmiB\n5f0vfRf0TYrrK46nchwkx1UihRCKNEeiRASd81wxlQosYg26rb4XjZVViAmb\nMRbPTnildRnvnqc1jIzuT1XP4bF7yr2mXX8o7YB2a/JfQhEyQ9QaiTUQ6XoQ\nD1D+\r\n=f88Y\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "3.1.5": {
+      "name": "webpack-dev-server",
+      "version": "3.1.5",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.1.3",
+        "webpack-log": "^1.1.2",
+        "yargs": "11.0.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^0.28.10",
+        "eslint": "^4.18.2",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.9.0",
+        "file-loader": "^1.1.11",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.3.17",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.4.2",
+        "style-loader": "^0.20.3",
+        "supertest": "^3.0.0",
+        "url-loader": "^0.6.2",
+        "webpack": "^4.16.1",
+        "webpack-cli": "^2.0.14",
+        "ws": "^4.1.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0-beta.1"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-LVHg+EPwZLHIlfvokSTgtJqO/vI5CQi89fASb5JEDtVMDjY0yuIEqPPdMiKaBJIB/Ab7v/UN/sYZ7WsZvntQKw==",
+        "shasum": "87477252e1ac6789303fb8cd3e585fa5d508a401",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.5.tgz",
+        "fileCount": 20,
+        "unpackedSize": 450108,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbVKDvCRA9TVsSAnZWagAAMiAP/1YqwG2SDbqtVCNb7g6Z\nDmMDks6gSAoewN4Nd4L+jGHAOxGbUO0zfcZiL9CixzkyUTaZ9BWLl7hul3r5\nR8EFsyqyBNCaVxTjvs2VJI7v/TThdftmxWyyOMhiqNLSnRxKzE9LUcjXPMFM\nOajmus4depo4awsudtyN08er0Pe1Hukjvc3Zrz8XEu2pF0o3QSCcGAmAMtmt\nR8EvHZtQ9aXRT3cfHDXpGC4fat4D9Yjiq4xG37snusvhN7NNfoA5XtwasPSJ\nQS+WCfVPV3lHAMjG8OUDOOkqq+yWD6wjPH3RYMTPvdg12iI4BUr4heeokdg6\n1tYrTcqrXr+csPHCFXbtCFYfG/85+rMGRZHP6HS0FIAsrps7hKQHvXJV21zj\nD4MAjlzZJOpUYvMPuwkVAfNLQn23mGbdz8CTPnhgiuk9ig24dhoX2W8RVV77\nnpCqCHoBCtlzkRBKSrPlmVURDxgKDbJBK05MGG3tW6B2QRKB+mnUPr6aaHdU\n8Gq+M8Do6CnJtSQJeLGwNCpyajWKTI3Wj7iaifQAISCoK+pjZX0BdC3YrbiB\nDOVOO1MvCbV/vFeBuUc6jgvucdqmKR/1ZB8IaClA0KsOmrOb/lNPkGQcxgCV\nhasf2YI1Bkr8hshd88rr4ZG7yKGjmBIeEZ4PrLhLzPpzvzTFBvgqNEKdCgem\nT8jx\r\n=wCHu\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "2.11.3": {
+      "name": "webpack-dev-server",
+      "version": "2.11.3",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.6.1",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.0-beta5",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-Qz22YEFhWx+M2vvJ+rQppRv39JA0h5NNbOOdODApdX6iZ52Diz7vTPXjF7kJlfn+Uc24Qr48I3SZ9yncQwRycg==",
+        "shasum": "3fd48a402164a6569d94d3d17f131432631b4873",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.3.tgz",
+        "fileCount": 19,
+        "unpackedSize": 457534,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfae1CRA9TVsSAnZWagAAtFkP/RyYSrj02zD8gq6UBXnN\n+zSno8wMSFpkQdbrblvzcVVBtknl3BqxrTBtyCaaAu3Tc8bIhTWssyYJzVw7\nF54IUadgrzOqPy5hQYSIXjeRE2L5iXBHGgklfyxalhltNV6CjgjpcdvE2Fli\nQbHsQEBNyegH2BiBISmh0vdxpwwbZGDGM9lOUMmGoPGrPQWxASZteVzqAV7E\nAYMPMBWx4uxxi7h/ht84ADY97mE8LWrMxElrmcbd850Vk/YVt6YhZ4QcUGRe\nMWF1dY6UksgnVUlPKeWUuqch5utVOyH+JCoLJv+QPqeTBJPEh/R0dV+wNc51\n1NFyhS5mlCCz/tLPxoi3LsdhnrNgjhFply+wAZJx6Jk0V9csTX1Q0xuga5P5\nBcgWmdPbvdaxg4pNEOLKiQuu7ZW/FkLxijWu30VQDEUVtoozz5U3kaOxSiOm\nWHuWVU7NYx8L/l9d+kMspwdtrNs1H9xW4s5AlE/DHGORAaz9JrCw0J6AqG5Y\ncqh3bpGseSCMNzvHKHIhtvNolg7Xb4vxOvlXyAnNWqBvw3XEU3r/jZ/NQBki\nxpvh9sCcuaMZMNPWjJlO/C7PmOoggtngngX0JTXUIzbLx1SJgSlb/SQq2e+s\nxr6qmdA9PsC0AemTqfVnNKCVpQzNhh2JxFTGYOK4GqnhW903jnOSlqJl2kIX\niTW9\r\n=MgxC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "3.1.6": {
+      "name": "webpack-dev-server",
+      "version": "3.1.6",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.2.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-uc6YP0DzzW4870TDKoK73uONytLgu27h+x6XfgSvERRChkpd5Ils7US6d5k22LBoh0sDkmPZ6ERHSsrkwtkFFQ==",
+        "shasum": "8617503768b1131fd539cf43c3e2e63bd34c1521",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.6.tgz",
+        "fileCount": 20,
+        "unpackedSize": 447069,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbgkvyCRA9TVsSAnZWagAAw68P/jO+HLgTL2IJfOaarqES\nWUPTYhQjda5enEc/JQsmUozgSrZHrWe0b6oSrhhMHejWHwwXRpo3Ph0wcc+f\nqcxDPORRKB3/eEAFbNWFp0Mf44uVmhZ21BSzfmnhyD44qN2w8+pkwhmV/qVb\n/NqyZZxSXlDq0qiEmFhDPsjaGL0OKoWUfksPVlgL65hpbTPOtDbdl0a1CUY/\nNC62UnGKOcB4L2Aj03pNqg8gFNp56hQfzVgEZlaEdWRBz1g5Wc8ZL7jiS89B\n+kKPTcHrsvnt4fgflqTeoF3yDdQU4jkVYStq/Ch7sZ7qcu9KnZvnWc48Ule1\nhmIjw1llY3DAjz0fZF+ZWNPf7+SmkzMH+wIepHV/fJO3d1DQN2yJGFeu9E11\nFDWvyJ8+JngLJOqHApmLHDCaX/oieiXTimN7pcQEWpjsZJUp5hkA9E1T0RXE\nYR49R4cQYMo7Bt4YBlHyflRcNhfOUBw3NBQQzRbnUEldvFF89/0BFLQuU5bK\nk2uboK9nXMq8f3zpkBj+6jDuEEQbjjAASvAAarMdEeR6XJYHJBsJ/qs0UN60\nK1FfNfEU/DPjDqgIInRYblCIrcsPn4h/m6oVkHMplOsZjQKTULnJLtW6CX3H\nkIPq7Ady/TIsLmEnVkd8C9Snk9WoYDSCcFCXattB8esJAfhT0YLkFhSO4v9R\nv57s\r\n=A0Bp\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.1.7": {
+      "name": "webpack-dev-server",
+      "version": "3.1.7",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^1.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.2.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.1"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-KagFrNHf3QKndS61cXqzkQ4gpdXo0d1LZTTplAJzNK1Ev2ZyJiu+BzerW/2dixYYfpnGzp0AcvCXpmYXIOkFOA==",
+        "shasum": "cbf8071cc092d9493732aee4f062f0e065994854",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.7.tgz",
+        "fileCount": 22,
+        "unpackedSize": 445797,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbhpARCRA9TVsSAnZWagAAfrwQAJz6OloxsZB/tZjtRy1g\nUCVCBNFgAOj4+jspni0+mtU0rYgR/2K0UJaa6OWMQbC/RxjeHJMTD6bg0Y09\ncDnk6AgDFKsQUPynwo5GzM6aTza40RBVxLcVGoOqSwNvAeotJqDfWbzTLLmv\ni4BQzWcNI84++MbuvfVcf9OT8vT7M6cPogip3fSxxqhI6+wLEozh2cfglAWY\n6KPI38lRU9Q3Xw50/F8Gh+1W7Z9Nv/OGoA6ZPMUN6D3xvGYxnkmG1gDzZ8Li\nnQR3DYYNWzcVvPa73SWxmEkkfpp8HFZHOCCwIgzk9eiY3H5A7V3CBqVr/0JZ\n5Mu1NUKjxay4MBdQR+kB4ggFG/GzQ8alzLMxHmAVI6eWqN3f+Vs++VoCmo6R\nrbZxWRlgev+mmOPoyzZj4EFtPwPaTbQzLJNhy866Q5/vaByaEt9Q+ZB1YC9w\nPk7Nq9bXPU1dqM0q0q+3/44jdZs57Tc0SNGrY2K57VE5LY4UEpk6H5UiO13N\npI/7mxEI+rl9wQuCzaFE2dgtYGIYq3I0z+hOP4KW8McWJeLpg76FM4kN8SNs\nPd+QFewahlOiLDoxlvjeVxM3XzHY96NL0BbI7h7HCAsm3djanjIaF1hgJCPg\ncM7n5ibN1QOo7gc1FdAfsmp8ogoz65AhB2V51UemJOvc+5EENcxz9mBP+Vvi\nA9lZ\r\n=0BoI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.1.8": {
+      "name": "webpack-dev-server",
+      "version": "3.1.8",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.2.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-c+tcJtDqnPdxCAzEEZKdIPmg3i5i7cAHe+B+0xFNK0BlCc2HF/unYccbU7xTgfGc5xxhCztCQzFmsqim+KhI+A==",
+        "shasum": "eb7a95945d1108170f902604fb3b939533d9daeb",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.8.tgz",
+        "fileCount": 21,
+        "unpackedSize": 443492,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbkWlLCRA9TVsSAnZWagAAOqkP/2u1PinFKPWs7omj4ZMn\nTpqTfxVi3K6cT/9kLIUmVGdB+eXIGlCVEUykrYD9XEqoxbOExWAWhMheBXDr\n8CIhPWZCSsRrtIn5TGa17HKHMoIpUMLPYs4Hv/KEFn/78Jjz+H9aWpk+U3CW\nyfTqqIV4Gr0vkaxK4s7mMkqQUtPcwbdNEobxHBC2oVMuB4won2yEY+hzx8eb\nli/N5PczBBgvjwyfUCnpBgJlQ0Yt6W/D3uJxn/JXq+1vfT+GHczG/No+hi43\nDYQIp5BEYdPeMYc6KTYNbXER3k05y/BhMok/QAWvFuO/fvTwAOBbZcggzuL6\nrZxxv0j6aBzHn/NJVYZsvWDnNO7JNUfQtb1ZGGOE4+JR7V2QW1VIC1ra51Bx\nQdCp4Enjkm2UTyTEF7eadM1tyF6wWzOFaQILskR5uYvRM8Dhv0y1AlXiPJFz\n7Nu7IFdd+seFInK6XEhw6eBGkpVgR6AU+YYhKMo8ZKXqKeQsJ7F+90qvmJIz\na7E/9BH+6qadJUsToQp+Hxz2eDdkCHImS4p4e0yEvpB9xDCqlzgBO5WXaLkf\nSLsTAyuzWx5lYkMyT7CNwGuZ6w7K11nKPjBXMJm83jCGMMC0PqEiToW0P932\n1tsIJ8nEs5zlOUYsYuvLOg4l9xCozD6hDZJ3JOFyKfDTFbDjYvERMpwkw0UG\nw/Zy\r\n=uK/P\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.1.9": {
+      "name": "webpack-dev-server",
+      "version": "3.1.9",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-fqPkuNalLuc/hRC2QMkVYJkgNmRvxZQo7ykA2e1XRg/tMJm3qY7ZaD6d89/Fqjxtj9bOrn5wZzLD2n84lJdvWg==",
+        "shasum": "8b32167624d2faff40dcedc2cbce17ed1f34d3e0",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.9.tgz",
+        "fileCount": 22,
+        "unpackedSize": 449779,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbqTiqCRA9TVsSAnZWagAApLAP/jcilJVkogU+NEsAWWaA\nbLtU959bX7G2+t3aeKDRUubVVsRJv33PHcWWoLyhMEOdDVVgjF9ckD51/iUJ\nwTdGAcplTNOPnCk2AKzYitGGwOt+DBOAFM9Kre0wrebfGGSAoSiAY9WjVqb8\njjEYz2RUuXaNkjECrGpdzoA3izhWP75zA1K0h5FYXqWD0/N/19BCeHsBEj2c\nxJUpPf66MvEkatyF1iHtuKR5rWIqVjMoW1GICowp31uOM603gOnNh415ggUD\n/ZJCh3qNa7AdZ7fnk9msSnaBpU/Mb2hCZcGTqGxv1IFTqb7a42ZTUZJID2sx\nT8sRfPrvVwd1GfvXwoxKhbrujV77fX1udueNI//9nVyz0A2uLqZOfSf/WppK\nAhgALiDhCVZ3PbOM2SqiyZMbgpQlPUiFkFX9KUJs0JQG90AZgVvj4bg8EgOu\nqvoFZUwADeWCbsDmvdH3hcaAZL4osAwtZ/RKwbgMCmol8eKE7urX5Y89xDh/\nSEkHOi2jCdcQuENqGw5Rlw82NUyIPxwQ1eFAUwR0PDrmhgi1qBbtcHXc41hn\n9rooew49Ee95M8e7e3VmAqY2xG+fwZqPl/DnSQdhaCZ3dN8j7QpA1NLBU69T\nPMHCmbNucgwkhVYOHf8Le3xzBiNmLcz58JYqF3E3cIU/9Yq9wvzJqBfVBq2O\nz+F5\r\n=ThU6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.1.10": {
+      "name": "webpack-dev-server",
+      "version": "3.1.10",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-RqOAVjfqZJtQcB0LmrzJ5y4Jp78lv9CK0MZ1YJDTaTmedMZ9PU9FLMQNrMCfVu8hHzaVLVOJKBlGEHMN10z+ww==",
+        "shasum": "507411bee727ee8d2fdffdc621b66a64ab3dea2b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.10.tgz",
+        "fileCount": 21,
+        "unpackedSize": 448536,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbzo4mCRA9TVsSAnZWagAA2a4P/1Umw4aItj3PzQrV3rj9\n/b7fb9cdb3a054piyzg2GsyTm6ZUOiwKFdreeh1gQ4lkmJPlYE6SseQv+82r\nSi+DrjlbDc2b9xNoQS9aw228S8nJmneA66ICtH3mCH+fVTO9MVuhyDjmX7P2\nodo3FMXyuRLCj3xkQLzfyagSI6S5+6ZnphsJHC1/zNVPhwg7lN0F+Kz3GD1G\nlfJQu9LfMt2osN5adsWYSeWHtOxIyeMAkuUGgxwL7kTM8Xod12ACBF4ZWz4i\nJEK1Al8+ij/E6bt5b7XoJSqBkxPP4todsQoZDhydvri+PIvyYGchy9yglwBo\n2kYp5oUOjiMxNobYABkI2l+quqC27h97Ha83T3JFujZD6vRS0hpDT2WW0pAY\nXKUN6fzs4iZG4al/+y+4zLi/IgcRD3a6TXduDmVDU9W6u2kG5q5jAUJsZyU0\no3cfN6ZMSmSUAQEAok2ie3Ga57Ogg5t/k+/KOWhHXWV6mJ+WnSHHJA27obZi\nFS8tRdW/JqL84QtfkdKetdMVBRNfKBLHrKRMn/fURxjTDOoDQh5VZx54LtWr\no4B3WHGDt14jIouRmEcPYwbWBK9h/9UGfUkgVvzSEArC/Ec30v+EwF28NThu\nrMYVhcxnF/hYJwJ95dowX50x3olPri5J6uBTgOEOYkGnIShX7LrqOtGdtphz\nQcUu\r\n=To2W\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.1.11": {
+      "name": "webpack-dev-server",
+      "version": "3.1.11",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-E/uGbO9ndXrXgNUzw+O2UrrvYY/eIw10fpJnbvJf8VOH/NWZuY3nUG7arbgB/kbkORlF/sPHxnv10tKFtKf3aA==",
+        "shasum": "3b698b5b32476f1f0d3d4014952fcf42ab118205",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.11.tgz",
+        "fileCount": 21,
+        "unpackedSize": 450572,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcHSpGCRA9TVsSAnZWagAA3BIP/iZyGWjeN0MsfrhVTl7p\n/dI7RFYbmfJ8wQU6lytvZcUF0Q2ylhTDepkGq9mRHV+/Fq9gIbXjMwN+q1JE\nFJjYHoUWbFg5+ly50MdEpCoawGERR+Z8iFFSNGX1CmkpOoRpv+yHTrpFqVWu\nuqgFO6KceoRg7OZ/XuSaU2sj9ZVAlNQHMWZIks3uFIZvpTfW3IUtBVP/d8Km\nyE6tAaiinlJUr1Xykxq+Po75NJgoJL36DhJUGs2K5RsYJ3+9wqBdr5U5gASV\nlyFz9tljsEdT9TxctWIhUGatzcqYnj54r+qxz5dwdZPJswaTAN3hwaTYCTmz\nTPvoyN/NDZxX6tHL1KcF5icWsi6ugy9HLoBDNsAjg62jvblPKL3fGVfdxaup\naZK7U+VsFucWSLZHpmAMeNSFTMfhaLz0U2ljoT8+CwJDTT2D4LnLqClrqK/w\nyg3v0Rup5xFkAAQUyxRrwPDPKPDcypRhidMuTlIzc0OJcuavKAdxj3DW4I5S\noyTFjBVc6I3TkZt9r5Fc+YuaqMEuuVu+/EJ7iL9hAIYU0VwDITe5PfREhKtk\npvccjzDH2s7mguhM9Eluay5RKSoCYL+2zlV8MqxGiavVQsTzUTKtJaoCIOV6\na7avjc+zqvBT87FQvBQA4JRekaC5IEbOU1PiHViuTj6iCwX/yfcbOtVtPC6y\nEF4g\r\n=QGZm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.1.12": {
+      "name": "webpack-dev-server",
+      "version": "3.1.12",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-BIh/RGi5GW0HQS3shpqoXThwxaROvwbi6eFb9VSkLCYflke8yrNSgbrtO+v/6BbUtpadyZPZiB/DpUEaKyYTCA==",
+        "shasum": "7419af1975877c37d1ab553c75932493a0709da3",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.12.tgz",
+        "fileCount": 21,
+        "unpackedSize": 451035,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcHlIOCRA9TVsSAnZWagAAbVAP/ixJJieKM6mEN2HQoIlV\nY0txfS3gSstYk9EfTkicr/hFg/L/dsI8sMFmEAGxS47FnLyzYgKEHm9Bx/Zv\nMz1xuVRD3Ij7FIWn8IRUAPY/AakU9GOFOHk/V8BO1R2acD+y0ubBjxXeOUH+\nIQQ/7ML3qTbejhHFnPuMiLhWQx9MuLkjqxyjNpJIKFQTmjbyMTLvNlf1lBza\nQIvgNLSR7UHhQskZ5uU2lwEcZ260qJlmnjXriZJDPK1yxTaNu0WuM+idM908\nMpx+YeQaAf78kSJEfiHkmrPZjfqvE/ArUisTLtENQ45MXJvft21UVAHPbBJS\n9hUVO/A0BeJVmlhVS3QXWR2xZetEPH+CaSuXddcCxVsnOuG0xlUN9iT2kHMH\nF/stWDKzsGS/Qm2V0FwqL7l8PhROrH0JSoiuO7NZaubW4MgDIlDcgCNEve9I\n1xhiUPYGLk/z7nuOIB3pYBRGo7T7X0knC9ZQjfe4ycVz4PRGfy7J0LakR6gh\njfvKwihtY5+rneSe8eKbBxNwWdqOs60Ry6ihyGVHF3j0PO6PHVV+AotXFWR6\nf/fUTxpgB+RR7aE/pltA9aNFvqs9nvSVBK2RDDssRfSrhaxCQwcZ7DPSHKPo\nPI4hYrcL+GCR6aLkrPDSA0xdJPGuDksmGKROyinIk/nGcwAim8tbvBHlQr5c\nB4DH\r\n=FoPK\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.1.13": {
+      "name": "webpack-dev-server",
+      "version": "3.1.13",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-o+crjlyTDCAnkZe1CGlP2XLGCgnMN6oSotYdB+r5OGbnf52Dl9T/fCOdKObvanl1jEnMuLBVDnjTXEmCMMksww==",
+        "shasum": "72ebc8dab4551f8a8e1fdf6357da97571aee6a23",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.13.tgz",
+        "fileCount": 21,
+        "unpackedSize": 451354,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcHo+YCRA9TVsSAnZWagAAfJ8P/0dT8pyZ+OBIKXO9N1QR\nRo78zphTww8o+K/cp4VFsarwIMaKKDrdCtpJSn2k2sl4z8BZqtvJ2IEWKEGP\n8TShQibX54W5TOTnn8GcLPTDYDkD5waiOieFqndjH+eOWPrJayrSVHvtt8iI\n17KU3dTtawsFgGPb6f48Y1NN2fggIMp7wrVCmQCLmt0XqEYvJvNPl0b+BLj2\nCZxYqgB9lznYtKF+kCUPAMiavHZjljFUJbIvEE2ZHv48mSuiiH0p4UPIgF4G\na2MMsmspb+FZy+pcs/iKYOgmJT255DDlEQ80W3KFpvwokdS5uGsi9Acwq247\nZTciXz9+2eb7e/Fg0tTknUi034N0cQPLBwUG2uNgQWKrDY75UulvQYlRl3J+\ncJSAYJHjrep3i0Nc1BSIg/tlaeLgdz678EO6+kVvF+sZmo91iIgWzk0ZQAvg\nTyylFzvy9sLK3na6tB6o/FQrDe8/yLAvdsrFifp304+k0KBTNThJeUG2TmXb\ndxV7SYoKX3sX1Okc5qvfWfQ/W8+0RD+pI7TEOSLdvYcPDblz2thJx17lks2m\nqiuHe6TUdyJdrWldm1J+nn45A3z9B1jHOYlmNOv56EZkohhD08KEd2NuOdgN\nbPzy/idwGk4I72+7DXlBTESSaKH9qqhb08YgyGs7bXqb9zy1M7ItQ4IMHPNx\n9HKZ\r\n=n5V4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.1.14": {
+      "name": "webpack-dev-server",
+      "version": "3.1.14",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.18.0",
+        "import-local": "^2.0.0",
+        "internal-ip": "^3.0.1",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "3.4.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.0",
+        "babel-loader": "^7.1.4",
+        "babel-preset-env": "^1.6.1",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^1.0.0",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "execa": "^0.11.0",
+        "file-loader": "^2.0.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "marked": "^0.5.0",
+        "mocha": "^5.2.0",
+        "mocha-sinon": "^2.0.0",
+        "nyc": "^12.0.2",
+        "rimraf": "^2.6.2",
+        "should": "^13.2.0",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "style-loader": "^0.22.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.17.1",
+        "webpack-cli": "^3.1.0",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-mGXDgz5SlTxcF3hUpfC8hrQ11yhAttuUQWf1Wmb+6zo3x6rb7b9mIfuQvAPLdfDRCGRGvakBWHdHOa0I9p/EVQ==",
+        "shasum": "60fb229b997fc5a0a1fc6237421030180959d469",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.14.tgz",
+        "fileCount": 21,
+        "unpackedSize": 452381,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcIK3fCRA9TVsSAnZWagAAEk0QAJ6UdLc8M+vFBcWKry3S\ncFhLLNtqERo+8tv4oCvtnlNtIrw+xpkhNfVHTEKcq9hjnc/ENM2vSXqE5298\n8eDLob0f3pQhxhD1OgjYostUI8apwmuNVcPsYtgxQ95Nj6vc85fMVjOS9Kiq\n55ALJYY1RQ9RkXH16EtDyvbAjh42pDHgab/Vwu0V4OAZr7FgYRNn7AYFH5qV\nbHocbRH0CSXTFrQWY/54/RXN7I4lhRaEOfZJXkYRiqTErt1es0SEkAF+BJNG\ng/5sOF0ioBBTokjZmNwYo5fbCqptbNTlCuT37oyiLdhuJz7+7gYXhm4Y4a9V\nF9AH8vRc8A60avOqkgtHBOuRmvAV8cwBI/L8JsBFJBNBQ0P0rTaIhRGIM1H/\nhON3fqbeCsGLBkzRKGmcuTb8QEy8g3lHalx+QwAHhNdbbYAd4ptv9/5noeB1\nl5IOcunb2fFJXsDZoFKZDhCRC4/f9R4WGRz0OBByqh9Z71T3qV9nS/E+qSFO\nUcHdZxjJ4r9AZkiTwde+4M7L1XFyjKUgVPWQzUPD5sSpgDdwCpP9oEy2k6nB\n2bVQQZrffOVZ9GSqaitQo3xSf7AXJbBgpz4yxexDLpc+vWpElI//E8U/HVNX\nMqwX1yp3Hl8YAiKg/dIAjKn55UE3qh1eRZVLklCUQLkcghloUXbYbckoqyva\n2Wgg\r\n=Irb9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.2.0": {
+      "name": "webpack-dev-server",
+      "version": "3.2.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^4.1.1",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.0.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.5.1",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.2.3",
+        "@babel/core": "^7.2.2",
+        "@babel/preset-env": "^7.3.1",
+        "babel-loader": "^8.0.5",
+        "copy-webpack-plugin": "^4.5.1",
+        "css-loader": "^2.1.0",
+        "eslint": "^5.4.0",
+        "eslint-config-prettier": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "eslint-plugin-prettier": "^3.0.1",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "husky": "^1.3.1",
+        "jest": "^24.0.0",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "lint-staged": "^8.1.1",
+        "marked": "^0.6.0",
+        "nyc": "^13.3.0",
+        "prettier": "^1.16.3",
+        "rimraf": "^2.6.2",
+        "standard-version": "^5.0.0",
+        "style-loader": "^0.23.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.29.0",
+        "webpack-cli": "^3.2.1",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-CUGPLQsUBVKa/qkZl1MMo8krm30bsOHAP8jtn78gUICpT+sR3esN4Zb0TSBzOEEQJF0zHNEbwx5GHInkqcmlsA==",
+        "shasum": "cf22c8819e0d41736ba1922dde985274716f1214",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.0.tgz",
+        "fileCount": 23,
+        "unpackedSize": 459766,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcbVoICRA9TVsSAnZWagAAXmsP/0SG/o9TTsxX4GFExHKc\nQY3RHMddqSwlp/7Oy/wNkNtIGkUuEoBu4+rHzakCBi8UlLQv32Lv7YNJiwJw\n86r0968oprJHNhBcEWaYuXJacRf5t3J+9bFbDkUd58PQjkXR/VCwAFU2KUq0\n/r2/Gy05SpnxbClXFj5AECZuAltAkjYO3YAcTV0pnDT5BO7Gxx+IrgtFQb3Q\nc57otglSQJupo/qw+pM15B91JsJN30cYsDsyrVw55rMIGSNDe4tGfEcwNbMi\nAlDx7C+PM2sSkQqIzvHrnC1hCdzeko4Bg3yjrL/8knGwPv80m948E5FT3FYs\nBFacBmg7VaoO5zrCMQRnAaTZK7gmzz1siUtxfN4KWehQcbFv6Q7xSyEUqVl8\nFsmEHdAdNG8mPWjnqMQ8b4TIwPwS7YqJkbfc7431a1TGFjyB4S6ff/r3gLjb\nIuhP688BhLk73R1xufftBbvc7piIuQoc+GsebUfdkn6BBimnH2FCBBXBHvLB\nsV4hAbdG5RevODZ5QMRf0TbtGUTjyaHn+PwsOeDzhVVSUc7obCnA2vroZ2Uy\ndlEaqvIUAsZRL9VR/QuuebWznTqmYYxDXElTfIz1450H09RK6QcosAY5OHNf\neVpy6UJLTvML59STdgpCPY0LREbZiFY4yIGBnurDP3kpR2dKLcZHwAWI+nkC\nAMMZ\r\n=BIsn\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.2.1": {
+      "name": "webpack-dev-server",
+      "version": "3.2.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.0.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^4.1.1",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.9.1",
+        "semver": "^5.6.0",
+        "serve-index": "^1.7.2",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.5.1",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.2"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.2.3",
+        "@babel/core": "^7.2.2",
+        "@babel/preset-env": "^7.3.1",
+        "babel-loader": "^8.0.5",
+        "copy-webpack-plugin": "^5.0.0",
+        "css-loader": "^2.1.0",
+        "eslint": "^5.4.0",
+        "eslint-config-prettier": "^4.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.9.0",
+        "eslint-plugin-prettier": "^3.0.1",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.0.6",
+        "husky": "^1.3.1",
+        "jest": "^24.0.0",
+        "jquery": "^3.2.1",
+        "less": "^3.7.1",
+        "less-loader": "^4.1.0",
+        "lint-staged": "^8.1.1",
+        "marked": "^0.6.1",
+        "nyc": "^13.3.0",
+        "prettier": "^1.16.3",
+        "rimraf": "^2.6.2",
+        "standard-version": "^5.0.0",
+        "style-loader": "^0.23.1",
+        "supertest": "^3.0.0",
+        "url-loader": "^1.1.1",
+        "webpack": "^4.29.0",
+        "webpack-cli": "^3.2.1",
+        "ws": "^6.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-sjuE4mnmx6JOh9kvSbPYw3u/6uxCLHNWfhWaIPwcXWsvWOPN+nc5baq4i9jui3oOBRXGonK9+OI0jVkaz6/rCw==",
+        "shasum": "1b45ce3ecfc55b6ebe5e36dab2777c02bc508c4e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.2.1.tgz",
+        "fileCount": 27,
+        "unpackedSize": 460337,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcc8xwCRA9TVsSAnZWagAAcfsP/2rX9FxeTmsGXars/VE4\nRZ0s1LPfiAkSJi053A3BYL8EDVcnlvpeMf5LSFy+lbij8CRc6H/hY+ap+Lbk\n0ErcBLx1cZNb6OXzoaQHKZwPHd4csJZqU7woj3CBuBAgle3hJp7mJ1TOB57o\nadP2gWiZsCp724oFIZbG1D6VtzlzZYupauCX0JjqmEPkvVCbFELmA9EVk3NK\nST9mu9ASlfxfav+G6OJnOit8TMJWM8fQpXlfPc2L8RBBhjDClsv1Q0Nua4gv\nB/ccmoCuPwQvIFVcXTONYMMFdgucjNUpNwpsIqdSOMxdsTXykcchwxAlz4IO\nigmN/mv09ICpxI+wuNIGYkFnZsU6Ta55opNPDuVfL5Ux/06T4wulYpDCGH5I\n32D395Yjn7YffktWiMiu9MRVRmniadyU4IK/ifs229H/hjXo2eW3jcltyEYL\nMJCrgvwEo/l829OSt5l/AbLHP+DqiN1wEUb2YcJBtu0XJhgfHF/E7GyGnJIk\n7XgqA3N+HvJGn5tR5psusDtoPLm8uLx2tI/sLrgLvetNUyeUFYwoaOxkqIV+\nosWAzIEXJXLc3R78Jt3UNIYTdyiZOUtNuOGqNWO2rhvgijMaSBSwK5FBRaVf\niEkJZTihU1tSfqNsfdPfGgFnjAv+PtY8Xe9I6msuCwZvZu3/7fD86AAJVV+y\nTA3L\r\n=7OiM\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "2.11.4": {
+      "name": "webpack-dev-server",
+      "version": "2.11.4",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.2",
+        "compression": "^1.7.3",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.3",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.7.0",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.3",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-12gcsaFIdcOS6kPlVy0G/WpsYkbOsNDdLxBPdzgCT+yiRgUNiVSFj1rjfJcgOtGIqPDQjYh+njeM/T7XIs65ig==",
+        "shasum": "9a02a63efe54d772ced8fd5f0222e0edcaa053fe",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.4.tgz",
+        "fileCount": 19,
+        "unpackedSize": 452707,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJclQ+eCRA9TVsSAnZWagAACZsP/iHM3RbSCoVt5PTCdzJc\nQoQxpxAvRn20fNg2BjlroH2LJDLfBHuCu2KTmqAqClFy9RR9g9rqdcTGz/Zg\ni8Bu38nYq1x5NR6rEfcBrMl5PPt1DeHskC0vnsY3H0ik2Ubl8/bW0FJWVUIN\nitfYQK9fs1Clsc/0LGQC8ooHs3MeOn62pZNaaH2t6Jn1iDJtKosESh3Bt0Gw\nMD1hhWALVhJjv4E2Y4CKBDS7KsvOyyMahGGEqnDnmvL8NbIMMaa8KE05Epuw\n3PrAe6857n/e645dnig11dN88hGxNNoAzr0RYan8OBMPSA7GYlwM6plAHqRq\nXPR+uxipGUyuLCTCV4IIYqwICcjEkcOKrhyLp6h8dHDGaNHULKQp+/CsHfm3\n2bkK8GrGbCfdAE9fjLGR/ISIjvHhlEsl59acvZfP44Zha/JI+qjVVHrYS76w\nScJKNMsFTqXaqooi7iE2b0Ohote8xSzYbrivw2r6shM8WYaJ6gWi7b3eR4K6\nPu/VhSNz6VcA78DfEzfOzc6I44ZECn5HK7n/RSFzWL9QiX7bURcP75jK264n\n/K2iXDaHpKNr/yzX5HCI/uksB+m41sY4qa3D+BeU4kS0/lX60RtAH6VkjVis\nAUAUEKHLElNXC592m4x3DmfKFNfFul8fHjS8DJGsntepxnm0BySUzRr7b7dz\nE6QK\r\n=VC3H\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "2.11.5": {
+      "name": "webpack-dev-server",
+      "version": "2.11.5",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "array-includes": "^3.0.3",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.2",
+        "compression": "^1.7.3",
+        "connect-history-api-fallback": "^1.3.0",
+        "debug": "^3.1.0",
+        "del": "^3.0.0",
+        "express": "^4.16.2",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^1.0.0",
+        "internal-ip": "1.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.0",
+        "loglevel": "^1.4.1",
+        "opn": "^5.1.0",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.1.5",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^5.1.0",
+        "webpack-dev-middleware": "1.12.2",
+        "yargs": "6.6.0"
+      },
+      "devDependencies": {
+        "babel-cli": "^6.26.0",
+        "babel-core": "^6.26.3",
+        "babel-loader": "^7.1.2",
+        "babel-preset-env": "^1.7.0",
+        "codecov.io": "^0.1.6",
+        "copy-webpack-plugin": "^4.3.1",
+        "css-loader": "^0.28.5",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "execa": "^0.8.0",
+        "file-loader": "^1.1.6",
+        "html-webpack-plugin": "^2.30.1",
+        "istanbul": "^0.4.5",
+        "jquery": "^3.2.1",
+        "less": "^2.5.1",
+        "less-loader": "^4.0.5",
+        "marked": "^0.3.9",
+        "mocha": "^3.5.3",
+        "mocha-sinon": "^2.0.0",
+        "pug": "^2.0.3",
+        "pug-loader": "^2.3.0",
+        "semver": "^5.4.1",
+        "should": "^13.2.0",
+        "sinon": "^4.1.3",
+        "style-loader": "^0.19.1",
+        "supertest": "^3.0.0",
+        "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+        "url-loader": "^0.6.2",
+        "webpack": "^3.10.0",
+        "ws": "^4.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^2.2.0 || ^3.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-7TdOKKt7G3sWEhPKV0zP+nD0c4V9YKUJ3wDdBwQsZNo58oZIRoVIu66pg7PYkBW8A74msP9C2kLwmxGHndz/pw==",
+        "shasum": "416fbdea0e04eebe44a626e791d5a2eb37fe8c48",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.11.5.tgz",
+        "fileCount": 19,
+        "unpackedSize": 452707,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJclmrjCRA9TVsSAnZWagAAtkwQAJmBAu7C35gY2QBJPke8\nUeu92F310fTlHT1zPoy8YYnBV01rEk7LaE+4JCwCKSPKq8ONYVStn6v8Kzcv\nzwNPRZR0mCT3mAbdG0Ke9cppRN2bg5B5sw/cdTqNZlOGsctMIS+b6wKwLMKk\nsb0lm1rgK9OybuQDE3l0RP+Qq3PeqcXSDpniyBNyRQ/u/h6c7wdpYLNL9mUV\nE/mw8YrcuzPD0mzauD5WsjHxAb5RcRE2Wk88riL+oDdEnlPRPX/Ke+TFVeWV\nK07q8AzgrLc9qHXFtDHWQsooLXjVXx2mKILQzZZLVyrn0ER2WI/9GP2bbVEN\nS3R2U+O7cHCWqWjOFC2+3PHy/tEOdwpptdHUsawtpFnEJbHAY7Tp7qyuTawP\nmMqPYgaDq92/SgYzRz4+a1LW6v9aPJgmrcD6nE2DGSiYIUJE6+CaHQno1SQ0\nihLxp/kFoVN4mVrtvNv3VSBQhBnQsjP/HkiN9rNQq8tVc9NanNDqeuSTZt8/\nowYsT5QVcQDUcgLf+vnQx+IkxNPwldrY9zpmjEAymtnt7IpF4TilYBFN/7xP\nq0ReektrrHREs506sPqc+sSR9lTGF6ZfC9suISyefPWYXzGLQwdyHzW9Y7Ei\nR6T/INfWkwnND9Ahg0VtH5olcfNzK9LgKcVf4zJzbqVr+P6Ex1ca4cmMfax0\nZtFv\r\n=7OVU\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=4.7"
+      }
+    },
+    "3.3.0": {
+      "name": "webpack-dev-server",
+      "version": "3.3.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.5",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.0",
+        "express": "^4.16.4",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.1",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.0.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.6.2",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "7.4.3",
+        "@babel/core": "7.4.3",
+        "@babel/preset-env": "7.4.3",
+        "babel-loader": "8.0.5",
+        "copy-webpack-plugin": "5.0.2",
+        "css-loader": "2.1.1",
+        "eslint": "5.16.0",
+        "eslint-config-prettier": "4.1.0",
+        "eslint-config-webpack": "1.2.5",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-prettier": "3.0.1",
+        "execa": "1.0.0",
+        "file-loader": "3.0.1",
+        "html-loader": "0.5.5",
+        "html-webpack-plugin": "3.2.0",
+        "husky": "1.3.1",
+        "jest": "24.7.1",
+        "jquery": "3.3.1",
+        "less": "3.9.0",
+        "less-loader": "4.1.0",
+        "lint-staged": "8.1.5",
+        "marked": "0.6.2",
+        "nyc": "13.3.0",
+        "prettier": "1.16.4",
+        "puppeteer": "1.14.0",
+        "rimraf": "2.6.3",
+        "standard-version": "5.0.2",
+        "style-loader": "0.23.1",
+        "supertest": "4.0.2",
+        "url-loader": "1.1.2",
+        "webpack": "4.29.6",
+        "webpack-cli": "3.3.0",
+        "ws": "6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-75LTgV367MRDVIC+IBETrKEy9175+i5fy9nkw8MW+udnPCzNzSfZtKUIG5thQcooaNruPZZoEV8fCZqKJszOIw==",
+        "shasum": "eee6b5cf0f754661aed796ffdcc9c6493a963a8b",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.3.0.tgz",
+        "fileCount": 30,
+        "unpackedSize": 470071,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcq3A5CRA9TVsSAnZWagAA8csP/jbv6witefOADNW0q2xS\nb86XVd+rtaLg8CD84IFzKGX6x28LC/VYMMh3Neme2N0HIZD8sbTteFWqzw0c\nf9WDciwHMEm44pqrLV+XI36ZVx1UA+lnkJJbJoAQmTKaEt6JMRu5c4rB2DwL\nuVyo+7doESmR5o/p2wxp/2hlfB1GbJVv+7PHL5foK2MadtMYuirzfb2N2eGH\nzhy1EbcumUxEAgf2at8AhbLg1gKFHnXq+gzOokv8RqATcEt8lJCBXVerSWpq\n05sVG98aA3n0Gzetrj6XRKp2QSLwhRB85smq6eknx28GltGgIFopZATMa2p2\nS7UuJfu2k8qFgmZ3UtUVa0l0CoaXciRfBKyXP8mq5wkMcTSnmQFDk8bMScmG\ndG69mXoCROupuQfARfUJ159EaIZpbC4MJ3WaIKH/46WZowEkGzK9CBrXxPMz\nUefSQe3cgmaIkSAaLoHXVvk7txUA6cDH7VLVE2zm3evUcICoi4wvMgCqPwpn\ne24M6IvysP9TMmfuRO46WE0rtL+j5wSrmPgsCxctmY+M26G4Sa3xhTO+c0TP\nm8oB/3oLh1zc4bNbbLOcRd5hcHuKw3pb6roatADFOWWS6DhX4vnha4UDGEy1\nmGCpOFpkbN3T1AVbi4Q7rObPvBGCg2T20x9wFBsxaa5+bIl7z6F44OFUHq3M\niPyS\r\n=UNm4\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.3.1": {
+      "name": "webpack-dev-server",
+      "version": "3.3.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.5",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.0",
+        "express": "^4.16.4",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.2.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.1",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.0.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.6.2",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "7.4.3",
+        "@babel/core": "7.4.3",
+        "@babel/preset-env": "7.4.3",
+        "babel-loader": "8.0.5",
+        "copy-webpack-plugin": "5.0.2",
+        "css-loader": "2.1.1",
+        "eslint": "5.16.0",
+        "eslint-config-prettier": "4.1.0",
+        "eslint-config-webpack": "1.2.5",
+        "eslint-plugin-import": "2.16.0",
+        "eslint-plugin-prettier": "3.0.1",
+        "execa": "1.0.0",
+        "file-loader": "3.0.1",
+        "html-loader": "0.5.5",
+        "html-webpack-plugin": "3.2.0",
+        "husky": "1.3.1",
+        "jest": "24.7.1",
+        "jquery": "3.3.1",
+        "less": "3.9.0",
+        "less-loader": "4.1.0",
+        "lint-staged": "8.1.5",
+        "marked": "0.6.2",
+        "nyc": "13.3.0",
+        "prettier": "1.16.4",
+        "puppeteer": "1.14.0",
+        "rimraf": "2.6.3",
+        "standard-version": "5.0.2",
+        "style-loader": "0.23.1",
+        "supertest": "4.0.2",
+        "url-loader": "1.1.2",
+        "webpack": "4.29.6",
+        "webpack-cli": "3.3.0",
+        "ws": "6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-jY09LikOyGZrxVTXK0mgIq9y2IhCoJ05848dKZqX1gAGLU1YDqgpOT71+W53JH/wI4v6ky4hm+KvSyW14JEs5A==",
+        "shasum": "7046e49ded5c1255a82c5d942bcdda552b72a62d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.3.1.tgz",
+        "fileCount": 30,
+        "unpackedSize": 470509,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcrRSzCRA9TVsSAnZWagAAPNwQAIAif9PKVJX9tr9f9/GC\nFDshK0BOe2wX0n74Lo+pnqdKGI3YjpJvOc1QkkKImyoZrLnHEwdHlAWlQEPI\nL+gO+hXfa+MClJTtSiGCIhbsTtvrsCZAHqhIhzvvMtsd6SoKd95z3SrpaT0Z\nuJMSQuvbO4hk1kwQd3RetHnvilBmY90knuMV8qa+ex7z1OaIwVQXuAXCIuG6\nhB1LwD0v6ICyLKZsfbzBb8CfULyXniAO1nvCVz/LhI8lkRWFdDm0khQmeHtf\nigP0b1l/vnJRM3TvmPCx/RURHJzaNNnKlVdfxYM7sXdEKmXJfD4Z9UWs2qiu\nB2IAqt33Lz6l89voPEcm8nr25D7HqElk1aB3UjPtIKiNpikmNuG5Mrez1Tto\nvH5w8pRzT00mH/fCFG/l5mAWZRM/NmwLSD+9LIFWf5QZX1l3d9klR/0Cdpwl\n6K0LLyfxt8SBiK+N1IAcQJbOJ0Nh+i3HjZo2GnYAjtL6O6Bcb5Q0XNeE+vK5\nAqXTDLO0jX5Z+/82Anxu6tXtx8VYzRwAJ46NkObuRlWdNucaPAHedInGFq1R\nP8x+psQvjw0D02sMhCYBX3ngCV9AznRNFXsUeLplPguhd91Iu82OAkTAKVsO\njaKq8wXTagH2eomei07j1cKoHhRyWz8HE0PfKqAoDXx5E4gYzmr4xAi6jaGc\nK+7z\r\n=Eh6w\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.4.0": {
+      "name": "webpack-dev-server",
+      "version": "3.4.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.0",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.1",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.0.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.4",
+        "@babel/preset-env": "^7.4.4",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "commitlint-azure-pipelines-cli": "^1.0.1",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.2",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^14.1.1",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.16.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.31.0",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-yOFL4Ol5B/aCRk0QN/DnSk1vjcJ0qLnEGE0l8pFjw6kYbkbEtt84D750yWHbyKWK9qVOGERk2oZGpEgoXo3cyw==",
+        "shasum": "d0928cb9dc77ca554593396f509b5ab4fa529c73",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.4.0.tgz",
+        "fileCount": 31,
+        "unpackedSize": 479641,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3qw9CRA9TVsSAnZWagAA2+4P/igmKz5ym7/fFtTEEZhb\nWGV39IuigSu+jt7G+W0xPgnNpgASYpZX8zsB9e7BQ1GvX3M5a77WI9RVqwFt\nAgccR3nYXyxWHDIUE9Rm+9s17E1j0roJJEsZgGxzsyw0JwCp0y3uQWJu1mF6\nN13i2GLoIztpJml6PFQsmP0PbvXmEcLvY33bQ5yugWYFIFGbrBnzzTMU49Ow\nO08SGwczt3l+8HuLYgKQLjtmZxKyl4ViCS9W3FHdBo+jnnlCw3CsN1n6qEYF\nj+LPjv3tB3t2DBkYwqoeuZ3DogvLauPNGB8uPWeGSIiZgA2RaqWDhJy87ka4\nj2zRZ70eF0pgFW5SKf1xmiOJU9XugHovAiPEfLh21fzduXUrx1B7ua9vXgTE\n08uQbW17WfaVQHhZbCcJ85NxrD9s2XkApxIuvd10YmdFGAHQk0qRITNtzp40\n/QsReGNYeHSx5p5x8+z/k/3rK9l+eQ7NJrvkKzDPCKjfu4tasgae0Vq8GRi2\nRkGzit1g0CAsM9QCI/uyWm09NbjOIUouwuMlW/zp+oYaGwPZydjHq/TXnXqH\nEC03m+jkwc3aEP4i65+SxXQX3kxHA9slO9yk1UewBo/F4oiHlGe+HFc1gfyl\nEHBnypyVbqF1IyLSs9tKGZWeECht67ovG4B+Kiu2QnReqxmogFdktKAnwcbn\nZzoF\r\n=ZSFC\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.4.1": {
+      "name": "webpack-dev-server",
+      "version": "3.4.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.0",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.1",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.0.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.4",
+        "@babel/preset-env": "^7.4.4",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "commitlint-azure-pipelines-cli": "^1.0.1",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.2",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^14.1.1",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.16.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.31.0",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-CRqZQX2ryMtrg0r3TXQPpNh76eM1HD3Wmu6zDBxIKi/d2y+4aa28Ia8weNT0bfgWpY6Vs3Oq/K8+DjfbR+tWYw==",
+        "shasum": "a5fd8dec95dec410098e7d9a037ff9405395d51a",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.4.1.tgz",
+        "fileCount": 31,
+        "unpackedSize": 480624,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc3ufDCRA9TVsSAnZWagAAj5EQAKOVXuGe/bu5/AyL0pMS\n+hptSyd2117hcQsBpuckKZuM09CVZw2MZBp3gS5dk8PNr4ych2ZzxOnmFuV/\nphBxcTZnkKSo9QsWKa7wpA8gPzo7pNCt/NXf7KqFshwWDrYlv3m0LYUlLMOd\nz5VKl65rHA2g12wxMvVRiAHmCHOCSGw60uUjom39z3jRi2Okfj95oKbckuDu\nxf4/51NN5Dg2IOmr9OF6ZTtP54DRiiSeS2EFKSlWlz1Ga/nHfiU71lv37q/q\nMugmGMSi1Qh7papgV7++RRCJF09Kqbc2bZjJdpVhrGMmxEPlgybcfDO1ReBQ\n1Ey3Xm/sM4zx3+EMSKENOAsbbF/y/woYl6nICD0gF0A9CWXMjRzTmHlCEYDl\nNVKFr90T0o+egWRf5G3wURVJJlPOl2GRW5RMblp0ME2C2MIdvDVG8oFTvbhL\nJza4Ty/rKZxp5CGqhA56WadBmeFYCwpi8fC8f1Luaxy28e1IZrQtkTqdGykt\nQWmLFKRDq2SS8iw+jD/T8rv//JRTG5Z1E1htkZLrGHgc7IBl/kk1E7+8jK4x\nluj3gaGkRxRe8VigrOs1OJFySBrKxfKUBenaTPw7ayyXYoHSf2aKJUL3TNwP\n2u8kX6O5u2brYwsl4JkyW+qJ3XJ8ALhxu8ix0YVFs4sR3vzA/EX2529MHqK4\nTIht\r\n=Sxyl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.5.0": {
+      "name": "webpack-dev-server",
+      "version": "3.5.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.1",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.2",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^14.1.1",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.32.2",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-Gr4tBz+BRliDy1Jh9YJBOuwf13CipVxf4PCH7alB/rV/heszJ/U8M7KYekzlQn8XvoGgyozw7Uef2GDFd0ZLvg==",
+        "shasum": "f1bca520526181e11cd6a643f3233bc10c693c29",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.5.0.tgz",
+        "fileCount": 37,
+        "unpackedSize": 483558,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc8VaSCRA9TVsSAnZWagAA2DEP+QHiI37PGFY2AP9ot7Bv\n8OGSYHuOFmGiox1ZS59Km0Ky+tBUaCfh2/hOSDT2KSkIyK0AV+ybUo1i2Qpw\nW8fCxYgIoOfme/OCr6F97OImL1ZEgBC3gVj9uF7wysB4MiLT54PwDtDII4PM\n40/CHVc/pmhuxycQsqtg+bYc93u3B5B8aFbP3pTYZWIkRRuHSgxER0jC8ONn\nMamM6OBaeA/dCBIDaDOIgocxGlY2/Z+6KwVEW7CMYhVJLNQ0fWG5OBnq4tFj\nvQJgDg5MRL4mhzv2akIDx7Y7UEzLHc5prDfUBRz2fC0GZ5oDEfrfYfzyBHzN\nqJ534t8w1SAWSnlCdi7VtoEp0nfkh3W0/259kgvUMeWxTQ4ushK2pozVkIIq\nt+x0+gwKENHESZLEU+0N8l1cVmfJhCZauQ+ueqfEAK5vv+UytBAuOf+gOQY5\nTvoMspH2s1P5ewcIqv5znpZHdcrsOhZMN7AWyxJ47d0iy/O4X5Fjl4FL/fRQ\nAN+FKlhsKZzyHG+yM2b88YEypawHViKd0g+8fBce6ZcrBbqq/MQKkBMLWp56\nOlc3Sbrr9XLJm4SkpKlHyPZkjC6raC1NBpZo2IRv17ktX9TuJRmnUUoOO9K1\nsUbrD/gyPHA0jJk51UnA2xShqcvSogrO7x/wWJjHj5R+MxpkpuKo7hQQwRfo\n5Mi6\r\n=rWYT\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.5.1": {
+      "name": "webpack-dev-server",
+      "version": "3.5.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.1",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "nyc": "^14.1.1",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.32.2",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-0IdMGddJcnK9zesZOeHWl4uAOVfypn7DSrdNWtclROkVBXy/TcBN+6eEG1wNfLT9dXVfaRZZsLTJt0mJtgTQgw==",
+        "shasum": "4290ac709bb989dc7382c912899f79fd5677dabf",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.5.1.tgz",
+        "fileCount": 41,
+        "unpackedSize": 485649,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc8ph+CRA9TVsSAnZWagAAAj8QAJ69NsfgXEubcF4UPIwR\nLnf6qz0+TGWDCr/CANrknc8xAYFw2iP7lopTZgrcJwhluMVl4Ou1IBm6RrtR\nwI53EjAOLksg0f3v7zs9A9fPG0g5Y6jW3rFA4LDUWkitYBGcdllvfKY/evwp\n08Mt9wjN7sQgl7RSiCHpH5OBfiHFvQR7vSn/4ykWbuzsRPDDlK6eNuQ7oDXK\nl/D5nTCIQMrZp+TbttL6FtEDnwD6S1olOvAeJC94XEwS8QyAyE1XHpMO8GlN\nvViQe3UoUZ4JPXDauZ+3GWqDY2ipCe9M3umhyWWxCUBKUq3ZNrmC8fyGrUTV\nyP4CCjZAaIyV3DOWYEsjWWjabwq2Kvd04aRzVh0/LR7eM1mBTMc7/iHeIvDR\nJzBqP4f+lO77yYeZ7kY/YZxH7pCJf6HHDXVScJoOg9f2dU7QjjR2xlSVZi2b\nWd3UvYZaJ+PIh7acZWCXvrE3rKd+rmCmy7tFFJcgl9GBPoqIxzMuEgR79TXt\na1leOqvnW0Mxg5lKup8sE9U3VC5x+X9i/LsQWNBSRt1p9K3OFT08FR+bm/fe\nASFD7tlmqy+cm09dmuMg95B9742FrTRYsX6Q7YapeRVxO91KmXItgVwLcfyh\nV7njCtlZVKtzSjdBfDs5uZJ1bZ3t29U9rOjcGLmE5LgrhKH0h38kQyock9q8\nTdtL\r\n=6Rrs\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.6.0": {
+      "name": "webpack-dev-server",
+      "version": "3.6.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.3.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.1.7",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-49CWhocbMzjNW2Dzo3ETnxtzifcKGx4Pa3Hx+sl0hBU5/t7zJTkOvMP1sCnu9/qGNDYW1PKCuszYQn5r2g5Sww==",
+        "shasum": "7f675f69bf0999e5f489d1e2532182cfdf55706c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.6.0.tgz",
+        "fileCount": 47,
+        "unpackedSize": 350340,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc98hyCRA9TVsSAnZWagAAObgQAJTkS1OxekyONpva/V9Q\nL6+OvgQ5DyJcSZeKA1vSCnb6Z2f0vIOKXjKcKIGaGjB78JhZFmTs9xUKosr7\niRv1T6KRHixfxoeG0ASEVMAOoFCehhRNwce+LNnENcTPvy2tM9dspM9FdEdA\nK7179S2+CkMnX9dsN5upRZd+eS1OOV2XNBJqWvv9XpQItLP1wTWzy8R2eDO4\n9BjRgcyLreIau8/ecQzAYQQmvw4qwmtfJkl0u18F/Xz+lLiwv67PLPX+hJs6\ns1r8EVIXnbsKbKBLapLy78GQUQG8sB5203P1QDJI9yNe0AiS8vOlQBNfeDAR\n1THoggSFONL8HkQzK2FCyjtlIa2X4BuaIgdFFBtNn5bFx8E5PITCuykpgtgP\nG7JQHsnr2TWqxfh8GJjoyl8TYnVbmY8C1oVQfKh17fMZe56lU6/QfBiua71e\nJHLdOgKTzAh7cWkoNb5pSB+ESR/icIEvMcaDFjDE9V6dgXlPUUBB5vJDeUW4\nuFXm+4INMR7z7YTc86khioTPmtm4E17EnFZX0cTm1YBeqPT1Mnydi1rQfKD2\njnCIm+7NhpkWJf+2tpuP8BaeO0WYKduF+iSmgTPcg1kXwmH5+gw4uSOkWQ1f\njT6rbJNV8Ip2UwyxN7CZ35WcHnnyrNlGZfLDZa8k4F8qTb0wZ6NS0ELhj5uT\ne/64\r\n=bxBm\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.7.0": {
+      "name": "webpack-dev-server",
+      "version": "3.7.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.4.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.2.0",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.17.1",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.2",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-B/c/aJoyOlhjgeGnxTWeJlDBvIEN/aBI2R6G1DiFHVluEs0KtuxylFcoDR2K6Um/edo4/BvZqMXS2tK+U7fsHw==",
+        "shasum": "7da016e4f5abec61c7b4af95a264d623bde4df3c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.7.0.tgz",
+        "fileCount": 47,
+        "unpackedSize": 356582,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc+TH6CRA9TVsSAnZWagAAQZAP/3eoNKV7bA/mjfguVaWx\n3alJDrcb0mGBaIIp/jwzTvcJOdUl8gkJYzqCVlqxqQi8RVWVLwceBR4j+NP4\nwRlweKnpCYei+g5fWOvcwghJ8NB6VIFQ0RFeubiiM59e04epspqz1/9134sB\nwQ1UZxDrmTe+9WpZUFdx/bO126q9Jnc26+WIjgEhPEnV23fUZdTCqQ3yBEdE\nsw9OKGmUt79AtMT5QXar0DWz4WNlh8q25IJm0UE1TO1A8fFfDOp85qdILH7s\n+ihjAXBo0jBHd2kiRco6Lvm/mxS+LIN3knLMIrbIHJl/sann4cN1vgx80OLm\n+/8srJuBGBb7MCgI6hYfZn+kvsSHwcyw+0vw8yfyBRi9ZdTqIsQT2ZmNGeqJ\n1PkZS0E+bQeVj2I0kDWvzY74U0hcRENxzz/hKYTWhMZvDmQaAx+QwiJSuN/r\nDAPaoJc8e9DocN25qaxEdIVbxBaqaNeF9audLH7/1ygmS0u0J618Q4eEs1IY\n58aqmWhQtOTkFpZsnrq8eIUHzb92AWFtXEYr1xpldQ0BGtEgBSe6yBC4ljoM\nyefkjmoyMqBf0B6TRfS/v9YHZjBp9ZE8Q0f5x81InsIBkbLibY5SkBJ8baFH\n73bGURzHkeMWEt9JWfP4erBXTJnMsSlJ9NELOwFV4bdPqEBpg+o91bKVzdFc\n2nOc\r\n=Uj6W\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.7.1": {
+      "name": "webpack-dev-server",
+      "version": "3.7.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.2",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^7.6.1",
+        "@commitlint/config-conventional": "^7.6.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^4.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.4.0",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.2.0",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.0",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.33.0",
+        "webpack-cli": "^3.3.3",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-GSBjjDMQ+uJI/Rcw/NfXDq5QpfE4HviafCy2SdbJ8Q22MwsnyoHd5TbWRfxgkbklsMx+ZNgWIKK+cB28ynjiDQ==",
+        "shasum": "ce10ca0ad6cf28b03e2ce9808684a8616039155d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.7.1.tgz",
+        "fileCount": 47,
+        "unpackedSize": 357167,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc+m0+CRA9TVsSAnZWagAA72EQAJi8XXkFr6ObYbusorzR\n2359jDUu40ky4wB7tJZ8Uu8T074nr99v6pcwKDnbIeSe9t107gbBqI68J3O9\nNkaUK7Gt+WpG485u9KfC2qDd/gMmS6JVG03NV8Zm3szfnP3p3U/Xn/H4qjAo\ngbJGzFBRFHmy120qFyeTKCadq/CQFH/4h7dBkHoQwTvpQNFShyR0e0pF8/W5\nbQ0TqxwGJ+7MLE0xh1CLHwdMqzMzsCHh3x4vbA+UF/1NNG7acpO9FUz99dBf\n+lsmSmo0gyucFs2UrhUWToAT9aan1jOGLaTUs31l5QB9Ysv3Nz7pYlQAkXZu\nUnpC+gzdpGXIWARO1sHmUcnC9uyvpNiFg1s1MUn6obhCukQrI1KL3d9/GSuX\neaOqaGCB8vOZtDO7G1shrSyKOLA6nXUmMq7UqfWMzZhD9bafhjDlv/KhmtKG\n0J75fqO/TUIKPgI3Dz2mQX3/xgKzXLQ2+hz7wLdLp++QGvjGD4LApoCmgfzG\nqaVHXj52fVJFtpPzibhAoaTy9DnjdgyylPCjjywUffK4BgoecxFM53uAsokI\nWAcT8tt3+2d3ihxj2nX2xW08PeOGdBhCDGHbU7SBR4xh4AyZxCu5LKaFKIOU\nDvTeWaxzSTWeDwfUAVxCqcqQcwqVcwf+3no24ie+mLGXGnAj7k5M9x5y174F\nGZ1S\r\n=EOPI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.7.2": {
+      "name": "webpack-dev-server",
+      "version": "3.7.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.3",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.20",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.1.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.0",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.4.4",
+        "@babel/core": "^7.4.5",
+        "@babel/plugin-transform-runtime": "^7.4.4",
+        "@babel/preset-env": "^7.4.5",
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.3",
+        "css-loader": "^2.1.1",
+        "eslint": "^5.16.0",
+        "eslint-config-prettier": "^5.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.17.3",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^2.4.1",
+        "jest": "^24.8.0",
+        "jest-junit": "^6.4.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^8.2.1",
+        "marked": "^0.6.2",
+        "memfs": "^2.15.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.17.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^6.0.1",
+        "style-loader": "^0.23.1",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.34.0",
+        "webpack-cli": "^3.3.4",
+        "ws": "^6.2.1"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-mjWtrKJW2T9SsjJ4/dxDC2fkFVUw8jlpemDERqV0ZJIkjjjamR2AbQlr3oz+j4JLhYCHImHnXZK5H06P2wvUew==",
+        "shasum": "f79caa5974b7f8b63268ef5421222a8486d792f5",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.7.2.tgz",
+        "fileCount": 47,
+        "unpackedSize": 502935,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdCCoqCRA9TVsSAnZWagAAEHMP/0YxxeZc2LgeOTKvBeUm\nfxIebYeGyltTbjNXODo7hyMV/08EjWI7GMnraXhlkBrh4r0STo6XQwEmMsEk\nWSlICjECy1Fni5SHZvwHTFcFeV7vxImBgCymDTQbgkr8qnIm2tXo7kQLwOvI\njczU6BufZsclpdsGOw0wHdszcLoVp2gwCD2ZScT794jHfXM94AXDsIRWkYMH\nIyZDnmT/+KzFlWQWoseV4lpR5cdr4NXiLHRfctBaVsZ7jzC0ctno/Wfk9bSp\nnbRFHrKwItchX9GEuZ/wqXSJnv7cjyxPg3NpRRWsWP/ldWuwm0KCse26D72H\ndOmndrR8uu/eiNgNZuU6tR2xRH17tzvDCX8peGdnlJkRx7U5RO+s9WqNQ+/b\nxm5mn59sPl5GsieitCjEOCSKSJyTTA6M0Mnu66PWWgnKJzspdcDZNzaRbYHi\nsb3YfegJ/5kPpNMbcG0KC5/0RGJrtrtaOXayaKLKXAB6114Mv2Fcpk5Amsfz\nBCBeiCITW3aEqYToo3tdGOgugj+X7KNYUvHBkxk3TDeqQkCKcgVWqEoowrK7\ng+bq3WE7iC/S29LGeeAS6++Rv6H3+XjPszP/4doPU2foQEG2JkGd0EjOG4Se\nbWpP/wWUlwwqBkzE4jUEwOOTcQKKQv0UueqDC29GglSIbWkXNvvmoqHs50u3\noBPy\r\n=0SAd\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.8.0": {
+      "name": "webpack-dev-server",
+      "version": "3.8.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.6",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.0",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.3",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.21",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.4",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.3.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.0",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.5.5",
+        "@babel/core": "^7.5.5",
+        "@babel/plugin-transform-runtime": "^7.5.5",
+        "@babel/preset-env": "^7.5.5",
+        "@babel/runtime": "^7.5.5",
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.1.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.4",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.1.0",
+        "eslint-config-prettier": "^6.0.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.18.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.0.3",
+        "jest": "^24.8.0",
+        "jest-junit": "^7.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.9.0",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.2.1",
+        "marked": "^0.7.0",
+        "memfs": "^2.15.5",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.19.0",
+        "rimraf": "^2.6.3",
+        "standard-version": "^7.0.0",
+        "style-loader": "^1.0.0",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.5.3",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.39.1",
+        "webpack-cli": "^3.3.6"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-Hs8K9yI6pyMvGkaPTeTonhD6JXVsigXDApYk9JLW4M7viVBspQvb1WdAcWxqtmttxNW4zf2UFLsLNe0y87pIGQ==",
+        "shasum": "06cc4fc2f440428508d0e9770da1fef10e5ef28d",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.0.tgz",
+        "fileCount": 49,
+        "unpackedSize": 510709,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdTalxCRA9TVsSAnZWagAApxUP/3mm21302yEoj3RE1k+n\nn2wIZTCexucDipFPO0of5jx4sztvE9/AMiCgH4DLPZgB8N6Wt6RYPtaTqfSF\nunSx1zPc/rlnlOk4k+spQk4MSp/Q7+CNmtiXRVjhm9IpKw0F65GSof3j+k8n\nlJfzbqlfnTopXZ7luS/f9A0UpQ8z/NuOmtrLSBzabqLf7nwEo/NH0m9l2RO6\nfFdUQFckFhEd+90d9ySDNPPl/g5u+jaQsLtNY3RAtMthaWc5fAw+7fa3YNVZ\nanAwmHEbVeCEYRS+yOGuQeOqsySeXAt5uAiNw2FoIK/GIK0dtSZ156m1UJH5\nxhm8aQ+Lmdl7/clwS8YtcO1fCURTjSWI/nynjAG0T7jt4uNdcDlkJ0/oZ6L1\nCLarbsZACfsHeWKfsP6UKK5qoE5JCuLLx3d2qTlGKTIOfTRAC/g0sfxSwBZ1\ny6AJIOlmx5D/EfsqAqb1YvnDQxoubUsa4ugnnkMMTUr2AIZ+pqyR7ElZL/9Y\n6xOlGB4L/b5w8NYdTwyfgoFwEzqNZLATo7MFIqApGMfWskkgFQE6WxIiczpS\nRBPMDxxl+6HBAaIWzZWFrCN8JXyzASaeT2sbdMsD5ac4eZ91ZanQAQBT+7p8\ntEIUndhTgR85kYcYzg9siXZkpHRdzffhRXH0fQ/xP5LwPX1Iovn1xuCF+wjn\nDpzF\r\n=+bLI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.8.1": {
+      "name": "webpack-dev-server",
+      "version": "3.8.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "^0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.2",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.4",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.24",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.6",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.1",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.6.0",
+        "@babel/core": "^7.6.0",
+        "@babel/plugin-transform-runtime": "^7.6.0",
+        "@babel/preset-env": "^7.6.0",
+        "@babel/runtime": "^7.6.0",
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.1.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.4",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.4.0",
+        "eslint-config-prettier": "^6.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.18.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.0.5",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.2.5",
+        "marked": "^0.7.0",
+        "memfs": "^2.15.5",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.0",
+        "style-loader": "^1.0.0",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.6.3",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.40.2",
+        "webpack-cli": "^3.3.8"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-9F5DnfFA9bsrhpUCAfQic/AXBVHvq+3gQS+x6Zj0yc1fVVE0erKh2MV4IV12TBewuTrYeeTIRwCH9qLMvdNvTw==",
+        "shasum": "485b64c4aadc23f601e72114b40c1b1fea31d9f1",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.1.tgz",
+        "fileCount": 49,
+        "unpackedSize": 512578,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdf5dWCRA9TVsSAnZWagAA2H8QAJdItidSQOssqckn9Rf9\njR1OeplaSpmqKt+R+X/eR39Zs0yitAqiWT11XqjUzktQrGOIDW40C7GDfaOd\nVqa/uqlpxyfIRghGewpXWKU6W/LmH0gMgh8cmq1HvhJHHhgd+pXaH/Hh7lPK\n3it59PXVphNLDvqNftgdRIS+e6rTqnsf16HFIqPdJKRxSJUwh1x+ChepsMIo\n6jnsjLdpOGwHiLKEtyjJTI2Uget2IgQbXkbG7ngBsZGrskjDsQlRR2TnIIlA\neXN/Ovsthgql2/oXFGBQex0g/0I1OxUQ5KQZekInyNDLJOlI/Z/KI1BEkJFI\nK+G28u5kI+EP8Icr6GVXQEfzIM1LkUccJftq+H6vW1+tFnyu8H2Qy4vYRJPq\nqnxMsxfcVRr0XoPGQGa/p9eXFx9DWn64Mwvf8moUltjOkrCaScdBfz2eW70u\n0HWBLQVAWL0no+RFxvrrrMgerFqqzdVr/nyamWOuVive7/XVcv6pAbyOk5Xx\ntu8QgbCErXRxaL/SvJGgXdDC1Jnyd9jpzybexIDswHltLxMiauBjxyRPKAEu\n82rhgm4uOuISNBQBBc7xyZum1gRbCX8yKEYuXPld6iingelzKjRjITcM44Zu\nO6eTEtzcF/zRN2ELEnB1tX8l1Sne4cY6cxFHxFEZhGRq+qi4gWOU/XlWEhx0\n6Bvq\r\n=HxGJ\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.8.2": {
+      "name": "webpack-dev-server",
+      "version": "3.8.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.4",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.24",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.6.2",
+        "@babel/core": "^7.6.2",
+        "@babel/plugin-transform-runtime": "^7.6.2",
+        "@babel/preset-env": "^7.6.2",
+        "@babel/runtime": "^7.6.2",
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.1.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.4",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.4.0",
+        "eslint-config-prettier": "^6.3.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.18.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.0.8",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.2.5",
+        "marked": "^0.7.0",
+        "memfs": "^2.15.5",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.0",
+        "style-loader": "^1.0.0",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.6.3",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.40.2",
+        "webpack-cli": "^3.3.9"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-0xxogS7n5jHDQWy0WST0q6Ykp7UGj4YvWh+HVN71JoE7BwPxMZrwgraBvmdEMbDVMBzF0u+mEzn8TQzBm5NYJQ==",
+        "shasum": "3292427bf6510da9a3ac2d500b924a4197667ff9",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.8.2.tgz",
+        "fileCount": 49,
+        "unpackedSize": 512719,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdlNGdCRA9TVsSAnZWagAAFnIP/2QAMo7OkEm+I/Jwj6Iy\nesZAoHUwzuY4jxgDYNDcJhsdzMDggCAdTRiqROXqOWg11qLh4orCoGel0Vgb\npSBLJxBnQWwMLUcXQlF9Bt3k6Zf+iBEGjlw0XkZjRYRMqjfFbf5uwZlQ42MS\nHid/u4zozvGy+TqqNZZLVR2gqrz0o51ugzaMwyVl1yEY9Vi6F32j0umK79mB\nm8GS+3vGFic1SLFAa+UzLolzqpSbM7oyCmIG+cWangIWUoY9OGy6loiHj32r\n4JAE+oS8teKZ1mga7G5kspwLGrO3/OLwtd0PTGAPoTQBBfVTHgjAQvhc6Mvw\nA2EU86nUxuRZyc3HtHTxJXZIh1+O7ekH/p/5oNgNGMt72oIbnMv+2GypfRBI\nvRErLH4VahdtT7snN3cgalAtXgywhNXp+eYfcTUM093UyGSeZDLGDS4XyS0j\nPg6xQkoiJAEccgWA7/8AuIpBjkXoSW7vVSv613WSKbDqEorTXQAQkESwFP4/\n+Deq3eANfm/KcflG/2FNAJ+30f0EnpwJRugzIZUWEDM1Dc5DkdK1mg73nvaS\n2KoP2WnHCCGUw7RBrH6CWGLhDqB8aUHTprSogZwh61kYDfOjogzUDhwUACZo\n070JkBMgXs/COG/5/Xbo39OkP/MI66HE1s9gUVx4/Q8LA3tQZN+dTsPd6X5w\n5/s2\r\n=qps1\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.9.0": {
+      "name": "webpack-dev-server",
+      "version": "3.9.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.4",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.6.4",
+        "@babel/core": "^7.6.4",
+        "@babel/plugin-transform-runtime": "^7.6.2",
+        "@babel/preset-env": "^7.6.3",
+        "@babel/runtime": "^7.6.3",
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.0.4",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.5.1",
+        "eslint-config-prettier": "^6.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.18.2",
+        "execa": "^1.0.0",
+        "file-loader": "^3.0.1",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.0.9",
+        "jest": "^24.9.0",
+        "jest-junit": "^8.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.4.2",
+        "marked": "^0.7.0",
+        "memfs": "^2.15.5",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.18.2",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.0",
+        "style-loader": "^1.0.0",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.6.4",
+        "url-loader": "^1.1.2",
+        "webpack": "^4.41.2",
+        "webpack-cli": "^3.3.9"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-E6uQ4kRrTX9URN9s/lIbqTAztwEPdvzVrcmHE8EQ9YnuT9J8Es5Wrd8n9BKg1a0oZ5EgEke/EQFgUsp18dSTBw==",
+        "shasum": "27c3b5d0f6b6677c4304465ac817623c8b27b89c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.9.0.tgz",
+        "fileCount": 50,
+        "unpackedSize": 518685,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdrzMJCRA9TVsSAnZWagAAs+AP/R/cmZbCPE2NzjXjec/2\nm7w7VumfNMaZyHzoPABUK32qESyHvgGGso01rKzx+qzE96QT2HkFHt1nbAnF\nipIuUc1dRPzCwl1zJyso/hPI6hyo4dSQoT+CsnJHiQxTH+atzXOHwQ7bcQfz\n3EEGlyfVMLUh0DnIF7f0K/bNOZBrVAjO3CoL+6zhvwS1b4CKVJzntBAoCvqA\n3mhxirmpHXOOSFP5a66r15Qw997eCkrVCdaITqxSlC86vDW21aUSP3FUH1+l\nZR90mS/6+/zjdt2lY+b+T1E8i6QSbxQjrxm1+FMNSO9MVIk4+RqB9r9M3Aw/\nH5nQVD16fSQPqSAQLo5rAj6ZO+8muRFI/xcey3TncW6Gfg/bnxrt+allQ3cQ\nDkf3I6vnxj26AsUeEG/YXQDEOQySp/IhNTDpM0irdwZe13815jqA2bqfmjwK\nkmXHX/KzrtSAzAxJoAb8mwn9X0jtKK2+3fCL+Cg0ftqOIWe/JksqR9mXSg3h\ncFDqPdKgVO/5tQah4T3o/tSCIWP5aldMDFGWA2SH8pC9dPnNdxVdge14wY8V\n5LtZYwGyn7gbal2fN2Eab3zXeKZqipPEq1D4S1NdNr3K+6AJtdKbyxfltDmf\nLDAejSgr8mMIcLD43t689Fb1eOU9oaVuSmRpTc7t8l2ov/Lxb52KX9u/tmxG\nW3ax\r\n=m8P9\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.10.0": {
+      "name": "webpack-dev-server",
+      "version": "3.10.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.6",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.7.5",
+        "@babel/core": "^7.7.5",
+        "@babel/plugin-transform-runtime": "^7.7.6",
+        "@babel/preset-env": "^7.7.6",
+        "@babel/runtime": "^7.7.6",
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.7.2",
+        "eslint-config-prettier": "^6.7.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.19.1",
+        "execa": "^1.0.0",
+        "file-loader": "^5.0.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.5.0",
+        "marked": "^0.8.0",
+        "memfs": "^3.0.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.1",
+        "style-loader": "^1.0.1",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.7.3",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.41.3",
+        "webpack-cli": "^3.3.10"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-dPNu0Kz9lh5QrRef/ulknAtEEHoZ/p49sUPE+4KbknmxkDU6V4evB2LdTWlw/DnDavxQC499+2jLHlgFjA6TmQ==",
+        "shasum": "725d0bdfd70a56d266a5a0ee167df8e6a422d533",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.0.tgz",
+        "fileCount": 53,
+        "unpackedSize": 518063,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd+jmVCRA9TVsSAnZWagAAHpIP/jCAFOpKFRgHP8jryLsH\nKlw4nhhO42AqVkHdBDKqCDyXDg2CYy8jnYD87WeEEtZHBmE4sicA0avTeGZD\nkPPRC5HgHxthfcBACxddZrfkzROkMIzQrx5FJczmMlPqE6YRoIJD0LJUYk6F\nQyAynX7gY+cny7bpWx5yn77fxuCoYm1/sCpKSbgc58+DeD6zemXLu7A08evc\nmK/TrLZKwTKjzvk9W8/GeF2drZrrplddFozXBXiTEkxZPtzVrK0IwUcMA/L+\n/nd5ZJIOdhqnpXSCBlu9S1eWfhRuniV5y7cv/NhYqVihlsFFdgq+KMpPfCg5\nphLUhZgpnr89rXEAbnkBe4WPLI/zVBSdnEHlVgdCvv2sq5+LgPA+zyqHjqjX\njbbccmkULxiQEqHWR3a/BzOYsf4nW6A1jFb+5QWlU7KBMun1h/laTRqWDSB9\ni//tSeMG37ZCemz8tsSzu7h+xjRvm+f2D2o2GMvyrfbpuGyh8vfqXmALl3Gh\nt9tYtidAg52ao1KhDiU3js7bnh4kVEqZfd7da4W6K+gI5K6ZtbiUYE7iloaH\nvOTXd0P0cLPQEIm8Det4lD8QjUXuI8xLgEq4iKGYZqMD3zp0s1jqsN/ICGOt\nmd3sFPAMmz0EihPD2suGtq13C+qrQD+1BcGJiY06cgWE9xWhYW8uxYSxzsIG\nJUXa\r\n=jUf6\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.10.1": {
+      "name": "webpack-dev-server",
+      "version": "3.10.1",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.6",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.7.5",
+        "@babel/core": "^7.7.5",
+        "@babel/plugin-transform-runtime": "^7.7.6",
+        "@babel/preset-env": "^7.7.6",
+        "@babel/runtime": "^7.7.6",
+        "@commitlint/cli": "^8.2.0",
+        "@commitlint/config-conventional": "^8.2.0",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.2",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.7.2",
+        "eslint-config-prettier": "^6.7.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.19.1",
+        "execa": "^1.0.0",
+        "file-loader": "^5.0.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^9.5.0",
+        "marked": "^0.8.0",
+        "memfs": "^3.0.1",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.0",
+        "standard-version": "^7.0.1",
+        "style-loader": "^1.0.1",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.7.3",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.41.3",
+        "webpack-cli": "^3.3.10"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-AGG4+XrrXn4rbZUueyNrQgO4KGnol+0wm3MPdqGLmmA+NofZl3blZQKxZ9BND6RDNuvAK9OMYClhjOSnxpWRoA==",
+        "shasum": "1ff3e5cccf8e0897aa3f5909c654e623f69b1c0e",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.1.tgz",
+        "fileCount": 53,
+        "unpackedSize": 518311,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJd+10TCRA9TVsSAnZWagAABP4P+wZsneg/iqI4yt8VtLyq\ndpDKhN0FaBKxRL5/xB6X4yn6yq+Vl5ejrxAJyR+o5xg1Oo8sVFVi1HFpmuGw\nf29WMJxlgSfwcnu91L4rf2lXFqtyhRdzFJ8fj1cjaX9SlFFpx7hEXRQpZsqY\nctTzwq1A2mZf1IE8QegJu7YBJcY1ub0Bolll0cwBBP6Du59GJrqhaz0IGAxl\nOdYY2Cn1sBrIy+crp4XZ7K78QqrezyC/d3T7zQLH1zYX/ZL+rM01l3bThMnE\nyN3dULxqjPmVTKUxiPr0jOHncgpIYhN4ThTG+jCr3VdlXvGwLzoLVQMeXTyl\njprcIAtS0n15i6EBUn77EBvrEhA8Du91Fz9u/wGSnuwKnthpb/o0GAeeoVWF\ncf76FwG0aeTuLkAzq0zUABbowEuP3UHuSoP0wvSRkFu1aonZqNUlvCPQIxrQ\n59A83zU25awzYrHpYt0FSux8Zlo7ep62zzqgnaJPDM5HkYyS8NBchrPJfnFj\n3gJSzWuYUq+2RR++k7Qn2iTrzlNQi4yzjZseQh/Tsrs3F17BLFZWjUu5AKsU\nu+b9Z/sUx5RqE8FbUINoDesGjvvySfdgJjRm1pV1PUyPDrIZBsamlUVoSaDh\nWJWUG4EgkRO6aKUzx1l6zA76FC/UdZuO7KWI9RwbC5aoC5RRE9aMkKTS9q4c\n+0wp\r\n=5gO7\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      }
+    },
+    "3.10.2": {
+      "name": "webpack-dev-server",
+      "version": "3.10.2",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.6",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.8.4",
+        "@babel/plugin-transform-runtime": "^7.8.3",
+        "@babel/preset-env": "^7.8.4",
+        "@babel/runtime": "^7.8.4",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.20.0",
+        "execa": "^1.0.0",
+        "file-loader": "^5.0.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^10.0.5",
+        "marked": "^0.8.0",
+        "memfs": "^3.0.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.1",
+        "standard-version": "^7.1.0",
+        "style-loader": "^1.1.3",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.7.5",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.41.5",
+        "webpack-cli": "^3.3.10"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-pxZKPYb+n77UN8u9YxXT4IaIrGcNtijh/mi8TXbErHmczw0DtPnMTTjHj+eNjkqLOaAZM/qD7V59j/qJsEiaZA==",
+        "shasum": "3403287d674c7407aab6d9b3f72259ecd0aa0874",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.2.tgz",
+        "fileCount": 50,
+        "unpackedSize": 521140,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeNEnoCRA9TVsSAnZWagAAjYUQAJixEUAbl9g58BkRxxcd\n1glZA55gkx5pcES/yaydA9+vVeevSjpJc6gjOiU6nWb0b2Myqq1cUTZUfN0f\nGw7hdxo6UmTJVQo/MHD85G/DTur8rTIPzQYvp/J75340Rh54ENn4lZDU8Ncy\n9N5kGNznmAy//IXlS93HOGTAD0OSsCN7CxM5n/Fa8KSogzgSLlTNs5GN8ESB\npRi26SU6aCuehK2nh2pRmP0R/VSPYCpEPnalDKF+P1ScGbZPZ+WQTwcIgvbY\n2/z1Rvn7tDiyszEx5L8yLZDaeLoJXdtNwfFVBi7+nG1A5nlOZD7/FcN8WHBR\nv/TgjWnhSB8FMPWdS31wQ7GcEBcCTHCFOSIOvN/DisdE9RnuOLvE9YZYi6qV\nGX3F4lJOKsa1jHZwHH+gcbVnd05Zz1VsU1VN4an3FbsCMDvcTEWgqG8Wpiqk\niSxykG2n4VzAt/wRCq63rItbMHbQdwRJs4saX7D/T1GZAxUPeOMO6RLfqNpq\noKVBFVe7HNfybplYF/PVFxslz8j1JZU5qkTVGjtTPeC9W7dllmc+q0Re8367\nbsT6ceKI2l21Y+6w7x89Sv2S5crjXLWWMmoOL/t7NGBGkGqYpZ/ff7poIUwu\nyMLan8RbAQinkAAblyztSWOAJykQdQn8jOJy9zTluJJfq0GSyYg4cE2iHyBm\nCWnC\r\n=68+T\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "3.10.3": {
+      "name": "webpack-dev-server",
+      "version": "3.10.3",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.2.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.6",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.25",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.19",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.1",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "12.0.5"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.8.4",
+        "@babel/plugin-transform-runtime": "^7.8.3",
+        "@babel/preset-env": "^7.8.4",
+        "@babel/runtime": "^7.8.4",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "babel-loader": "^8.0.6",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.10.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.20.1",
+        "execa": "^1.0.0",
+        "file-loader": "^5.0.2",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^3.1.0",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.4.1",
+        "less": "^3.10.3",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^10.0.7",
+        "marked": "^0.8.0",
+        "memfs": "^3.0.4",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.1",
+        "standard-version": "^7.1.0",
+        "style-loader": "^1.1.3",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.7.5",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.41.5",
+        "webpack-cli": "^3.3.10"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-e4nWev8YzEVNdOMcNzNeCN947sWJNd43E5XvsJzbAL08kGc2frm1tQ32hTJslRS+H65LCb/AaUCYU7fjHCpDeQ==",
+        "shasum": "f35945036813e57ef582c2420ef7b470e14d3af0",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.3.tgz",
+        "fileCount": 50,
+        "unpackedSize": 521645,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJeOqlnCRA9TVsSAnZWagAAmHQQAJdhKZUQqn47VkiKtQ+H\nz8Q02rFF3wG2W4lKBP4ZpTLnTmJiKgvu5Dg16GU4y2Av8dAr4NAfhEg6x2oI\nsExEJ3OGH9ObkegBoURQOA/yCDkiGj/xWYFryGk+gTKWZITQPmbimDq0UKol\nF9LuLmXi6QrVJ/8QCsVh3+pW6FhCgtScCEfAE/qTpRdlGP2vdzDqSIMbKkBi\nATkWlMNk3IP4Kbn64KU29WAxr+vPRJvF54nhdTUK4BncHchshka/JoCfmBAY\nDOYxcNN+BvpeC6mo76mUNlEgTVFR+ElBNuV23XBMAi2qAAO/YSvlAG8cP/hL\n8NQrCPe1hiIQw8emmxcwt1k8IBAuI/aDEk555nh0qWfNkhQL08NLj+6CGBaS\ni1Inuuwt6AKaQ8aysatQi4TbN2wCBu7AL7H/W0ZPeJqKfEdgJ1aowCNh4hs8\nD0Qati5fNcyqCT0lNKjQiao/fYdf4j3EBvYsKfOmpddxk3hNf+ZG4L7nOsbw\n1u0gZkikEmFxT279sK6GpM2eD5ryeLtceJ9LS9M+Dumc18e4zUuxRsnZfnX2\n0MC174CsoEiZ1ngWiXLxNlnqRG36jYv8BcsGhfoIkKgZyP2AypsbCVqbS+EU\nWGr0UyEmMIvXZD1yFTepiPjsJHNShERyIXl+SNhzYcrUi1k+SAWsw/D93UEL\nNr82\r\n=unCS\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "3.11.0": {
+      "name": "webpack-dev-server",
+      "version": "3.11.0",
+      "dependencies": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.3.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.8",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.26",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.20",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.2",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "^13.3.2"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.8.4",
+        "@babel/core": "^7.9.6",
+        "@babel/plugin-transform-runtime": "^7.9.6",
+        "@babel/preset-env": "^7.9.6",
+        "@babel/runtime": "^7.9.6",
+        "@commitlint/cli": "^8.3.5",
+        "@commitlint/config-conventional": "^8.3.4",
+        "babel-loader": "^8.1.0",
+        "body-parser": "^1.19.0",
+        "commitlint-azure-pipelines-cli": "^1.0.3",
+        "copy-webpack-plugin": "^5.1.1",
+        "css-loader": "^2.1.1",
+        "eslint": "^6.8.0",
+        "eslint-config-prettier": "^6.11.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.20.2",
+        "execa": "^1.0.0",
+        "file-loader": "^5.1.0",
+        "html-loader": "^0.5.5",
+        "html-webpack-plugin": "^3.2.0",
+        "husky": "^4.2.5",
+        "jest": "^24.9.0",
+        "jest-junit": "^10.0.0",
+        "jquery": "^3.5.1",
+        "less": "^3.11.1",
+        "less-loader": "^5.0.0",
+        "lint-staged": "^10.2.2",
+        "marked": "^0.8.2",
+        "memfs": "^3.1.2",
+        "npm-run-all": "^4.1.5",
+        "prettier": "^1.19.1",
+        "puppeteer": "^1.20.0",
+        "rimraf": "^3.0.2",
+        "standard-version": "^8.0.0",
+        "style-loader": "^1.2.1",
+        "supertest": "^4.0.2",
+        "tcp-port-used": "^1.0.1",
+        "typescript": "^3.8.3",
+        "url-loader": "^3.0.0",
+        "webpack": "^4.43.0",
+        "webpack-cli": "^3.3.11"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "dist": {
+        "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
+        "shasum": "8f154a3bce1bcfd1cc618ef4e703278855e7ff8c",
+        "tarball": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
+        "fileCount": 50,
+        "unpackedSize": 529149,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJetXgQCRA9TVsSAnZWagAAHnkP/0cRrVB4Zrk5U+6j3vU/\nLhxbtxMIQ2hE80xbJjAbY2nwR/EOTRb2TvbhY92PmtmUFrfUhS4+3Q4KIf5S\n/pDhnS1l778CG8WErp1Qge34njyu3aAzhdjTN5ZYdwoXn1X2Lsu6dHMDueJ5\nDgRnO2f7yqaBD62m7ltE+YKMFVXqfOtQ+ei8PgUCqPwuNuu57rEbBXb6py7j\nEyvfmvtKyUyjziXnvNJDXtjFdRJ7tpkHl2jzHHA3MqG8D/WujaEoKJMF0URd\nqJfAcoSoaL/isDiDLikTrW2HeudTyrwaEHs2BhOv3fQOfTIhXinp6l5goSxt\nndJ7FJttFikj9lz9uVMZDN78wkIlZpwwPXpD1Sx4Rvt0NiFh/PglJ3jXvOvF\n2/MXD7DZPDWERP+npFtnfqxlWPnGOCGaJBeyQ4kVGRPtelWNL0QkicK1qKaG\ned+s18J4e8zxy/34P5GjkCrqtFGVJEkMwU6L9Rd/pir9iCIQUHMxPoPOlDj3\nIdPnezo5wE0YAoff2cRIiD9BS8TgOCkXv5vPLuxBiDNHsmxgk84LH81E1aRn\nX/c7TfB2eW7u6GjZNCSgMQJwl+IE6yFXXT3LIZHASiaolCOsKZrPuq4WVHo2\nxT7JJ6CESoqm2ZGMxcZygfVkOwlOog43y2s4Uf/dEO2tGYoKCbFQFcaRzY2Y\nztLc\r\n=VywW\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6.11.5"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    }
+  },
+  "modified": "2020-05-08T15:17:38.856Z"
+}

--- a/test/fixtures/registry-mocks/content/webpack-log.json
+++ b/test/fixtures/registry-mocks/content/webpack-log.json
@@ -1,0 +1,937 @@
+{
+  "_id": "webpack-log",
+  "_rev": "18-e3b74c41db192c2a7d3def79e0eadf9d",
+  "name": "webpack-log",
+  "description": "A logger for the Webpack ecosystem",
+  "dist-tags": {
+    "latest": "3.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "webpack-log",
+      "version": "1.0.0",
+      "description": "A common logging module for the Webpack ecosystem",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack-contrib/webpack-log.git"
+      },
+      "author": {
+        "name": "Andrew Powell",
+        "email": "andrew@shellscape.org"
+      },
+      "homepage": "http://github.com/webpack-contrib/webpack-log",
+      "maintainers": [
+        {
+          "name": "Andrew Powell",
+          "email": "andrew@shellscape.org",
+          "url": "shellscape.org"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js test",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "gitHead": "61803b1f37db33e32b798f6e73e019c9de249590",
+      "bugs": {
+        "url": "https://github.com/webpack-contrib/webpack-log/issues"
+      },
+      "_id": "webpack-log@1.0.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-fgsoQ4Tdpz7k/7bAQz3by2RmVr84gg+Oz2iseNJdEupMf9kOjHuyUzzxM7iaW+XKwIVzCpkIZarH9fKBllT4OA==",
+        "shasum": "8325bef8ff3e713c07260b4a2c3a35e2135fd7e5",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.0.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log-1.0.0.tgz_1513576152926_0.8748496437910944"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "webpack-log",
+      "version": "1.0.1",
+      "description": "A common logging module for the Webpack ecosystem",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack-contrib/webpack-log.git"
+      },
+      "author": {
+        "name": "Andrew Powell",
+        "email": "andrew@shellscape.org"
+      },
+      "homepage": "http://github.com/webpack-contrib/webpack-log",
+      "maintainers": [
+        {
+          "name": "bebraw",
+          "email": "bebraw@gmail.com"
+        },
+        {
+          "name": "d3viant0ne",
+          "email": "wiens.joshua@gmail.com"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js test",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "gitHead": "113e94c8d434f3fca0c898dd17487c0455b20bfa",
+      "bugs": {
+        "url": "https://github.com/webpack-contrib/webpack-log/issues"
+      },
+      "_id": "webpack-log@1.0.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-7EgLQB5DhM5S2JXBkKAXpycJIAPM25NDEegOnsQbnDWTH+2F9eLn1NZzrHSCmB7e/SwXBEE5xnM0T3lNxF2uGA==",
+        "shasum": "1f5818b5c20aaa81583cac76b6ba2e34e9f6a486",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.0.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log-1.0.1.tgz_1513613911239_0.15471291169524193"
+      },
+      "directories": {}
+    },
+    "1.0.2": {
+      "name": "webpack-log",
+      "version": "1.0.2",
+      "description": "A common logging module for the Webpack ecosystem",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack-contrib/webpack-log.git"
+      },
+      "author": {
+        "name": "Andrew Powell",
+        "email": "andrew@shellscape.org"
+      },
+      "homepage": "http://github.com/webpack-contrib/webpack-log",
+      "maintainers": [
+        {
+          "name": "bebraw",
+          "email": "bebraw@gmail.com"
+        },
+        {
+          "name": "d3viant0ne",
+          "email": "wiens.joshua@gmail.com"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js test",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "gitHead": "99d515edd044e0423fa2fc90a1c31855c7429d54",
+      "bugs": {
+        "url": "https://github.com/webpack-contrib/webpack-log/issues"
+      },
+      "_id": "webpack-log@1.0.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-IQUfem3xNSwumQb9lIit/erI/NgjQ+ueAFhOoA0+w3MH15ZgyVZMDMs9kDGSRgcVWH5v3pcDabbF5ArQ41RrNQ==",
+        "shasum": "880298b80ff81a4e30baa6e28dc44f4637b4bbf1",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.0.2.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log-1.0.2.tgz_1513663262401_0.24997188313864172"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "webpack-log",
+      "version": "1.1.0",
+      "description": "A common logging module for the Webpack ecosystem",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack-contrib/webpack-log.git"
+      },
+      "author": {
+        "name": "Andrew Powell",
+        "email": "andrew@shellscape.org"
+      },
+      "homepage": "http://github.com/webpack-contrib/webpack-log",
+      "maintainers": [
+        {
+          "name": "bebraw",
+          "email": "bebraw@gmail.com"
+        },
+        {
+          "name": "d3viant0ne",
+          "email": "wiens.joshua@gmail.com"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js test",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "gitHead": "6972d0b7c79796d68c2d0475d85fdbef37096e80",
+      "bugs": {
+        "url": "https://github.com/webpack-contrib/webpack-log/issues"
+      },
+      "_id": "webpack-log@1.1.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-2//tYK+vKiTaOcRd4JJ6nVLJTbOEQKmgp5SEQC1Bt7ghJtOIt9b7xHr8UuAYBNOXgOLkM3QJpXVwoVkOlgF7jA==",
+        "shasum": "fc17ce3aba349130d09464ee31d04686e8023f6a",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.1.0.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log-1.1.0.tgz_1513966754242_0.05544974305666983"
+      },
+      "directories": {}
+    },
+    "1.1.1": {
+      "name": "webpack-log",
+      "version": "1.1.1",
+      "description": "A common logging module for the Webpack ecosystem",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack-contrib/webpack-log.git"
+      },
+      "author": {
+        "name": "Andrew Powell",
+        "email": "andrew@shellscape.org"
+      },
+      "homepage": "http://github.com/webpack-contrib/webpack-log",
+      "maintainers": [
+        {
+          "name": "bebraw",
+          "email": "bebraw@gmail.com"
+        },
+        {
+          "name": "d3viant0ne",
+          "email": "wiens.joshua@gmail.com"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js test",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "gitHead": "1acd8d198982f63302f7c8d7640e50d1efa67ea6",
+      "bugs": {
+        "url": "https://github.com/webpack-contrib/webpack-log/issues"
+      },
+      "_id": "webpack-log@1.1.1",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-9AeZ12uxaS+DGpcIInWxNuoJMW2JbAc45bkn3fhWcdl4wK36MAq/yiyiITt5IS0TaZWjtLIWxwULCuT9V7/xoA==",
+        "shasum": "a0c7beb385245da7b2172afe46c02cf3a471ef31",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.1.1.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log-1.1.1.tgz_1515331696703_0.302024363540113"
+      },
+      "directories": {}
+    },
+    "1.1.2": {
+      "name": "webpack-log",
+      "version": "1.1.2",
+      "description": "A common logging module for the Webpack ecosystem",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack-contrib/webpack-log.git"
+      },
+      "author": {
+        "name": "Andrew Powell",
+        "email": "andrew@shellscape.org"
+      },
+      "homepage": "http://github.com/webpack-contrib/webpack-log",
+      "maintainers": [
+        {
+          "name": "bebraw",
+          "email": "bebraw@gmail.com"
+        },
+        {
+          "name": "d3viant0ne",
+          "email": "wiens.joshua@gmail.com"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js test",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "gitHead": "be4a381ec7103cd0ad850bdfd7e5a2e7972c77dd",
+      "bugs": {
+        "url": "https://github.com/webpack-contrib/webpack-log/issues"
+      },
+      "_id": "webpack-log@1.1.2",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-B53SD4N4BHpZdUwZcj4st2QT7gVfqZtqHDruC1N+K2sciq0Rt/3F1Dx6RlylVkcrToMLTaiaeT48k9Lq4iDVDA==",
+        "shasum": "cdc76016537eed24708dc6aa3d1e52189efee107",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.1.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7283
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log_1.1.2_1518195148983_0.24370942076791202"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.2.0": {
+      "name": "webpack-log",
+      "version": "1.2.0",
+      "description": "A common logging module for the Webpack ecosystem",
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack-contrib/webpack-log.git"
+      },
+      "author": {
+        "name": "Andrew Powell",
+        "email": "andrew@shellscape.org"
+      },
+      "homepage": "http://github.com/webpack-contrib/webpack-log",
+      "maintainers": [
+        {
+          "name": "bebraw",
+          "email": "bebraw@gmail.com"
+        },
+        {
+          "name": "d3viant0ne",
+          "email": "wiens.joshua@gmail.com"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        }
+      ],
+      "main": "index.js",
+      "engines": {
+        "node": ">=6"
+      },
+      "scripts": {
+        "beautify": "npm run lint -- --fix",
+        "ci": "npm run cover -- --report lcovonly && npm run test",
+        "cover": "istanbul cover node_modules/mocha/bin/_mocha",
+        "lint": "eslint index.js test",
+        "mocha": "mocha --full-trace --check-leaks",
+        "test": "npm run lint && npm run mocha"
+      },
+      "files": [
+        "index.js"
+      ],
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "gitHead": "9e215a07efa0a0a069b27c30291652241c0f4c82",
+      "bugs": {
+        "url": "https://github.com/webpack-contrib/webpack-log/issues"
+      },
+      "_id": "webpack-log@1.2.0",
+      "_npmVersion": "5.8.0",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "dist": {
+        "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
+        "shasum": "a4b34cda6b22b518dbb0ab32e567962d5c72a43d",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7589
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log_1.2.0_1522949930569_0.09172597649872105"
+      },
+      "_hasShrinkwrap": false
+    },
+    "2.0.0": {
+      "name": "webpack-log",
+      "version": "2.0.0",
+      "description": "A common logger for the webpack ecosystem",
+      "main": "src/index.js",
+      "files": [
+        "src"
+      ],
+      "engines": {
+        "node": ">= 6"
+      },
+      "scripts": {
+        "lint": "eslint src test",
+        "test": "nyc --reporter lcovonly mocha --full-trace --check-leaks",
+        "release": "standard-version"
+      },
+      "dependencies": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "author": {
+        "name": "Andrew Powell",
+        "email": "andrew@shellscape.org"
+      },
+      "issues": "https://github.com/webpack-contrib/webpack-log/issues",
+      "homepage": "https://github.com/webpack-contrib/webpack-log#readme",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/webpack-contrib/webpack-log.git"
+      },
+      "license": "MIT",
+      "gitHead": "72c77ea020425e6aeec956db01b8e500ed80ca1b",
+      "bugs": {
+        "url": "https://github.com/webpack-contrib/webpack-log/issues"
+      },
+      "_id": "webpack-log@2.0.0",
+      "_npmVersion": "6.4.0",
+      "_nodeVersion": "10.9.0",
+      "_npmUser": {
+        "name": "michael-ciniawsky",
+        "email": "michael.ciniawsky@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+        "shasum": "5b7928e0637593f119d32f6227c1e0ac31e1b47f",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 15708,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfuXiCRA9TVsSAnZWagAACJwQAJEIjdDQi2uXld+6gZZT\n6J7QMyswVA0P6r8WEgbUaG74o0BS9kJETHiEiAV5dR8KhmdGO3m08A9T+N8V\nHcKNoGr4QdEhxSiXTJWK0EPwpGFSTWScv40WeQt7Y/DqC6sjvQ3o2zUan2vq\n7fK3ei29rnH+U3obY6pTVGX5kaeik2HS3mF7PDDt1LHEGZotePoN7r/YGEVw\nY5irVs7eKa15ivT86T8AvR6V9r6YxUW04y8jaEwQcdtskyu3jPX6DttCkYDq\nzSgzJhVwLV0/6GdnSr4p8f5Xz99l3vT4d67MlpXoZa/XhsP2OGbzshxYoIcT\nPUHPR89FryStTEms1KYWF9hkOpI66lb3SnM/OG3iEYfGwk08gDw+et8e/pni\nz+eik5IsBSMVh2mIoUjLXEBXncDjRaVRRqtZQO5D/f1AchJJLMmt/inBHIVC\n4cITHt/iX1oK64BU6hf954GbTc/2rhh2OZabYW7BhBBykUdXN61hdu9suNpe\na/D39sXrLa26+oe3rPuQK4abekqfTRBMsqsP9Vk/SvPWaba494cE61GL29ZV\ncoN5ov2GFGOwWbDFYNzOx0Fn4TygvR0bILNwnx/xsh2/CP7f9kvIR2ct1jvW\n6x0sCbGOO0OD7+owzxhpdgBchqpLnS5YpK/zl84hP3SqK3do/V0v2bwq6wrN\nAeiE\r\n=8lsh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "bebraw",
+          "email": "bebraw@gmail.com"
+        },
+        {
+          "name": "d3viant0ne",
+          "email": "wiens.joshua@gmail.com"
+        },
+        {
+          "name": "shellscape",
+          "email": "andrew@shellscape.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log_2.0.0_1535043041935_0.6962136441284803"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.0": {
+      "name": "webpack-log",
+      "version": "3.0.0",
+      "description": "A Development Server in a Webpack Plugin",
+      "license": "MPL-2.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/shellscape/webpack-log.git"
+      },
+      "author": {
+        "name": "shellscape"
+      },
+      "homepage": "https://github.com/shellscape/webpack-log",
+      "bugs": {
+        "url": "https://github.com/shellscape/webpack-log/issues"
+      },
+      "bin": "",
+      "main": "lib/index.js",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "scripts": {
+        "ci:coverage": "nyc npm run test && nyc report --reporter=text-lcov > coverage.lcov",
+        "ci:lint": "npm run lint && npm run security",
+        "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
+        "ci:test": "npm run test -- --verbose",
+        "commitlint": "commitlint",
+        "commitmsg": "commitlint -e $GIT_PARAMS",
+        "lint": "eslint --fix --cache lib test",
+        "lint-staged": "lint-staged",
+        "security": "npm audit",
+        "test": "ava"
+      },
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "loglevelnext": "^3.0.1",
+        "nanoid": "^2.0.3"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "ava": "^2.2.0",
+        "cpy": "^7.0.1",
+        "eslint": "^6.0.1",
+        "eslint-config-shellscape": "^2.0.2",
+        "lint-staged": "^9.2.0",
+        "nyc": "^14.1.1",
+        "pre-commit": "^1.2.2",
+        "prettier": "^1.14.3",
+        "sinon": "^7.3.2",
+        "standard-version": "^7.0.0"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "console",
+        "terminal",
+        "webpack"
+      ],
+      "ava": {
+        "files": [
+          "!**/fixtures/**",
+          "!**/helpers/**",
+          "!**/recipes/**"
+        ]
+      },
+      "lint-staged": {
+        "*.js": [
+          "eslint --fix",
+          "git add"
+        ]
+      },
+      "nyc": {
+        "include": [
+          "lib/**/*.js"
+        ],
+        "exclude": [
+          "lib/client*.js",
+          "test/"
+        ]
+      },
+      "pre-commit": "lint-staged",
+      "gitHead": "b3f88a0cd7a4c370289ba04f91d22684dc6eb9b8",
+      "_id": "webpack-log@3.0.0",
+      "_nodeVersion": "12.3.1",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-Ewl+ZCAa33zIcfqq6wd1EJn+fTjxMnCyHUUMe72TzzOG4P8oZblmCrJzl6N6CEb9qz8fAKB3aUpC1xYTdQommA==",
+        "shasum": "ab46af6a67dc5d41b9720eeba8ba15336fa53cde",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-3.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 23217,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdQyp/CRA9TVsSAnZWagAA8BEP/2yvzSN/JNXAk8fL6Jjc\nXpWBb2bNffr+5F6yOrw0dcZJl4ZDszHJjG21ZLNQOMLCZvfR7C15Ffm66Vpf\nTS63LJN6QOYjwKIwMIElBozH/GuQMw90NfnkzDMr2zhz4oZT6mfbfrgdO9Tx\nW1OOX8RWz1IDBMMcgVYGeK8tD9W2wsW2L6q6b/fM6Cc/JjQ7qiMG3kvEFNZd\nV64/tYheVU8/1avz6oJWMxfO5jJoJVPBsGeIUlePvK2Syr5APVNK91meHbXf\ne0wFwKQAzLfgvjfUql5JEmRMNiOmGo8AGrcZ8QpehMuCtk+mb0ceaeGkOvhn\n0gwe/1uR2jegsWzsEhU0xDpHaODzkZXFAwM6t8gBw9g99h0lhqoHuaHWE+Sk\n/PnWB6xeL/jeQ1Pvvpsb5A7C2Kl1neqx0Bra6N4PWo5F27YkH1Kz7fzrGOnA\nndWgMemjt1u72/JsWpuGdwnMvF7a9pz+q7aKHVLMdWM9Yq8B9AQf7+58mIRc\no1jrTmqZjSLACyA8JIbJMYesYVYdz2ICFZDYhYNfL0K6oyraaxpNAUoqre27\nVPA3E65cTpKGVEQjbv0BN4aMkWfudwWjdm5/YRVsAEukfrpzDoEXQFvIvG6u\ngPQMsX87LPH3/zxRCl/jHIdGq+aTeOGqfVo3crlfDrSY/SuU5T2Yl3hLNgoE\nker4\r\n=vnVl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        }
+      ],
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log_3.0.0_1564682879003_0.8357037719333116"
+      },
+      "_hasShrinkwrap": false
+    },
+    "3.0.1": {
+      "name": "webpack-log",
+      "version": "3.0.1",
+      "description": "A logger for the Webpack ecosystem",
+      "license": "MPL-2.0",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/shellscape/webpack-log.git"
+      },
+      "author": {
+        "name": "shellscape"
+      },
+      "homepage": "https://github.com/shellscape/webpack-log",
+      "bugs": {
+        "url": "https://github.com/shellscape/webpack-log/issues"
+      },
+      "bin": "",
+      "main": "lib/index.js",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "scripts": {
+        "ci:coverage": "nyc npm run test && nyc report --reporter=text-lcov > coverage.lcov",
+        "ci:lint": "npm run lint && npm run security",
+        "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
+        "ci:test": "npm run test -- --verbose",
+        "commitlint": "commitlint",
+        "commitmsg": "commitlint -e $GIT_PARAMS",
+        "lint": "eslint --fix --cache lib test",
+        "lint-staged": "lint-staged",
+        "security": "npm audit",
+        "test": "ava"
+      },
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "loglevelnext": "^3.0.1",
+        "nanoid": "^2.0.3"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "ava": "^2.2.0",
+        "cpy": "^7.0.1",
+        "eslint": "^6.0.1",
+        "eslint-config-shellscape": "^2.0.2",
+        "lint-staged": "^9.2.0",
+        "nyc": "^14.1.1",
+        "pre-commit": "^1.2.2",
+        "prettier": "^1.14.3",
+        "sinon": "^7.3.2",
+        "standard-version": "^7.0.0"
+      },
+      "keywords": [
+        "log",
+        "logger",
+        "logging",
+        "console",
+        "terminal",
+        "webpack"
+      ],
+      "ava": {
+        "files": [
+          "!**/fixtures/**",
+          "!**/helpers/**",
+          "!**/recipes/**"
+        ]
+      },
+      "lint-staged": {
+        "*.js": [
+          "eslint --fix",
+          "git add"
+        ]
+      },
+      "nyc": {
+        "include": [
+          "lib/**/*.js"
+        ],
+        "exclude": [
+          "lib/client*.js",
+          "test/"
+        ]
+      },
+      "pre-commit": "lint-staged",
+      "gitHead": "7f4464c0ba4f681a94fbcb4de87875210e5415bb",
+      "_id": "webpack-log@3.0.1",
+      "_nodeVersion": "12.3.1",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-mX/6BJPPpxco6BGCFZJ96NjgnwBrLQx6d7Kxe1PaJ7KvjI3LFmJK9QgRPCAr9tXrPVawPN1cuM8hJ2Vadnwm+Q==",
+        "shasum": "647c42231b6f74d7cc3c3a66510370e635d066ea",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-3.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 23211,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdQzEFCRA9TVsSAnZWagAAoawP/1ovQnkDOz0mz+NBo7MW\nybpv6GqJ6BD+3i36kQsMK/nnz/gQcudU5D1JIVZr+eTmegVpn+xLVe4pXF97\nypJfnHO9R9DODoeHQU3Nk6arsm9vvlUuEQwlCR3E7LGwsGjov4ycEaY3Efsy\nsHoXiVFfkEdHb1p6ZUwBigbsW8SjC02fPyCEISEefP/2qfuDIsbBsYbr8E/5\nsn2CliAlfBbibuhgQfhGDgSh17KX7PGKNE1qVg4p9m4r8OHy6QLdfhbtQK3x\nIecFOzqioC+FRvxhP1VarNTgsD54y7jTf4lz3GijtzlvkTcqAkcoJn+8Pjev\nmOQosVYqN2ybE6YfJbtsyxPVutW8w9hFZE0xGkwvy3Etx4RHtqWsEcp7fEc4\nqnNLhz3/qvT1Lg9XPokxh2m0oxqXM2xABCw/QH5Tl93cQwvpzL7bqd4ccGtf\ni0JsnpEYub+dsu8kVSE7pU84KJwss9cAxPYO/jjzjKY1fec9EZ+dJBvcG0OZ\n8xqIKOQUjnYyo+2tKuMHzq+VIclGfLxyZYDdYoQCNgWERgpmnjnrts0NsMYU\nlcBT5e5aqtS0OLA+A6aioH19TuY7sDn6DTG2KGFk0IsjszxmlDIYWALQjn0x\nWILd+H9phQLHbil+yFovex501VCIcd22Ndu/PzM4rKwnJfFRpKkTnc/piUWp\nRaK5\r\n=kPem\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "email": "wiens.joshua@gmail.com",
+          "name": "d3viant0ne"
+        },
+        {
+          "email": "andrew@shellscape.org",
+          "name": "shellscape"
+        }
+      ],
+      "_npmUser": {
+        "name": "shellscape",
+        "email": "andrew@shellscape.org"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/webpack-log_3.0.1_1564684548566_0.14153951681926746"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "[tests]: \thttps://img.shields.io/circleci/project/github/shellscape/webpack-log.svg\n[tests-url]: https://circleci.com/gh/shellscape/webpack-log\n\n[cover]: https://codecov.io/gh/shellscape/webpack-log/branch/master/graph/badge.svg\n[cover-url]: https://codecov.io/gh/shellscape/webpack-log\n\n[size]: https://packagephobia.now.sh/badge?p=webpack-log\n[size-url]: https://packagephobia.now.sh/result?p=webpack-log\n\n<div align=\"center\">\n\t<img width=\"180\" src=\"https://raw.githubusercontent.com/shellscape/webpack-log/master/assets/log.svg?sanitize=true\" alt=\"webpack-log\"><br/><br/>\n</div>\n\n[![tests][tests]][tests-url]\n[![cover][cover]][cover-url]\n[![size][size]][size-url]\n[![libera manifesto](https://img.shields.io/badge/libera-manifesto-lightgrey.svg)](https://liberamanifesto.com)\n\n# webpack-log\n\nA logger for the Webpack ecosystem.\n\n<a href=\"https://www.patreon.com/shellscape\">\n  <img src=\"https://c5.patreon.com/external/logo/become_a_patron_button@2x.png\" width=\"160\">\n</a>\n\n_Please consider donating if you find this project useful._\n\n## Requirements\n\nThis module requires an [LTS](https://github.com/nodejs/Release) Node version (v8.0.0+).\n\n## Install\n\nUsing npm:\n\n```console\nnpm install webpack-log --save-dev\n```\n\n## Usage\n\nCreate a new logger and use it to log something wild:\n\n```js\nconst getLogger = require('webpack-log');\nconst log = getLogger({ name: 'webpack-batman' });\n\nlog.info('Jingle Bells, Batman Smells');\nlog.warn('Robin laid an egg');\nlog.error('The Batmobile lost a wheel');\nlog.debug('And the Joker got away');\n```\n\nAnd there will appear magic in your console:\n\n<div align=\"center\">\n\t<img width=\"369\" src=\"assets/demo.png\" alt=\"console magic\"><br/><br/>\n</div>\n\n## Options\n\n### `level`\nType: `String`<br>\nDefault: `info`\n\nSpecifies the level the logger should use. A logger will not produce output for\nany log level _beneath_ the specified level. Valid level names, and their order are:\n\n```js\n[\n  'trace',\n  'debug',\n  'info',\n  'warn',\n  'error',\n  'silent'\n]\n```\n\nFor example, If a level was passed as `{ level: 'warn'}` then only calls to `warn` and `error` will be displayed in the terminal.\n\n### `name`\nType: `String`<br>\nDefault: `<webpack-log>`\n\nSpecifies the name of the logger to create. This value will be part of the log output prefix.\n\n### `timestamp`\nType: `Boolean`<br>\nDefault: `false`\n\nIf `true`, the logger will display a timestamp for log output, preceding all other data\n\n### `unique`\nType: `Boolean`<br>\nDefault: `true`\n\nIf `false`, the logger will use cached versions of a log with the same name. Due to the nature of the `webpack` ecosystem and multiple plugin/loader use in the same process, loggers are created as unique instances by default.\n\n## Meta\n\n[CONTRIBUTING](./.github/CONTRIBUTING.md)\n\n[LICENSE (Mozilla Public License)](./LICENSE)\n",
+  "maintainers": [
+    {
+      "name": "shellscape",
+      "email": "andrew@shellscape.org"
+    }
+  ],
+  "time": {
+    "modified": "2019-08-08T17:42:24.924Z",
+    "created": "2017-12-18T05:49:13.840Z",
+    "1.0.0": "2017-12-18T05:49:13.840Z",
+    "1.0.1": "2017-12-18T16:18:32.148Z",
+    "1.0.2": "2017-12-19T06:01:03.571Z",
+    "1.1.0": "2017-12-22T18:19:15.459Z",
+    "1.1.1": "2018-01-07T13:28:17.605Z",
+    "1.1.2": "2018-02-09T16:52:29.673Z",
+    "1.2.0": "2018-04-05T17:38:50.708Z",
+    "2.0.0": "2018-08-23T16:50:42.006Z",
+    "3.0.0": "2019-08-01T18:07:59.126Z",
+    "3.0.1": "2019-08-01T18:35:48.690Z"
+  },
+  "homepage": "https://github.com/shellscape/webpack-log",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shellscape/webpack-log.git"
+  },
+  "author": {
+    "name": "shellscape"
+  },
+  "bugs": {
+    "url": "https://github.com/shellscape/webpack-log/issues"
+  },
+  "license": "MPL-2.0",
+  "readmeFilename": "README.md",
+  "keywords": [
+    "log",
+    "logger",
+    "logging",
+    "console",
+    "terminal",
+    "webpack"
+  ]
+}

--- a/test/fixtures/registry-mocks/content/webpack-log.min.json
+++ b/test/fixtures/registry-mocks/content/webpack-log.min.json
@@ -1,0 +1,311 @@
+{
+  "name": "webpack-log",
+  "dist-tags": {
+    "latest": "3.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "webpack-log",
+      "version": "1.0.0",
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-fgsoQ4Tdpz7k/7bAQz3by2RmVr84gg+Oz2iseNJdEupMf9kOjHuyUzzxM7iaW+XKwIVzCpkIZarH9fKBllT4OA==",
+        "shasum": "8325bef8ff3e713c07260b4a2c3a35e2135fd7e5",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.0.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "1.0.1": {
+      "name": "webpack-log",
+      "version": "1.0.1",
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-7EgLQB5DhM5S2JXBkKAXpycJIAPM25NDEegOnsQbnDWTH+2F9eLn1NZzrHSCmB7e/SwXBEE5xnM0T3lNxF2uGA==",
+        "shasum": "1f5818b5c20aaa81583cac76b6ba2e34e9f6a486",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.0.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "1.0.2": {
+      "name": "webpack-log",
+      "version": "1.0.2",
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-IQUfem3xNSwumQb9lIit/erI/NgjQ+ueAFhOoA0+w3MH15ZgyVZMDMs9kDGSRgcVWH5v3pcDabbF5ArQ41RrNQ==",
+        "shasum": "880298b80ff81a4e30baa6e28dc44f4637b4bbf1",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.0.2.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "1.1.0": {
+      "name": "webpack-log",
+      "version": "1.1.0",
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-2//tYK+vKiTaOcRd4JJ6nVLJTbOEQKmgp5SEQC1Bt7ghJtOIt9b7xHr8UuAYBNOXgOLkM3QJpXVwoVkOlgF7jA==",
+        "shasum": "fc17ce3aba349130d09464ee31d04686e8023f6a",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "1.1.1": {
+      "name": "webpack-log",
+      "version": "1.1.1",
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-9AeZ12uxaS+DGpcIInWxNuoJMW2JbAc45bkn3fhWcdl4wK36MAq/yiyiITt5IS0TaZWjtLIWxwULCuT9V7/xoA==",
+        "shasum": "a0c7beb385245da7b2172afe46c02cf3a471ef31",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "1.1.2": {
+      "name": "webpack-log",
+      "version": "1.1.2",
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-B53SD4N4BHpZdUwZcj4st2QT7gVfqZtqHDruC1N+K2sciq0Rt/3F1Dx6RlylVkcrToMLTaiaeT48k9Lq4iDVDA==",
+        "shasum": "cdc76016537eed24708dc6aa3d1e52189efee107",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.1.2.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7283
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "1.2.0": {
+      "name": "webpack-log",
+      "version": "1.2.0",
+      "dependencies": {
+        "chalk": "^2.1.0",
+        "log-symbols": "^2.1.0",
+        "loglevelnext": "^1.0.1",
+        "uuid": "^3.1.0"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "codecov.io": "^0.1.6",
+        "eslint": "^4.5.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.7.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^4.0.0",
+        "sinon": "^4.0.1",
+        "strip-ansi": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
+        "shasum": "a4b34cda6b22b518dbb0ab32e567962d5c72a43d",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 7589
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "2.0.0": {
+      "name": "webpack-log",
+      "version": "2.0.0",
+      "dependencies": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
+      },
+      "devDependencies": {
+        "assert": "^1.4.1",
+        "eslint": "^5.4.0",
+        "eslint-config-webpack": "^1.2.5",
+        "eslint-plugin-import": "^2.14.0",
+        "mocha": "^5.2.0",
+        "nyc": "^12.0.2",
+        "sinon": "^6.1.5",
+        "standard-version": "^4.4.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+        "shasum": "5b7928e0637593f119d32f6227c1e0ac31e1b47f",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+        "fileCount": 9,
+        "unpackedSize": 15708,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbfuXiCRA9TVsSAnZWagAACJwQAJEIjdDQi2uXld+6gZZT\n6J7QMyswVA0P6r8WEgbUaG74o0BS9kJETHiEiAV5dR8KhmdGO3m08A9T+N8V\nHcKNoGr4QdEhxSiXTJWK0EPwpGFSTWScv40WeQt7Y/DqC6sjvQ3o2zUan2vq\n7fK3ei29rnH+U3obY6pTVGX5kaeik2HS3mF7PDDt1LHEGZotePoN7r/YGEVw\nY5irVs7eKa15ivT86T8AvR6V9r6YxUW04y8jaEwQcdtskyu3jPX6DttCkYDq\nzSgzJhVwLV0/6GdnSr4p8f5Xz99l3vT4d67MlpXoZa/XhsP2OGbzshxYoIcT\nPUHPR89FryStTEms1KYWF9hkOpI66lb3SnM/OG3iEYfGwk08gDw+et8e/pni\nz+eik5IsBSMVh2mIoUjLXEBXncDjRaVRRqtZQO5D/f1AchJJLMmt/inBHIVC\n4cITHt/iX1oK64BU6hf954GbTc/2rhh2OZabYW7BhBBykUdXN61hdu9suNpe\na/D39sXrLa26+oe3rPuQK4abekqfTRBMsqsP9Vk/SvPWaba494cE61GL29ZV\ncoN5ov2GFGOwWbDFYNzOx0Fn4TygvR0bILNwnx/xsh2/CP7f9kvIR2ct1jvW\n6x0sCbGOO0OD7+owzxhpdgBchqpLnS5YpK/zl84hP3SqK3do/V0v2bwq6wrN\nAeiE\r\n=8lsh\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "3.0.0": {
+      "name": "webpack-log",
+      "version": "3.0.0",
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "loglevelnext": "^3.0.1",
+        "nanoid": "^2.0.3"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "ava": "^2.2.0",
+        "cpy": "^7.0.1",
+        "eslint": "^6.0.1",
+        "eslint-config-shellscape": "^2.0.2",
+        "lint-staged": "^9.2.0",
+        "nyc": "^14.1.1",
+        "pre-commit": "^1.2.2",
+        "prettier": "^1.14.3",
+        "sinon": "^7.3.2",
+        "standard-version": "^7.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-Ewl+ZCAa33zIcfqq6wd1EJn+fTjxMnCyHUUMe72TzzOG4P8oZblmCrJzl6N6CEb9qz8fAKB3aUpC1xYTdQommA==",
+        "shasum": "ab46af6a67dc5d41b9720eeba8ba15336fa53cde",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-3.0.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 23217,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdQyp/CRA9TVsSAnZWagAA8BEP/2yvzSN/JNXAk8fL6Jjc\nXpWBb2bNffr+5F6yOrw0dcZJl4ZDszHJjG21ZLNQOMLCZvfR7C15Ffm66Vpf\nTS63LJN6QOYjwKIwMIElBozH/GuQMw90NfnkzDMr2zhz4oZT6mfbfrgdO9Tx\nW1OOX8RWz1IDBMMcgVYGeK8tD9W2wsW2L6q6b/fM6Cc/JjQ7qiMG3kvEFNZd\nV64/tYheVU8/1avz6oJWMxfO5jJoJVPBsGeIUlePvK2Syr5APVNK91meHbXf\ne0wFwKQAzLfgvjfUql5JEmRMNiOmGo8AGrcZ8QpehMuCtk+mb0ceaeGkOvhn\n0gwe/1uR2jegsWzsEhU0xDpHaODzkZXFAwM6t8gBw9g99h0lhqoHuaHWE+Sk\n/PnWB6xeL/jeQ1Pvvpsb5A7C2Kl1neqx0Bra6N4PWo5F27YkH1Kz7fzrGOnA\nndWgMemjt1u72/JsWpuGdwnMvF7a9pz+q7aKHVLMdWM9Yq8B9AQf7+58mIRc\no1jrTmqZjSLACyA8JIbJMYesYVYdz2ICFZDYhYNfL0K6oyraaxpNAUoqre27\nVPA3E65cTpKGVEQjbv0BN4aMkWfudwWjdm5/YRVsAEukfrpzDoEXQFvIvG6u\ngPQMsX87LPH3/zxRCl/jHIdGq+aTeOGqfVo3crlfDrSY/SuU5T2Yl3hLNgoE\nker4\r\n=vnVl\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "3.0.1": {
+      "name": "webpack-log",
+      "version": "3.0.1",
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "loglevelnext": "^3.0.1",
+        "nanoid": "^2.0.3"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^8.1.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "ava": "^2.2.0",
+        "cpy": "^7.0.1",
+        "eslint": "^6.0.1",
+        "eslint-config-shellscape": "^2.0.2",
+        "lint-staged": "^9.2.0",
+        "nyc": "^14.1.1",
+        "pre-commit": "^1.2.2",
+        "prettier": "^1.14.3",
+        "sinon": "^7.3.2",
+        "standard-version": "^7.0.0"
+      },
+      "dist": {
+        "integrity": "sha512-mX/6BJPPpxco6BGCFZJ96NjgnwBrLQx6d7Kxe1PaJ7KvjI3LFmJK9QgRPCAr9tXrPVawPN1cuM8hJ2Vadnwm+Q==",
+        "shasum": "647c42231b6f74d7cc3c3a66510370e635d066ea",
+        "tarball": "https://registry.npmjs.org/webpack-log/-/webpack-log-3.0.1.tgz",
+        "fileCount": 4,
+        "unpackedSize": 23211,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdQzEFCRA9TVsSAnZWagAAoawP/1ovQnkDOz0mz+NBo7MW\nybpv6GqJ6BD+3i36kQsMK/nnz/gQcudU5D1JIVZr+eTmegVpn+xLVe4pXF97\nypJfnHO9R9DODoeHQU3Nk6arsm9vvlUuEQwlCR3E7LGwsGjov4ycEaY3Efsy\nsHoXiVFfkEdHb1p6ZUwBigbsW8SjC02fPyCEISEefP/2qfuDIsbBsYbr8E/5\nsn2CliAlfBbibuhgQfhGDgSh17KX7PGKNE1qVg4p9m4r8OHy6QLdfhbtQK3x\nIecFOzqioC+FRvxhP1VarNTgsD54y7jTf4lz3GijtzlvkTcqAkcoJn+8Pjev\nmOQosVYqN2ybE6YfJbtsyxPVutW8w9hFZE0xGkwvy3Etx4RHtqWsEcp7fEc4\nqnNLhz3/qvT1Lg9XPokxh2m0oxqXM2xABCw/QH5Tl93cQwvpzL7bqd4ccGtf\ni0JsnpEYub+dsu8kVSE7pU84KJwss9cAxPYO/jjzjKY1fec9EZ+dJBvcG0OZ\n8xqIKOQUjnYyo+2tKuMHzq+VIclGfLxyZYDdYoQCNgWERgpmnjnrts0NsMYU\nlcBT5e5aqtS0OLA+A6aioH19TuY7sDn6DTG2KGFk0IsjszxmlDIYWALQjn0x\nWILd+H9phQLHbil+yFovex501VCIcd22Ndu/PzM4rKwnJfFRpKkTnc/piUWp\nRaK5\r\n=kPem\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    }
+  },
+  "modified": "2019-08-08T17:42:24.924Z"
+}

--- a/test/fixtures/registry-mocks/content/websocket-driver.json
+++ b/test/fixtures/registry-mocks/content/websocket-driver.json
@@ -1,0 +1,1590 @@
+{
+  "_id": "websocket-driver",
+  "_rev": "51-8934fe5ce187af0af30e9d7c3605a357",
+  "name": "websocket-driver",
+  "description": "WebSocket protocol handler with pluggable I/O",
+  "dist-tags": {
+    "latest": "0.7.4"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": "http://github.com/faye/websocket-driver-node/issues",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/websocket-driver-node.git"
+        }
+      ],
+      "_id": "websocket-driver@0.1.0",
+      "dist": {
+        "shasum": "14bdc1f671d8df4311cd29b92162786b396e893e",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "version": "0.2.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": "http://github.com/faye/websocket-driver-node/issues",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/websocket-driver-node.git"
+        }
+      ],
+      "_id": "websocket-driver@0.2.0",
+      "dist": {
+        "shasum": "d344ae28f46b411d0ecb5088f10bec6ace721920",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "version": "0.2.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "scripts": {
+        "test": "node spec/runner.js"
+      },
+      "bugs": "http://github.com/faye/websocket-driver-node/issues",
+      "licenses": [
+        {
+          "type": "MIT",
+          "url": "http://www.opensource.org/licenses/mit-license.php"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/faye/websocket-driver-node.git"
+        }
+      ],
+      "_id": "websocket-driver@0.2.1",
+      "dist": {
+        "shasum": "666622a997665e21268a89b30c05b7b739e9afa7",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.18",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.2": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.2.2",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "_id": "websocket-driver@0.2.2",
+      "dist": {
+        "shasum": "998bc1855d8cd0d1e9aa8f8056b83b46ac3e81ef",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.2.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.32",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.3.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "_id": "websocket-driver@0.3.0",
+      "dist": {
+        "shasum": "497b258c508b987249ab9b6f79f0c21dd3467c64",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.3.1",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "_id": "websocket-driver@0.3.1",
+      "dist": {
+        "shasum": "25f86b4e7ca9d8f8136cd225ffcee71a3d2869cf",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.14",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.2": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.3.2",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "_id": "websocket-driver@0.3.2",
+      "dist": {
+        "shasum": "f177ef6611390e2401ae47f35e8386dda987daca",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.2.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.21",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.3": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.3.3",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "_id": "websocket-driver@0.3.3",
+      "dist": {
+        "shasum": "11a8986d26bd81a684048a21b18c0f2ef292ef06",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.3.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.4.3",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.4": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.3.4",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "_id": "websocket-driver@0.3.4",
+      "_shasum": "f37ab303f6a602c4b0dbcaa1cdd771e442b04ea7",
+      "_from": ".",
+      "_npmVersion": "1.4.9",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "f37ab303f6a602c4b0dbcaa1cdd771e442b04ea7",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.5": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.3.5",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "dbedb370b791a6af9ca5dcb939123552cdd88990",
+      "_id": "websocket-driver@0.3.5",
+      "_shasum": "e3a51ff538f1653a49e62d78ecfc1eb1bde9e5a0",
+      "_from": ".",
+      "_npmVersion": "1.4.20",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "e3a51ff538f1653a49e62d78ecfc1eb1bde9e5a0",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.5.tgz"
+      },
+      "directories": {}
+    },
+    "0.3.6": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.3.6",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "1c33c0ce5698c43e24e043b647fa6a965b075d60",
+      "_id": "websocket-driver@0.3.6",
+      "_shasum": "85d03e26be0b820b4466a78bbf36a6596bc2aa75",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "85d03e26be0b820b4466a78bbf36a6596bc2aa75",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.6.tgz"
+      },
+      "directories": {}
+    },
+    "0.4.0": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.4.0",
+      "engines": {
+        "node": ">=0.4.0"
+      },
+      "main": "./lib/websocket/driver",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "22d483a5ee76f7f4b16e92b8500c0b7706b5b3dc",
+      "_id": "websocket-driver@0.4.0",
+      "_shasum": "71fa992e5d41c2cc5e290420687d0601efd06b7a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "71fa992e5d41c2cc5e290420687d0601efd06b7a",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.4.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.0": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.5.0",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "e8992add2335f8bec677c59273b3f32d6925097a",
+      "_id": "websocket-driver@0.5.0",
+      "_shasum": "7dc0d0c2d77975d55494ff85e67400841887aca1",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "7dc0d0c2d77975d55494ff85e67400841887aca1",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.1": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.5.1",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "57e74231cf24e63b902347a8a5d5836247762559",
+      "_id": "websocket-driver@0.5.1",
+      "_shasum": "dd954c0a42a9962a31296f84cc465ca4b74c2611",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "dd954c0a42a9962a31296f84cc465ca4b74c2611",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.2": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.5.2",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "0b7eedc3b55db9cbd8a482a009c229380201da97",
+      "_id": "websocket-driver@0.5.2",
+      "_shasum": "8c7c85da0713b4060556b4d71c01775ee1269eb9",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8c7c85da0713b4060556b4d71c01775ee1269eb9",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.3": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.5.3",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "2b99c23788a2341baf5aaa23f2cf2c044d109cc5",
+      "_id": "websocket-driver@0.5.3",
+      "_shasum": "775d079018f8985e1c255eb8efa9224895acacc3",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "775d079018f8985e1c255eb8efa9224895acacc3",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.5.4": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.5.4",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "1cc0f33e1c82d9ed93ba8fa40b4bbd2dd9368d9c",
+      "_id": "websocket-driver@0.5.4",
+      "_shasum": "4c65278c92929384eacfcd908d3e9e0a5691c29e",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.1",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4c65278c92929384eacfcd908d3e9e0a5691c29e",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.0": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.6.0",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "7a1cb15b8c20d7e225172e7631133fd84c505b5f",
+      "_id": "websocket-driver@0.6.0",
+      "_shasum": "0d9e0e0ea66e392f0c613c535d806e076b42ff5d",
+      "_from": ".",
+      "_npmVersion": "2.11.2",
+      "_nodeVersion": "0.12.6",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "0d9e0e0ea66e392f0c613c535d806e076b42ff5d",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.1": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.6.1",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "c84cce9a1f9e4273d8c39a4533963b4eb8fd459b",
+      "_id": "websocket-driver@0.6.1",
+      "_shasum": "8b86f082e48f306f597e98e60092810501f09725",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8b86f082e48f306f597e98e60092810501f09725",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.2": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.6.2",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "fa8b82d424bddef1eba51e725ddc6a48965fd605",
+      "_id": "websocket-driver@0.6.2",
+      "_shasum": "8281dba3e299e5bd7a42b65d4577a8928c26f898",
+      "_from": ".",
+      "_npmVersion": "2.11.3",
+      "_nodeVersion": "0.12.7",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "8281dba3e299e5bd7a42b65d4577a8928c26f898",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.2.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.3": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "http://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.6.3",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "10481b81dbf80f83dbacffd8439405ba0a90e477",
+      "_id": "websocket-driver@0.6.3",
+      "_shasum": "fd21911bb46dee34ad85bdbc5676bf9024ed087b",
+      "_from": ".",
+      "_npmVersion": "3.3.6",
+      "_nodeVersion": "5.0.0",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "fd21911bb46dee34ad85bdbc5676bf9024ed087b",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.3.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.4": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "https://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.6.4",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "2be829546b462aa7d552214e17d6f3e42b6a4bd0",
+      "_id": "websocket-driver@0.6.4",
+      "_shasum": "65b84d02113480d3fc05e63e809322042bdc940b",
+      "_from": ".",
+      "_npmVersion": "3.3.12",
+      "_nodeVersion": "5.2.0",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "65b84d02113480d3fc05e63e809322042bdc940b",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz"
+      },
+      "directories": {}
+    },
+    "0.6.5": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "https://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.6.5",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "c4494ff88ac196f726bbb77a301c2177124b199e",
+      "_id": "websocket-driver@0.6.5",
+      "_shasum": "5cb2556ceb85f4373c6d8238aa691c8454e13a36",
+      "_from": ".",
+      "_npmVersion": "2.15.1",
+      "_nodeVersion": "4.4.4",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "5cb2556ceb85f4373c6d8238aa691c8454e13a36",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+      },
+      "_npmOperationalInternal": {
+        "host": "packages-12-west.internal.npmjs.com",
+        "tmp": "tmp/websocket-driver-0.6.5.tgz_1463730072239_0.9899731166660786"
+      },
+      "directories": {}
+    },
+    "0.7.0": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "https://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.7.0",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "files": [
+        "lib"
+      ],
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "permessage-deflate": "*"
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "8128bec1e03c4eeb3c3bdb250a4356a4c69fe10f",
+      "_id": "websocket-driver@0.7.0",
+      "_shasum": "0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.8.4",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "dist": {
+        "shasum": "0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/websocket-driver-0.7.0.tgz_1505163256798_0.4708031218033284"
+      },
+      "directories": {}
+    },
+    "0.7.1": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "https://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "Apache-2.0",
+      "version": "0.7.1",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "http-parser-js": ">=0.4.0",
+        "safe-buffer": ">=5.1.1",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "permessage-deflate": "*"
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "b5ac8564438b21faaac12b8b62897ced90e1c176",
+      "_id": "websocket-driver@0.7.1",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-EC4YX5LEHtiB1XjaCh6++35jGaFmhT7687pySyCfPX9bB8Quw7+Fpx8gSCpkD78tPjalxuoOm8TtTz8K4dAQEg==",
+        "shasum": "d58fa3269f51e480f5af051db7f5c5c1a1092d20",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 66849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/j3jCRA9TVsSAnZWagAAb6MQAIEZRr0sgqXYfO8WVdEN\nO3LTJNnfRjbiED3X0DKdLOoCpA7H0zvVGAQRnXxOhvdcp4KeZwO49x78Cp6P\nlkJ8AVcTIrodC6qGkynyc80qzGIT5UZg35oIxv7/4+gOhS5RXKXVS0u7c4UO\n00A33VLzS3vzgV9647u21bVJPmBNCXH2AHu03xhSja24PGTA9t5n6tiIC3T4\nhshZr+JAGqtEiMnCunKK9fxu9aOsT4UZoRFJCm5/1illS2FsxqEjl+4FrQx1\ndMe0+A1glwxMYKtFWOXKnhOvMskEBFSFoQUmq/lb29oZ/F0mC58c1VyeSUUt\ng/mTF7EBfC5JMiXuCu2978mhwwBtaWYaWijBXVK6ChivQPzoDdLRPcHw+Cri\nHlvFoa4OH9/4YC9A0tIJxqlwLf78PpVcdLGKcO/6EkntsK+2p8odxOddV5Ty\nASG/TepUHMy/vHCSmuH3QRJacXrFLc42jnFbDfCTCxK53zLrudycCrYTop7k\n8yoJ1hV+uaFNUaL4w1XSfkrIDLPIvcv3HgQBbL05jK9Iqs3Q6DWw10sSZzeV\nKXDjmmWpvJXhh3kQHvl3KbzDh8EvkzohuvbDsEIhS5wVuEMFEQ4UmZS6kvRJ\ngPV03Wd8NkR2nkU2ERxXHWsifeNPErEb3t/lc/H0Qg0zbRycRYNpKxRblK6P\n9d0X\r\n=0c4o\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/websocket-driver_0.7.1_1560165858709_0.33665151907526014"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.7.3": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "https://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "Apache-2.0",
+      "version": "0.7.3",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "permessage-deflate": "*"
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "03aebd19fb2b5f8fece4fff054ea034a54640ff3",
+      "_id": "websocket-driver@0.7.3",
+      "_nodeVersion": "12.4.0",
+      "_npmVersion": "6.9.0",
+      "dist": {
+        "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+        "shasum": "a2d4e0d4f4f116f1e6297eba58b05d430100e9f9",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+        "fileCount": 18,
+        "unpackedSize": 67219,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAm60CRA9TVsSAnZWagAAp/AP/A/hJd3gs3SWezEyTgP7\nGEK/8gTlL1dlCm0zaXFW6mfY6GmZ24OB3PqVR77fJaKiip2fL6PGAbhaMyPo\nW0vj/YpYvpyPyL7omwxjqoc/AOTAn9iSQdac8Gfs9MEbf9krXTgDlRP5GGew\n8BMJncAARGAjC2w4prDJk3nlXJP+YnnoBGuuZ6S0FCzGhETez6+SCu3/Ul18\nVT6TpJIN262dlmW9xILIbVmjOfEmjvamBP7IA6xEND0yWiFdgnz6ABnvdj78\n0GDoHsYU8hb6KSbw1ZD+gGJ4P7eXQrncFmLvE0XP3Z/mckdhT4XUmx9Te21v\nDGojJVHmz/djGPHo5GzDOsmHhuOj5AoVebjH02cEWnXom64QNS4Kea+HWPyn\nB9T6PKjvJnXuPfds7NbbNLikFflX519xQt9nvZjIuPuXuN+nRBIn6MQJVZqo\nGedQXSQoyJ+b2BeF5SxvnKKk0oUiBZRcHyASH6mg7V/d8kuyYqop/RUXuqb6\n98xb5Byv70x3/zM5nm2wSgvNEFgetrNzdAByoS3WzmB13ISMHifiop19vOad\nrVg3EHeA0c/DGXTzl7MERonql6jLTvQtPRrQzWxyu6n9JGP1cDz91pw08RXV\nbEwZuD2IeA3Jwrm8Z8VRe4lLvGsegAc8JPqeSpapoen77gP0A672DmDwnJ8z\ny/8v\r\n=ul2X\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/websocket-driver_0.7.3_1560440499731_0.8651938304954445"
+      },
+      "_hasShrinkwrap": false
+    },
+    "0.7.4": {
+      "name": "websocket-driver",
+      "description": "WebSocket protocol handler with pluggable I/O",
+      "homepage": "https://github.com/faye/websocket-driver-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "Apache-2.0",
+      "version": "0.7.4",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "main": "./lib/websocket/driver",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "permessage-deflate": "*"
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-driver-node.git"
+      },
+      "bugs": {
+        "url": "https://github.com/faye/websocket-driver-node/issues"
+      },
+      "gitHead": "5f711f089234a46f8d1e50054115ea169257eaa4",
+      "_id": "websocket-driver@0.7.4",
+      "_nodeVersion": "14.3.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+        "shasum": "89ad5295bbf64b480abcba31e4953aca706f5760",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+        "fileCount": 18,
+        "unpackedSize": 67439,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJex+l7CRA9TVsSAnZWagAA07sP/2qjaq/S4+7L8g59srrf\n5aiA8rYmL7cx9s+GWzeWzlgtoIgalXUPZKaCibOFeHLkIGrbpKmhWTZ4ogMT\n8fj9xiRf/0g/B5G4dSiFBIcu6VNVX9VSrt3x8Wfy6EQJv0lTuAvBiQ6tvVyv\nOZv6WjwwPvFS+Sp9lILieizFXUygjpjakatc/yBPyDVDA2uSmrp3j9MflQKA\nBmkef/ysQzbwsoYmdnBLJKp92zn/zYZXlAcRtT0ADF/aFdBfsl7mAC7cxnep\ntqGp9ZyUxYOHyt0MDJTBzRWCLmyuOqfkJ8/e2s1K8qQTSRiTXmvMwJUapD4h\nNLdZ260y1qG/1kaXRAX7WmlKMeEy2IxjO5dFq7GA9iW3xgzJHy1zMB6lBpWu\nm+/D1YrwbdHmYhF0cEk8XDda1x5t/hHzPkeIflLAvx+/tttOzEfm3D493Kc7\nsOxTWz8AWre4Bt8DdbRkLROlErl/6ny/bpRH7uBiPhLtmxjhK0vXMrfx0Fu+\nDspyLxdq6BIjSupiSfcS7yBLpRbTPtmQy8FRHEf8slg2Df4Qkj12R2uhSlWT\ntPSFhAIbgmfTnvV7IYTE8IirTiarJckQ81kVTBZ6TLeofBLWHoKbRVwSIYo1\nPylXwZNCARDgmjv8jzS0twcMTHH0wVx2Q5lleUJd1xeKpBnPVAhydDcoB7Q6\ns2RM\r\n=NYqI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/websocket-driver_0.7.4_1590159738877_0.13982233289170365"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# websocket-driver [![Build Status](https://travis-ci.org/faye/websocket-driver-node.svg)](https://travis-ci.org/faye/websocket-driver-node)\n\nThis module provides a complete implementation of the WebSocket protocols that\ncan be hooked up to any I/O stream. It aims to simplify things by decoupling the\nprotocol details from the I/O layer, such that users only need to implement code\nto stream data in and out of it without needing to know anything about how the\nprotocol actually works. Think of it as a complete WebSocket system with\npluggable I/O.\n\nDue to this design, you get a lot of things for free. In particular, if you hook\nthis module up to some I/O object, it will do all of this for you:\n\n- Select the correct server-side driver to talk to the client\n- Generate and send both server- and client-side handshakes\n- Recognize when the handshake phase completes and the WS protocol begins\n- Negotiate subprotocol selection based on `Sec-WebSocket-Protocol`\n- Negotiate and use extensions via the\n  [websocket-extensions](https://github.com/faye/websocket-extensions-node)\n  module\n- Buffer sent messages until the handshake process is finished\n- Deal with proxies that defer delivery of the draft-76 handshake body\n- Notify you when the socket is open and closed and when messages arrive\n- Recombine fragmented messages\n- Dispatch text, binary, ping, pong and close frames\n- Manage the socket-closing handshake process\n- Automatically reply to ping frames with a matching pong\n- Apply masking to messages sent by the client\n\nThis library was originally extracted from the [Faye](http://faye.jcoglan.com)\nproject but now aims to provide simple WebSocket support for any Node-based\nproject.\n\n\n## Installation\n\n```\n$ npm install websocket-driver\n```\n\n\n## Usage\n\nThis module provides protocol drivers that have the same interface on the server\nand on the client. A WebSocket driver is an object with two duplex streams\nattached; one for incoming/outgoing messages and one for managing the wire\nprotocol over an I/O stream. The full API is described below.\n\n\n### Server-side with HTTP\n\nA Node webserver emits a special event for 'upgrade' requests, and this is where\nyou should handle WebSockets. You first check whether the request is a\nWebSocket, and if so you can create a driver and attach the request's I/O stream\nto it.\n\n```js\nvar http = require('http'),\n    websocket = require('websocket-driver');\n\nvar server = http.createServer();\n\nserver.on('upgrade', function(request, socket, body) {\n  if (!websocket.isWebSocket(request)) return;\n\n  var driver = websocket.http(request);\n\n  driver.io.write(body);\n  socket.pipe(driver.io).pipe(socket);\n\n  driver.messages.on('data', function(message) {\n    console.log('Got a message', message);\n  });\n\n  driver.start();\n});\n```\n\nNote the line `driver.io.write(body)` - you must pass the `body` buffer to the\nsocket driver in order to make certain versions of the protocol work.\n\n\n### Server-side with TCP\n\nYou can also handle WebSocket connections in a bare TCP server, if you're not\nusing an HTTP server and don't want to implement HTTP parsing yourself.\n\nThe driver will emit a `connect` event when a request is received, and at this\npoint you can detect whether it's a WebSocket and handle it as such. Here's an\nexample using the Node `net` module:\n\n```js\nvar net = require('net'),\n    websocket = require('websocket-driver');\n\nvar server = net.createServer(function(connection) {\n  var driver = websocket.server();\n\n  driver.on('connect', function() {\n    if (websocket.isWebSocket(driver)) {\n      driver.start();\n    } else {\n      // handle other HTTP requests\n    }\n  });\n\n  driver.on('close', function() { connection.end() });\n  connection.on('error', function() {});\n\n  connection.pipe(driver.io).pipe(connection);\n\n  driver.messages.pipe(driver.messages);\n});\n\nserver.listen(4180);\n```\n\nIn the `connect` event, the driver gains several properties to describe the\nrequest, similar to a Node request object, such as `method`, `url` and\n`headers`. However you should remember it's not a real request object; you\ncannot write data to it, it only tells you what request data we parsed from the\ninput.\n\nIf the request has a body, it will be in the `driver.body` buffer, but only as\nmuch of the body as has been piped into the driver when the `connect` event\nfires.\n\n\n### Client-side\n\nSimilarly, to implement a WebSocket client you just need to make a driver by\npassing in a URL. After this you use the driver API as described below to\nprocess incoming data and send outgoing data.\n\n\n```js\nvar net = require('net'),\n    websocket = require('websocket-driver');\n\nvar driver = websocket.client('ws://www.example.com/socket'),\n    tcp = net.connect(80, 'www.example.com');\n\ntcp.pipe(driver.io).pipe(tcp);\n\ntcp.on('connect', function() {\n  driver.start();\n});\n\ndriver.messages.on('data', function(message) {\n  console.log('Got a message', message);\n});\n```\n\nClient drivers have two additional properties for reading the HTTP data that was\nsent back by the server:\n\n- `driver.statusCode` - the integer value of the HTTP status code\n- `driver.headers` - an object containing the response headers\n\n\n### HTTP Proxies\n\nThe client driver supports connections via HTTP proxies using the `CONNECT`\nmethod. Instead of sending the WebSocket handshake immediately, it will send a\n`CONNECT` request, wait for a `200` response, and then proceed as normal.\n\nTo use this feature, call `driver.proxy(url)` where `url` is the origin of the\nproxy, including a username and password if required. This produces a duplex\nstream that you should pipe in and out of your TCP connection to the proxy\nserver. When the proxy emits `connect`, you can then pipe `driver.io` to your\nTCP stream and call `driver.start()`.\n\n```js\nvar net = require('net'),\n    websocket = require('websocket-driver');\n\nvar driver = websocket.client('ws://www.example.com/socket'),\n    proxy  = driver.proxy('http://username:password@proxy.example.com'),\n    tcp    = net.connect(80, 'proxy.example.com');\n\ntcp.pipe(proxy).pipe(tcp, { end: false });\n\ntcp.on('connect', function() {\n  proxy.start();\n});\n\nproxy.on('connect', function() {\n  driver.io.pipe(tcp).pipe(driver.io);\n  driver.start();\n});\n\ndriver.messages.on('data', function(message) {\n  console.log('Got a message', message);\n});\n```\n\nThe proxy's `connect` event is also where you should perform a TLS handshake on\nyour TCP stream, if you are connecting to a `wss:` endpoint.\n\nIn the event that proxy connection fails, `proxy` will emit an `error`. You can\ninspect the proxy's response via `proxy.statusCode` and `proxy.headers`.\n\n```js\nproxy.on('error', function(error) {\n  console.error(error.message);\n  console.log(proxy.statusCode);\n  console.log(proxy.headers);\n});\n```\n\nBefore calling `proxy.start()` you can set custom headers using\n`proxy.setHeader()`:\n\n```js\nproxy.setHeader('User-Agent', 'node');\nproxy.start();\n```\n\n\n### Driver API\n\nDrivers are created using one of the following methods:\n\n```js\ndriver = websocket.http(request, options)\ndriver = websocket.server(options)\ndriver = websocket.client(url, options)\n```\n\nThe `http` method returns a driver chosen using the headers from a Node HTTP\nrequest object. The `server` method returns a driver that will parse an HTTP\nrequest and then decide which driver to use for it using the `http` method. The\n`client` method always returns a driver for the RFC version of the protocol with\nmasking enabled on outgoing frames.\n\nThe `options` argument is optional, and is an object. It may contain the\nfollowing fields:\n\n- `maxLength` - the maximum allowed size of incoming message frames, in bytes.\n  The default value is `2^26 - 1`, or 1 byte short of 64 MiB.\n- `protocols` - an array of strings representing acceptable subprotocols for use\n  over the socket. The driver will negotiate one of these to use via the\n  `Sec-WebSocket-Protocol` header if supported by the other peer.\n\nA driver has two duplex streams attached to it:\n\n- **`driver.io`** - this stream should be attached to an I/O socket like a TCP\n  stream. Pipe incoming TCP chunks to this stream for them to be parsed, and\n  pipe this stream back into TCP to send outgoing frames.\n- **`driver.messages`** - this stream emits messages received over the\n  WebSocket.  Writing to it sends messages to the other peer by emitting frames\n  via the `driver.io` stream.\n\nAll drivers respond to the following API methods, but some of them are no-ops\ndepending on whether the client supports the behaviour.\n\nNote that most of these methods are commands: if they produce data that should\nbe sent over the socket, they will give this to you by emitting `data` events on\nthe `driver.io` stream.\n\n#### `driver.on('open', function(event) {})`\n\nAdds a callback to execute when the socket becomes open.\n\n#### `driver.on('message', function(event) {})`\n\nAdds a callback to execute when a message is received. `event` will have a\n`data` attribute containing either a string in the case of a text message or a\n`Buffer` in the case of a binary message.\n\nYou can also listen for messages using the `driver.messages.on('data')` event,\nwhich emits strings for text messages and buffers for binary messages.\n\n#### `driver.on('error', function(event) {})`\n\nAdds a callback to execute when a protocol error occurs due to the other peer\nsending an invalid byte sequence. `event` will have a `message` attribute\ndescribing the error.\n\n#### `driver.on('close', function(event) {})`\n\nAdds a callback to execute when the socket becomes closed. The `event` object\nhas `code` and `reason` attributes.\n\n#### `driver.on('ping', function(event) {})`\n\nAdds a callback block to execute when a ping is received. You do not need to\nhandle this by sending a pong frame yourself; the driver handles this for you.\n\n#### `driver.on('pong', function(event) {})`\n\nAdds a callback block to execute when a pong is received. If this was in\nresponse to a ping you sent, you can also handle this event via the\n`driver.ping(message, function() { ... })` callback.\n\n#### `driver.addExtension(extension)`\n\nRegisters a protocol extension whose operation will be negotiated via the\n`Sec-WebSocket-Extensions` header. `extension` is any extension compatible with\nthe [websocket-extensions](https://github.com/faye/websocket-extensions-node)\nframework.\n\n#### `driver.setHeader(name, value)`\n\nSets a custom header to be sent as part of the handshake response, either from\nthe server or from the client. Must be called before `start()`, since this is\nwhen the headers are serialized and sent.\n\n#### `driver.start()`\n\nInitiates the protocol by sending the handshake - either the response for a\nserver-side driver or the request for a client-side one. This should be the\nfirst method you invoke.  Returns `true` if and only if a handshake was sent.\n\n#### `driver.parse(string)`\n\nTakes a string and parses it, potentially resulting in message events being\nemitted (see `on('message')` above) or in data being sent to `driver.io`.  You\nshould send all data you receive via I/O to this method by piping a stream into\n`driver.io`.\n\n#### `driver.text(string)`\n\nSends a text message over the socket. If the socket handshake is not yet\ncomplete, the message will be queued until it is. Returns `true` if the message\nwas sent or queued, and `false` if the socket can no longer send messages.\n\nThis method is equivalent to `driver.messages.write(string)`.\n\n#### `driver.binary(buffer)`\n\nTakes a `Buffer` and sends it as a binary message. Will queue and return `true`\nor `false` the same way as the `text` method. It will also return `false` if the\ndriver does not support binary messages.\n\nThis method is equivalent to `driver.messages.write(buffer)`.\n\n#### `driver.ping(string = '', function() {})`\n\nSends a ping frame over the socket, queueing it if necessary. `string` and the\ncallback are both optional. If a callback is given, it will be invoked when the\nsocket receives a pong frame whose content matches `string`. Returns `false` if\nframes can no longer be sent, or if the driver does not support ping/pong.\n\n#### `driver.pong(string = '')`\n\nSends a pong frame over the socket, queueing it if necessary. `string` is\noptional. Returns `false` if frames can no longer be sent, or if the driver does\nnot support ping/pong.\n\nYou don't need to call this when a ping frame is received; pings are replied to\nautomatically by the driver. This method is for sending unsolicited pongs.\n\n#### `driver.close()`\n\nInitiates the closing handshake if the socket is still open. For drivers with no\nclosing handshake, this will result in the immediate execution of the\n`on('close')` driver. For drivers with a closing handshake, this sends a closing\nframe and `emit('close')` will execute when a response is received or a protocol\nerror occurs.\n\n#### `driver.version`\n\nReturns the WebSocket version in use as a string. Will either be `hixie-75`,\n`hixie-76` or `hybi-$version`.\n\n#### `driver.protocol`\n\nReturns a string containing the selected subprotocol, if any was agreed upon\nusing the `Sec-WebSocket-Protocol` mechanism. This value becomes available after\n`emit('open')` has fired.\n",
+  "maintainers": [
+    {
+      "name": "jcoglan",
+      "email": "jcoglan@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-05-22T15:02:21.325Z",
+    "created": "2013-05-04T19:42:42.782Z",
+    "0.1.0": "2013-05-04T19:42:46.505Z",
+    "0.2.0": "2013-05-12T14:20:55.284Z",
+    "0.2.1": "2013-05-17T10:52:13.231Z",
+    "0.2.2": "2013-07-05T14:17:43.729Z",
+    "0.3.0": "2013-09-09T21:17:15.895Z",
+    "0.3.1": "2013-12-03T00:47:11.161Z",
+    "0.3.2": "2013-12-29T12:25:51.236Z",
+    "0.3.3": "2014-04-24T22:33:58.247Z",
+    "0.3.4": "2014-05-08T01:19:47.964Z",
+    "0.3.5": "2014-07-06T09:20:17.409Z",
+    "0.3.6": "2014-10-04T07:32:33.399Z",
+    "0.4.0": "2014-11-08T19:47:11.581Z",
+    "0.5.0": "2014-12-13T13:11:19.014Z",
+    "0.5.1": "2014-12-18T02:24:20.881Z",
+    "0.5.2": "2015-02-19T09:51:28.802Z",
+    "0.5.3": "2015-02-22T21:14:08.632Z",
+    "0.5.4": "2015-03-29T22:13:46.951Z",
+    "0.6.0": "2015-07-08T20:02:22.490Z",
+    "0.6.1": "2015-07-13T19:24:51.453Z",
+    "0.6.2": "2015-07-18T16:48:39.984Z",
+    "0.6.3": "2015-11-06T22:17:25.225Z",
+    "0.6.4": "2016-01-07T08:58:34.783Z",
+    "0.6.5": "2016-05-20T07:41:14.593Z",
+    "0.7.0": "2017-09-11T20:54:17.920Z",
+    "0.7.1": "2019-06-10T11:24:18.915Z",
+    "0.7.2": "2019-06-13T06:48:01.916Z",
+    "0.7.3": "2019-06-13T15:41:39.923Z",
+    "0.7.4": "2020-05-22T15:02:19.046Z"
+  },
+  "author": {
+    "name": "James Coglan",
+    "email": "jcoglan@gmail.com",
+    "url": "http://jcoglan.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/faye/websocket-driver-node.git"
+  },
+  "users": {
+    "brianloveswords": true,
+    "asilvas": true,
+    "huangjia86": true,
+    "hollobit": true,
+    "staydan": true,
+    "jimknopf": true
+  },
+  "homepage": "https://github.com/faye/websocket-driver-node",
+  "keywords": [
+    "websocket"
+  ],
+  "bugs": {
+    "url": "https://github.com/faye/websocket-driver-node/issues"
+  },
+  "license": "Apache-2.0",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/websocket-driver.min.json
+++ b/test/fixtures/registry-mocks/content/websocket-driver.min.json
@@ -1,0 +1,466 @@
+{
+  "name": "websocket-driver",
+  "dist-tags": {
+    "latest": "0.7.4"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "websocket-driver",
+      "version": "0.1.0",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "14bdc1f671d8df4311cd29b92162786b396e893e",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.2.0": {
+      "name": "websocket-driver",
+      "version": "0.2.0",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "d344ae28f46b411d0ecb5088f10bec6ace721920",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.2.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.2.1": {
+      "name": "websocket-driver",
+      "version": "0.2.1",
+      "devDependencies": {
+        "jsclass": ""
+      },
+      "dist": {
+        "shasum": "666622a997665e21268a89b30c05b7b739e9afa7",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.2.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.2.2": {
+      "name": "websocket-driver",
+      "version": "0.2.2",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "998bc1855d8cd0d1e9aa8f8056b83b46ac3e81ef",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.2.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.0": {
+      "name": "websocket-driver",
+      "version": "0.3.0",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "497b258c508b987249ab9b6f79f0c21dd3467c64",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.1": {
+      "name": "websocket-driver",
+      "version": "0.3.1",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "25f86b4e7ca9d8f8136cd225ffcee71a3d2869cf",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.2": {
+      "name": "websocket-driver",
+      "version": "0.3.2",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "f177ef6611390e2401ae47f35e8386dda987daca",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.3": {
+      "name": "websocket-driver",
+      "version": "0.3.3",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "11a8986d26bd81a684048a21b18c0f2ef292ef06",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.4": {
+      "name": "websocket-driver",
+      "version": "0.3.4",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "f37ab303f6a602c4b0dbcaa1cdd771e442b04ea7",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.5": {
+      "name": "websocket-driver",
+      "version": "0.3.5",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "e3a51ff538f1653a49e62d78ecfc1eb1bde9e5a0",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.3.6": {
+      "name": "websocket-driver",
+      "version": "0.3.6",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "85d03e26be0b820b4466a78bbf36a6596bc2aa75",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.3.6.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.4.0": {
+      "name": "websocket-driver",
+      "version": "0.4.0",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "71fa992e5d41c2cc5e290420687d0601efd06b7a",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.4.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "0.5.0": {
+      "name": "websocket-driver",
+      "version": "0.5.0",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "7dc0d0c2d77975d55494ff85e67400841887aca1",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.5.1": {
+      "name": "websocket-driver",
+      "version": "0.5.1",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.0"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "dd954c0a42a9962a31296f84cc465ca4b74c2611",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.5.2": {
+      "name": "websocket-driver",
+      "version": "0.5.2",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "8c7c85da0713b4060556b4d71c01775ee1269eb9",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.5.3": {
+      "name": "websocket-driver",
+      "version": "0.5.3",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "775d079018f8985e1c255eb8efa9224895acacc3",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.5.4": {
+      "name": "websocket-driver",
+      "version": "0.5.4",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "4c65278c92929384eacfcd908d3e9e0a5691c29e",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.6.0": {
+      "name": "websocket-driver",
+      "version": "0.6.0",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "0d9e0e0ea66e392f0c613c535d806e076b42ff5d",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.6.1": {
+      "name": "websocket-driver",
+      "version": "0.6.1",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "8b86f082e48f306f597e98e60092810501f09725",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.6.2": {
+      "name": "websocket-driver",
+      "version": "0.6.2",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "8281dba3e299e5bd7a42b65d4577a8928c26f898",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.6.3": {
+      "name": "websocket-driver",
+      "version": "0.6.3",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "fd21911bb46dee34ad85bdbc5676bf9024ed087b",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.6.4": {
+      "name": "websocket-driver",
+      "version": "0.6.4",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "65b84d02113480d3fc05e63e809322042bdc940b",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.6.5": {
+      "name": "websocket-driver",
+      "version": "0.6.5",
+      "dependencies": {
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "",
+        "permessage-deflate": ""
+      },
+      "dist": {
+        "shasum": "5cb2556ceb85f4373c6d8238aa691c8454e13a36",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.7.0": {
+      "name": "websocket-driver",
+      "version": "0.7.0",
+      "dependencies": {
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "permessage-deflate": "*"
+      },
+      "dist": {
+        "shasum": "0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.7.1": {
+      "name": "websocket-driver",
+      "version": "0.7.1",
+      "dependencies": {
+        "http-parser-js": ">=0.4.0",
+        "safe-buffer": ">=5.1.1",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "permessage-deflate": "*"
+      },
+      "dist": {
+        "integrity": "sha512-EC4YX5LEHtiB1XjaCh6++35jGaFmhT7687pySyCfPX9bB8Quw7+Fpx8gSCpkD78tPjalxuoOm8TtTz8K4dAQEg==",
+        "shasum": "d58fa3269f51e480f5af051db7f5c5c1a1092d20",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.1.tgz",
+        "fileCount": 18,
+        "unpackedSize": 66849,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJc/j3jCRA9TVsSAnZWagAAb6MQAIEZRr0sgqXYfO8WVdEN\nO3LTJNnfRjbiED3X0DKdLOoCpA7H0zvVGAQRnXxOhvdcp4KeZwO49x78Cp6P\nlkJ8AVcTIrodC6qGkynyc80qzGIT5UZg35oIxv7/4+gOhS5RXKXVS0u7c4UO\n00A33VLzS3vzgV9647u21bVJPmBNCXH2AHu03xhSja24PGTA9t5n6tiIC3T4\nhshZr+JAGqtEiMnCunKK9fxu9aOsT4UZoRFJCm5/1illS2FsxqEjl+4FrQx1\ndMe0+A1glwxMYKtFWOXKnhOvMskEBFSFoQUmq/lb29oZ/F0mC58c1VyeSUUt\ng/mTF7EBfC5JMiXuCu2978mhwwBtaWYaWijBXVK6ChivQPzoDdLRPcHw+Cri\nHlvFoa4OH9/4YC9A0tIJxqlwLf78PpVcdLGKcO/6EkntsK+2p8odxOddV5Ty\nASG/TepUHMy/vHCSmuH3QRJacXrFLc42jnFbDfCTCxK53zLrudycCrYTop7k\n8yoJ1hV+uaFNUaL4w1XSfkrIDLPIvcv3HgQBbL05jK9Iqs3Q6DWw10sSZzeV\nKXDjmmWpvJXhh3kQHvl3KbzDh8EvkzohuvbDsEIhS5wVuEMFEQ4UmZS6kvRJ\ngPV03Wd8NkR2nkU2ERxXHWsifeNPErEb3t/lc/H0Qg0zbRycRYNpKxRblK6P\n9d0X\r\n=0c4o\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.7.3": {
+      "name": "websocket-driver",
+      "version": "0.7.3",
+      "dependencies": {
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "permessage-deflate": "*"
+      },
+      "dist": {
+        "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+        "shasum": "a2d4e0d4f4f116f1e6297eba58b05d430100e9f9",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+        "fileCount": 18,
+        "unpackedSize": 67219,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJdAm60CRA9TVsSAnZWagAAp/AP/A/hJd3gs3SWezEyTgP7\nGEK/8gTlL1dlCm0zaXFW6mfY6GmZ24OB3PqVR77fJaKiip2fL6PGAbhaMyPo\nW0vj/YpYvpyPyL7omwxjqoc/AOTAn9iSQdac8Gfs9MEbf9krXTgDlRP5GGew\n8BMJncAARGAjC2w4prDJk3nlXJP+YnnoBGuuZ6S0FCzGhETez6+SCu3/Ul18\nVT6TpJIN262dlmW9xILIbVmjOfEmjvamBP7IA6xEND0yWiFdgnz6ABnvdj78\n0GDoHsYU8hb6KSbw1ZD+gGJ4P7eXQrncFmLvE0XP3Z/mckdhT4XUmx9Te21v\nDGojJVHmz/djGPHo5GzDOsmHhuOj5AoVebjH02cEWnXom64QNS4Kea+HWPyn\nB9T6PKjvJnXuPfds7NbbNLikFflX519xQt9nvZjIuPuXuN+nRBIn6MQJVZqo\nGedQXSQoyJ+b2BeF5SxvnKKk0oUiBZRcHyASH6mg7V/d8kuyYqop/RUXuqb6\n98xb5Byv70x3/zM5nm2wSgvNEFgetrNzdAByoS3WzmB13ISMHifiop19vOad\nrVg3EHeA0c/DGXTzl7MERonql6jLTvQtPRrQzWxyu6n9JGP1cDz91pw08RXV\nbEwZuD2IeA3Jwrm8Z8VRe4lLvGsegAc8JPqeSpapoen77gP0A672DmDwnJ8z\ny/8v\r\n=ul2X\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.7.4": {
+      "name": "websocket-driver",
+      "version": "0.7.4",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "devDependencies": {
+        "jstest": "*",
+        "permessage-deflate": "*"
+      },
+      "dist": {
+        "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+        "shasum": "89ad5295bbf64b480abcba31e4953aca706f5760",
+        "tarball": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+        "fileCount": 18,
+        "unpackedSize": 67439,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJex+l7CRA9TVsSAnZWagAA07sP/2qjaq/S4+7L8g59srrf\n5aiA8rYmL7cx9s+GWzeWzlgtoIgalXUPZKaCibOFeHLkIGrbpKmhWTZ4ogMT\n8fj9xiRf/0g/B5G4dSiFBIcu6VNVX9VSrt3x8Wfy6EQJv0lTuAvBiQ6tvVyv\nOZv6WjwwPvFS+Sp9lILieizFXUygjpjakatc/yBPyDVDA2uSmrp3j9MflQKA\nBmkef/ysQzbwsoYmdnBLJKp92zn/zYZXlAcRtT0ADF/aFdBfsl7mAC7cxnep\ntqGp9ZyUxYOHyt0MDJTBzRWCLmyuOqfkJ8/e2s1K8qQTSRiTXmvMwJUapD4h\nNLdZ260y1qG/1kaXRAX7WmlKMeEy2IxjO5dFq7GA9iW3xgzJHy1zMB6lBpWu\nm+/D1YrwbdHmYhF0cEk8XDda1x5t/hHzPkeIflLAvx+/tttOzEfm3D493Kc7\nsOxTWz8AWre4Bt8DdbRkLROlErl/6ny/bpRH7uBiPhLtmxjhK0vXMrfx0Fu+\nDspyLxdq6BIjSupiSfcS7yBLpRbTPtmQy8FRHEf8slg2Df4Qkj12R2uhSlWT\ntPSFhAIbgmfTnvV7IYTE8IirTiarJckQ81kVTBZ6TLeofBLWHoKbRVwSIYo1\nPylXwZNCARDgmjv8jzS0twcMTHH0wVx2Q5lleUJd1xeKpBnPVAhydDcoB7Q6\ns2RM\r\n=NYqI\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    }
+  },
+  "modified": "2020-05-22T15:02:21.325Z"
+}

--- a/test/fixtures/registry-mocks/content/websocket-extensions.json
+++ b/test/fixtures/registry-mocks/content/websocket-extensions.json
@@ -1,0 +1,335 @@
+{
+  "_id": "websocket-extensions",
+  "_rev": "9-672d4a01418f5a0647845718f5aa1390",
+  "name": "websocket-extensions",
+  "description": "Generic extension manager for WebSocket connections",
+  "dist-tags": {
+    "latest": "0.1.4"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "websocket-extensions",
+      "description": "Generic extension manager for WebSocket connections",
+      "homepage": "http://github.com/faye/websocket-extensions-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket_extensions",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-extensions-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-extensions-node/issues"
+      },
+      "gitHead": "ea98426dc116d67c2ff7b51b0fa491d5f6058fb7",
+      "_id": "websocket-extensions@0.1.0",
+      "_shasum": "43567457158085e83ce7050f17ac6d988936320a",
+      "_from": ".",
+      "_npmVersion": "1.4.28",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "43567457158085e83ce7050f17ac6d988936320a",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.1": {
+      "name": "websocket-extensions",
+      "description": "Generic extension manager for WebSocket connections",
+      "homepage": "http://github.com/faye/websocket-extensions-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.1.1",
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "main": "./lib/websocket_extensions",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-extensions-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-extensions-node/issues"
+      },
+      "gitHead": "89104ddd48ccbbff20237e3fc5c123b4d4c5d9c1",
+      "_id": "websocket-extensions@0.1.1",
+      "_shasum": "76899499c184b6ef754377c2dbb0cd6cb55d29e7",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.0",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "76899499c184b6ef754377c2dbb0cd6cb55d29e7",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+      },
+      "directories": {}
+    },
+    "0.1.2": {
+      "name": "websocket-extensions",
+      "description": "Generic extension manager for WebSocket connections",
+      "homepage": "http://github.com/faye/websocket-extensions-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.1.2",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "files": [
+        "lib"
+      ],
+      "main": "./lib/websocket_extensions",
+      "devDependencies": {
+        "jstest": "*"
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-extensions-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-extensions-node/issues"
+      },
+      "gitHead": "5f040a15af1343f512af2fce9b12339044ce25eb",
+      "_id": "websocket-extensions@0.1.2",
+      "_shasum": "0e18781de629a18308ce1481650f67ffa2693a5d",
+      "_from": ".",
+      "_npmVersion": "2.15.11",
+      "_nodeVersion": "4.8.4",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "dist": {
+        "shasum": "0e18781de629a18308ce1481650f67ffa2693a5d",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/websocket-extensions-0.1.2.tgz_1505062237525_0.6339729737956077"
+      },
+      "directories": {}
+    },
+    "0.1.3": {
+      "name": "websocket-extensions",
+      "description": "Generic extension manager for WebSocket connections",
+      "homepage": "http://github.com/faye/websocket-extensions-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "MIT",
+      "version": "0.1.3",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "files": [
+        "lib"
+      ],
+      "main": "./lib/websocket_extensions",
+      "devDependencies": {
+        "jstest": "*"
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-extensions-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-extensions-node/issues"
+      },
+      "gitHead": "2af2c182515de125938430a82d1fe2c85a71c88b",
+      "_id": "websocket-extensions@0.1.3",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.1",
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "dist": {
+        "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+        "shasum": "5d2ff22977003ec687a4b87073dfbbac146ccf29",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/websocket-extensions-0.1.3.tgz_1510363474240_0.04513196274638176"
+      },
+      "directories": {}
+    },
+    "0.1.4": {
+      "name": "websocket-extensions",
+      "description": "Generic extension manager for WebSocket connections",
+      "homepage": "http://github.com/faye/websocket-extensions-node",
+      "author": {
+        "name": "James Coglan",
+        "email": "jcoglan@gmail.com",
+        "url": "http://jcoglan.com/"
+      },
+      "keywords": [
+        "websocket"
+      ],
+      "license": "Apache-2.0",
+      "version": "0.1.4",
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "main": "./lib/websocket_extensions",
+      "devDependencies": {
+        "jstest": "*"
+      },
+      "scripts": {
+        "test": "jstest spec/runner.js"
+      },
+      "repository": {
+        "type": "git",
+        "url": "git://github.com/faye/websocket-extensions-node.git"
+      },
+      "bugs": {
+        "url": "http://github.com/faye/websocket-extensions-node/issues"
+      },
+      "_resolved": "",
+      "_integrity": "",
+      "_from": "file:websocket-extensions-0.1.4.tgz",
+      "_id": "websocket-extensions@0.1.4",
+      "_nodeVersion": "14.3.0",
+      "_npmVersion": "6.14.5",
+      "dist": {
+        "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+        "shasum": "7f8473bc839dfd87608adb95d7eb075211578a42",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+        "fileCount": 12,
+        "unpackedSize": 55037,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe1k1ZCRA9TVsSAnZWagAAMw0P/0szPpEF3uzh53+imaau\nnA5kKAlDuoEw2H3wnW5A2yfMrSz6+VjkgzPH6y5aagZxLHOgXSuPJuWzRe1y\n2avLUXzKbqKSrsBhYwuDK2ysmMKAphcEl7GgmDoBrkHfJR31qHnxq6a3zPVX\nckOfDASA5vC+5aJIqyVsMudqV0Mu1fmqFzwgGedcAxNZfNurI8jIytrkXeL1\n/DfhaMGOiRFSW2J77ECrY0hRs1SyMXXISshFuM8FReRV1Y8/FsWvznEpnwRa\n83MGMP1m1KIgabj8mp/9WYTEIM6Wr01ilYew7dIiQKYS+nPp+yCVcdtGqjCm\nFKsQWI7rSAeP5itkLxSJu1MIEnIn7Z2pE0wiXyMIYH9jSZ6uzzGhJXBz8bYF\nq/HarfusWLFgUOPPSNx34ZMPzoX7Vs4AGIEFk/EEPrFlzvjOXeNpfJzsHzG1\nNKEARo2HwgxC0d64XXaKeloxTx1vNMvptaXRUaAd8rQH3BJJDIuvlmmFMYQF\nOpTahn3ZQ1u2YKYO2q9hHGxP02A8dYvq1lWd0yKaHW+xCVObx2SSY7noB1Vz\nlJ7bRd8aConiB57+hMb9U7vzZmFDN9w6pvcbajznDi9F3tpNIPv/DLUJQIre\n+zNluPmXM31BUp/xLfKNNuqh+v6duwguMji/C4cnHTi1hU8eScWAm6npRnu0\n6CT3\r\n=S4is\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "jcoglan",
+          "email": "jcoglan@gmail.com"
+        }
+      ],
+      "_npmUser": {
+        "name": "jcoglan",
+        "email": "jcoglan@gmail.com"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/websocket-extensions_0.1.4_1591102809396_0.3827298260434504"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# websocket-extensions [![Build status](https://secure.travis-ci.org/faye/websocket-extensions-node.svg)](http://travis-ci.org/faye/websocket-extensions-node)\n\nA minimal framework that supports the implementation of WebSocket extensions in\na way that's decoupled from the main protocol. This library aims to allow a\nWebSocket extension to be written and used with any protocol library, by\ndefining abstract representations of frames and messages that allow modules to\nco-operate.\n\n`websocket-extensions` provides a container for registering extension plugins,\nand provides all the functions required to negotiate which extensions to use\nduring a session via the `Sec-WebSocket-Extensions` header. By implementing the\nAPIs defined in this document, an extension may be used by any WebSocket library\nbased on this framework.\n\n## Installation\n\n```\n$ npm install websocket-extensions\n```\n\n## Usage\n\nThere are two main audiences for this library: authors implementing the\nWebSocket protocol, and authors implementing extensions. End users of a\nWebSocket library or an extension should be able to use any extension by passing\nit as an argument to their chosen protocol library, without needing to know how\neither of them work, or how the `websocket-extensions` framework operates.\n\nThe library is designed with the aim that any protocol implementation and any\nextension can be used together, so long as they support the same abstract\nrepresentation of frames and messages.\n\n### Data types\n\nThe APIs provided by the framework rely on two data types; extensions will\nexpect to be given data and to be able to return data in these formats:\n\n#### *Frame*\n\n*Frame* is a structure representing a single WebSocket frame of any type. Frames\nare simple objects that must have at least the following properties, which\nrepresent the data encoded in the frame:\n\n| property     | description                                                        |\n| ------------ | ------------------------------------------------------------------ |\n| `final`      | `true` if the `FIN` bit is set, `false` otherwise                  |\n| `rsv1`       | `true` if the `RSV1` bit is set, `false` otherwise                 |\n| `rsv2`       | `true` if the `RSV2` bit is set, `false` otherwise                 |\n| `rsv3`       | `true` if the `RSV3` bit is set, `false` otherwise                 |\n| `opcode`     | the numeric opcode (`0`, `1`, `2`, `8`, `9`, or `10`) of the frame |\n| `masked`     | `true` if the `MASK` bit is set, `false` otherwise                 |\n| `maskingKey` | a 4-byte `Buffer` if `masked` is `true`, otherwise `null`          |\n| `payload`    | a `Buffer` containing the (unmasked) application data              |\n\n#### *Message*\n\nA *Message* represents a complete application message, which can be formed from\ntext, binary and continuation frames. It has the following properties:\n\n| property | description                                                       |\n| -------- | ----------------------------------------------------------------- |\n| `rsv1`   | `true` if the first frame of the message has the `RSV1` bit set   |\n| `rsv2`   | `true` if the first frame of the message has the `RSV2` bit set   |\n| `rsv3`   | `true` if the first frame of the message has the `RSV3` bit set   |\n| `opcode` | the numeric opcode (`1` or `2`) of the first frame of the message |\n| `data`   | the concatenation of all the frame payloads in the message        |\n\n### For driver authors\n\nA driver author is someone implementing the WebSocket protocol proper, and who\nwishes end users to be able to use WebSocket extensions with their library.\n\nAt the start of a WebSocket session, on both the client and the server side,\nthey should begin by creating an extension container and adding whichever\nextensions they want to use.\n\n```js\nvar Extensions = require('websocket-extensions'),\n    deflate    = require('permessage-deflate');\n\nvar exts = new Extensions();\nexts.add(deflate);\n```\n\nIn the following examples, `exts` refers to this `Extensions` instance.\n\n#### Client sessions\n\nClients will use the methods `generateOffer()` and `activate(header)`.\n\nAs part of the handshake process, the client must send a\n`Sec-WebSocket-Extensions` header to advertise that it supports the registered\nextensions. This header should be generated using:\n\n```js\nrequest.headers['sec-websocket-extensions'] = exts.generateOffer();\n```\n\nThis returns a string, for example `\"permessage-deflate;\nclient_max_window_bits\"`, that represents all the extensions the client is\noffering to use, and their parameters. This string may contain multiple offers\nfor the same extension.\n\nWhen the client receives the handshake response from the server, it should pass\nthe incoming `Sec-WebSocket-Extensions` header in to `exts` to activate the\nextensions the server has accepted:\n\n```js\nexts.activate(response.headers['sec-websocket-extensions']);\n```\n\nIf the server has sent any extension responses that the client does not\nrecognize, or are in conflict with one another for use of RSV bits, or that use\ninvalid parameters for the named extensions, then `exts.activate()` will\n`throw`. In this event, the client driver should fail the connection with\nclosing code `1010`.\n\n#### Server sessions\n\nServers will use the method `generateResponse(header)`.\n\nA server session needs to generate a `Sec-WebSocket-Extensions` header to send\nin its handshake response:\n\n```js\nvar clientOffer = request.headers['sec-websocket-extensions'],\n    extResponse = exts.generateResponse(clientOffer);\n\nresponse.headers['sec-websocket-extensions'] = extResponse;\n```\n\nCalling `exts.generateResponse(header)` activates those extensions the client\nhas asked to use, if they are registered, asks each extension for a set of\nresponse parameters, and returns a string containing the response parameters for\nall accepted extensions.\n\n#### In both directions\n\nBoth clients and servers will use the methods `validFrameRsv(frame)`,\n`processIncomingMessage(message)` and `processOutgoingMessage(message)`.\n\nThe WebSocket protocol requires that frames do not have any of the `RSV` bits\nset unless there is an extension in use that allows otherwise. When processing\nan incoming frame, sessions should pass a *Frame* object to:\n\n```js\nexts.validFrameRsv(frame)\n```\n\nIf this method returns `false`, the session should fail the WebSocket connection\nwith closing code `1002`.\n\nTo pass incoming messages through the extension stack, a session should\nconstruct a *Message* object according to the above datatype definitions, and\ncall:\n\n```js\nexts.processIncomingMessage(message, function(error, msg) {\n  // hand the message off to the application\n});\n```\n\nIf any extensions fail to process the message, then the callback will yield an\nerror and the session should fail the WebSocket connection with closing code\n`1010`. If `error` is `null`, then `msg` should be passed on to the application.\n\nTo pass outgoing messages through the extension stack, a session should\nconstruct a *Message* as before, and call:\n\n```js\nexts.processOutgoingMessage(message, function(error, msg) {\n  // write message to the transport\n});\n```\n\nIf any extensions fail to process the message, then the callback will yield an\nerror and the session should fail the WebSocket connection with closing code\n`1010`. If `error` is `null`, then `message` should be converted into frames\n(with the message's `rsv1`, `rsv2`, `rsv3` and `opcode` set on the first frame)\nand written to the transport.\n\nAt the end of the WebSocket session (either when the protocol is explicitly\nended or the transport connection disconnects), the driver should call:\n\n```js\nexts.close(function() {})\n```\n\nThe callback is invoked when all extensions have finished processing any\nmessages in the pipeline and it's safe to close the socket.\n\n### For extension authors\n\nAn extension author is someone implementing an extension that transforms\nWebSocket messages passing between the client and server. They would like to\nimplement their extension once and have it work with any protocol library.\n\nExtension authors will not install `websocket-extensions` or call it directly.\nInstead, they should implement the following API to allow their extension to\nplug into the `websocket-extensions` framework.\n\nAn `Extension` is any object that has the following properties:\n\n| property | description                                                                  |\n| -------- | ---------------------------------------------------------------------------- |\n| `name`   | a string containing the name of the extension as used in negotiation headers |\n| `type`   | a string, must be `\"permessage\"`                                             |\n| `rsv1`   | either `true` if the extension uses the RSV1 bit, `false` otherwise          |\n| `rsv2`   | either `true` if the extension uses the RSV2 bit, `false` otherwise          |\n| `rsv3`   | either `true` if the extension uses the RSV3 bit, `false` otherwise          |\n\nIt must also implement the following methods:\n\n```js\next.createClientSession()\n```\n\nThis returns a *ClientSession*, whose interface is defined below.\n\n```js\next.createServerSession(offers)\n```\n\nThis takes an array of offer params and returns a *ServerSession*, whose\ninterface is defined below. For example, if the client handshake contains the\noffer header:\n\n```\nSec-WebSocket-Extensions: permessage-deflate; server_no_context_takeover; server_max_window_bits=8, \\\n                          permessage-deflate; server_max_window_bits=15\n```\n\nthen the `permessage-deflate` extension will receive the call:\n\n```js\next.createServerSession([\n  { server_no_context_takeover: true, server_max_window_bits: 8 },\n  { server_max_window_bits: 15 }\n]);\n```\n\nThe extension must decide which set of parameters it wants to accept, if any,\nand return a *ServerSession* if it wants to accept the parameters and `null`\notherwise.\n\n#### *ClientSession*\n\nA *ClientSession* is the type returned by `ext.createClientSession()`. It must\nimplement the following methods, as well as the *Session* API listed below.\n\n```js\nclientSession.generateOffer()\n// e.g.  -> [\n//            { server_no_context_takeover: true, server_max_window_bits: 8 },\n//            { server_max_window_bits: 15 }\n//          ]\n```\n\nThis must return a set of parameters to include in the client's\n`Sec-WebSocket-Extensions` offer header. If the session wants to offer multiple\nconfigurations, it can return an array of sets of parameters as shown above.\n\n```js\nclientSession.activate(params) // -> true\n```\n\nThis must take a single set of parameters from the server's handshake response\nand use them to configure the client session. If the client accepts the given\nparameters, then this method must return `true`. If it returns any other value,\nthe framework will interpret this as the client rejecting the response, and will\n`throw`.\n\n#### *ServerSession*\n\nA *ServerSession* is the type returned by `ext.createServerSession(offers)`. It\nmust implement the following methods, as well as the *Session* API listed below.\n\n```js\nserverSession.generateResponse()\n// e.g.  -> { server_max_window_bits: 8 }\n```\n\nThis returns the set of parameters the server session wants to send in its\n`Sec-WebSocket-Extensions` response header. Only one set of parameters is\nreturned to the client per extension. Server sessions that would confict on\ntheir use of RSV bits are not activated.\n\n#### *Session*\n\nThe *Session* API must be implemented by both client and server sessions. It\ncontains two methods, `processIncomingMessage(message)` and\n`processOutgoingMessage(message)`.\n\n```js\nsession.processIncomingMessage(message, function(error, msg) { ... })\n```\n\nThe session must implement this method to take an incoming *Message* as defined\nabove, transform it in any way it needs, then return it via the callback. If\nthere is an error processing the message, this method should yield an error as\nthe first argument.\n\n```js\nsession.processOutgoingMessage(message, function(error, msg) { ... })\n```\n\nThe session must implement this method to take an outgoing *Message* as defined\nabove, transform it in any way it needs, then return it via the callback. If\nthere is an error processing the message, this method should yield an error as\nthe first argument.\n\nNote that both `processIncomingMessage()` and `processOutgoingMessage()` can\nperform their logic asynchronously, are allowed to process multiple messages\nconcurrently, and are not required to complete working on messages in the same\norder the messages arrive. `websocket-extensions` will reorder messages as your\nextension emits them and will make sure every extension is given messages in the\norder they arrive from the driver. This allows extensions to maintain state that\ndepends on the messages' wire order, for example keeping a DEFLATE compression\ncontext between messages.\n\n```js\nsession.close()\n```\n\nThe framework will call this method when the WebSocket session ends, allowing\nthe session to release any resources it's using.\n\n## Examples\n\n- Consumer: [websocket-driver](https://github.com/faye/websocket-driver-node)\n- Provider: [permessage-deflate](https://github.com/faye/permessage-deflate-node)\n",
+  "maintainers": [
+    {
+      "name": "jcoglan",
+      "email": "jcoglan@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2020-06-02T13:00:13.735Z",
+    "created": "2014-12-13T12:22:20.526Z",
+    "0.1.0": "2014-12-13T12:22:20.526Z",
+    "0.1.1": "2015-02-19T09:48:20.048Z",
+    "0.1.2": "2017-09-10T16:50:38.683Z",
+    "0.1.3": "2017-11-11T01:24:35.510Z",
+    "0.1.4": "2020-06-02T13:00:09.535Z"
+  },
+  "homepage": "http://github.com/faye/websocket-extensions-node",
+  "keywords": [
+    "websocket"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/faye/websocket-extensions-node.git"
+  },
+  "author": {
+    "name": "James Coglan",
+    "email": "jcoglan@gmail.com",
+    "url": "http://jcoglan.com/"
+  },
+  "bugs": {
+    "url": "http://github.com/faye/websocket-extensions-node/issues"
+  },
+  "license": "Apache-2.0",
+  "readmeFilename": "README.md",
+  "users": {
+    "staydan": true,
+    "jimknopf": true
+  }
+}

--- a/test/fixtures/registry-mocks/content/websocket-extensions.min.json
+++ b/test/fixtures/registry-mocks/content/websocket-extensions.min.json
@@ -1,0 +1,84 @@
+{
+  "name": "websocket-extensions",
+  "dist-tags": {
+    "latest": "0.1.4"
+  },
+  "versions": {
+    "0.1.0": {
+      "name": "websocket-extensions",
+      "version": "0.1.0",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "43567457158085e83ce7050f17ac6d988936320a",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.0.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.1.1": {
+      "name": "websocket-extensions",
+      "version": "0.1.1",
+      "devDependencies": {
+        "jstest": ""
+      },
+      "dist": {
+        "shasum": "76899499c184b6ef754377c2dbb0cd6cb55d29e7",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "0.1.2": {
+      "name": "websocket-extensions",
+      "version": "0.1.2",
+      "devDependencies": {
+        "jstest": "*"
+      },
+      "dist": {
+        "shasum": "0e18781de629a18308ce1481650f67ffa2693a5d",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.2.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.1.3": {
+      "name": "websocket-extensions",
+      "version": "0.1.3",
+      "devDependencies": {
+        "jstest": "*"
+      },
+      "dist": {
+        "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+        "shasum": "5d2ff22977003ec687a4b87073dfbbac146ccf29",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "0.1.4": {
+      "name": "websocket-extensions",
+      "version": "0.1.4",
+      "devDependencies": {
+        "jstest": "*"
+      },
+      "dist": {
+        "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+        "shasum": "7f8473bc839dfd87608adb95d7eb075211578a42",
+        "tarball": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+        "fileCount": 12,
+        "unpackedSize": 55037,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJe1k1ZCRA9TVsSAnZWagAAMw0P/0szPpEF3uzh53+imaau\nnA5kKAlDuoEw2H3wnW5A2yfMrSz6+VjkgzPH6y5aagZxLHOgXSuPJuWzRe1y\n2avLUXzKbqKSrsBhYwuDK2ysmMKAphcEl7GgmDoBrkHfJR31qHnxq6a3zPVX\nckOfDASA5vC+5aJIqyVsMudqV0Mu1fmqFzwgGedcAxNZfNurI8jIytrkXeL1\n/DfhaMGOiRFSW2J77ECrY0hRs1SyMXXISshFuM8FReRV1Y8/FsWvznEpnwRa\n83MGMP1m1KIgabj8mp/9WYTEIM6Wr01ilYew7dIiQKYS+nPp+yCVcdtGqjCm\nFKsQWI7rSAeP5itkLxSJu1MIEnIn7Z2pE0wiXyMIYH9jSZ6uzzGhJXBz8bYF\nq/HarfusWLFgUOPPSNx34ZMPzoX7Vs4AGIEFk/EEPrFlzvjOXeNpfJzsHzG1\nNKEARo2HwgxC0d64XXaKeloxTx1vNMvptaXRUaAd8rQH3BJJDIuvlmmFMYQF\nOpTahn3ZQ1u2YKYO2q9hHGxP02A8dYvq1lWd0yKaHW+xCVObx2SSY7noB1Vz\nlJ7bRd8aConiB57+hMb9U7vzZmFDN9w6pvcbajznDi9F3tpNIPv/DLUJQIre\n+zNluPmXM31BUp/xLfKNNuqh+v6duwguMji/C4cnHTi1hU8eScWAm6npRnu0\n6CT3\r\n=S4is\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    }
+  },
+  "modified": "2020-06-02T13:00:13.735Z"
+}

--- a/test/fixtures/registry-mocks/content/worker-farm.json
+++ b/test/fixtures/registry-mocks/content/worker-farm.json
@@ -1,0 +1,1359 @@
+{
+  "_id": "worker-farm",
+  "_rev": "79-8c079b200b067c75a9d52a5e6421f130",
+  "name": "worker-farm",
+  "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+  "dist-tags": {
+    "latest": "1.7.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with a simple API, durability & custom concurrency requirements",
+      "version": "0.0.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "*"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "_id": "worker-farm@0.0.0",
+      "dist": {
+        "shasum": "d2d85a67fd6dd86f532d712ad018bd5b0a53cb0f",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.0.0.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.1": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "0.0.1",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "tape": "*"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "_id": "worker-farm@0.0.1",
+      "dist": {
+        "shasum": "4d89a951611d850975742d601854330177553818",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.0.1.tgz"
+      },
+      "_npmVersion": "1.1.69",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "0.1.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "xtend": "~2.0.6"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@0.1.0",
+      "dist": {
+        "shasum": "77f0346c70dcf67d19ecae337910ab918972f2dc",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.1.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "0.2.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "xtend": "~2.0.6",
+        "errno": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@0.2.0",
+      "dist": {
+        "shasum": "b48d64c4be59a1743ac42641d5f460118d91f516",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.1": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "0.2.1",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "xtend": "~2.0.6",
+        "errno": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@0.2.1",
+      "dist": {
+        "shasum": "c028dce0c201cb682f0798d7d8f601c7cde57167",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.2.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "0.3.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "xtend": "~2.0.6",
+        "errno": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@0.3.0",
+      "dist": {
+        "shasum": "5263f11f93bece2a12119d4dba5c72de7db80b6d",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.3.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.11",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.3.1": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "0.3.1",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "xtend": "~2.1.1",
+        "errno": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@0.3.1",
+      "dist": {
+        "shasum": "3e80fd2c6e79a95fb12b6d7d904859be2fd81fe6",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.3.1.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.3.8",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {}
+    },
+    "1.0.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.0.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "gitHead": "9a70f871f29b09bdddc0d2ec657f9bf74eb99c40",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.0.0",
+      "_shasum": "23dddda1dafc560c9ab7456ed93cf1ee812e0103",
+      "_from": ".",
+      "_npmVersion": "1.4.24",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "23dddda1dafc560c9ab7456ed93cf1ee812e0103",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.0.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.0.1": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.0.1",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "gitHead": "5edfc6dfa0628c25248f0a2bb179048a3ee5d878",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.0.1",
+      "_shasum": "358837e0187c9795eb6d7a07fe00fc956fbbf6ae",
+      "_from": ".",
+      "_npmVersion": "1.4.24",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "358837e0187c9795eb6d7a07fe00fc956fbbf6ae",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.0.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.1.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.1.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=3.0.3 <3.1.0-0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "gitHead": "893a858145e50a83c053036016146b816b8c50d0",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.1.0",
+      "_shasum": "19670d0d1c157a5a5638c41c967ae5b54c538ec7",
+      "_from": ".",
+      "_npmVersion": "2.1.6",
+      "_nodeVersion": "0.10.33",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "19670d0d1c157a5a5638c41c967ae5b54c538ec7",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.1.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.2.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.2.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=3.0.3 <3.1.0-0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "gitHead": "b9fbf74126c3b228d488883a88e8f2db9c96bb63",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.2.0",
+      "_shasum": "2aa0f1d40321fb519124a05e56b68827eee31040",
+      "_from": ".",
+      "_npmVersion": "2.4.1",
+      "_nodeVersion": "1.1.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "2aa0f1d40321fb519124a05e56b68827eee31040",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.2.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.3.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=3.0.3 <3.1.0-0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "gitHead": "419f0a992645049300ccc00ce0451d37975de962",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.3.0",
+      "_shasum": "f69d4c4d180a934c60d0f315c04074a3d999ee66",
+      "_from": ".",
+      "_npmVersion": "2.9.0",
+      "_nodeVersion": "2.0.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "dist": {
+        "shasum": "f69d4c4d180a934c60d0f315c04074a3d999ee66",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.0.tgz"
+      },
+      "directories": {}
+    },
+    "1.3.1": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.3.1",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=3.0.3 <3.1.0-0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "gitHead": "36edd5f28b05bd08b99c3543ab2be87e53e11dbf",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.3.1",
+      "_shasum": "4333112bb49b17aa050b87895ca6b2cacf40e5ff",
+      "_from": ".",
+      "_npmVersion": "2.5.1",
+      "_nodeVersion": "0.12.1",
+      "_npmUser": {
+        "name": "amasad",
+        "email": "amjad.masad@gmail.com"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        }
+      ],
+      "dist": {
+        "shasum": "4333112bb49b17aa050b87895ca6b2cacf40e5ff",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz"
+      },
+      "directories": {}
+    },
+    "1.4.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.4.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "gitHead": "592dae67b1149ad542a217bc2842bedbfeb78d6a",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.4.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.1.2",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "dist": {
+        "integrity": "sha512-RWvBTapIvTAKGFVUyp6UsIU6vv6NBcZ9p0OLauWtW6ZqT168PO7ZNYla8RAsHCAlN3Zs2xNu7rQ3yy6CnuE6Qg==",
+        "shasum": "8b6484ccbcac7d1c54eba234a30b02fa1be37083",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm-1.4.0.tgz_1498781469696_0.6677367349620908"
+      },
+      "directories": {}
+    },
+    "1.4.1": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.4.1",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "license": "MIT",
+      "gitHead": "8a74573c8e7dfbe045a0cab209276dcb483d941d",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.4.1",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "8.1.2",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "rod@vagg.org"
+      },
+      "dist": {
+        "integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
+        "shasum": "a438bc993a7a7d133bcb6547c95eca7cff4897d8",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm-1.4.1.tgz_1498781964257_0.6519602912012488"
+      },
+      "directories": {}
+    },
+    "1.5.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.5.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "types": "./index.d.ts",
+      "license": "MIT",
+      "gitHead": "1ee4adb56f7c78eb1f840d58586194e0a4c7474a",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.5.0",
+      "_npmVersion": "5.0.3",
+      "_nodeVersion": "9.0.0-v8-canary20170609cd40078f1f",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
+        "shasum": "adfdf0cd40581465ed0a1f648f9735722afd5c8d",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm-1.5.0.tgz_1502693768260_0.5901387543417513"
+      },
+      "directories": {}
+    },
+    "1.5.1": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.5.1",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "types": "./index.d.ts",
+      "license": "MIT",
+      "gitHead": "7d5c8507e3f5b4a78770c4ba087d53ce096a8215",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.5.1",
+      "_npmVersion": "5.4.2",
+      "_nodeVersion": "8.7.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-T5NH6Wqsd8MwGD4AK8BBllUy6LmHaqjEOyo/YIUEegZui6/v5Bqde//3jwyE3PGiGYMmWi06exFBi5LNhhPFNw==",
+        "shasum": "8e9f4a7da4f3c595aa600903051b969390423fa1",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm-1.5.1.tgz_1509360127611_0.8198427087627351"
+      },
+      "directories": {}
+    },
+    "1.5.2": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.5.2",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "types": "./index.d.ts",
+      "license": "MIT",
+      "gitHead": "f63d988c307a6805e03b1650f8ef0fb7ca6f1546",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.5.2",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.2.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+        "shasum": "32b312e5dc3d5d45d79ef44acc2587491cd729ae",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        },
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm-1.5.2.tgz_1510810485113_0.15678795706480742"
+      },
+      "directories": {}
+    },
+    "1.5.3": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.5.3",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "~0.1.7",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "tape": "~4.9.0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "types": "./index.d.ts",
+      "license": "MIT",
+      "gitHead": "07e09e9ef2b956cb94475147c6a0f837b60c3185",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.5.3",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-oHM+VYIbqxWnDLjFbrZ9xvucrCF2yCMlTH4YWZUJAddlwDZI9movv1wXY1ele3UJdoTjKoaldjeMvlSsiag7qA==",
+        "shasum": "30d945313620490e88f16f25b7e072b24851becd",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.3.tgz",
+        "fileCount": 16,
+        "unpackedSize": 45576
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm_1.5.3_1519612961676_0.9854356611965469"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.5.4": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.5.4",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "~0.1.7",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "tape": "~4.9.0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "types": "./index.d.ts",
+      "license": "MIT",
+      "gitHead": "56f3660103a6a9edd59a1c47c6884ecb3fed9fa1",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.5.4",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "8.9.3",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==",
+        "shasum": "4debbe46b40edefcc717ebde74a90b1ae1e909a1",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.4.tgz",
+        "fileCount": 16,
+        "unpackedSize": 45584
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm_1.5.4_1519613041640_0.5768859864651479"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.6.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.6.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "~0.1.7"
+      },
+      "devDependencies": {
+        "tape": "~4.9.0"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "types": "./index.d.ts",
+      "license": "MIT",
+      "gitHead": "f61372e0ad99338d472b8fd09b4900a4cbff5166",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.6.0",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.10.0",
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "dist": {
+        "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+        "shasum": "aecc405976fab5a95526180846f0dba288f3a4a0",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 47168
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm_1.6.0_1520565271783_0.5530085286716173"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.7.0": {
+      "name": "worker-farm",
+      "description": "Distribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options.",
+      "version": "1.7.0",
+      "homepage": "https://github.com/rvagg/node-worker-farm",
+      "authors": [
+        "Rod Vagg @rvagg <rod@vagg.org> (https://github.com/rvagg)"
+      ],
+      "keywords": [
+        "worker",
+        "child",
+        "processing",
+        "farm"
+      ],
+      "main": "./lib/index.js",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/rvagg/node-worker-farm.git"
+      },
+      "dependencies": {
+        "errno": "~0.1.7"
+      },
+      "devDependencies": {
+        "tape": "~4.10.1"
+      },
+      "scripts": {
+        "test": "node ./tests/"
+      },
+      "types": "./index.d.ts",
+      "license": "MIT",
+      "gitHead": "3e699ba3d7ea70475b35564f102d4514fa71d50a",
+      "bugs": {
+        "url": "https://github.com/rvagg/node-worker-farm/issues"
+      },
+      "_id": "worker-farm@1.7.0",
+      "_nodeVersion": "11.10.1",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+        "shasum": "26a94c5391bbca926152002f69b84a4bf772e5a8",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 49864,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJczEB8CRA9TVsSAnZWagAAYl8QAJgCWqB5uqNDgPIXrwKC\nCeYeTaKRf4NLT0h2+57z1PEdfyH1Nm8ZoasCz13uMNHhH0tV0B9nlCeFSsL7\nI3CDtpB+xcG5EAsw2hu6/inDIZKopPMkuHqE8akwWVt5lVy81kJ7f1QAllvf\n8ayAwr/Dg/yQmXHvOoV9wEe64pPc7bLfz8+65nNzILLwnaBs+u2J4oENk+70\nQRvs8Xn+3N3z/rsGr6DEIvMBdFuc30DfSzPpAuNjSoPJ57OoMUXPen6SXPHr\nQwq3Kd5KF3cGy++V1lnfc+1EtupnxeD1jWAcQrRpjGX+xEC9fdSSeHj+v/Ox\n8tpS89ygo+TCYOKGPauss4G8v8hX8YQNm3wnIJGLg9367appPOf60vohZ5/2\nsnzGpJWY/lxXE8P4HjqIsPyD6Je+bXNhTMX8pFQBlDMIdG0nLoiIaLxhjFMZ\nVyHVXBjUkHsi33XMCX2u831Nj+ikXFjpIWQhpYlC2n3Ru+Bdmz1mIoRC1Vsa\nzkPFWbzQmFNbmkReRZe/iDjiCeWDKK561CZ5wFkOekFE+g11PJMTIIf4fnxU\njv6AQuPlMEC6MwG6c+uHNpKWyO+kDR5QJM+tQVaIWzNbUp8oq0MVgkNh8a32\nso51YbVZjW6nvtJHJeRzkUSSKriI3AxWjZUXwjN7Yoxvu8sssu9Rfwz5ICk2\n+Una\r\n=g/dP\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "amasad",
+          "email": "amjad.masad@gmail.com"
+        },
+        {
+          "name": "rvagg",
+          "email": "rod@vagg.org"
+        }
+      ],
+      "_npmUser": {
+        "name": "rvagg",
+        "email": "r@va.gg"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/worker-farm_1.7.0_1556889724363_0.7071190864654575"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "readme": "# Worker Farm [![Build Status](https://secure.travis-ci.org/rvagg/node-worker-farm.svg)](http://travis-ci.org/rvagg/node-worker-farm)\n\n[![NPM](https://nodei.co/npm/worker-farm.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/worker-farm/) [![NPM](https://nodei.co/npm-dl/worker-farm.png?months=6&height=3)](https://nodei.co/npm/worker-farm/)\n\n\nDistribute processing tasks to child processes with an über-simple API and baked-in durability & custom concurrency options. *Available in npm as <strong>worker-farm</strong>*.\n\n## Example\n\nGiven a file, *child.js*:\n\n```js\nmodule.exports = function (inp, callback) {\n  callback(null, inp + ' BAR (' + process.pid + ')')\n}\n```\n\nAnd a main file:\n\n```js\nvar workerFarm = require('worker-farm')\n  , workers    = workerFarm(require.resolve('./child'))\n  , ret        = 0\n\nfor (var i = 0; i < 10; i++) {\n  workers('#' + i + ' FOO', function (err, outp) {\n    console.log(outp)\n    if (++ret == 10)\n      workerFarm.end(workers)\n  })\n}\n```\n\nWe'll get an output something like the following:\n\n```\n#1 FOO BAR (8546)\n#0 FOO BAR (8545)\n#8 FOO BAR (8545)\n#9 FOO BAR (8546)\n#2 FOO BAR (8548)\n#4 FOO BAR (8551)\n#3 FOO BAR (8549)\n#6 FOO BAR (8555)\n#5 FOO BAR (8553)\n#7 FOO BAR (8557)\n```\n\nThis example is contained in the *[examples/basic](https://github.com/rvagg/node-worker-farm/tree/master/examples/basic/)* directory.\n\n### Example #1: Estimating π using child workers\n\nYou will also find a more complex example in *[examples/pi](https://github.com/rvagg/node-worker-farm/tree/master/examples/pi/)* that estimates the value of **π** by using a Monte Carlo *area-under-the-curve* method and compares the speed of doing it all in-process vs using child workers to complete separate portions.\n\nRunning `node examples/pi` will give you something like:\n\n```\nDoing it the slow (single-process) way...\nπ ≈ 3.1416269360000006  (0.0000342824102075312 away from actual!)\ntook 8341 milliseconds\nDoing it the fast (multi-process) way...\nπ ≈ 3.1416233600000036  (0.00003070641021052367 away from actual!)\ntook 1985 milliseconds\n```\n\n## Durability\n\nAn important feature of Worker Farm is **call durability**. If a child process dies for any reason during the execution of call(s), those calls will be re-queued and taken care of by other child processes. In this way, when you ask for something to be done, unless there is something *seriously* wrong with what you're doing, you should get a result on your callback function.\n\n## My use-case\n\nThere are other libraries for managing worker processes available but my use-case was fairly specific: I need to make heavy use of the [node-java](https://github.com/nearinfinity/node-java) library to interact with JVM code. Unfortunately, because the JVM garbage collector is so difficult to interact with, it's prone to killing your Node process when the GC kicks under heavy load. For safety I needed a durable way to make calls so that (1) it wouldn't kill my main process and (2) any calls that weren't successful would be resubmitted for processing.\n\nWorker Farm allows me to spin up multiple JVMs to be controlled by Node, and have a single, uncomplicated API that acts the same way as an in-process API and the calls will be taken care of by a child process even if an error kills a child process while it is working as the call will simply be passed to a new child process.\n\n**But**, don't think that Worker Farm is specific to that use-case, it's designed to be very generic and simple to adapt to anything requiring the use of child Node processes.\n\n## API\n\nWorker Farm exports a main function and an `end()` method. The main function sets up a \"farm\" of coordinated child-process workers and it can be used to instantiate multiple farms, all operating independently.\n\n### workerFarm([options, ]pathToModule[, exportedMethods])\n\nIn its most basic form, you call `workerFarm()` with the path to a module file to be invoked by the child process. You should use an **absolute path** to the module file, the best way to obtain the path is with `require.resolve('./path/to/module')`, this function can be used in exactly the same way as `require('./path/to/module')` but it returns an absolute path.\n\n#### `exportedMethods`\n\nIf your module exports a single function on `module.exports` then you should omit the final parameter. However, if you are exporting multiple functions on `module.exports` then you should list them in an Array of Strings:\n\n```js\nvar workers = workerFarm(require.resolve('./mod'), [ 'doSomething', 'doSomethingElse' ])\nworkers.doSomething(function () {})\nworkers.doSomethingElse(function () {})\n```\n\nListing the available methods will instruct Worker Farm what API to provide you with on the returned object. If you don't list a `exportedMethods` Array then you'll get a single callable function to use; but if you list the available methods then you'll get an object with callable functions by those names.\n\n**It is assumed that each function you call on your child module will take a `callback` function as the last argument.**\n\n#### `options`\n\nIf you don't provide an `options` object then the following defaults will be used:\n\n```js\n{\n    workerOptions               : {}\n  , maxCallsPerWorker           : Infinity\n  , maxConcurrentWorkers        : require('os').cpus().length\n  , maxConcurrentCallsPerWorker : 10\n  , maxConcurrentCalls          : Infinity\n  , maxCallTime                 : Infinity\n  , maxRetries                  : Infinity\n  , autoStart                   : false\n  , onChild                     : function() {}\n}\n```\n\n  * **<code>workerOptions</code>** allows you to customize all the parameters passed to child nodes. This object supports [all possible options of `child_process.fork`](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options). The default options passed are the parent `execArgv`, `cwd` and `env`. Any (or all) of them can be overridden, and others can be added as well.\n\n  * **<code>maxCallsPerWorker</code>** allows you to control the lifespan of your child processes. A positive number will indicate that you only want each child to accept that many calls before it is terminated. This may be useful if you need to control memory leaks or similar in child processes.\n\n  * **<code>maxConcurrentWorkers</code>** will set the number of child processes to maintain concurrently. By default it is set to the number of CPUs available on the current system, but it can be any reasonable number, including `1`.\n\n  * **<code>maxConcurrentCallsPerWorker</code>** allows you to control the *concurrency* of individual child processes. Calls are placed into a queue and farmed out to child processes according to the number of calls they are allowed to handle concurrently. It is arbitrarily set to 10 by default so that calls are shared relatively evenly across workers, however if your calls predictably take a similar amount of time then you could set it to `Infinity` and Worker Farm won't queue any calls but spread them evenly across child processes and let them go at it. If your calls aren't I/O bound then it won't matter what value you use here as the individual workers won't be able to execute more than a single call at a time.\n\n  * **<code>maxConcurrentCalls</code>** allows you to control the maximum number of calls in the queue&mdash;either actively being processed or waiting for a worker to be processed. `Infinity` indicates no limit but if you have conditions that may endlessly queue jobs and you need to set a limit then provide a `>0` value and any calls that push the limit will return on their callback with a `MaxConcurrentCallsError` error (check `err.type == 'MaxConcurrentCallsError'`).\n\n  * **<code>maxCallTime</code>** *(use with caution, understand what this does before you use it!)* when `!== Infinity`, will cap a time, in milliseconds, that *any single call* can take to execute in a worker. If this time limit is exceeded by just a single call then the worker running that call will be killed and any calls running on that worker will have their callbacks returned with a `TimeoutError` (check `err.type == 'TimeoutError'`). If you are running with `maxConcurrentCallsPerWorker` value greater than `1` then **all calls currently executing** will fail and will be automatically resubmitted uless you've changed the `maxRetries` option. Use this if you have jobs that may potentially end in infinite loops that you can't programatically end with your child code. Preferably run this with a `maxConcurrentCallsPerWorker` so you don't interrupt other calls when you have a timeout. This timeout operates on a per-call basis but will interrupt a whole worker.\n\n  * **<code>maxRetries</code>** allows you to control the max number of call requeues after worker termination (unexpected or timeout). By default this option is set to `Infinity` which means that each call of each terminated worker will always be auto requeued. When the number of retries exceeds `maxRetries` value, the job callback will be executed with a `ProcessTerminatedError`. Note that if you are running with finite `maxCallTime` and `maxConcurrentCallsPerWorkers` greater than `1` then any `TimeoutError` will increase the retries counter *for each* concurrent call of the terminated worker.\n\n  * **<code>autoStart</code>** when set to `true` will start the workers as early as possible. Use this when your workers have to do expensive initialization. That way they'll be ready when the first request comes through.\n\n  * **<code>onChild</code>** when new child process starts this callback will be called with subprocess object as an argument. Use this when you need to add some custom communication with child processes.\n\n### workerFarm.end(farm)\n\nChild processes stay alive waiting for jobs indefinitely and your farm manager will stay alive managing its workers, so if you need it to stop then you have to do so explicitly. If you send your farm API to `workerFarm.end()` then it'll cleanly end your worker processes. Note though that it's a *soft* ending so it'll wait for child processes to finish what they are working on before asking them to die.\n\nAny calls that are queued and not yet being handled by a child process will be discarded. `end()` only waits for those currently in progress.\n\nOnce you end a farm, it won't handle any more calls, so don't even try!\n\n## Related\n\n* [farm-cli](https://github.com/Kikobeats/farm-cli) – Launch a farm of workers from CLI.\n\n## License\n\nWorker Farm is Copyright (c) 2014 Rod Vagg [@rvagg](https://twitter.com/rvagg) and licensed under the MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.\n",
+  "maintainers": [
+    {
+      "name": "amasad",
+      "email": "amjad.masad@gmail.com"
+    },
+    {
+      "name": "rvagg",
+      "email": "rod@vagg.org"
+    }
+  ],
+  "time": {
+    "modified": "2019-05-03T13:22:06.876Z",
+    "created": "2013-01-01T12:19:22.535Z",
+    "0.0.0": "2013-01-01T12:19:26.838Z",
+    "0.0.1": "2013-01-09T00:21:30.302Z",
+    "0.1.0": "2013-08-29T06:24:32.998Z",
+    "0.2.0": "2013-08-29T11:43:07.592Z",
+    "0.2.1": "2013-08-29T11:47:48.914Z",
+    "0.3.0": "2013-09-17T06:13:27.069Z",
+    "0.3.1": "2013-09-19T06:07:04.745Z",
+    "1.0.0": "2014-08-16T06:17:07.743Z",
+    "1.0.1": "2014-08-16T06:19:53.729Z",
+    "1.1.0": "2014-11-17T15:38:30.691Z",
+    "1.2.0": "2015-02-04T04:42:25.940Z",
+    "1.3.0": "2015-05-11T05:56:04.562Z",
+    "1.3.1": "2015-05-21T18:13:15.900Z",
+    "1.4.0": "2017-06-30T00:11:09.792Z",
+    "1.4.1": "2017-06-30T00:19:24.490Z",
+    "1.5.0": "2017-08-14T06:56:08.399Z",
+    "1.5.1": "2017-10-30T10:42:07.700Z",
+    "1.5.2": "2017-11-16T05:34:45.257Z",
+    "1.5.3": "2018-02-26T02:42:41.800Z",
+    "1.5.4": "2018-02-26T02:44:01.701Z",
+    "1.6.0": "2018-03-09T03:14:31.858Z",
+    "1.7.0": "2019-05-03T13:22:04.472Z"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rvagg/node-worker-farm.git"
+  },
+  "users": {
+    "6174": true,
+    "luk": true,
+    "humantriangle": true,
+    "matthiasg": true,
+    "mastayoda": true,
+    "antoniobrandao": true,
+    "dwayneford": true,
+    "chocolateboy": true,
+    "alectic": true,
+    "qlqllu": true,
+    "leodutra": true,
+    "guananddu": true,
+    "nicomf1982": true,
+    "moimikey": true,
+    "bcoe": true,
+    "surajs21": true,
+    "jakedetels": true,
+    "chriszs": true,
+    "du1970": true,
+    "bobxuyang": true,
+    "ahmed-dinar": true,
+    "nbuchanan": true,
+    "fabriece": true,
+    "d-band": true,
+    "drewigg": true,
+    "shanewholloway": true,
+    "aliem": true,
+    "jujyfruits": true,
+    "tzq1011": true,
+    "teamsteamdev": true,
+    "larrychen": true,
+    "sdolard": true,
+    "keyn": true,
+    "darikspark": true,
+    "joakin": true,
+    "unconfident": true
+  },
+  "homepage": "https://github.com/rvagg/node-worker-farm",
+  "keywords": [
+    "worker",
+    "child",
+    "processing",
+    "farm"
+  ],
+  "bugs": {
+    "url": "https://github.com/rvagg/node-worker-farm/issues"
+  },
+  "license": "MIT",
+  "readmeFilename": "README.md"
+}

--- a/test/fixtures/registry-mocks/content/worker-farm.min.json
+++ b/test/fixtures/registry-mocks/content/worker-farm.min.json
@@ -1,0 +1,346 @@
+{
+  "name": "worker-farm",
+  "dist-tags": {
+    "latest": "1.7.0"
+  },
+  "versions": {
+    "0.0.0": {
+      "name": "worker-farm",
+      "version": "0.0.0",
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "d2d85a67fd6dd86f532d712ad018bd5b0a53cb0f",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.0.0.tgz"
+      }
+    },
+    "0.0.1": {
+      "name": "worker-farm",
+      "version": "0.0.1",
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "4d89a951611d850975742d601854330177553818",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.0.1.tgz"
+      }
+    },
+    "0.1.0": {
+      "name": "worker-farm",
+      "version": "0.1.0",
+      "dependencies": {
+        "xtend": "~2.0.6"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "77f0346c70dcf67d19ecae337910ab918972f2dc",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.1.0.tgz"
+      }
+    },
+    "0.2.0": {
+      "name": "worker-farm",
+      "version": "0.2.0",
+      "dependencies": {
+        "xtend": "~2.0.6",
+        "errno": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "b48d64c4be59a1743ac42641d5f460118d91f516",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.2.0.tgz"
+      }
+    },
+    "0.2.1": {
+      "name": "worker-farm",
+      "version": "0.2.1",
+      "dependencies": {
+        "xtend": "~2.0.6",
+        "errno": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "c028dce0c201cb682f0798d7d8f601c7cde57167",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.2.1.tgz"
+      }
+    },
+    "0.3.0": {
+      "name": "worker-farm",
+      "version": "0.3.0",
+      "dependencies": {
+        "xtend": "~2.0.6",
+        "errno": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "5263f11f93bece2a12119d4dba5c72de7db80b6d",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.3.0.tgz"
+      }
+    },
+    "0.3.1": {
+      "name": "worker-farm",
+      "version": "0.3.1",
+      "dependencies": {
+        "xtend": "~2.1.1",
+        "errno": "~0.1.0"
+      },
+      "devDependencies": {
+        "tape": "*"
+      },
+      "dist": {
+        "shasum": "3e80fd2c6e79a95fb12b6d7d904859be2fd81fe6",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-0.3.1.tgz"
+      }
+    },
+    "1.0.0": {
+      "name": "worker-farm",
+      "version": "1.0.0",
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "23dddda1dafc560c9ab7456ed93cf1ee812e0103",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.0.0.tgz"
+      }
+    },
+    "1.0.1": {
+      "name": "worker-farm",
+      "version": "1.0.1",
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=2.14.0 <2.15.0-0"
+      },
+      "dist": {
+        "shasum": "358837e0187c9795eb6d7a07fe00fc956fbbf6ae",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.0.1.tgz"
+      }
+    },
+    "1.1.0": {
+      "name": "worker-farm",
+      "version": "1.1.0",
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=3.0.3 <3.1.0-0"
+      },
+      "dist": {
+        "shasum": "19670d0d1c157a5a5638c41c967ae5b54c538ec7",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.1.0.tgz"
+      }
+    },
+    "1.2.0": {
+      "name": "worker-farm",
+      "version": "1.2.0",
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=3.0.3 <3.1.0-0"
+      },
+      "dist": {
+        "shasum": "2aa0f1d40321fb519124a05e56b68827eee31040",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.2.0.tgz"
+      }
+    },
+    "1.3.0": {
+      "name": "worker-farm",
+      "version": "1.3.0",
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=3.0.3 <3.1.0-0"
+      },
+      "dist": {
+        "shasum": "f69d4c4d180a934c60d0f315c04074a3d999ee66",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.0.tgz"
+      }
+    },
+    "1.3.1": {
+      "name": "worker-farm",
+      "version": "1.3.1",
+      "dependencies": {
+        "errno": ">=0.1.1 <0.2.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
+      },
+      "devDependencies": {
+        "tape": ">=3.0.3 <3.1.0-0"
+      },
+      "dist": {
+        "shasum": "4333112bb49b17aa050b87895ca6b2cacf40e5ff",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz"
+      }
+    },
+    "1.4.0": {
+      "name": "worker-farm",
+      "version": "1.4.0",
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-RWvBTapIvTAKGFVUyp6UsIU6vv6NBcZ9p0OLauWtW6ZqT168PO7ZNYla8RAsHCAlN3Zs2xNu7rQ3yy6CnuE6Qg==",
+        "shasum": "8b6484ccbcac7d1c54eba234a30b02fa1be37083",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.0.tgz"
+      }
+    },
+    "1.4.1": {
+      "name": "worker-farm",
+      "version": "1.4.1",
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
+        "shasum": "a438bc993a7a7d133bcb6547c95eca7cff4897d8",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz"
+      }
+    },
+    "1.5.0": {
+      "name": "worker-farm",
+      "version": "1.5.0",
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
+        "shasum": "adfdf0cd40581465ed0a1f648f9735722afd5c8d",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz"
+      }
+    },
+    "1.5.1": {
+      "name": "worker-farm",
+      "version": "1.5.1",
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-T5NH6Wqsd8MwGD4AK8BBllUy6LmHaqjEOyo/YIUEegZui6/v5Bqde//3jwyE3PGiGYMmWi06exFBi5LNhhPFNw==",
+        "shasum": "8e9f4a7da4f3c595aa600903051b969390423fa1",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.1.tgz"
+      }
+    },
+    "1.5.2": {
+      "name": "worker-farm",
+      "version": "1.5.2",
+      "dependencies": {
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
+      },
+      "devDependencies": {
+        "tape": "^4.7.0"
+      },
+      "dist": {
+        "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+        "shasum": "32b312e5dc3d5d45d79ef44acc2587491cd729ae",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz"
+      }
+    },
+    "1.5.3": {
+      "name": "worker-farm",
+      "version": "1.5.3",
+      "dependencies": {
+        "errno": "~0.1.7",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-oHM+VYIbqxWnDLjFbrZ9xvucrCF2yCMlTH4YWZUJAddlwDZI9movv1wXY1ele3UJdoTjKoaldjeMvlSsiag7qA==",
+        "shasum": "30d945313620490e88f16f25b7e072b24851becd",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.3.tgz",
+        "fileCount": 16,
+        "unpackedSize": 45576
+      }
+    },
+    "1.5.4": {
+      "name": "worker-farm",
+      "version": "1.5.4",
+      "dependencies": {
+        "errno": "~0.1.7",
+        "xtend": "~4.0.1"
+      },
+      "devDependencies": {
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==",
+        "shasum": "4debbe46b40edefcc717ebde74a90b1ae1e909a1",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.4.tgz",
+        "fileCount": 16,
+        "unpackedSize": 45584
+      }
+    },
+    "1.6.0": {
+      "name": "worker-farm",
+      "version": "1.6.0",
+      "dependencies": {
+        "errno": "~0.1.7"
+      },
+      "devDependencies": {
+        "tape": "~4.9.0"
+      },
+      "dist": {
+        "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+        "shasum": "aecc405976fab5a95526180846f0dba288f3a4a0",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 47168
+      }
+    },
+    "1.7.0": {
+      "name": "worker-farm",
+      "version": "1.7.0",
+      "dependencies": {
+        "errno": "~0.1.7"
+      },
+      "devDependencies": {
+        "tape": "~4.10.1"
+      },
+      "dist": {
+        "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+        "shasum": "26a94c5391bbca926152002f69b84a4bf772e5a8",
+        "tarball": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+        "fileCount": 17,
+        "unpackedSize": 49864,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJczEB8CRA9TVsSAnZWagAAYl8QAJgCWqB5uqNDgPIXrwKC\nCeYeTaKRf4NLT0h2+57z1PEdfyH1Nm8ZoasCz13uMNHhH0tV0B9nlCeFSsL7\nI3CDtpB+xcG5EAsw2hu6/inDIZKopPMkuHqE8akwWVt5lVy81kJ7f1QAllvf\n8ayAwr/Dg/yQmXHvOoV9wEe64pPc7bLfz8+65nNzILLwnaBs+u2J4oENk+70\nQRvs8Xn+3N3z/rsGr6DEIvMBdFuc30DfSzPpAuNjSoPJ57OoMUXPen6SXPHr\nQwq3Kd5KF3cGy++V1lnfc+1EtupnxeD1jWAcQrRpjGX+xEC9fdSSeHj+v/Ox\n8tpS89ygo+TCYOKGPauss4G8v8hX8YQNm3wnIJGLg9367appPOf60vohZ5/2\nsnzGpJWY/lxXE8P4HjqIsPyD6Je+bXNhTMX8pFQBlDMIdG0nLoiIaLxhjFMZ\nVyHVXBjUkHsi33XMCX2u831Nj+ikXFjpIWQhpYlC2n3Ru+Bdmz1mIoRC1Vsa\nzkPFWbzQmFNbmkReRZe/iDjiCeWDKK561CZ5wFkOekFE+g11PJMTIIf4fnxU\njv6AQuPlMEC6MwG6c+uHNpKWyO+kDR5QJM+tQVaIWzNbUp8oq0MVgkNh8a32\nso51YbVZjW6nvtJHJeRzkUSSKriI3AxWjZUXwjN7Yoxvu8sssu9Rfwz5ICk2\n+Una\r\n=g/dP\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2019-05-03T13:22:06.876Z"
+}


### PR DESCRIPTION
Discovered an interesting issue with the following dependency set:

```json
{
  "devDependencies": {
    "webpack-dev-server": "^3.11.0",
    "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3"
  }
}
```

`webpack-dev-server` here has a peerDependency on webpack v4.  But, the
dependencies of `@pmmmwh/react-refresh-webpack-plugin` have peer
dependencies on webpack at `4 || 5`.

So, a resolution _should_ be possible.  Since the
`@pmmmwh/react-refresh-webpack-plugin` package is alphabetically first,
it loads its deps, and ends up placing webpack@5 to satisfy the dep with
the latest and greatest.  Then when `webpack-dev-server` gets to its
eventual peer dep on webpack, it can't replace it, because `webpack@5`
has a dependency on `terser-webpack-plugin@^5.0.3`, which in turn has a
peer dependency on `webpack@5.4.0`.

When we check to see if webpack 5 can be replaced, we find it has a
dependent, and reject the replacement.  But that dependent is only
present as a dependency of the thing being replaced, so should not be
considered.

Second, while the source of the `terser-webpack-plugin` is `webpack`, it
cannot be installed there, because it has peer deps that are also peer
deps of webpack.  So, we _must_ place it in the root node_modules, but
were not attempting the "source" location overrides, because the root is
not the source.  This was a second issue resulting in `ERESOLVE` errors
even when `--force` was applied, with the following dependency set:

```json
{
  "devDependencies": {
    "webpack-dev-server": "^3.11.0",
    "webpack": "^5.0.0"
  }
}
```

Fixes: #180
Fixes: https://github.com/npm/cli/issues/2123
